### PR TITLE
docs: update activerecord roadmap with completed work

### DIFF
--- a/docs/activerecord-100-percent.md
+++ b/docs/activerecord-100-percent.md
@@ -1,6 +1,6 @@
 # ActiveRecord: Road to 100% Test Coverage
 
-Current state: **50.6%** (4,242 implemented / 8,385 total Ruby tests). 340/342 files mapped, 0 misplaced, 79 wrong describes, 3,899 skipped.
+Current state: **52.0%** (4,358 implemented / 8,385 total Ruby tests). 340/342 files mapped, 0 misplaced, 79 wrong describes, 3,783 skipped.
 
 ## How coverage is measured
 
@@ -10,11 +10,11 @@ The percentage reflects **implemented** (non-skipped) tests only. Skipped stubs 
 
 Columns in the output: `OK` (implemented, non-skipped), `Skip` (matched but `it.skip`), `Desc` (wrong describe block), `Move` (misplaced — wrong file), `Miss` (no TS equivalent at all), `Tot` (total Ruby tests in file).
 
-## The gap: 4,143 tests
+## The gap: 4,027 tests
 
-To reach 100%, we need to implement 4,143 more tests (8,385 - 4,242). These break down into:
+To reach 100%, we need to implement 4,027 more tests (8,385 - 4,358). These break down into:
 
-- **3,899 skipped tests** — `it.skip()` stubs that need real implementations
+- **3,783 skipped tests** — `it.skip()` stubs that need real implementations
 - **244 unmatched tests** — Ruby tests with no TS equivalent (across existing and 2 missing files)
 
 ## Completed work
@@ -33,11 +33,24 @@ Converted fixture-dependent tests in has-many-through, where-chain, transaction-
 
 ### Counter cache (done: PR #76)
 
-Implemented counter cache callbacks. Unskipped counter-cache.test.ts tests.
+Fixed `resetCounters` (was broken — treated `_associations` as Map instead of array). Added `resolveCounterColumn` helper for custom counter cache columns, `countHasMany` for efficient counting. Unskipped 9 counter-cache tests.
 
 ### Inverse associations (done: PR #87)
 
-Implemented automatic inverse detection, inverse validation, stale state tracking.
+Added `InverseOfAssociationNotFoundError` with Levenshtein-based "Did you mean?" suggestions. Validation runs at association load time. Unskipped 5 inverse association tests.
+
+### Readonly checks (done: PR #93)
+
+Added readonly guards to `touch()` and `updateColumns()`. Unskipped 2 tests.
+
+### Async callback chain (done: PRs #102, #110, #112)
+
+Major refactor: `CallbackChain` is now async-first. `run()`/`runBefore()`/`runAfter()` are async and properly await promise-returning callbacks. Sync variants (`runSync`/`runBeforeSync`/`runAfterSync`) exist for constructors and validation.
+
+- `destroy()` respects `beforeDestroy` halt, returns `false`, `destroyBang()` throws `RecordNotDestroyed`
+- `afterCreate`/`afterUpdate`/`afterDestroy` fire after DB operation completes
+- Around callbacks support async `proceed()`, block execution tracking
+- ~24 tests unskipped as a side effect
 
 ### Insert all / upsert (done: PR #90)
 
@@ -47,7 +60,7 @@ Implemented timestamps tracking, RETURNING clause, adapter-specific SQL generati
 
 Unskipped store and dirty tracking edge case tests.
 
-### Batch unskips (done: PRs #82–#86, #88)
+### Batch unskips (done: PRs #82–#86, #88, #108)
 
 Various batches of test unskips across core ORM, callbacks, and associations.
 
@@ -61,7 +74,7 @@ Most of the original 382 wrong describes have been fixed. The remaining 79 are s
 
 ---
 
-### Area 2: Unskip tests (3,910 skipped)
+### Area 2: Unskip tests (3,783 skipped)
 
 Grouped by the feature/capability that blocks them.
 
