### PR TITLE
Implement SchemaCreation visitor for DDL SQL generation

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -1,0 +1,166 @@
+/**
+ * SchemaCreation — visitor that accepts definition objects and produces SQL.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::SchemaCreation
+ *
+ * This is the base implementation. Per-adapter subclasses can override
+ * visit methods for dialect-specific SQL generation.
+ */
+
+import {
+  type ColumnType,
+  type ColumnOptions,
+  type ReferentialAction,
+  ColumnDefinition,
+  AddColumnDefinition,
+  CreateIndexDefinition,
+  ForeignKeyDefinition,
+  CheckConstraintDefinition,
+  TableDefinition,
+} from "./schema-definitions.js";
+import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "../../quoting.js";
+
+type Definition =
+  | TableDefinition
+  | ColumnDefinition
+  | AddColumnDefinition
+  | CreateIndexDefinition
+  | ForeignKeyDefinition
+  | CheckConstraintDefinition;
+
+export class SchemaCreation {
+  constructor(protected adapterName: "sqlite" | "postgres" | "mysql") {}
+
+  accept(o: Definition): string {
+    if (o instanceof TableDefinition) return this.visitTableDefinition(o);
+    if (o instanceof AddColumnDefinition) return this.visitAddColumnDefinition(o);
+    if (o instanceof ColumnDefinition) return this.visitColumnDefinition(o);
+    if (o instanceof CreateIndexDefinition) return this.visitCreateIndexDefinition(o);
+    if (o instanceof ForeignKeyDefinition) return this.visitForeignKeyDefinition(o);
+    if (o instanceof CheckConstraintDefinition) return this.visitCheckConstraintDefinition(o);
+    throw new Error(`Unknown definition type: ${(o as any).constructor.name}`);
+  }
+
+  protected visitTableDefinition(o: TableDefinition): string {
+    let sql = "CREATE TABLE ";
+    sql += `${quoteTableName(o.tableName, this.adapterName)} `;
+
+    const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
+
+    if (statements.length > 0) {
+      sql += `(${statements.join(", ")})`;
+    }
+
+    return sql;
+  }
+
+  protected visitColumnDefinition(o: ColumnDefinition): string {
+    const sqlType = o.sqlType ?? this.typeToSql(o.type, o.options);
+    let sql = `${quoteIdentifier(o.name, this.adapterName)} ${sqlType}`;
+    if (o.type !== "primary_key") {
+      sql = this.addColumnOptions(sql, o.options);
+    }
+    return sql;
+  }
+
+  protected visitAddColumnDefinition(o: AddColumnDefinition): string {
+    return `ADD ${this.accept(o.column)}`;
+  }
+
+  protected visitCreateIndexDefinition(o: CreateIndexDefinition): string {
+    const index = o.index;
+    const parts: string[] = ["CREATE"];
+    if (index.unique) parts.push("UNIQUE");
+    parts.push("INDEX");
+    if (o.algorithm) parts.push(o.algorithm);
+    if (o.ifNotExists) parts.push("IF NOT EXISTS");
+    parts.push(
+      `${quoteIdentifier(index.name, this.adapterName)} ON ${quoteTableName(index.table, this.adapterName)}`,
+    );
+    parts.push(`(${index.columns.map((c) => quoteIdentifier(c, this.adapterName)).join(", ")})`);
+    return parts.join(" ");
+  }
+
+  protected visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
+    let sql = `CONSTRAINT ${quoteIdentifier(o.name, this.adapterName)} `;
+    sql += `FOREIGN KEY (${quoteIdentifier(o.column, this.adapterName)}) `;
+    sql += `REFERENCES ${quoteTableName(o.toTable, this.adapterName)} (${quoteIdentifier(o.primaryKey, this.adapterName)})`;
+    if (o.onDelete) sql += ` ${this.actionSql("DELETE", o.onDelete)}`;
+    if (o.onUpdate) sql += ` ${this.actionSql("UPDATE", o.onUpdate)}`;
+    return sql;
+  }
+
+  protected visitCheckConstraintDefinition(o: CheckConstraintDefinition): string {
+    let sql = `CONSTRAINT ${quoteIdentifier(o.name, this.adapterName)} CHECK (${o.expression})`;
+    if (!o.validate) {
+      if (this.adapterName !== "postgres") {
+        throw new Error("Check constraint validate: false is only supported on PostgreSQL");
+      }
+      sql += " NOT VALID";
+    }
+    return sql;
+  }
+
+  addColumnOptions(sql: string, options: ColumnOptions): string {
+    if (options.default !== undefined) {
+      sql += quoteDefaultExpression(options.default);
+    }
+    if (options.null === false) {
+      sql += " NOT NULL";
+    }
+    if (options.primaryKey) {
+      sql += " PRIMARY KEY";
+    }
+    return sql;
+  }
+
+  typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
+    switch (type) {
+      case "string":
+        return `VARCHAR(${options.limit ?? 255})`;
+      case "text":
+        return "TEXT";
+      case "integer":
+        return "INTEGER";
+      case "float":
+        return this.adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL";
+      case "decimal":
+        return `DECIMAL(${options.precision ?? 10}, ${options.scale ?? 0})`;
+      case "boolean":
+        return "BOOLEAN";
+      case "date":
+        return "DATE";
+      case "datetime":
+      case "timestamp":
+        return this.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
+      case "binary":
+        return this.adapterName === "postgres" ? "BYTEA" : "BLOB";
+      case "json":
+        return "JSON";
+      case "jsonb":
+        return this.adapterName === "postgres" ? "JSONB" : "JSON";
+      case "primary_key":
+        if (this.adapterName === "postgres") return "SERIAL PRIMARY KEY";
+        if (this.adapterName === "mysql") return "INT AUTO_INCREMENT PRIMARY KEY";
+        return "INTEGER PRIMARY KEY AUTOINCREMENT";
+    }
+  }
+
+  actionSql(action: string, dependency: ReferentialAction): string {
+    switch (dependency) {
+      case "cascade":
+        return `ON ${action} CASCADE`;
+      case "nullify":
+        return `ON ${action} SET NULL`;
+      case "restrict":
+        return `ON ${action} RESTRICT`;
+      case "no_action":
+        return `ON ${action} NO ACTION`;
+      default:
+        throw new Error(
+          `'${String(dependency)}' is not supported for on_update or on_delete. ` +
+            `Supported values are: cascade, nullify, restrict, no_action`,
+        );
+    }
+  }
+}

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -18,10 +18,63 @@ export type ColumnType =
   | "jsonb"
   | "primary_key";
 
