### PR TITLE
test: unskip 2 tests enabled by async callback chain

### DIFF
--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -96,8 +96,7 @@ describe("SignedIdTest", () => {
     expect(() => u.signedId()).toThrow();
   });
 
-  it.skip("can get a signed ID in an after_create", async () => {
-    // _newRecord is still true when afterCreate fires, so signedId() throws
+  it("can get a signed ID in an after_create", async () => {
     const { User } = makeModel();
     let capturedToken: string | null = null;
     User.afterCreate((record: any) => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -470,8 +470,22 @@ describe("TransactionTest", () => {
     expect(log).toContain("committed:updated");
   });
 
-  it.skip("after_commit on destroy", () => {
-    /* destroy doesn't trigger afterCommit callbacks */
+  it("after_commit on destroy", async () => {
+    const adp = freshAdapter();
+    const log: string[] = [];
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+        this.afterCommit(() => {
+          log.push("committed");
+        });
+      }
+    }
+    const p = await Post.create({ title: "test" });
+    log.length = 0;
+    await p.destroy();
+    expect(log).toContain("committed");
   });
 
   it("after commit fires in correct order", async () => {


### PR DESCRIPTION
## What

Unskips 2 tests that now pass thanks to the async callback chain (PR #102).

## Tests unskipped

- **signed-id: "can get a signed ID in an after_create"** — Previously skipped because `_newRecord` was still true when `afterCreate` fired (the INSERT hadn't completed). With `runAsync`, the INSERT completes before `afterCreate` runs, so `signedId()` works.

- **transactions: "after_commit on destroy"** — Previously skipped because destroy didn't trigger afterCommit callbacks. The destroy refactor in PR #102 now fires commit callbacks after successful deletion.

Both were blocked by callback timing issues that the async callback chain resolved.