@@ -73,39 +86,39 @@ Grouped by the feature/capability that blocks them.
 | 2A.2  | Eager loading — includes/preload (~84 tests) | Open            |
 | 2A.3  | Counter cache (~35 tests)                    | Done (#76)      |
 | 2A.4  | Inverse associations (~40 tests)             | Done (#87)      |
-| 2A.5  | Has-one features (~33 tests)                 | Open            |
+| 2A.5  | Has-one features (~33 tests)                 | Partial (#107)  |
 | 2A.6  | Has-one-through features (~29 tests)         | Open            |
 | 2A.7  | HABTM features (~48 tests)                   | Open            |
 | 2A.8  | Nested through associations (~54 tests)      | Open            |
-| 2A.9  | Strict loading modes (~37 tests)             | Open            |
+| 2A.9  | Strict loading modes (~37 tests)             | Partial (#107)  |
 | 2A.10 | Autosave edge cases (~40 tests)              | Open            |
 
 #### Sub-area 2B: Core ORM features
 
-| PR    | Area                                     | Status     |
-| ----- | ---------------------------------------- | ---------- |
-| 2B.1  | Base class features (~74 tests)          | Open       |
-| 2B.2  | Locking (~33 tests)                      | Open       |
-| 2B.3  | Where clause features (~36 tests)        | Open       |
-| 2B.4  | Where chain (~31 tests)                  | Open       |
-| 2B.5  | Reflection API (~43 tests)               | Open       |
-| 2B.6  | Serialized attributes (~19 tests)        | Open       |
-| 2B.7  | Transaction callbacks (~22 tests)        | Open       |
-| 2B.8  | Insert all / upsert (~42 tests)          | Done (#90) |
-| 2B.9  | Nested attributes edge cases (~19 tests) | Open       |
-| 2B.10 | Migration features (~50 tests)           | Open       |
+| PR    | Area                                     | Status         |
+| ----- | ---------------------------------------- | -------------- |
+| 2B.1  | Base class features (~74 tests)          | Partial (#101) |
+| 2B.2  | Locking (~33 tests)                      | Partial (#101) |
+| 2B.3  | Where clause features (~36 tests)        | Open           |
+| 2B.4  | Where chain (~31 tests)                  | Open           |
+| 2B.5  | Reflection API (~43 tests)               | Partial (#101) |
+| 2B.6  | Serialized attributes (~19 tests)        | Partial (#101) |
+| 2B.7  | Transaction callbacks (~22 tests)        | Partial (#101) |
+| 2B.8  | Insert all / upsert (~42 tests)          | Done (#90)     |
+| 2B.9  | Nested attributes edge cases (~19 tests) | Open           |
+| 2B.10 | Migration features (~50 tests)           | Open           |
 
 #### Sub-area 2C: Smaller files
 
-| PR   | File(s)                           | Skipped | Status     |
-| ---- | --------------------------------- | ------- | ---------- |
-| 2C.1 | store.test.ts                     | 7       | Done (#72) |
-| 2C.2 | dirty.test.ts                     | 5       | Done (#72) |
-| 2C.3 | scoping/named-scoping.test.ts     | 6       | Open       |
-| 2C.4 | token-for.test.ts                 | 2       | Open       |
-| 2C.5 | associations/join-model.test.ts   | 54      | Open       |
-| 2C.6 | view.test.ts                      | 5       | Open       |
-| 2C.7 | associations/has-many (remaining) | 5       | Open       |
+| PR   | File(s)                           | Skipped | Status         |
+| ---- | --------------------------------- | ------- | -------------- |
+| 2C.1 | store.test.ts                     | 7       | Done (#72)     |
+| 2C.2 | dirty.test.ts                     | 5       | Done (#72)     |
+| 2C.3 | scoping/named-scoping.test.ts     | 6       | Partial (#105) |
+| 2C.4 | token-for.test.ts                 | 2       | Done (#71)     |
+| 2C.5 | associations/join-model.test.ts   | 54      | Done (#106)    |
+| 2C.6 | view.test.ts                      | 5       | Open           |
+| 2C.7 | associations/has-many (remaining) | 5       | Partial (#105) |
 
 ---
 
@@ -119,15 +132,15 @@ Only 2 files remain unmapped. The bulk of missing file stubs were generated in P
 
 All files in `adapters/postgresql/`. Requires `PG_TEST_URL`.
 
-| PR  | Area                    | Tests | Status |
-| --- | ----------------------- | ----- | ------ |
-| 4.1 | PostgreSQL schema tests | ~71   | Open   |
-| 4.2 | PostgreSQL adapter core | ~60   | Open   |
-| 4.3 | Range type support      | ~46   | Open   |
-| 4.4 | HStore type support     | ~44   | Open   |
-| 4.5 | Array type support      | ~41   | Open   |
-| 4.6 | Geometric types         | ~29   | Open   |
-| 4.7 | Smaller PG type files   | ~50   | Open   |
+| PR  | Area                    | Tests | Status      |
+| --- | ----------------------- | ----- | ----------- |
+| 4.1 | PostgreSQL schema tests | ~71   | Done (#99)  |
+| 4.2 | PostgreSQL adapter core | ~60   | Done (#103) |
+| 4.3 | Range type support      | ~46   | Open        |
+| 4.4 | HStore type support     | ~44   | Open        |
+| 4.5 | Array type support      | ~41   | Open        |
+| 4.6 | Geometric types         | ~29   | Open        |
+| 4.7 | Smaller PG type files   | ~50   | Open        |
 
 ---
 
@@ -148,13 +161,3 @@ Three people could work simultaneously on:
 3. **Track C: Core ORM + PostgreSQL** — Areas 2B and 4. Implements ORM features and PG adapter.
 
 Each track touches different files and can merge independently.
-
----
-
-## Follow-up PRs (callback chain)
-
-These were identified during PR #102 (async callback chain) and deferred:
-
-1. **Async-aware `runBefore`/`runAfter`** — `CallbackFn` allows `Promise<void | boolean>` but `runBefore()`/`runAfter()` don't await promise-returning callbacks. An async before callback that resolves to `false` won't halt the chain. Fix: add `runBeforeAsync()`/`runAfterAsync()` variants and use them from `runAsync()`.
-
-2. **Split `AroundCallbackFn` type for sync vs async** — `AroundCallbackFn` now allows returning a `Promise`, but the synchronous `run()` doesn't await it. This means async around callbacks silently run out-of-order when used with `run()`. Fix: keep `AroundCallbackFn` sync-only for `run()`, introduce `AsyncAroundCallbackFn` for `runAsync()`.


### PR DESCRIPTION
Updates the activerecord 100% roadmap to reflect work done in this session and by other tracks.

Key updates:
- Added completed PRs from Track B callback chain work (#76, #87, #93, #102, #108, #110, #112)
- Marked token-for (2C.4) as done
- Removed completed callback chain follow-ups section
- Updated stats (52.0%, 3,783 skipped)
- Added partial status for items worked on by other tracks (#101, #105, #107)