### PR TITLE
Convert 226 placeholder tests to it.todo

### DIFF
--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -383,63 +383,27 @@ describe("DirtyTest", () => {
     adapter = freshAdapter();
   });
 
-  it("time attributes changes with time zone", () => {
-    expect(true).toBe(true);
-  });
-  it("setting time attributes with time zone field to itself should not be marked as a change", () => {
-    expect(true).toBe(true);
-  });
-  it("time attributes changes without time zone by skip", () => {
-    expect(true).toBe(true);
-  });
-  it("time attributes changes without time zone", () => {
-    expect(true).toBe(true);
-  });
-  it("nullable decimal not marked as changed if new value is blank", () => {
-    expect(true).toBe(true);
-  });
-  it("nullable float not marked as changed if new value is blank", () => {
-    expect(true).toBe(true);
-  });
-  it("nullable datetime not marked as changed if new value is blank", () => {
-    expect(true).toBe(true);
-  });
-  it("integer zero to integer zero not marked as changed", () => {
-    expect(true).toBe(true);
-  });
-  it("float zero to string zero not marked as changed", () => {
-    expect(true).toBe(true);
-  });
-  it("zero to blank marked as changed", () => {
-    expect(true).toBe(true);
-  });
-  it("virtual attribute will change", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute should be compared with type cast", () => {
-    expect(true).toBe(true);
-  });
-  it("partial update with optimistic locking", () => {
-    expect(true).toBe(true);
-  });
-  it("save always should update timestamps when serialized attributes are present", () => {
-    expect(true).toBe(true);
-  });
-  it("save should not save serialized attribute with partial writes if not present", () => {
-    expect(true).toBe(true);
-  });
-  it("changes to save should not mutate array of hashes", () => {
-    expect(true).toBe(true);
-  });
-  it("field named field", () => {
-    expect(true).toBe(true);
-  });
-  it("datetime attribute can be updated with fractional seconds", () => {
-    expect(true).toBe(true);
-  });
-  it("datetime attribute doesnt change if zone is modified in string", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("time attributes changes with time zone");
+  it.todo(
+    "setting time attributes with time zone field to itself should not be marked as a change",
+  );
+  it.todo("time attributes changes without time zone by skip");
+  it.todo("time attributes changes without time zone");
+  it.todo("nullable decimal not marked as changed if new value is blank");
+  it.todo("nullable float not marked as changed if new value is blank");
+  it.todo("nullable datetime not marked as changed if new value is blank");
+  it.todo("integer zero to integer zero not marked as changed");
+  it.todo("float zero to string zero not marked as changed");
+  it.todo("zero to blank marked as changed");
+  it.todo("virtual attribute will change");
+  it.todo("attribute should be compared with type cast");
+  it.todo("partial update with optimistic locking");
+  it.todo("save always should update timestamps when serialized attributes are present");
+  it.todo("save should not save serialized attribute with partial writes if not present");
+  it.todo("changes to save should not mutate array of hashes");
+  it.todo("field named field");
+  it.todo("datetime attribute can be updated with fractional seconds");
+  it.todo("datetime attribute doesnt change if zone is modified in string");
   it("partial insert", async () => {
     class Post extends Base {
       static {
@@ -460,39 +424,17 @@ describe("DirtyTest", () => {
     const p = await Post.create({});
     expect((p as any).isPersisted()).toBe(true);
   });
-  it("in place mutation detection", () => {
-    expect(true).toBe(true);
-  });
-  it("in place mutation for binary", () => {
-    expect(true).toBe(true);
-  });
-  it("changes is correct for subclass", () => {
-    expect(true).toBe(true);
-  });
-  it("changes is correct if override attribute reader", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute_changed? doesn't compute in-place changes for unrelated attributes", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute_will_change! doesn't try to save non-persistable attributes", () => {
-    expect(true).toBe(true);
-  });
-  it("virtual attributes are not written with partial_writes off", () => {
-    expect(true).toBe(true);
-  });
-  it("mutating and then assigning doesn't remove the change", () => {
-    expect(true).toBe(true);
-  });
-  it("getters with side effects are allowed", () => {
-    expect(true).toBe(true);
-  });
-  it("attributes assigned but not selected are dirty", () => {
-    expect(true).toBe(true);
-  });
-  it("attributes not selected are still missing after save", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("in place mutation detection");
+  it.todo("in place mutation for binary");
+  it.todo("changes is correct for subclass");
+  it.todo("changes is correct if override attribute reader");
+  it.todo("attribute_changed? doesn't compute in-place changes for unrelated attributes");
+  it.todo("attribute_will_change! doesn't try to save non-persistable attributes");
+  it.todo("virtual attributes are not written with partial_writes off");
+  it.todo("mutating and then assigning doesn't remove the change");
+  it.todo("getters with side effects are allowed");
+  it.todo("attributes assigned but not selected are dirty");
+  it.todo("attributes not selected are still missing after save");
   it("saved_changes? returns whether the last call to save changed anything", async () => {
     class Post extends Base {
       static {
@@ -503,21 +445,11 @@ describe("DirtyTest", () => {
     const p = (await Post.create({ title: "a" })) as any;
     expect(p.isPersisted()).toBe(true);
   });
-  it("changed? in around callbacks after yield returns false", () => {
-    expect(true).toBe(true);
-  });
-  it("partial insert off with unchanged default function attribute", () => {
-    expect(true).toBe(true);
-  });
-  it("partial insert off with changed default function attribute", () => {
-    expect(true).toBe(true);
-  });
-  it("partial insert off with changed composite identity primary key attribute", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute_changed? properly type casts enum values", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("changed? in around callbacks after yield returns false");
+  it.todo("partial insert off with unchanged default function attribute");
+  it.todo("partial insert off with changed default function attribute");
+  it.todo("partial insert off with changed composite identity primary key attribute");
+  it.todo("attribute_changed? properly type casts enum values");
 });
 
 describe("DirtyTest", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -727,12 +727,8 @@ describe("EnumTest", () => {
     adapter = freshAdapter();
   });
 
-  it("type.cast", () => {
-    expect(true).toBe(true);
-  });
-  it("type.serialize", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("type.cast");
+  it.todo("type.serialize");
   it("find via where with strings", () => {
     class Post extends Base {
       static {
@@ -770,177 +766,67 @@ describe("EnumTest", () => {
     const p = await Post.create({ status: "active" });
     expect((p as any).isPersisted()).toBe(true);
   });
-  it("enum methods are overwritable", () => {
-    expect(true).toBe(true);
-  });
-  it("enum value after write symbol", () => {
-    expect(true).toBe(true);
-  });
-  it("enum attribute was", () => {
-    expect(true).toBe(true);
-  });
-  it("enum attribute changed", () => {
-    expect(true).toBe(true);
-  });
-  it("enum attribute changed to", () => {
-    expect(true).toBe(true);
-  });
-  it("enum attribute changed from", () => {
-    expect(true).toBe(true);
-  });
-  it("enum attribute changed from old status to new status", () => {
-    expect(true).toBe(true);
-  });
-  it("enum didn't change", () => {
-    expect(true).toBe(true);
-  });
-  it("assign non existing value raises an error", () => {
-    expect(true).toBe(true);
-  });
-  it("validation with 'validate: true' option", () => {
-    expect(true).toBe(true);
-  });
-  it("validation with 'validate: hash' option", () => {
-    expect(true).toBe(true);
-  });
-  it("NULL values from database should be casted to nil", () => {
-    expect(true).toBe(true);
-  });
-  it("deserialize nil value to enum which defines nil value to hash", () => {
-    expect(true).toBe(true);
-  });
-  it("assign nil value", () => {
-    expect(true).toBe(true);
-  });
-  it("assign nil value to enum which defines nil value to hash", () => {
-    expect(true).toBe(true);
-  });
-  it("assign empty string value", () => {
-    expect(true).toBe(true);
-  });
-  it("assign false value to a field defined as not boolean", () => {
-    expect(true).toBe(true);
-  });
-  it("assign false value to a field defined as boolean", () => {
-    expect(true).toBe(true);
-  });
-  it("assign long empty string value", () => {
-    expect(true).toBe(true);
-  });
-  it("constant to access the mapping", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute_before_type_cast", () => {
-    expect(true).toBe(true);
-  });
-  it("attribute_for_database", () => {
-    expect(true).toBe(true);
-  });
-  it("attributes_for_database", () => {
-    expect(true).toBe(true);
-  });
-  it("invalid definition values raise an ArgumentError", () => {
-    expect(true).toBe(true);
-  });
-  it("reserved enum names", () => {
-    expect(true).toBe(true);
-  });
-  it("can use id as a value with a prefix or suffix", () => {
-    expect(true).toBe(true);
-  });
-  it("overriding enum method should not raise", () => {
-    expect(true).toBe(true);
-  });
-  it("validate inclusion of value in array", () => {
-    expect(true).toBe(true);
-  });
-  it("enums are inheritable", () => {
-    expect(true).toBe(true);
-  });
-  it("attempting to modify enum raises error", () => {
-    expect(true).toBe(true);
-  });
-  it("declare multiple enums with suffix: true", () => {
-    expect(true).toBe(true);
-  });
-  it("enum with alias_attribute", () => {
-    expect(true).toBe(true);
-  });
-  it("uses default status when no status is provided in fixtures", () => {
-    expect(true).toBe(true);
-  });
-  it("uses default value from database on initialization", () => {
-    expect(true).toBe(true);
-  });
-  it("uses default value from database on initialization when using custom mapping", () => {
-    expect(true).toBe(true);
-  });
-  it("data type of Enum type", () => {
-    expect(true).toBe(true);
-  });
-  it("overloaded default by :default", () => {
-    expect(true).toBe(true);
-  });
-  it(":_default is invalid in the new API", () => {
-    expect(true).toBe(true);
-  });
-  it(":_prefix is invalid in the new API", () => {
-    expect(true).toBe(true);
-  });
-  it(":_suffix is invalid in the new API", () => {
-    expect(true).toBe(true);
-  });
-  it(":_scopes is invalid in the new API", () => {
-    expect(true).toBe(true);
-  });
-  it(":_instance_methods is invalid in the new API", () => {
-    expect(true).toBe(true);
-  });
-  it("scopes can be disabled by :scopes", () => {
-    expect(true).toBe(true);
-  });
-  it("enum labels as keyword arguments", () => {
-    expect(true).toBe(true);
-  });
-  it("option names can be used as label", () => {
-    expect(true).toBe(true);
-  });
-  it("capital characters for enum names", () => {
-    expect(true).toBe(true);
-  });
-  it("unicode characters for enum names", () => {
-    expect(true).toBe(true);
-  });
-  it("mangling collision for enum names", () => {
-    expect(true).toBe(true);
-  });
-  it("deserialize enum value to original hash key", () => {
-    expect(true).toBe(true);
-  });
-  it("serializable? with large number label", () => {
-    expect(true).toBe(true);
-  });
-  it("enum logs a warning if auto-generated negative scopes would clash with other enum names", () => {
-    expect(true).toBe(true);
-  });
-  it("enum logs a warning if auto-generated negative scopes would clash with other enum names regardless of order", () => {
-    expect(true).toBe(true);
-  });
-  it("enum doesn't log a warning if no clashes detected", () => {
-    expect(true).toBe(true);
-  });
-  it("enum doesn't log a warning if opting out of scopes", () => {
-    expect(true).toBe(true);
-  });
-  it("raises for attributes with undeclared type", () => {
-    expect(true).toBe(true);
-  });
-  it("supports attributes declared with a explicit type", () => {
-    expect(true).toBe(true);
-  });
-  it("default methods can be disabled by :instance_methods", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("enum methods are overwritable");
+  it.todo("enum value after write symbol");
+  it.todo("enum attribute was");
+  it.todo("enum attribute changed");
+  it.todo("enum attribute changed to");
+  it.todo("enum attribute changed from");
+  it.todo("enum attribute changed from old status to new status");
+  it.todo("enum didn't change");
+  it.todo("assign non existing value raises an error");
+  it.todo("validation with 'validate: true' option");
+  it.todo("validation with 'validate: hash' option");
+  it.todo("NULL values from database should be casted to nil");
+  it.todo("deserialize nil value to enum which defines nil value to hash");
+  it.todo("assign nil value");
+  it.todo("assign nil value to enum which defines nil value to hash");
+  it.todo("assign empty string value");
+  it.todo("assign false value to a field defined as not boolean");
+  it.todo("assign false value to a field defined as boolean");
+  it.todo("assign long empty string value");
+  it.todo("constant to access the mapping");
+  it.todo("attribute_before_type_cast");
+  it.todo("attribute_for_database");
+  it.todo("attributes_for_database");
+  it.todo("invalid definition values raise an ArgumentError");
+  it.todo("reserved enum names");
+  it.todo("can use id as a value with a prefix or suffix");
+  it.todo("overriding enum method should not raise");
+  it.todo("validate inclusion of value in array");
+  it.todo("enums are inheritable");
+  it.todo("attempting to modify enum raises error");
+  it.todo("declare multiple enums with suffix: true");
+  it.todo("enum with alias_attribute");
+  it.todo("uses default status when no status is provided in fixtures");
+  it.todo("uses default value from database on initialization");
+  it.todo("uses default value from database on initialization when using custom mapping");
+  it.todo("data type of Enum type");
+  it.todo("overloaded default by :default");
+  it.todo(":_default is invalid in the new API");
+  it.todo(":_prefix is invalid in the new API");
+  it.todo(":_suffix is invalid in the new API");
+  it.todo(":_scopes is invalid in the new API");
+  it.todo(":_instance_methods is invalid in the new API");
+  it.todo("scopes can be disabled by :scopes");
+  it.todo("enum labels as keyword arguments");
+  it.todo("option names can be used as label");
+  it.todo("capital characters for enum names");
+  it.todo("unicode characters for enum names");
+  it.todo("mangling collision for enum names");
+  it.todo("deserialize enum value to original hash key");
+  it.todo("serializable? with large number label");
+  it.todo(
+    "enum logs a warning if auto-generated negative scopes would clash with other enum names",
+  );
+  it.todo(
+    "enum logs a warning if auto-generated negative scopes would clash with other enum names regardless of order",
+  );
+  it.todo("enum doesn't log a warning if no clashes detected");
+  it.todo("enum doesn't log a warning if opting out of scopes");
+  it.todo("raises for attributes with undeclared type");
+  it.todo("supports attributes declared with a explicit type");
+  it.todo("default methods can be disabled by :instance_methods");
 });
 
 describe("EnumTest", () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -774,51 +774,21 @@ describe("PersistenceTest", () => {
     adapter = freshAdapter();
   });
 
-  it("populates non primary key autoincremented column", () => {
-    expect(true).toBe(true);
-  });
-  it("populates autoincremented id pk regardless of its position in columns list", () => {
-    expect(true).toBe(true);
-  });
-  it("fills auto populated columns on creation", () => {
-    expect(true).toBe(true);
-  });
-  it("update many with duplicated ids!", () => {
-    expect(true).toBe(true);
-  });
-  it("update many with invalid id!", () => {
-    expect(true).toBe(true);
-  });
-  it("update many with active record base object!", () => {
-    expect(true).toBe(true);
-  });
-  it("update many with array of active record base objects!", () => {
-    expect(true).toBe(true);
-  });
-  it("destroy with single composite primary key", () => {
-    expect(true).toBe(true);
-  });
-  it("destroy with multiple composite primary keys", () => {
-    expect(true).toBe(true);
-  });
-  it("destroy with invalid ids for a model that expects composite keys", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes after reload schema from cache", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes wont break mutation tracking", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes includes changed attributes", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes initializes missing attributes", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes keeps extra attributes", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("populates non primary key autoincremented column");
+  it.todo("populates autoincremented id pk regardless of its position in columns list");
+  it.todo("fills auto populated columns on creation");
+  it.todo("update many with duplicated ids!");
+  it.todo("update many with invalid id!");
+  it.todo("update many with active record base object!");
+  it.todo("update many with array of active record base objects!");
+  it.todo("destroy with single composite primary key");
+  it.todo("destroy with multiple composite primary keys");
+  it.todo("destroy with invalid ids for a model that expects composite keys");
+  it.todo("becomes after reload schema from cache");
+  it.todo("becomes wont break mutation tracking");
+  it.todo("becomes includes changed attributes");
+  it.todo("becomes initializes missing attributes");
+  it.todo("becomes keeps extra attributes");
   it("decrement with touch an attribute updates timestamps", async () => {
     class Post extends Base {
       static {
@@ -830,12 +800,8 @@ describe("PersistenceTest", () => {
     const p = (await Post.create({ views: 5 })) as any;
     expect(p.isPersisted()).toBe(true);
   });
-  it("create model with uuid pk populates id", () => {
-    expect(true).toBe(true);
-  });
-  it("create model with custom named uuid pk populates id", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("create model with uuid pk populates id");
+  it.todo("create model with custom named uuid pk populates id");
   it("create through factory with block", async () => {
     class Post extends Base {
       static {
@@ -856,18 +822,10 @@ describe("PersistenceTest", () => {
     const p = await Post.create({ title: "factory2" });
     expect((p as any).isPersisted()).toBe(true);
   });
-  it("preserve original sti type", () => {
-    expect(true).toBe(true);
-  });
-  it("update sti subclass type", () => {
-    expect(true).toBe(true);
-  });
-  it("becomes default sti subclass", () => {
-    expect(true).toBe(true);
-  });
-  it("destroy for a failed to destroy cpk record", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("preserve original sti type");
+  it.todo("update sti subclass type");
+  it.todo("becomes default sti subclass");
+  it.todo("destroy for a failed to destroy cpk record");
   it("update all with custom sql as value", async () => {
     class Post extends Base {
       static {
@@ -878,48 +836,20 @@ describe("PersistenceTest", () => {
     await Post.create({ title: "old" });
     expect(await Post.count()).toBeGreaterThan(0);
   });
-  it("update attribute for readonly attribute", () => {
-    expect(true).toBe(true);
-  });
-  it("update attribute for readonly attribute!", () => {
-    expect(true).toBe(true);
-  });
-  it("update attribute with one updated!", () => {
-    expect(true).toBe(true);
-  });
-  it("update attribute for aborted callback!", () => {
-    expect(true).toBe(true);
-  });
-  it("update column with model having primary key other than id", () => {
-    expect(true).toBe(true);
-  });
-  it("update columns with model having primary key other than id", () => {
-    expect(true).toBe(true);
-  });
-  it("update columns should not modify updated at", () => {
-    expect(true).toBe(true);
-  });
-  it("update columns with default scope", () => {
-    expect(true).toBe(true);
-  });
-  it("reset column information resets children", () => {
-    expect(true).toBe(true);
-  });
-  it("reload uses query constraints config", () => {
-    expect(true).toBe(true);
-  });
-  it("destroy uses query constraints config", () => {
-    expect(true).toBe(true);
-  });
-  it("delete uses query constraints config", () => {
-    expect(true).toBe(true);
-  });
-  it("update attribute uses query constraints config", () => {
-    expect(true).toBe(true);
-  });
-  it("it is possible to update parts of the query constraints config", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("update attribute for readonly attribute");
+  it.todo("update attribute for readonly attribute!");
+  it.todo("update attribute with one updated!");
+  it.todo("update attribute for aborted callback!");
+  it.todo("update column with model having primary key other than id");
+  it.todo("update columns with model having primary key other than id");
+  it.todo("update columns should not modify updated at");
+  it.todo("update columns with default scope");
+  it.todo("reset column information resets children");
+  it.todo("reload uses query constraints config");
+  it.todo("destroy uses query constraints config");
+  it.todo("delete uses query constraints config");
+  it.todo("update attribute uses query constraints config");
+  it.todo("it is possible to update parts of the query constraints config");
 });
 
 describe("PersistenceTest", () => {
@@ -4345,31 +4275,17 @@ describe("PersistenceTest", () => {
     expect(u.isPersisted()).toBe(true);
   });
 
-  it("query constraints list is nil if primary key is nil", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("query constraints list is nil if primary key is nil");
 
-  it("query constraints list is nil for non cpk model", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("query constraints list is nil for non cpk model");
 
-  it("query constraints list equals to composite primary key", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("query constraints list equals to composite primary key");
 
-  it("child keeps parents query constraints", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("child keeps parents query constraints");
 
-  it("child keeps parents query contraints derived from composite pk", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("child keeps parents query contraints derived from composite pk");
 
-  it("query constraints raises an error when no columns provided", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("query constraints raises an error when no columns provided");
 
-  it("child class with query constraints overrides parents", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("child class with query constraints overrides parents");
 });

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1449,30 +1449,16 @@ describe("DefaultScopingTest", () => {
     adapter = freshAdapter();
   });
 
-  it("default scope as class method referencing scope", () => {
-    expect(true).toBe(true);
-  });
-  it("default scope with all queries runs on update columns", () => {
-    expect(true).toBe(true);
-  });
-  it("nilable default scope with all queries runs on update columns", () => {
-    expect(true).toBe(true);
-  });
-  it("default scope with all queries runs on destroy", () => {
-    expect(true).toBe(true);
-  });
-  it("nilable default scope with all queries runs on destroy", () => {
-    expect(true).toBe(true);
-  });
-  it("default scope with all queries runs on reload", () => {
-    expect(true).toBe(true);
-  });
-  it("default scope with all queries runs on reload but default scope without all queries does not", () => {
-    expect(true).toBe(true);
-  });
-  it("nilable default scope with all queries runs on reload", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("default scope as class method referencing scope");
+  it.todo("default scope with all queries runs on update columns");
+  it.todo("nilable default scope with all queries runs on update columns");
+  it.todo("default scope with all queries runs on destroy");
+  it.todo("nilable default scope with all queries runs on destroy");
+  it.todo("default scope with all queries runs on reload");
+  it.todo(
+    "default scope with all queries runs on reload but default scope without all queries does not",
+  );
+  it.todo("nilable default scope with all queries runs on reload");
   it("order after reorder combines orders", () => {
     class Post extends Base {
       static {
@@ -1521,9 +1507,7 @@ describe("DefaultScopingTest", () => {
     }
     expect(Post.where({ title: "a" }).unscope("where")).toBeInstanceOf(Relation);
   });
-  it("unscope with grouping attributes", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("unscope with grouping attributes");
   it("unscope reverse order", () => {
     class Post extends Base {
       static {
@@ -1533,36 +1517,16 @@ describe("DefaultScopingTest", () => {
     }
     expect(Post.order("title").unscope("order")).toBeInstanceOf(Relation);
   });
-  it("unscope joins and select on developers projects", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope left outer joins", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope left joins", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope includes", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope eager load", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope preloads", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope having", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope errors with invalid value", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope errors with non where hash keys", () => {
-    expect(true).toBe(true);
-  });
-  it("unscope errors with non symbol or hash arguments", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("unscope joins and select on developers projects");
+  it.todo("unscope left outer joins");
+  it.todo("unscope left joins");
+  it.todo("unscope includes");
+  it.todo("unscope eager load");
+  it.todo("unscope preloads");
+  it.todo("unscope having");
+  it.todo("unscope errors with invalid value");
+  it.todo("unscope errors with non where hash keys");
+  it.todo("unscope errors with non symbol or hash arguments");
   it("where attribute merge", () => {
     class Post extends Base {
       static {
@@ -1592,9 +1556,7 @@ describe("DefaultScopingTest", () => {
     const p = await Post.create({ title: "nested" });
     expect((p as any).isPersisted()).toBe(true);
   });
-  it("joins not affected by scope other than default or unscoped", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("joins not affected by scope other than default or unscoped");
   it("default scope order ignored by aggregations", async () => {
     class Post extends Base {
       static {
@@ -1605,12 +1567,8 @@ describe("DefaultScopingTest", () => {
     await Post.create({ title: "a" });
     expect(await Post.count()).toBeGreaterThan(0);
   });
-  it("default scope with references works through collection association", () => {
-    expect(true).toBe(true);
-  });
-  it("default scope with references works through association", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("default scope with references works through collection association");
+  it.todo("default scope with references works through association");
   it("default scope with references works with find by", async () => {
     class Post extends Base {
       static {
@@ -1622,30 +1580,18 @@ describe("DefaultScopingTest", () => {
     const p = await Post.findBy({ title: "ref" });
     expect(p).not.toBeNull();
   });
-  it("additional conditions are ANDed with the default scope", () => {
-    expect(true).toBe(true);
-  });
-  it("additional conditions in a scope are ANDed with the default scope", () => {
-    expect(true).toBe(true);
-  });
-  it("with abstract class where clause should not be duplicated", () => {
-    expect(true).toBe(true);
-  });
-  it("sti conditions are not carried in default scope", () => {
-    expect(true).toBe(true);
-  });
-  it("with abstract class scope should be executed in correct context", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("additional conditions are ANDed with the default scope");
+  it.todo("additional conditions in a scope are ANDed with the default scope");
+  it.todo("with abstract class where clause should not be duplicated");
+  it.todo("sti conditions are not carried in default scope");
+  it.todo("with abstract class scope should be executed in correct context");
 });
 
 // ==========================================================================
 // DefaultScopingWithThreadTest — from scoping/default_scoping_test.rb
 // ==========================================================================
 describe("DefaultScopingTest", () => {
-  it("default scoping with threads", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("default scoping with threads");
 });
 
 describe("DefaultScopingTest", () => {

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -989,21 +989,11 @@ describe("NamedScopingTest", () => {
     adapter = freshAdapter();
   });
 
-  it("has many associations have access to scopes", () => {
-    expect(true).toBe(true);
-  });
-  it("scope with STI", () => {
-    expect(true).toBe(true);
-  });
-  it("has many through associations have access to scopes", () => {
-    expect(true).toBe(true);
-  });
-  it("scopes honor current scopes from when defined", () => {
-    expect(true).toBe(true);
-  });
-  it("scopes body is a callable", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("has many associations have access to scopes");
+  it.todo("scope with STI");
+  it.todo("has many through associations have access to scopes");
+  it.todo("scopes honor current scopes from when defined");
+  it.todo("scopes body is a callable");
   it("spaces in scope names", () => {
     class Post extends Base {
       static {
@@ -1027,18 +1017,10 @@ describe("NamedScopingTest", () => {
     expect(r1.length).toBe(1);
     expect(r2.length).toBe(1);
   });
-  it("table names for chaining scopes with and without table name included", () => {
-    expect(true).toBe(true);
-  });
-  it("scopes are cached on associations", () => {
-    expect(true).toBe(true);
-  });
-  it("scopes with arguments are cached on associations", () => {
-    expect(true).toBe(true);
-  });
-  it("scoped are lazy loaded if table still does not exist", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("table names for chaining scopes with and without table name included");
+  it.todo("scopes are cached on associations");
+  it.todo("scopes with arguments are cached on associations");
+  it.todo("scoped are lazy loaded if table still does not exist");
 });
 
 describe("NamedScopingTest", () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -877,36 +877,16 @@ describe("TransactionTest", () => {
     adapter = freshAdapter();
   });
 
-  it("rollback dirty changes even with raise during rollback removes from pool", () => {
-    expect(true).toBe(true);
-  });
-  it("rollback dirty changes even with raise during rollback doesnt commit transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("connection removed from pool when commit raises and rollback raises", () => {
-    expect(true).toBe(true);
-  });
-  it("connection removed from pool when begin raises after successfully beginning a transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("connection removed from pool when thread killed in begin after successfully beginning a transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("rollback dirty changes then retry save on new record with autosave association", () => {
-    expect(true).toBe(true);
-  });
-  it("add to null transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("deprecation on ruby timeout outside inner transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("rolling back in a callback rollbacks before save", () => {
-    expect(true).toBe(true);
-  });
-  it("raising exception in nested transaction restore state in save", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("rollback dirty changes even with raise during rollback removes from pool");
+  it.todo("rollback dirty changes even with raise during rollback doesnt commit transaction");
+  it.todo("connection removed from pool when commit raises and rollback raises");
+  it.todo("connection removed from pool when begin raises after successfully beginning a transaction");
+  it.todo("connection removed from pool when thread killed in begin after successfully beginning a transaction");
+  it.todo("rollback dirty changes then retry save on new record with autosave association");
+  it.todo("add to null transaction");
+  it.todo("deprecation on ruby timeout outside inner transaction");
+  it.todo("rolling back in a callback rollbacks before save");
+  it.todo("raising exception in nested transaction restore state in save");
   it("transaction state is cleared when record is persisted", async () => {
     class Post extends Base {
       static {
@@ -917,153 +897,71 @@ describe("TransactionTest", () => {
     const p = await Post.create({ title: "txn-state" });
     expect((p as any).isPersisted()).toBe(true);
   });
-  it("cancellation from before destroy rollbacks in destroy", () => {
-    expect(true).toBe(true);
-  });
-  it("callback rollback in create with record invalid exception", () => {
-    expect(true).toBe(true);
-  });
-  it("callback rollback in create with rollback exception", () => {
-    expect(true).toBe(true);
-  });
-  it("nested transaction with new transaction applies parent state on rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("nested transaction without new transaction applies parent state on rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("double nested transaction applies parent state on rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("invalid keys for transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("no savepoint in nested transaction without force", () => {
-    expect(true).toBe(true);
-  });
-  it("many savepoints", () => {
-    expect(true).toBe(true);
-  });
-  it("using named savepoints", () => {
-    expect(true).toBe(true);
-  });
-  it("releasing named savepoints", () => {
-    expect(true).toBe(true);
-  });
-  it("savepoints name", () => {
-    expect(true).toBe(true);
-  });
-  it("rollback when thread killed", () => {
-    expect(true).toBe(true);
-  });
-  it("dont restore new record in subsequent transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("assign custom primary key after rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("read attribute with custom primary key after rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("write attribute after rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("write attribute with custom primary key after rollback", () => {
-    expect(true).toBe(true);
-  });
-  it("sqlite add column in transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("sqlite default transaction mode is immediate", () => {
-    expect(true).toBe(true);
-  });
-  it("mark transaction state as committed", () => {
-    expect(true).toBe(true);
-  });
-  it("mark transaction state as rolledback", () => {
-    expect(true).toBe(true);
-  });
-  it("mark transaction state as nil", () => {
-    expect(true).toBe(true);
-  });
-  it("transaction rollback with primarykeyless tables", () => {
-    expect(true).toBe(true);
-  });
-  it("unprepared statement materializes transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("nested transactions skip excess savepoints", () => {
-    expect(true).toBe(true);
-  });
-  it("prepared statement materializes transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("savepoint does not materialize transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("raising does not materialize transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("accessing raw connection materializes transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("accessing raw connection disables lazy transactions", () => {
-    expect(true).toBe(true);
-  });
-  it("checking in connection reenables lazy transactions", () => {
-    expect(true).toBe(true);
-  });
-  it("transactions can be manually materialized", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("cancellation from before destroy rollbacks in destroy");
+  it.todo("callback rollback in create with record invalid exception");
+  it.todo("callback rollback in create with rollback exception");
+  it.todo("nested transaction with new transaction applies parent state on rollback");
+  it.todo("nested transaction without new transaction applies parent state on rollback");
+  it.todo("double nested transaction applies parent state on rollback");
+  it.todo("invalid keys for transaction");
+  it.todo("no savepoint in nested transaction without force");
+  it.todo("many savepoints");
+  it.todo("using named savepoints");
+  it.todo("releasing named savepoints");
+  it.todo("savepoints name");
+  it.todo("rollback when thread killed");
+  it.todo("dont restore new record in subsequent transaction");
+  it.todo("assign custom primary key after rollback");
+  it.todo("read attribute with custom primary key after rollback");
+  it.todo("write attribute after rollback");
+  it.todo("write attribute with custom primary key after rollback");
+  it.todo("sqlite add column in transaction");
+  it.todo("sqlite default transaction mode is immediate");
+  it.todo("mark transaction state as committed");
+  it.todo("mark transaction state as rolledback");
+  it.todo("mark transaction state as nil");
+  it.todo("transaction rollback with primarykeyless tables");
+  it.todo("unprepared statement materializes transaction");
+  it.todo("nested transactions skip excess savepoints");
+  it.todo("prepared statement materializes transaction");
+  it.todo("savepoint does not materialize transaction");
+  it.todo("raising does not materialize transaction");
+  it.todo("accessing raw connection materializes transaction");
+  it.todo("accessing raw connection disables lazy transactions");
+  it.todo("checking in connection reenables lazy transactions");
+  it.todo("transactions can be manually materialized");
 });
 
 // ==========================================================================
 // TransactionsWithTransactionalFixturesTest — from transactions_test.rb
 // ==========================================================================
 describe("TransactionsWithTransactionalFixturesTest", () => {
-  it("automatic savepoint in outer transaction", () => {
-    expect(true).toBe(true);
-  });
-  it("no automatic savepoint for inner transaction", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("automatic savepoint in outer transaction");
+  it.todo("no automatic savepoint for inner transaction");
 });
 
 // ==========================================================================
 // TransactionUUIDTest — from transactions_test.rb
 // ==========================================================================
 describe("TransactionUUIDTest", () => {
-  it("the uuid is lazily computed", () => {
-    expect(true).toBe(true);
-  });
-  it("the uuid for regular transactions is generated and memoized", () => {
-    expect(true).toBe(true);
-  });
-  it("the uuid for null transactions is nil", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("the uuid is lazily computed");
+  it.todo("the uuid for regular transactions is generated and memoized");
+  it.todo("the uuid for null transactions is nil");
 });
 
 // ==========================================================================
 // ConcurrentTransactionTest — from transactions_test.rb
 // ==========================================================================
 describe("ConcurrentTransactionTest", () => {
-  it("transaction per thread", () => {
-    expect(true).toBe(true);
-  });
-  it("transaction isolation  read committed", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("transaction per thread");
+  it.todo("transaction isolation  read committed");
 });
 
 // ==========================================================================
 // after current transaction commit multidb nested transactions (standalone)
 // ==========================================================================
 describe("TransactionTest", () => {
-  it("after current transaction commit multidb nested transactions", () => {
-    expect(true).toBe(true);
-  });
+  it.todo("after current transaction commit multidb nested transactions");
 });
 
 describe("TransactionTest", () => {

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -272,10 +272,7 @@ describe("DurationTest", () => {
     expect(result instanceof Date).toBe(true);
   });
 
-  it("since and ago anchored to time zone now when time zone is set", () => {
-    // No TimeWithZone in JS — skip timezone-specific behavior
-    expect(true).toBe(true);
-  });
+  it.todo("since and ago anchored to time zone now when time zone is set");
 
   it("before and after", () => {
     const t = new Date(2000, 0, 1, 0, 0, 0, 0);

--- a/packages/activesupport/src/core-ext/file.test.ts
+++ b/packages/activesupport/src/core-ext/file.test.ts
@@ -45,16 +45,5 @@ describe("AtomicWriteTest", () => {
     expect(result).toBe("returned value");
   });
 
-  it("probe stat in when no dir", () => {
-    // When directory doesn't exist, we simulate error handling
-    let error: Error | null = null;
-    try {
-      // A real implementation would throw if directory doesn't exist
-      const r = atomicWrite("/nonexistent/dir/file.txt", () => "data");
-    } catch (e) {
-      error = e as Error;
-    }
-    // Since our test impl doesn't check fs, just verify the concept
-    expect(true).toBe(true);
-  });
+  it.todo("probe stat in when no dir");
 });


### PR DESCRIPTION
## Summary

Converts 226 tests that had `expect(true).toBe(true)` as their only assertion to `it.todo()`. These were placeholder tests that passed but tested nothing — they inflated the passing count without providing any value.

Files affected:
- activerecord/scoping/default-scoping.test.ts (28)
- activerecord/scoping/named-scoping.test.ts (9)
- activerecord/dirty.test.ts (35)
- activerecord/enum.test.ts (59)
- activerecord/persistence.test.ts (42)
- activerecord/transactions.test.ts (51)
- activesupport/core-ext/duration.test.ts (1)
- activesupport/core-ext/file.test.ts (1)

## Test plan

- All test files pass
- No real test coverage lost (these tested nothing)