### PR TITLE
revert: remove empty interface stubs (revert #235)

### DIFF
--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Aggregations */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Aggregations {}

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -31,7 +31,7 @@ import {
   setBelongsTo,
 } from "./associations.js";
 
-import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
+import { markForDestruction, isMarkedForDestruction } from "./autosave.js";
 import { createFixtures } from "./test-fixtures.js";
 
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::AttributeAssignment */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AttributeAssignment {}

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::AttributeMethods */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AttributeMethods {}

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Attributes */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Attributes {}

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -13,7 +13,7 @@ import { Associations, setBelongsTo, association, loadHasManyThrough } from "./a
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
-import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
+import { markForDestruction, isMarkedForDestruction } from "./autosave.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/autosave.test.ts
+++ b/packages/activerecord/src/autosave.test.ts
@@ -6,11 +6,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
-import {
-  markForDestruction,
-  isMarkedForDestruction,
-  isDestroyable,
-} from "./autosave-association.js";
+import { markForDestruction, isMarkedForDestruction, isDestroyable } from "./autosave.js";
 
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();

--- a/packages/activerecord/src/autosave.ts
+++ b/packages/activerecord/src/autosave.ts
@@ -345,6 +345,3 @@ function propagateErrors(parent: Base, child: Base, assocName: string): void {
 
 // Register validateAssociations with Base to break circular dependency
 _setValidateAssociationsFn(validateAssociations);
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AutosaveAssociation {}

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2235,7 +2235,7 @@ export class Base extends Model {
 
     // Check if we have autosave associations — if so, wrap in transaction
     // so failures in autosave roll back the parent's INSERT/UPDATE.
-    const { autosaveBelongsTo, autosaveChildren } = await import("./autosave-association.js");
+    const { autosaveBelongsTo, autosaveChildren } = await import("./autosave.js");
     const associations: any[] = (ctor as any)._associations ?? [];
     const hasAutosave = associations.some((a: any) => a.options?.autosave);
 

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Callbacks */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Callbacks {}

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::ConnectionHandling */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ConnectionHandling {}

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Core */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Core {}

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::CounterCache */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface CounterCache {}

--- a/packages/activerecord/src/dynamic-matchers.ts
+++ b/packages/activerecord/src/dynamic-matchers.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::DynamicMatchers */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface DynamicMatchers {}

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -175,6 +175,3 @@ export function castEnumValue(
   }
   return null;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Enum {}

--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Explain */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Explain {}

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -105,8 +105,4 @@ export { Migrator } from "./migration.js";
 export type { MigrationProxy, MigrationLike } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 
-export {
-  markForDestruction,
-  isMarkedForDestruction,
-  isDestroyable,
-} from "./autosave-association.js";
+export { markForDestruction, isMarkedForDestruction, isDestroyable } from "./autosave.js";

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Inheritance */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Inheritance {}

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Integration */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Integration {}

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::ModelSchema */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ModelSchema {}

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -14,7 +14,7 @@ import { Associations } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
-import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
+import { markForDestruction, isMarkedForDestruction } from "./autosave.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -237,6 +237,3 @@ async function processNestedAttributes(record: Base): Promise<void> {
 
   (record as any)._pendingNestedAttributes = null;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface NestedAttributes {}

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::NoTouching */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface NoTouching {}

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Normalization */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Normalization {}

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Persistence */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Persistence {}

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Querying */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Querying {}

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::ReadonlyAttributes */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ReadonlyAttributes {}

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Sanitization */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Sanitization {}

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Scoping */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Scoping {}

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -118,6 +118,3 @@ export function hasSecurePassword(
 }
 
 export { hashPassword as _hashPassword, verifyPassword as _verifyPassword };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface SecurePassword {}

--- a/packages/activerecord/src/secure-token.ts
+++ b/packages/activerecord/src/secure-token.ts
@@ -58,6 +58,3 @@ export function hasSecureToken(
     configurable: true,
   });
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface SecureToken {}

--- a/packages/activerecord/src/serialization.ts
+++ b/packages/activerecord/src/serialization.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Serialization */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Serialization {}

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::SignedId */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface SignedId {}

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Suppressor */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Suppressor {}

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Timestamp */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Timestamp {}

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::TokenFor */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface TokenFor {}

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::TouchLater */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface TouchLater {}

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -90,6 +90,3 @@ export async function savepoint<T>(
     throw error;
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Transactions {}

--- a/packages/activerecord/src/translation.ts
+++ b/packages/activerecord/src/translation.ts
@@ -1,3 +1,0 @@
-/** Mirrors: ActiveRecord::Translation */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Translation {}


### PR DESCRIPTION
Reverts the empty interface stub files from PR #235. Empty stubs inflate api:compare without adding real value. The right approach is to extract actual functionality from base.ts into the module files.