### PR TITLE
refactor: fix PostgreSQL adapter wrong describes

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgresAdapter, PG_TEST_URL } from "./test-helper.js";
 
-describeIfPg("PostgresAdapter", () => {
+describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgresAdapter;
   beforeEach(async () => {
     adapter = new PostgresAdapter(PG_TEST_URL);
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlBindParameterTest", () => {
+  describe("BindParameterTest", () => {
     beforeEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "bind_test"`);
       await adapter.exec(`

--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgresAdapter, PG_TEST_URL } from "./test-helper.js";
 
-describeIfPg("PostgresAdapter", () => {
+describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgresAdapter;
   beforeEach(async () => {
     adapter = new PostgresAdapter(PG_TEST_URL);

--- a/packages/activerecord/src/adapters/postgresql/collation.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/collation.test.ts
@@ -13,28 +13,24 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlCollationTest", () => {
+  describe("PostgreSQLCollationTest", () => {
     it.skip("columns collation", async () => {});
     it.skip("collation change", async () => {});
     it.skip("collation add", async () => {});
     it.skip("collation schema dump", async () => {});
     it.skip("collation default", async () => {});
+    it.skip("string column with collation", () => {
+      /* needs PostgreSQL-specific collation syntax */
+    });
+    it.skip("text column with collation", () => {
+      /* needs PostgreSQL-specific collation syntax */
+    });
+    it.skip("add column with collation", () => {
+      /* needs PostgreSQL-specific collation syntax */
+    });
+    it.skip("change column with collation", () => {
+      /* needs PostgreSQL-specific collation syntax */
+    });
+    it.skip("schema dump includes collation", () => {});
   });
-  it.skip("string column with collation", () => {
-    /* needs PostgreSQL-specific collation syntax */
-  });
-
-  it.skip("text column with collation", () => {
-    /* needs PostgreSQL-specific collation syntax */
-  });
-
-  it.skip("add column with collation", () => {
-    /* needs PostgreSQL-specific collation syntax */
-  });
-
-  it.skip("change column with collation", () => {
-    /* needs PostgreSQL-specific collation syntax */
-  });
-
-  it.skip("schema dump includes collation", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlConnectionTest", () => {
+  describe("PostgreSQLConnectionTest", () => {
     it("encoding", async () => {
       const rows = await adapter.execute(
         `SELECT pg_encoding_to_char(encoding) AS encoding FROM pg_database WHERE datname = current_database()`,

--- a/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlCreateUnloggedTablesTest", () => {
+  describe("UnloggedTablesTest", () => {
     it.skip("create unlogged table", async () => {});
     it.skip("create unlogged table with index", async () => {});
     it.skip("create unlogged table from select", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlDatatypeTest", () => {
+  describe("PostgreSQLInternalDataTypeTest", () => {
     it.skip("money column", async () => {});
     it.skip("number column", async () => {});
     it.skip("time column", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlForeignTableTest", () => {
+  describe("ForeignTableTest", () => {
     it.skip("create foreign table", async () => {});
     it.skip("drop foreign table", async () => {});
     it.skip("foreign table exists", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlNumbersTest", () => {
+  describe("PostgreSQLNumberTest", () => {
     it.skip("numeric column", async () => {});
     it.skip("numeric default", async () => {});
     it.skip("numeric type cast", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlOptimizerHintsTest", () => {
+  describe("PostgreSQLOptimizerHintsTest", () => {
     it.skip("optimizer hints", async () => {});
     it.skip("optimizer hints with count", async () => {});
     it.skip("optimizer hints with delete all", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlPreparedStatementsDisabledTest", () => {
+  describe("PreparedStatementsDisabledTest", () => {
     it.skip("prepared statements disabled", async () => {});
     it.skip("select query works even when prepared statements are disabled", async () => {});
   });

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgresAdapter, PG_TEST_URL } from "./test-helper.js";
 
-describeIfPg("PostgresAdapter", () => {
+describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgresAdapter;
   beforeEach(async () => {
     adapter = new PostgresAdapter(PG_TEST_URL);
@@ -19,7 +19,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlQuotingTest", () => {
+  describe("PostgreSQLQuotingTest", () => {
     it("type cast true", async () => {
       const rows = await adapter.execute("SELECT TRUE AS val");
       expect(rows[0].val).toBe(true);

--- a/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlSchemaAuthorizationTest", () => {
+  describe("SchemaAuthorizationTest", () => {
     it.skip("schema authorization", async () => {});
     it.skip("schema authorization with quoted names", async () => {});
     it.skip("session authorization", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgresAdapter, PG_TEST_URL } from "./test-helper.js";
 
-describeIfPg("PostgresAdapter", () => {
+describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgresAdapter;
   beforeEach(async () => {
     adapter = new PostgresAdapter(PG_TEST_URL);

--- a/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlTransactionNestedTest", () => {
+  describe("PostgreSQLTransactionNestedTest", () => {
     it.skip("nested transaction rollback", async () => {});
     it.skip("nested transaction commit", async () => {});
     it.skip("double nested transaction", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlTransactionTest", () => {
+  describe("PostgreSQLTransactionTest", () => {
     it.skip("transaction isolation read committed", async () => {});
     it.skip("transaction isolation repeatable read", async () => {});
     it.skip("transaction isolation serializable", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/utils.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/utils.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlUtilsTest", () => {
+  describe("PostgreSQLNameTest", () => {
     it.skip("reset pk sequence on empty table", async () => {});
     it.skip("reset pk sequence with custom pk", async () => {});
     it.skip("distinct zero", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlVirtualColumnTest", () => {
+  describe("PostgreSQLVirtualColumnTest", () => {
     it.skip("virtual column", async () => {});
     it.skip("virtual column default", async () => {});
     it.skip("virtual column type cast", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/xml.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/xml.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlXmlTest", () => {
+  describe("PostgreSQLXMLTest", () => {
     it.skip("xml column", async () => {});
     it.skip("xml default", async () => {});
     it.skip("xml type cast", async () => {});


### PR DESCRIPTION
## Summary

Renames describe blocks across 18 PostgreSQL adapter test files to match the Ruby test class names that convention:compare expects. Also moves tests in collation.test.ts from outside the inner describe into the correct one.

Wrong-describe count drops from 297 to 269 (28 fixed). The remaining ~200 PG wrong describes are in multi-class files (schema.test.ts with 71, geometric.test.ts with 24, uuid.test.ts with 15, etc.) that need more surgical restructuring.

No test logic changed -- purely structural renames.