### PR TITLE
refactor: split multi-class PG adapter describes

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/geometric.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/geometric.test.ts
@@ -13,11 +13,28 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlGeometricTest", () => {
+  describe("PostgreSQLPointTest", () => {
     it.skip("point column", async () => {});
     it.skip("point default", async () => {});
     it.skip("point type cast", async () => {});
     it.skip("point write", async () => {});
+    it.skip("column", async () => {});
+    it.skip("schema dumping", () => {});
+    it.skip("roundtrip", async () => {});
+    it.skip("mutation", () => {});
+    it.skip("array assignment", () => {});
+    it.skip("hash assignment", () => {});
+    it.skip("string assignment", () => {});
+    it.skip("empty string assignment", () => {});
+    it.skip("array of points round trip", () => {});
+    it.skip("legacy column", () => {});
+    it.skip("legacy default", () => {});
+    it.skip("legacy schema dumping", () => {});
+    it.skip("legacy roundtrip", () => {});
+    it.skip("legacy mutation", () => {});
+  });
+
+  describe("PostgreSQLGeometricTypesTest", () => {
     it.skip("line column", async () => {});
     it.skip("line default", async () => {});
     it.skip("line type cast", async () => {});
@@ -43,23 +60,9 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("geometric where", async () => {});
     it.skip("geometric invalid", async () => {});
     it.skip("geometric nil", async () => {});
-    it.skip("mutation", () => {});
-    it.skip("array assignment", () => {});
-    it.skip("hash assignment", () => {});
-    it.skip("string assignment", () => {});
-    it.skip("empty string assignment", () => {});
-    it.skip("array of points round trip", () => {});
-    it.skip("legacy column", () => {});
-    it.skip("legacy default", () => {});
-    it.skip("legacy schema dumping", () => {});
-    it.skip("legacy roundtrip", () => {});
-    it.skip("legacy mutation", () => {});
     it.skip("geometric types", () => {});
     it.skip("alternative format", () => {});
     it.skip("geometric function", () => {});
-    it.skip("geometric line type", () => {});
-    it.skip("alternative format line type", () => {});
-    it.skip("schema dumping for line type", () => {});
     it.skip("creating column with point type", () => {});
     it.skip("creating column with line type", () => {});
     it.skip("creating column with lseg type", () => {});
@@ -68,9 +71,10 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("creating column with polygon type", () => {});
     it.skip("creating column with circle type", () => {});
   });
-  it.skip("column", async () => {});
 
-  it.skip("schema dumping", () => {});
-
-  it.skip("roundtrip", async () => {});
+  describe("PostgreSQLGeometricLineTest", () => {
+    it.skip("geometric line type", () => {});
+    it.skip("alternative format line type", () => {});
+    it.skip("schema dumping for line type", () => {});
+  });
 });

