### PR TITLE
fix: fix 26 wrong describes across 9 test files

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7012,6 +7012,9 @@ describe("PreloaderTest", () => {
       expect((p as any)._preloadedAssociations.has("pkbaAuthor")).toBe(true);
     }
   });
+});
+
+describe("OverridingAssociationsTest", () => {
   it("habtm association redefinition callbacks should differ and not inherited", () => {
     const oaAdapter = freshAdapter();
     class OAParent extends Base {
@@ -7220,7 +7223,9 @@ describe("PreloaderTest", () => {
       loadBelongsTo(record, "nonexistent", { foreignKey: "nonexistent_id" }),
     ).rejects.toThrow(/not found in registry/);
   });
+});
 
+describe("GeneratedMethodsTest", () => {
   it("association methods override attribute methods of same name", () => {
     const adapter = freshAdapter();
     class Post extends Base {
@@ -7263,7 +7268,9 @@ describe("PreloaderTest", () => {
     expect(ref).not.toBeNull();
     expect(ref!.name).toBe("tag");
   });
+});
 
+describe("WithAnnotationsTest", () => {
   it("belongs to with annotation includes a query comment", () => {
     const adapter = freshAdapter();
     class Post extends Base {

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -3746,6 +3746,14 @@ describe("BelongsToAssociationsTest", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.readAttribute("title")).toBe("Hello");
   });
+});
+
+describe("AsyncBelongsToAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
   it("async load belongs to", async () => {
     class AlbtCompany extends Base {
       static {
@@ -3770,6 +3778,14 @@ describe("BelongsToAssociationsTest", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.readAttribute("name")).toBe("AsyncCo");
   });
+});
+
+describe("BelongsToAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
   it("belongs to", async () => {
     // Rails: test_belongs_to
     class BtCompany extends Base {

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -7845,6 +7845,13 @@ describe("HasManyAssociationsTest", () => {
     });
     expect(remaining.length).toBe(0);
   });
+});
+
+describe("HasManyAssociationsTestPrimaryKeys", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
 
   it("has many custom primary key", async () => {
     class CpkAuthor extends Base {
@@ -7890,6 +7897,14 @@ describe("HasManyAssociationsTest", () => {
     const post = await CpkAsgPost.create({ author_id: author.id, title: "A" });
     expect((post as any).readAttribute("author_id")).toBe(author.id);
   });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
   it("do not call callbacks for delete all", async () => {
     class NoCbAuthor extends Base {
       static {
@@ -8171,6 +8186,14 @@ describe("HasManyAssociationsTest", () => {
     expect(posts1.length).toBe(2);
     expect(posts2.length).toBe(2);
   });
+});
+
+describe("AsyncHasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
   it("async load has many", async () => {
     class AsyncAuthor extends Base {
       static {
@@ -8196,6 +8219,14 @@ describe("HasManyAssociationsTest", () => {
     });
     expect(posts.length).toBe(2);
   });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
   it("custom named counter cache", async () => {
     // Rails: test_custom_named_counter_cache / test_custom_counter_cache
     class CnPost extends Base {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -1212,7 +1212,9 @@ describe("HasOneAssociationsTest", () => {
     });
     expect((loaded as any).readAttribute("name")).toBe("Acme");
   });
+});
 
+describe("AsyncHasOneAssociationsTest", () => {
   it("async load has one", async () => {
     const adapter = freshAdapter();
     class AHFirm extends Base {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1497,14 +1497,14 @@ describe("MigrationTest", () => {
         }
         expect(new NoTs().version).toBe("99999999999999");
       });
-    }); // MigrationValidationTest
 
-    it("copied migrations at timestamp boundary are valid", () => {
-      class Boundary extends Migration {
-        static version = "20231231235959";
-        async change() {}
-      }
-      expect(new Boundary().version).toBe("20231231235959");
-    });
+      it("copied migrations at timestamp boundary are valid", () => {
+        class Boundary extends Migration {
+          static version = "20231231235959";
+          async change() {}
+        }
+        expect(new Boundary().version).toBe("20231231235959");
+      });
+    }); // MigrationValidationTest
   }); // CopyMigrationsTest
 });

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -279,7 +279,7 @@ describe("OrTest", () => {
   });
 });
 
-describe("OrTest", () => {
+describe("TooManyOrTest", () => {
   it("too many or", () => {
     const adapter = freshAdapter();
     class Post extends Base {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -1001,7 +1001,9 @@ describe("DefaultScopingTest", () => {
     const results = await (Post as any).includingDrafts().toArray();
     expect(results.length).toBe(2);
   });
+});
 
+describe("DefaultScopingWithThreadTest", () => {
   it("default scope is threadsafe", async () => {
     const adp = freshAdapter();
     class Post extends Base {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -454,10 +454,10 @@ describe("SerializedAttributeTest", () => {
     const reloaded = await User.find(u.id);
     expect(reloaded.readAttribute("preferences")).toBeNull();
   });
-  it.skip("supports permitted classes for default column serializer", () => {});
 });
 
 describe("SerializedAttributeTestWithYamlSafeLoad", () => {
+  it.skip("supports permitted classes for default column serializer", () => {});
   // These tests cover YAML safe_load behavior which is Ruby/YAML-specific.
   // TypeScript uses JSON serialization instead, so these are not applicable.
   it.skip("serialized attribute — YAML-specific, not applicable to TypeScript", () => {});

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -1484,7 +1484,7 @@ describe("UniquenessWithCompositeKey", () => {
   });
 });
 
-describe("UniquenessValidator", () => {
+describe("UniquenessValidationTest", () => {
   it("validate uniqueness", async () => {
     const adapter = freshAdapter();
 


### PR DESCRIPTION
## What

Fixes 26 of the remaining 79 wrong describe blocks by moving tests into the correct describe blocks to match Rails test class structure. Purely structural changes, no feature code.

## Changes

| File | Tests Fixed | What |
|------|------------|------|
| associations.test.ts | 17 | Split PreloaderTest into OverridingAssociationsTest, GeneratedMethodsTest, WithAnnotationsTest |
| has-many-associations.test.ts | 3 | Extract HasManyAssociationsTestPrimaryKeys, AsyncHasManyAssociationsTest |
| belongs-to-associations.test.ts | 1 | Extract AsyncBelongsToAssociationsTest |
| has-one-associations.test.ts | 1 | Extract AsyncHasOneAssociationsTest |
| default-scoping.test.ts | 1 | Extract DefaultScopingWithThreadTest |
| uniqueness-validation.test.ts | 1 | Rename UniquenessValidator to UniquenessValidationTest |
| or.test.ts | 1 | Rename OrTest to TooManyOrTest |
| serialized-attribute.test.ts | 1 | Move test to SerializedAttributeTestWithYamlSafeLoad |
| migration.test.ts | 1 | Move test inside MigrationValidationTest sub-describe |

This brings wrong describes from 79 down to 53. The remaining 53 are split between nested-attributes.test.ts (18) and PostgreSQL adapter files (~35).