### PR TITLE
feat(activerecord): dirty tracking, default values, and scoping quick wins

### DIFF
--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -255,7 +255,7 @@ describe("RelationScopingTest", () => {
     });
   });
 
-  it("find with annotation unscoped", async () => {
+  it("find with annotation unscoped", () => {
     class AnnUnscopedPost extends Base {
       static {
         this.attribute("title", "string");


### PR DESCRIPTION
## Summary

14 new passing tests across dirty tracking, default values, and relation scoping.

- **Dirty tracking** (3 tests): saved_change_to_attribute? with from/to filtering, saved_change_to_attribute returning [old, new] values, attribute_before_last_save returning pre-save value.

- **Default values** (7 tests): Default values for integer, string, boolean, float, and text types. Defaults available on new records and accessible through class-level columnDefaults.

- **Relation scoping** (4 tests): Scoped find with annotation (verifies annotate() SQL comment), annotation with unscoped, scoped joins, and scoped where with Range conditions.