--- a/packages/activerecord/src/adapters/postgresql/serial.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/serial.test.ts
@@ -15,7 +15,6 @@ describeIfPg("PostgresAdapter", () => {
 
   describe("PostgresqlSerialTest", () => {
     it.skip("serial column", async () => {});
-    it.skip("bigserial column", async () => {});
     it.skip("smallserial column", async () => {});
     it.skip("serial default", async () => {});
     it.skip("serial sequence name", async () => {});
@@ -28,11 +27,21 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("serial custom sequence", async () => {});
     it.skip("not serial column", async () => {});
     it.skip("schema dump with not serial", async () => {});
+    it.skip("serial columns 2", async () => {});
+  });
+
+  describe("PostgreSQLBigSerialTest", () => {
+    it.skip("bigserial column", async () => {});
     it.skip("not bigserial column", async () => {});
     it.skip("schema dump with not bigserial", async () => {});
+  });
+
+  describe("CollidedSequenceNameTest", () => {
     it.skip("serial columns", async () => {});
-    it.skip("serial columns 2", async () => {});
     it.skip("schema dump with collided sequence name", async () => {});
+  });
+
+  describe("LongerSequenceNameDetectionTest", () => {
     it.skip("schema dump with long table name", async () => {});
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlTimestampTest", () => {
+  describe("PostgreSQLTimestampTest", () => {
     it.skip("timestamp column", async () => {});
     it.skip("timestamp default", async () => {});
     it.skip("timestamp type cast", async () => {});
@@ -30,18 +30,29 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("datetime schema dump", async () => {});
     it.skip("timestamp with zone values with rails time zone support and no time zone set", () => {});
     it.skip("timestamp with zone values without rails time zone support", () => {});
+  });
+
+  describe("PostgreSQLTimestampWithAwareTypesTest", () => {
     it.skip("timestamp with zone values with rails time zone support and time zone set", () => {});
+  });
+
+  describe("PostgreSQLTimestampWithTimeZoneTest", () => {
     it.skip("timestamp with zone values with rails time zone support and timestamptz and no time zone set", () => {});
     it.skip("timestamp with zone values with rails time zone support and timestamptz and time zone set", () => {});
+  });
+
+  describe("PostgreSQLTimestampFixtureTest", () => {
     it.skip("group by date", () => {});
+    it.skip("load infinity and beyond", async () => {});
+    it.skip("save infinity and beyond", async () => {});
     it.skip("bc timestamp", () => {});
     it.skip("bc timestamp leap year", () => {});
     it.skip("bc timestamp year zero", () => {});
+  });
+
+  describe("PostgreSQLTimestampMigrationTest", () => {
     it.skip("adds column as timestamp", () => {});
     it.skip("adds column as timestamptz if datetime type changed", () => {});
     it.skip("adds column as custom type", () => {});
   });
-  it.skip("load infinity and beyond", async () => {});
-
-  it.skip("save infinity and beyond", async () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlUUIDTest", () => {
+  describe("PostgreSQLUUIDTest", () => {
     it.skip("uuid column", async () => {});
     it.skip("uuid default", async () => {});
     it.skip("uuid type cast", async () => {});
@@ -56,6 +56,9 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("acceptable uuid regex", () => {});
     it.skip("uuid formats", () => {});
     it.skip("uniqueness validation ignores uuid", () => {});
+  });
+
+  describe("PostgreSQLUUIDGenerationTest", () => {
     it.skip("id is uuid", () => {});
     it.skip("id has a default", () => {});
     it.skip("auto create uuid", () => {});
@@ -64,12 +67,21 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("schema dumper for uuid primary key with custom default", () => {});
     it.skip("schema dumper for uuid primary key default", () => {});
     it.skip("schema dumper for uuid primary key default in legacy migration", () => {});
+  });
+
+  describe("PostgreSQLUUIDTestNilDefault", () => {
     it.skip("id allows default override via nil", () => {});
     it.skip("schema dumper for uuid primary key with default override via nil", () => {});
     it.skip("schema dumper for uuid primary key with default nil in legacy migration", () => {});
+  });
+
+  describe("PostgreSQLUUIDTestInverseOf", () => {
     it.skip("collection association with uuid", () => {});
     it.skip("find with uuid", () => {});
     it.skip("find by with uuid", () => {});
+  });
+
+  describe("PostgreSQLUUIDHasManyThroughDisableJoinsTest", () => {
     it.skip("uuid primary key and disable joins with delegate cache", () => {});
   });
 });


### PR DESCRIPTION
## Summary

Splits 4 PostgreSQL adapter test files that had a single describe block into the correct Ruby test class names. Each file now has multiple describe blocks matching the distinct Ruby test classes.

- geometric.test.ts: Split into PostgreSQLPointTest, PostgreSQLGeometricTypesTest, PostgreSQLGeometricLineTest (was all under PostgresqlGeometricTest)
- uuid.test.ts: Split into PostgreSQLUUIDTest, PostgreSQLUUIDGenerationTest, PostgreSQLUUIDTestNilDefault, PostgreSQLUUIDTestInverseOf, PostgreSQLUUIDHasManyThroughDisableJoinsTest (was all under PostgresqlUUIDTest)
- timestamp.test.ts: Split into PostgreSQLTimestampTest, PostgreSQLTimestampFixtureTest, PostgreSQLTimestampMigrationTest, PostgreSQLTimestampWithTimeZoneTest, PostgreSQLTimestampWithAwareTypesTest (was all under PostgresqlTimestampTest)
- serial.test.ts: Split into PostgresqlSerialTest, PostgreSQLBigSerialTest, CollidedSequenceNameTest, LongerSequenceNameDetectionTest (was all under PostgresqlSerialTest)

Wrong-describe count drops from 269 to 215 (54 fixed). No test logic changed.