-interface ColumnDefinition {
-  name: string;
-  type: ColumnType;
-  options: ColumnOptions;
+export type ReferentialAction = "cascade" | "nullify" | "restrict" | "no_action";
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::ColumnDefinition
+ */
+export class ColumnDefinition {
+  sqlType?: string;
+  constructor(
+    readonly name: string,
+    readonly type: ColumnType,
+    readonly options: ColumnOptions = {},
+  ) {}
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::AddColumnDefinition
+ */
+export class AddColumnDefinition {
+  constructor(readonly column: ColumnDefinition) {}
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::CreateIndexDefinition
+ */
+export class CreateIndexDefinition {
+  constructor(
+    readonly index: IndexDefinition,
+    readonly ifNotExists: boolean = false,
+    readonly algorithm?: string,
+  ) {}
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
+ */
+export class ForeignKeyDefinition {
+  constructor(
+    readonly fromTable: string,
+    readonly toTable: string,
+    readonly column: string,
+    readonly primaryKey: string,
+    readonly name: string,
+    readonly onDelete?: ReferentialAction,
+    readonly onUpdate?: ReferentialAction,
+  ) {}
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::CheckConstraintDefinition
+ */
+export class CheckConstraintDefinition {
+  constructor(
+    readonly tableName: string,
+    readonly expression: string,
+    readonly name: string,
+    readonly validate: boolean = true,
+  ) {}
 }
 
 export interface ColumnOptions {
@@ -73,21 +126,17 @@ export class TableDefinition {
     this._id = options.id !== false;
 
     if (this._id) {
-      this.columns.push({
-        name: "id",
-        type: "primary_key",
-        options: { primaryKey: true },
-      });
+      this.columns.push(new ColumnDefinition("id", "primary_key", { primaryKey: true }));
     }
   }
 
   string(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "string", options });
+    this.columns.push(new ColumnDefinition(name, "string", options));
     return this;
   }
 
   text(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "text", options });
+    this.columns.push(new ColumnDefinition(name, "text", options));
     return this;
   }
 
@@ -97,7 +146,7 @@ export class TableDefinition {
   }
 
   float(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "float", options });
+    this.columns.push(new ColumnDefinition(name, "float", options));
     return this;
   }
 
@@ -105,42 +154,42 @@ export class TableDefinition {
     if (options.scale !== undefined && options.precision === undefined) {
       throw new Error("Error adding decimal column: precision is required if scale is specified");
     }
-    this.columns.push({ name, type: "decimal", options });
+    this.columns.push(new ColumnDefinition(name, "decimal", options));
     return this;
   }
 
   boolean(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "boolean", options });
+    this.columns.push(new ColumnDefinition(name, "boolean", options));
     return this;
   }
 
   date(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "date", options });
+    this.columns.push(new ColumnDefinition(name, "date", options));
     return this;
   }
 
   datetime(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "datetime", options });
