### PR TITLE
Speed up Rails comparison CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,17 @@ jobs:
         with:
           ruby-version: "3.3"
       - run: npm ci
-      - run: npm run api:compare
-      - run: npm run test:compare
-      - run: npm run convention:compare
+      - name: Fetch Rails source
+        run: bash scripts/api-compare/fetch-rails.sh
+      - name: Fetch Rails test source + Rack
+        run: bash scripts/test-compare/fetch-rails-tests.sh
+      - name: Extract Ruby API
+        run: cd scripts/api-compare && ruby extract-ruby-api.rb
+      - name: Extract Ruby tests
+        run: cd scripts/test-compare && ruby extract-ruby-tests.rb
+      - name: API comparison
+        run: cd scripts/api-compare && npx tsx extract-ts-api.ts && npx tsx compare.ts
+      - name: Test comparison
+        run: cd scripts/test-compare && npx tsx extract-ts-tests.ts && npx tsx compare.ts
+      - name: Convention comparison
+        run: cd scripts/test-compare && npx tsx convention-compare.ts


### PR DESCRIPTION
## Summary

The Rails API/Test Comparison CI job was doing redundant work -- each of the three comparison scripts (api:compare, test:compare, convention:compare) independently fetched the Rails source and ran the Ruby extraction. The fetch scripts are idempotent so the git clone only happened once, but the Ruby extraction was running multiple times unnecessarily.

This breaks the CI step into individual named steps so:
- Rails source is fetched once
- Ruby API extraction runs once
- Ruby test extraction runs once
- The three TS comparisons run against the already-extracted JSON

Should shave some time off the job, and also makes it easier to see which step failed if something breaks.

## Test plan

- [ ] CI passes -- the Rails comparison job should produce the same results, just faster