### PR TITLE
refactor: split PG schema describes + fix extractor for describeIfPg

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -19,7 +19,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgreSQLQuotingTest", () => {
+  describe("QuotingTest", () => {
     it("type cast true", async () => {
       const rows = await adapter.execute("SELECT TRUE AS val");
       expect(rows[0].val).toBe(true);

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlSchemaTest", () => {
+  describe("SchemaTest", () => {
     it.skip("schema test 1", async () => {});
     it.skip("schema test 2", async () => {});
     it.skip("schema test 3", async () => {});
@@ -29,8 +29,10 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("drop schema with nonexisting schema", () => {});
     it.skip("raise wrapped exception on bad prepare", () => {});
     it.skip("schema change with prepared stmt", () => {});
+    it.skip("data source exists?", () => {});
     it.skip("data source exists when on schema search path", () => {});
     it.skip("data source exists when not on schema search path", () => {});
+    it.skip("data source exists wrong schema", () => {});
     it.skip("data source exists quoted names", () => {});
     it.skip("data source exists quoted table", () => {});
     it.skip("with schema prefixed table name", () => {});
@@ -56,39 +58,62 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("current schema", () => {});
     it.skip("prepared statements with multiple schemas", () => {});
     it.skip("schema exists?", () => {});
+    it.skip("reset pk sequence", async () => {});
     it.skip("set pk sequence", () => {});
     it.skip("rename index", () => {});
     it.skip("dumping schemas", () => {});
+  });
+
+  describe("SchemaForeignKeyTest", () => {
     it.skip("dump foreign key targeting different schema", () => {});
     it.skip("create foreign key same schema", () => {});
     it.skip("create foreign key different schemas", () => {});
+  });
+
+  describe("SchemaIndexOpclassTest", () => {
     it.skip("string opclass is dumped", () => {});
     it.skip("non default opclass is dumped", () => {});
     it.skip("opclass class parsing on non reserved and cannot be function or type keyword", () => {});
+  });
+
+  describe("SchemaIndexNullsOrderTest", () => {
     it.skip("nulls order is dumped", () => {});
     it.skip("non default order with nulls is dumped", () => {});
+  });
+
+  describe("DefaultsUsingMultipleSchemasAndDomainTest", () => {
     it.skip("text defaults in new schema when overriding domain", () => {});
     it.skip("string defaults in new schema when overriding domain", () => {});
     it.skip("decimal defaults in new schema when overriding domain", () => {});
     it.skip("bpchar defaults in new schema when overriding domain", () => {});
     it.skip("text defaults after updating column default", () => {});
     it.skip("default containing quote and colons", () => {});
+  });
+
+  describe("SchemaWithDotsTest", () => {
     it.skip("rename_table", () => {});
     it.skip("Active Record basics", () => {});
+  });
+
+  describe("SchemaJointTablesTest", () => {
     it.skip("create join table", () => {});
+  });
+
+  describe("SchemaIndexIncludeColumnsTest", () => {
     it.skip("schema dumps index included columns", () => {});
+  });
+
+  describe("SchemaIndexNullsNotDistinctTest", () => {
     it.skip("nulls not distinct is dumped", () => {});
     it.skip("nulls distinct is dumped", () => {});
     it.skip("nulls not set is dumped", () => {});
+  });
+
+  describe("SchemaCreateTableOptionsTest", () => {
     it.skip("list partition options is dumped", () => {});
     it.skip("range partition options is dumped", () => {});
     it.skip("inherited table options is dumped", () => {});
     it.skip("multiple inherited table options is dumped", () => {});
     it.skip("no partition options are dumped", () => {});
   });
-  it.skip("data source exists?", () => {});
-
-  it.skip("data source exists wrong schema", () => {});
-
-  it.skip("reset pk sequence", async () => {});
 });

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -100,7 +100,11 @@ function extractFileTests(filePath: string): TestFileInfo {
       if (ts.isIdentifier(expression)) {
         const funcName = expression.text;
 
-        if (funcName === "describe") {
+        if (
+          funcName === "describe" ||
+          funcName === "describeIfPg" ||
+          funcName === "describeIfMysql"
+        ) {
           const title = getFirstArgString(node);
           if (title) {
             currentAncestors.push(title);
@@ -125,9 +129,17 @@ function extractFileTests(filePath: string): TestFileInfo {
           }
         }
       } else if (ts.isPropertyAccessExpression(expression)) {
-        // Handle it.skip, it.todo, it.only, etc.
+        // Handle describe.skip, it.skip, it.todo, it.only, etc.
         const base = expression.expression;
-        if (ts.isIdentifier(base) && (base.text === "it" || base.text === "test")) {
+        if (ts.isIdentifier(base) && base.text === "describe") {
+          const title = getFirstArgString(node);
+          if (title) {
+            currentAncestors.push(title);
+            ts.forEachChild(node, visit);
+            currentAncestors.pop();
+            return;
+          }
+        } else if (ts.isIdentifier(base) && (base.text === "it" || base.text === "test")) {
           const modifier = expression.name.text;
           const title = getFirstArgString(node);
           if (title) {


### PR DESCRIPTION
## Summary

Two improvements that together fix 102 wrong-describe tests (215 to 113):

1. Split schema.test.ts (71 wrong describes) into 10 distinct Ruby test classes: SchemaTest, SchemaForeignKeyTest, SchemaIndexOpclassTest, SchemaIndexNullsOrderTest, DefaultsUsingMultipleSchemasAndDomainTest, SchemaWithDotsTest, SchemaJointTablesTest, SchemaIndexIncludeColumnsTest, SchemaIndexNullsNotDistinctTest, SchemaCreateTableOptionsTest.

2. Fix extract-ts-tests.ts to recognize `describeIfPg`, `describeIfMysql`, and `describe.skip` as describe blocks. Previously the outer wrapper describe in all PG and MySQL adapter test files was invisible to convention:compare, so the describe path was missing its outermost level. This was the root cause of many PG wrong describes -- the inner describe names were correct but the path was one level too shallow.

3. With the extractor fix, rename quoting.test.ts inner describe from PostgreSQLQuotingTest to QuotingTest (matching the Ruby class name). This was previously impossible because the missing outer wrapper caused a misplaced-test false positive.

The extractor fix is the key insight here -- it likely means many of the remaining PG wrong describes can now be fixed with simple inner-describe renames.