### PR TITLE
feat(activerecord): implement 15 autosave test stubs (Phase 1 remaining)

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -959,11 +959,14 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     ];
     const firm = await CsFirm.create({ name: "LLC" });
     log.length = 0;
+    const account = new CsAccount({ credit_limit: 10 });
+    cacheAssoc(firm, "csAccount", account);
     firm.name = "Updated";
     await firm.save();
     expect(log).toContain("before_save");
     expect(log).toContain("after_save");
     expect(log.indexOf("before_save")).toBeLessThan(log.indexOf("after_save"));
+    expect(account.isNewRecord()).toBe(false);
   });
   it("callbacks on child when parent autosaves child", async () => {
     const log: string[] = [];


### PR DESCRIPTION
## Summary

Implements 15 previously-skipped autosave test stubs that our infrastructure already supports. Autosave tests: 146/187 passing (was 131).

Tests implemented:
- 6 validation method generation (has_many, has_one, belongs_to, HABTM with validate true/false)
- 2 callback ordering (update + save)
- 2 callback cancellation (before_save returns false)
- 1 belongs_to defined as record (should not raise)
- 1 autosave with touch (should not stack overflow)
- 2 has_one_through not autosaved
- 1 update children when parent new but child is not

The remaining 41 skipped tests need deeper infrastructure:
- Transaction rollback + state revert (4 tests)
- CPK (4 tests)
- Error indexing/i18n (6 tests)
- Polymorphic inverse (3 tests)
- save!/RecordInvalid (3 tests)
- FK sync for stored-in-two-relations (3 tests)
- Duplicate callback prevention (5 tests)
- Others (13 tests)