### PR TITLE
Add Base.establishConnection and auto-connect from DATABASE_URL

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -15,6 +15,41 @@ import {
 } from "./errors.js";
 import { encrypts as _encrypts, getEncryptor } from "./encryption.js";
 import { Association as AssociationInstance } from "./associations/association.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
+import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
+import { HashConfig } from "./database-configurations/hash-config.js";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+import { pathToFileURL } from "url";
+
+type AdapterConstructor = new (config: any) => DatabaseAdapter;
+
+const _adapterCache: Record<string, AdapterConstructor> = {};
+
+async function _loadAdapter(name: string): Promise<AdapterConstructor> {
+  if (_adapterCache[name]) return _adapterCache[name];
+  switch (name) {
+    case "postgresql": {
+      const mod = await import("./adapters/postgres-adapter.js");
+      _adapterCache[name] = mod.PostgresAdapter;
+      return mod.PostgresAdapter;
+    }
+    case "mysql": {
+      const mod = await import("./adapters/mysql-adapter.js");
+      _adapterCache[name] = mod.MysqlAdapter;
+      return mod.MysqlAdapter;
+    }
+    case "sqlite": {
+      const mod = await import("./adapters/sqlite-adapter.js");
+      _adapterCache[name] = mod.SqliteAdapter;
+      return mod.SqliteAdapter;
+    }
+    default:
+      throw new Error(
+        `Unknown database adapter "${name}". Supported adapters: postgresql, mysql, sqlite`,
+      );
+  }
+}
 import { ScopeRegistry } from "./scoping.js";
 import { Default as DefaultScoping } from "./scoping/default.js";
 import { Named as NamedScoping } from "./scoping/named.js";
