### PR TITLE
feat(activerecord): add FixtureSet class, unskip 42 fixture tests

### DIFF
--- a/packages/activerecord/src/fixtures.test.ts
+++ b/packages/activerecord/src/fixtures.test.ts
@@ -15,7 +15,7 @@ describe("FixturesTest", () => {
     expect(set.size).toBe(2);
     set.forEach((label, fixture) => {
       for (const key of Object.keys(fixture)) {
-        expect(key).toMatch(/^[a-zA-Z][-\w]*/);
+        expect(key).toMatch(/^[a-zA-Z][-\w]*$/);
       }
     });
   });

--- a/packages/activerecord/src/fixtures.ts
+++ b/packages/activerecord/src/fixtures.ts
@@ -30,7 +30,7 @@ export function compositeIdentify(label: string, keyColumns: string[]): Record<s
   const baseId = identify(label);
   const result: Record<string, number> = {};
   for (let i = 0; i < keyColumns.length; i++) {
-    result[keyColumns[i]] = (((baseId << i) % MAX_ID) + MAX_ID) % MAX_ID;
+    result[keyColumns[i]] = Number((BigInt(baseId) * (1n << BigInt(i))) % BigInt(MAX_ID));
   }
   return result;
 }


### PR DESCRIPTION
## Summary

PR B4 from the activerecord 100% plan -- Fixtures.

This builds the core fixture infrastructure from scratch and implements 42 of 149 previously-skipped tests.

New `fixtures.ts` module:
- `identify(label)` -- deterministic integer ID from a string label using CRC-32, matching Rails' `Zlib.crc32` algorithm exactly (verified against Ruby output: `identify("ruby") === 207281424`)
- `compositeIdentify(label, keyColumns)` -- deterministic IDs for composite primary keys using Rails' bit-shift algorithm (`identify(label) << index`)
- `FixtureSet` class -- loads fixture data from objects, strips the `DEFAULTS` key (merging defaults into each fixture), provides iteration/lookup, and generates rows with auto-assigned IDs

The remaining 107 tests need deeper infrastructure: YAML file loading from disk, DB fixture insertion with bulk INSERT, transactional fixtures, belongs_to/HABTM association resolution in fixtures, accessor method generation, and multi-connection support. Those are better tackled incrementally as the ORM matures.