### PR TITLE
refactor: fix core ORM and transaction callback wrong describes

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2111,30 +2111,28 @@ describe("BasicsTest", () => {
 
 describe("BasicsTest", () => {
   // -- Table name inference --
-  describe("table name inference", () => {
-    it("table name guesses", () => {
-      class User extends Base {}
-      expect(User.tableName).toBe("users");
-    });
+  it("table name guesses", () => {
+    class User extends Base {}
+    expect(User.tableName).toBe("users");
+  });
 
-    it("handles CamelCase class names", () => {
-      class BlogPost extends Base {}
-      expect(BlogPost.tableName).toBe("blog_posts");
-    });
+  it("handles CamelCase class names", () => {
+    class BlogPost extends Base {}
+    expect(BlogPost.tableName).toBe("blog_posts");
+  });
 
-    it("handles names ending in y", () => {
-      class Category extends Base {}
-      expect(Category.tableName).toBe("categories");
-    });
+  it("handles names ending in y", () => {
+    class Category extends Base {}
+    expect(Category.tableName).toBe("categories");
+  });
 
-    it("switching between table name", () => {
-      class User extends Base {
-        static {
-          this.tableName = "people";
-        }
+  it("switching between table name", () => {
+    class User extends Base {
+      static {
+        this.tableName = "people";
       }
-      expect(User.tableName).toBe("people");
-    });
+    }
+    expect(User.tableName).toBe("people");
   });
 
   // -- Primary key --
@@ -2305,25 +2303,23 @@ describe("BasicsTest", () => {
   });
 
   // -- Reload --
-  describe("reload", () => {
-    it("reload", async () => {
-      const adapter = freshAdapter();
-      class User extends Base {
-        static {
-          this.attribute("name", "string");
-          this.adapter = adapter;
-        }
+  it("reload", async () => {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
       }
-      const u = await User.create({ name: "Original" });
-      // Directly modify via another instance
-      const u2 = await User.find(u.id);
-      await u2.update({ name: "Modified" });
+    }
+    const u = await User.create({ name: "Original" });
+    // Directly modify via another instance
+    const u2 = await User.find(u.id);
+    await u2.update({ name: "Modified" });
 
-      // u still has old value
-      expect(u.readAttribute("name")).toBe("Original");
-      await u.reload();
-      expect(u.readAttribute("name")).toBe("Modified");
-    });
+    // u still has old value
+    expect(u.readAttribute("name")).toBe("Original");
+    await u.reload();
+    expect(u.readAttribute("name")).toBe("Modified");
   });
 
   // -- Callbacks --

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -362,7 +362,7 @@ describe("OptimisticLockingWithSchemaChangeTest", () => {
   });
 });
 
-describe("optimistic locking", () => {
+describe("OptimisticLockingTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {
@@ -408,7 +408,7 @@ describe("optimistic locking", () => {
   });
 });
 
-describe("Optimistic Locking (Rails-guided)", () => {
+describe("OptimisticLockingTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -240,17 +240,19 @@ describe("MigrationTest", () => {
     }).toThrow(/precision/i);
   });
 
-  it("add and remove index", async () => {
-    const { ctx } = freshContext();
-    await ctx.createTable("users", {}, (t) => {
-      t.string("email");
+  describe("IndexForTableWithSchemaMigrationTest", () => {
+    it("add and remove index", async () => {
+      const { ctx } = freshContext();
+      await ctx.createTable("users", {}, (t) => {
+        t.string("email");
+      });
+
+      await ctx.addIndex("users", "email");
+      expect(ctx.indexExists("users", "email")).toBe(true);
+
+      await ctx.removeIndex("users", { column: "email" });
+      expect(ctx.indexExists("users", "email")).toBe(false);
     });
-
-    await ctx.addIndex("users", "email");
-    expect(ctx.indexExists("users", "email")).toBe(true);
-
-    await ctx.removeIndex("users", { column: "email" });
-    expect(ctx.indexExists("users", "email")).toBe(false);
   });
 });
 
@@ -1091,406 +1093,418 @@ describe("MigrationTest", () => {
     expect(cols["content"]).toBeDefined();
     expect(typeof cols["content"].name).toBe("string");
   });
-  it.skip("drop index from table named values", () => {
-    /* fixture-dependent */
+  describe("ReservedWordsMigrationTest", () => {
+    it.skip("drop index from table named values", () => {
+      /* fixture-dependent */
+    });
   });
 
-  it.skip("drop index by name", () => {
-    /* fixture-dependent */
+  describe("ExplicitlyNamedIndexMigrationTest", () => {
+    it.skip("drop index by name", () => {
+      /* fixture-dependent */
+    });
   });
 
-  // Helper for bulk alter table tests — fresh adapter per test via beforeEach
-  let bulkAdapter: DatabaseAdapter;
-  beforeEach(() => {
-    bulkAdapter = freshAdapter();
-  });
-  function makeBulkMig(m: Migration): Migration {
-    (m as any).adapter = bulkAdapter;
-    return m;
-  }
-
-  it("adding multiple columns", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk1", (t) => {
-            t.string("name");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.addColumn("bk1", "age", "integer");
-          await this.addColumn("bk1", "email", "string");
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Verify table exists and columns work by inserting data
-    await bulkAdapter.executeMutation(
-      `INSERT INTO "bk1" ("name", "age", "email") VALUES ('test', 25, 'a@b.c')`,
-    );
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk1"`);
-    expect(rows.length).toBe(1);
-    expect(rows[0].age).toBe(25);
-    expect(rows[0].email).toBe("a@b.c");
-  });
-
-  it("rename columns", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk2", (t) => {
-            t.string("old_c");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.renameColumn("bk2", "old_c", "new_c");
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Verify rename worked by inserting with new column name
-    await bulkAdapter.executeMutation(`INSERT INTO "bk2" ("new_c") VALUES ('test')`);
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk2"`);
-    expect(rows.length).toBe(1);
-    expect(rows[0].new_c).toBe("test");
-  });
-
-  it("removing columns", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk3", (t) => {
-            t.string("a");
-            t.string("b");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.removeColumns("bk3", "b");
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Verify column removal - migration ran without error
-    await bulkAdapter.executeMutation(`INSERT INTO "bk3" ("a") VALUES ('test')`);
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk3"`);
-    expect(rows.length).toBe(1);
-  });
-
-  it("adding timestamps", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk4", (t) => {
-            t.string("x");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.addTimestamps("bk4");
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Verify timestamps were added by inserting with those columns
-    await bulkAdapter.executeMutation(
-      `INSERT INTO "bk4" ("x", "created_at", "updated_at") VALUES ('test', '2023-01-01', '2023-01-01')`,
-    );
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk4"`);
-    expect(rows.length).toBe(1);
-    const createdAt = rows[0].created_at;
-    expect(
-      createdAt instanceof Date ? createdAt.toISOString().slice(0, 10) : String(createdAt),
-    ).toBe("2023-01-01");
-  });
-
-  it("removing timestamps", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk5", (t) => {
-            t.string("x");
-            t.datetime("created_at");
-            t.datetime("updated_at");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.removeTimestamps("bk5");
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Verify remove timestamps ran without error
-    await bulkAdapter.executeMutation(`INSERT INTO "bk5" ("x") VALUES ('test')`);
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk5"`);
-    expect(rows.length).toBe(1);
-  });
-
-  it("adding indexes", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk6", (t) => {
-            t.string("email");
-          });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.addIndex("bk6", "email", { unique: true });
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Index was created without error
-    await bulkAdapter.executeMutation(`INSERT INTO "bk6" ("email") VALUES ('test@test.com')`);
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk6"`);
-    expect(rows.length).toBe(1);
-  });
-
-  it("removing index", async () => {
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.createTable("bk7", (t) => {
-            t.string("email");
-          });
-          await this.addIndex("bk7", "email", { name: "bk7_idx" });
-        }
-        async down() {}
-      })(),
-    ).up();
-    await makeBulkMig(
-      new (class extends Migration {
-        async up() {
-          await this.removeIndex("bk7", { name: "bk7_idx" });
-        }
-        async down() {}
-      })(),
-    ).up();
-    // Index removal ran without error
-    await bulkAdapter.executeMutation(`INSERT INTO "bk7" ("email") VALUES ('test@test.com')`);
-    const rows = await bulkAdapter.execute(`SELECT * FROM "bk7"`);
-    expect(rows.length).toBe(1);
-  });
-
-  it.skip("changing columns", () => {
-    /* ALTER COLUMN TYPE not supported in SQLite/MemoryAdapter */
-  });
-
-  it.skip("changing column null with default", () => {
-    /* ALTER COLUMN not supported */
-  });
-
-  it.skip("default functions on columns", () => {
-    /* not supported */
-  });
-
-  it.skip("updating auto increment", () => {
-    /* not supported */
-  });
-
-  it.skip("changing index", () => {
-    /* ALTER INDEX not supported */
-  });
-
-  it("bulk revert", async () => {
-    const rvAdapter = freshAdapter();
-    function makeRvMig(m: Migration): Migration {
-      (m as any).adapter = rvAdapter;
+  describe("BulkAlterTableMigrationsTest", () => {
+    // Helper for bulk alter table tests — fresh adapter per test via beforeEach
+    let bulkAdapter: DatabaseAdapter;
+    beforeEach(() => {
+      bulkAdapter = freshAdapter();
+    });
+    function makeBulkMig(m: Migration): Migration {
+      (m as any).adapter = bulkAdapter;
       return m;
     }
-    // Create a table, add a column, then revert (down) both
-    class BulkMig extends Migration {
-      async change() {
-        await this.createTable("rv_bulk", (t) => {
-          t.string("name");
-        });
-        await this.addColumn("rv_bulk", "extra", "string");
+
+    it("adding multiple columns", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk1", (t) => {
+              t.string("name");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.addColumn("bk1", "age", "integer");
+            await this.addColumn("bk1", "email", "string");
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Verify table exists and columns work by inserting data
+      await bulkAdapter.executeMutation(
+        `INSERT INTO "bk1" ("name", "age", "email") VALUES ('test', 25, 'a@b.c')`,
+      );
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk1"`);
+      expect(rows.length).toBe(1);
+      expect(rows[0].age).toBe(25);
+      expect(rows[0].email).toBe("a@b.c");
+    });
+
+    it("rename columns", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk2", (t) => {
+              t.string("old_c");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.renameColumn("bk2", "old_c", "new_c");
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Verify rename worked by inserting with new column name
+      await bulkAdapter.executeMutation(`INSERT INTO "bk2" ("new_c") VALUES ('test')`);
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk2"`);
+      expect(rows.length).toBe(1);
+      expect(rows[0].new_c).toBe("test");
+    });
+
+    it("removing columns", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk3", (t) => {
+              t.string("a");
+              t.string("b");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.removeColumns("bk3", "b");
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Verify column removal - migration ran without error
+      await bulkAdapter.executeMutation(`INSERT INTO "bk3" ("a") VALUES ('test')`);
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk3"`);
+      expect(rows.length).toBe(1);
+    });
+
+    it("adding timestamps", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk4", (t) => {
+              t.string("x");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.addTimestamps("bk4");
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Verify timestamps were added by inserting with those columns
+      await bulkAdapter.executeMutation(
+        `INSERT INTO "bk4" ("x", "created_at", "updated_at") VALUES ('test', '2023-01-01', '2023-01-01')`,
+      );
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk4"`);
+      expect(rows.length).toBe(1);
+      const createdAt = rows[0].created_at;
+      expect(
+        createdAt instanceof Date ? createdAt.toISOString().slice(0, 10) : String(createdAt),
+      ).toBe("2023-01-01");
+    });
+
+    it("removing timestamps", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk5", (t) => {
+              t.string("x");
+              t.datetime("created_at");
+              t.datetime("updated_at");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.removeTimestamps("bk5");
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Verify remove timestamps ran without error
+      await bulkAdapter.executeMutation(`INSERT INTO "bk5" ("x") VALUES ('test')`);
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk5"`);
+      expect(rows.length).toBe(1);
+    });
+
+    it("adding indexes", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk6", (t) => {
+              t.string("email");
+            });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.addIndex("bk6", "email", { unique: true });
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Index was created without error
+      await bulkAdapter.executeMutation(`INSERT INTO "bk6" ("email") VALUES ('test@test.com')`);
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk6"`);
+      expect(rows.length).toBe(1);
+    });
+
+    it("removing index", async () => {
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.createTable("bk7", (t) => {
+              t.string("email");
+            });
+            await this.addIndex("bk7", "email", { name: "bk7_idx" });
+          }
+          async down() {}
+        })(),
+      ).up();
+      await makeBulkMig(
+        new (class extends Migration {
+          async up() {
+            await this.removeIndex("bk7", { name: "bk7_idx" });
+          }
+          async down() {}
+        })(),
+      ).up();
+      // Index removal ran without error
+      await bulkAdapter.executeMutation(`INSERT INTO "bk7" ("email") VALUES ('test@test.com')`);
+      const rows = await bulkAdapter.execute(`SELECT * FROM "bk7"`);
+      expect(rows.length).toBe(1);
+    });
+
+    it.skip("changing columns", () => {
+      /* ALTER COLUMN TYPE not supported in SQLite/MemoryAdapter */
+    });
+
+    it.skip("changing column null with default", () => {
+      /* ALTER COLUMN not supported */
+    });
+
+    it.skip("default functions on columns", () => {
+      /* not supported */
+    });
+
+    it.skip("updating auto increment", () => {
+      /* not supported */
+    });
+
+    it.skip("changing index", () => {
+      /* ALTER INDEX not supported */
+    });
+  }); // BulkAlterTableMigrationsTest
+
+  describe("RevertBulkAlterTableMigrationsTest", () => {
+    it("bulk revert", async () => {
+      const rvAdapter = freshAdapter();
+      function makeRvMig(m: Migration): Migration {
+        (m as any).adapter = rvAdapter;
+        return m;
       }
-    }
-    const m = makeRvMig(new BulkMig());
-    await m.up();
-    // Verify table was created with the extra column
-    await rvAdapter.executeMutation(
-      `INSERT INTO "rv_bulk" ("name", "extra") VALUES ('test', 'val')`,
-    );
-    const rows = await rvAdapter.execute(`SELECT * FROM "rv_bulk"`);
-    expect(rows.length).toBe(1);
-    expect(rows[0].extra).toBe("val");
-    // Revert should drop the table
-    await m.down();
-    // Table should be gone - selecting from it should return empty or throw
-    try {
-      const after = await rvAdapter.execute(`SELECT * FROM "rv_bulk"`);
-      expect(after.length).toBe(0);
-    } catch {
-      // Table doesn't exist, which is expected
-    }
-  });
-
-  it("copying migrations without timestamps", () => {
-    class CM1 extends Migration {
-      static version = "001";
-      async change() {}
-    }
-    expect(new CM1().version).toBe("001");
-  });
-
-  it("copying migrations without timestamps from 2 sources", () => {
-    class CM1 extends Migration {
-      static version = "001";
-      async change() {}
-    }
-    class CM2 extends Migration {
-      static version = "002";
-      async change() {}
-    }
-    expect(new CM1().version).toBe("001");
-    expect(new CM2().version).toBe("002");
-  });
-
-  it("copying migrations with timestamps", () => {
-    class CM1 extends Migration {
-      static version = "20230101120000";
-      async change() {}
-    }
-    expect(new CM1().version).toBe("20230101120000");
-  });
-
-  it("copying migrations with timestamps from 2 sources", () => {
-    class CM1 extends Migration {
-      static version = "20230101120000";
-      async change() {}
-    }
-    class CM2 extends Migration {
-      static version = "20230201120000";
-      async change() {}
-    }
-    expect(new CM1().version).toBe("20230101120000");
-    expect(new CM2().version).toBe("20230201120000");
-  });
-
-  it.skip("copying migrations with timestamps to destination with timestamps in future", () => {
-    /* filesystem-dependent */
-  });
-
-  it.skip("copying migrations preserving magic comments", () => {
-    /* filesystem-dependent */
-  });
-
-  it("skipping migrations", () => {
-    class CM1 extends Migration {
-      static version = "001";
-      async change() {}
-    }
-    expect(new CM1().version).toBe("001");
-    expect(new CM1().name).toBe("CM1");
-  });
-
-  it.skip("skip is not called if migrations are from the same plugin", () => {
-    /* plugin system not implemented */
-  });
-
-  it.skip("copying migrations to non existing directory", () => {
-    /* filesystem-dependent */
-  });
-
-  it.skip("copying migrations to empty directory", () => {
-    /* filesystem-dependent */
-  });
-
-  it("check pending with stdlib logger", async () => {
-    const cpAdapter = freshAdapter();
-    class CPM1 extends Migration {
-      static version = "001";
-      async change() {
-        await this.createTable("pend_t", (t) => {
-          t.string("x");
-        });
+      // Create a table, add a column, then revert (down) both
+      class BulkMig extends Migration {
+        async change() {
+          await this.createTable("rv_bulk", (t) => {
+            t.string("name");
+          });
+          await this.addColumn("rv_bulk", "extra", "string");
+        }
       }
-    }
-    const { MigrationRunner } = await import("./migration-runner.js");
-    const runner = new MigrationRunner(cpAdapter, [new CPM1()]);
-    const status = await runner.status();
-    expect(status.length).toBe(1);
-    expect(status[0].status).toBe("down");
-  });
+      const m = makeRvMig(new BulkMig());
+      await m.up();
+      // Verify table was created with the extra column
+      await rvAdapter.executeMutation(
+        `INSERT INTO "rv_bulk" ("name", "extra") VALUES ('test', 'val')`,
+      );
+      const rows = await rvAdapter.execute(`SELECT * FROM "rv_bulk"`);
+      expect(rows.length).toBe(1);
+      expect(rows[0].extra).toBe("val");
+      // Revert should drop the table
+      await m.down();
+      // Table should be gone - selecting from it should return empty or throw
+      try {
+        const after = await rvAdapter.execute(`SELECT * FROM "rv_bulk"`);
+        expect(after.length).toBe(0);
+      } catch {
+        // Table doesn't exist, which is expected
+      }
+    });
+  }); // RevertBulkAlterTableMigrationsTest
 
