### PR TITLE
Add BIGINT, CHAR(n), and TEXT[] column types

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -115,35 +115,65 @@ export class SchemaCreation {
   }
 
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
+    let sql: string;
     switch (type) {
       case "string":
-        return `VARCHAR(${options.limit ?? 255})`;
+        sql = `VARCHAR(${options.limit ?? 255})`;
+        break;
       case "text":
-        return "TEXT";
+        sql = "TEXT";
+        break;
       case "integer":
-        return "INTEGER";
+        sql = "INTEGER";
+        break;
+      case "bigint":
+        sql = "BIGINT";
+        break;
       case "float":
-        return this.adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL";
+        sql = this.adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL";
+        break;
       case "decimal":
-        return `DECIMAL(${options.precision ?? 10}, ${options.scale ?? 0})`;
+        sql = `DECIMAL(${options.precision ?? 10}, ${options.scale ?? 0})`;
+        break;
       case "boolean":
-        return "BOOLEAN";
+        sql = "BOOLEAN";
+        break;
       case "date":
-        return "DATE";
+        sql = "DATE";
+        break;
       case "datetime":
       case "timestamp":
-        return this.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
+        sql = this.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
+        break;
       case "binary":
-        return this.adapterName === "postgres" ? "BYTEA" : "BLOB";
+        sql = this.adapterName === "postgres" ? "BYTEA" : "BLOB";
+        break;
       case "json":
-        return "JSON";
+        sql = "JSON";
+        break;
       case "jsonb":
-        return this.adapterName === "postgres" ? "JSONB" : "JSON";
+        sql = this.adapterName === "postgres" ? "JSONB" : "JSON";
+        break;
+      case "char":
+        sql = `CHAR(${options.limit ?? 1})`;
+        break;
       case "primary_key":
-        if (this.adapterName === "postgres") return "SERIAL PRIMARY KEY";
-        if (this.adapterName === "mysql") return "INT AUTO_INCREMENT PRIMARY KEY";
-        return "INTEGER PRIMARY KEY AUTOINCREMENT";
+        if (this.adapterName === "postgres") sql = "SERIAL PRIMARY KEY";
+        else if (this.adapterName === "mysql") sql = "INT AUTO_INCREMENT PRIMARY KEY";
+        else sql = "INTEGER PRIMARY KEY AUTOINCREMENT";
+        break;
+      default:
+        throw new Error(`Unknown column type: ${String(type)}`);
     }
