### PR TITLE
refactor: fix MySQL adapter wrong describes

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfMysql, MysqlAdapter, MYSQL_TEST_URL } from "./test-helper.js";
 
-describeIfMysql("MysqlAdapter", () => {
+describeIfMysql("AbstractMySQLAdapter", () => {
   let adapter: MysqlAdapter;
   beforeEach(async () => {
     adapter = new MysqlAdapter(MYSQL_TEST_URL);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -20,6 +20,9 @@ describeIfMysql("MysqlAdapter", () => {
     it.skip("data source exists", () => {});
     it.skip("dump indexes", () => {});
     it.skip("drop temporary table", () => {});
+  });
+
+  describe("MySQLAnsiQuotesTest", () => {
     it.skip("primary key method with ansi quotes", () => {});
     it.skip("foreign keys method with ansi quotes", () => {});
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -21,6 +21,9 @@ describeIfMysql("MysqlAdapter", () => {
     it.skip("charset and collation options", () => {});
     it.skip("charset and partitioned table options", () => {});
     it.skip("schema dump works with NO_TABLE_OPTIONS sql mode", () => {});
+  });
+
+  describe("DefaultEngineOptionTest", () => {
     it.skip("new migrations do not contain default ENGINE=InnoDB option", () => {});
     it.skip("legacy migrations contain default ENGINE=InnoDB option", () => {});
   });

--- a/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
@@ -17,7 +17,7 @@ describeIfMysql("MysqlAdapter", () => {
     await adapter.close();
   });
 
-  describe("CheckConstraintQuotingTest", () => {
+  describe("MySQL2CheckConstraintQuotingTest", () => {
     it.skip("check constraint no duplicate expression quoting", () => {});
   });
 });


### PR DESCRIPTION
## Summary

Fixes 15 wrong-describe tests across 4 MySQL adapter test files by renaming and adding sub-describes to match the Ruby test class names.

- bind-parameter.test.ts: Rename outer describe to AbstractMySQLAdapter (10 tests)
- schema.test.ts: Add MySQLAnsiQuotesTest sub-describe (2 tests)
- table-options.test.ts: Add DefaultEngineOptionTest sub-describe (2 tests)
- check-constraint-quoting.test.ts: Rename to MySQL2CheckConstraintQuotingTest (1 test)

Wrong-describe count drops from 307 to ~292. All structural, no test logic changed.