-  it("unknown migration version should raise an argument error", () => {
-    expect(Migration.get("nonexistent")).toBeNull();
-  });
+  describe("CopyMigrationsTest", () => {
+    it("copying migrations without timestamps", () => {
+      class CM1 extends Migration {
+        static version = "001";
+        async change() {}
+      }
+      expect(new CM1().version).toBe("001");
+    });
 
-  it("migration raises if timestamp greater than 14 digits", () => {
-    // Version strings longer than 14 chars are still stored as-is
-    class LongV extends Migration {
-      static version = "123456789012345";
-      async change() {}
-    }
-    expect(new LongV().version).toBe("123456789012345");
-  });
+    it("copying migrations without timestamps from 2 sources", () => {
+      class CM1 extends Migration {
+        static version = "001";
+        async change() {}
+      }
+      class CM2 extends Migration {
+        static version = "002";
+        async change() {}
+      }
+      expect(new CM1().version).toBe("001");
+      expect(new CM2().version).toBe("002");
+    });
 
-  it.skip("migration raises if timestamp is future date", () => {
-    /* timestamp validation not implemented */
-  });
+    it("copying migrations with timestamps", () => {
+      class CM1 extends Migration {
+        static version = "20230101120000";
+        async change() {}
+      }
+      expect(new CM1().version).toBe("20230101120000");
+    });
 
-  it("migration succeeds if timestamp is less than one day in the future", () => {
-    const now = Date.now();
-    const ts = String(now);
-    class FutureM extends Migration {
-      static version = ts;
-      async change() {}
-    }
-    expect(new FutureM().version).toBe(ts);
-  });
+    it("copying migrations with timestamps from 2 sources", () => {
+      class CM1 extends Migration {
+        static version = "20230101120000";
+        async change() {}
+      }
+      class CM2 extends Migration {
+        static version = "20230201120000";
+        async change() {}
+      }
+      expect(new CM1().version).toBe("20230101120000");
+      expect(new CM2().version).toBe("20230201120000");
+    });
 
-  it("migration succeeds despite future timestamp if validate timestamps is false", () => {
-    class FutureM2 extends Migration {
-      static version = "99991231235959";
-      async change() {}
-    }
-    expect(new FutureM2().version).toBe("99991231235959");
-  });
+    it.skip("copying migrations with timestamps to destination with timestamps in future", () => {
+      /* filesystem-dependent */
+    });
 
-  it("migration succeeds despite future timestamp if timestamped migrations is false", () => {
-    class NoTs extends Migration {
-      static version = "99999999999999";
-      async change() {}
-    }
-    expect(new NoTs().version).toBe("99999999999999");
-  });
+    it.skip("copying migrations preserving magic comments", () => {
+      /* filesystem-dependent */
+    });
 
-  it("copied migrations at timestamp boundary are valid", () => {
-    class Boundary extends Migration {
-      static version = "20231231235959";
-      async change() {}
-    }
-    expect(new Boundary().version).toBe("20231231235959");
-  });
+    it("skipping migrations", () => {
+      class CM1 extends Migration {
+        static version = "001";
+        async change() {}
+      }
+      expect(new CM1().version).toBe("001");
+      expect(new CM1().name).toBe("CM1");
+    });
+
+    it.skip("skip is not called if migrations are from the same plugin", () => {
+      /* plugin system not implemented */
+    });
+
+    it.skip("copying migrations to non existing directory", () => {
+      /* filesystem-dependent */
+    });
+
+    it.skip("copying migrations to empty directory", () => {
+      /* filesystem-dependent */
+    });
+
+    it("check pending with stdlib logger", async () => {
+      const cpAdapter = freshAdapter();
+      class CPM1 extends Migration {
+        static version = "001";
+        async change() {
+          await this.createTable("pend_t", (t) => {
+            t.string("x");
+          });
+        }
+      }
+      const { MigrationRunner } = await import("./migration-runner.js");
+      const runner = new MigrationRunner(cpAdapter, [new CPM1()]);
+      const status = await runner.status();
+      expect(status.length).toBe(1);
+      expect(status[0].status).toBe("down");
+    });
+
+    it("unknown migration version should raise an argument error", () => {
+      expect(Migration.get("nonexistent")).toBeNull();
+    });
+
+    describe("MigrationValidationTest", () => {
+      it("migration raises if timestamp greater than 14 digits", () => {
+        // Version strings longer than 14 chars are still stored as-is
+        class LongV extends Migration {
+          static version = "123456789012345";
+          async change() {}
+        }
+        expect(new LongV().version).toBe("123456789012345");
+      });
+
+      it.skip("migration raises if timestamp is future date", () => {
+        /* timestamp validation not implemented */
+      });
+
+      it("migration succeeds if timestamp is less than one day in the future", () => {
+        const now = Date.now();
+        const ts = String(now);
+        class FutureM extends Migration {
+          static version = ts;
+          async change() {}
+        }
+        expect(new FutureM().version).toBe(ts);
+      });
+
+      it("migration succeeds despite future timestamp if validate timestamps is false", () => {
+        class FutureM2 extends Migration {
+          static version = "99991231235959";
+          async change() {}
+        }
+        expect(new FutureM2().version).toBe("99991231235959");
+      });
+
+      it("migration succeeds despite future timestamp if timestamped migrations is false", () => {
+        class NoTs extends Migration {
+          static version = "99999999999999";
+          async change() {}
+        }
+        expect(new NoTs().version).toBe("99999999999999");
+      });
+    }); // MigrationValidationTest
+
+    it("copied migrations at timestamp boundary are valid", () => {
+      class Boundary extends Migration {
+        static version = "20231231235959";
+        async change() {}
+      }
+      expect(new Boundary().version).toBe("20231231235959");
+    });
+  }); // CopyMigrationsTest
 });

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1945,20 +1945,22 @@ describe("PersistenceTest", () => {
     expect(found.readAttribute("title")).toBe("new");
   });
 
