### PR TITLE
feat: add readonly checks to touch and updateColumns

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2538,6 +2538,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base#touch
    */
   async touch(...names: string[]): Promise<boolean> {
+    if (this._readonly) throw new ReadOnlyRecord(this);
     if (!this.isPersisted()) return false;
     const now = new Date();
     const attrs: Record<string, unknown> = {};
@@ -2590,6 +2591,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base#update_columns
    */
   async updateColumns(attrs: Record<string, unknown>): Promise<void> {
+    if (this._readonly) throw new ReadOnlyRecord(this);
     if (!this.isPersisted()) {
       throw new Error("Cannot update columns on a new or destroyed record");
     }

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -152,8 +152,32 @@ describe("ReadonlyTest", () => {
     return { Post };
   }
 
-  it.skip("cant touch readonly record", () => {});
-  it.skip("cant update column readonly record", () => {});
+  it("cant touch readonly record", async () => {
+    class Dev extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("updated_at", "string");
+        this.adapter = adapter;
+      }
+    }
+    const dev = await Dev.create({ name: "Alice" });
+    dev.readonlyBang();
+    expect(dev.isReadonly()).toBe(true);
+    await expect(dev.touch()).rejects.toThrow(ReadOnlyRecord);
+  });
+
+  it("cant update column readonly record", async () => {
+    class Dev extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const dev = await Dev.create({ name: "Alice" });
+    dev.readonlyBang();
+    expect(dev.isReadonly()).toBe(true);
+    await expect(dev.updateColumn("name", "New name")).rejects.toThrow(ReadOnlyRecord);
+  });
 });
 
 describe("ReadonlyTest", () => {


### PR DESCRIPTION
## What

Adds readonly guard checks to `touch()` and `updateColumns()` so they throw `ReadOnlyRecord` when called on a readonly record. Previously these methods bypassed the readonly check, which meant a record marked with `readonlyBang()` could still be modified through `touch()` or `updateColumn()`/`updateColumns()`.

## Why

Rails raises `ActiveRecord::ReadOnlyRecord` from `touch` and `update_column` on readonly records. Our implementation was missing these guards, allowing silent mutations on records that should be immutable.

## Tests unskipped

- "cant touch readonly record"
- "cant update column readonly record"