### PR TITLE
feat(activerecord): implement Queue + Reaper to match Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -48,8 +48,9 @@ describe("ConnectionPool::Queue", () => {
     try {
       const q = new Queue();
       const promise = q.poll(5) as Promise<DatabaseAdapter>;
+      const rejection = expect(promise).rejects.toThrow(ConnectionTimeoutError);
       vi.advanceTimersByTime(5000);
-      await expect(promise).rejects.toThrow(ConnectionTimeoutError);
+      await rejection;
     } finally {
       vi.useRealTimers();
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -239,7 +239,7 @@ describe("ConnectionPool::BiasableQueue", () => {
     const c = fakeConn();
 
     let innerPromise: Promise<DatabaseAdapter>;
-    BiasableQueue.prototype.withABiasFor.call(q, "ctx", () => {
+    BiasableQueue.withABiasFor.call(q as any, "ctx", () => {
       innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
     });
 
@@ -257,7 +257,7 @@ describe("ConnectionPool::BiasableQueue", () => {
       const c = fakeConn();
 
       let innerPromise: Promise<DatabaseAdapter>;
-      BiasableQueue.prototype.withABiasFor.call(q, "ctx", () => {
+      BiasableQueue.withABiasFor.call(q as any, "ctx", () => {
         innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
       });
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Queue, ConnectionLeasingQueue, BiasedConditionVariable, BiasableQueue } from "./queue.js";
 import type { DatabaseAdapter } from "../../../adapter.js";
 import { ConnectionTimeoutError } from "../../../errors.js";
@@ -44,9 +44,15 @@ describe("ConnectionPool::Queue", () => {
   });
 
   it("poll with timeout throws ConnectionTimeoutError", async () => {
-    const q = new Queue();
-    const promise = q.poll(0.01) as Promise<DatabaseAdapter>;
-    await expect(promise).rejects.toThrow(ConnectionTimeoutError);
+    vi.useFakeTimers();
+    try {
+      const q = new Queue();
+      const promise = q.poll(5) as Promise<DatabaseAdapter>;
+      vi.advanceTimersByTime(5000);
+      await expect(promise).rejects.toThrow(ConnectionTimeoutError);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("fairness: no-wait poll blocked when waiters exist", async () => {
@@ -138,17 +144,35 @@ describe("ConnectionPool::BiasedConditionVariable", () => {
     expect(cv.signal(fakeConn())).toBe(false);
   });
 
-  it("broadcastOnBiased resolves local waiters", async () => {
+  it("broadcastOnBiased resolves local waiters and returns remainder", async () => {
     const cv = new BiasedConditionVariable();
     const p1 = cv.wait(1);
     const p2 = cv.wait(1);
 
     const c1 = fakeConn(1);
     const c2 = fakeConn(2);
-    cv.broadcastOnBiased([c1, c2]);
+    const c3 = fakeConn(3);
+    const remaining = cv.broadcastOnBiased([c1, c2, c3]);
 
     expect(await p1).toBe(c1);
     expect(await p2).toBe(c2);
+    expect(remaining).toEqual([c3]);
+  });
+
+  it("broadcast does not double-deliver connections", async () => {
+    const other = new BiasedConditionVariable();
+    const biased = new BiasedConditionVariable(undefined, other);
+
+    const pBiased = biased.wait(1);
+    const pOther = other.wait(1);
+
+    const c1 = fakeConn(1);
+    const c2 = fakeConn(2);
+    biased.broadcast([c1, c2]);
+
+    // c1 goes to biased, c2 goes to other — no double-delivery
+    expect(await pBiased).toBe(c1);
+    expect(await pOther).toBe(c2);
   });
 
   it("signal delegates to otherCond when no local waiters", async () => {
@@ -170,9 +194,7 @@ describe("ConnectionPool::BiasedConditionVariable", () => {
 
     const c1 = fakeConn(1);
     const c2 = fakeConn(2);
-    // First signal goes to biased (local) waiter
     expect(biased.signal(c1)).toBe(true);
-    // Second signal falls through to other
     expect(biased.signal(c2)).toBe(true);
 
     expect(await pBiased).toBe(c1);
@@ -196,17 +218,39 @@ describe("ConnectionPool::BiasableQueue", () => {
     expect(BiasableQueue.BiasedConditionVariable).toBe(BiasedConditionVariable);
   });
 
-  it("withABiasFor restores cond and wakes biased sleepers", async () => {
+  it("withABiasFor restores cond and transfers orphaned waiters", async () => {
     const q = new ConnectionLeasingQueue();
     const c = fakeConn();
 
-    // withABiasFor swaps cond, runs fn, restores cond
     let innerCond: unknown;
+    const outerCond = (q as any)._cond;
+
     q.withABiasFor("ctx", () => {
       innerCond = (q as any)._cond;
+      // innerCond is the temporary biased cond
+      expect(innerCond).not.toBe(outerCond);
     });
-    // After withABiasFor, cond should be restored
-    expect((q as any)._cond).not.toBe(innerCond);
+
+    // After withABiasFor, cond should be restored to the original
+    expect((q as any)._cond).toBe(outerCond);
+  });
+
+  it("withABiasFor migrates pending waiters to restored cond", async () => {
+    const q = new Queue();
+    const c = fakeConn();
+
+    // Create a waiter inside the biased section
+    let innerPromise: Promise<DatabaseAdapter>;
+    // Use BiasableQueue.prototype directly since Queue doesn't have withABiasFor
+    BiasableQueue.prototype.withABiasFor.call(q, "ctx", () => {
+      innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
+    });
+
+    // The waiter was on the biased cond, but should have been
+    // transferred to the restored cond. An add() should reach it.
+    q.add(c);
+    const result = await innerPromise!;
+    expect(result).toBe(c);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -239,9 +239,7 @@ describe("ConnectionPool::BiasableQueue", () => {
     const q = new Queue();
     const c = fakeConn();
 
-    // Create a waiter inside the biased section
     let innerPromise: Promise<DatabaseAdapter>;
-    // Use BiasableQueue.prototype directly since Queue doesn't have withABiasFor
     BiasableQueue.prototype.withABiasFor.call(q, "ctx", () => {
       innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
     });
@@ -251,6 +249,30 @@ describe("ConnectionPool::BiasableQueue", () => {
     q.add(c);
     const result = await innerPromise!;
     expect(result).toBe(c);
+  });
+
+  it("timed-out migrated waiter does not consume future connections", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new Queue();
+      const c = fakeConn();
+
+      let innerPromise: Promise<DatabaseAdapter>;
+      BiasableQueue.prototype.withABiasFor.call(q, "ctx", () => {
+        innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
+      });
+
+      // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
+      const rejection = expect(innerPromise!).rejects.toBeInstanceOf(ConnectionTimeoutError);
+      await vi.advanceTimersByTimeAsync(6000);
+      await rejection;
+
+      // A subsequent add should go to the queue, not a stale waiter
+      q.add(c);
+      expect(q.poll()).toBe(c);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import { Queue, ConnectionLeasingQueue, BiasedConditionVariable, BiasableQueue } from "./queue.js";
+import type { DatabaseAdapter } from "../../../adapter.js";
+import { ConnectionTimeoutError } from "../../../errors.js";
+
+function fakeConn(id = 1): DatabaseAdapter {
+  return { id } as unknown as DatabaseAdapter;
+}
+
+describe("ConnectionPool::Queue", () => {
+  it("add and poll without waiting", () => {
+    const q = new Queue();
+    const c1 = fakeConn(1);
+    const c2 = fakeConn(2);
+
+    q.add(c1);
+    q.add(c2);
+    expect(q.length).toBe(2);
+
+    // poll without timeout returns LIFO (pop)
+    const out = q.poll();
+    expect(out).toBe(c2);
+    expect(q.length).toBe(1);
+  });
+
+  it("poll returns undefined when empty and no timeout", () => {
+    const q = new Queue();
+    expect(q.poll()).toBeUndefined();
+  });
+
+  it("poll with timeout waits for add", async () => {
+    const q = new Queue();
+    const c = fakeConn();
+
+    const promise = q.poll(1) as Promise<DatabaseAdapter>;
+    expect(q.isAnyWaiting()).toBe(true);
+    expect(q.numWaiting()).toBe(1);
+
+    // add resolves the waiting poll via signal
+    q.add(c);
+    const result = await promise;
+    expect(result).toBe(c);
+    expect(q.numWaiting()).toBe(0);
+  });
+
+  it("poll with timeout throws ConnectionTimeoutError", async () => {
+    const q = new Queue();
+    const promise = q.poll(0.01) as Promise<DatabaseAdapter>;
+    await expect(promise).rejects.toThrow(ConnectionTimeoutError);
+  });
+
+  it("fairness: no-wait poll blocked when waiters exist", async () => {
+    const q = new Queue();
+    const c = fakeConn();
+
+    // Start a waiter
+    const promise = q.poll(1) as Promise<DatabaseAdapter>;
+    expect(q.numWaiting()).toBe(1);
+
+    // Add a connection — it goes to the waiter, not the queue
+    q.add(c);
+    expect(q.length).toBe(0);
+
+    // A no-wait poll should get nothing
+    expect(q.poll()).toBeUndefined();
+
+    await promise;
+  });
+
+  it("delete removes and returns element", () => {
+    const q = new Queue();
+    const c1 = fakeConn(1);
+    const c2 = fakeConn(2);
+
+    q.add(c1);
+    q.add(c2);
+
+    expect(q.delete(c1)).toBe(c1);
+    expect(q.length).toBe(1);
+    expect(q.delete(fakeConn(99))).toBeUndefined();
+  });
+
+  it("clear empties queue and returns elements", () => {
+    const q = new Queue();
+    q.add(fakeConn(1));
+    q.add(fakeConn(2));
+
+    const cleared = q.clear();
+    expect(cleared).toHaveLength(2);
+    expect(q.length).toBe(0);
+  });
+
+  it("isAnyWaiting and numWaiting", async () => {
+    const q = new Queue();
+    expect(q.isAnyWaiting()).toBe(false);
+    expect(q.numWaiting()).toBe(0);
+
+    const p = q.poll(1) as Promise<DatabaseAdapter>;
+    expect(q.isAnyWaiting()).toBe(true);
+    expect(q.numWaiting()).toBe(1);
+
+    q.add(fakeConn());
+    await p;
+
+    expect(q.isAnyWaiting()).toBe(false);
+    expect(q.numWaiting()).toBe(0);
+  });
+
+  it("any reflects queue state", () => {
+    const q = new Queue();
+    expect(q.any).toBe(false);
+    q.add(fakeConn());
+    expect(q.any).toBe(true);
+  });
+});
+
+describe("ConnectionPool::BiasedConditionVariable", () => {
+  it("constructor accepts lock, otherCond, preferredThread", () => {
+    const cv = new BiasedConditionVariable({}, null, "thread-1");
+    expect(cv.waitingCount).toBe(0);
+  });
+
+  it("signal resolves a waiter", async () => {
+    const cv = new BiasedConditionVariable();
+    const p = cv.wait(1);
+    expect(cv.waitingCount).toBe(1);
+
+    const c = fakeConn();
+    expect(cv.signal(c)).toBe(true);
+    expect(cv.waitingCount).toBe(0);
+
+    const result = await p;
+    expect(result).toBe(c);
+  });
+
+  it("signal returns false when no waiters", () => {
+    const cv = new BiasedConditionVariable();
+    expect(cv.signal(fakeConn())).toBe(false);
+  });
+
+  it("broadcastOnBiased resolves local waiters", async () => {
+    const cv = new BiasedConditionVariable();
+    const p1 = cv.wait(1);
+    const p2 = cv.wait(1);
+
+    const c1 = fakeConn(1);
+    const c2 = fakeConn(2);
+    cv.broadcastOnBiased([c1, c2]);
+
+    expect(await p1).toBe(c1);
+    expect(await p2).toBe(c2);
+  });
+
+  it("signal delegates to otherCond when no local waiters", async () => {
+    const other = new BiasedConditionVariable();
+    const biased = new BiasedConditionVariable(undefined, other);
+
+    const p = other.wait(1);
+    const c = fakeConn();
+    expect(biased.signal(c)).toBe(true);
+    expect(await p).toBe(c);
+  });
+
+  it("signal prefers local waiters over otherCond", async () => {
+    const other = new BiasedConditionVariable();
+    const biased = new BiasedConditionVariable(undefined, other);
+
+    const pBiased = biased.wait(1);
+    const pOther = other.wait(1);
+
+    const c1 = fakeConn(1);
+    const c2 = fakeConn(2);
+    // First signal goes to biased (local) waiter
+    expect(biased.signal(c1)).toBe(true);
+    // Second signal falls through to other
+    expect(biased.signal(c2)).toBe(true);
+
+    expect(await pBiased).toBe(c1);
+    expect(await pOther).toBe(c2);
+  });
+
+  it("broadcast propagates to otherCond", async () => {
+    const other = new BiasedConditionVariable();
+    const biased = new BiasedConditionVariable(undefined, other);
+
+    const pOther = other.wait(1);
+    const c = fakeConn();
+    biased.broadcast([c]);
+
+    expect(await pOther).toBe(c);
+  });
+});
+
+describe("ConnectionPool::BiasableQueue", () => {
+  it("exposes BiasedConditionVariable", () => {
+    expect(BiasableQueue.BiasedConditionVariable).toBe(BiasedConditionVariable);
+  });
+
+  it("withABiasFor restores cond and wakes biased sleepers", async () => {
+    const q = new ConnectionLeasingQueue();
+    const c = fakeConn();
+
+    // withABiasFor swaps cond, runs fn, restores cond
+    let innerCond: unknown;
+    q.withABiasFor("ctx", () => {
+      innerCond = (q as any)._cond;
+    });
+    // After withABiasFor, cond should be restored
+    expect((q as any)._cond).not.toBe(innerCond);
+  });
+});
+
+describe("ConnectionPool::ConnectionLeasingQueue", () => {
+  it("withABiasFor delegates to BiasableQueue", () => {
+    const q = new ConnectionLeasingQueue();
+    let called = false;
+    q.withABiasFor("ctx", () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+  });
+
+  it("poll calls lease on returned connection", () => {
+    const q = new ConnectionLeasingQueue();
+    let leased = false;
+    const c = fakeConn();
+    (c as any).lease = () => {
+      leased = true;
+    };
+    q.add(c);
+    q.poll();
+    expect(leased).toBe(true);
+  });
+
+  it("async poll calls lease on returned connection", async () => {
+    const q = new ConnectionLeasingQueue();
+    let leased = false;
+    const c = fakeConn();
+    (c as any).lease = () => {
+      leased = true;
+    };
+
+    const promise = q.poll(1) as Promise<DatabaseAdapter>;
+    q.add(c);
+    await promise;
+    expect(leased).toBe(true);
+  });
+
+  it("leaseTo/unlease/leasedTo track leases", () => {
+    const q = new ConnectionLeasingQueue();
+    const c = fakeConn();
+
+    q.leaseTo(c, "thread-1");
+    expect(q.leasedTo(c)).toBe("thread-1");
+
+    q.unlease(c);
+    expect(q.leasedTo(c)).toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -220,7 +220,6 @@ describe("ConnectionPool::BiasableQueue", () => {
 
   it("withABiasFor restores cond and transfers orphaned waiters", async () => {
     const q = new ConnectionLeasingQueue();
-    const c = fakeConn();
 
     let innerCond: unknown;
     const outerCond = (q as any)._cond;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -192,6 +192,8 @@ export class Queue {
     return false;
   }
 
+  poll(): DatabaseAdapter | undefined;
+  poll(timeout: number): Promise<DatabaseAdapter> | DatabaseAdapter;
   poll(timeout?: number): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
     return this.internalPoll(timeout);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -79,17 +79,30 @@ export class BiasedConditionVariable {
   }
 
   broadcast(connections: DatabaseAdapter[]): void {
-    this.broadcastOnBiased(connections);
-    if (this._otherCond) {
-      this._otherCond.broadcast(connections);
+    const remaining = this.broadcastOnBiased(connections);
+    if (this._otherCond && remaining.length > 0) {
+      this._otherCond.broadcast(remaining);
     }
   }
 
-  broadcastOnBiased(connections: DatabaseAdapter[]): void {
-    for (const conn of connections) {
-      const waiter = this._waiters.shift();
-      if (!waiter) break;
-      waiter(conn);
+  broadcastOnBiased(connections: DatabaseAdapter[]): DatabaseAdapter[] {
+    let i = 0;
+    while (i < connections.length && this._waiters.length > 0) {
+      const waiter = this._waiters.shift()!;
+      waiter(connections[i]);
+      i++;
+    }
+    return connections.slice(i);
+  }
+
+  /**
+   * Transfer all pending waiters to another condition variable.
+   * Used by withABiasFor cleanup to migrate orphaned waiters back to
+   * the restored cond so they can be signaled by future add() calls.
+   */
+  transferWaitersTo(target: BiasedConditionVariable): void {
+    while (this._waiters.length > 0) {
+      target._waiters.push(this._waiters.shift()!);
     }
   }
 }
@@ -114,7 +127,7 @@ export class BiasableQueue {
       return fn();
     } finally {
       this._cond = previousCond;
-      newCond.broadcastOnBiased([]);
+      newCond.transferWaitersTo(previousCond);
     }
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -21,6 +21,12 @@ import { ConnectionTimeoutError } from "../../../errors.js";
  * is structurally a no-op, but we implement the full API so that callers
  * (ConnectionLeasingQueue, withABiasFor) work identically.
  */
+interface WaiterState {
+  container: Array<(conn: DatabaseAdapter) => void>;
+  timer: ReturnType<typeof setTimeout> | null;
+  settled: boolean;
+}
+
 export class BiasedConditionVariable {
   private _waiters: Array<(conn: DatabaseAdapter) => void> = [];
   private _otherCond: BiasedConditionVariable | null;
@@ -39,18 +45,27 @@ export class BiasedConditionVariable {
 
   wait(timeout: number): Promise<DatabaseAdapter> {
     return new Promise((resolve, reject) => {
-      const state = { timer: null as ReturnType<typeof setTimeout> | null };
-
-      const waiter = (conn: DatabaseAdapter) => {
-        if (state.timer) clearTimeout(state.timer);
-        const idx = this._waiters.indexOf(waiter);
-        if (idx >= 0) this._waiters.splice(idx, 1);
-        resolve(conn);
+      const state: WaiterState = {
+        container: this._waiters,
+        timer: null,
+        settled: false,
       };
 
+      const waiter = (conn: DatabaseAdapter) => {
+        if (state.settled) return;
+        state.settled = true;
+        if (state.timer) clearTimeout(state.timer);
+        const idx = state.container.indexOf(waiter);
+        if (idx >= 0) state.container.splice(idx, 1);
+        resolve(conn);
+      };
+      (waiter as any)._state = state;
+
       state.timer = setTimeout(() => {
-        const idx = this._waiters.indexOf(waiter);
-        if (idx >= 0) this._waiters.splice(idx, 1);
+        if (state.settled) return;
+        state.settled = true;
+        const idx = state.container.indexOf(waiter);
+        if (idx >= 0) state.container.splice(idx, 1);
         const msg =
           `could not obtain a connection from the pool within ${timeout.toFixed(3)} seconds; ` +
           `all pooled connections were in use`;
@@ -99,10 +114,17 @@ export class BiasedConditionVariable {
    * Transfer all pending waiters to another condition variable.
    * Used by withABiasFor cleanup to migrate orphaned waiters back to
    * the restored cond so they can be signaled by future add() calls.
+   * Updates each waiter's container ref so timeout cleanup targets
+   * the correct array.
    */
   transferWaitersTo(target: BiasedConditionVariable): void {
     while (this._waiters.length > 0) {
-      target._waiters.push(this._waiters.shift()!);
+      const waiter = this._waiters.shift()!;
+      const waiterState = (waiter as any)._state as WaiterState | undefined;
+      if (waiterState) {
+        waiterState.container = target._waiters;
+      }
+      target._waiters.push(waiter);
     }
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -54,7 +54,10 @@ export class BiasedConditionVariable {
       const waiter = (conn: DatabaseAdapter) => {
         if (state.settled) return;
         state.settled = true;
-        if (state.timer) clearTimeout(state.timer);
+        if (state.timer != null) {
+          clearTimeout(state.timer);
+          state.timer = null;
+        }
         const idx = state.container.indexOf(waiter);
         if (idx >= 0) state.container.splice(idx, 1);
         resolve(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -8,9 +8,24 @@ import type { DatabaseAdapter } from "../../../adapter.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::BiasableQueue::BiasedConditionVariable
+ *
+ * In Rails this is a condition variable that preferentially wakes a biased thread.
+ * In TS (single-threaded), we model the same API using Promise-based waiters.
+ * The `otherCond` and `preferredThread` params exist for API parity but the
+ * bias behavior is a no-op in a single-threaded environment.
  */
 export class BiasedConditionVariable {
   private _waiters: Array<(conn: DatabaseAdapter) => void> = [];
+  private _otherCond: BiasedConditionVariable | null;
+  private _numWaitingOnRealCond = 0;
+
+  constructor(
+    _lock?: unknown,
+    otherCond?: BiasedConditionVariable | null,
+    _preferredThread?: unknown,
+  ) {
+    this._otherCond = otherCond ?? null;
+  }
 
   get waitingCount(): number {
     return this._waiters.length;
@@ -47,6 +62,14 @@ export class BiasedConditionVariable {
   }
 
   broadcast(connections: DatabaseAdapter[]): void {
+    this.broadcastOnBiased(connections);
+    if (this._otherCond) {
+      this._otherCond.broadcast(connections);
+    }
+  }
+
+  broadcastOnBiased(connections: DatabaseAdapter[]): void {
+    this._numWaitingOnRealCond = 0;
     for (const conn of connections) {
       if (!this.signal(conn)) break;
     }
@@ -55,9 +78,30 @@ export class BiasedConditionVariable {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::BiasableQueue
+ *
+ * In Rails this is a module included into ConnectionLeasingQueue that adds
+ * `with_a_bias_for(thread)` to temporarily bias the queue's condition variable
+ * toward a specific thread. In TS (single-threaded), we implement the API
+ * for parity; the bias is effectively a no-op.
  */
-export interface BiasableQueue {
-  readonly BiasedConditionVariable: typeof BiasedConditionVariable;
+export class BiasableQueue {
+  static BiasedConditionVariable = BiasedConditionVariable;
+
+  /** @internal — subclass must provide */
+  protected _cond!: BiasedConditionVariable;
+
+  withABiasFor<T>(context: unknown, fn: () => T): T {
+    const previousCond = this._cond;
+    const newCond = new BiasedConditionVariable(undefined, this._cond, context);
+    this._cond = newCond;
+    try {
+      return fn();
+    } finally {
+      this._cond = previousCond;
+      // wake up any remaining sleepers on the biased cond
+      newCond.broadcastOnBiased([]);
+    }
+  }
 }
 
 /**
@@ -65,14 +109,27 @@ export interface BiasableQueue {
  */
 export class Queue {
   private _queue: DatabaseAdapter[] = [];
-  private _cv = new BiasedConditionVariable();
+  protected _cond: BiasedConditionVariable;
+  private _numWaiting = 0;
+
+  constructor(lock?: unknown) {
+    this._cond = new BiasedConditionVariable(lock);
+  }
 
   get length(): number {
     return this._queue.length;
   }
 
   get waitingCount(): number {
-    return this._cv.waitingCount;
+    return this._cond.waitingCount;
+  }
+
+  isAnyWaiting(): boolean {
+    return this._numWaiting > 0;
+  }
+
+  numWaiting(): number {
+    return this._numWaiting;
   }
 
   get any(): boolean {
@@ -80,9 +137,17 @@ export class Queue {
   }
 
   add(conn: DatabaseAdapter): void {
-    if (!this._cv.signal(conn)) {
-      this._queue.push(conn);
+    this._queue.push(conn);
+    this._cond.signal(conn);
+  }
+
+  delete(element: DatabaseAdapter): DatabaseAdapter | undefined {
+    const idx = this._queue.indexOf(element);
+    if (idx >= 0) {
+      this._queue.splice(idx, 1);
+      return element;
     }
+    return undefined;
   }
 
   remove(conn: DatabaseAdapter): boolean {
@@ -94,16 +159,35 @@ export class Queue {
     return false;
   }
 
-  poll(timeout: number): Promise<DatabaseAdapter> {
-    const conn = this._queue.shift();
-    if (conn) return Promise.resolve(conn);
-    return this._cv.wait(timeout);
+  poll(timeout?: number): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
+    const conn = this.noWaitPoll();
+    if (conn) return conn;
+    if (timeout != null) return this.waitPoll(timeout);
+    return undefined;
   }
 
   clear(): DatabaseAdapter[] {
     const items = [...this._queue];
     this._queue = [];
     return items;
+  }
+
+  private canRemoveNoWait(): boolean {
+    return this._queue.length > this._numWaiting;
+  }
+
+  private noWaitPoll(): DatabaseAdapter | undefined {
+    if (this.canRemoveNoWait()) {
+      return this._queue.pop();
+    }
+    return undefined;
+  }
+
+  private waitPoll(timeout: number): Promise<DatabaseAdapter> {
+    this._numWaiting++;
+    return this._cond.wait(timeout).finally(() => {
+      this._numWaiting--;
+    });
   }
 }
 
@@ -112,6 +196,10 @@ export class Queue {
  */
 export class ConnectionLeasingQueue extends Queue {
   private _leasedTo = new Map<DatabaseAdapter, string>();
+
+  withABiasFor<T>(context: unknown, fn: () => T): T {
+    return BiasableQueue.prototype.withABiasFor.call(this, context, fn) as T;
+  }
 
   leaseTo(conn: DatabaseAdapter, key: string): void {
     this._leasedTo.set(conn, key);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -12,6 +12,7 @@
 
 import type { DatabaseAdapter } from "../../../adapter.js";
 import { ConnectionTimeoutError } from "../../../errors.js";
+import { include, type Included } from "@blazetrails/activesupport";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::BiasableQueue::BiasedConditionVariable
@@ -133,18 +134,24 @@ export class BiasedConditionVariable {
 }
 
 /**
+ * Host interface for BiasableQueue mixin — the including class must
+ * expose a mutable `_cond` field.
+ */
+interface BiasableQueueHost {
+  _cond: BiasedConditionVariable;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::BiasableQueue
  *
  * In Rails this is a module included into ConnectionLeasingQueue that adds
  * `with_a_bias_for(thread)` to temporarily bias the queue's condition variable
- * toward a specific thread. Subclasses must expose a `_cond` field.
+ * toward a specific thread.
  */
-export class BiasableQueue {
-  static BiasedConditionVariable = BiasedConditionVariable;
+export const BiasableQueue = {
+  BiasedConditionVariable,
 
-  protected _cond!: BiasedConditionVariable;
-
-  withABiasFor<T>(context: unknown, fn: () => T): T {
+  withABiasFor<T>(this: BiasableQueueHost, context: unknown, fn: () => T): T {
     const previousCond = this._cond;
     const newCond = new BiasedConditionVariable(undefined, this._cond, context);
     this._cond = newCond;
@@ -154,8 +161,8 @@ export class BiasableQueue {
       this._cond = previousCond;
       newCond.transferWaitersTo(previousCond);
     }
-  }
-}
+  },
+};
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Queue
@@ -262,12 +269,11 @@ export class Queue {
  * the queue's critical section, matching Rails where internal_poll calls
  * conn.lease before returning.
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unsafe-declaration-merging
+export interface ConnectionLeasingQueue extends Included<typeof BiasableQueue> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ConnectionLeasingQueue extends Queue {
   private _leasedTo = new Map<DatabaseAdapter, string>();
-
-  withABiasFor<T>(context: unknown, fn: () => T): T {
-    return BiasableQueue.prototype.withABiasFor.call(this, context, fn) as T;
-  }
 
   protected override internalPoll(
     timeout?: number,
@@ -303,3 +309,6 @@ export class ConnectionLeasingQueue extends Queue {
     }
   }
 }
+
+// Rails: `include BiasableQueue` in ConnectionLeasingQueue
+include(ConnectionLeasingQueue, BiasableQueue);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -2,22 +2,28 @@
  * Connection pool queue — manages waiting for available connections.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Queue
+ *
+ * Rails uses Monitor-based synchronization with condition variables.
+ * In single-threaded Node we model the same fairness semantics using
+ * Promise-based waiters: `signal` resolves a pending waiter's promise
+ * directly with the connection, while `poll` either takes from the
+ * internal array (if fairness allows) or creates a new waiter promise.
  */
 
 import type { DatabaseAdapter } from "../../../adapter.js";
+import { ConnectionTimeoutError } from "../../../errors.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::BiasableQueue::BiasedConditionVariable
  *
- * In Rails this is a condition variable that preferentially wakes a biased thread.
- * In TS (single-threaded), we model the same API using Promise-based waiters.
- * The `otherCond` and `preferredThread` params exist for API parity but the
- * bias behavior is a no-op in a single-threaded environment.
+ * In Rails this wraps two condition variables (one biased, one fallback) and
+ * preferentially wakes the biased thread. In Node (single-threaded) the bias
+ * is structurally a no-op, but we implement the full API so that callers
+ * (ConnectionLeasingQueue, withABiasFor) work identically.
  */
 export class BiasedConditionVariable {
   private _waiters: Array<(conn: DatabaseAdapter) => void> = [];
   private _otherCond: BiasedConditionVariable | null;
-  private _numWaitingOnRealCond = 0;
 
   constructor(
     _lock?: unknown,
@@ -33,10 +39,10 @@ export class BiasedConditionVariable {
 
   wait(timeout: number): Promise<DatabaseAdapter> {
     return new Promise((resolve, reject) => {
-      const state = { timer: 0 as unknown as ReturnType<typeof setTimeout> };
+      const state = { timer: null as ReturnType<typeof setTimeout> | null };
 
       const waiter = (conn: DatabaseAdapter) => {
-        clearTimeout(state.timer);
+        if (state.timer) clearTimeout(state.timer);
         const idx = this._waiters.indexOf(waiter);
         if (idx >= 0) this._waiters.splice(idx, 1);
         resolve(conn);
@@ -45,18 +51,29 @@ export class BiasedConditionVariable {
       state.timer = setTimeout(() => {
         const idx = this._waiters.indexOf(waiter);
         if (idx >= 0) this._waiters.splice(idx, 1);
-        reject(new Error("Connection pool timeout"));
+        const msg =
+          `could not obtain a connection from the pool within ${timeout.toFixed(3)} seconds; ` +
+          `all pooled connections were in use`;
+        reject(new ConnectionTimeoutError(msg));
       }, timeout * 1000);
 
       this._waiters.push(waiter);
     });
   }
 
+  /**
+   * In Rails, signal prefers the biased thread's cond, then falls back to
+   * the other cond. In Node (single-threaded) all waiters land on this CV's
+   * _waiters, so we try local first, then delegate to _otherCond.
+   */
   signal(conn: DatabaseAdapter): boolean {
     const waiter = this._waiters.shift();
     if (waiter) {
       waiter(conn);
       return true;
+    }
+    if (this._otherCond) {
+      return this._otherCond.signal(conn);
     }
     return false;
   }
@@ -69,9 +86,10 @@ export class BiasedConditionVariable {
   }
 
   broadcastOnBiased(connections: DatabaseAdapter[]): void {
-    this._numWaitingOnRealCond = 0;
     for (const conn of connections) {
-      if (!this.signal(conn)) break;
+      const waiter = this._waiters.shift();
+      if (!waiter) break;
+      waiter(conn);
     }
   }
 }
@@ -81,13 +99,11 @@ export class BiasedConditionVariable {
  *
  * In Rails this is a module included into ConnectionLeasingQueue that adds
  * `with_a_bias_for(thread)` to temporarily bias the queue's condition variable
- * toward a specific thread. In TS (single-threaded), we implement the API
- * for parity; the bias is effectively a no-op.
+ * toward a specific thread. Subclasses must expose a `_cond` field.
  */
 export class BiasableQueue {
   static BiasedConditionVariable = BiasedConditionVariable;
 
-  /** @internal — subclass must provide */
   protected _cond!: BiasedConditionVariable;
 
   withABiasFor<T>(context: unknown, fn: () => T): T {
@@ -98,7 +114,6 @@ export class BiasableQueue {
       return fn();
     } finally {
       this._cond = previousCond;
-      // wake up any remaining sleepers on the biased cond
       newCond.broadcastOnBiased([]);
     }
   }
@@ -106,6 +121,10 @@ export class BiasableQueue {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Queue
+ *
+ * Threadsafe, fair, LIFO queue. In Rails, fairness is enforced by tracking
+ * `@num_waiting` — a no-timeout poll only succeeds when queue size exceeds
+ * the number of threads blocked in wait_poll. We mirror this with _numWaiting.
  */
 export class Queue {
   private _queue: DatabaseAdapter[] = [];
@@ -136,9 +155,10 @@ export class Queue {
     return this._queue.length > 0;
   }
 
-  add(conn: DatabaseAdapter): void {
-    this._queue.push(conn);
-    this._cond.signal(conn);
+  add(element: DatabaseAdapter): void {
+    if (!this._cond.signal(element)) {
+      this._queue.push(element);
+    }
   }
 
   delete(element: DatabaseAdapter): DatabaseAdapter | undefined {
@@ -160,16 +180,20 @@ export class Queue {
   }
 
   poll(timeout?: number): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
-    const conn = this.noWaitPoll();
-    if (conn) return conn;
-    if (timeout != null) return this.waitPoll(timeout);
-    return undefined;
+    return this.internalPoll(timeout);
   }
 
   clear(): DatabaseAdapter[] {
     const items = [...this._queue];
     this._queue = [];
     return items;
+  }
+
+  protected internalPoll(timeout?: number): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
+    const conn = this.noWaitPoll();
+    if (conn) return conn;
+    if (timeout != null) return this.waitPoll(timeout);
+    return undefined;
   }
 
   private canRemoveNoWait(): boolean {
@@ -193,12 +217,32 @@ export class Queue {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::ConnectionLeasingQueue
+ *
+ * Connections returned by poll are automatically leased while still inside
+ * the queue's critical section, matching Rails where internal_poll calls
+ * conn.lease before returning.
  */
 export class ConnectionLeasingQueue extends Queue {
   private _leasedTo = new Map<DatabaseAdapter, string>();
 
   withABiasFor<T>(context: unknown, fn: () => T): T {
     return BiasableQueue.prototype.withABiasFor.call(this, context, fn) as T;
+  }
+
+  protected override internalPoll(
+    timeout?: number,
+  ): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
+    const result = super.internalPoll(timeout);
+    if (result && typeof (result as any).then === "function") {
+      return (result as Promise<DatabaseAdapter>).then((conn) => {
+        this._leaseConn(conn);
+        return conn;
+      });
+    }
+    if (result) {
+      this._leaseConn(result as DatabaseAdapter);
+    }
+    return result;
   }
 
   leaseTo(conn: DatabaseAdapter, key: string): void {
@@ -211,5 +255,11 @@ export class ConnectionLeasingQueue extends Queue {
 
   leasedTo(conn: DatabaseAdapter): string | undefined {
     return this._leasedTo.get(conn);
+  }
+
+  private _leaseConn(conn: DatabaseAdapter): void {
+    if (typeof (conn as any).lease === "function") {
+      (conn as any).lease();
+    }
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -50,12 +50,19 @@ export class Reaper {
       Reaper._timers.set(frequency, Reaper._spawnTimer(frequency));
     }
 
-    let refs = Reaper._pools.get(frequency);
-    if (!refs) {
-      refs = [];
-      Reaper._pools.set(frequency, refs);
+    const refs = Reaper._pools.get(frequency) ?? [];
+    const alive = refs.filter((ref) => {
+      const p = ref.deref();
+      return p != null && !p.isDiscarded?.();
+    });
+
+    if (alive.some((ref) => ref.deref() === pool)) {
+      Reaper._pools.set(frequency, alive);
+      return;
     }
-    refs.push(new WeakRef(pool));
+
+    alive.push(new WeakRef(pool));
+    Reaper._pools.set(frequency, alive);
   }
 
   private static _spawnTimer(frequency: number): ReturnType<typeof setInterval> {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -47,6 +47,7 @@ export class Reaper {
 
   static registerPool(pool: ReapablePool, frequency: number): void {
     if (!frequency || frequency <= 0 || !Number.isFinite(frequency)) return;
+    if (pool.isDiscarded?.()) return;
 
     if (!Reaper._timers.has(frequency)) {
       Reaper._timers.set(frequency, Reaper._spawnTimer(frequency));

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -46,6 +46,8 @@ export class Reaper {
   private static _timers = new Map<number, ReturnType<typeof setInterval>>();
 
   static registerPool(pool: ReapablePool, frequency: number): void {
+    if (!frequency || frequency <= 0 || !Number.isFinite(frequency)) return;
+
     if (!Reaper._timers.has(frequency)) {
       Reaper._timers.set(frequency, Reaper._spawnTimer(frequency));
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -1,37 +1,112 @@
 /**
- * Connection pool reaper — removes stale connections.
+ * Connection pool reaper — periodically reaps and flushes idle connections.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper
+ *
+ * Every `frequency` seconds, the reaper calls `reap()` and `flush()` on each
+ * registered pool. A reaper instantiated with a zero or null frequency will
+ * never reap the connection pool.
+ *
+ * Rails uses a class-level registry (`@pools`, `@threads`) so that one timer
+ * is shared across all pools with the same frequency. We mirror this with
+ * static maps + `setInterval`.
  */
 
+export interface ReapablePool {
+  reap?(): void;
+  flush?(): void;
+  isDiscarded?(): boolean;
+  removeStaleConnections?(): void;
+}
+
 export class Reaper {
-  private _interval: number;
-  private _timer: ReturnType<typeof setInterval> | null = null;
-  private _pool: { removeStaleConnections?(): void };
+  private _pool: ReapablePool;
+  private _frequency: number;
 
-  constructor(pool: { removeStaleConnections?(): void }, interval: number) {
+  constructor(pool: ReapablePool, frequency: number) {
     this._pool = pool;
-    this._interval = interval;
+    this._frequency = frequency;
   }
 
-  get interval(): number {
-    return this._interval;
+  get pool(): ReapablePool {
+    return this._pool;
   }
 
-  start(): void {
-    if (this._interval <= 0 || this._timer) return;
-    this._timer = setInterval(() => {
-      this._pool.removeStaleConnections?.();
-    }, this._interval * 1000);
-    if (this._timer) {
-      (this._timer as any).unref?.();
+  get frequency(): number {
+    return this._frequency;
+  }
+
+  run(): void {
+    if (!this._frequency || this._frequency <= 0) return;
+    Reaper.registerPool(this._pool, this._frequency);
+  }
+
+  // --- Class-level registry (mirrors Rails @mutex/@pools/@threads) ---
+
+  private static _pools = new Map<number, WeakRef<ReapablePool>[]>();
+  private static _timers = new Map<number, ReturnType<typeof setInterval>>();
+
+  static registerPool(pool: ReapablePool, frequency: number): void {
+    if (!Reaper._timers.has(frequency)) {
+      Reaper._timers.set(frequency, Reaper._spawnTimer(frequency));
     }
+
+    let refs = Reaper._pools.get(frequency);
+    if (!refs) {
+      refs = [];
+      Reaper._pools.set(frequency, refs);
+    }
+    refs.push(new WeakRef(pool));
   }
 
-  stop(): void {
-    if (this._timer) {
-      clearInterval(this._timer);
-      this._timer = null;
+  private static _spawnTimer(frequency: number): ReturnType<typeof setInterval> {
+    const timer = setInterval(() => {
+      const refs = Reaper._pools.get(frequency);
+      if (!refs) {
+        Reaper._stopTimer(frequency);
+        return;
+      }
+
+      // Filter out GC'd or discarded pools
+      const alive = refs.filter((ref) => {
+        const p = ref.deref();
+        return p != null && !p.isDiscarded?.();
+      });
+
+      if (alive.length === 0) {
+        Reaper._pools.delete(frequency);
+        Reaper._stopTimer(frequency);
+        return;
+      }
+
+      Reaper._pools.set(frequency, alive);
+
+      for (const ref of alive) {
+        const p = ref.deref();
+        if (p) {
+          try {
+            p.reap?.();
+            p.flush?.();
+          } catch {
+            // WeakRef may have been collected between check and call
+          }
+        }
+      }
+    }, frequency * 1000);
+
+    // Don't keep the process alive just for reaping
+    if (typeof timer === "object" && "unref" in timer) {
+      (timer as NodeJS.Timeout).unref();
+    }
+
+    return timer;
+  }
+
+  private static _stopTimer(frequency: number): void {
+    const timer = Reaper._timers.get(frequency);
+    if (timer) {
+      clearInterval(timer);
+      Reaper._timers.delete(frequency);
     }
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -7,16 +7,15 @@
  * registered pool. A reaper instantiated with a zero or null frequency will
  * never reap the connection pool.
  *
- * Rails uses a class-level registry (`@pools`, `@threads`) so that one timer
- * is shared across all pools with the same frequency. We mirror this with
- * static maps + `setInterval`.
+ * Rails uses a class-level registry (`@pools`, `@threads`) so that one reaper
+ * timer is shared across all pools with the same frequency. We mirror this with
+ * static maps and `setInterval`, using WeakRef to avoid preventing pool GC.
  */
 
 export interface ReapablePool {
   reap?(): void;
   flush?(): void;
   isDiscarded?(): boolean;
-  removeStaleConnections?(): void;
 }
 
 export class Reaper {
@@ -67,7 +66,6 @@ export class Reaper {
         return;
       }
 
-      // Filter out GC'd or discarded pools
       const alive = refs.filter((ref) => {
         const p = ref.deref();
         return p != null && !p.isDiscarded?.();
@@ -88,13 +86,12 @@ export class Reaper {
             p.reap?.();
             p.flush?.();
           } catch {
-            // WeakRef may have been collected between check and call
+            // Pool may have been collected between filter and use
           }
         }
       }
     }, frequency * 1000);
 
-    // Don't keep the process alive just for reaping
     if (typeof timer === "object" && "unref" in timer) {
       (timer as NodeJS.Timeout).unref();
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -92,12 +92,8 @@ export class Reaper {
       for (const ref of alive) {
         const p = ref.deref();
         if (p) {
-          try {
-            p.reap?.();
-            p.flush?.();
-          } catch {
-            // Pool may have been collected between filter and use
-          }
+          p.reap?.();
+          p.flush?.();
         }
       }
     }, frequency * 1000);

--- a/packages/activerecord/src/reaper.test.ts
+++ b/packages/activerecord/src/reaper.test.ts
@@ -23,20 +23,22 @@ function makePool(): ReapablePool & {
   };
 }
 
+function clearReaperState() {
+  (Reaper as any)._timers.forEach((timer: any) => clearInterval(timer));
+  (Reaper as any)._timers.clear();
+  (Reaper as any)._pools.clear();
+}
+
 describe("ReaperTest", () => {
-  afterEach(() => {
-    // Clean up any registered timers by accessing private static state
-    // This prevents timer leaks across tests
-    (Reaper as any)._timers.forEach((timer: any) => clearInterval(timer));
-    (Reaper as any)._timers.clear();
-    (Reaper as any)._pools.clear();
-  });
+  afterEach(clearReaperState);
 
   it("nil time", () => {
     const pool = makePool();
     const reaper = new Reaper(pool, 0);
     reaper.run();
-    expect(reaper.frequency).toBe(0);
+    // With frequency 0, run() should be a no-op — no timers registered
+    expect((Reaper as any)._pools.size).toBe(0);
+    expect((Reaper as any)._timers.size).toBe(0);
   });
 
   it("some time", () => {
@@ -58,37 +60,66 @@ describe("ReaperTest", () => {
     expect(reaper.frequency).toBe(100);
   });
 
-  it("connection pool starts reaper", () => {
+  it("connection pool starts reaper", async () => {
     const pool = makePool();
     const reaper = new Reaper(pool, 0.001);
     reaper.run();
-    // Reaper should have registered the pool
     expect((Reaper as any)._pools.size).toBe(1);
+    // Wait for the timer to fire at least once
+    await new Promise((r) => setTimeout(r, 15));
+    expect(pool.reaped).toBeGreaterThanOrEqual(1);
+    expect(pool.flushed).toBeGreaterThanOrEqual(1);
   });
 
-  it.skip("reaper works after pool discard", () => {});
+  it("reaper works after pool discard", async () => {
+    const pool1 = makePool();
+    const pool2 = makePool();
+    const freq = 0.001;
+
+    // Register two pools at the same frequency
+    new Reaper(pool1, freq).run();
+    new Reaper(pool2, freq).run();
+
+    await new Promise((r) => setTimeout(r, 15));
+    expect(pool1.reaped).toBeGreaterThanOrEqual(1);
+    expect(pool2.reaped).toBeGreaterThanOrEqual(1);
+
+    // Discard pool1 — pool2 should keep getting reaped
+    const pool1Reaped = pool1.reaped;
+    pool1._discarded = true;
+
+    await new Promise((r) => setTimeout(r, 15));
+    // pool1 should not have been reaped again
+    expect(pool1.reaped).toBe(pool1Reaped);
+    // pool2 should still be reaped
+    expect(pool2.reaped).toBeGreaterThan(1);
+  });
 
   it("reap flush on discarded pool", async () => {
     const pool = makePool();
     pool._discarded = true;
     const reaper = new Reaper(pool, 0.001);
     reaper.run();
-    // Wait for one tick
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 15));
+    // Discarded pools are filtered out before reap/flush
     expect(pool.reaped).toBe(0);
     expect(pool.flushed).toBe(0);
   });
 
-  it.skip("connection pool starts reaper in fork", () => {});
+  it.skip("connection pool starts reaper in fork", () => {
+    // N/A: Node.js does not fork processes the way Ruby does
+  });
 
   it("reaper does not reap discarded connection pools", async () => {
     const pool = makePool();
     const reaper = new Reaper(pool, 0.001);
     reaper.run();
+
+    // Immediately mark as discarded before first tick
     pool._discarded = true;
-    // Wait for reaper cycle
-    await new Promise((r) => setTimeout(r, 10));
-    // After being marked discarded, the pool should not be reaped
+    await new Promise((r) => setTimeout(r, 15));
+
     expect(pool.reaped).toBe(0);
+    expect(pool.flushed).toBe(0);
   });
 });

--- a/packages/activerecord/src/reaper.test.ts
+++ b/packages/activerecord/src/reaper.test.ts
@@ -1,13 +1,94 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { Reaper } from "./connection-adapters/abstract/connection-pool/reaper.js";
+import type { ReapablePool } from "./connection-adapters/abstract/connection-pool/reaper.js";
+
+function makePool(): ReapablePool & {
+  reaped: number;
+  flushed: number;
+  _discarded: boolean;
+} {
+  return {
+    reaped: 0,
+    flushed: 0,
+    _discarded: false,
+    reap() {
+      this.reaped++;
+    },
+    flush() {
+      this.flushed++;
+    },
+    isDiscarded() {
+      return this._discarded;
+    },
+  };
+}
 
 describe("ReaperTest", () => {
-  it.skip("nil time", () => {});
-  it.skip("some time", () => {});
-  it.skip("pool has reaper", () => {});
-  it.skip("reaping frequency configuration", () => {});
-  it.skip("connection pool starts reaper", () => {});
+  afterEach(() => {
+    // Clean up any registered timers by accessing private static state
+    // This prevents timer leaks across tests
+    (Reaper as any)._timers.forEach((timer: any) => clearInterval(timer));
+    (Reaper as any)._timers.clear();
+    (Reaper as any)._pools.clear();
+  });
+
+  it("nil time", () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 0);
+    reaper.run();
+    expect(reaper.frequency).toBe(0);
+  });
+
+  it("some time", () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 60);
+    expect(reaper.frequency).toBe(60);
+    expect(reaper.pool).toBe(pool);
+  });
+
+  it("pool has reaper", () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 60);
+    expect(reaper.pool).toBe(pool);
+  });
+
+  it("reaping frequency configuration", () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 100);
+    expect(reaper.frequency).toBe(100);
+  });
+
+  it("connection pool starts reaper", () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 0.001);
+    reaper.run();
+    // Reaper should have registered the pool
+    expect((Reaper as any)._pools.size).toBe(1);
+  });
+
   it.skip("reaper works after pool discard", () => {});
-  it.skip("reap flush on discarded pool", () => {});
+
+  it("reap flush on discarded pool", async () => {
+    const pool = makePool();
+    pool._discarded = true;
+    const reaper = new Reaper(pool, 0.001);
+    reaper.run();
+    // Wait for one tick
+    await new Promise((r) => setTimeout(r, 10));
+    expect(pool.reaped).toBe(0);
+    expect(pool.flushed).toBe(0);
+  });
+
   it.skip("connection pool starts reaper in fork", () => {});
-  it.skip("reaper does not reap discarded connection pools", () => {});
+
+  it("reaper does not reap discarded connection pools", async () => {
+    const pool = makePool();
+    const reaper = new Reaper(pool, 0.001);
+    reaper.run();
+    pool._discarded = true;
+    // Wait for reaper cycle
+    await new Promise((r) => setTimeout(r, 10));
+    // After being marked discarded, the pool should not be reaped
+    expect(pool.reaped).toBe(0);
+  });
 });

--- a/packages/activerecord/src/reaper.test.ts
+++ b/packages/activerecord/src/reaper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import { Reaper } from "./connection-adapters/abstract/connection-pool/reaper.js";
 import type { ReapablePool } from "./connection-adapters/abstract/connection-pool/reaper.js";
 
@@ -30,13 +30,19 @@ function clearReaperState() {
 }
 
 describe("ReaperTest", () => {
-  afterEach(clearReaperState);
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clearReaperState();
+    vi.useRealTimers();
+  });
 
   it("nil time", () => {
     const pool = makePool();
     const reaper = new Reaper(pool, 0);
     reaper.run();
-    // With frequency 0, run() should be a no-op — no timers registered
     expect((Reaper as any)._pools.size).toBe(0);
     expect((Reaper as any)._timers.size).toBe(0);
   });
@@ -60,48 +66,46 @@ describe("ReaperTest", () => {
     expect(reaper.frequency).toBe(100);
   });
 
-  it("connection pool starts reaper", async () => {
+  it("connection pool starts reaper", () => {
     const pool = makePool();
-    const reaper = new Reaper(pool, 0.001);
+    const reaper = new Reaper(pool, 60);
     reaper.run();
     expect((Reaper as any)._pools.size).toBe(1);
-    // Wait for the timer to fire at least once
-    await new Promise((r) => setTimeout(r, 15));
-    expect(pool.reaped).toBeGreaterThanOrEqual(1);
-    expect(pool.flushed).toBeGreaterThanOrEqual(1);
+
+    vi.advanceTimersByTime(60_000);
+    expect(pool.reaped).toBe(1);
+    expect(pool.flushed).toBe(1);
+
+    vi.advanceTimersByTime(60_000);
+    expect(pool.reaped).toBe(2);
+    expect(pool.flushed).toBe(2);
   });
 
-  it("reaper works after pool discard", async () => {
+  it("reaper works after pool discard", () => {
     const pool1 = makePool();
     const pool2 = makePool();
-    const freq = 0.001;
 
-    // Register two pools at the same frequency
-    new Reaper(pool1, freq).run();
-    new Reaper(pool2, freq).run();
+    new Reaper(pool1, 60).run();
+    new Reaper(pool2, 60).run();
 
-    await new Promise((r) => setTimeout(r, 15));
-    expect(pool1.reaped).toBeGreaterThanOrEqual(1);
-    expect(pool2.reaped).toBeGreaterThanOrEqual(1);
+    vi.advanceTimersByTime(60_000);
+    expect(pool1.reaped).toBe(1);
+    expect(pool2.reaped).toBe(1);
 
-    // Discard pool1 — pool2 should keep getting reaped
-    const pool1Reaped = pool1.reaped;
     pool1._discarded = true;
 
-    await new Promise((r) => setTimeout(r, 15));
-    // pool1 should not have been reaped again
-    expect(pool1.reaped).toBe(pool1Reaped);
-    // pool2 should still be reaped
-    expect(pool2.reaped).toBeGreaterThan(1);
+    vi.advanceTimersByTime(60_000);
+    expect(pool1.reaped).toBe(1);
+    expect(pool2.reaped).toBe(2);
   });
 
-  it("reap flush on discarded pool", async () => {
+  it("reap flush on discarded pool", () => {
     const pool = makePool();
     pool._discarded = true;
-    const reaper = new Reaper(pool, 0.001);
+    const reaper = new Reaper(pool, 60);
     reaper.run();
-    await new Promise((r) => setTimeout(r, 15));
-    // Discarded pools are filtered out before reap/flush
+
+    vi.advanceTimersByTime(60_000);
     expect(pool.reaped).toBe(0);
     expect(pool.flushed).toBe(0);
   });
@@ -110,15 +114,14 @@ describe("ReaperTest", () => {
     // N/A: Node.js does not fork processes the way Ruby does
   });
 
-  it("reaper does not reap discarded connection pools", async () => {
+  it("reaper does not reap discarded connection pools", () => {
     const pool = makePool();
-    const reaper = new Reaper(pool, 0.001);
+    const reaper = new Reaper(pool, 60);
     reaper.run();
 
-    // Immediately mark as discarded before first tick
     pool._discarded = true;
-    await new Promise((r) => setTimeout(r, 15));
 
+    vi.advanceTimersByTime(60_000);
     expect(pool.reaped).toBe(0);
     expect(pool.flushed).toBe(0);
   });


### PR DESCRIPTION
## Summary
- **Queue**: add explicit `constructor`, `isAnyWaiting`, `numWaiting`, `delete`; rework `BiasedConditionVariable` with constructor, `broadcastOnBiased` (returns unconsumed connections to prevent double-delivery), and `transferWaitersTo` for proper cleanup; convert `BiasableQueue` from interface to class with `withABiasFor` that migrates orphaned waiters on exit
- **ConnectionLeasingQueue**: override `internalPoll` to call `conn.lease()` on checkout, matching Rails' `internal_poll` override
- **Reaper**: add `pool`/`frequency` getters, `run()` method, and static `registerPool()` with idempotent shared timer registry using WeakRef pool tracking (mirrors Rails class-level `@pools`/`@threads` pattern)
- Both files now at **100%** in `api:compare` (queue: 50% → 100%, reaper: 20% → 100%)
- Uses `ConnectionTimeoutError` with Rails-format message for pool timeouts

PR 3 of 7 in the [connection pool infrastructure plan](../docs/activerecord-connections-and-pools.md).

## Test plan
- [x] `api:compare` shows 100% for both `queue.rb` and `reaper.rb`
- [x] 24 queue tests covering add/poll fairness, delete, timeout, bias signal delegation, broadcast non-double-delivery, waiter migration, and lease-on-checkout
- [x] 8 reaper tests (1 skipped — fork N/A in Node) using fake timers for deterministic assertions
- [x] Full activerecord test suite passes (171 files, 7928 tests)
- [x] TypeScript compiles cleanly