-  it("primary key stays the same", async () => {
-    const adapter = freshAdapter();
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+  describe("QueryConstraintsTest", () => {
+    it("primary key stays the same", async () => {
+      const adapter = freshAdapter();
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const t = await Topic.create({ title: "test" });
-    const id = t.id;
-    t.writeAttribute("title", "updated");
-    await t.save();
-    expect(t.id).toBe(id);
-  });
+      const t = await Topic.create({ title: "test" });
+      const id = t.id;
+      t.writeAttribute("title", "updated");
+      await t.save();
+      expect(t.id).toBe(id);
+    });
+  }); // QueryConstraintsTest
 });
 
 describe("PersistenceTest", () => {
@@ -4345,31 +4347,33 @@ describe("PersistenceTest", () => {
     expect(u.isPersisted()).toBe(true);
   });
 
-  it("query constraints list is nil if primary key is nil", () => {
-    expect(true).toBe(true);
-  });
+  describe("QueryConstraintsTest", () => {
+    it("query constraints list is nil if primary key is nil", () => {
+      expect(true).toBe(true);
+    });
 
-  it("query constraints list is nil for non cpk model", () => {
-    expect(true).toBe(true);
-  });
+    it("query constraints list is nil for non cpk model", () => {
+      expect(true).toBe(true);
+    });
 
-  it("query constraints list equals to composite primary key", () => {
-    expect(true).toBe(true);
-  });
+    it("query constraints list equals to composite primary key", () => {
+      expect(true).toBe(true);
+    });
 
-  it("child keeps parents query constraints", () => {
-    expect(true).toBe(true);
-  });
+    it("child keeps parents query constraints", () => {
+      expect(true).toBe(true);
+    });
 
-  it("child keeps parents query contraints derived from composite pk", () => {
-    expect(true).toBe(true);
-  });
+    it("child keeps parents query contraints derived from composite pk", () => {
+      expect(true).toBe(true);
+    });
 
-  it("query constraints raises an error when no columns provided", () => {
-    expect(true).toBe(true);
-  });
+    it("query constraints raises an error when no columns provided", () => {
+      expect(true).toBe(true);
+    });
 
-  it("child class with query constraints overrides parents", () => {
-    expect(true).toBe(true);
-  });
+    it("child class with query constraints overrides parents", () => {
+      expect(true).toBe(true);
+    });
+  }); // QueryConstraintsTest
 });

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -16,34 +16,38 @@ describe("DelegationTest", () => {
     expect("arel" in post).toBe(false);
   });
 
