### PR TITLE
refactor: fix describe blocks from copilot review

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
@@ -19,40 +19,42 @@ describe("SQLite3Adapter", () => {
     adapter.exec(`CREATE TABLE "topics" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT)`);
   });
 
-  it("where with string for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["hello"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["hello"]);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].title).toBe("hello");
-  });
+  describe("BindParameterTest", () => {
+    it("where with string for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["hello"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["hello"]);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].title).toBe("hello");
+    });
 
-  it("where with integer for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["123"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["123"]);
-    expect(rows).toHaveLength(1);
-  });
+    it("where with integer for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["123"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["123"]);
+      expect(rows).toHaveLength(1);
+    });
 
-  it("where with float for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["1.5"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["1.5"]);
-    expect(rows).toHaveLength(1);
-  });
+    it("where with float for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["1.5"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["1.5"]);
+      expect(rows).toHaveLength(1);
+    });
 
-  it("where with boolean for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["true"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["true"]);
-    expect(rows).toHaveLength(1);
-  });
+    it("where with boolean for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["true"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["true"]);
+      expect(rows).toHaveLength(1);
+    });
 
-  it("where with decimal for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["99.99"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["99.99"]);
-    expect(rows).toHaveLength(1);
-  });
+    it("where with decimal for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["99.99"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["99.99"]);
+      expect(rows).toHaveLength(1);
+    });
 
-  it("where with rational for string column using bind parameters", async () => {
-    await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["1/3"]);
-    const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["1/3"]);
-    expect(rows).toHaveLength(1);
-  });
+    it("where with rational for string column using bind parameters", async () => {
+      await adapter.executeMutation(`INSERT INTO "topics" ("title") VALUES (?)`, ["1/3"]);
+      const rows = await adapter.execute(`SELECT * FROM "topics" WHERE "title" = ?`, ["1/3"]);
+      expect(rows).toHaveLength(1);
+    });
+  }); // BindParameterTest
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 // -- Rails test class: sqlite3_create_folder_test.rb --
-describe("SQLite3Adapter", () => {
+describe("SQLite3CreateFolder", () => {
   it("sqlite creates directory", async () => {
     const fs = await import("fs");
     const path = await import("path");

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -33,190 +33,192 @@ describe("ActiveRecord::Relation", () => {
     return { Post };
   }
 
-  it("where with hash produces sql", () => {
-    const adapter = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+  describe("WhereClauseTest", () => {
+    it("where with hash produces sql", () => {
+      const adapter = freshAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const sql = Post.where({ title: "hello" }).toSql();
-    expect(sql).toContain("WHERE");
-  });
+      const sql = Post.where({ title: "hello" }).toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("where not with hash produces negation", () => {
-    const adapter = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+    it("where not with hash produces negation", () => {
+      const adapter = freshAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const sql = Post.all().whereNot({ title: "hello" }).toSql();
-    expect(sql).toContain("!=");
-  });
-  it("+ combines two where clauses", () => {
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("status", "string");
-        this.adapter = adapter;
+      const sql = Post.all().whereNot({ title: "hello" }).toSql();
+      expect(sql).toContain("!=");
+    });
+    it("+ combines two where clauses", () => {
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("status", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const rel = Post.where({ title: "hello" }).and(Post.where({ status: "active" }));
-    const sql = rel.toSql();
-    expect(sql).toContain("title");
-    expect(sql).toContain("status");
-  });
+      const rel = Post.where({ title: "hello" }).and(Post.where({ status: "active" }));
+      const sql = rel.toSql();
+      expect(sql).toContain("title");
+      expect(sql).toContain("status");
+    });
 
-  it("or returns an empty where clause when either side is empty", () => {
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+    it("or returns an empty where clause when either side is empty", () => {
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const rel = Post.where({ title: "hello" }).or(Post.all());
-    const sql = rel.toSql();
-    // When one side is empty (all), OR should still produce valid SQL
-    expect(sql).toContain("FROM");
-  });
+      const rel = Post.where({ title: "hello" }).or(Post.all());
+      const sql = rel.toSql();
+      // When one side is empty (all), OR should still produce valid SQL
+      expect(sql).toContain("FROM");
+    });
 
-  it("+ is associative, but not commutative", () => {
-    const { Post } = makeModel();
-    const sql1 = Post.where({ title: "a" }).where({ author: "b" }).toSql();
-    expect(sql1).toContain("WHERE");
-  });
+    it("+ is associative, but not commutative", () => {
+      const { Post } = makeModel();
+      const sql1 = Post.where({ title: "a" }).where({ author: "b" }).toSql();
+      expect(sql1).toContain("WHERE");
+    });
 
-  it("an empty where clause is the identity value for +", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "x", author: "y" });
-    const results = await Post.all().toArray();
-    expect(results.length).toBe(1);
-  });
+    it("an empty where clause is the identity value for +", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "x", author: "y" });
+      const results = await Post.all().toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("merge combines two where clauses", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "a", author: "alice" });
-    const r = Post.where({ title: "a" }).merge(Post.where({ author: "alice" }));
-    const results = await r.toArray();
-    expect(results.length).toBe(1);
-  });
+    it("merge combines two where clauses", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "a", author: "alice" });
+      const r = Post.where({ title: "a" }).merge(Post.where({ author: "alice" }));
+      const results = await r.toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("merge keeps the right side, when two equality clauses reference the same column", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "a" })
-      .merge(Post.where({ title: "b" }))
-      .toSql();
-    expect(sql).toContain("WHERE");
-  });
+    it("merge keeps the right side, when two equality clauses reference the same column", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "a" })
+        .merge(Post.where({ title: "b" }))
+        .toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("merge removes bind parameters matching overlapping equality clauses", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "x", author: "alice" });
-    const r = Post.where({ author: "alice" }).merge(Post.where({ title: "x" }));
-    const results = await r.toArray();
-    expect(results.length).toBe(1);
-  });
+    it("merge removes bind parameters matching overlapping equality clauses", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "x", author: "alice" });
+      const r = Post.where({ author: "alice" }).merge(Post.where({ title: "x" }));
+      const results = await r.toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("merge allows for columns with the same name from different tables", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "t", author: "a" });
-    const r = Post.where({ title: "t" }).merge(Post.where({ author: "a" }));
-    const results = await r.toArray();
-    expect(results.length).toBe(1);
-  });
+    it("merge allows for columns with the same name from different tables", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "t", author: "a" });
+      const r = Post.where({ title: "t" }).merge(Post.where({ author: "a" }));
+      const results = await r.toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("a clause knows if it is empty", () => {
-    const { Post } = makeModel();
-    const sql = Post.all().toSql();
-    expect(sql).toContain("SELECT");
-  });
+    it("a clause knows if it is empty", () => {
+      const { Post } = makeModel();
+      const sql = Post.all().toSql();
+      expect(sql).toContain("SELECT");
+    });
 
