### PR TITLE
Add onDelete/onUpdate to addForeignKey

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -53,6 +53,14 @@ export class CreateIndexDefinition {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
  */
+export interface AddForeignKeyOptions {
+  column?: string;
+  primaryKey?: string;
+  name?: string;
+  onDelete?: ReferentialAction;
+  onUpdate?: ReferentialAction;
+}
+
 export class ForeignKeyDefinition {
   constructor(
     readonly fromTable: string,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -18,6 +18,7 @@ import {
   CreateIndexDefinition,
   ForeignKeyDefinition,
   CheckConstraintDefinition,
+  type AddForeignKeyOptions,
   type ColumnType,
   type ColumnOptions,
 } from "./schema-definitions.js";
@@ -315,12 +316,20 @@ export class SchemaStatements {
   async addForeignKey(
     fromTable: string,
     toTable: string,
-    options: { column?: string; primaryKey?: string; name?: string } = {},
+    options: AddForeignKeyOptions = {},
   ): Promise<void> {
     const column = options.column ?? `${toTable.replace(/s$/, "")}_id`;
     const pk = options.primaryKey ?? "id";
     const name = options.name ?? `fk_${fromTable}_${column}`;
-    const fkDef = new ForeignKeyDefinition(fromTable, toTable, column, pk, name);
+    const fkDef = new ForeignKeyDefinition(
+      fromTable,
+      toTable,
+      column,
+      pk,
+      name,
+      options.onDelete,
+      options.onUpdate,
+    );
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(fromTable)} ADD ${this.schemaCreation.accept(fkDef)}`,
     );

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -16,6 +16,7 @@ export type {
   ColumnType,
   ColumnOptions,
   ReferentialAction,
+  AddForeignKeyOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
 export { SchemaCreation } from "./connection-adapters/abstract/schema-creation.js";
 export { Schema } from "./schema.js";

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1746,29 +1746,29 @@ describe("MigrationTest", () => {
   }); // CopyMigrationsTest
 });
 
-describe("addCheckConstraint / removeCheckConstraint", () => {
-  function mockMigration(): { migration: Migration; sql: string[] } {
-    const sql: string[] = [];
-    const migration = new (class extends Migration {
-      static version = "20240101000000";
-      async change() {}
-    })();
-    (migration as any).adapter = {
-      execute: async () => [],
-      executeMutation: async (s: string) => {
-        sql.push(s);
-        return 0;
-      },
-      beginTransaction: async () => {},
-      commit: async () => {},
-      rollback: async () => {},
-      createSavepoint: async () => {},
-      releaseSavepoint: async () => {},
-      rollbackToSavepoint: async () => {},
-    };
-    return { migration, sql };
-  }
+function mockMigration(): { migration: Migration; sql: string[] } {
+  const sql: string[] = [];
+  const migration = new (class extends Migration {
+    static version = "20240101000000";
+    async change() {}
+  })();
+  (migration as any).adapter = {
+    execute: async () => [],
+    executeMutation: async (s: string) => {
+      sql.push(s);
+      return 0;
+    },
+    beginTransaction: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+    createSavepoint: async () => {},
+    releaseSavepoint: async () => {},
+    rollbackToSavepoint: async () => {},
+  };
+  return { migration, sql };
+}
 
+describe("addCheckConstraint / removeCheckConstraint", () => {
   it("generates ADD CONSTRAINT CHECK SQL", async () => {
     const { migration, sql } = mockMigration();
     await migration.addCheckConstraint("games", "status IN ('active', 'waiting')", {
@@ -1831,5 +1831,53 @@ describe("addCheckConstraint / removeCheckConstraint", () => {
     await expect(migration.removeCheckConstraint("games")).rejects.toThrow(
       /requires either an expression or/,
     );
+  });
+});
+
+describe("addForeignKey with referential actions", () => {
+  it("generates correct SQL with ON DELETE CASCADE", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addForeignKey("chess_moves", "games", {
+      column: "game_id",
+      onDelete: "cascade",
+    });
+    expect(sql[0]).toContain("ON DELETE CASCADE");
+    expect(sql[0]).not.toContain("ON UPDATE");
+  });
+
+  it("generates correct SQL with ON UPDATE SET NULL", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addForeignKey("children", "parents", {
+      column: "parent_id",
+      onUpdate: "nullify",
+    });
+    expect(sql[0]).toContain("ON UPDATE SET NULL");
+  });
+
+  it("generates correct SQL with both actions", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addForeignKey("books", "authors", {
+      column: "author_id",
+      onDelete: "cascade",
+      onUpdate: "restrict",
+    });
+    expect(sql[0]).toContain("ON DELETE CASCADE");
+    expect(sql[0]).toContain("ON UPDATE RESTRICT");
+  });
+
+  it("generates ON DELETE NO ACTION", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addForeignKey("posts", "users", {
+      column: "user_id",
+      onDelete: "no_action",
+    });
+    expect(sql[0]).toContain("ON DELETE NO ACTION");
+  });
+
+  it("omits referential actions when not specified", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addForeignKey("players", "teams", { column: "team_id" });
+    expect(sql[0]).not.toContain("ON DELETE");
+    expect(sql[0]).not.toContain("ON UPDATE");
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -4,9 +4,15 @@ import {
   Table,
   type ColumnType,
   type ColumnOptions,
+  type AddForeignKeyOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import { detectAdapterName } from "./adapter-name.js";
+
+export type {
+  ReferentialAction,
+  AddForeignKeyOptions,
+} from "./connection-adapters/abstract/schema-definitions.js";
 
 interface RecordedOperation {
   method: string;
@@ -349,7 +355,7 @@ export abstract class Migration {
   async addForeignKey(
     fromTable: string,
     toTable: string,
-    options: { column?: string; primaryKey?: string; name?: string } = {},
+    options: AddForeignKeyOptions = {},
   ): Promise<void> {
     if (this._recording) {
       this._recordedOps.push({ method: "addForeignKey", args: [fromTable, toTable, options] });


### PR DESCRIPTION
This adds referential action support to `addForeignKey` so you don't need raw SQL for cascade deletes anymore.

```ts
await this.addForeignKey("chess_moves", "games", {
  column: "game_id",
  onDelete: "cascade",
});
```

The options map to standard SQL: `cascade` -> CASCADE, `nullify` -> SET NULL, `restrict` -> RESTRICT, `no_action` -> NO ACTION. Both `onDelete` and `onUpdate` are supported, and they're omitted from the SQL when not specified (preserving the existing behavior).

Found while dogfooding on deanmarano/website#1 where ~10 FK relationships needed cascade deletes.

Closes #256