-  it("delegate querying methods", async () => {
-    const adapter = createTestAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+  describe("QueryingMethodsDelegationTest", () => {
+    it("delegate querying methods", async () => {
+      const adapter = createTestAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    await Post.create({ title: "a" });
-    await Post.create({ title: "b" });
-    const all = await Post.all().toArray();
-    expect(all.length).toBe(2);
-    const filtered = await Post.where({ title: "a" }).toArray();
-    expect(filtered.length).toBe(1);
-    const ordered = Post.order("title");
-    expect(ordered.toSql()).toContain("ORDER");
-  });
+      await Post.create({ title: "a" });
+      await Post.create({ title: "b" });
+      const all = await Post.all().toArray();
+      expect(all.length).toBe(2);
+      const filtered = await Post.where({ title: "a" }).toArray();
+      expect(filtered.length).toBe(1);
+      const ordered = Post.order("title");
+      expect(ordered.toSql()).toContain("ORDER");
+    });
+  }); // QueryingMethodsDelegationTest
 
-  it("delegation doesn't override methods defined in other relation subclasses", () => {
-    const adapter = createTestAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
+  describe("DelegationCachingTest", () => {
+    it("delegation doesn't override methods defined in other relation subclasses", () => {
+      const adapter = createTestAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
       }
-    }
-    const r1 = Post.where({ title: "x" });
-    const r2 = Post.where({ title: "y" });
-    expect(r1.toSql()).not.toBe(r2.toSql());
-  });
+      const r1 = Post.where({ title: "x" });
+      const r2 = Post.where({ title: "y" });
+      expect(r1.toSql()).not.toBe(r2.toSql());
+    });
+  }); // DelegationCachingTest
 });

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -6746,29 +6746,32 @@ describe("RelationTest", () => {
     /* needs block/yield support in create */
   });
 
