### PR TITLE
Add addCheckConstraint and removeCheckConstraint to migrations

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -17,6 +17,7 @@ import {
   AddColumnDefinition,
   CreateIndexDefinition,
   ForeignKeyDefinition,
+  CheckConstraintDefinition,
   type ColumnType,
   type ColumnOptions,
 } from "./schema-definitions.js";
@@ -343,6 +344,45 @@ export class SchemaStatements {
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(fromTable)} DROP CONSTRAINT ${this._qi(name)}`,
     );
+  }
+
+  async addCheckConstraint(
+    tableName: string,
+    expression: string,
+    options: { name?: string; validate?: boolean } = {},
+  ): Promise<void> {
+    const name = options.name ?? this._checkConstraintName(tableName, expression);
+    const validate = options.validate !== false;
+    const chkDef = new CheckConstraintDefinition(tableName, expression, name, validate);
+    await this.adapter.executeMutation(
+      `ALTER TABLE ${this._qi(tableName)} ADD ${this.schemaCreation.accept(chkDef)}`,
+    );
+  }
+
+  async removeCheckConstraint(
+    tableName: string,
+    expressionOrOptions?: string | { name?: string },
+  ): Promise<void> {
+    let name: string;
+    if (typeof expressionOrOptions === "string") {
+      name = this._checkConstraintName(tableName, expressionOrOptions);
+    } else if (expressionOrOptions?.name) {
+      name = expressionOrOptions.name;
+    } else {
+      throw new Error("removeCheckConstraint requires either an expression or { name } option");
+    }
+    await this.adapter.executeMutation(
+      `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(name)}`,
+    );
+  }
+
+  _checkConstraintName(tableName: string, expression: string): string {
+    let hash = 0;
+    for (let i = 0; i < expression.length; i++) {
+      hash = ((hash << 5) - hash + expression.charCodeAt(i)) | 0;
+    }
+    const hex = (hash >>> 0).toString(16).padStart(8, "0");
+    return `chk_${tableName}_${hex}`;
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1745,3 +1745,91 @@ describe("MigrationTest", () => {
     }); // MigrationValidationTest
   }); // CopyMigrationsTest
 });
+
+describe("addCheckConstraint / removeCheckConstraint", () => {
+  function mockMigration(): { migration: Migration; sql: string[] } {
+    const sql: string[] = [];
+    const migration = new (class extends Migration {
+      static version = "20240101000000";
+      async change() {}
+    })();
+    (migration as any).adapter = {
+      execute: async () => [],
+      executeMutation: async (s: string) => {
+        sql.push(s);
+        return 0;
+      },
+      beginTransaction: async () => {},
+      commit: async () => {},
+      rollback: async () => {},
+      createSavepoint: async () => {},
+      releaseSavepoint: async () => {},
+      rollbackToSavepoint: async () => {},
+    };
+    return { migration, sql };
+  }
+
+  it("generates ADD CONSTRAINT CHECK SQL", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addCheckConstraint("games", "status IN ('active', 'waiting')", {
+      name: "games_status_check",
+    });
+    expect(sql[0]).toBe(
+      `ALTER TABLE "games" ADD CONSTRAINT "games_status_check" CHECK (status IN ('active', 'waiting'))`,
+    );
+  });
+
+  it("generates unique default name from expression", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addCheckConstraint("games", "score >= 0");
+    expect(sql[0]).toMatch(/"chk_games_[0-9a-f]{8}"/);
+  });
+
+  it("different expressions produce different default names", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addCheckConstraint("games", "score >= 0");
+    await migration.addCheckConstraint("games", "score <= 100");
+    const name1 = sql[0].match(/"(chk_games_[0-9a-f]{8})"/)?.[1];
+    const name2 = sql[1].match(/"(chk_games_[0-9a-f]{8})"/)?.[1];
+    expect(name1).not.toBe(name2);
+  });
+
+  it("validate: false throws on non-postgres adapters", async () => {
+    const { migration } = mockMigration();
+    await expect(
+      migration.addCheckConstraint("games", "score >= 0", {
+        name: "games_score_check",
+        validate: false,
+      }),
+    ).rejects.toThrow(/only supported on PostgreSQL/);
+  });
+
+  it("omits NOT VALID by default", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addCheckConstraint("games", "score >= 0", {
+      name: "games_score_check",
+    });
+    expect(sql[0]).not.toContain("NOT VALID");
+  });
+
+  it("generates DROP CONSTRAINT SQL with name", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.removeCheckConstraint("games", { name: "games_status_check" });
+    expect(sql[0]).toBe(`ALTER TABLE "games" DROP CONSTRAINT "games_status_check"`);
+  });
+
+  it("removes by expression using same default name", async () => {
+    const { migration, sql } = mockMigration();
+    await migration.addCheckConstraint("games", "score >= 0");
+    await migration.removeCheckConstraint("games", "score >= 0");
+    const addName = sql[0].match(/"(chk_games_[0-9a-f]{8})"/)?.[1];
+    expect(sql[1]).toContain(`"${addName}"`);
+  });
+
+  it("throws when no expression or name given to remove", async () => {
+    const { migration } = mockMigration();
+    await expect(migration.removeCheckConstraint("games")).rejects.toThrow(
+      /requires either an expression or/,
+    );
+  });
+});

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -150,6 +150,21 @@ export abstract class Migration {
         break;
       case "dropJoinTable":
         throw new Error("Cannot reverse dropJoinTable without table definition");
+      case "addCheckConstraint": {
+        const [table, expr, opts] = op.args as [string, string, { name?: string }?];
+        const constraintName = opts?.name ?? this.schema._checkConstraintName(table, expr);
+        await this.removeCheckConstraint(table, { name: constraintName });
+        break;
+      }
+      case "removeCheckConstraint": {
+        const [rmTable, rmArg] = op.args as [string, string | { name?: string } | undefined];
+        if (typeof rmArg === "string") {
+          await this.addCheckConstraint(rmTable, rmArg);
+        } else {
+          throw new Error("Cannot reverse removeCheckConstraint without expression");
+        }
+        break;
+      }
       default:
         throw new Error(`Cannot reverse operation: ${op.method}`);
     }
@@ -354,6 +369,34 @@ export abstract class Migration {
     await this.schema.removeForeignKey(fromTable, toTableOrOptions);
   }
 
+  async addCheckConstraint(
+    tableName: string,
+    expression: string,
+    options: { name?: string; validate?: boolean } = {},
+  ): Promise<void> {
+    if (this._recording) {
+      this._recordedOps.push({
+        method: "addCheckConstraint",
+        args: [tableName, expression, options],
+      });
+      return;
+    }
+    await this.schema.addCheckConstraint(tableName, expression, options);
+  }
+
+  async removeCheckConstraint(
+    tableName: string,
+    expressionOrOptions?: string | { name?: string },
+  ): Promise<void> {
+    if (this._recording) {
+      this._recordedOps.push({
+        method: "removeCheckConstraint",
+        args: [tableName, expressionOrOptions],
+      });
+      return;
+    }
+    await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
+  }
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
     if (this._recording) {
       this._recordedOps.push({ method: "addTimestamps", args: [tableName, options] });


### PR DESCRIPTION
Adds check constraint support to migrations so you don't need raw SQL for enum-like validations at the database level.

```ts
await this.addCheckConstraint("games", "status IN ('active', 'waiting')", {
  name: "games_status_check",
});

await this.removeCheckConstraint("games", { name: "games_status_check" });
```

Also supports `validate: false` for adding NOT VALID constraints to large tables without locking (a Postgres feature that lets you add the constraint without checking existing rows, then validate separately).

Closes #255