### PR TITLE
refactor: fix remaining PG adapter wrong describes

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgresAdapter, PG_TEST_URL } from "./test-helper.js";
 
-describeIfPg("PostgresAdapter", () => {
+describeIfPg("Migration", () => {
   let adapter: PostgresAdapter;
   beforeEach(async () => {
     adapter = new PostgresAdapter(PG_TEST_URL);
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlChangeSchemaTest", () => {
+  describe("PgChangeSchemaTest", () => {
     it.skip("change column", async () => {});
     it.skip("change column with null", async () => {});
     it.skip("change column with default", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgreSQLInternalDataTypeTest", () => {
+  describe("PostgreSQLDataTypeTest", () => {
     it.skip("money column", async () => {});
     it.skip("number column", async () => {});
     it.skip("time column", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -23,18 +23,12 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("prevent writes allows explain", async () => {});
     it.skip("prevent writes toggle", async () => {});
     it.skip("doesnt error when a read query with cursors is called while preventing writes", async () => {});
+    it.skip("errors when an insert query is called while preventing writes", () => {});
+    it.skip("errors when an update query is called while preventing writes", () => {});
+    it.skip("errors when a delete query is called while preventing writes", () => {});
+    it.skip("doesnt error when a select query is called while preventing writes", () => {});
+    it.skip("doesnt error when a show query is called while preventing writes", () => {});
+    it.skip("doesnt error when a set query is called while preventing writes", () => {});
+    it.skip("doesnt error when a read query with leading chars is called while preventing writes", () => {});
   });
-  it.skip("errors when an insert query is called while preventing writes", () => {});
-
-  it.skip("errors when an update query is called while preventing writes", () => {});
-
-  it.skip("errors when a delete query is called while preventing writes", () => {});
-
-  it.skip("doesnt error when a select query is called while preventing writes", () => {});
-
-  it.skip("doesnt error when a show query is called while preventing writes", () => {});
-
-  it.skip("doesnt error when a set query is called while preventing writes", () => {});
-
-  it.skip("doesnt error when a read query with leading chars is called while preventing writes", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -326,36 +326,24 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("date decoding disabled", async () => {});
     it.skip("disable extension with schema", async () => {});
     it.skip("disable extension without schema", async () => {});
+    it.skip("connection error", () => {});
+    it.skip("reconnection error", () => {});
+    it.skip("database exists returns true when the database exists", () => {});
+    it.skip("columns for distinct zero orders", () => {});
+    it.skip("columns for distinct one order", () => {});
+    it.skip("columns for distinct few orders", () => {});
+    it.skip("columns for distinct with case", () => {});
+    it.skip("columns for distinct blank not nil orders", () => {});
+    it.skip("columns for distinct with arel order", () => {});
+    it.skip("bad connection", () => {});
+    it.skip("database exists returns false when the database does not exist", () => {
+      /* needs adapter.databaseExists() API */
+    });
+    it.skip("exec insert with returning disabled", () => {
+      /* needs table setup and RETURNING-disabled adapter mode */
+    });
+    it.skip("pk and sequence for", async () => {});
   });
-  it.skip("connection error", () => {});
-
-  it.skip("reconnection error", () => {});
-
-  it.skip("database exists returns true when the database exists", () => {});
-
-  it.skip("columns for distinct zero orders", () => {});
-
-  it.skip("columns for distinct one order", () => {});
-
-  it.skip("columns for distinct few orders", () => {});
-
-  it.skip("columns for distinct with case", () => {});
-
-  it.skip("columns for distinct blank not nil orders", () => {});
-
-  it.skip("columns for distinct with arel order", () => {});
-
-  it.skip("bad connection", () => {});
-
-  it.skip("database exists returns false when the database does not exist", () => {
-    /* needs adapter.databaseExists() API */
-  });
-
-  it.skip("exec insert with returning disabled", () => {
-    /* needs table setup and RETURNING-disabled adapter mode */
-  });
-
-  it.skip("pk and sequence for", async () => {});
 
   // ── Transaction lifecycle tests ───────────────────────────────────
   describe("Transactions", () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -95,7 +95,7 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("Active Record basics", () => {});
   });
 
-  describe("SchemaJointTablesTest", () => {
+  describe("SchemaJoinTablesTest", () => {
     it.skip("create join table", () => {});
   });
 


### PR DESCRIPTION
## Summary

Moves orphan tests inside their correct inner describe blocks and fixes describe names across 5 PostgreSQL adapter test files.

- postgresql-adapter.test.ts: Move 13 tests from outer PostgresAdapter into PostgreSQLAdapterTest
- postgresql-adapter-prevent-writes.test.ts: Move 7 tests inside PostgreSQLAdapterPreventWritesTest
- change-schema.test.ts: Rename outer to Migration and inner to PgChangeSchemaTest
- datatype.test.ts: Fix to PostgreSQLDataTypeTest (was incorrectly renamed to InternalDataTypeTest)
- schema.test.ts: Fix SchemaJoinTablesTest typo (had extra t)

Wrong-describe count drops from 113 to 79. Combined with the previous PRs, we've gone from 1,266 wrong describes to 79 (94% reduction).