-  it("multiple find or create by within transactions", async () => {
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
+  describe("CreateOrFindByWithinTransactions", () => {
+    it("multiple find or create by within transactions", async () => {
+      const adp = freshAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
       }
-    }
-    const p = await Post.create({ title: "txn1" });
-    expect((p as any).isPersisted()).toBe(true);
-  });
+      const p = await Post.create({ title: "txn1" });
+      expect((p as any).isPersisted()).toBe(true);
+    });
 
-  it("multiple find or create by bang within transactions", async () => {
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
+    it("multiple find or create by bang within transactions", async () => {
+      const adp = freshAdapter();
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
       }
-    }
-    const p = await Post.create({ title: "txn2" });
-    expect((p as any).isPersisted()).toBe(true);
-  });
+      const p = await Post.create({ title: "txn2" });
+      expect((p as any).isPersisted()).toBe(true);
+    });
+  }); // CreateOrFindByWithinTransactions
+
   it(" with blank value", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1642,7 +1642,7 @@ describe("DefaultScopingTest", () => {
 // ==========================================================================
 // DefaultScopingWithThreadTest — from scoping/default_scoping_test.rb
 // ==========================================================================
-describe("DefaultScopingTest", () => {
+describe("DefaultScopingWithThreadTest", () => {
   it("default scoping with threads", () => {
     expect(true).toBe(true);
   });

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -215,7 +215,9 @@ describe("RelationScopingTest", () => {
   });
 
   it.skip("default scope filters on joins", () => {});
-  it.skip("should maintain default scope on associations", () => {});
+  describe("HasManyScopingTest", () => {
+    it.skip("should maintain default scope on associations", () => {});
+  });
 });
 
 describe("NestedRelationScopingTest", () => {
@@ -328,29 +330,31 @@ describe("Static shorthands (Rails-guided)", () => {
     /* TODO: needs helpers from original file */
   });
 
-  it.skip("forwarding of static methods", () => {
-    /* TODO: needs helpers from original file */
-  });
+  describe("HasManyScopingTest", () => {
+    it.skip("forwarding of static methods", () => {
+      /* TODO: needs helpers from original file */
+    });
 
-  it.skip("nested scope finder", () => {
-    /* TODO: needs helpers from original file */
-  });
+    it.skip("nested scope finder", () => {
+      /* TODO: needs helpers from original file */
+    });
 
-  it.skip("none scoping", () => {
-    /* TODO: needs helpers from original file */
-  });
+    it.skip("none scoping", () => {
+      /* TODO: needs helpers from original file */
+    });
 
-  it.skip("forwarding to scoped", () => {
-    /* TODO: needs helpers from original file */
-  });
+    it.skip("forwarding to scoped", () => {
+      /* TODO: needs helpers from original file */
+    });
 
-  it.skip("should default scope on associations is overridden by association conditions", () => {
-    /* TODO: needs helpers from original file */
-  });
+    it.skip("should default scope on associations is overridden by association conditions", () => {
+      /* TODO: needs helpers from original file */
+    });
 
-  it.skip("should maintain default scope on eager loaded associations", () => {
-    /* TODO: needs helpers from original file */
-  });
+    it.skip("should maintain default scope on eager loaded associations", () => {
+      /* TODO: needs helpers from original file */
+    });
+  }); // HasManyScopingTest
 
   it.skip("scoping applies to all queries on has many when set", () => {
     /* TODO: needs helpers from original file */

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -300,7 +300,7 @@ describe("TimestampTest", () => {
   });
 });
 
-describe("TimestampTest", () => {
+describe("TimestampsWithoutTransactionTest", () => {
   it("do not write timestamps on save if they are not attributes", async () => {
     const adapter = freshAdapter();
     class Post extends Base {

--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -440,7 +440,9 @@ describe("TransactionCallbacksTest", () => {
 
   it.skip("only call after commit on create after transaction commits for new record", () => {});
   it.skip("save in after create commit wont invoke extra after create commit", () => {});
-  it.skip("callbacks run in order defined in model if not using run after transaction callbacks in order defined", () => {});
+  describe("CallbackOrderTest", () => {
+    it.skip("callbacks run in order defined in model if not using run after transaction callbacks in order defined", () => {});
+  });
 });
 
 describe("TransactionCallbacksTest", () => {
@@ -515,381 +517,395 @@ describe("TransactionCallbacksTest", () => {
     });
     expect(log).toContain("invoice committed");
   });
-  it("after commit callbacks with optimistic locking", async () => {
-    const adapter = freshAdapter();
-    const log: string[] = [];
-    class Post extends Base {
-      static {
-        this._tableName = "posts";
-        this.attribute("title", "string");
-        this.attribute("lock_version", "integer", { default: 0 });
-        this.adapter = adapter;
-        this.afterCreate(function () {
-          log.push("created");
-        });
-        this.afterUpdate(function () {
-          log.push("updated");
-        });
+  describe("TransactionAfterCommitCallbacksWithOptimisticLockingTest", () => {
+    it("after commit callbacks with optimistic locking", async () => {
+      const adapter = freshAdapter();
+      const log: string[] = [];
+      class Post extends Base {
+        static {
+          this._tableName = "posts";
+          this.attribute("title", "string");
+          this.attribute("lock_version", "integer", { default: 0 });
+          this.adapter = adapter;
+          this.afterCreate(function () {
+            log.push("created");
+          });
+          this.afterUpdate(function () {
+            log.push("updated");
+          });
+        }
       }
-    }
-    const p = await Post.create({ title: "test" });
-    expect(log).toContain("created");
-    await p.update({ title: "changed" });
-    expect(log).toContain("updated");
-    expect(p.readAttribute("lock_version")).toBe(1);
-  });
-
-  it("after commit on multiple actions", async () => {
-    const adapter = freshAdapter();
-    const log: string[] = [];
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
-        this.afterCreate(function () {
-          log.push("created");
-        });
-        this.afterUpdate(function () {
-          log.push("updated");
-        });
-        this.afterDestroy(function () {
-          log.push("destroyed");
-        });
-      }
-    }
-    const p = await Post.create({ title: "a" });
-    expect(log).toContain("created");
-    p.writeAttribute("title", "b");
-    await p.save();
-    expect(log).toContain("updated");
-    await p.destroy();
-    expect(log).toContain("destroyed");
-  });
-
-  it.skip("before commit actions", () => {
-    /* fixture-dependent */
-  });
-
-  it.skip("before commit update in same transaction", () => {
-    /* fixture-dependent */
-  });
-
-  it("callbacks run in order defined in model if using run after transaction callbacks in order defined", async () => {
-    const adapter = freshAdapter();
-    const log: string[] = [];
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
-        this.beforeCreate(function () {
-          log.push("first");
-        });
-        this.beforeCreate(function () {
-          log.push("second");
-        });
-        this.afterCreate(function () {
-          log.push("after");
-        });
-      }
-    }
-    await Post.create({ title: "test" });
-    expect(log[0]).toBe("first");
-    expect(log[1]).toBe("second");
-    expect(log[2]).toBe("after");
-  });
-
-  it("trigger once on multiple deletion within transaction", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterDestroy((record: any) => {
-          log.push("destroyed:" + record.readAttribute("title"));
-        });
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    await transaction(Topic, async () => {
-      await t1.destroy();
+      const p = await Post.create({ title: "test" });
+      expect(log).toContain("created");
+      await p.update({ title: "changed" });
+      expect(log).toContain("updated");
+      expect(p.readAttribute("lock_version")).toBe(1);
     });
-    expect(log.filter((l) => l === "destroyed:a").length).toBe(1);
-  });
+  }); // TransactionAfterCommitCallbacksWithOptimisticLockingTest
 
-  it("trigger once on multiple deletions", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterDestroy((record: any) => {
-          log.push("destroyed:" + record.readAttribute("title"));
-        });
+  describe("CallbacksOnMultipleActionsTest", () => {
+    it("after commit on multiple actions", async () => {
+      const adapter = freshAdapter();
+      const log: string[] = [];
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.afterCreate(function () {
+            log.push("created");
+          });
+          this.afterUpdate(function () {
+            log.push("updated");
+          });
+          this.afterDestroy(function () {
+            log.push("destroyed");
+          });
+        }
       }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    await t1.destroy();
-    await t2.destroy();
-    expect(log.length).toBe(2);
-  });
+      const p = await Post.create({ title: "a" });
+      expect(log).toContain("created");
+      p.writeAttribute("title", "b");
+      await p.save();
+      expect(log).toContain("updated");
+      await p.destroy();
+      expect(log).toContain("destroyed");
+    });
 
-  it("trigger once on multiple deletions in a transaction", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterDestroy((record: any) => {
-          log.push("destroyed:" + record.readAttribute("title"));
-        });
+    it.skip("before commit actions", () => {
+      /* fixture-dependent */
+    });
+
+    it.skip("before commit update in same transaction", () => {
+      /* fixture-dependent */
+    });
+  }); // CallbacksOnMultipleActionsTest
+
+  describe("CallbackOrderTest", () => {
+    it("callbacks run in order defined in model if using run after transaction callbacks in order defined", async () => {
+      const adapter = freshAdapter();
+      const log: string[] = [];
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.beforeCreate(function () {
+            log.push("first");
+          });
+          this.beforeCreate(function () {
+            log.push("second");
+          });
+          this.afterCreate(function () {
+            log.push("after");
+          });
+        }
       }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    await transaction(Topic, async () => {
+      await Post.create({ title: "test" });
+      expect(log[0]).toBe("first");
+      expect(log[1]).toBe("second");
+      expect(log[2]).toBe("after");
+    });
+  }); // CallbackOrderTest
+
+  describe("CallbacksOnDestroyUpdateActionRaceTest", () => {
+    it("trigger once on multiple deletion within transaction", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterDestroy((record: any) => {
+            log.push("destroyed:" + record.readAttribute("title"));
+          });
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      await transaction(Topic, async () => {
+        await t1.destroy();
+      });
+      expect(log.filter((l) => l === "destroyed:a").length).toBe(1);
+    });
+
+    it("trigger once on multiple deletions", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterDestroy((record: any) => {
+            log.push("destroyed:" + record.readAttribute("title"));
+          });
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
       await t1.destroy();
       await t2.destroy();
+      expect(log.length).toBe(2);
     });
-    expect(log.length).toBe(2);
-    expect(log).toContain("destroyed:a");
-    expect(log).toContain("destroyed:b");
-  });
 
-  it("rollback on multiple deletions", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterDestroy((record: any) => {
-          log.push("destroyed");
-        });
+    it("trigger once on multiple deletions in a transaction", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterDestroy((record: any) => {
+            log.push("destroyed:" + record.readAttribute("title"));
+          });
+        }
       }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    const rollbackLog: string[] = [];
-    try {
-      await transaction(Topic, async (tx) => {
-        tx.afterRollback(() => {
-          rollbackLog.push("rollback");
-        });
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      await transaction(Topic, async () => {
         await t1.destroy();
         await t2.destroy();
-        throw new Error("rollback");
       });
-    } catch {}
-    expect(rollbackLog.length).toBeGreaterThan(0);
-  });
+      expect(log.length).toBe(2);
+      expect(log).toContain("destroyed:a");
+      expect(log).toContain("destroyed:b");
+    });
 
-  it("trigger on update where row was deleted", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterUpdate(function () {
-          log.push("updated");
+    it("rollback on multiple deletions", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterDestroy((record: any) => {
+            log.push("destroyed");
+          });
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      const rollbackLog: string[] = [];
+      try {
+        await transaction(Topic, async (tx) => {
+          tx.afterRollback(() => {
+            rollbackLog.push("rollback");
+          });
+          await t1.destroy();
+          await t2.destroy();
+          throw new Error("rollback");
         });
-        this.afterDestroy(function () {
-          log.push("destroyed");
-        });
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    await t1.destroy();
-    expect(log).toContain("destroyed");
-    // Attempting to modify a destroyed (frozen) record should throw, not trigger afterUpdate
-    expect(() => t1.writeAttribute("title", "b")).toThrow();
-    expect(log).not.toContain("updated");
-  });
+      } catch {}
+      expect(rollbackLog.length).toBeGreaterThan(0);
+    });
 
-  it("callback on action with condition", async () => {
-    const adapter = freshAdapter();
-    const log: string[] = [];
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("published", "boolean", { default: false });
-        this.adapter = adapter;
-        this.beforeSave(function (record: any) {
-          if (record.readAttribute("published")) {
-            log.push("published_save");
-          }
-        });
+    it("trigger on update where row was deleted", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterUpdate(function () {
+            log.push("updated");
+          });
+          this.afterDestroy(function () {
+            log.push("destroyed");
+          });
+        }
       }
-    }
-    await Post.create({ title: "draft", published: false });
-    expect(log).not.toContain("published_save");
-    await Post.create({ title: "live", published: true });
-    expect(log).toContain("published_save");
-  });
-
-  it("created callback called on last to save of separate instances in a transaction", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterCreate((record: any) => {
-          log.push("created:" + record.readAttribute("title"));
-        });
-      }
-    }
-    await transaction(Topic, async () => {
-      await Topic.create({ title: "first" });
-      await Topic.create({ title: "second" });
-    });
-    expect(log).toContain("created:first");
-    expect(log).toContain("created:second");
-    expect(log.length).toBe(2);
-  });
-
-  it("created callback called on first to save in transaction with old configuration", async () => {
-    const adp = freshAdapter();
-    const log: string[] = [];
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-        this.afterCreate((record: any) => {
-          log.push("created:" + record.readAttribute("title"));
-        });
-      }
-    }
-    await transaction(Topic, async () => {
-      await Topic.create({ title: "first" });
-      await Topic.create({ title: "second" });
-    });
-    expect(log[0]).toBe("created:first");
-  });
-
-  it("updated callback called on last to save of separate instances in a transaction", async () => {
-    const adp = freshAdapter();
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    const log: string[] = [];
-    Topic.afterUpdate((record: any) => {
-      log.push("updated:" + record.readAttribute("title"));
-    });
-    await transaction(Topic, async () => {
-      await t1.update({ title: "a2" });
-      await t2.update({ title: "b2" });
-    });
-    expect(log).toContain("updated:a2");
-    expect(log).toContain("updated:b2");
-    expect(log.length).toBe(2);
-  });
-
-  it("updated callback called on first to save in transaction with old configuration", async () => {
-    const adp = freshAdapter();
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    const log: string[] = [];
-    Topic.afterUpdate((record: any) => {
-      log.push("updated:" + record.readAttribute("title"));
-    });
-    await transaction(Topic, async () => {
-      await t1.update({ title: "a2" });
-      await t2.update({ title: "b2" });
-    });
-    expect(log[0]).toBe("updated:a2");
-  });
-
-  it("destroyed callback called on destroyed instance when preceded in transaction by save from separate instance", async () => {
-    const adp = freshAdapter();
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    const log: string[] = [];
-    Topic.afterDestroy((record: any) => {
-      log.push("destroyed:" + record.readAttribute("title"));
-    });
-    Topic.afterUpdate((record: any) => {
-      log.push("updated:" + record.readAttribute("title"));
-    });
-    await transaction(Topic, async () => {
-      await t1.update({ title: "a2" });
-      await t2.destroy();
-    });
-    expect(log).toContain("destroyed:b");
-    expect(log).toContain("updated:a2");
-  });
-
-  it.skip("updated callback called on first to save when followed in transaction by destroy from separate instance with old configuration", () => {
-    /* fixture-dependent */
-  });
-
-  it("destroyed callbacks called on destroyed instance even when followed by update from separate instances in a transaction", async () => {
-    const adp = freshAdapter();
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adp;
-      }
-    }
-    const t1 = await Topic.create({ title: "a" });
-    const t2 = await Topic.create({ title: "b" });
-    const log: string[] = [];
-    Topic.afterDestroy((record: any) => {
-      log.push("destroyed:" + record.readAttribute("title"));
-    });
-    Topic.afterUpdate((record: any) => {
-      log.push("updated:" + record.readAttribute("title"));
-    });
-    await transaction(Topic, async () => {
+      const t1 = await Topic.create({ title: "a" });
       await t1.destroy();
-      await t2.update({ title: "b2" });
+      expect(log).toContain("destroyed");
+      // Attempting to modify a destroyed (frozen) record should throw, not trigger afterUpdate
+      expect(() => t1.writeAttribute("title", "b")).toThrow();
+      expect(log).not.toContain("updated");
     });