@@ -95,6 +130,8 @@ export class Base extends Model {
   static _tableName: string | null = null;
   static _primaryKey: string | string[] = "id";
   static _adapter: DatabaseAdapter | null = null;
+  static _connectionHandler: ConnectionHandler = new ConnectionHandler();
+  static _configPath: string | null = null;
   static _abstractClass = false;
   static _tableNamePrefix = "";
   static _tableNameSuffix = "";
@@ -317,19 +354,299 @@ export class Base extends Model {
 
   /**
    * Set the database adapter for this model class.
+   *
+   * This is a convenience setter that bypasses the ConnectionHandler/ConnectionPool
+   * infrastructure. Prefer `establishConnection` for production use.
    */
   static set adapter(adapter: DatabaseAdapter) {
     this._adapter = adapter;
     if (_onAdapterSet) _onAdapterSet(this);
   }
 
+  /**
+   * Get the database connection for this model.
+   *
+   * Returns the adapter from either:
+   * 1. Directly assigned adapter (via `Model.adapter = ...`)
+   * 2. Connection checked out from ConnectionHandler pool
+   *    (set up by `await establishConnection()`)
+   *
+   * Throws if no connection has been established.
+   *
+   * Mirrors: ActiveRecord::Base.connection
+   */
   static get adapter(): DatabaseAdapter {
-    if (!this._adapter) {
+    // Fast path: directly assigned adapter (used by tests and simple setups)
+    if (this._adapter) return this._adapter;
+
+    // Check for a model-specific pool first
+    const modelPool = this._connectionHandler.retrieveConnectionPool(this.name);
+    if (modelPool) {
+      this._adapter = modelPool.checkout();
+      if (_onAdapterSet) _onAdapterSet(this);
+      return this._adapter;
+    }
+
+    // Fall back to the shared primary pool — cache on Base so all subclasses
+    // share one connection instead of checking out per-model connections
+    const primaryPool = this._connectionHandler.retrieveConnectionPool("primary");
+    if (primaryPool) {
+      if (!Base._adapter) {
+        Base._adapter = primaryPool.checkout();
+        if (_onAdapterSet) _onAdapterSet(Base);
+      }
+      return Base._adapter;
+    }
+
+    throw new Error(
+      `No database configuration found for ${this.name}. ` +
+        `Call await ${this.name}.establishConnection() or set ${this.name}.adapter directly`,
+    );
+  }
+
+  static get connectionHandler(): ConnectionHandler {
+    return this._connectionHandler;
+  }
+
+  /**
+   * Establish a database connection from a URL, config object, or config file.
+   *
+   * Accepts:
+   * - A URL string: `Base.establishConnection("postgres://localhost/mydb")`
+   * - A config object: `Base.establishConnection({ adapter: "postgresql", url: "..." })`
+   * - No arguments: loads from `config/database.json` for NODE_ENV, or DATABASE_URL
+   *
+   * Creates a ConnectionPool managed by the ConnectionHandler, mirroring how
+   * Rails wires establish_connection → ConnectionHandler → ConnectionPool.
+   *
+   * Mirrors: ActiveRecord::Base.establish_connection
+   */
+  static async establishConnection(
+    config?:
+      | string
+      | {
+          adapter?: string;
+          url?: string;
+          database?: string;
+          host?: string;
+          port?: number;
+          username?: string;
+          password?: string;
+          [key: string]: unknown;
+        },
+  ): Promise<void> {
+    this._adapter = null;
+    Base._adapter = null;
+
+    if (config === undefined) {
+      await this._autoConnect();
+      return;
+    }
+
+    const resolved = this._resolveConfig(config);
+    await this._establishWithConfig(resolved.adapterName, resolved.url, resolved.config);
+  }
+
+  private static async _establishWithConfig(
+    adapterName: string,
+    url: string,
+    config?: Record<string, unknown>,
+  ): Promise<void> {
+    const normalized = this._normalizeAdapterName(adapterName);
+    const AdapterClass = await _loadAdapter(normalized);
+
+    // Build the argument for the adapter constructor:
+    // - sqlite: always a filename/path
+    // - postgres/mysql: URL string if available, otherwise config object
+    let adapterArg: unknown;
+    if (normalized === "sqlite") {
+      adapterArg = this._parseSqliteUrl(url || (config?.database as string) || ":memory:");
+    } else if (url) {
+      adapterArg = url;
+    } else if (config) {
+      // Pass through the full config, stripping internal keys and
+      // mapping Rails-style username -> driver-style user
+      const { adapter: _a, url: _u, username, ...rest } = config;
+      const adapterConfig: Record<string, unknown> = { ...rest };
+      if (adapterConfig.user === undefined && username !== undefined) {
+        adapterConfig.user = username;
+      }
+      if (adapterConfig.host === undefined) {
+        adapterConfig.host = "localhost";
+      }
+      adapterArg = adapterConfig;
+    } else {
+      adapterArg = url;
+    }
+
+    const dbConfig = new HashConfig(
+      process.env.NODE_ENV || DatabaseConfigurations.defaultEnv,
+      "primary",
+      { adapter: adapterName, url, ...config },
+    );
+
+    this._connectionHandler.establishConnection(dbConfig, {
+      owner: "primary",
+      adapterFactory: () => new AdapterClass(adapterArg),
+    });
+  }
+
+  /**
+   * Auto-connect by loading database configuration.
+   *
+   * Loads config/database.json if present, with DATABASE_URL merged in
+   * by DatabaseConfigurations (matching how Rails merges DATABASE_URL
+   * into database.yml). Resolves the config for the current NODE_ENV
+   * and establishes the connection through ConnectionHandler.
+   */
+  private static async _autoConnect(): Promise<void> {
+    const raw = await this._loadConfigFile();
+    const configs = DatabaseConfigurations.fromEnv(raw);
+    const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+    const primaryConfigs = configs.configsFor({ envName: env, name: "primary" });
+    const dbConfig = primaryConfigs[0] ?? configs.findDbConfig(env);
+
+    if (!dbConfig) {
       throw new Error(
-        `No adapter configured for ${this.name}. Set ${this.name}.adapter = yourAdapter`,
+        `No database configuration found for ${this.name}. ` +
+          `Add config/database.json, set DATABASE_URL, or call ${this.name}.establishConnection(url)`,
       );
     }
-    return this._adapter;
+
+    const url = dbConfig.configuration.url || "";
+    const adapterName = dbConfig.adapter || (url ? this._adapterNameFromUrl(url) : undefined);
+    if (!adapterName) {
+      throw new Error(
+        `Database configuration for "${env}" must include an adapter name or a URL. ` +
+          `Add config/database.json, set DATABASE_URL, or call ${this.name}.establishConnection(url)`,
+      );
+    }
+    await this._establishWithConfig(
+      adapterName,
+      url,
+      dbConfig.configuration as Record<string, unknown>,
+    );
+  }
+
+  private static _resolveConfig(
+    config: string | { adapter?: string; url?: string; database?: string; [key: string]: unknown },
+  ): { adapterName: string; url: string; config?: Record<string, unknown> } {
+    let url: string;
+    let adapterName: string | undefined;
+    let fullConfig: Record<string, unknown> | undefined;
+
+    if (typeof config === "string") {
+      url = config;
+    } else {
+      adapterName = config.adapter;
+      url = config.url || "";
+      fullConfig = config as Record<string, unknown>;
+    }
+
+    if (!adapterName && !url && !fullConfig?.database) {
+      throw new Error("Database configuration must include a url, database, or adapter name");
+    }
+
+    if (!adapterName) {
+      adapterName = this._adapterNameFromUrl(url || (fullConfig?.database as string) || "");
+    }
+
+    return { adapterName, url, config: fullConfig };
+  }
+
+  private static async _loadConfigFile(): Promise<Record<string, any>> {
+    // If a specific config path is set (e.g. in tests), use it directly
+    if (this._configPath) {
+      return this._loadJsonConfig(this._configPath);
+    }
+
+    const cwd = process.cwd();
+
+    // Try TS/JS config files first (matching the CLI's loadDatabaseConfig)
+    const tsCandidates = [
+      resolve(cwd, "config", "database.ts"),
+      resolve(cwd, "config", "database.js"),
+      resolve(cwd, "src", "config", "database.ts"),
+      resolve(cwd, "src", "config", "database.js"),
+    ];
+
+    for (const candidate of tsCandidates) {
+      if (existsSync(candidate)) {
+        try {
+          const mod = await import(pathToFileURL(candidate).href);
+          return mod.default ?? mod;
+        } catch (error: unknown) {
+          throw new Error(
+            `Failed to load database config at ${candidate}: ${(error as Error).message}`,
+            { cause: error },
+          );
+        }
+      }
+    }
+
+    // Fall back to JSON config
+    return this._loadJsonConfig(resolve(cwd, "config", "database.json"));
+  }
+
+  private static _loadJsonConfig(configPath: string): Record<string, any> {
+    try {
+      return JSON.parse(readFileSync(configPath, "utf-8"));
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return {};
+      }
+      throw new Error(
+        `Failed to load database config at ${configPath}: ${(error as Error).message}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private static _normalizeAdapterName(name: string): string {
+    switch (name) {
+      case "postgresql":
+      case "postgres":
+        return "postgresql";
+      case "mysql":
+      case "mysql2":
+        return "mysql";
+      case "sqlite":
+      case "sqlite3":
+        return "sqlite";
+      default:
+        return name;
+    }
+  }
+
+  private static _parseSqliteUrl(url: string): string {
+    if (url.startsWith("sqlite3://") || url.startsWith("sqlite://")) {
+      const stripped = url.replace(/^sqlite3?:\/\//, "");
+      return stripped || ":memory:";
+    }
+    return url;
+  }
+
+  private static _adapterNameFromUrl(url: string): string {
+    if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
+      return "postgresql";
+    }
+    if (url.startsWith("mysql://") || url.startsWith("mysql2://")) {
+      return "mysql";
+    }
+    if (
+      url.startsWith("sqlite://") ||
+      url.startsWith("sqlite3://") ||
+      url.endsWith(".sqlite3") ||
+      url.endsWith(".db") ||
+      url === ":memory:"
+    ) {
+      return "sqlite";
+    }
+    throw new Error(
+      `Cannot detect database adapter from URL "${url}". ` +
+        `Use a URL starting with postgres://, mysql://, or sqlite://, ` +
+        `or pass { adapter: "postgresql", url: "..." }`,
+    );
   }
 
   /**

--- a/packages/activerecord/src/core.test.ts
+++ b/packages/activerecord/src/core.test.ts
@@ -470,7 +470,7 @@ describe("Base features (Rails-guided) - core", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => NoAdapter.adapter).toThrow("No adapter configured");
+    expect(() => NoAdapter.adapter).toThrow("No database configuration found");
   });
 
   it("arelTable returns Table with correct name", () => {
@@ -826,7 +826,7 @@ describe("Base (extended)", () => {
   describe("adapter", () => {
     it("throws when no adapter is set", () => {
       class Orphan extends Base {}
-      expect(() => Orphan.adapter).toThrow("No adapter configured");
+      expect(() => Orphan.adapter).toThrow("No database configuration found");
     });
   });
 });

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -80,6 +80,64 @@ export class DatabaseConfigurations {
     customHandlers.delete(key);
   }
 
+  /**
+   * Build a DatabaseConfigurations from the current environment.
+   *
+   * If `DATABASE_URL` is set and no raw config is provided, it synthesizes
+   * a configuration for the current environment from the URL. This mirrors
+   * how Rails' DatabaseConfigurations handles DATABASE_URL.
+   */
+  static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
+    const instance = new DatabaseConfigurations([]);
+    instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw));
+    return instance;
+  }
+
+  /**
+   * Merge DATABASE_URL into the raw configurations.
+   *
+   * When DATABASE_URL is set:
+   * - If raw configs exist, the URL is merged into each environment's
+   *   primary config (the URL takes precedence).
+   * - If no raw configs exist, a config is synthesized for the current env.
+   *
+   * Mirrors: ActiveRecord::DatabaseConfigurations#build_url_hash
+   */
+  private _mergeDatabaseUrl(raw: RawConfigurations): RawConfigurations {
+    const databaseUrl = process.env.DATABASE_URL;
+    if (!databaseUrl) return raw;
+
+    const hasConfigs = Object.keys(raw).length > 0;
+
+    if (!hasConfigs) {
+      const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
+      return { [env]: { url: databaseUrl } };
+    }
+
+    const merged: RawConfigurations = {};
+    for (const [envName, envConfig] of Object.entries(raw)) {
+      if (typeof envConfig !== "object" || envConfig === null) {
+        merged[envName] = envConfig;
+        continue;
+      }
+
+      if (this._isThreeLevelConfig(envConfig)) {
+        // Three-level: merge URL into the "primary" entry only
+        const nested = { ...envConfig } as Record<string, DatabaseConfigOptions>;
+        if (nested.primary) {
+          nested.primary = { ...nested.primary, url: databaseUrl };
+        } else {
+          // Add a primary entry if one doesn't exist
+          nested.primary = { url: databaseUrl };
+        }
+        merged[envName] = nested;
+      } else {
+        merged[envName] = { ...envConfig, url: databaseUrl } as DatabaseConfigOptions;
+      }
+    }
+    return merged;
+  }
+
   private _buildConfigs(raw: RawConfigurations): DatabaseConfig[] {
     const configs: DatabaseConfig[] = [];
 

--- a/packages/activerecord/src/establish-connection.test.ts
+++ b/packages/activerecord/src/establish-connection.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "./base.js";
+import { PostgresAdapter } from "./adapters/postgres-adapter.js";
+import { SqliteAdapter } from "./adapters/sqlite-adapter.js";
+import { MysqlAdapter } from "./adapters/mysql-adapter.js";
+import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+function resetConnection() {
+  Base._adapter = null;
+  Base._connectionHandler.clearAllConnections();
+  Base._connectionHandler = new ConnectionHandler();
+}
+
+describe("Base.establishConnection", () => {
+  beforeEach(() => resetConnection());
+  afterEach(() => resetConnection());
+
+  it("creates a PostgresAdapter from a postgres:// URL", async () => {
+    await Base.establishConnection("postgres://localhost:5432/testdb");
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool).toBeDefined();
+    expect(pool!.checkout()).toBeInstanceOf(PostgresAdapter);
+  });
+
+  it("creates a PostgresAdapter from a postgresql:// URL", async () => {
+    await Base.establishConnection("postgresql://localhost:5432/testdb");
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(PostgresAdapter);
+  });
+
+  it("creates a MysqlAdapter from a mysql:// URL", async () => {
+    await Base.establishConnection("mysql://localhost:3306/testdb");
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(MysqlAdapter);
+  });
+
+  it("creates a SqliteAdapter from a :memory: URL", async () => {
+    await Base.establishConnection(":memory:");
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("creates a SqliteAdapter from a .sqlite3 file path", async () => {
+    await Base.establishConnection(join(tmpdir(), "test.sqlite3"));
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("accepts a config object with adapter name", async () => {
+    await Base.establishConnection({ adapter: "sqlite", database: ":memory:" });
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("throws for an unrecognized URL scheme", async () => {
+    await expect(Base.establishConnection("ftp://localhost/db")).rejects.toThrow(
+      /Cannot detect database adapter/,
+    );
+  });
+
+  it("throws for an unknown adapter name", async () => {
+    await expect(
+      Base.establishConnection({ adapter: "oracle", url: "oracle://localhost" }),
+    ).rejects.toThrow(/Unknown database adapter "oracle"/);
+  });
+
+  it("registers the pool with the ConnectionHandler", async () => {
+    await Base.establishConnection(":memory:");
+    expect(Base.connectionHandler.connectionPools.length).toBe(1);
+  });
+
+  it("accepts sqlite3 as an adapter name alias", async () => {
+    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:" });
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("accepts postgres as an adapter name alias", async () => {
+    await Base.establishConnection({ adapter: "postgres", url: "postgres://localhost/db" });
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(PostgresAdapter);
+  });
+
+  it("accepts mysql2 as an adapter name alias", async () => {
+    await Base.establishConnection({ adapter: "mysql2", url: "mysql://localhost/db" });
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(MysqlAdapter);
+  });
+
+  it("parses sqlite:// URLs into file paths", async () => {
+    await Base.establishConnection("sqlite3:///tmp/test.sqlite3");
+    const pool = Base.connectionHandler.retrieveConnectionPool("primary");
+    expect(pool!.checkout()).toBeInstanceOf(SqliteAdapter);
+  });
+});
+
+describe("Base.establishConnection with config file", () => {
+  const originalEnv = process.env.DATABASE_URL;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const tempDir = join(tmpdir(), `rails-ts-test-${process.pid}`);
+  const configPath = join(tempDir, "database.json");
+
+  beforeEach(() => {
+    resetConnection();
+    mkdirSync(tempDir, { recursive: true });
+    Base._configPath = configPath;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalEnv;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    Base._configPath = null;
+    resetConnection();
+    try {
+      rmSync(tempDir, { recursive: true });
+    } catch {}
+  });
+
+  it("connects from DATABASE_URL", async () => {
+    process.env.DATABASE_URL = ":memory:";
+    await Base.establishConnection();
+    expect(Base.adapter).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("connects from config/database.json", async () => {
+    delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "development";
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        development: {
+          adapter: "sqlite",
+          database: ":memory:",
+        },
+      }),
+    );
+
+    await Base.establishConnection();
+    expect(Base.adapter).toBeInstanceOf(SqliteAdapter);
+  });
+
+  it("uses NODE_ENV to select the environment from config", async () => {
+    delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "production";
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        development: {
+          adapter: "sqlite",
+          database: ":memory:",
+        },
+        production: {
+          adapter: "postgresql",
+          url: "postgres://localhost:5432/prod",
+        },
+      }),
+    );
+
+    await Base.establishConnection();
+    expect(Base.adapter).toBeInstanceOf(PostgresAdapter);
+  });
+
+  it("DATABASE_URL overrides url in config file", async () => {
+    process.env.DATABASE_URL = "postgres://localhost/override";
+    process.env.NODE_ENV = "development";
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        development: {
+          adapter: "postgresql",
+          url: "postgres://localhost/from-config",
+        },
+      }),
+    );
+
+    await Base.establishConnection();
+    expect(Base.adapter).toBeInstanceOf(PostgresAdapter);
+  });
+
+  it("throws when no config file and no DATABASE_URL", async () => {
+    delete process.env.DATABASE_URL;
+    await expect(Base.establishConnection()).rejects.toThrow(/No database configuration found/);
+  });
+
+  it("connection goes through ConnectionHandler pool", async () => {
+    process.env.DATABASE_URL = ":memory:";
+    await Base.establishConnection();
+    void Base.adapter; // trigger pool checkout
+    expect(Base.connectionHandler.connectionPools.length).toBe(1);
+  });
+});
+
+describe("Base.establishConnection with JS config file", () => {
+  const originalEnv = process.env.DATABASE_URL;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalCwd = process.cwd();
+  const tempDir = join(tmpdir(), `rails-ts-jsconfig-${process.pid}`);
+  const configDir = join(tempDir, "config");
+
+  beforeEach(() => {
+    resetConnection();
+    mkdirSync(configDir, { recursive: true });
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalEnv;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    process.chdir(originalCwd);
+    Base._configPath = null;
+    resetConnection();
+    try {
+      rmSync(tempDir, { recursive: true });
+    } catch {}
+  });
+
+  it("loads config/database.js when present", async () => {
+    delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "development";
+    writeFileSync(
+      join(configDir, "database.js"),
+      `module.exports = { development: { adapter: "sqlite", database: ":memory:" } };`,
+    );
+
+    await Base.establishConnection();
+    expect(Base.adapter).toBeInstanceOf(SqliteAdapter);
+  });
+});
+
+describe("Base.adapter without establishConnection", () => {
+  beforeEach(() => resetConnection());
+  afterEach(() => resetConnection());
+
+  it("throws when no connection is established", () => {
+    delete process.env.DATABASE_URL;
+    expect(() => Base.adapter).toThrow(/No database configuration found/);
+  });
+});


### PR DESCRIPTION
This wires up the database connection infrastructure that was already in the codebase -- ConnectionHandler, ConnectionPool, DatabaseConfigurations -- so that setting up a database connection goes from ~30 lines of boilerplate to one line.

The main change is `Base.establishConnection()`, which works three ways:

```ts
// 1. Explicit URL -- detects adapter from scheme
await Base.establishConnection("postgres://localhost/mydb");

// 2. Config object
await Base.establishConnection({ adapter: "sqlite3", database: ":memory:" });

// 3. No args -- reads config/database.json for NODE_ENV, merges DATABASE_URL
await Base.establishConnection();
```

Under the hood it goes through ConnectionHandler -> ConnectionPool, matching how Rails wires `establish_connection`. Adapter modules (pg, mysql2, better-sqlite3) are lazy-loaded via dynamic `import()` so importing Base doesn't pull in all three native drivers -- only the one you actually use gets loaded.

I think this should make the SvelteKit experience from deanmarano/website#1 way nicer -- instead of creating adapters manually and calling `connectModels()` at the top of every server function, it's just one `await Base.establishConnection()` at app startup.

DATABASE_URL handling lives inside DatabaseConfigurations (matching how Rails merges it into database.yml), not as a separate fallback path in Base.

Closes #253