+    this.columns.push(new ColumnDefinition(name, "datetime", options));
     return this;
   }
 
   timestamp(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "timestamp", options });
+    this.columns.push(new ColumnDefinition(name, "timestamp", options));
     return this;
   }
 
   binary(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "binary", options });
+    this.columns.push(new ColumnDefinition(name, "binary", options));
     return this;
   }
 
   json(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "json", options });
+    this.columns.push(new ColumnDefinition(name, "json", options));
     return this;
   }
 
   jsonb(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "jsonb", options });
+    this.columns.push(new ColumnDefinition(name, "jsonb", options));
     return this;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -12,17 +12,32 @@ import type { DatabaseAdapter } from "../../adapter.js";
 import {
   TableDefinition,
   Table,
+  IndexDefinition,
+  ColumnDefinition,
+  AddColumnDefinition,
+  CreateIndexDefinition,
+  ForeignKeyDefinition,
   type ColumnType,
   type ColumnOptions,
 } from "./schema-definitions.js";
+import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
 import { quoteIdentifier, quoteDefaultExpression } from "../../quoting.js";
 
 export class SchemaStatements {
+  private _schemaCreation?: SchemaCreation;
+
   constructor(
     protected adapter: DatabaseAdapter,
     protected adapterName: "sqlite" | "postgres" | "mysql" = detectAdapterName(adapter),
   ) {}
+
+  get schemaCreation(): SchemaCreation {
+    if (!this._schemaCreation) {
+      this._schemaCreation = new SchemaCreation(this.adapterName);
+    }
+    return this._schemaCreation;
+  }
 
   protected _qi(name: string): string {
     return quoteIdentifier(name, this.adapterName);
@@ -87,12 +102,10 @@ export class SchemaStatements {
     if (options.ifNotExists && (await this.columnExists(tableName, columnName))) {
       return;
     }
-    const sqlType = this.typeToSql(type, options);
-    const nullable = options.null === false ? " NOT NULL" : "";
-    const defaultClause = this._defaultClause(options.default);
-
+    const colDef = new ColumnDefinition(columnName, type, options);
+    const addDef = new AddColumnDefinition(colDef);
     await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(tableName)} ADD COLUMN ${this._qi(columnName)} ${sqlType}${nullable}${defaultClause}`,
+      `ALTER TABLE ${this._qi(tableName)} ${this.schemaCreation.accept(addDef)}`,
     );
   }
 
@@ -121,13 +134,10 @@ export class SchemaStatements {
     options: { unique?: boolean; name?: string } = {},
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
-    const indexName = options.name ?? `index_${tableName}_on_${cols.join("_and_")}`;
-    const unique = options.unique ? "UNIQUE " : "";
-    const quotedCols = cols.map((c) => quoteIdentifier(c, this.adapterName)).join(", ");
-
-    await this.adapter.executeMutation(
-      `CREATE ${unique}INDEX ${quoteIdentifier(indexName, this.adapterName)} ON ${quoteIdentifier(tableName, this.adapterName)} (${quotedCols})`,
-    );
+    const indexName = options.name ?? this.indexName(tableName, { column: cols });
+    const indexDef = new IndexDefinition(tableName, indexName, options.unique ?? false, cols);
+    const createDef = new CreateIndexDefinition(indexDef);
+    await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
   }
 
   async removeIndex(
@@ -159,13 +169,13 @@ export class SchemaStatements {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
-    const sqlType = this.typeToSql(type, options);
+    const sqlType = this.schemaCreation.typeToSql(type, options);
     const table = this._qi(tableName);
     const col = this._qi(columnName);
 
     if (this.adapterName === "mysql") {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = this._defaultClause(options.default);
+      const defaultClause = quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -177,12 +187,12 @@ export class SchemaStatements {
         );
       }
       if (options.default !== undefined) {
-        clauses.push(`ALTER COLUMN ${col} SET${this._defaultClause(options.default)}`);
+        clauses.push(`ALTER COLUMN ${col} SET${quoteDefaultExpression(options.default)}`);
       }
       await this.adapter.executeMutation(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = this._defaultClause(options.default);
+      const defaultClause = quoteDefaultExpression(options.default);
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -245,7 +255,7 @@ export class SchemaStatements {
       typeof options === "object" && options !== null && "to" in (options as any)
         ? (options as any).to
         : options;
-    const clause = this._defaultClause(defaultVal);
+    const clause = quoteDefaultExpression(defaultVal);
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET${clause || " DEFAULT NULL"}`,
     );
@@ -309,8 +319,9 @@ export class SchemaStatements {
     const column = options.column ?? `${toTable.replace(/s$/, "")}_id`;
     const pk = options.primaryKey ?? "id";
     const name = options.name ?? `fk_${fromTable}_${column}`;
+    const fkDef = new ForeignKeyDefinition(fromTable, toTable, column, pk, name);
     await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(fromTable)} ADD CONSTRAINT ${this._qi(name)} FOREIGN KEY (${this._qi(column)}) REFERENCES ${this._qi(toTable)} (${this._qi(pk)})`,
+      `ALTER TABLE ${this._qi(fromTable)} ADD ${this.schemaCreation.accept(fkDef)}`,
     );
   }
 
@@ -660,38 +671,6 @@ export class SchemaStatements {
   }
 
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
-    switch (type) {
-      case "string":
-        return `VARCHAR(${options.limit ?? 255})`;
-      case "text":
-        return "TEXT";
-      case "integer":
-        return "INTEGER";
-      case "float":
-        return this.adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL";
-      case "decimal":
-        return `DECIMAL(${options.precision ?? 10}, ${options.scale ?? 0})`;
-      case "boolean":
-        return "BOOLEAN";
-      case "date":
-        return "DATE";
-      case "datetime":
-      case "timestamp":
-        return this.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
-      case "binary":
-        return this.adapterName === "postgres" ? "BYTEA" : "BLOB";
-      case "json":
-        return "JSON";
-      case "jsonb":
-        return this.adapterName === "postgres" ? "JSONB" : "JSON";
-      case "primary_key":
-        if (this.adapterName === "postgres") return "SERIAL PRIMARY KEY";
-        if (this.adapterName === "mysql") return "INT AUTO_INCREMENT PRIMARY KEY";
-        return "INTEGER PRIMARY KEY AUTOINCREMENT";
-    }
-  }
-
-  protected _defaultClause(defaultValue: unknown): string {
-    return quoteDefaultExpression(defaultValue);
+    return this.schemaCreation.typeToSql(type, options);
   }
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -2,11 +2,22 @@ export { Base } from "./base.js";
 export { Relation, Range } from "./relation.js";
 export type { DatabaseAdapter } from "./adapter.js";
 export { Migration, MigrationContext } from "./migration.js";
-export { TableDefinition, Table } from "./connection-adapters/abstract/schema-definitions.js";
+export {
+  TableDefinition,
+  Table,
+  ColumnDefinition,
+  AddColumnDefinition,
+  CreateIndexDefinition,
+  IndexDefinition,
+  ForeignKeyDefinition,
+  CheckConstraintDefinition,
+} from "./connection-adapters/abstract/schema-definitions.js";
 export type {
   ColumnType,
   ColumnOptions,
+  ReferentialAction,
 } from "./connection-adapters/abstract/schema-definitions.js";
+export { SchemaCreation } from "./connection-adapters/abstract/schema-creation.js";
 export { Schema } from "./schema.js";
 export { MigrationRunner } from "./migration-runner.js";
 export {


### PR DESCRIPTION
This implements the Rails SchemaCreation pattern -- a visitor that accepts definition objects and produces adapter-specific SQL, replacing the inline SQL string building in SchemaStatements.

In Rails, SchemaStatements doesn't build SQL directly. Instead it creates definition objects (ColumnDefinition, ForeignKeyDefinition, etc.) and passes them to schema_creation.accept(definition), which dispatches to the appropriate visit method. This is what makes per-adapter DDL overrides clean -- a PostgresSchemaCreation can override visitForeignKeyDefinition to add DEFERRABLE support without touching SchemaStatements.

New definition classes (in schema-definitions.ts, matching Rails):
- ColumnDefinition -- name, type, options, sqlType
- AddColumnDefinition -- wraps ColumnDefinition for ALTER TABLE ADD
- CreateIndexDefinition -- wraps IndexDefinition with ifNotExists/algorithm
- ForeignKeyDefinition -- fromTable, toTable, column, primaryKey, name, onDelete, onUpdate
- CheckConstraintDefinition -- tableName, expression, name, validate
- ReferentialAction type -- cascade, nullify, restrict, no_action

SchemaCreation (new file, matching Rails' schema_creation.rb):
- accept() dispatcher that routes by instanceof
- visitTableDefinition, visitColumnDefinition, visitAddColumnDefinition
- visitCreateIndexDefinition, visitForeignKeyDefinition, visitCheckConstraintDefinition
- typeToSql (moved from SchemaStatements)
- addColumnOptions, actionSql helpers

SchemaStatements rewired to use SchemaCreation for:
- addColumn (via AddColumnDefinition)
- addIndex (via CreateIndexDefinition)
- addForeignKey (via ForeignKeyDefinition)
- typeToSql (delegates to schemaCreation)

7,570 tests pass, 0 regressions.