-    expect(log).toContain("destroyed:a");
-    expect(log).toContain("updated:b2");
-  });
+  }); // CallbacksOnDestroyUpdateActionRaceTest
 
-  it.skip("destroyed callbacks called on first saved instance in transaction with old configuration", () => {
-    /* fixture-dependent */
-  });
-
-  it("set callback with on", async () => {
-    const adapter = freshAdapter();
-    const log: string[] = [];
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.adapter = adapter;
-        this.beforeCreate(function () {
-          log.push("before_create");
-        });
-        this.beforeSave(function () {
-          log.push("before_save");
-        });
+  describe("CallbacksOnActionAndConditionTest", () => {
+    it("callback on action with condition", async () => {
+      const adapter = freshAdapter();
+      const log: string[] = [];
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("published", "boolean", { default: false });
+          this.adapter = adapter;
+          this.beforeSave(function (record: any) {
+            if (record.readAttribute("published")) {
+              log.push("published_save");
+            }
+          });
+        }
       }
-    }
-    await Post.create({ title: "test" });
-    expect(log).toContain("before_create");
-    expect(log).toContain("before_save");
-  });
+      await Post.create({ title: "draft", published: false });
+      expect(log).not.toContain("published_save");
+      await Post.create({ title: "live", published: true });
+      expect(log).toContain("published_save");
+    });
+  }); // CallbacksOnActionAndConditionTest
+
+  describe("CallbacksOnMultipleInstancesInATransactionTest", () => {
+    it("created callback called on last to save of separate instances in a transaction", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterCreate((record: any) => {
+            log.push("created:" + record.readAttribute("title"));
+          });
+        }
+      }
+      await transaction(Topic, async () => {
+        await Topic.create({ title: "first" });
+        await Topic.create({ title: "second" });
+      });
+      expect(log).toContain("created:first");
+      expect(log).toContain("created:second");
+      expect(log.length).toBe(2);
+    });
+
+    it("created callback called on first to save in transaction with old configuration", async () => {
+      const adp = freshAdapter();
+      const log: string[] = [];
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+          this.afterCreate((record: any) => {
+            log.push("created:" + record.readAttribute("title"));
+          });
+        }
+      }
+      await transaction(Topic, async () => {
+        await Topic.create({ title: "first" });
+        await Topic.create({ title: "second" });
+      });
+      expect(log[0]).toBe("created:first");
+    });
+
+    it("updated callback called on last to save of separate instances in a transaction", async () => {
+      const adp = freshAdapter();
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      const log: string[] = [];
+      Topic.afterUpdate((record: any) => {
+        log.push("updated:" + record.readAttribute("title"));
+      });
+      await transaction(Topic, async () => {
+        await t1.update({ title: "a2" });
+        await t2.update({ title: "b2" });
+      });
+      expect(log).toContain("updated:a2");
+      expect(log).toContain("updated:b2");
+      expect(log.length).toBe(2);
+    });
+
+    it("updated callback called on first to save in transaction with old configuration", async () => {
+      const adp = freshAdapter();
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      const log: string[] = [];
+      Topic.afterUpdate((record: any) => {
+        log.push("updated:" + record.readAttribute("title"));
+      });
+      await transaction(Topic, async () => {
+        await t1.update({ title: "a2" });
+        await t2.update({ title: "b2" });
+      });
+      expect(log[0]).toBe("updated:a2");
+    });
+
+    it("destroyed callback called on destroyed instance when preceded in transaction by save from separate instance", async () => {
+      const adp = freshAdapter();
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      const log: string[] = [];
+      Topic.afterDestroy((record: any) => {
+        log.push("destroyed:" + record.readAttribute("title"));
+      });
+      Topic.afterUpdate((record: any) => {
+        log.push("updated:" + record.readAttribute("title"));
+      });
+      await transaction(Topic, async () => {
+        await t1.update({ title: "a2" });
+        await t2.destroy();
+      });
+      expect(log).toContain("destroyed:b");
+      expect(log).toContain("updated:a2");
+    });
+
+    it.skip("updated callback called on first to save when followed in transaction by destroy from separate instance with old configuration", () => {
+      /* fixture-dependent */
+    });
+
+    it("destroyed callbacks called on destroyed instance even when followed by update from separate instances in a transaction", async () => {
+      const adp = freshAdapter();
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adp;
+        }
+      }
+      const t1 = await Topic.create({ title: "a" });
+      const t2 = await Topic.create({ title: "b" });
+      const log: string[] = [];
+      Topic.afterDestroy((record: any) => {
+        log.push("destroyed:" + record.readAttribute("title"));
+      });
+      Topic.afterUpdate((record: any) => {
+        log.push("updated:" + record.readAttribute("title"));
+      });
+      await transaction(Topic, async () => {
+        await t1.destroy();
+        await t2.update({ title: "b2" });
+      });
+      expect(log).toContain("destroyed:a");
+      expect(log).toContain("updated:b2");
+    });
+
+    it.skip("destroyed callbacks called on first saved instance in transaction with old configuration", () => {
+      /* fixture-dependent */
+    });
+  }); // CallbacksOnMultipleInstancesInATransactionTest
+
+  describe("SetCallbackTest", () => {
+    it("set callback with on", async () => {
+      const adapter = freshAdapter();
+      const log: string[] = [];
+      class Post extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.beforeCreate(function () {
+            log.push("before_create");
+          });
+          this.beforeSave(function () {
+            log.push("before_save");
+          });
+        }
+      }
+      await Post.create({ title: "test" });
+      expect(log).toContain("before_create");
+      expect(log).toContain("before_save");
+    });
+  }); // SetCallbackTest
 });


### PR DESCRIPTION
## Summary

Fixes 80 wrong-describe tests across 10 activerecord test files by adding sub-describes and renaming describe blocks to match the Ruby test class names that convention:compare expects. Wrong-describe count drops from 382 to 302.

This is Track C work (PR 1.2 + PR 1.3 from the roadmap), covering transaction callbacks, migration, persistence, base, locking, timestamp, scoping, delegation, and relations.

The biggest changes are in migration.test.ts (34 fixed -- BulkAlterTableMigrationsTest, CopyMigrationsTest, MigrationValidationTest, etc.) and transaction-callbacks.test.ts (21 fixed -- 7 distinct Ruby test classes).

All 6,646 tests still pass. No test logic or assertions changed.