-  it("invert cannot handle nil", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "x" }).toSql();
-    expect(sql).toContain("WHERE");
-  });
+    it("invert cannot handle nil", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "x" }).toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("invert wraps the ast inside a NAND node", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "x" }).toSql();
-    expect(sql).toContain("WHERE");
-  });
+    it("invert wraps the ast inside a NAND node", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "x" }).toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("except removes binary predicates referencing a given column", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "a", author: "alice" });
-    await Post.create({ title: "b", author: "bob" });
-    const results = await Post.all().toArray();
-    expect(results.length).toBe(2);
-  });
+    it("except removes binary predicates referencing a given column", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "a", author: "alice" });
+      await Post.create({ title: "b", author: "bob" });
+      const results = await Post.all().toArray();
+      expect(results.length).toBe(2);
+    });
 
-  it("except jumps over unhandled binds (like with OR) correctly", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "a" })
-      .or(Post.where({ title: "b" }))
-      .toSql();
-    expect(sql).toContain("OR");
-  });
+    it("except jumps over unhandled binds (like with OR) correctly", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "a" })
+        .or(Post.where({ title: "b" }))
+        .toSql();
+      expect(sql).toContain("OR");
+    });
 
-  it("ast groups its predicates with AND", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "a" }).where({ author: "b" }).toSql();
-    expect(sql).toContain("WHERE");
-  });
+    it("ast groups its predicates with AND", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "a" }).where({ author: "b" }).toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("ast wraps any SQL literals in parenthesis", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "a" }).toSql();
-    expect(sql).toContain("WHERE");
-  });
+    it("ast wraps any SQL literals in parenthesis", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "a" }).toSql();
+      expect(sql).toContain("WHERE");
+    });
 
-  it("ast removes any empty strings", () => {
-    const { Post } = makeModel();
-    const sql = Post.all().toSql();
-    expect(sql).toContain("SELECT");
-  });
+    it("ast removes any empty strings", () => {
+      const { Post } = makeModel();
+      const sql = Post.all().toSql();
+      expect(sql).toContain("SELECT");
+    });
 
-  it("or joins the two clauses using OR", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ title: "a" })
-      .or(Post.where({ title: "b" }))
-      .toSql();
-    expect(sql).toContain("OR");
-  });
+    it("or joins the two clauses using OR", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ title: "a" })
+        .or(Post.where({ title: "b" }))
+        .toSql();
+      expect(sql).toContain("OR");
+    });
 
