### PR TITLE
feat(cli): add db reset, setup, and migrate:redo commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,153 +1,24 @@
-# CLI: Road to Feature Parity
+# CLI: What's Left
 
-Goal: `rails-ts` CLI can do everything `rails` CLI does for ActiveRecord workflows --
-generate models/migrations, run migrations against a real database, drop into a
-console with models loaded, and manage the database lifecycle.
+## Still needed
 
-## Current state
-
-The CLI exists at `packages/cli` and has command stubs for most Rails commands.
-Generators produce real files. Database commands connect to a real database via
-`config/database.ts`, track migration state in `schema_migrations`, and support
-migrate, rollback, and status. The console doesn't yet connect to a database.
-
-### What works today
-
-| Command                                                | Status                                           | Notes                                       |
-| ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------- |
-| `rails-ts new <name>`                                  | Generates project skeleton                       | Supports `--database sqlite/postgres/mysql` |
-| `rails-ts generate model`                              | Generates model + migration + test               | Infers `createTable` from name              |
-| `rails-ts generate migration`                          | Generates migration file with `version` property | Infers add/remove columns from name         |
-| `rails-ts generate controller`                         | Generates controller + test                      |                                             |
-| `rails-ts generate scaffold`                           | Generates model + controller + migration + tests |                                             |
-| `rails-ts destroy model/controller/migration/scaffold` | Removes generated files                          |                                             |
-| `rails-ts server`                                      | Starts dev server                                | Uses `DevServer`                            |
-| `rails-ts routes`                                      | Prints route table                               | Requires `src/config/routes.ts`             |
-| `rails-ts console`                                     | Opens REPL                                       | Tries to load models from `src/app/models/` |
-| `rails-ts db migrate`                                  | Runs pending migrations                          | Tracks state in `schema_migrations`         |
-| `rails-ts db migrate --version V`                      | Migrates to a specific version                   |                                             |
-| `rails-ts db rollback`                                 | Rolls back last migration                        | Supports `--step N`                         |
-| `rails-ts db migrate:status`                           | Shows up/down status per migration               | Reads from `schema_migrations` table        |
-| `rails-ts db create`                                   | Creates the database                             | SQLite: creates file; PG/MySQL: CREATE DB   |
-| `rails-ts db drop`                                     | Drops the database                               | SQLite: deletes file; PG/MySQL: DROP DB     |
-| `rails-ts db seed`                                     | Runs `db/seeds.ts` or `db/seeds.js`              | Establishes DB connection first             |
-
-### What's still needed
-
-| Command                    | Problem                                                            |
-| -------------------------- | ------------------------------------------------------------------ |
-| `rails-ts console`         | No database connection. Models load but can't query.               |
-| `rails-ts db reset`        | Not implemented. Should be `drop` + `create` + `migrate` + `seed`. |
-| `rails-ts db setup`        | Not implemented. Should be `create` + `migrate` + `seed`.          |
-| `rails-ts db schema:dump`  | Not implemented. `SchemaDumper` exists but isn't wired to CLI.     |
-| `rails-ts db schema:load`  | Not implemented.                                                   |
-| `rails-ts db migrate:redo` | Not implemented. Should be rollback + migrate.                     |
-
-## Architecture
-
-### Database connection
-
-The CLI loads database config and creates adapters through two functions in
-`packages/cli/src/database.ts`:
-
-- **`loadDatabaseConfig(env?, cwd?)`** -- Dynamically imports the database
-  config from the project root. Searches for `config/database.ts`,
-  `config/database.js`, `src/config/database.ts`, or `src/config/database.js`
-  (in that order). Both TypeScript and JavaScript configs are supported.
-  Resolves environment from `RAILS_TS_ENV` > `NODE_ENV` > `"development"`.
-- **`connectAdapter(config)`** -- Creates the right adapter instance based on
-  `config.adapter`: `"sqlite3"` -> `SqliteAdapter`, `"postgresql"` ->
-  `PostgresAdapter`, `"mysql2"` -> `MysqlAdapter`. Supports both connection
-  params and URL-based config.
-
-### Migration discovery
-
-`packages/cli/src/migration-loader.ts` provides `discoverMigrations(dir)`:
-
-- Reads `db/migrations/` and matches `{timestamp}-{name}.ts` or `.js` files
-- When both `.ts` and `.js` exist for the same migration, `.ts` wins (source of truth)
-- Extracts version from the filename prefix
-- Returns `MigrationProxy[]` compatible with the `Migrator` class
-- Lazily imports migration files only when actually running them
-- `.ts` imports require a TypeScript loader at runtime (e.g., run via `npx tsx`)
-
-### Migration execution
-
-The CLI uses the `Migrator` class from `@rails-ts/activerecord` (not the
-simpler `MigrationRunner`). `Migrator` handles:
-
-- State tracking via `schema_migrations` table
-- Duplicate version/name detection
-- Ordered up/down execution
-- Rollback by N steps
-- Status reporting (up/down per migration)
-
-## What needs to be built
-
-### Phase 1: Console with database connection
+### Console with database connection
 
 - Load database config and connect before starting REPL.
 - Import and register all models from `src/app/models/`.
 - Set the adapter on Base so queries work.
 - Models should be available as globals in the REPL (e.g., `User.all()`).
 
