### PR TITLE
Rename packages from @rails-ts to @blazetrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,9 @@ This is a TypeScript monorepo. Packages live under `packages/`:
   raw strings when possible, but always support the string form for parity.
 - **Use the package ecosystem like Rails does**: ActiveRecord's power comes
   from Arel. When building queries, subqueries, or SQL conditions in
-  `activerecord`, use `@rails-ts/arel` (Table, SelectManager, Nodes, Attribute)
+  `activerecord`, use `@blazetrails/arel` (Table, SelectManager, Nodes, Attribute)
   to build AST nodes — never construct raw SQL strings. Similarly, use
-  `@rails-ts/activemodel` for validations/callbacks and `@rails-ts/activesupport`
+  `@blazetrails/activemodel` for validations/callbacks and `@blazetrails/activesupport`
   for inflection/utilities rather than reimplementing them.
 - **Implementation-first**: The goal is to implement Rails features in
   TypeScript. Tests being unskipped is a side effect of implementation, not

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "mysql2": "^3.18.2",
-    "pg": "^8.19.0"
+    "pg": "^8.19.0",
+    "yaml": "^2.8.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/actionpack/package.json
+++ b/packages/actionpack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/actionpack",
+  "name": "@blazetrails/actionpack",
   "version": "0.1.0",
   "description": "ActionController and ActionDispatch — mirroring Rails ActionPack",
   "type": "module",
@@ -13,6 +13,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails-ts/rack": "workspace:*"
+    "@blazetrails/rack": "workspace:*"
   }
 }

--- a/packages/actionpack/src/actioncontroller/integration-test.ts
+++ b/packages/actionpack/src/actioncontroller/integration-test.ts
@@ -7,7 +7,7 @@
  *
  * Usage with Vitest:
  *
