### PR TITLE
feat: split AroundCallbackFn into sync and async types

### DIFF
--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -5,10 +5,29 @@ type AnyRecord = any;
  * Callback types.
  */
 export type CallbackFn = (record: AnyRecord) => void | boolean | Promise<void | boolean>;
-export type AroundCallbackFn = (
+/**
+ * Sync around callback — used by the synchronous run() method.
+ * proceed() is synchronous and must be called (not awaited).
+ */
+export type SyncAroundCallbackFn = (record: AnyRecord, proceed: () => void) => void;
+
+/**
+ * Async-compatible around callback — used by runAsync().
+ * proceed() returns a Promise and can be awaited. The callback
+ * itself may return a Promise.
+ */
+export type AsyncAroundCallbackFn = (
   record: AnyRecord,
   proceed: () => void | Promise<void>,
 ) => void | Promise<void>;
+
+/**
+ * Around callback type accepted by register(). Compatible with both
+ * run() (sync) and runAsync() (async). If used with run(), the callback
+ * MUST be synchronous — async callbacks will silently run out of order.
+ * Use runAsync() for async around callbacks.
+ */
+export type AroundCallbackFn = AsyncAroundCallbackFn;
 
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
@@ -81,7 +100,7 @@ export class CallbackChain {
     let chain = block;
     for (const cb of [...arounds].reverse()) {
       const prev = chain;
-      chain = () => (cb.fn as AroundCallbackFn)(record, prev);
+      chain = () => (cb.fn as SyncAroundCallbackFn)(record, prev);
     }
     chain();
 
@@ -128,7 +147,7 @@ export class CallbackChain {
           return result;
         };
         try {
-          await (cb.fn as AroundCallbackFn)(record, wrappedProceed);
+          await (cb.fn as AsyncAroundCallbackFn)(record, wrappedProceed);
           if (pendingProceed) await pendingProceed;
         } catch (aroundError) {
           if (pendingProceed) await pendingProceed.catch(() => {});

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -4,7 +4,13 @@ export { Errors, NestedError } from "./errors.js";
 export { ModelName } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
 export { CallbackChain } from "./callbacks.js";
-export type { CallbackConditions } from "./callbacks.js";
+export type {
+  CallbackConditions,
+  CallbackFn,
+  AroundCallbackFn,
+  SyncAroundCallbackFn,
+  AsyncAroundCallbackFn,
+} from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
 export { Type } from "./types/type.js";
 


### PR DESCRIPTION
## What

Splits `AroundCallbackFn` into explicit sync and async variants, completing follow-up #2 from the callback chain roadmap (documented in docs/activerecord-100-percent.md).

## The problem

`AroundCallbackFn` allowed returning a `Promise`, but the synchronous `run()` doesn't await it. This meant async around callbacks could silently run out-of-order when used with `run()`, with no type-level indication of the problem.

## The fix

Three types, each with clear documentation:

- **`SyncAroundCallbackFn`** — `proceed()` is `() => void`, callback returns `void`. Used by `run()` internally.
- **`AsyncAroundCallbackFn`** — `proceed()` returns `void | Promise<void>`, callback may return `Promise<void>`. Used by `runAsync()` internally.
- **`AroundCallbackFn`** — alias for `AsyncAroundCallbackFn`. Used in the public API (`register`, `aroundSave`, etc). JSDoc documents that async callbacks require `runAsync()`.

All types exported from the package entrypoint for consumer use.