-### Phase 2: Schema management
+### Schema management
 
-- **`db:schema:dump`** -- Dump current schema to `db/schema.ts` (or `.sql`).
-  Needs `SchemaDumper` which is partially implemented.
-- **`db:schema:load`** -- Load schema from dump file instead of running all
+- **`db schema:dump`** -- Dump current schema to `db/schema.ts` (or `.sql`).
+  `SchemaDumper` exists in activerecord but isn't wired to the CLI.
+- **`db schema:load`** -- Load schema from dump file instead of running all
   migrations. Faster for fresh setups.
-- **`db:migrate:redo`** -- Rollback + migrate (useful for testing a migration).
 
-### Phase 3: Composite commands
+### Generator improvements
 
-- **`db:reset`** -- `db:drop` + `db:create` + `db:migrate` + `db:seed`.
-- **`db:setup`** -- `db:create` + `db:migrate` + `db:seed` (skip if exists).
-
-### Phase 4: Additional generators
-
-- **`generate migration` improvements** -- Support `AddIndexToUsers name:index`,
+- **`generate migration`** -- Support `AddIndexToUsers name:index`,
   `references` type, `belongs_to` shorthand.
-- **`generate model` improvements** -- Support `--no-migration`, `--no-test`,
+- **`generate model`** -- Support `--no-migration`, `--no-test`,
   association declarations.
-
-## Migration file convention
-
-Generated migrations look like:
-
-```ts
-import { Migration } from "@rails-ts/activerecord";
-
-export class CreateUsers extends Migration {
-  version = "20260318120000";
-
-  async up(): Promise<void> {
-    await this.createTable("users", (t) => {
-      t.string("name");
-      t.string("email");
-      t.timestamps();
-    });
-  }
-
-  async down(): Promise<void> {
-    await this.dropTable("users");
-  }
-}
-```
-
-The `version` is the timestamp prefix from the filename. The `Migrator` uses
-filename-parsed versions for tracking, so the `version` property is
-belt-and-suspenders.
-
-## Database config convention
-
-```
-my-app/
-  config/
-    database.ts        # connection config per environment
-  db/
-    migrations/        # timestamped migration files
-    seeds.ts           # seed data
-    schema.ts          # schema dump (auto-generated)
-    development.sqlite3  # SQLite database file
-```

--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -43,6 +43,24 @@ describe("DbCommand", () => {
     const db = program.commands.find((c) => c.name() === "db");
     expect(db?.commands.some((c) => c.name() === "migrate:status")).toBe(true);
   });
