### PR TITLE
fix: fix ~27 wrong describes across 14 PostgreSQL adapter test files

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlCidrTest", () => {
+  describe("CidrTest", () => {
     it.skip("cidr column", async () => {});
     it.skip("cidr type cast", async () => {});
     it.skip("cidr invalid", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -96,8 +96,7 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("reset with transaction", async () => {});
     it.skip("prepare false with binds", async () => {});
     it.skip("reconnection after actual disconnection with verify", async () => {});
+    it.skip("get and release advisory lock", () => {});
+    it.skip("release non existent advisory lock", () => {});
   });
-  it.skip("get and release advisory lock", () => {});
-
-  it.skip("release non existent advisory lock", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgresAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgreSQLDataTypeTest", () => {
+  describe("PostgreSQLInternalDatatypeTest", () => {
     it.skip("money column", async () => {});
     it.skip("number column", async () => {});
     it.skip("time column", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -30,8 +30,8 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("insert record", async () => {});
     it.skip("update record", async () => {});
     it.skip("delete record", async () => {});
-  });
-  it.skip("attribute names", () => {
-    /* TODO: needs imports from original file */
+    it.skip("attribute names", () => {
+      /* TODO: needs imports from original file */
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/geometric.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/geometric.test.ts
@@ -60,9 +60,6 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("geometric where", async () => {});
     it.skip("geometric invalid", async () => {});
     it.skip("geometric nil", async () => {});
-    it.skip("geometric types", () => {});
-    it.skip("alternative format", () => {});
-    it.skip("geometric function", () => {});
     it.skip("creating column with point type", () => {});
     it.skip("creating column with line type", () => {});
     it.skip("creating column with lseg type", () => {});
@@ -70,6 +67,12 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("creating column with path type", () => {});
     it.skip("creating column with polygon type", () => {});
     it.skip("creating column with circle type", () => {});
+  });
+
+  describe("PostgreSQLGeometricTest", () => {
+    it.skip("geometric types", () => {});
+    it.skip("alternative format", () => {});
+    it.skip("geometric function", () => {});
   });
 
   describe("PostgreSQLGeometricLineTest", () => {

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -96,10 +96,11 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("hstore with serialized attributes", () => {});
     it.skip("clone hstore with serialized attributes", () => {});
     it.skip("supports to unsafe h values", () => {});
+
+    it.skip("select", async () => {});
+
+    it.skip("contains nils", async () => {});
+
+    it.skip("schema dump with shorthand", async () => {});
   });
-  it.skip("select", async () => {});
-
-  it.skip("contains nils", async () => {});
-
-  it.skip("schema dump with shorthand", async () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -23,8 +23,8 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("values", async () => {});
     it.skip("reassigning infinity does not mark record as changed", async () => {});
     it.skip("reassigning nan does not mark record as changed", async () => {});
-  });
-  it.skip("update", () => {
-    /* TODO: needs imports from original file */
+    it.skip("update", () => {
+      /* TODO: needs imports from original file */
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
@@ -19,12 +19,13 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("optimizer hints with delete all", async () => {});
     it.skip("optimizer hints with update all", async () => {});
     it.skip("optimizer hints with pluck", async () => {});
+
+    it.skip("optimizer hints with count subquery", () => {});
+
+    it.skip("optimizer hints is sanitized", () => {});
+
+    it.skip("optimizer hints with unscope", () => {});
+
+    it.skip("optimizer hints with or", () => {});
   });
-  it.skip("optimizer hints with count subquery", () => {});
-
-  it.skip("optimizer hints is sanitized", () => {});
-
-  it.skip("optimizer hints with unscope", () => {});
-
-  it.skip("optimizer hints with or", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -13,7 +13,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.close();
   });
 
-  describe("PostgresqlStatementPoolTest", () => {
+  describe("StatementPoolTest", () => {
     it.skip("statement pool", async () => {});
     it.skip("statement pool max", async () => {});
     it.skip("statement pool clear", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
@@ -21,6 +21,7 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("unserializable transaction raises SerializationFailure inside nested SavepointTransaction", async () => {});
     it.skip("SerializationFailure inside nested SavepointTransaction is recoverable", async () => {});
     it.skip("deadlock raises Deadlocked inside nested SavepointTransaction", async () => {});
+
+    it.skip("deadlock inside nested SavepointTransaction is recoverable", () => {});
   });
-  it.skip("deadlock inside nested SavepointTransaction is recoverable", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -23,10 +23,11 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("raises SerializationFailure when a serialization failure occurs", async () => {});
     it.skip("raises QueryCanceled when statement timeout exceeded", async () => {});
     it.skip("raises Interrupt when canceling statement via interrupt", async () => {});
+
+    it.skip("raises Deadlocked when a deadlock is encountered", () => {});
+
+    it.skip("raises LockWaitTimeout when lock wait timeout exceeded", () => {});
+
+    it.skip("raises QueryCanceled when canceling statement due to user request", () => {});
   });
-  it.skip("raises Deadlocked when a deadlock is encountered", () => {});
-
-  it.skip("raises LockWaitTimeout when lock wait timeout exceeded", () => {});
-
-  it.skip("raises QueryCanceled when canceling statement due to user request", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -35,9 +35,9 @@ describeIfPg("PostgresAdapter", () => {
   });
   it.skip("virtual column with full inserts", () => {
     /* needs PostgreSQL GENERATED ALWAYS AS ... STORED syntax (no VIRTUAL in PG) */
+
+    it.skip("stored column", () => {});
+
+    it.skip("change table", () => {});
   });
-
-  it.skip("stored column", () => {});
-
-  it.skip("change table", () => {});
 });

--- a/packages/activerecord/src/adapters/postgresql/xml.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/xml.test.ts
@@ -21,8 +21,8 @@ describeIfPg("PostgresAdapter", () => {
     it.skip("xml schema dump", async () => {});
     it.skip("null xml", async () => {});
     it.skip("round trip", async () => {});
-  });
-  it.skip("update all", () => {
-    /* TODO: needs imports from original file */
+    it.skip("update all", () => {
+      /* TODO: needs imports from original file */
+    });
   });
 });


### PR DESCRIPTION
## What

Fixes ~27 wrong describe blocks across 14 PostgreSQL adapter test files. Tests were at the outer `describeIfPg("PostgresAdapter")` level but needed to be inside their respective inner sub-describes, or the sub-describe names didn't match Rails test class names.

## Changes

Tests moved inside correct inner describes:
- connection, foreign-table, hstore, numbers, optimizer-hints, transaction-nested, transaction, virtual-column, xml

Describes renamed to match Rails:
- cidr: `PostgresqlCidrTest` -> `CidrTest`
- datatype: `PostgreSQLDataTypeTest` -> `PostgreSQLInternalDatatypeTest`
- statement-pool: `PostgresqlStatementPoolTest` -> `StatementPoolTest`

New describe added:
- geometric: `PostgreSQLGeometricTest` for 3 tests that were in `PostgreSQLGeometricTypesTest`

Combined with PR #116, this should bring wrong describes from 79 down to ~26 (18 in nested-attributes + a few remaining).