### PR TITLE
feat(activerecord): implement PoolConfig lifecycle matching Rails API

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -90,4 +90,5 @@ export interface DatabaseAdapter {
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   isWriteQuery(sql: string): boolean;
   emptyInsertStatementValue(pk?: string | null): string;
+  getDatabaseVersion?(): unknown;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -63,19 +63,12 @@ export class ConnectionHandler {
     const role = options.role ?? "writing";
     const shard = options.shard ?? "default";
 
-    const poolConfig = new PoolConfig(dbConfig, {
-      role,
-      shard,
+    const connectionClass = ownerName ?? new ConnectionDescriptor(dbConfig.name);
+    const poolConfig = new PoolConfig(connectionClass, dbConfig, role, shard, {
       adapterFactory: options.adapterFactory,
     });
 
-    if (ownerName) {
-      poolConfig.connectionDescriptor = ownerName;
-    }
-
-    // Key the pool manager by the descriptor name (e.g. "Base" for primary,
-    // "MyModel" for custom connection classes, or the raw string owner).
-    const poolKey = poolConfig.connectionDescriptor?.name ?? dbConfig.name;
+    const poolKey = poolConfig.connectionDescriptor.name;
     const poolManager = this._setPoolManager(poolKey);
 
     const existingPoolConfig = poolManager.getPoolConfig(role, shard);

--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PoolConfig } from "./pool-config.js";
+import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import { SchemaReflection } from "./schema-cache.js";
+
+function makeDbConfig(name = "primary") {
+  return new HashConfig("default", name, {
+    adapter: "sqlite3",
+    database: ":memory:",
+  });
+}
+
+function makeDescriptor(name = "primary") {
+  return new ConnectionDescriptor(name);
+}
+
+describe("PoolConfig", () => {
+  let config: PoolConfig;
+
+  beforeEach(() => {
+    config = new PoolConfig(makeDescriptor(), makeDbConfig());
+  });
+
+  describe("constructor", () => {
+    it("stores role, shard, and dbConfig", () => {
+      expect(config.role).toBe("writing");
+      expect(config.shard).toBe("default");
+      expect(config.dbConfig.adapter).toBe("sqlite3");
+    });
+
+    it("sets connectionDescriptor from constructor arg", () => {
+      expect(config.connectionDescriptor).toBeInstanceOf(ConnectionDescriptor);
+      expect(config.connectionDescriptor.name).toBe("primary");
+    });
+
+    it("accepts a ConnectionOwner as first arg", () => {
+      const owner = { name: "MyModel", primaryClassQ: () => false };
+      const pc = new PoolConfig(owner, makeDbConfig());
+      expect(pc.connectionDescriptor).toBeInstanceOf(ConnectionDescriptor);
+      expect(pc.connectionDescriptor.name).toBe("MyModel");
+    });
+  });
+
+  describe("connectionDescriptor", () => {
+    it("can be set to a ConnectionDescriptor", () => {
+      const desc = new ConnectionDescriptor("other");
+      config.connectionDescriptor = desc;
+      expect(config.connectionDescriptor).toBe(desc);
+    });
+
+    it("wraps ConnectionOwner objects into ConnectionDescriptor", () => {
+      config.connectionDescriptor = { name: "MyModel", primaryClassQ: () => false };
+      expect(config.connectionDescriptor).toBeInstanceOf(ConnectionDescriptor);
+      expect(config.connectionDescriptor.name).toBe("MyModel");
+    });
+
+    it("wraps primary class owners correctly", () => {
+      config.connectionDescriptor = { name: "Base", primaryClassQ: () => true };
+      expect(config.connectionDescriptor.isPrimary).toBe(true);
+      expect(config.connectionDescriptor.name).toBe("Base");
+    });
+  });
+
+  describe("pool", () => {
+    it("lazily creates a ConnectionPool on first access", () => {
+      expect(config.poolInitialized).toBe(false);
+      const pool = config.pool;
+      expect(pool).toBeTruthy();
+      expect(config.poolInitialized).toBe(true);
+    });
+
+    it("returns the same pool on subsequent accesses", () => {
+      const pool1 = config.pool;
+      const pool2 = config.pool;
+      expect(pool1).toBe(pool2);
+    });
+  });
+
+  describe("disconnectBang", () => {
+    it("is a no-op when pool is not initialized", () => {
+      expect(() => config.disconnectBang()).not.toThrow();
+    });
+
+    it("disconnects the pool when initialized", () => {
+      const pool = config.pool;
+      const spy = vi.spyOn(pool, "disconnect");
+      config.disconnectBang();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe("discardPoolBang", () => {
+    it("is a no-op when pool is not initialized", () => {
+      expect(() => config.discardPoolBang()).not.toThrow();
+      expect(config.poolInitialized).toBe(false);
+    });
+
+    it("disconnects and nulls the pool", () => {
+      const pool = config.pool;
+      expect(config.poolInitialized).toBe(true);
+      const spy = vi.spyOn(pool, "disconnect");
+      config.discardPoolBang();
+      expect(spy).toHaveBeenCalled();
+      expect(config.poolInitialized).toBe(false);
+    });
+
+    it("creates a new pool after discard", () => {
+      const pool1 = config.pool;
+      config.discardPoolBang();
+      const pool2 = config.pool;
+      expect(pool2).not.toBe(pool1);
+    });
+  });
+
+  describe("schemaReflection", () => {
+    it("lazily creates a SchemaReflection", () => {
+      const ref = config.schemaReflection;
+      expect(ref).toBeInstanceOf(SchemaReflection);
+    });
+
+    it("can be set", () => {
+      const custom = new SchemaReflection(null);
+      config.schemaReflection = custom;
+      expect(config.schemaReflection).toBe(custom);
+    });
+  });
+
+  describe("serverVersion", () => {
+    it("returns a function that caches the version from a connection", () => {
+      const mockConn = { getDatabaseVersion: vi.fn().mockReturnValue("3.39.0") };
+      const version = config.serverVersion(mockConn as any);
+      expect(version).toBe("3.39.0");
+      expect(mockConn.getDatabaseVersion).toHaveBeenCalledTimes(1);
+
+      config.serverVersion(mockConn as any);
+      expect(mockConn.getDatabaseVersion).toHaveBeenCalledTimes(1);
+    });
+
+    it("can be set directly via the setter", () => {
+      config.serverVersion = "15.0";
+      const mockConn = { getDatabaseVersion: vi.fn() };
+      const version = config.serverVersion(mockConn as any);
+      expect(version).toBe("15.0");
+      expect(mockConn.getDatabaseVersion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("static discardPoolsBang", () => {
+    it("discards pools on all tracked instances", () => {
+      const c1 = new PoolConfig(makeDescriptor("a"), makeDbConfig("a"));
+      const c2 = new PoolConfig(makeDescriptor("b"), makeDbConfig("b"));
+      void c1.pool;
+      void c2.pool;
+      expect(c1.poolInitialized).toBe(true);
+      expect(c2.poolInitialized).toBe(true);
+      PoolConfig.discardPoolsBang();
+      expect(c1.poolInitialized).toBe(false);
+      expect(c2.poolInitialized).toBe(false);
+    });
+  });
+
+  describe("static disconnectAllBang", () => {
+    it("disconnects all tracked instances", () => {
+      const c1 = new PoolConfig(makeDescriptor("a"), makeDbConfig("a"));
+      const c2 = new PoolConfig(makeDescriptor("b"), makeDbConfig("b"));
+      const pool1 = c1.pool;
+      const pool2 = c2.pool;
+      const spy1 = vi.spyOn(pool1, "disconnect");
+      const spy2 = vi.spyOn(pool2, "disconnect");
+      PoolConfig.disconnectAllBang();
+      expect(spy1).toHaveBeenCalled();
+      expect(spy2).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -9,6 +9,15 @@ import type { DatabaseAdapter } from "../adapter.js";
 import type { SchemaCache } from "./schema-cache.js";
 import { ConnectionPool } from "./abstract/connection-pool.js";
 import { ConnectionDescriptor, type ConnectionOwner } from "./abstract/connection-descriptor.js";
+import { SchemaReflection } from "./schema-cache.js";
+
+const INSTANCES = new Set<WeakRef<PoolConfig>>();
+const registry =
+  typeof FinalizationRegistry !== "undefined"
+    ? new FinalizationRegistry<WeakRef<PoolConfig>>((ref) => {
+        INSTANCES.delete(ref);
+      })
+    : null;
 
 export class PoolConfig {
   readonly role: string;
@@ -17,20 +26,60 @@ export class PoolConfig {
   readonly adapterFactory?: () => DatabaseAdapter;
   private _schemaCache: SchemaCache | null = null;
   private _pool: ConnectionPool | null = null;
-  private _connectionDescriptor: ConnectionDescriptor | null = null;
+  private _connectionDescriptor!: ConnectionDescriptor;
+  private _schemaReflection: SchemaReflection | null = null;
+  private _serverVersion: unknown;
+  private _serverVersionCached = false;
+  private _serverVersionFn: ((connection: DatabaseAdapter) => unknown) | null = null;
 
   constructor(
+    connectionClass: ConnectionDescriptor | ConnectionOwner,
     dbConfig: DatabaseConfig,
+    role: string = "writing",
+    shard: string = "default",
     options: {
-      role?: string;
-      shard?: string;
       adapterFactory?: () => DatabaseAdapter;
     } = {},
   ) {
+    this.connectionDescriptor = connectionClass;
     this.dbConfig = dbConfig;
-    this.role = options.role ?? "writing";
-    this.shard = options.shard ?? "default";
+    this.role = role;
+    this.shard = shard;
     this.adapterFactory = options.adapterFactory;
+
+    const ref = new WeakRef(this);
+    INSTANCES.add(ref);
+    registry?.register(this, ref);
+  }
+
+  get schemaReflection(): SchemaReflection {
+    if (!this._schemaReflection) {
+      this._schemaReflection = new SchemaReflection(null);
+    }
+    return this._schemaReflection;
+  }
+
+  set schemaReflection(value: SchemaReflection) {
+    this._schemaReflection = value;
+  }
+
+  get serverVersion(): (connection: DatabaseAdapter) => unknown {
+    if (!this._serverVersionFn) {
+      this._serverVersionFn = (connection: DatabaseAdapter) => {
+        if (!this._serverVersionCached) {
+          this._serverVersion = connection.getDatabaseVersion?.();
+          this._serverVersionCached = true;
+        }
+        return this._serverVersion;
+      };
+    }
+    return this._serverVersionFn;
+  }
+
+  set serverVersion(value: unknown) {
+    this._serverVersion = value;
+    this._serverVersionCached = true;
+    this._serverVersionFn = null;
   }
 
   get pool(): ConnectionPool {
@@ -48,9 +97,45 @@ export class PoolConfig {
     return this._pool !== null;
   }
 
+  disconnectBang(options: { automaticReconnect?: boolean } = {}): void {
+    if (!this._pool) return;
+    if (options.automaticReconnect !== undefined) {
+      (this._pool as any).automaticReconnect = options.automaticReconnect;
+    }
+    this._pool.disconnect();
+  }
+
   disconnect(): void {
     if (this._pool) {
       this._pool.disconnect();
+    }
+  }
+
+  discardPoolBang(): void {
+    if (!this._pool) return;
+    this._pool.disconnect();
+    this._pool = null;
+  }
+
+  static discardPoolsBang(): void {
+    for (const ref of INSTANCES) {
+      const config = ref.deref();
+      if (!config) {
+        INSTANCES.delete(ref);
+        continue;
+      }
+      config.discardPoolBang();
+    }
+  }
+
+  static disconnectAllBang(): void {
+    for (const ref of INSTANCES) {
+      const config = ref.deref();
+      if (!config) {
+        INSTANCES.delete(ref);
+        continue;
+      }
+      config.disconnectBang({ automaticReconnect: true });
     }
   }
 
@@ -74,10 +159,7 @@ export class PoolConfig {
     return `${this.connectionSpecName}:${this.role}:${this.shard}`;
   }
 
-  /**
-   * Mirrors: ActiveRecord::ConnectionAdapters::PoolConfig#connection_descriptor=
-   */
-  get connectionDescriptor(): ConnectionDescriptor | null {
+  get connectionDescriptor(): ConnectionDescriptor {
     return this._connectionDescriptor;
   }
 

--- a/packages/activerecord/src/connection-adapters/pool-manager.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { PoolManager } from "./pool-manager.js";
 import { PoolConfig } from "./pool-config.js";
+import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 
 function makePoolConfig(name: string, opts: { role?: string; shard?: string } = {}): PoolConfig {
+  const role = opts.role ?? "writing";
+  const shard = opts.shard ?? "default";
   const dbConfig = new HashConfig("default", name, {
     adapter: "sqlite3",
     database: ":memory:",
   });
-  return new PoolConfig(dbConfig, {
-    role: opts.role ?? "writing",
-    shard: opts.shard ?? "default",
-  });
+  return new PoolConfig(new ConnectionDescriptor(name), dbConfig, role, shard);
 }
 
 describe("PoolManager", () => {


### PR DESCRIPTION
## Summary

- Adds PoolConfig lifecycle methods to reach **100%** in api:compare (12/12)
- `schemaReflection` lazy getter/setter backed by SchemaReflection
- `serverVersion` getter returns a memoized cached lookup function, setter allows direct assignment
- `disconnectBang()` disconnects pool if initialized, no-op otherwise
- `discardPoolBang()` disconnects and nulls the pool for re-creation
- Static `discardPoolsBang()` / `disconnectAllBang()` using WeakRef instance tracking with dead-ref cleanup during iteration
- `getDatabaseVersion` added to DatabaseAdapter interface for type safety
- Builds on #475's ConnectionDescriptor and connection_class foundation

## Test plan

- [x] New `pool-config.test.ts` with 17 tests covering all lifecycle methods
- [x] pool-manager and connection-handler tests passing
- [x] establish-connection tests passing
- [x] api:compare confirms 100% for pool_config.rb (12/12)