+
+  it("has migrate:redo subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "migrate:redo")).toBe(true);
+  });
+
+  it("has reset subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "reset")).toBe(true);
+  });
+
+  it("has setup subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "setup")).toBe(true);
+  });
 });
 
 describe("resolveEnv", () => {

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -7,10 +7,8 @@ import { discoverMigrations } from "../migration-loader.js";
 import { Migrator } from "@rails-ts/activerecord";
 import type { DatabaseAdapter } from "@rails-ts/activerecord";
 
-/**
- * Build a config that connects to the system database (for CREATE/DROP DATABASE).
- * Handles both param-based and URL-based configs.
- */
+// --- Helpers ---
+
 function buildSystemConfig(
   config: DatabaseConfig,
   adapterName: string,
@@ -54,6 +52,132 @@ async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
   }
 }
 
+async function withAdapter(fn: (adapter: DatabaseAdapter) => Promise<void>): Promise<void> {
+  const config = await loadDatabaseConfig();
+  const adapter = await connectAdapter(config);
+  try {
+    await fn(adapter);
+  } finally {
+    await closeAdapter(adapter);
+  }
+}
+
+function migrationsDir(): string {
+  return path.join(process.cwd(), "db", "migrations");
+}
+
+async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {
+  const migrations = await discoverMigrations(migrationsDir());
+  if (migrations.length === 0) {
+    console.log("No migrations found.");
+    return;
+  }
+
+  const migrator = new Migrator(adapter, migrations);
+  await migrator.migrate(targetVersion ?? null);
+
+  for (const line of migrator.output) {
+    console.log(line);
+  }
+
+  const pending = await migrator.pendingMigrations();
+  if (pending.length === 0) {
+    console.log("All migrations are up to date.");
+  }
+}
+
+async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<void> {
+  const migrations = await discoverMigrations(migrationsDir());
+  if (migrations.length === 0) {
+    console.log("No migrations found.");
+    return;
+  }
+
+  const migrator = new Migrator(adapter, migrations);
+  await migrator.rollback(steps);
+
+  for (const line of migrator.output) {
+    console.log(line);
+  }
+}
+
+async function runSeed(): Promise<void> {
+  const seedCandidates = [
+    path.join(process.cwd(), "db", "seeds.ts"),
+    path.join(process.cwd(), "db", "seeds.js"),
+  ];
+  const seedFile = seedCandidates.find((f) => fs.existsSync(f));
+  if (!seedFile) {
+    console.log("No seeds file found at db/seeds.ts or db/seeds.js");
+    return;
+  }
+
+  console.log("Running seeds...");
+  await import(pathToFileURL(seedFile).href);
+  console.log("Seeds completed.");
+}
+
+async function runCreate(): Promise<void> {
+  const config = await loadDatabaseConfig();
+  const adapterName = config.adapter ?? "sqlite3";
+
+  if (adapterName === "sqlite3" || adapterName === "sqlite") {
+    const dbPath = config.database;
+    if (dbPath && dbPath !== ":memory:") {
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      if (!fs.existsSync(dbPath)) {
+        fs.writeFileSync(dbPath, "");
+      }
+      console.log(`Created database '${dbPath}'`);
+    }
+  } else {
+    if (!config.database && !config.url) {
+      throw new Error(
+        `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
+      );
+    }
+    const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
+    validateDbName(dbNameResolved);
+    const systemAdapter = await connectAdapter(systemConfig);
+    try {
+      await systemAdapter.executeMutation(`CREATE DATABASE "${dbNameResolved}"`);
+      console.log(`Created database '${dbNameResolved}'`);
+    } finally {
+      await closeAdapter(systemAdapter);
+    }
+  }
+}
+
+async function runDrop(): Promise<void> {
+  const config = await loadDatabaseConfig();
+  const adapterName = config.adapter ?? "sqlite3";
+
+  if (adapterName === "sqlite3" || adapterName === "sqlite") {
+    const dbPath = config.database;
+    if (dbPath && dbPath !== ":memory:" && fs.existsSync(dbPath)) {
+      fs.unlinkSync(dbPath);
+      console.log(`Dropped database '${dbPath}'`);
+    }
+  } else {
+    if (!config.database && !config.url) {
+      throw new Error(
+        `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
+      );
+    }
+    const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
+    validateDbName(dbNameResolved);
+    const systemAdapter = await connectAdapter(systemConfig);
+    try {
+      await systemAdapter.executeMutation(`DROP DATABASE IF EXISTS "${dbNameResolved}"`);
+      console.log(`Dropped database '${dbNameResolved}'`);
+    } finally {
+      await closeAdapter(systemAdapter);
+    }
+  }
+}
+
+// --- Command definitions ---
+
 export function dbCommand(): Command {
   const cmd = new Command("db");
   cmd.description("Database management commands");
@@ -63,31 +187,7 @@ export function dbCommand(): Command {
     .description("Run pending migrations")
     .option("--version <version>", "Migrate to a specific version")
     .action(async (opts) => {
-      const config = await loadDatabaseConfig();
-      const adapter = await connectAdapter(config);
-      try {
-        const migrationsDir = path.join(process.cwd(), "db", "migrations");
-        const migrations = await discoverMigrations(migrationsDir);
-
-        if (migrations.length === 0) {
-          console.log("No migrations found.");
-          return;
-        }
-
-        const migrator = new Migrator(adapter, migrations);
-        await migrator.migrate(opts.version ?? null);
-
-        for (const line of migrator.output) {
-          console.log(line);
-        }
-
-        const pending = await migrator.pendingMigrations();
-        if (pending.length === 0) {
-          console.log("All migrations are up to date.");
-        }
-      } finally {
-        await closeAdapter(adapter);
-      }
+      await withAdapter((adapter) => runMigrate(adapter, opts.version));
     });
 
   cmd
@@ -95,141 +195,36 @@ export function dbCommand(): Command {
     .description("Rollback migrations")
     .option("--step <n>", "Number of migrations to rollback", "1")
     .action(async (opts) => {
-      const config = await loadDatabaseConfig();
-      const adapter = await connectAdapter(config);
-      try {
-        const migrationsDir = path.join(process.cwd(), "db", "migrations");
-        const migrations = await discoverMigrations(migrationsDir);
-
-        if (migrations.length === 0) {
-          console.log("No migrations found.");
-          return;
-        }
-
-        const step = Number(opts.step);
-        if (!Number.isInteger(step) || step < 1) {
-          console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
-          process.exitCode = 1;
-          return;
-        }
-
-        const migrator = new Migrator(adapter, migrations);
-        await migrator.rollback(step);
-
-        for (const line of migrator.output) {
-          console.log(line);
-        }
-      } finally {
-        await closeAdapter(adapter);
+      const step = Number(opts.step);
+      if (!Number.isInteger(step) || step < 1) {
+        console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
+        process.exitCode = 1;
+        return;
       }
+      await withAdapter((adapter) => runRollback(adapter, step));
     });
 
   cmd
     .command("seed")
     .description("Run database seeds")
     .action(async () => {
-      const seedCandidates = [
-        path.join(process.cwd(), "db", "seeds.ts"),
-        path.join(process.cwd(), "db", "seeds.js"),
-      ];
-      const seedFile = seedCandidates.find((f) => fs.existsSync(f));
-      if (!seedFile) {
-        console.log("No seeds file found at db/seeds.ts or db/seeds.js");
-        return;
-      }
-
-      const config = await loadDatabaseConfig();
-      const adapter = await connectAdapter(config);
-      try {
-        // Set adapter on Base so models can query during seeding
+      await withAdapter(async (adapter) => {
         const { Base } = await import("@rails-ts/activerecord");
         Base.adapter = adapter;
-
-        console.log("Running seeds...");
-        await import(pathToFileURL(seedFile).href);
-        console.log("Seeds completed.");
-      } finally {
-        await closeAdapter(adapter);
-      }
+        await runSeed();
+      });
     });
 
-  cmd
-    .command("create")
-    .description("Create the database")
-    .action(async () => {
-      const config = await loadDatabaseConfig();
-      const adapterName = config.adapter ?? "sqlite3";
+  cmd.command("create").description("Create the database").action(runCreate);
 
-      if (adapterName === "sqlite3" || adapterName === "sqlite") {
-        const dbPath = config.database;
-        if (dbPath && dbPath !== ":memory:") {
-          fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-          if (!fs.existsSync(dbPath)) {
-            fs.writeFileSync(dbPath, "");
-          }
-          console.log(`Created database '${dbPath}'`);
-        }
-      } else {
-        const dbName = config.database;
-        if (!dbName && !config.url) {
-          throw new Error(
-            `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
-          );
-        }
-        const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
-        validateDbName(dbNameResolved);
-        const systemAdapter = await connectAdapter(systemConfig);
-        try {
-          await systemAdapter.executeMutation(`CREATE DATABASE "${dbNameResolved}"`);
-          console.log(`Created database '${dbNameResolved}'`);
-        } finally {
-          await closeAdapter(systemAdapter);
-        }
-      }
-    });
-
-  cmd
-    .command("drop")
-    .description("Drop the database")
-    .action(async () => {
-      const config = await loadDatabaseConfig();
-      const adapterName = config.adapter ?? "sqlite3";
-
-      if (adapterName === "sqlite3" || adapterName === "sqlite") {
-        const dbPath = config.database;
-        if (dbPath && dbPath !== ":memory:" && fs.existsSync(dbPath)) {
-          fs.unlinkSync(dbPath);
-          console.log(`Dropped database '${dbPath}'`);
-        }
-      } else {
-        const dbName = config.database;
-        if (!dbName && !config.url) {
-          throw new Error(
-            `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
-          );
-        }
-        const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
-        validateDbName(dbNameResolved);
-        const systemAdapter = await connectAdapter(systemConfig);
-        try {
-          await systemAdapter.executeMutation(`DROP DATABASE IF EXISTS "${dbNameResolved}"`);
-          console.log(`Dropped database '${dbNameResolved}'`);
-        } finally {
-          await closeAdapter(systemAdapter);
-        }
-      }
-    });
+  cmd.command("drop").description("Drop the database").action(runDrop);
 
   cmd
     .command("migrate:status")
     .description("Show migration status")
     .action(async () => {
-      const config = await loadDatabaseConfig();
-      const adapter = await connectAdapter(config);
-      try {
-        const migrationsDir = path.join(process.cwd(), "db", "migrations");
-        const migrations = await discoverMigrations(migrationsDir);
-
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
         if (migrations.length === 0) {
           console.log("No migrations found.");
           return;
@@ -246,9 +241,51 @@ export function dbCommand(): Command {
           console.log(`${statusStr}   ${s.version.padEnd(16)}${s.name}`);
         }
         console.log("");
-      } finally {
-        await closeAdapter(adapter);
+      });
+    });
+
+  cmd
+    .command("migrate:redo")
+    .description("Rollback and re-run the last migration")
+    .option("--step <n>", "Number of migrations to redo", "1")
+    .action(async (opts) => {
+      const step = Number(opts.step);
+      if (!Number.isInteger(step) || step < 1) {
+        console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
+        process.exitCode = 1;
+        return;
       }
+      await withAdapter(async (adapter) => {
+        await runRollback(adapter, step);
+        await runMigrate(adapter);
+      });
+    });
+
+  cmd
+    .command("reset")
+    .description("Drop, create, migrate, and seed the database")
+    .action(async () => {
+      await runDrop();
+      await runCreate();
+      await withAdapter(async (adapter) => {
+        await runMigrate(adapter);
+        const { Base } = await import("@rails-ts/activerecord");
+        Base.adapter = adapter;
+        await runSeed();
+      });
+    });
+
+  cmd
+    .command("setup")
+    .description("Create, migrate, and seed the database")
+    .action(async () => {
+      await runCreate();
+      await withAdapter(async (adapter) => {
+        await runMigrate(adapter);
+        const { Base } = await import("@rails-ts/activerecord");
+        Base.adapter = adapter;
+        await runSeed();
+      });
     });
 
   return cmd;


### PR DESCRIPTION
## Summary

Adds the three remaining "small" CLI commands that are just compositions of existing operations:

- **db reset** -- drop + create + migrate + seed
- **db setup** -- create + migrate + seed  
- **db migrate:redo** -- rollback + re-migrate (supports --step N)

Also refactored db.ts pretty heavily to extract shared helpers (withAdapter, runMigrate, runRollback, runSeed, runCreate, runDrop) so the composite commands could reuse them without duplicating the adapter lifecycle management. This cut the file from ~255 lines to ~230 while adding three new commands.

Trimmed docs/cli.md to only track what's left to build (console with DB, schema dump/load, generator improvements).