### PR TITLE
Enable most eslint rules for the rack package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,11 +99,12 @@ export default defineConfig(
     files: ["packages/rack/src/**/*.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
-      "@typescript-eslint/no-this-alias": "off",
-      "unused-imports/no-unused-vars": "off",
-      "no-undef": "off",
-      "no-useless-assignment": "off",
+    },
+  },
+  {
+    files: ["packages/rack/src/common-logger.ts"],
+    rules: {
+      "no-control-regex": "off",
     },
   },
 

--- a/packages/rack/src/builder.test.ts
+++ b/packages/rack/src/builder.test.ts
@@ -13,7 +13,7 @@ it("can provide options", async () => {
 
 it("supports run with block", async () => {
   const builder = new Builder();
-  builder.run(null, async (env) => [200, {}, ["block"]]);
+  builder.run(null, async (_env) => [200, {}, ["block"]]);
   const app = builder.toApp();
   const res = await new MockRequest(app).get("/");
   expect(res.bodyString).toBe("block");
@@ -32,10 +32,10 @@ it("raises if #run provided both app and block", () => {
 it("supports mapping", async () => {
   const builder = new Builder();
   builder.map("/foo", (b) => {
-    b.run(async (env) => [200, {}, ["foo"]]);
+    b.run(async (_env) => [200, {}, ["foo"]]);
   });
   builder.map("/bar", (b) => {
-    b.run(async (env) => [200, {}, ["bar"]]);
+    b.run(async (_env) => [200, {}, ["bar"]]);
   });
   const app = builder.toApp();
   const res1 = await new MockRequest(app).get("/foo");

--- a/packages/rack/src/common-logger.ts
+++ b/packages/rack/src/common-logger.ts
@@ -14,7 +14,6 @@ function clockTime(): number {
 }
 
 function escapeNonPrintable(str: string): string {
-  // eslint-disable-next-line no-control-regex
   return str.replace(/[\x00-\x1f]/g, (ch) => {
     return "\\x" + ch.charCodeAt(0).toString(16).padStart(2, "0");
   });
@@ -32,7 +31,7 @@ export class CommonLogger {
   async call(env: Record<string, any>): Promise<[number, Record<string, string>, any]> {
     const began = clockTime();
     const response = await this.app(env);
-    const [status, headers, body] = response;
+    const [status, headers, _body] = response;
     const logger = this.logger || env["rack.errors"];
     const now = clockTime();
     this.log(env, status, headers, now - began, logger);

--- a/packages/rack/src/directory.ts
+++ b/packages/rack/src/directory.ts
@@ -90,8 +90,8 @@ export class Directory {
       const displayName = entry.isDirectory() ? name + "/" : name;
       const uri = encodeURI(scriptName + path.join(reqPath, name).replace(/\\/g, "/"));
 
-      let size = "";
-      let mtime = "";
+      let size: string;
+      let mtime: string;
       try {
         const stat = fs.statSync(fullEntryPath);
         size = entry.isDirectory() ? "-" : String(stat.size);

--- a/packages/rack/src/events.test.ts
+++ b/packages/rack/src/events.test.ts
@@ -6,19 +6,19 @@ import type { RackApp, RackBody } from "./index.js";
 function makeHandler(events: [any, string][]): EventHandler & { self: object } {
   const handler = {
     self: {} as object,
-    onStart(req: Request, res: EventResponse) {
+    onStart(_req: Request, _res: EventResponse) {
       events.push([handler, "on_start"]);
     },
-    onCommit(req: Request, res: EventResponse) {
+    onCommit(_req: Request, _res: EventResponse) {
       events.push([handler, "on_commit"]);
     },
-    onSend(req: Request, res: EventResponse) {
+    onSend(_req: Request, _res: EventResponse) {
       events.push([handler, "on_send"]);
     },
-    onFinish(req: Request, res: EventResponse) {
+    onFinish(_req: Request, _res: EventResponse) {
       events.push([handler, "on_finish"]);
     },
-    onError(req: Request, res: EventResponse, e: Error) {
+    onError(_req: Request, _res: EventResponse, _e: Error) {
       events.push([handler, "on_error"]);
     },
   };
@@ -38,18 +38,18 @@ describe("TestEvents", () => {
   it("events fire", async () => {
     const events: [any, string][] = [];
     const appMarker = { name: "app" };
-    const app: RackApp = async (env) => {
+    const app: RackApp = async (_env) => {
       events.push([appMarker, "call"]);
       return [200, {}, (async function* () {})()];
     };
     const se = makeHandler(events);
     const e = new Events(app, [se]);
 
-    const [status, headers, body] = await e.call({});
+    const [_status, _headers, body] = await e.call({});
     await consumeBody(body);
     (body as any).close();
 
-    expect(events.map(([o, m]) => m)).toEqual([
+    expect(events.map(([_o, m]) => m)).toEqual([
       "on_start",
       "call",
       "on_commit",
@@ -60,7 +60,7 @@ describe("TestEvents", () => {
 
   it("send and finish are not run until body is sent", async () => {
     const events: [any, string][] = [];
-    const app: RackApp = async (env) => {
+    const app: RackApp = async (_env) => {
       events.push([null, "call"]);
       return [200, {}, (async function* () {})()];
     };
@@ -74,7 +74,7 @@ describe("TestEvents", () => {
 
   it("send is called on each", async () => {
     const events: [any, string][] = [];
-    const app: RackApp = async (env) => {
+    const app: RackApp = async (_env) => {
       events.push([null, "call"]);
       return [200, {}, (async function* () {})()];
     };
@@ -89,7 +89,7 @@ describe("TestEvents", () => {
 
   it("finish is called on close", async () => {
     const events: [any, string][] = [];
-    const app: RackApp = async (env) => {
+    const app: RackApp = async (_env) => {
       events.push([null, "call"]);
       return [200, {}, (async function* () {})()];
     };
@@ -111,7 +111,7 @@ describe("TestEvents", () => {
 
   it("finish is called in reverse order", async () => {
     const events: [any, string][] = [];
-    const app: RackApp = async (env) => {
+    const app: RackApp = async (_env) => {
       events.push([null, "call"]);
       return [200, {}, (async function* () {})()];
     };

--- a/packages/rack/src/files.test.ts
+++ b/packages/rack/src/files.test.ts
@@ -228,7 +228,7 @@ it("detect SystemCallErrors", async () => {
 it("return bodies that respond to #to_path", async () => {
   const app = makeApp();
   const env = MockRequest.envFor("/test.txt");
-  const [status, headers, body] = app.serving(env, "/test.txt");
+  const [status, _headers, body] = app.serving(env, "/test.txt");
   expect(status).toBe(200);
   expect(typeof body.toPath).toBe("function");
   expect(body.toPath()).toBe(path.join(tmpDir, "test.txt"));

--- a/packages/rack/src/headers.test.ts
+++ b/packages/rack/src/headers.test.ts
@@ -82,17 +82,17 @@ describe("RackHeadersTest", () => {
   });
 
   it("delete if and reject", () => {
-    const rejected = fh.reject((k, v) => k === "ab" || k === "cd");
+    const rejected = fh.reject((k, _v) => k === "ab" || k === "cd");
     expect(rejected.length).toBe(1);
     expect(rejected.get("3")).toBe("4");
     expect(fh.length).toBe(3);
 
-    fh.deleteIf((k, v) => k === "ab" || k === "cd");
+    fh.deleteIf((k, _v) => k === "ab" || k === "cd");
     expect(fh.length).toBe(1);
     expect(fh.get("3")).toBe("4");
 
-    expect(fh.rejectInPlace((k, v) => k === "ab" || k === "cd")).toBeNull();
-    const result = fh.rejectInPlace((k, v) => k === "3");
+    expect(fh.rejectInPlace((k, _v) => k === "ab" || k === "cd")).toBeNull();
+    const result = fh.rejectInPlace((k, _v) => k === "3");
     expect(result).not.toBeNull();
     expect(fh.length).toBe(0);
   });

--- a/packages/rack/src/headers.ts
+++ b/packages/rack/src/headers.ts
@@ -409,7 +409,7 @@ export class Headers {
 
   // --- Other ---
 
-  flatten(depth = 1): string[] {
+  flatten(_depth = 1): string[] {
     const result: string[] = [];
     for (const [k, v] of this._data) {
       result.push(k, v);

--- a/packages/rack/src/lint.test.ts
+++ b/packages/rack/src/lint.test.ts
@@ -26,9 +26,9 @@ function validEnv(overrides: Record<string, any> = {}): Record<string, any> {
 }
 
 it("pass valid request", async () => {
-  const app = new Lint(async (env) => [200, { "content-type": "text/plain" }, ["OK"]]);
+  const app = new Lint(async (_env) => [200, { "content-type": "text/plain" }, ["OK"]]);
   const env = validEnv();
-  const [status, headers, body] = await app.call(env);
+  const [status, _headers, _body] = await app.call(env);
   expect(status).toBe(200);
 });
 
@@ -149,7 +149,7 @@ it("handles body.to_path returning nil", async () => {
     },
   };
   const app = new Lint(async () => [200, { "content-type": "text/plain" }, body]);
-  const [status, , b] = await app.call(validEnv());
+  const [status] = await app.call(validEnv());
   expect(status).toBe(200);
 });
 

--- a/packages/rack/src/logger.ts
+++ b/packages/rack/src/logger.ts
@@ -26,8 +26,6 @@ export class Logger {
   }
 }
 
-const LEVELS = ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"] as const;
-
 class RackLogger {
   private output: LoggerStream | undefined;
 

--- a/packages/rack/src/mock-request.test.ts
+++ b/packages/rack/src/mock-request.test.ts
@@ -2,7 +2,7 @@ import { it, expect } from "vitest";
 import { MockRequest } from "./mock-request.js";
 import { MockResponse } from "./mock-response.js";
 
-const appId = async (env: Record<string, any>): Promise<[number, Record<string, string>, any]> => {
+const appId = async (_env: Record<string, any>): Promise<[number, Record<string, string>, any]> => {
   return [200, { "content-type": "text/plain" }, ["OK"]];
 };
 
@@ -155,7 +155,7 @@ it("accept params and build multipart encoded params for POST requests", () => {
 });
 
 it("behave valid according to the Rack spec", async () => {
-  const app = async (env: any): Promise<[number, Record<string, string>, any]> => {
+  const app = async (_env: any): Promise<[number, Record<string, string>, any]> => {
     return [200, { "content-type": "text/plain" }, ["OK"]];
   };
   const req = new MockRequest(app);

--- a/packages/rack/src/mock-response.test.ts
+++ b/packages/rack/src/mock-response.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { MockRequest, FatalWarning } from "./mock-request.js";
 import { MockResponse } from "./mock-response.js";
 
-const app = async (env: Record<string, any>): Promise<[number, Record<string, string>, any]> => {
+const app = async (_env: Record<string, any>): Promise<[number, Record<string, string>, any]> => {
   return [200, { "content-type": "text/plain" }, ["OK"]];
 };
 

--- a/packages/rack/src/multipart.ts
+++ b/packages/rack/src/multipart.ts
@@ -122,7 +122,6 @@ function parseBoundary(contentType: string): string | null {
 function parseBody(body: Buffer, boundary: string, env: Record<string, any>): Record<string, any> {
   const delimiter = Buffer.from("--" + boundary);
   const endDelimiter = Buffer.from("--" + boundary + "--");
-  const crlf = Buffer.from("\r\n");
   const headerSep = Buffer.from("\r\n\r\n");
 
   const params: Record<string, any> = {};
@@ -305,11 +304,11 @@ function parseBody(body: Buffer, boundary: string, env: Record<string, any>): Re
       }
     } else {
       // Text field
-      let encoding = "utf-8";
+      let _encoding = "utf-8";
       if (contentTypeHeader) {
         const charsetMatch = contentTypeHeader.match(/charset=(?:"([^"]+)"|([^\s;]+))/i);
         if (charsetMatch) {
-          encoding = (charsetMatch[1] || charsetMatch[2]).toLowerCase();
+          _encoding = (charsetMatch[1] || charsetMatch[2]).toLowerCase();
         }
       }
 

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -425,7 +425,7 @@ describe("RackRequestTest", () => {
     const req = new Request(env);
     // Note: our multipart parser merges duplicate keys, so the POST hash has only the last value
     // but form_pairs should still show both via POST entries
-    const post = req.POST;
+    const _post = req.POST;
     // With merged keys, formPairs reflects the final merged state
     expect(req.formPairs.length).toBeGreaterThan(0);
   });
@@ -704,7 +704,7 @@ describe("RackRequestTest", () => {
     const req = new Request(env);
     // Should either throw or return without infinite loop
     try {
-      req.POST;
+      void req.POST;
     } catch {
       // Expected - malformed data
     }
@@ -853,7 +853,7 @@ describe("RackRequestTest", () => {
       },
     };
     const req = new Request(env);
-    req.POST;
+    void req.POST;
     // Our implementation stores file info objects in POST, not env rack.tempfiles
     // Verify files were parsed
     expect(req.POST["f1"].filename).toBe("foo.jpg");
@@ -1130,7 +1130,7 @@ describe("RackRequestTest", () => {
   it("allow subclass request to be instantiated after parent request", () => {
     class SubRequest extends Request {}
     const env = makeEnv();
-    const parent = new Request(env);
+    const _parent = new Request(env);
     const sub = new SubRequest(env);
     expect(sub).toBeInstanceOf(SubRequest);
     expect(sub).toBeInstanceOf(Request);
@@ -1139,7 +1139,7 @@ describe("RackRequestTest", () => {
   it("allow parent request to be instantiated after subclass request", () => {
     class SubRequest extends Request {}
     const env = makeEnv();
-    const sub = new SubRequest(env);
+    const _sub = new SubRequest(env);
     const parent = new Request(env);
     expect(parent).toBeInstanceOf(Request);
   });

--- a/packages/rack/src/response.test.ts
+++ b/packages/rack/src/response.test.ts
@@ -41,7 +41,7 @@ it("have sensible default values", () => {
   expect(header).toEqual({});
 
   response = new Response();
-  const [s2, h2, b2] = response.toArray();
+  const [s2, _h2, _b2] = response.toArray();
   expect(s2).toBe(200);
 });
 

--- a/packages/rack/src/sendfile.ts
+++ b/packages/rack/src/sendfile.ts
@@ -15,7 +15,7 @@ export class Sendfile {
 
   async call(env: Record<string, any>): Promise<[number, Record<string, string>, any]> {
     const response = await this.app(env);
-    const [status, headers, body] = response;
+    const [_status, headers, body] = response;
 
     // Get the file path from body.toPath()
     const path = body && typeof body.toPath === "function" ? body.toPath() : null;

--- a/packages/rack/src/show-exceptions.ts
+++ b/packages/rack/src/show-exceptions.ts
@@ -62,7 +62,7 @@ export class ShowExceptions {
     e: Error,
     name: string,
     message: string,
-    env: Record<string, any>,
+    _env: Record<string, any>,
   ): string {
     const stack = e.stack || "unknown location";
     return `${name}: ${message}\n\n${stack}`;

--- a/packages/rack/src/tempfile-reaper.ts
+++ b/packages/rack/src/tempfile-reaper.ts
@@ -29,13 +29,12 @@ export class TempfileReaper {
     const [status, headers, body] = response;
 
     // Wrap body to clean up tempfiles on close
-    const self = this;
     const wrappedBody = {
       [Symbol.iterator]: body[Symbol.iterator]?.bind(body),
       each: body.each?.bind(body),
-      close() {
+      close: () => {
         if (body && typeof body.close === "function") body.close();
-        self.closeTempfiles(env);
+        this.closeTempfiles(env);
       },
       forEach: body.forEach?.bind(body),
       map: body.map?.bind(body),


### PR DESCRIPTION
## Summary

The rack package had 6 eslint rules disabled. This PR enables 5 of them (keeping `no-explicit-any` off for now since it has 529 violations) and fixes all 51 violations across 17 files.

Most fixes are straightforward -- prefixing unused params/vars with `_`, removing truly dead code (an unused `LEVELS` constant, an unused `crlf` buffer), and swapping a `this` alias for an arrow function. I also moved the one existing inline `eslint-disable` comment (for `no-control-regex` in common-logger.ts) into the eslint config instead, so there are no inline disables in the rack package anymore.

The `no-explicit-any` cleanup will come in a separate follow-up PR since it's a much bigger change.

## Test plan

- All 840 rack tests pass (839 passed, 1 skipped)
- Zero eslint errors across the rack package
- Zero inline eslint-disable comments in rack