### PR TITLE
feat(activerecord): ConnectionPool attrs, NullPool, Lease, ExecutorHooks

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -6,7 +6,33 @@
 
 import type { DatabaseAdapter } from "../../adapter.js";
 import type { DatabaseConfig } from "../../database-configurations/database-config.js";
+import type { PoolConfig } from "../pool-config.js";
+import type { ConnectionDescriptor } from "./connection-descriptor.js";
 import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.js";
+import { SchemaReflection } from "../schema-cache.js";
+import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
+import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+
+let _contextIdCounter = 0;
+let _contextStorage: AsyncContext<number> | null = null;
+
+function executionContextId(): number {
+  if (!_contextStorage) {
+    _contextStorage = getAsyncContext().create<number>();
+  }
+  return _contextStorage.getStore() ?? 0;
+}
+
+/**
+ * Run a callback in a new isolated execution context.
+ * Leases obtained inside will not collide with the outer context.
+ */
+export function withExecutionContext<T>(fn: () => T): T {
+  if (!_contextStorage) {
+    _contextStorage = getAsyncContext().create<number>();
+  }
+  return _contextStorage.run(++_contextIdCounter, fn);
+}
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractPool
@@ -19,21 +45,47 @@ export interface AbstractPool {
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
  */
 export class NullConfig {
+  [key: string]: unknown;
+
   get schemaCache(): null {
     return null;
   }
 }
 
+const NULL_CONFIG = new NullConfig();
+
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
-  readonly config = new NullConfig();
-
   static readonly NullConfig = NullConfig;
+  static readonly NULL_CONFIG = NULL_CONFIG;
+
+  private _serverVersion: unknown = null;
+  private _serverVersionCached = false;
+  private _schemaReflection: SchemaReflection | null = null;
+
+  serverVersion(connection: DatabaseAdapter): unknown {
+    if (!this._serverVersionCached) {
+      this._serverVersion = connection.getDatabaseVersion?.();
+      this._serverVersionCached = true;
+    }
+    return this._serverVersion;
+  }
+
+  get schemaReflection(): SchemaReflection {
+    if (!this._schemaReflection) {
+      this._schemaReflection = new SchemaReflection(null);
+    }
+    return this._schemaReflection;
+  }
 
   get schemaCache(): null {
     return null;
+  }
+
+  get connectionDescriptor(): undefined {
+    return undefined;
   }
 
   checkout(): never {
@@ -42,25 +94,60 @@ export class NullPool implements AbstractPool {
 
   checkin(_conn: DatabaseAdapter): void {}
 
+  remove(_conn: DatabaseAdapter): void {}
+
+  get asyncExecutor(): null {
+    return null;
+  }
+
+  get dbConfig(): NullConfig {
+    return NULL_CONFIG;
+  }
+
+  get dirtiesQueryCache(): boolean {
+    return true;
+  }
+
   disconnect(): void {}
 }
 
 /**
- * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::WeakThreadKeyMap
+ * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Lease
  */
-export class WeakThreadKeyMap<V> {
-  private _map = new Map<number, V>();
+export class Lease {
+  connection: DatabaseAdapter | null = null;
+  sticky: boolean | null = null;
 
-  get(key: number): V | undefined {
-    return this._map.get(key);
+  release(): DatabaseAdapter | null {
+    const conn = this.connection;
+    this.connection = null;
+    this.sticky = null;
+    return conn;
   }
 
-  set(key: number, value: V): void {
-    this._map.set(key, value);
+  clear(connection: DatabaseAdapter): boolean {
+    if (this.connection === connection) {
+      this.connection = null;
+      this.sticky = null;
+      return true;
+    }
+    return false;
   }
+}
 
-  delete(key: number): boolean {
-    return this._map.delete(key);
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::LeaseRegistry
+ */
+export class LeaseRegistry {
+  private _map = new Map<string, Lease>();
+
+  get(context: string): Lease {
+    let lease = this._map.get(context);
+    if (!lease) {
+      lease = new Lease();
+      this._map.set(context, lease);
+    }
+    return lease;
   }
 
   clear(): void {
@@ -69,90 +156,141 @@ export class WeakThreadKeyMap<V> {
 }
 
 /**
- * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Lease
- */
-export class Lease {
-  private _connection: DatabaseAdapter | null = null;
-
-  get connection(): DatabaseAdapter | null {
-    return this._connection;
-  }
-
-  take(conn: DatabaseAdapter): void {
-    this._connection = conn;
-  }
-
-  clear(): void {
-    this._connection = null;
-  }
-}
-
-/**
- * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::LeaseRegistry
- */
-export class LeaseRegistry {
-  private _leases = new Map<string, Lease>();
-
-  getOrCreate(key: string): Lease {
-    let lease = this._leases.get(key);
-    if (!lease) {
-      lease = new Lease();
-      this._leases.set(key, lease);
-    }
-    return lease;
-  }
-
-  clear(): void {
-    this._leases.clear();
-  }
-}
-
-/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::ExecutorHooks
+ *
+ * In Rails, complete() iterates connection pools and releases connections
+ * whose transactions are closed or not joinable. This requires
+ * Base.connectionHandler which creates a circular dependency at module level.
+ * Wired up when ConnectionHandler is complete (PR 6).
  */
-export interface ExecutorHooks {
-  toRun(): void;
-  toComplete(): void;
-}
+export const ExecutorHooks = {
+  run(): void {
+    // noop — matches Rails
+  },
 
-export class ConnectionPool {
+  complete(): void {
+    // Wired up in PR 6 when ConnectionHandler.eachConnectionPool exists
+  },
+};
+
+export class ConnectionPool implements ReapablePool {
+  readonly poolConfig: PoolConfig;
   readonly dbConfig: DatabaseConfig;
-  readonly size: number;
-  readonly checkoutTimeout: number;
-  readonly idleTimeout: number | null;
   readonly role: string;
   readonly shard: string;
+  readonly size: number;
+  readonly reaper: Reaper;
+  readonly asyncExecutor: null = null;
 
-  private _connections: DatabaseAdapter[] = [];
-  private _available: DatabaseAdapter[] = [];
+  automaticReconnect = true;
+  checkoutTimeout: number;
+
+  private _connections: DatabaseAdapter[] | null = [];
+  private _available: DatabaseAdapter[] | null = [];
   private _checkedOut = new Set<DatabaseAdapter>();
-  private _adapterFactory?: () => DatabaseAdapter;
+  private _leases: LeaseRegistry | null = new LeaseRegistry();
+  private _idleTimeout: number | null;
+  private _lastCheckinAt = new Map<DatabaseAdapter, number>();
 
-  constructor(
-    dbConfig: DatabaseConfig,
-    options: {
-      role?: string;
-      shard?: string;
-      adapterFactory?: () => DatabaseAdapter;
-    } = {},
-  ) {
-    this.dbConfig = dbConfig;
-    this.size = dbConfig.pool;
-    this.checkoutTimeout = 5;
-    this.idleTimeout = 300;
-    this.role = options.role ?? "writing";
-    this.shard = options.shard ?? "default";
-    this._adapterFactory = options.adapterFactory;
+  constructor(poolConfig: PoolConfig) {
+    this.poolConfig = poolConfig;
+    this.dbConfig = poolConfig.dbConfig;
+    this.role = poolConfig.role;
+    this.shard = poolConfig.shard;
+
+    this.size = this.dbConfig.pool;
+    this.checkoutTimeout = this.dbConfig.checkoutTimeout;
+    this._idleTimeout = this.dbConfig.idleTimeout;
+
+    this.reaper = new Reaper(this, this.dbConfig.reapingFrequency ?? 0);
+    this.reaper.run();
   }
 
+  // --- Delegation to PoolConfig ---
+
+  get schemaReflection(): SchemaReflection {
+    return this.poolConfig.schemaReflection;
+  }
+
+  set schemaReflection(value: SchemaReflection) {
+    this.poolConfig.schemaReflection = value;
+  }
+
+  serverVersion(connection: DatabaseAdapter): unknown {
+    return this.poolConfig.serverVersion(connection);
+  }
+
+  get connectionDescriptor(): ConnectionDescriptor {
+    return this.poolConfig.connectionDescriptor;
+  }
+
+  // --- Pool state ---
+
+  get dirtiesQueryCache(): boolean {
+    return true;
+  }
+
+  get activeConnection(): DatabaseAdapter | null {
+    return this._connectionLease().connection;
+  }
+
+  isConnected(): boolean {
+    return this._connections != null && this._connections.length > 0;
+  }
+
+  get connections(): DatabaseAdapter[] {
+    return this._connections ? [...this._connections] : [];
+  }
+
+  isDiscarded(): boolean {
+    return this._connections === null;
+  }
+
+  // --- Install executor hooks ---
+
+  static installExecutorHooks(executor?: {
+    registerHook(hooks: typeof ExecutorHooks): void;
+  }): void {
+    executor?.registerHook(ExecutorHooks);
+  }
+
+  // --- Lease management ---
+
+  leaseConnection(): DatabaseAdapter {
+    const lease = this._connectionLease();
+    lease.sticky = true;
+    if (!lease.connection) {
+      lease.connection = this.checkout();
+    }
+    return lease.connection;
+  }
+
+  isPermanentLease(): boolean {
+    return this._connectionLease().sticky === null;
+  }
+
+  releaseConnection(): boolean {
+    const conn = this._connectionLease().release();
+    if (conn) {
+      this.checkin(conn);
+      return true;
+    }
+    return false;
+  }
+
+  // --- Checkout / Checkin ---
+
   checkout(): DatabaseAdapter {
-    if (this._available.length > 0) {
+    if (this.isDiscarded()) {
+      throw new ConnectionNotEstablished("Connection pool has been discarded");
+    }
+    if (this._available && this._available.length > 0) {
       const conn = this._available.pop()!;
       this._checkedOut.add(conn);
       return conn;
     }
-    if (this._connections.length < this.size) {
-      const conn = this._newConnection();
+    if (this._connections && this._connections.length < this.size) {
+      const conn = this.newConnection();
       this._connections.push(conn);
       this._checkedOut.add(conn);
       return conn;
@@ -164,44 +302,57 @@ export class ConnectionPool {
   }
 
   checkin(conn: DatabaseAdapter): void {
+    this._connectionLease().clear(conn);
     if (this._checkedOut.has(conn)) {
       this._checkedOut.delete(conn);
-      this._available.push(conn);
+      this._available?.push(conn);
+      this._lastCheckinAt.set(conn, Date.now());
     }
   }
 
-  withConnection<T>(fn: (conn: DatabaseAdapter) => T): T {
-    const conn = this.checkout();
-    try {
-      const result = fn(conn);
-      if (result && typeof (result as any).then === "function") {
-        return (result as any).finally(() => this.checkin(conn));
+  withConnection<T>(
+    fn: (conn: DatabaseAdapter) => T,
+    options: { preventPermanentCheckout?: boolean } = {},
+  ): T {
+    const preventPermanent = options.preventPermanentCheckout ?? false;
+    const lease = this._connectionLease();
+    const stickyWas = lease.sticky;
+    if (preventPermanent) lease.sticky = false;
+
+    const restoreSticky = () => {
+      if (preventPermanent && !stickyWas) lease.sticky = stickyWas;
+    };
+
+    if (lease.connection) {
+      try {
+        return fn(lease.connection);
+      } finally {
+        restoreSticky();
       }
-      this.checkin(conn);
+    }
+
+    lease.connection = this.checkout();
+    try {
+      const result = fn(lease.connection);
+      if (result && typeof (result as any).then === "function") {
+        return Promise.resolve(result).finally(() => {
+          restoreSticky();
+          if (!lease.sticky) this.releaseConnection();
+        }) as T;
+      }
+      restoreSticky();
+      if (!lease.sticky) this.releaseConnection();
       return result;
     } catch (error) {
-      this.checkin(conn);
+      restoreSticky();
+      if (!lease.sticky) this.releaseConnection();
       throw error;
     }
   }
 
-  get activeConnection(): boolean {
-    return this._checkedOut.size > 0;
-  }
+  // --- Pool statistics ---
 
-  get connectedCount(): number {
-    return this._connections.length;
-  }
-
-  get busyCount(): number {
-    return this._checkedOut.size;
-  }
-
-  get idleCount(): number {
-    return this._available.length;
-  }
-
-  get waitingCount(): number {
+  numWaitingInQueue(): number {
     return 0;
   }
 
@@ -211,34 +362,121 @@ export class ConnectionPool {
     busy: number;
     idle: number;
     waiting: number;
+    checkoutTimeout: number;
   } {
     return {
       size: this.size,
-      connections: this.connectedCount,
-      busy: this.busyCount,
-      idle: this.idleCount,
-      waiting: this.waitingCount,
+      connections: this._connections?.length ?? 0,
+      busy: this._checkedOut.size,
+      idle: this._available?.length ?? 0,
+      waiting: this.numWaitingInQueue(),
+      checkoutTimeout: this.checkoutTimeout,
     };
   }
 
+  // --- Lifecycle ---
+
   disconnect(): void {
-    this._available = [];
+    if (this._connections) this._connections.length = 0;
+    if (this._available) this._available.length = 0;
     this._checkedOut.clear();
-    this._connections = [];
+    this._leases?.clear();
+    this._lastCheckinAt.clear();
   }
 
-  removeConnection(conn: DatabaseAdapter): void {
-    this._checkedOut.delete(conn);
-    const availIdx = this._available.indexOf(conn);
-    if (availIdx >= 0) this._available.splice(availIdx, 1);
-    const connIdx = this._connections.indexOf(conn);
-    if (connIdx >= 0) this._connections.splice(connIdx, 1);
+  disconnectBang(): void {
+    this.disconnect();
   }
 
-  private _newConnection(): DatabaseAdapter {
-    if (this._adapterFactory) {
-      return this._adapterFactory();
+  discardBang(): void {
+    if (this.isDiscarded()) return;
+    this._connections = null;
+    this._available = null;
+    this._leases = null;
+    this._checkedOut.clear();
+    this._lastCheckinAt.clear();
+  }
+
+  clearReloadableConnections(): void {
+    this.disconnect();
+  }
+
+  clearReloadableConnectionsBang(): void {
+    this.clearReloadableConnections();
+  }
+
+  reap(): void {
+    if (this.isDiscarded()) return;
+    // In Rails, reap recovers connections whose owner thread has died.
+    // JS is single-threaded so there are no dead-owner connections to recover.
+  }
+
+  flush(minimumIdle?: number | null): void {
+    if (minimumIdle === undefined) minimumIdle = this._idleTimeout;
+    if (minimumIdle === null) return;
+    if (this.isDiscarded()) return;
+    if (!this._connections || !this._available) return;
+
+    const now = Date.now();
+    const minimumIdleMs = minimumIdle * 1000;
+    const toRemove: DatabaseAdapter[] = [];
+
+    for (const conn of this._available) {
+      if (this._checkedOut.has(conn)) continue;
+      const lastCheckin = this._lastCheckinAt.get(conn) ?? 0;
+      const idleMs = now - lastCheckin;
+      if (idleMs >= minimumIdleMs) {
+        toRemove.push(conn);
+      }
+    }
+
+    for (const conn of toRemove) {
+      const availIdx = this._available.indexOf(conn);
+      if (availIdx >= 0) this._available.splice(availIdx, 1);
+      const connIdx = this._connections.indexOf(conn);
+      if (connIdx >= 0) this._connections.splice(connIdx, 1);
+      this._lastCheckinAt.delete(conn);
+    }
+  }
+
+  flushBang(): void {
+    this.reap();
+    this.flush(-1);
+  }
+
+  // --- Connection creation ---
+
+  newConnection(): DatabaseAdapter {
+    if (this.poolConfig.adapterFactory) {
+      return this.poolConfig.adapterFactory();
     }
     throw new ConnectionNotEstablished("No adapter factory configured for connection pool");
+  }
+
+  remove(conn: DatabaseAdapter): void {
+    this._connectionLease().clear(conn);
+    this._checkedOut.delete(conn);
+    this._lastCheckinAt.delete(conn);
+    if (this._available) {
+      const availIdx = this._available.indexOf(conn);
+      if (availIdx >= 0) this._available.splice(availIdx, 1);
+    }
+    if (this._connections) {
+      const connIdx = this._connections.indexOf(conn);
+      if (connIdx >= 0) this._connections.splice(connIdx, 1);
+    }
+  }
+
+  scheduleQuery(futureResult: { executeOrSkip(): void }): void {
+    futureResult.executeOrSkip();
+  }
+
+  // --- Private ---
+
+  private _connectionLease(): Lease {
+    if (!this._leases) {
+      this._leases = new LeaseRegistry();
+    }
+    return this._leases.get(String(executionContextId()));
   }
 }

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -120,9 +120,9 @@ describe("ConnectionHandlerTest", () => {
     });
     handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
     const pool = handler.retrieveConnectionPool("primary")!;
-    const conn = pool.checkout();
+    pool.leaseConnection();
     expect(handler.activeConnections).toBe(true);
-    pool.checkin(conn);
+    pool.releaseConnection();
   });
 
   it("retrieve connection pool", () => {

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -84,11 +84,7 @@ export class PoolConfig {
 
   get pool(): ConnectionPool {
     if (!this._pool) {
-      this._pool = new ConnectionPool(this.dbConfig, {
-        role: this.role,
-        shard: this.shard,
-        adapterFactory: this.adapterFactory,
-      });
+      this._pool = new ConnectionPool(this);
     }
     return this._pool;
   }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect } from "vitest";
 import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
+import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
+import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
 
 function makePool(size: number = 5): ConnectionPool {
-  const config = new HashConfig("test", "primary", {
+  const dbConfig = new HashConfig("test", "primary", {
     adapter: "sqlite3",
     database: "test.db",
     pool: size,
   });
-  return new ConnectionPool(config, { adapterFactory: createTestAdapter });
+  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+    adapterFactory: createTestAdapter,
+  });
+  return new ConnectionPool(pc);
 }
 
 describe("ConnectionPoolThreadTest", () => {
@@ -33,22 +38,49 @@ it("with connection", async () => {
     return "ok";
   });
   expect(result).toBe("ok");
-  expect(pool.busyCount).toBe(0);
-  expect(pool.idleCount).toBe(1);
+  expect(pool.stat().busy).toBe(0);
+  expect(pool.stat().idle).toBe(1);
 
   const asyncResult = await pool.withConnection(async (conn) => {
     expect(conn).toBeTruthy();
     return "async-ok";
   });
   expect(asyncResult).toBe("async-ok");
-  expect(pool.busyCount).toBe(0);
+  expect(pool.stat().busy).toBe(0);
 
   await expect(
     pool.withConnection(async () => {
       throw new Error("boom");
     }),
   ).rejects.toThrow("boom");
-  expect(pool.busyCount).toBe(0);
+  expect(pool.stat().busy).toBe(0);
+});
+
+it("with connection prevent permanent checkout releases connection", () => {
+  const pool = makePool();
+  pool.leaseConnection();
+  expect(pool.activeConnection).toBeTruthy();
+  pool.withConnection(
+    (conn) => {
+      expect(conn).toBeTruthy();
+    },
+    { preventPermanentCheckout: true },
+  );
+  // sticky was restored so connection is still leased
+  expect(pool.activeConnection).toBeTruthy();
+  pool.releaseConnection();
+});
+
+it("with connection prevent permanent checkout on fresh lease releases", () => {
+  const pool = makePool();
+  pool.withConnection(
+    (conn) => {
+      expect(conn).toBeTruthy();
+    },
+    { preventPermanentCheckout: true },
+  );
+  // No prior sticky lease, so connection should be released
+  expect(pool.activeConnection).toBeNull();
 });
 
 it.skip("new connection no query", () => {
@@ -57,11 +89,11 @@ it.skip("new connection no query", () => {
 
 it("active connection in use", () => {
   const pool = makePool();
-  expect(pool.activeConnection).toBe(false);
-  const conn = pool.checkout();
-  expect(pool.activeConnection).toBe(true);
-  pool.checkin(conn);
-  expect(pool.activeConnection).toBe(false);
+  expect(pool.activeConnection).toBeNull();
+  const conn = pool.leaseConnection();
+  expect(pool.activeConnection).toBe(conn);
+  pool.releaseConnection();
+  expect(pool.activeConnection).toBeNull();
 });
 
 it("full pool exception", () => {
@@ -102,20 +134,38 @@ it.skip("disable flush", () => {
   /* needs flush implementation */
 });
 
-it.skip("flush", () => {
-  /* needs flush implementation */
+it("flush", () => {
+  const pool = makePool(5);
+  const conn = pool.checkout();
+  pool.checkin(conn);
+  expect(pool.stat().connections).toBe(1);
+  expect(pool.stat().idle).toBe(1);
+  // Flush with high idle threshold — nothing removed
+  pool.flush(9999);
+  expect(pool.stat().connections).toBe(1);
+  // Flush with 0 threshold — removes all idle
+  pool.flush(0);
+  expect(pool.stat().connections).toBe(0);
 });
 
-it.skip("flush bang", () => {
-  /* needs flush implementation */
+it("flush bang", () => {
+  const pool = makePool(5);
+  const c1 = pool.checkout();
+  const c2 = pool.checkout();
+  pool.checkin(c1);
+  pool.checkin(c2);
+  expect(pool.stat().idle).toBe(2);
+  pool.flushBang();
+  expect(pool.stat().connections).toBe(0);
+  expect(pool.stat().idle).toBe(0);
 });
 
 it("remove connection", () => {
   const pool = makePool();
   const conn = pool.checkout();
-  expect(pool.connectedCount).toBe(1);
-  pool.removeConnection(conn);
-  expect(pool.connectedCount).toBe(0);
+  expect(pool.stat().connections).toBe(1);
+  pool.remove(conn);
+  expect(pool.stat().connections).toBe(0);
 });
 
 it.skip("remove connection for thread", () => {
@@ -124,10 +174,10 @@ it.skip("remove connection for thread", () => {
 
 it("active connection?", () => {
   const pool = makePool();
-  expect(pool.activeConnection).toBe(false);
-  const conn = pool.checkout();
-  expect(pool.activeConnection).toBe(true);
-  pool.checkin(conn);
+  expect(pool.activeConnection).toBeNull();
+  const conn = pool.leaseConnection();
+  expect(pool.activeConnection).toBe(conn);
+  pool.releaseConnection();
 });
 
 it("checkout behavior", () => {
@@ -229,15 +279,14 @@ it.skip("public connections access threadsafe", () => {
 });
 
 it("role and shard is returned", () => {
-  const config = new HashConfig("test", "primary", {
+  const dbConfig = new HashConfig("test", "primary", {
     adapter: "sqlite3",
     database: "test.db",
   });
-  const pool = new ConnectionPool(config, {
-    role: "reading",
-    shard: "shard_one",
+  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "reading", "shard_one", {
     adapterFactory: createTestAdapter,
   });
+  const pool = new ConnectionPool(pc);
   expect(pool.role).toBe("reading");
   expect(pool.shard).toBe("shard_one");
 });

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -7,6 +7,9 @@ export interface DatabaseConfigOptions {
   password?: string;
   encoding?: string;
   pool?: number;
+  checkoutTimeout?: number;
+  idleTimeout?: number | null;
+  reapingFrequency?: number | null;
   url?: string;
   replicaOf?: string;
   replica?: boolean;
@@ -46,6 +49,22 @@ export class DatabaseConfig {
 
   get pool(): number {
     return this.configuration.pool ?? 5;
+  }
+
+  get checkoutTimeout(): number {
+    return (this.configuration.checkoutTimeout as number) ?? 5;
+  }
+
+  get idleTimeout(): number | null {
+    const val = this.configuration.idleTimeout;
+    if (val === null || val === 0) return null;
+    return (val as number) ?? 300;
+  }
+
+  get reapingFrequency(): number | null {
+    const val = this.configuration.reapingFrequency;
+    if (val === null || val === 0) return null;
+    return (val as number) ?? 60;
   }
 
   get replica(): boolean {


### PR DESCRIPTION
## Summary

- Reworks ConnectionPool constructor to accept PoolConfig (matching Rails `ConnectionPool.new(pool_config)`)
- Delegates `schemaReflection`, `serverVersion`, `connectionDescriptor` to PoolConfig
- Adds `automaticReconnect`, `checkoutTimeout`, `reaper`, `poolConfig`, `asyncExecutor` attrs
- Lease: `sticky` accessor, `release()` returns connection, `clear(connection)` matching Rails
- NullPool: `serverVersion`, `schemaReflection`, `connectionDescriptor`, `remove`, `asyncExecutor`, `dirtiesQueryCache`, `dbConfig`
- ExecutorHooks: `run()` noop, `complete()` placeholder
- `installExecutorHooks` static method
- Lease-based `leaseConnection`, `releaseConnection`, `isPermanentLease`
- Lifecycle: `disconnectBang`, `discardBang`, `isDiscarded`, `clearReloadableConnections`, `clearReloadableConnectionsBang`, `reap`, `flush`, `flushBang`
- `activeConnection` returns the connection (not boolean), matching Rails `active_connection?`
- DatabaseConfig: `checkoutTimeout`, `idleTimeout`, `reapingFrequency`
- PoolConfig.pool now passes `this` to ConnectionPool constructor
- `numWaitingInQueue`, `scheduleQuery`, `newConnection`, `isConnected`

PR 4 of 7 in the [connection pool infrastructure plan](docs/activerecord-connections-and-pools.md).

## Test plan

- [x] All existing pool tests updated and passing (86 passed, 54 skipped)
- [x] Full activerecord suite passes (7948 tests, 172 files)
- [x] api:compare: connection_pool 31% → 87%, pool_config 50% → 100%