### PR TITLE
fix: call changesApplied() before afterSave callbacks

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2017,10 +2017,6 @@ export class Base extends Model {
       if (!updateResult) saved = false;
     }
 
-    if (saved) {
-      ctor._callbackChain.runAfter("save", this);
-    }
-
     // Wait for the async operation
     if (this._pendingOperation) {
       await this._pendingOperation;
@@ -2033,6 +2029,8 @@ export class Base extends Model {
       this._previouslyNewRecord = wasNewRecord;
       this._newRecord = false;
       this.changesApplied();
+
+      ctor._callbackChain.runAfter("save", this);
 
       // Counter cache: increment on create
       if (wasNewRecord) {


### PR DESCRIPTION
## Summary

Fixes a callback ordering bug where `changed?` returned `true` in `after_save` callbacks instead of `false`.

In Rails, `changes_applied` runs before `after_save` callbacks fire, so `changed?` returns `false` and `previous_changes` is populated by the time the callback runs. Our implementation had the order reversed -- `afterSave` fired first, then `changesApplied()`.

This is a small reorder of the save flow in `base.ts`. The "changed? in after callbacks returns false" test (already unskipped in PR #71) now passes because the underlying behavior is correct.

All 6,659 tests pass.