- *   import { IntegrationTest } from "@rails-ts/actionpack/actioncontroller/integration-test";
+ *   import { IntegrationTest } from "@blazetrails/actionpack/actioncontroller/integration-test";
  *
  *   describe("Posts API", () => {
  *     const app = new IntegrationTest();

--- a/packages/actionpack/src/actioncontroller/metal.ts
+++ b/packages/actionpack/src/actioncontroller/metal.ts
@@ -9,8 +9,8 @@ import { AbstractController } from "./abstract-controller.js";
 import { Request } from "../actiondispatch/request.js";
 import { Response } from "../actiondispatch/response.js";
 import { Parameters } from "../actiondispatch/parameters.js";
-import type { RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 const STATUS_CODES: Record<string, number> = {
   ok: 200,

--- a/packages/actionpack/src/actioncontroller/test-case.ts
+++ b/packages/actionpack/src/actioncontroller/test-case.ts
@@ -9,7 +9,7 @@
  *
  * Usage with Vitest:
  *
- *   import { TestCase } from "@rails-ts/actionpack/actioncontroller/test-case";
+ *   import { TestCase } from "@blazetrails/actionpack/actioncontroller/test-case";
  *
  *   class PostsController extends Base {
  *     async index() { this.render({ json: [{ id: 1 }] }); }

--- a/packages/actionpack/src/actiondispatch/dispatch/debug-exceptions.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/debug-exceptions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { DebugExceptions, type Logger } from "../middleware/debug-exceptions.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString, bodyToString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString, bodyToString } from "@blazetrails/rack";
 
 const okApp = async (_env: RackEnv): Promise<RackResponse> => [
   200,

--- a/packages/actionpack/src/actiondispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/host-authorization.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { HostAuthorization } from "../middleware/host-authorization.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString, bodyToString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString, bodyToString } from "@blazetrails/rack";
 
 const okApp = async (_env: RackEnv): Promise<RackResponse> => [
   200,

--- a/packages/actionpack/src/actiondispatch/dispatch/middleware-stack.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/middleware-stack.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { MiddlewareStack } from "../middleware/stack.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 type RackApp = (env: RackEnv) => Promise<RackResponse>;
 

--- a/packages/actionpack/src/actiondispatch/dispatch/request-id.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/request-id.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { RequestId } from "../middleware/request-id.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 const echoApp = async (env: RackEnv): Promise<RackResponse> => [
   200,

--- a/packages/actionpack/src/actiondispatch/dispatch/routing.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/routing.test.ts
@@ -3,7 +3,7 @@ import { RouteSet } from "../routing/route-set.js";
 import { Route } from "../routing/route.js";
 import { escapePath, escapeSegment, escapeFragment, unescapeUri } from "../routing/utils.js";
 import { RoutesInspector } from "../routing/inspector.js";
-import { bodyToString } from "@rails-ts/rack";
+import { bodyToString } from "@blazetrails/rack";
 
 // ==========================================================================
 // Journey::Route tests (journey/route_test.rb)

--- a/packages/actionpack/src/actiondispatch/dispatch/ssl.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/ssl.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SSL } from "../middleware/ssl.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 const okApp = async (_env: RackEnv): Promise<RackResponse> => [
   200,

--- a/packages/actionpack/src/actiondispatch/dispatch/static.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/static.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Static } from "../middleware/static.js";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString, bodyToString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString, bodyToString } from "@blazetrails/rack";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";

--- a/packages/actionpack/src/actiondispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/debug-exceptions.ts
@@ -5,8 +5,8 @@
  * in development mode.
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 import { ExceptionWrapper } from "../exception-wrapper.js";
 
 type RackApp = (env: RackEnv) => Promise<RackResponse>;

--- a/packages/actionpack/src/actiondispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/host-authorization.ts
@@ -5,8 +5,8 @@
  * only allowing requests to specified hosts.
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 export interface HostAuthorizationOptions {
   hosts: (string | RegExp)[];

--- a/packages/actionpack/src/actiondispatch/middleware/request-id.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/request-id.ts
@@ -5,7 +5,7 @@
  */
 
 import { randomUUID } from "crypto";
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
 type RackApp = (env: RackEnv) => Promise<RackResponse>;
 

--- a/packages/actionpack/src/actiondispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/ssl.ts
@@ -7,8 +7,8 @@
  * - Sets secure cookies flag
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 
 export interface SSLOptions {
   redirect?: boolean | { status?: number; body?: string; port?: number };

--- a/packages/actionpack/src/actiondispatch/middleware/stack.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/stack.ts
@@ -4,7 +4,7 @@
  * An ordered list of middleware with insertion/removal operations.
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
 type RackApp = (env: RackEnv) => Promise<RackResponse>;
 type MiddlewareFactory = new (

--- a/packages/actionpack/src/actiondispatch/middleware/static.ts
+++ b/packages/actionpack/src/actiondispatch/middleware/static.ts
@@ -4,8 +4,8 @@
  * Middleware that serves static files from a directory.
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 import * as fs from "fs";
 import * as path from "path";
 

--- a/packages/actionpack/src/actiondispatch/request.ts
+++ b/packages/actionpack/src/actiondispatch/request.ts
@@ -5,7 +5,7 @@
  * mirroring the Rails Request API.
  */
 
-import type { RackEnv } from "@rails-ts/rack";
+import type { RackEnv } from "@blazetrails/rack";
 
 export class Request {
   readonly env: RackEnv;

--- a/packages/actionpack/src/actiondispatch/routing/controller-routing.test.ts
+++ b/packages/actionpack/src/actiondispatch/routing/controller-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { RouteSet } from "./route-set.js";
-import type { RackEnv } from "@rails-ts/rack";
+import type { RackEnv } from "@blazetrails/rack";
 
 // ==========================================================================
 // Controller routing integration tests

--- a/packages/actionpack/src/actiondispatch/routing/route-set.ts
+++ b/packages/actionpack/src/actiondispatch/routing/route-set.ts
@@ -8,8 +8,8 @@
  * - Rack-compatible call() for dispatching
  */
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 import { Mapper } from "./mapper.js";
 import type { MatchedRoute } from "./route.js";
 import { Route } from "./route.js";

--- a/packages/actionpack/src/actionview/ejs-handler.ts
+++ b/packages/actionpack/src/actionview/ejs-handler.ts
@@ -12,7 +12,7 @@
  * rendered content to wrap.
  *
  * Usage:
- *   import { EjsHandler } from "@rails-ts/actionpack/actionview/ejs-handler";
+ *   import { EjsHandler } from "@blazetrails/actionpack/actionview/ejs-handler";
  *   TemplateHandlerRegistry.register(new EjsHandler());
  */
 

--- a/packages/actionpack/src/actionview/template-handler.ts
+++ b/packages/actionpack/src/actionview/template-handler.ts
@@ -6,7 +6,7 @@
  *
  * To add a new template engine:
  *
- *   import { TemplateHandler, TemplateHandlerRegistry } from "@rails-ts/actionpack/actionview";
+ *   import { TemplateHandler, TemplateHandlerRegistry } from "@blazetrails/actionpack/actionview";
  *
  *   class ReactHandler implements TemplateHandler {
  *     extensions = ["tsx", "jsx"];

--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/activemodel",
+  "name": "@blazetrails/activemodel",
   "version": "0.1.0",
   "description": "Attributes, validations, callbacks, and serialization, mirroring Ruby's ActiveModel",
   "type": "module",
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails-ts/activesupport": "workspace:*",
+    "@blazetrails/activesupport": "workspace:*",
     "bcryptjs": "^3.0.3",
     "yaml": "^2.8.3"
   }

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -1,4 +1,4 @@
-import { humanize } from "@rails-ts/activesupport";
+import { humanize } from "@blazetrails/activesupport";
 import { I18n } from "./i18n.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -1,4 +1,4 @@
-import { deepDup, deepMergeInPlace } from "@rails-ts/activesupport";
+import { deepDup, deepMergeInPlace } from "@blazetrails/activesupport";
 
 type TranslationValue = string | { one?: string; other?: string } | TranslationTree;
 interface TranslationTree {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1,6 +1,6 @@
 import { Errors, StrictValidationFailed } from "./errors.js";
 import { ValidationError, ValidationContext } from "./validations.js";
-import { humanize, underscore } from "@rails-ts/activesupport";
+import { humanize, underscore } from "@blazetrails/activesupport";
 import { I18n } from "./i18n.js";
 import { typeRegistry } from "./type/registry.js";
 import { Type } from "./type/value.js";

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveModel::Name
  */
-import { underscore, pluralize, humanize } from "@rails-ts/activesupport";
+import { underscore, pluralize, humanize } from "@blazetrails/activesupport";
 import { I18n } from "./i18n.js";
 
 interface ModelLike {

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcryptjs";
-import { humanize } from "@rails-ts/activesupport";
+import { humanize } from "@blazetrails/activesupport";
 import { Model } from "./model.js";
 
 const MIN_COST = 4;

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface AbsenceOptions extends ConditionalOptions {
   message?: string;

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { humanize } from "@rails-ts/activesupport";
+import { humanize } from "@blazetrails/activesupport";
 
 export interface ConfirmationOptions extends ConditionalOptions {
   message?: string;

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface ExclusionOptions extends ConditionalOptions {
   in?: unknown[] | (() => unknown[]);

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface FormatOptions extends ConditionalOptions {
   with?: RegExp | ((record: AnyRecord) => RegExp);

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface InclusionOptions extends ConditionalOptions {
   in: unknown[] | (() => unknown[]);

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface LengthOptions extends ConditionalOptions {
   minimum?: number | (() => number);

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 type NumericValue = number | ((record: AnyRecord) => number) | string;
 

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -5,7 +5,7 @@ import type {
   ValidatorContract as Validator,
 } from "../validator.js";
 import { shouldValidate } from "../validator.js";
-import { isBlank } from "@rails-ts/activesupport";
+import { isBlank } from "@blazetrails/activesupport";
 
 export interface PresenceOptions extends ConditionalOptions {
   message?: string | ((record: AnyRecord) => string);

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -1,5 +1,5 @@
 import type { Errors } from "./errors.js";
-import { isBlank, underscore } from "@rails-ts/activesupport";
+import { isBlank, underscore } from "@blazetrails/activesupport";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyRecord = any;

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@rails-ts/activerecord",
+  "name": "@blazetrails/activerecord",
   "version": "0.1.0",
-  "description": "ORM layer mirroring Ruby's ActiveRecord, built on @rails-ts/arel and @rails-ts/activemodel",
+  "description": "ORM layer mirroring Ruby's ActiveRecord, built on @blazetrails/arel and @blazetrails/activemodel",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,9 +9,9 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@rails-ts/activesupport": "workspace:*",
-    "@rails-ts/arel": "workspace:*",
-    "@rails-ts/activemodel": "workspace:*"
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/arel": "workspace:*",
+    "@blazetrails/activemodel": "workspace:*"
   },
   "files": [
     "dist"

--- a/packages/activerecord/src/adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/adapters/postgresql-adapter.ts
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { singularize, underscore } from "@rails-ts/activesupport";
+import { singularize, underscore } from "@blazetrails/activesupport";
 import { splitQuotedIdentifier } from "./postgresql/utils.js";
 import type { DatabaseAdapter } from "../adapter.js";
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { Table as ArelTable } from "@rails-ts/arel";
+import { Table as ArelTable } from "@blazetrails/arel";
 import { CollectionProxy } from "./associations/collection-proxy.js";
 import { StrictLoadingViolationError } from "./errors.js";
 import {
@@ -7,7 +7,7 @@ import {
   InverseOfAssociationNotFoundError,
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./associations/errors.js";
-import { underscore, singularize, pluralize, camelize } from "@rails-ts/activesupport";
+import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./sti.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
 import { HasOne as HasOneBuilder } from "./associations/builder/has-one.js";

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,4 +1,4 @@
-import { underscore } from "@rails-ts/activesupport";
+import { underscore } from "@blazetrails/activesupport";
 import { SingularAssociation } from "./singular-association.js";
 
 /**

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -1,4 +1,4 @@
-import { underscore, singularize, pluralize, camelize } from "@rails-ts/activesupport";
+import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 
 /**
  * Builder for has_and_belongs_to_many associations. Internally creates

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
-import { Table as ArelTable } from "@rails-ts/arel";
-import { underscore, singularize, pluralize, camelize } from "@rails-ts/activesupport";
+import { Table as ArelTable } from "@blazetrails/arel";
+import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { StrictLoadingViolationError } from "../errors.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -15,7 +15,7 @@ import {
   underscore as _toUnderscore,
   camelize as _camelize,
   singularize as _singularize,
-} from "@rails-ts/activesupport";
+} from "@blazetrails/activesupport";
 import { modelRegistry } from "../associations.js";
 import { getInheritanceColumn, isStiSubclass } from "../sti.js";
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
 import { _setValidateAssociationsFn } from "./base.js";
 import type { AssociationDefinition } from "./associations.js";
-import { underscore } from "@rails-ts/activesupport";
+import { underscore } from "@blazetrails/activesupport";
 
 const MARKED_FOR_DESTRUCTION = Symbol("markedForDestruction");
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,6 +1,6 @@
-import { Model } from "@rails-ts/activemodel";
-import { Table, quoteArrayLiteral } from "@rails-ts/arel";
-import { pluralize, underscore } from "@rails-ts/activesupport";
+import { Model } from "@blazetrails/activemodel";
+import { Table, quoteArrayLiteral } from "@blazetrails/arel";
+import { pluralize, underscore } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "./adapter.js";
 import { NameError, SubclassNotFound } from "./errors.js";
 import { modelRegistry } from "./associations.js";

--- a/packages/activerecord/src/i18n.test.ts
+++ b/packages/activerecord/src/i18n.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
-import { I18n } from "@rails-ts/activemodel";
+import { I18n } from "@blazetrails/activemodel";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -285,7 +285,7 @@ describe("InsertAllTest", () => {
   it("insert_all with raw sql on_duplicate", async () => {
     const Book = makeBookWithAdapter();
     const book = await Book.create({ title: "Existing", author: "Original" });
-    const { sql } = await import("@rails-ts/arel");
+    const { sql } = await import("@blazetrails/arel");
     const isMysql = !!process.env.MYSQL_TEST_URL;
     const expr = isMysql ? sql("`author` = VALUES(`author`)") : sql('"author" = EXCLUDED."author"');
     await Book.upsertAll([{ id: book.id, title: "Existing", author: "Updated" }], {
@@ -437,7 +437,7 @@ describe("InsertAllTest", () => {
   it("insert_all with on_duplicate raw sql", async () => {
     const Book = makeBookWithAdapter();
     const existing = await Book.create({ title: "Existing", author: "A" });
-    const { sql } = await import("@rails-ts/arel");
+    const { sql } = await import("@blazetrails/arel");
     const isMysql = !!process.env.MYSQL_TEST_URL;
     const expr = isMysql ? sql("`author` = VALUES(`author`)") : sql('"author" = EXCLUDED."author"');
     await Book.upsertAll([{ id: existing.id, title: "Existing", author: "B" }], {
@@ -537,7 +537,7 @@ describe("InsertAllTest", () => {
   it("upsert all updates using provided sql", async () => {
     const Book = makeBookWithAdapter();
     const book = await Book.create({ title: "Original", author: "Alice" });
-    const { sql } = await import("@rails-ts/arel");
+    const { sql } = await import("@blazetrails/arel");
     const isMysql = !!process.env.MYSQL_TEST_URL;
     const expr = isMysql ? sql("`author` = VALUES(`author`)") : sql('"author" = EXCLUDED."author"');
     await Book.upsertAll([{ id: book.id, title: "Original", author: "Bob" }], {
@@ -551,7 +551,7 @@ describe("InsertAllTest", () => {
   it("upsert all updates using provided sql and unique by", async () => {
     const Book = makeBookWithAdapter();
     const book = await Book.create({ title: "Original", author: "Alice", status: 0 });
-    const { sql } = await import("@rails-ts/arel");
+    const { sql } = await import("@blazetrails/arel");
     const isMysql = !!process.env.MYSQL_TEST_URL;
     const expr = isMysql ? sql("`author` = VALUES(`author`)") : sql('"author" = EXCLUDED."author"');
     await Book.upsertAll([{ id: book.id, title: "Original", author: "Bob", status: 1 }], {

--- a/packages/activerecord/src/instrumentation.test.ts
+++ b/packages/activerecord/src/instrumentation.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 
-import { Notifications } from "@rails-ts/activesupport";
+import { Notifications } from "@blazetrails/activesupport";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 

--- a/packages/activerecord/src/ordered-options.test.ts
+++ b/packages/activerecord/src/ordered-options.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { OrderedOptions, InheritableOptions } from "@rails-ts/activesupport";
+import { OrderedOptions, InheritableOptions } from "@blazetrails/activesupport";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { underscore, pluralize, singularize } from "@rails-ts/activesupport";
+import { underscore, pluralize, singularize } from "@blazetrails/activesupport";
 import { modelRegistry } from "./associations.js";
 
 /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1,4 +1,4 @@
-import { Table, SelectManager, Nodes, Visitors } from "@rails-ts/arel";
+import { Table, SelectManager, Nodes, Visitors } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotFound, SoleRecordExceeded } from "./errors.js";
@@ -9,7 +9,7 @@ import {
   camelize as _camelize,
   singularize as _singularize,
   pluralize as _pluralize,
-} from "@rails-ts/activesupport";
+} from "@blazetrails/activesupport";
 
 import { Range } from "./connection-adapters/postgresql/oid/range.js";
 export { Range };

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -1,4 +1,4 @@
-import { Table, Nodes } from "@rails-ts/arel";
+import { Table, Nodes } from "@blazetrails/arel";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 
 /**

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -1554,7 +1554,7 @@ describe("WhereTest Arel nodes", () => {
   });
 
   it("where accepts an Arel node", async () => {
-    const { Table } = await import("@rails-ts/arel");
+    const { Table } = await import("@blazetrails/arel");
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -1572,7 +1572,7 @@ describe("WhereTest Arel nodes", () => {
   });
 
   it("where accepts an Arel In node with subquery", async () => {
-    const { Table } = await import("@rails-ts/arel");
+    const { Table } = await import("@blazetrails/arel");
     class Author extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -128,7 +128,7 @@ describe("serializableHash with include", () => {
     };
     (author as any)._preloadedAssociations = new Map([["posts", [fakePost]]]);
 
-    const { serializableHash } = await import("@rails-ts/activemodel");
+    const { serializableHash } = await import("@blazetrails/activemodel");
     const hash = serializableHash(author, { include: ["posts"] });
     expect(hash.name).toBe("Alice");
     expect(Array.isArray(hash.posts)).toBe(true);

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { quote, quoteDefaultExpression } from "./quoting.js";
-import { Nodes } from "@rails-ts/arel";
+import { Nodes } from "@blazetrails/arel";
 
 describe("quote", () => {
   it("returns NULL for null", () => {

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/activesupport",
+  "name": "@blazetrails/activesupport",
   "version": "0.1.0",
   "description": "Core utilities and inflection, mirroring Ruby's ActiveSupport",
   "type": "module",

--- a/packages/arel/package.json
+++ b/packages/arel/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/arel",
+  "name": "@blazetrails/arel",
   "version": "0.1.0",
   "description": "SQL AST builder and query generation, mirroring Ruby's Arel",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/cli",
+  "name": "@blazetrails/cli",
   "version": "0.1.0",
   "type": "module",
   "bin": {
@@ -12,9 +12,9 @@
     "dist"
   ],
   "dependencies": {
-    "@rails-ts/activerecord": "workspace:*",
-    "@rails-ts/activesupport": "workspace:*",
-    "@rails-ts/rack": "workspace:*",
-    "@rails-ts/actionpack": "workspace:*"
+    "@blazetrails/activerecord": "workspace:*",
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/rack": "workspace:*",
+    "@blazetrails/actionpack": "workspace:*"
   }
 }

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -17,7 +17,7 @@ export function consoleCommand(): Command {
       const { loadDatabaseConfig, connectAdapter } = await import("../database.js");
       const config = await loadDatabaseConfig();
       dbAdapter = await connectAdapter(config);
-      const { Base } = await import("@rails-ts/activerecord");
+      const { Base } = await import("@blazetrails/activerecord");
       Base.adapter = dbAdapter;
       console.log(
         `Connected to ${config.adapter ?? "sqlite3"} (${config.database ?? "in-memory"})`,
@@ -87,7 +87,7 @@ export function consoleCommand(): Command {
 
     // Make activerecord Base available
     try {
-      const ar = await import("@rails-ts/activerecord");
+      const ar = await import("@blazetrails/activerecord");
       r.context.Base = ar.Base;
       r.context.Migration = ar.Migration;
     } catch {

--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createProgram } from "../cli.js";
 import { loadDatabaseConfig, connectAdapter, resolveEnv } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import { Migrator } from "@rails-ts/activerecord";
+import { Migrator } from "@blazetrails/activerecord";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -244,12 +244,12 @@ describe("full migration flow", () => {
   });
 
   it("migrate, status, rollback with SQLite", async () => {
-    const { SQLite3Adapter } = await import("@rails-ts/activerecord");
+    const { SQLite3Adapter } = await import("@blazetrails/activerecord");
     adapter = new SQLite3Adapter(":memory:");
 
     fs.writeFileSync(
       path.join(tmpDir, "20260101000000-create-posts.ts"),
-      `import { Migration } from "@rails-ts/activerecord";
+      `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() {
     await this.createTable("posts", (t) => {
@@ -302,7 +302,7 @@ export class CreatePosts extends Migration {
 describe("schema dump and load", () => {
   it("dumps schema from SQLite and loads it into a fresh database", async () => {
     const { SQLite3Adapter, SchemaDumper, MigrationContext } =
-      await import("@rails-ts/activerecord");
+      await import("@blazetrails/activerecord");
     const { AdapterSchemaSource } = await import("../schema-source.js");
 
     const sourceAdapter = new SQLite3Adapter(":memory:");

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -4,8 +4,8 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { loadDatabaseConfig, connectAdapter, type DatabaseConfig } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import { Migrator, SchemaDumper } from "@rails-ts/activerecord";
-import type { DatabaseAdapter } from "@rails-ts/activerecord";
+import { Migrator, SchemaDumper } from "@blazetrails/activerecord";
+import type { DatabaseAdapter } from "@blazetrails/activerecord";
 import { AdapterSchemaSource } from "../schema-source.js";
 
 // --- Helpers ---
@@ -210,7 +210,7 @@ export function dbCommand(): Command {
     .description("Run database seeds")
     .action(async () => {
       await withAdapter(async (adapter) => {
-        const { Base } = await import("@rails-ts/activerecord");
+        const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
       });
@@ -270,7 +270,7 @@ export function dbCommand(): Command {
       await runCreate();
       await withAdapter(async (adapter) => {
         await runMigrate(adapter);
-        const { Base } = await import("@rails-ts/activerecord");
+        const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
       });
@@ -283,7 +283,7 @@ export function dbCommand(): Command {
       await runCreate();
       await withAdapter(async (adapter) => {
         await runMigrate(adapter);
-        const { Base } = await import("@rails-ts/activerecord");
+        const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
       });
@@ -319,7 +319,7 @@ export function dbCommand(): Command {
       }
 
       await withAdapter(async (adapter) => {
-        const { MigrationContext } = await import("@rails-ts/activerecord");
+        const { MigrationContext } = await import("@blazetrails/activerecord");
         const ctx = new MigrationContext(adapter);
         let mod: any;
         try {

--- a/packages/cli/src/database.ts
+++ b/packages/cli/src/database.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { pathToFileURL } from "node:url";
-import type { DatabaseAdapter } from "@rails-ts/activerecord";
+import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
   adapter?: string;
@@ -88,12 +88,12 @@ export async function connectAdapter(config: DatabaseConfig): Promise<DatabaseAd
   switch (adapter) {
     case "sqlite3":
     case "sqlite": {
-      const { SQLite3Adapter } = await import("@rails-ts/activerecord");
+      const { SQLite3Adapter } = await import("@blazetrails/activerecord");
       return new SQLite3Adapter(config.database ?? ":memory:");
     }
     case "postgresql":
     case "postgres": {
-      const { PostgreSQLAdapter } = await import("@rails-ts/activerecord");
+      const { PostgreSQLAdapter } = await import("@blazetrails/activerecord");
       if (config.url) {
         return new PostgreSQLAdapter(config.url);
       }
@@ -107,7 +107,7 @@ export async function connectAdapter(config: DatabaseConfig): Promise<DatabaseAd
     }
     case "mysql2":
     case "mysql": {
-      const { Mysql2Adapter } = await import("@rails-ts/activerecord");
+      const { Mysql2Adapter } = await import("@blazetrails/activerecord");
       if (config.url) {
         return new Mysql2Adapter(config.url);
       }

--- a/packages/cli/src/generators/app-generator.test.ts
+++ b/packages/cli/src/generators/app-generator.test.ts
@@ -45,7 +45,7 @@ describe("AppGenerator", () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, "my-app/package.json"), "utf-8"));
     expect(pkg.name).toBe("my-app");
     expect(pkg.dependencies["better-sqlite3"]).toBeDefined();
-    expect(pkg.dependencies["@rails-ts/activerecord"]).toBeDefined();
+    expect(pkg.dependencies["@blazetrails/activerecord"]).toBeDefined();
   });
 
   it("configures postgres database", async () => {

--- a/packages/cli/src/generators/app-generator.ts
+++ b/packages/cli/src/generators/app-generator.ts
@@ -36,11 +36,11 @@ export class AppGenerator extends GeneratorBase {
             "db:migrate": "rails-ts db migrate",
           },
           dependencies: {
-            "@rails-ts/activerecord": "*",
-            "@rails-ts/activesupport": "*",
-            "@rails-ts/rack": "*",
-            "@rails-ts/actionpack": "*",
-            "@rails-ts/cli": "*",
+            "@blazetrails/activerecord": "*",
+            "@blazetrails/activesupport": "*",
+            "@blazetrails/rack": "*",
+            "@blazetrails/actionpack": "*",
+            "@blazetrails/cli": "*",
             ...this.dbDependency(options.database),
           },
           devDependencies: {
@@ -135,7 +135,7 @@ export function drawRoutes(router: any): void {
     // Application controller
     this.createFile(
       "src/app/controllers/application-controller.ts",
-      `import { ActionController } from "@rails-ts/actionpack";
+      `import { ActionController } from "@blazetrails/actionpack";
 
 export class ApplicationController extends ActionController.Base {
   // Base controller — all controllers inherit from this.

--- a/packages/cli/src/generators/base.ts
+++ b/packages/cli/src/generators/base.ts
@@ -5,7 +5,7 @@ import {
   camelize as _camelize,
   tableize as _tableize,
   dasherize as _dasherize,
-} from "@rails-ts/activesupport";
+} from "@blazetrails/activesupport";
 
 export interface GeneratorOptions {
   cwd: string;

--- a/packages/cli/src/generators/controller-generator.test.ts
+++ b/packages/cli/src/generators/controller-generator.test.ts
@@ -117,7 +117,7 @@ describe("ControllerGenerator (JavaScript project)", () => {
       path.join(jsTmpDir, "src/app/controllers/posts-controller.js"),
       "utf-8",
     );
-    expect(content).toContain('import { ActionController } from "@rails-ts/actionpack"');
+    expect(content).toContain('import { ActionController } from "@blazetrails/actionpack"');
     expect(content).toContain("export class PostsController");
   });
 });

--- a/packages/cli/src/generators/controller-generator.ts
+++ b/packages/cli/src/generators/controller-generator.ts
@@ -20,7 +20,7 @@ export class ControllerGenerator extends GeneratorBase {
 
     this.createFile(
       `src/app/controllers/${fileName}${ext}`,
-      `import { ActionController } from "@rails-ts/actionpack";
+      `import { ActionController } from "@blazetrails/actionpack";
 
 export class ${className} extends ActionController.Base {
 ${actionMethods}

--- a/packages/cli/src/generators/migration-generator.test.ts
+++ b/packages/cli/src/generators/migration-generator.test.ts
@@ -209,7 +209,7 @@ describe("MigrationGeneratorTest (JavaScript project)", () => {
     const gen = makeJsGen();
     const files = gen.run("CreateUsers", []);
     const content = readJsMigration(files);
-    expect(content).toContain('import { Migration } from "@rails-ts/activerecord"');
+    expect(content).toContain('import { Migration } from "@blazetrails/activerecord"');
     expect(content).not.toContain("require(");
   });
 

--- a/packages/cli/src/generators/migration-generator.ts
+++ b/packages/cli/src/generators/migration-generator.ts
@@ -116,7 +116,7 @@ export class MigrationGenerator extends GeneratorBase {
 
     this.createFile(
       filename,
-      `import { Migration } from "@rails-ts/activerecord";
+      `import { Migration } from "@blazetrails/activerecord";
 
 export class ${className} extends Migration {
   static version = "${timestamp}";

--- a/packages/cli/src/generators/model-generator.test.ts
+++ b/packages/cli/src/generators/model-generator.test.ts
@@ -32,7 +32,7 @@ describe("ModelGeneratorTest", () => {
     const gen = makeGen();
     gen.run("User", []);
     const content = fs.readFileSync(path.join(tmpDir, "src/app/models/user.ts"), "utf-8");
-    expect(content).toContain('import { Base } from "@rails-ts/activerecord"');
+    expect(content).toContain('import { Base } from "@blazetrails/activerecord"');
     expect(content).toContain("class User extends Base");
   });
 
@@ -219,7 +219,7 @@ describe("ModelGenerator (JavaScript project)", () => {
     const gen = makeJsGen();
     gen.run("User", ["name:string"]);
     const content = fs.readFileSync(path.join(jsTmpDir, "src/app/models/user.js"), "utf-8");
-    expect(content).toContain('import { Base } from "@rails-ts/activerecord"');
+    expect(content).toContain('import { Base } from "@blazetrails/activerecord"');
     expect(content).toContain("export class User");
   });
 });

--- a/packages/cli/src/generators/model-generator.ts
+++ b/packages/cli/src/generators/model-generator.ts
@@ -50,7 +50,7 @@ export class ModelGenerator extends GeneratorBase {
 
     this.createFile(
       `src/app/models/${fileName}${ext}`,
-      `import { Base } from "@rails-ts/activerecord";
+      `import { Base } from "@blazetrails/activerecord";
 
 export class ${className} extends Base {${staticBlock}}
 `,

--- a/packages/cli/src/generators/scaffold-generator.ts
+++ b/packages/cli/src/generators/scaffold-generator.ts
@@ -92,7 +92,7 @@ export class ScaffoldGenerator extends GeneratorBase {
     const ts = this.isTypeScript();
     const returnType = ts ? ": Promise<void>" : "";
 
-    return `import { ActionController } from "@rails-ts/actionpack";
+    return `import { ActionController } from "@blazetrails/actionpack";
 
 export class ${controllerClassName} extends ActionController.Base {
   async index()${returnType} {

--- a/packages/cli/src/migration-loader.ts
+++ b/packages/cli/src/migration-loader.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { MigrationProxy } from "@rails-ts/activerecord";
+import type { MigrationProxy } from "@blazetrails/activerecord";
 
 const MIGRATION_FILE_PATTERN = /^(\d+)-(.+)\.(ts|js)$/;
 
@@ -56,12 +56,12 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       filename: filePath,
       migration: () => {
         const loader = {
-          async up(adapter: import("@rails-ts/activerecord").DatabaseAdapter): Promise<void> {
+          async up(adapter: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "up");
           },
-          async down(adapter: import("@rails-ts/activerecord").DatabaseAdapter): Promise<void> {
+          async down(adapter: import("@blazetrails/activerecord").DatabaseAdapter): Promise<void> {
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
             await instance.run(adapter, "down");

--- a/packages/cli/src/schema-source.ts
+++ b/packages/cli/src/schema-source.ts
@@ -1,5 +1,5 @@
-import type { DatabaseAdapter } from "@rails-ts/activerecord";
-import type { SchemaSource, ColumnInfo, IndexInfo } from "@rails-ts/activerecord";
+import type { DatabaseAdapter } from "@blazetrails/activerecord";
+import type { SchemaSource, ColumnInfo, IndexInfo } from "@blazetrails/activerecord";
 
 /** Escape a SQLite identifier (double internal quotes). */
 function sqliteId(name: string): string {
@@ -9,7 +9,7 @@ function sqliteId(name: string): string {
 /** Detect adapter type via instanceof (falls back to constructor name for subclasses). */
 async function detectAdapter(adapter: DatabaseAdapter): Promise<"sqlite" | "postgres" | "mysql"> {
   const { SQLite3Adapter, PostgreSQLAdapter, Mysql2Adapter } =
-    await import("@rails-ts/activerecord");
+    await import("@blazetrails/activerecord");
   if (adapter instanceof PostgreSQLAdapter) return "postgres";
   if (adapter instanceof Mysql2Adapter) return "mysql";
   if (adapter instanceof SQLite3Adapter) return "sqlite";

--- a/packages/cli/src/server/application.ts
+++ b/packages/cli/src/server/application.ts
@@ -9,8 +9,8 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { pathToFileURL } from "node:url";
 
-import type { RackEnv, RackResponse } from "@rails-ts/rack";
-import { bodyFromString } from "@rails-ts/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString } from "@blazetrails/rack";
 import {
   RouteSet,
   Mapper,
@@ -18,7 +18,7 @@ import {
   Response,
   ActionController,
   ActionView,
-} from "@rails-ts/actionpack";
+} from "@blazetrails/actionpack";
 
 export interface ApplicationOptions {
   cwd: string;

--- a/packages/cli/src/server/dev-server.ts
+++ b/packages/cli/src/server/dev-server.ts
@@ -1,6 +1,6 @@
 import * as http from "node:http";
-import { bodyToString } from "@rails-ts/rack";
-import type { RackEnv } from "@rails-ts/rack";
+import { bodyToString } from "@blazetrails/rack";
+import type { RackEnv } from "@blazetrails/rack";
 import { Application } from "./application.js";
 
 export interface DevServerOptions {

--- a/packages/rack/package.json
+++ b/packages/rack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rails-ts/rack",
+  "name": "@blazetrails/rack",
   "version": "0.1.0",
   "description": "Modular web server interface, mirroring Ruby's Rack",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       pg:
         specifier: ^8.19.0
         version: 8.20.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -62,13 +65,13 @@ importers:
 
   packages/actionpack:
     dependencies:
-      "@rails-ts/rack":
+      "@blazetrails/rack":
         specifier: workspace:*
         version: link:../rack
 
   packages/activemodel:
     dependencies:
-      "@rails-ts/activesupport":
+      "@blazetrails/activesupport":
         specifier: workspace:*
         version: link:../activesupport
       bcryptjs:
@@ -80,13 +83,13 @@ importers:
 
   packages/activerecord:
     dependencies:
-      "@rails-ts/activemodel":
+      "@blazetrails/activemodel":
         specifier: workspace:*
         version: link:../activemodel
-      "@rails-ts/activesupport":
+      "@blazetrails/activesupport":
         specifier: workspace:*
         version: link:../activesupport
-      "@rails-ts/arel":
+      "@blazetrails/arel":
         specifier: workspace:*
         version: link:../arel
 
@@ -96,16 +99,16 @@ importers:
 
   packages/cli:
     dependencies:
-      "@rails-ts/actionpack":
+      "@blazetrails/actionpack":
         specifier: workspace:*
         version: link:../actionpack
-      "@rails-ts/activerecord":
+      "@blazetrails/activerecord":
         specifier: workspace:*
         version: link:../activerecord
-      "@rails-ts/activesupport":
+      "@blazetrails/activesupport":
         specifier: workspace:*
         version: link:../activesupport
-      "@rails-ts/rack":
+      "@blazetrails/rack":
         specifier: workspace:*
         version: link:../rack
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,13 +4,13 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: {
-      "@rails-ts/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
-      "@rails-ts/arel/src": path.resolve(__dirname, "packages/arel/src"),
-      "@rails-ts/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
-      "@rails-ts/activemodel": path.resolve(__dirname, "packages/activemodel/src/index.ts"),
-      "@rails-ts/activerecord": path.resolve(__dirname, "packages/activerecord/src/index.ts"),
-      "@rails-ts/rack": path.resolve(__dirname, "packages/rack/src/index.ts"),
-      "@rails-ts/actionpack": path.resolve(__dirname, "packages/actionpack/src/index.ts"),
+      "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
+      "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
+      "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
+      "@blazetrails/activemodel": path.resolve(__dirname, "packages/activemodel/src/index.ts"),
+      "@blazetrails/activerecord": path.resolve(__dirname, "packages/activerecord/src/index.ts"),
+      "@blazetrails/rack": path.resolve(__dirname, "packages/rack/src/index.ts"),
+      "@blazetrails/actionpack": path.resolve(__dirname, "packages/actionpack/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
This renames all packages from `@rails-ts/*` to `@blazetrails/*` to match the new npm org and domain. I claimed the `blazetrails` npm package, the `@blazetrails` org on npm, and the dev domain, so this should set us up for publishing under the new name.

The change is a straightforward find-and-replace across all package.json files, import paths, and config. Also resolved a few pre-existing merge conflicts in the cli package that were lurking around adapter class renames.

All 15,823 tests still pass.