### PR TITLE
fix(activemodel): reject on: option for non-commit/rollback callbacks

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -503,61 +503,73 @@ export class Model {
   }
 
   static beforeSave(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("before", "save", fn, conditions);
   }
 
   static afterSave(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "save", fn, conditions);
   }
 
   static beforeCreate(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("before", "create", fn, conditions);
   }
 
   static afterCreate(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "create", fn, conditions);
   }
 
   static beforeUpdate(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("before", "update", fn, conditions);
   }
 
   static afterUpdate(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "update", fn, conditions);
   }
 
   static beforeDestroy(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("before", "destroy", fn, conditions);
   }
 
   static afterDestroy(fn: CallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "destroy", fn, conditions);
   }
 
   static aroundSave(fn: AroundCallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("around", "save", fn, conditions);
   }
 
   static aroundCreate(fn: AroundCallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("around", "create", fn, conditions);
   }
 
   static aroundUpdate(fn: AroundCallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("around", "update", fn, conditions);
   }
 
   static aroundDestroy(fn: AroundCallbackFn, conditions?: CallbackConditions): void {
+    _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
     this._callbackChain.register("around", "destroy", fn, conditions);
   }
@@ -1472,6 +1484,12 @@ function _validateOnCondition(on: string | string[]): void {
         `:on conditions for after_commit and after_rollback callbacks have to be one of [:create, :destroy, :update]`,
       );
     }
+  }
+}
+
+function _rejectOnOption(conditions?: CallbackConditions): void {
+  if (conditions && "on" in conditions) {
+    throw new ArgumentError("Unknown key: :on. Valid keys are: :if, :unless, :prepend");
   }
 }
 

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -147,14 +147,43 @@ describe("CallbacksTest", () => {
     expect(log).toContain("before_create");
   });
 
-  it.skip("before save doesnt allow on option", () => {
-    /* fixture-dependent */
+  it("before save doesnt allow on option", () => {
+    expect(() => {
+      class T extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.beforeSave(() => {}, { on: "create" } as any);
+        }
+      }
+      void T;
+    }).toThrow("Unknown key: :on. Valid keys are: :if, :unless, :prepend");
   });
-  it.skip("around save doesnt allow on option", () => {
-    /* fixture-dependent */
+
+  it("around save doesnt allow on option", () => {
+    expect(() => {
+      class T extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.aroundSave((_r, proceed) => proceed(), { on: "create" } as any);
+        }
+      }
+      void T;
+    }).toThrow("Unknown key: :on. Valid keys are: :if, :unless, :prepend");
   });
-  it.skip("after save doesnt allow on option", () => {
-    /* fixture-dependent */
+
+  it("after save doesnt allow on option", () => {
+    expect(() => {
+      class T extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+          this.afterSave(() => {}, { on: "create" } as any);
+        }
+      }
+      void T;
+    }).toThrow("Unknown key: :on. Valid keys are: :if, :unless, :prepend");
   });
 
   it("before validation returns false", async () => {


### PR DESCRIPTION
## Summary

Small fix to match Rails behavior: the `on:` option should only be accepted by `afterCommit` and `afterRollback` callbacks. Passing it to `beforeSave`, `afterSave`, `aroundSave`, or any other lifecycle callback now raises an `ArgumentError` with the message `"Unknown key: :on. Valid keys are: :if, :unless, :prepend"`, matching Rails exactly.

This unskips the 3 remaining Rails-mapped tests in activerecord's `callbacks.test.ts`, bringing it to 21/21 matched.

## Test plan

- 3 previously-skipped tests now pass (78 passing total in callbacks.test.ts)
- All activemodel callback tests still pass
- All transaction callback tests still pass