### PR TITLE
Move actioncontroller test files to match Rails convention paths

### DIFF
--- a/packages/actionpack/src/actioncontroller/controller/base.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/base.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Base, API, DoubleRenderError } from "./base.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
+import { Base, API, DoubleRenderError } from "../base.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -19,7 +19,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/base_test.rb — Rendering
 // ==========================================================================
-describe("ActionController::Base rendering", () => {
+describe("ControllerInstanceTests", () => {
   it("render json", async () => {
     class JsonController extends Base {
       async index() {

--- a/packages/actionpack/src/actioncontroller/controller/caching.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/caching.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Base } from "./base.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
+import { Base } from "../base.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -18,7 +18,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/caching_test.rb — Conditional GET
 // ==========================================================================
-describe("ActionController conditional GET", () => {
+describe("FragmentCachingTest", () => {
   it("freshWhen sets ETag", async () => {
     class C extends Base {
       async show() {

--- a/packages/actionpack/src/actioncontroller/controller/filters.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/filters.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Base } from "./base.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
+import { Base } from "../base.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -18,7 +18,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/filters_test.rb — Controller-level filters
 // ==========================================================================
-describe("ActionController Filters", () => {
+describe("FilterTest", () => {
   it("before_action on controller", async () => {
     const log: string[] = [];
     class AppController extends Base {

--- a/packages/actionpack/src/actioncontroller/controller/metal.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/metal.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { Metal } from "./metal.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
-import { Parameters } from "../actiondispatch/parameters.js";
+import { Metal } from "../metal.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
+import { Parameters } from "../../actiondispatch/parameters.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -20,7 +20,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/metal_test.rb
 // ==========================================================================
-describe("ActionController::Metal", () => {
+describe("MetalControllerInstanceTests", () => {
   it("has default status 200", () => {
     class TestController extends Metal {
       async index() {}

--- a/packages/actionpack/src/actioncontroller/controller/params-wrapper.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/params-wrapper.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { wrapParameters, applyParamsWrapper, deriveWrapperKey } from "./params-wrapper.js";
-import { Parameters } from "../actiondispatch/parameters.js";
+import { wrapParameters, applyParamsWrapper, deriveWrapperKey } from "../params-wrapper.js";
+import { Parameters } from "../../actiondispatch/parameters.js";
 
 // ==========================================================================
 // action_controller/params_wrapper_test.rb
 // ==========================================================================
-describe("ActionController::ParamsWrapper", () => {
+describe("ParamsWrapperTest", () => {
   describe("wrapParameters", () => {
     it("creates config with key", () => {
       const config = wrapParameters("user");

--- a/packages/actionpack/src/actioncontroller/controller/redirect.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/redirect.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Base, DoubleRenderError } from "./base.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
+import { Base, DoubleRenderError } from "../base.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -18,7 +18,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/redirect_test.rb
 // ==========================================================================
-describe("ActionController redirecting", () => {
+describe("RedirectTest", () => {
   it("redirect_to with path", async () => {
     class C extends Base {
       async index() {

--- a/packages/actionpack/src/actioncontroller/controller/rescue.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/rescue.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Base } from "./base.js";
-import { Request } from "../actiondispatch/request.js";
-import { Response } from "../actiondispatch/response.js";
+import { Base } from "../base.js";
+import { Request } from "../../actiondispatch/request.js";
+import { Response } from "../../actiondispatch/response.js";
 
 function makeRequest(opts: Record<string, string> = {}): Request {
   return new Request({
@@ -18,7 +18,7 @@ function makeResponse(): Response {
 // ==========================================================================
 // action_controller/rescue_test.rb
 // ==========================================================================
-describe("ActionController rescue_from", () => {
+describe("RescueControllerTest", () => {
   it("rescues a known error", async () => {
     class AppError extends Error {
       name = "AppError";

--- a/packages/actionpack/src/actioncontroller/controller/test-case.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/test-case.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { TestCase } from "./test-case.js";
-import { Base } from "./base.js";
-import { Metal } from "./metal.js";
+import { TestCase } from "../test-case.js";
+import { Base } from "../base.js";
+import { Metal } from "../metal.js";
 
 // ==========================================================================
 // Test controllers
@@ -80,7 +80,7 @@ class PostsController extends Base {
 // ==========================================================================
 // action_controller/test_case_test.rb
 // ==========================================================================
-describe("ActionController::TestCase", () => {
+describe("TestCaseTest", () => {
   let tc: TestCase;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Moves 8 actioncontroller test files into the `controller/` subdirectory to match Rails' `actionpack/test/controller/` directory structure, and renames describe blocks to match Ruby test class names.

File moves:
- base, caching, filters, metal, params-wrapper, redirect, rescue, test-case all moved from root to controller/

Describe renames:
- FilterTest, RedirectTest, TestCaseTest, ParamsWrapperTest, RescueControllerTest, ControllerInstanceTests, FragmentCachingTest, MetalControllerInstanceTests

The remaining 4 unmoved files (abstract-controller, integration-test, rendering, template-rendering) don't have direct Ruby test file mappings.

Results: 0/91 to 8/91 matched files, 0 wrong describes.

## Test plan

- All 326 actioncontroller tests pass
- convention:compare shows 8/91 files matched with 0 wrong describes