-  it("or places common conditions before the OR", () => {
-    const { Post } = makeModel();
-    const sql = Post.where({ author: "alice" })
-      .where({ title: "a" })
-      .or(Post.where({ author: "alice" }).where({ title: "b" }))
-      .toSql();
-    expect(sql).toContain("OR");
-  });
+    it("or places common conditions before the OR", () => {
+      const { Post } = makeModel();
+      const sql = Post.where({ author: "alice" })
+        .where({ title: "a" })
+        .or(Post.where({ author: "alice" }).where({ title: "b" }))
+        .toSql();
+      expect(sql).toContain("OR");
+    });
 
-  it("or can detect identical or as being a common condition", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "a", author: "alice" });
-    const r = Post.where({ title: "a" }).or(Post.where({ title: "a" }));
-    const results = await r.toArray();
-    expect(results.length).toBe(1);
-  });
+    it("or can detect identical or as being a common condition", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "a", author: "alice" });
+      const r = Post.where({ title: "a" }).or(Post.where({ title: "a" }));
+      const results = await r.toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("or will use only common conditions if one side only has common conditions", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "a", author: "alice" });
-    const r = Post.where({ title: "a" }).or(Post.where({ title: "b" }));
-    const results = await r.toArray();
-    expect(results.length).toBe(1);
-  });
+    it("or will use only common conditions if one side only has common conditions", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "a", author: "alice" });
+      const r = Post.where({ title: "a" }).or(Post.where({ title: "b" }));
+      const results = await r.toArray();
+      expect(results.length).toBe(1);
+    });
 
-  it("supports hash equality", async () => {
-    const { Post } = makeModel();
-    await Post.create({ title: "eq", author: "a" });
-    const results = await Post.where({ title: "eq" }).toArray();
-    expect(results.length).toBe(1);
-  });
+    it("supports hash equality", async () => {
+      const { Post } = makeModel();
+      await Post.create({ title: "eq", author: "a" });
+      const results = await Post.where({ title: "eq" }).toArray();
+      expect(results.length).toBe(1);
+    });
+  }); // WhereClauseTest
 });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -14,7 +14,7 @@ function freshAdapter(): DatabaseAdapter {
 }
 
 // ==========================================================================
-// ScopingTest — targets scoping/default_scoping_test.rb, scoping/named_scoping_test.rb
+// DefaultScopingTest — targets scoping/default_scoping_test.rb
 // ==========================================================================
 describe("DefaultScopingTest", () => {
   let adapter: DatabaseAdapter;

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1021,7 +1021,7 @@ describe("TransactionTest", () => {
 // ==========================================================================
 // TransactionsWithTransactionalFixturesTest — from transactions_test.rb
 // ==========================================================================
-describe("TransactionTest", () => {
+describe("TransactionsWithTransactionalFixturesTest", () => {
   it("automatic savepoint in outer transaction", () => {
     expect(true).toBe(true);
   });
@@ -1033,7 +1033,7 @@ describe("TransactionTest", () => {
 // ==========================================================================
 // TransactionUUIDTest — from transactions_test.rb
 // ==========================================================================
-describe("TransactionTest", () => {
+describe("TransactionUUIDTest", () => {
   it("the uuid is lazily computed", () => {
     expect(true).toBe(true);
   });
@@ -1048,7 +1048,7 @@ describe("TransactionTest", () => {
 // ==========================================================================
 // ConcurrentTransactionTest — from transactions_test.rb
 // ==========================================================================
-describe("TransactionTest", () => {
+describe("ConcurrentTransactionTest", () => {
   it("transaction per thread", () => {
     expect(true).toBe(true);
   });


### PR DESCRIPTION
## Summary

Follow-up to PR #66 addressing copilot's review comments, verified against convention:compare.

- Restored correct multi-class describes in transactions.test.ts (TransactionsWithTransactionalFixturesTest, TransactionUUIDTest, ConcurrentTransactionTest) -- these are distinct Ruby test classes that should not have been flattened to TransactionTest
- Added WhereClauseTest sub-describe under ActiveRecord::Relation in where-clause.test.ts to match Ruby's nested class structure
- Added BindParameterTest sub-describe under SQLite3Adapter in sqlite3 bind-parameter.test.ts
- Renamed sqlite3-create-folder describe to SQLite3CreateFolder (matching Ruby class name)
- Fixed section header comment in default-scoping.test.ts

Wrong-describe count goes from 540 to 441 (99 more fixed).