### PR TITLE
feat(activerecord): implement PostgreSQL money type tests

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -127,8 +127,10 @@ describeIfPg("PostgresAdapter", () => {
     });
 
     it("money format", async () => {
-      const rows = await adapter.execute("SELECT 1234.56::numeric::money::numeric AS val");
-      expect(Number(rows[0].val)).toBeCloseTo(1234.56, 2);
+      const rows = await adapter.execute("SELECT 1234.56::numeric::money::text AS val");
+      // Formatted text includes thousands separator (locale-dependent, but value is preserved)
+      const numeric = parseFloat(String(rows[0].val).replace(/[^0-9.-]/g, ""));
+      expect(numeric).toBeCloseTo(1234.56, 2);
     });
 
     it("money values", async () => {


### PR DESCRIPTION
## Summary

This implements test bodies for 15 of the 20 PostgreSQL money type tests that were previously empty skipped stubs. The tests exercise money types at the adapter level -- column introspection, defaults, type casting, read/write, arithmetic, comparison, WHERE filtering, ORDER BY, SUM aggregation, formatting with commas, negative values, and CRUD operations.

5 tests remain skipped because they need ORM-level features: schema dumper, BigDecimal type casting, regex backtracking in the type system, pluck, and sum with expressions.

## Test plan

- Tests pass when PG is available (`PG_TEST_URL` set)
- Tests skip cleanly when PG is unavailable
- No changes to source code, just test implementations