+
+    if (options.array && type !== "primary_key") {
+      if (this.adapterName !== "postgres") {
+        throw new Error("Array columns are only supported on PostgreSQL");
+      }
+      sql += "[]";
+    }
+
+    return sql;
   }
 
   actionSql(action: string, dependency: ReferentialAction): string {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -7,6 +7,7 @@ export type ColumnType =
   | "string"
   | "text"
   | "integer"
+  | "bigint"
   | "float"
   | "decimal"
   | "boolean"
@@ -16,6 +17,7 @@ export type ColumnType =
   | "binary"
   | "json"
   | "jsonb"
+  | "char"
   | "primary_key";
 
 export type ReferentialAction = "cascade" | "nullify" | "restrict" | "no_action";
@@ -86,6 +88,7 @@ export interface ColumnOptions {
   index?: boolean;
   unique?: boolean;
   primaryKey?: boolean;
+  array?: boolean;
 }
 
 /**
@@ -141,7 +144,12 @@ export class TableDefinition {
   }
 
   integer(name: string, options: ColumnOptions = {}): this {
-    this.columns.push({ name, type: "integer", options });
+    this.columns.push(new ColumnDefinition(name, "integer", options));
+    return this;
+  }
+
+  bigint(name: string, options: ColumnOptions = {}): this {
+    this.columns.push(new ColumnDefinition(name, "bigint", options));
     return this;
   }
 
@@ -190,6 +198,16 @@ export class TableDefinition {
 
   jsonb(name: string, options: ColumnOptions = {}): this {
     this.columns.push(new ColumnDefinition(name, "jsonb", options));
+    return this;
+  }
+
+  char(name: string, options: ColumnOptions = {}): this {
+    this.columns.push(new ColumnDefinition(name, "char", options));
+    return this;
+  }
+
+  array(name: string, type: ColumnType, options: ColumnOptions = {}): this {
+    this.columns.push(new ColumnDefinition(name, type, { ...options, array: true }));
     return this;
   }
 
@@ -273,6 +291,21 @@ export class TableDefinition {
         case "jsonb":
           parts.push(this._adapterName === "postgres" ? "JSONB" : "JSON");
           break;
+        case "bigint":
+          parts.push("BIGINT");
+          break;
+        case "char":
+          parts.push(`CHAR(${col.options.limit ?? 1})`);
+          break;
+      }
+
+      if (col.options.array && col.type !== "primary_key") {
+        if (this._adapterName !== "postgres") {
+          throw new Error("Array columns are only supported on PostgreSQL");
+        }
+        // Append [] to the last part (the type)
+        const lastIdx = parts.length - 1;
+        parts[lastIdx] = parts[lastIdx] + "[]";
       }
 
       if (col.options.null === false && col.type !== "primary_key") {
@@ -325,6 +358,15 @@ export class Table {
   }
   async datetime(name: string, options: ColumnOptions = {}): Promise<void> {
     await this._schema.addColumn(this._tableName, name, "datetime", options);
+  }
+  async bigint(name: string, options: ColumnOptions = {}): Promise<void> {
+    await this._schema.addColumn(this._tableName, name, "bigint", options);
+  }
+  async char(name: string, options: ColumnOptions = {}): Promise<void> {
+    await this._schema.addColumn(this._tableName, name, "char", options);
+  }
+  async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
+    await this._schema.addColumn(this._tableName, name, type, { ...options, array: true });
   }
   async remove(name: string): Promise<void> {
     await this._schema.removeColumn(this._tableName, name);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -91,6 +91,8 @@ const SQL_TYPE_MAP: Record<string, DslMapping> = {
   oid: { dslType: "oid" },
   serial: { dslType: "serial" },
   bigserial: { dslType: "bigserial" },
+  character: { dslType: "char" },
+  bpchar: { dslType: "char" },
   // SQLite types
   blob: { dslType: "binary" },
   "integer primary key autoincrement": { dslType: "integer" },
@@ -108,6 +110,7 @@ const KNOWN_DSL_TYPES = new Set([
   "datetime",
   "timestamp",
   "binary",
+  "char",
 ]);
 
 function sqlTypeToDsl(sqlType: string): DslMapping {
@@ -123,31 +126,37 @@ function sqlTypeToDsl(sqlType: string): DslMapping {
     if (varcharMatch) {
       result = { dslType: "string", extraOpts: { limit: Number(varcharMatch[1]) } };
     } else {
-      const numericMatch = baseType.match(/^(?:numeric|decimal)\((\d+),\s*(\d+)\)$/);
-      if (numericMatch) {
+      const charMatch = baseType.match(/^(?:character|char|bpchar)\((\d+)\)$/);
+      const numericMatch = !charMatch
+        ? baseType.match(/^(?:numeric|decimal)\((\d+),\s*(\d+)\)$/)
+        : null;
+      const tsMatch =
+        !charMatch && !numericMatch
+          ? baseType.match(/^timestamp(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/)
+          : null;
+      const timeMatch =
+        !charMatch && !numericMatch && !tsMatch
+          ? baseType.match(/^time(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/)
+          : null;
+
+      if (charMatch) {
+        result = { dslType: "char", extraOpts: { limit: Number(charMatch[1]) } };
+      } else if (numericMatch) {
         result = {
           dslType: "decimal",
           extraOpts: { precision: Number(numericMatch[1]), scale: Number(numericMatch[2]) },
         };
+      } else if (tsMatch) {
+        result =
+          tsMatch[2].startsWith("with ") || tsMatch[2] === "with time zone"
+            ? { dslType: "timestamptz" }
+            : { dslType: "datetime" };
+      } else if (timeMatch) {
+        result = { dslType: "time" };
+      } else if (KNOWN_DSL_TYPES.has(baseType)) {
+        result = { dslType: baseType };
       } else {
-        // Handle precision-bearing timestamp/time types: timestamp(3) without time zone
-        const tsMatch = baseType.match(/^timestamp(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/);
-        if (tsMatch) {
-          result =
-            tsMatch[2].startsWith("with ") || tsMatch[2] === "with time zone"
-              ? { dslType: "timestamptz" }
-              : { dslType: "datetime" };
-        } else if (baseType.match(/^time(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/)) {
-          result = { dslType: "time" };
-        } else {
-          // If it's already a known DSL type name, pass it through
-          if (KNOWN_DSL_TYPES.has(baseType)) {
-            result = { dslType: baseType };
-          } else {
-            // Unknown types (enums, domains, etc.)
-            result = { dslType: "enum", extraOpts: { enum_type: baseType } };
-          }
-        }
+        result = { dslType: "enum", extraOpts: { enum_type: baseType } };
       }
     }
   }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -408,6 +408,62 @@ describe("Migrations", () => {
       const sql = td.toSql();
       expect(sql).toContain('"slug" VARCHAR(100)');
     });
+
+    it("supports bigint columns", () => {
+      const td = new TableDefinition("counters");
+      td.bigint("value");
+
+      const sql = td.toSql();
+      expect(sql).toContain('"value" BIGINT');
+    });
+
+    it("supports char columns with limit", () => {
+      const td = new TableDefinition("games");
+      td.char("board", { limit: 9 });
+
+      const sql = td.toSql();
+      expect(sql).toContain('"board" CHAR(9)');
+    });
+
+    it("supports char columns with default limit of 1", () => {
+      const td = new TableDefinition("flags");
+      td.char("status");
+
+      const sql = td.toSql();
+      expect(sql).toContain('"status" CHAR(1)');
+    });
+
+    it("supports array columns on postgres", () => {
+      const td = new TableDefinition("routes", { adapterName: "postgres" });
+      td.array("transports", "text");
+
+      const sql = td.toSql();
+      expect(sql).toContain('"transports" TEXT[]');
+    });
+
+    it("throws for array columns on sqlite", () => {
+      const td = new TableDefinition("routes", { adapterName: "sqlite" });
+      td.array("transports", "text");
+
+      expect(() => td.toSql()).toThrow(/only supported on PostgreSQL/);
+    });
+
+    it("throws for array columns on mysql", () => {
+      const td = new TableDefinition("routes", { adapterName: "mysql" });
+      td.array("transports", "text");
+
+      expect(() => td.toSql()).toThrow(/only supported on PostgreSQL/);
+    });
+
+    it("supports array: true flag on any column type", () => {
+      const td = new TableDefinition("posts", { adapterName: "postgres" });
+      td.text("tags", { array: true });
+      td.integer("scores", { array: true });
+
+      const sql = td.toSql();
+      expect(sql).toContain('"tags" TEXT[]');
+      expect(sql).toContain('"scores" INTEGER[]');
+    });
   });
 
   describe("Migration class", () => {


### PR DESCRIPTION
Adds three column types that were missing from migrations, found while dogfooding on deanmarano/website#1.

```ts
// BIGINT -- large integer counters
t.bigint("counter", { default: 0 });

// CHAR(n) -- fixed-length strings
t.char("board", { limit: 9, default: "---------" });

// PostgreSQL array columns -- array: true flag on any type (matching Rails)
t.array("transports", "text");       // TEXT[]
t.array("scores", "integer");        // INTEGER[]
t.string("tags", { array: true });   // VARCHAR(255)[]
```

BIGINT and CHAR work on all adapters. Array columns are PostgreSQL-only (throws on sqlite/mysql since they don't support native array types).

The array support matches Rails' approach -- `array: true` is a flag on ColumnOptions, not a separate column type. `typeToSql` generates the base type normally and appends `[]` when the flag is set, just like Rails' `type_to_sql` does with the `array:` keyword argument.

Closes #257