### PR TITLE
feat(activerecord): rewrite transaction classes to match Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -9,6 +9,11 @@ import type { Nodes } from "@blazetrails/arel";
 import { ReadOnlyError } from "../errors.js";
 import { SchemaCache } from "./schema-cache.js";
 import { isWriteQuerySql, stripSqlComments } from "./sql-classification.js";
+import {
+  TransactionManager,
+  type Transaction,
+  type NullTransaction,
+} from "./abstract/transaction.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -68,6 +73,7 @@ export class AbstractAdapter {
   private _idleSince = Date.now();
   protected _lastActivity = 0;
   protected _config: Record<string, unknown> = {};
+  _transactionManager: TransactionManager = new TransactionManager(this as any);
 
   pool: unknown = null;
   logger: unknown = null;
@@ -287,7 +293,34 @@ export class AbstractAdapter {
     this.clearCacheBang();
   }
 
-  resetTransaction(): void {}
+  resetTransaction(options?: { restore?: boolean }): void {
+    const oldState =
+      options?.restore && this._transactionManager?.isRestorable()
+        ? this._transactionManager
+        : null;
+
+    this._transactionManager = new TransactionManager(this as any);
+
+    if (oldState) {
+      this._transactionManager = oldState;
+      this._transactionManager.restoreTransactions();
+    }
+  }
+
+  get transactionManager(): TransactionManager {
+    return this._transactionManager;
+  }
+
+  currentTransaction(): Transaction | NullTransaction {
+    return this._transactionManager.currentTransaction;
+  }
+
+  async withinNewTransaction<T>(
+    opts: { isolation?: string | null; joinable?: boolean },
+    fn: (tx?: unknown) => Promise<T> | T,
+  ): Promise<T> {
+    return this._transactionManager.withinNewTransaction(opts, fn as any);
+  }
 
   close(): void {
     this.expire();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -293,7 +293,9 @@ export class AbstractAdapter {
     this.clearCacheBang();
   }
 
-  async resetTransaction(options?: { restore?: boolean }): Promise<void> {
+  resetTransaction(): void;
+  resetTransaction(options: { restore: true }): Promise<void>;
+  resetTransaction(options?: { restore?: boolean }): void | Promise<void> {
     const oldState =
       options?.restore && this._transactionManager?.isRestorable()
         ? this._transactionManager
@@ -303,7 +305,7 @@ export class AbstractAdapter {
 
     if (oldState) {
       this._transactionManager = oldState;
-      await this._transactionManager.restoreTransactions();
+      return this._transactionManager.restoreTransactions().then(() => {});
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -293,7 +293,7 @@ export class AbstractAdapter {
     this.clearCacheBang();
   }
 
-  resetTransaction(options?: { restore?: boolean }): void {
+  async resetTransaction(options?: { restore?: boolean }): Promise<void> {
     const oldState =
       options?.restore && this._transactionManager?.isRestorable()
         ? this._transactionManager
@@ -303,7 +303,7 @@ export class AbstractAdapter {
 
     if (oldState) {
       this._transactionManager = oldState;
-      this._transactionManager.restoreTransactions();
+      await this._transactionManager.restoreTransactions();
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -296,17 +296,12 @@ export class AbstractAdapter {
   resetTransaction(): void;
   resetTransaction(options: { restore: true }): Promise<void>;
   resetTransaction(options?: { restore?: boolean }): void | Promise<void> {
-    const oldState =
-      options?.restore && this._transactionManager?.isRestorable()
-        ? this._transactionManager
-        : null;
+    if (options?.restore && this._transactionManager?.isRestorable()) {
+      const oldState = this._transactionManager;
+      return oldState.restoreTransactions().then(() => {});
+    }
 
     this._transactionManager = new TransactionManager(this as any);
-
-    if (oldState) {
-      this._transactionManager = oldState;
-      return this._transactionManager.restoreTransactions().then(() => {});
-    }
   }
 
   get transactionManager(): TransactionManager {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -296,9 +296,12 @@ export class AbstractAdapter {
   resetTransaction(): void;
   resetTransaction(options: { restore: true }): Promise<void>;
   resetTransaction(options?: { restore?: boolean }): void | Promise<void> {
-    if (options?.restore && this._transactionManager?.isRestorable()) {
-      const oldState = this._transactionManager;
-      return oldState.restoreTransactions().then(() => {});
+    if (options?.restore) {
+      if (this._transactionManager?.isRestorable()) {
+        return this._transactionManager.restoreTransactions().then(() => {});
+      }
+      this._transactionManager = new TransactionManager(this as any);
+      return Promise.resolve();
     }
 
     this._transactionManager = new TransactionManager(this as any);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -901,6 +901,10 @@ export async function rawExecQuery(
   if (!this.rawExecute) {
     throw new Error("rawExecQuery requires rawExecute on the adapter");
   }
+  // Materialize lazy transactions before executing SQL, matching Rails'
+  // with_raw_connection which calls materialize_transactions.
+  const tm = (this as any)._transactionManager as TransactionManager | undefined;
+  if (tm) await tm.materializeTransactions();
   const rawResult = await this.rawExecute(sql, name ?? "SQL", binds);
   return this.castResult ? this.castResult(rawResult) : rawResult;
 }
@@ -917,6 +921,9 @@ export async function internalExecQuery(
   name?: string | null,
   binds?: unknown[],
 ): Promise<unknown> {
+  // Materialize lazy transactions before executing SQL
+  const tm = (this as any)._transactionManager as TransactionManager | undefined;
+  if (tm) await tm.materializeTransactions();
   if (this?.internalExecute) {
     const rawResult = await this.internalExecute(sql, name ?? "SQL", binds);
     return this.castResult ? this.castResult(rawResult) : rawResult;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -7,6 +7,7 @@
 import { sql as arelSql, Nodes } from "@blazetrails/arel";
 import { TransactionIsolationError } from "../../errors.js";
 import { quote, quoteTableName, quoteColumnName } from "./quoting.js";
+import { TransactionManager } from "./transaction.js";
 
 /**
  * Host interface for DatabaseStatements mixin methods that need adapter context.
@@ -544,7 +545,7 @@ export async function transaction<T>(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction_manager
  */
-export function transactionManager(this: DatabaseStatementsHost): unknown {
+export function transactionManager(this: DatabaseStatementsHost): TransactionManager | null {
   return (this as any)._transactionManager ?? null;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -159,7 +159,14 @@ export class TransactionInstrumenter {
     }
     if (this._event) {
       this._event.finish();
-      Notifications.publish("transaction.active_record", this._event.payload);
+      // Publish with the finished event's payload including timing and outcome.
+      // Ideally we'd publish the Event instance directly (like Rails' handle.finish),
+      // but Notifications.publish creates a new Event. The payload carries the
+      // outcome; duration can be derived from the event's time/end if needed.
+      Notifications.publish("transaction.active_record", {
+        ...this._event.payload,
+        duration: this._event.duration,
+      });
     }
   }
 }
@@ -378,7 +385,8 @@ export class Transaction {
   }
 
   get records(): unknown[] | null {
-    if (this._lazyEnrollmentRecords && this._records) {
+    if (this._lazyEnrollmentRecords) {
+      if (!this._records) this._records = [];
       for (const value of this._lazyEnrollmentRecords.values()) {
         this._records.push(value);
       }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -424,10 +424,11 @@ export class Transaction {
     if (recs) {
       const ite = this._uniqueRecords(recs);
       const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+      let idx = 0;
 
       try {
-        while (ite.length > 0) {
-          const record = ite.shift()!;
+        for (; idx < ite.length; idx++) {
+          const record = ite[idx];
           const shouldRunCallbacks =
             instanceMap.get(record) === record &&
             typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
@@ -441,7 +442,8 @@ export class Transaction {
           }
         }
       } finally {
-        for (const i of ite) {
+        for (; idx < ite.length; idx++) {
+          const i = ite[idx];
           if (typeof (i as any).rolledbackBang === "function") {
             await (i as any).rolledbackBang({
               forceRestoreState: this.isFullRollback(),
@@ -485,10 +487,11 @@ export class Transaction {
 
       if (this._runCommitCallbacks) {
         const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+        let idx = 0;
 
         try {
-          while (ite.length > 0) {
-            const record = ite.shift()!;
+          for (; idx < ite.length; idx++) {
+            const record = ite[idx];
             const shouldRunCallbacks =
               instanceMap.get(record) === record &&
               typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
@@ -499,15 +502,15 @@ export class Transaction {
             }
           }
         } finally {
-          for (const i of ite) {
+          for (; idx < ite.length; idx++) {
+            const i = ite[idx];
             if (typeof (i as any).committedBang === "function") {
               await (i as any).committedBang({ shouldRunCallbacks: false });
             }
           }
         }
       } else {
-        while (ite.length > 0) {
-          const record = ite.shift()!;
+        for (const record of ite) {
           this._connection.addTransactionRecord?.(record);
         }
       }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -348,7 +348,7 @@ export class Transaction {
     return this._materialized;
   }
 
-  materializeBang(): void {
+  async materializeBang(): Promise<void> {
     this._materialized = true;
     this._instrumenter.start();
   }
@@ -359,11 +359,11 @@ export class Transaction {
     }
   }
 
-  restoreBang(): void {
+  async restoreBang(): Promise<void> {
     if (this.isMaterialized()) {
       this.incompleteBang();
       this._materialized = false;
-      this.materializeBang();
+      await this.materializeBang();
     }
   }
 
@@ -519,7 +519,7 @@ export class Transaction {
     }
   }
 
-  restart(): void {
+  async restart(): Promise<void> {
     // No-op: subclasses (RealTransaction, SavepointTransaction) override with actual restart logic
   }
 
@@ -631,21 +631,21 @@ export class RestartParentTransaction extends Transaction {
     parentTransaction.state.addChild(this.state);
   }
 
-  override materializeBang(): void {
-    this._parent.materializeBang();
+  override async materializeBang(): Promise<void> {
+    await this._parent.materializeBang();
   }
 
   override isMaterialized(): boolean {
     return this._parent.isMaterialized();
   }
 
-  restart(): void {
-    this._parent.restart();
+  async restart(): Promise<void> {
+    await this._parent.restart();
   }
 
   override async rollback(): Promise<void> {
     this.state.rollbackBang();
-    this._parent.restart();
+    await this._parent.restart();
   }
 
   override async commit(): Promise<void> {
@@ -680,18 +680,18 @@ export class SavepointTransaction extends Transaction {
     this.savepointName = savepointName;
   }
 
-  override materializeBang(): void {
-    this.connection.createSavepoint(this.savepointName);
-    super.materializeBang();
+  override async materializeBang(): Promise<void> {
+    await this.connection.createSavepoint(this.savepointName);
+    await super.materializeBang();
   }
 
-  restart(): void {
+  async restart(): Promise<void> {
     if (!this.isMaterialized()) return;
 
     this._instrumenter.finish("restart");
     this._instrumenter.start();
 
-    this.connection.rollbackToSavepoint(this.savepointName);
+    await this.connection.rollbackToSavepoint(this.savepointName);
   }
 
   override async rollback(): Promise<void> {
@@ -726,38 +726,38 @@ export class SavepointTransaction extends Transaction {
  * Mirrors: ActiveRecord::ConnectionAdapters::RealTransaction
  */
 export class RealTransaction extends Transaction {
-  override materializeBang(): void {
+  override async materializeBang(): Promise<void> {
     if (this.joinable) {
       if (this.isolationLevel) {
-        this.connection.beginIsolatedDbTransaction?.(this.isolationLevel);
+        await this.connection.beginIsolatedDbTransaction?.(this.isolationLevel);
       } else {
-        this.connection.beginDbTransaction?.();
+        await this.connection.beginDbTransaction?.();
       }
     } else {
-      this.connection.beginDeferredTransaction?.(this.isolationLevel);
+      await this.connection.beginDeferredTransaction?.(this.isolationLevel);
     }
-    super.materializeBang();
+    await super.materializeBang();
   }
 
-  restart(): void {
+  async restart(): Promise<void> {
     if (!this.isMaterialized()) return;
 
     this._instrumenter.finish("restart");
 
     if (this.connection.supportsRestartDbTransaction?.()) {
       this._instrumenter.start();
-      this.connection.restartDbTransaction?.();
+      await this.connection.restartDbTransaction?.();
     } else {
-      this.connection.rollbackDbTransaction?.();
-      this.materializeBang();
+      await this.connection.rollbackDbTransaction?.();
+      await this.materializeBang();
     }
   }
 
   override async rollback(): Promise<void> {
     if (this.isMaterialized()) {
-      this.connection.rollbackDbTransaction?.();
+      await this.connection.rollbackDbTransaction?.();
       if (this.isolationLevel) {
-        this.connection.resetIsolationLevel?.();
+        await this.connection.resetIsolationLevel?.();
       }
     }
     this.state.fullRollbackBang();
@@ -768,9 +768,9 @@ export class RealTransaction extends Transaction {
 
   override async commit(): Promise<void> {
     if (this.isMaterialized()) {
-      this.connection.commitDbTransaction?.();
+      await this.connection.commitDbTransaction?.();
       if (this.isolationLevel) {
-        this.connection.resetIsolationLevel?.();
+        await this.connection.resetIsolationLevel?.();
       }
     }
     this.state.fullCommitBang();
@@ -845,7 +845,7 @@ export class TransactionManager {
       ) {
         this._hasUnmaterializedTransactions = true;
       } else {
-        transaction.materializeBang();
+        await transaction.materializeBang();
       }
     }
 
@@ -853,8 +853,8 @@ export class TransactionManager {
     return transaction;
   }
 
-  disableLazyTransactionsBang(): void {
-    this.materializeTransactions();
+  async disableLazyTransactionsBang(): Promise<void> {
+    await this.materializeTransactions();
     this._lazyTransactionsEnabled = false;
   }
 
@@ -873,11 +873,11 @@ export class TransactionManager {
     }
   }
 
-  restoreTransactions(): boolean {
+  async restoreTransactions(): Promise<boolean> {
     if (!this.isRestorable()) return false;
     for (const t of this._stack) {
       if (t instanceof Transaction) {
-        t.restoreBang();
+        await t.restoreBang();
       }
     }
     return true;
@@ -890,7 +890,7 @@ export class TransactionManager {
     });
   }
 
-  materializeTransactions(): void {
+  async materializeTransactions(): Promise<void> {
     if (this._materializingTransactions) return;
 
     if (this._hasUnmaterializedTransactions) {
@@ -898,7 +898,7 @@ export class TransactionManager {
         this._materializingTransactions = true;
         for (const t of this._stack) {
           if (t instanceof Transaction && !t.isMaterialized()) {
-            t.materializeBang();
+            await t.materializeBang();
           }
         }
       } finally {

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -520,9 +520,7 @@ export class Transaction {
   }
 
   restart(): void {
-    // Overridden by RealTransaction, SavepointTransaction, RestartParentTransaction.
-    // Base implementation is intentionally empty — only subclasses that represent
-    // actual DB transactions have restart behavior.
+    // No-op: subclasses (RealTransaction, SavepointTransaction) override with actual restart logic
   }
 
   isFullRollback(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1,50 +1,102 @@
 import type { DatabaseAdapter } from "../../adapter.js";
-import { Notifications } from "@blazetrails/activesupport";
+import { ActiveRecordTransaction } from "../../transaction.js";
+import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::TransactionState
  */
 export class TransactionState {
-  private _state: "committed" | "rolledBack" | "nullified" | null = null;
+  private _state:
+    | "committed"
+    | "fully_committed"
+    | "rolledback"
+    | "fully_rolledback"
+    | "invalidated"
+    | null = null;
+  private _children: TransactionState[] | null = null;
+
+  constructor(state: TransactionState["_state"] = null) {
+    this._state = state;
+  }
+
+  addChild(state: TransactionState): void {
+    if (!this._children) this._children = [];
+    this._children.push(state);
+  }
 
   get finalized(): boolean {
     return this._state !== null;
   }
 
   get committed(): boolean {
-    return this._state === "committed";
+    return this._state === "committed" || this._state === "fully_committed";
   }
 
-  get rolledBack(): boolean {
-    return this._state === "rolledBack";
-  }
-
-  get nullified(): boolean {
-    return this._state === "nullified";
+  isCommitted(): boolean {
+    return this.committed;
   }
 
   get fullyCommitted(): boolean {
-    return this._state === "committed";
+    return this._state === "fully_committed";
+  }
+
+  isFullyCommitted(): boolean {
+    return this.fullyCommitted;
+  }
+
+  isRolledback(): boolean {
+    return this._state === "rolledback" || this._state === "fully_rolledback";
+  }
+
+  get rolledBack(): boolean {
+    return this.isRolledback();
+  }
+
+  isFullyRolledback(): boolean {
+    return this._state === "fully_rolledback";
   }
 
   get fullyRolledBack(): boolean {
-    return this._state === "rolledBack";
+    return this.isFullyRolledback();
+  }
+
+  isInvalidated(): boolean {
+    return this._state === "invalidated";
+  }
+
+  isCompleted(): boolean {
+    return this.committed || this.isRolledback();
   }
 
   get fullyCompleted(): boolean {
-    return this.fullyCommitted || this.fullyRolledBack;
+    return this.isCompleted();
   }
 
-  setCommitted(): void {
+  rollbackBang(): void {
+    this._children?.forEach((c) => c.rollbackBang());
+    this._state = "rolledback";
+  }
+
+  fullRollbackBang(): void {
+    this._children?.forEach((c) => c.rollbackBang());
+    this._state = "fully_rolledback";
+  }
+
+  invalidateBang(): void {
+    this._children?.forEach((c) => c.invalidateBang());
+    this._state = "invalidated";
+  }
+
+  commitBang(): void {
     this._state = "committed";
   }
 
-  setRolledBack(): void {
-    this._state = "rolledBack";
+  fullCommitBang(): void {
+    this._state = "fully_committed";
   }
 
-  setNullified(): void {
-    this._state = "nullified";
+  nullifyBang(): void {
+    this._state = null;
   }
 }
 
@@ -52,7 +104,7 @@ export class TransactionState {
  * Mirrors: ActiveRecord::ConnectionAdapters::TransactionInstrumenter::InstrumentationNotStartedError
  */
 export class InstrumentationNotStartedError extends Error {
-  constructor(message = "Instrumentation has not been started") {
+  constructor(message = "Called finish on a transaction that hasn't started") {
     super(message);
     this.name = "InstrumentationNotStartedError";
   }
@@ -62,7 +114,7 @@ export class InstrumentationNotStartedError extends Error {
  * Mirrors: ActiveRecord::ConnectionAdapters::TransactionInstrumenter::InstrumentationAlreadyStartedError
  */
 export class InstrumentationAlreadyStartedError extends Error {
-  constructor(message = "Instrumentation has already been started") {
+  constructor(message = "Called start on an already started transaction") {
     super(message);
     this.name = "InstrumentationAlreadyStartedError";
   }
@@ -76,25 +128,39 @@ export class TransactionInstrumenter {
   static readonly InstrumentationAlreadyStartedError = InstrumentationAlreadyStartedError;
 
   private _started = false;
-  private _startTime?: number;
+  private _basePayload: Record<string, unknown>;
+  private _payload: Record<string, unknown> | null = null;
+  private _event: NotificationEvent | null = null;
+
+  constructor(payload: Record<string, unknown> = {}) {
+    this._basePayload = payload;
+  }
 
   start(): void {
     if (this._started) {
       throw new InstrumentationAlreadyStartedError();
     }
     this._started = true;
-    this._startTime = Date.now();
-    Notifications.instrument("start_transaction.active_record", {});
+
+    Notifications.instrument("start_transaction.active_record", this._basePayload);
+
+    this._payload = { ...this._basePayload };
+    this._event = new NotificationEvent("transaction.active_record", new Date(), this._payload);
   }
 
-  finish(): number {
+  finish(outcome: string): void {
     if (!this._started) {
       throw new InstrumentationNotStartedError();
     }
     this._started = false;
-    const duration = Date.now() - this._startTime!;
-    this._startTime = undefined;
-    return duration;
+
+    if (this._payload) {
+      this._payload.outcome = outcome;
+    }
+    if (this._event) {
+      this._event.finish();
+      Notifications.publish("transaction.active_record", this._event.payload);
+    }
   }
 }
 
@@ -102,7 +168,7 @@ export class TransactionInstrumenter {
  * Mirrors: ActiveRecord::ConnectionAdapters::NullTransaction
  */
 export class NullTransaction {
-  readonly state = new TransactionState();
+  state: TransactionState | undefined = undefined;
 
   get open(): boolean {
     return false;
@@ -115,16 +181,70 @@ export class NullTransaction {
   get joinable(): boolean {
     return false;
   }
+
+  isRestartable(): boolean {
+    return false;
+  }
+
+  isDirty(): boolean {
+    return false;
+  }
+
+  dirtyBang(): void {}
+
+  isInvalidated(): boolean {
+    return false;
+  }
+
+  invalidateBang(): void {}
+
+  isMaterialized(): boolean {
+    return false;
+  }
+
+  addRecord(_record: unknown, _ensureFinalize = true): void {}
+
+  beforeCommit(fn?: () => void | Promise<void>): void | Promise<void> {
+    if (fn) return fn();
+  }
+
+  afterCommit(fn?: () => void | Promise<void>): void | Promise<void> {
+    if (fn) return fn();
+  }
+
+  afterRollback(_fn?: () => void | Promise<void>): void {}
+
+  get userTransaction(): ActiveRecordTransaction {
+    return ActiveRecordTransaction.NULL_TRANSACTION;
+  }
 }
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::Transaction::Callback
  */
 export class TransactionCallback {
+  private _event: "before_commit" | "after_commit" | "after_rollback";
+  private _callback: () => void | Promise<void>;
+
   constructor(
-    readonly event: "commit" | "rollback",
-    readonly fn: () => void | Promise<void>,
-  ) {}
+    event: "before_commit" | "after_commit" | "after_rollback",
+    callback: () => void | Promise<void>,
+  ) {
+    this._event = event;
+    this._callback = callback;
+  }
+
+  beforeCommit(): void | Promise<void> {
+    if (this._event === "before_commit") return this._callback();
+  }
+
+  afterCommit(): void | Promise<void> {
+    if (this._event === "after_commit") return this._callback();
+  }
+
+  afterRollback(): void | Promise<void> {
+    if (this._event === "after_rollback") return this._callback();
+  }
 }
 
 /**
@@ -132,62 +252,258 @@ export class TransactionCallback {
  */
 export class Transaction {
   readonly state = new TransactionState();
-  private _callbacks: TransactionCallback[] = [];
-  private _adapter: DatabaseAdapter;
+  private _callbacks: TransactionCallback[] | null = null;
+  private _records: unknown[] | null = null;
+  private _lazyEnrollmentRecords: WeakMap<object, unknown> | null = null;
+  private _connection: DatabaseAdapter;
   private _joinable: boolean;
-  private _open = true;
+  readonly isolationLevel: string | null;
+  private _materialized = false;
+  private _runCommitCallbacks: boolean;
+  private _dirty = false;
+  written = false;
+  readonly userTransaction: ActiveRecordTransaction;
+  protected _instrumenter: TransactionInstrumenter;
 
   static readonly Callback = TransactionCallback;
 
-  constructor(adapter: DatabaseAdapter, options: { joinable?: boolean } = {}) {
-    this._adapter = adapter;
+  constructor(
+    connection: DatabaseAdapter,
+    options: {
+      isolation?: string | null;
+      joinable?: boolean;
+      runCommitCallbacks?: boolean;
+    } = {},
+  ) {
+    this._connection = connection;
     this._joinable = options.joinable ?? true;
+    this.isolationLevel = options.isolation ?? null;
+    this._runCommitCallbacks = options.runCommitCallbacks ?? false;
+    this.userTransaction = this._joinable
+      ? new ActiveRecordTransaction(this)
+      : ActiveRecordTransaction.NULL_TRANSACTION;
+    this._instrumenter = new TransactionInstrumenter({
+      connection,
+      transaction: this.userTransaction,
+    });
+  }
+
+  get connection(): DatabaseAdapter {
+    return this._connection;
   }
 
   get open(): boolean {
-    return this._open;
+    return true;
   }
 
   get closed(): boolean {
-    return !this._open;
+    return false;
   }
 
   get joinable(): boolean {
     return this._joinable;
   }
 
-  get connection(): DatabaseAdapter {
-    return this._adapter;
+  invalidateBang(): void {
+    this.state.invalidateBang();
+  }
+
+  isInvalidated(): boolean {
+    return this.state.isInvalidated();
+  }
+
+  dirtyBang(): void {
+    this._dirty = true;
+  }
+
+  isDirty(): boolean {
+    return this._dirty;
+  }
+
+  isRestartable(): boolean {
+    return this.joinable && !this.isDirty();
+  }
+
+  isMaterialized(): boolean {
+    return this._materialized;
+  }
+
+  materializeBang(): void {
+    this._materialized = true;
+    this._instrumenter.start();
+  }
+
+  incompleteBang(): void {
+    if (this.isMaterialized()) {
+      this._instrumenter.finish("incomplete");
+    }
+  }
+
+  restoreBang(): void {
+    if (this.isMaterialized()) {
+      this.incompleteBang();
+      this._materialized = false;
+      this.materializeBang();
+    }
+  }
+
+  addRecord(record: unknown, ensureFinalize = true): void {
+    if (!this._records) this._records = [];
+    if (ensureFinalize) {
+      this._records.push(record);
+    } else {
+      if (!this._lazyEnrollmentRecords) this._lazyEnrollmentRecords = new WeakMap();
+      this._lazyEnrollmentRecords.set(record as object, record);
+    }
+  }
+
+  get records(): unknown[] | null {
+    if (this._lazyEnrollmentRecords && this._records) {
+      // WeakMap doesn't have .values() — lazy records are best-effort
+      this._lazyEnrollmentRecords = null;
+    }
+    return this._records;
+  }
+
+  beforeCommit(fn: () => void | Promise<void>): void {
+    if (this.state.finalized) {
+      throw new Error("Cannot register callbacks on a finalized transaction");
+    }
+    if (!this._callbacks) this._callbacks = [];
+    this._callbacks.push(new TransactionCallback("before_commit", fn));
   }
 
   afterCommit(fn: () => void | Promise<void>): void {
-    this._callbacks.push(new TransactionCallback("commit", fn));
+    if (this.state.finalized) {
+      throw new Error("Cannot register callbacks on a finalized transaction");
+    }
+    if (!this._callbacks) this._callbacks = [];
+    this._callbacks.push(new TransactionCallback("after_commit", fn));
   }
 
   afterRollback(fn: () => void | Promise<void>): void {
-    this._callbacks.push(new TransactionCallback("rollback", fn));
+    if (this.state.finalized) {
+      throw new Error("Cannot register callbacks on a finalized transaction");
+    }
+    if (!this._callbacks) this._callbacks = [];
+    this._callbacks.push(new TransactionCallback("after_rollback", fn));
+  }
+
+  async rollbackRecords(): Promise<void> {
+    if (this._records) {
+      const ite = this._uniqueRecords();
+      for (const record of ite) {
+        if (typeof (record as any).rolledbackBang === "function") {
+          await (record as any).rolledbackBang({
+            forceRestoreState: this.isFullRollback(),
+            shouldRunCallbacks: true,
+          });
+        }
+      }
+    }
+    if (this._callbacks) {
+      for (const cb of this._callbacks) {
+        await cb.afterRollback();
+      }
+    }
+  }
+
+  async beforeCommitRecords(): Promise<void> {
+    if (this._runCommitCallbacks) {
+      if (this._records) {
+        const ite = this._uniqueRecords();
+        for (const record of ite) {
+          if (typeof (record as any).beforeCommittedBang === "function") {
+            await (record as any).beforeCommittedBang();
+          }
+        }
+      }
+      if (this._callbacks) {
+        for (const cb of this._callbacks) {
+          await cb.beforeCommit();
+        }
+      }
+    }
+  }
+
+  async commitRecords(): Promise<void> {
+    if (this._records) {
+      const ite = this._uniqueRecords();
+      if (this._runCommitCallbacks) {
+        for (const record of ite) {
+          if (typeof (record as any).committedBang === "function") {
+            await (record as any).committedBang({ shouldRunCallbacks: true });
+          }
+        }
+      } else {
+        for (const record of ite) {
+          if (typeof (this._connection as any).addTransactionRecord === "function") {
+            (this._connection as any).addTransactionRecord(record);
+          }
+        }
+      }
+    }
+
+    if (this._runCommitCallbacks) {
+      if (this._callbacks) {
+        for (const cb of this._callbacks) {
+          await cb.afterCommit();
+        }
+      }
+    } else if (this._callbacks) {
+      const current = (this._connection as any).currentTransaction?.();
+      if (current && typeof current.appendCallbacks === "function") {
+        current.appendCallbacks(this._callbacks);
+      }
+    }
+  }
+
+  restart(): void {
+    // Subclasses override
+  }
+
+  isFullRollback(): boolean {
+    return true;
+  }
+
+  appendCallbacks(callbacks: TransactionCallback[]): void {
+    if (!this._callbacks) this._callbacks = [];
+    this._callbacks.push(...callbacks);
   }
 
   async commit(): Promise<void> {
-    this.state.setCommitted();
-    this._open = false;
+    this.state.commitBang();
   }
 
   async rollback(): Promise<void> {
-    this.state.setRolledBack();
-    this._open = false;
+    this.state.rollbackBang();
   }
 
   async runAfterCommitCallbacks(): Promise<void> {
+    if (!this._callbacks) return;
     for (const cb of this._callbacks) {
-      if (cb.event === "commit") await cb.fn();
+      await cb.afterCommit();
     }
   }
 
   async runAfterRollbackCallbacks(): Promise<void> {
+    if (!this._callbacks) return;
     for (const cb of this._callbacks) {
-      if (cb.event === "rollback") await cb.fn();
+      await cb.afterRollback();
     }
+  }
+
+  private _uniqueRecords(): unknown[] {
+    if (!this._records) return [];
+    const seen = new Set<unknown>();
+    const result: unknown[] = [];
+    for (const record of this._records) {
+      if (!seen.has(record)) {
+        seen.add(record);
+        result.push(record);
+      }
+    }
+    return result;
   }
 }
 
@@ -195,8 +511,47 @@ export class Transaction {
  * Mirrors: ActiveRecord::ConnectionAdapters::RestartParentTransaction
  */
 export class RestartParentTransaction extends Transaction {
-  constructor(adapter: DatabaseAdapter, options: { joinable?: boolean } = {}) {
-    super(adapter, options);
+  private _parent: Transaction;
+
+  constructor(
+    connection: DatabaseAdapter,
+    parentTransaction: Transaction,
+    options: { isolation?: string | null; joinable?: boolean; runCommitCallbacks?: boolean } = {},
+  ) {
+    super(connection, options);
+
+    this._parent = parentTransaction;
+
+    if (this.isolationLevel) {
+      throw new Error("cannot set transaction isolation in a nested transaction");
+    }
+
+    parentTransaction.state.addChild(this.state);
+  }
+
+  override materializeBang(): void {
+    this._parent.materializeBang();
+  }
+
+  override isMaterialized(): boolean {
+    return this._parent.isMaterialized();
+  }
+
+  restart(): void {
+    this._parent.restart();
+  }
+
+  override async rollback(): Promise<void> {
+    this.state.rollbackBang();
+    this._parent.restart();
+  }
+
+  override async commit(): Promise<void> {
+    this.state.commitBang();
+  }
+
+  override isFullRollback(): boolean {
+    return false;
   }
 }
 
@@ -207,22 +562,58 @@ export class SavepointTransaction extends Transaction {
   readonly savepointName: string;
 
   constructor(
-    adapter: DatabaseAdapter,
+    connection: DatabaseAdapter,
     savepointName: string,
-    options: { joinable?: boolean } = {},
+    parentTransaction: Transaction,
+    options: { isolation?: string | null; joinable?: boolean; runCommitCallbacks?: boolean } = {},
   ) {
-    super(adapter, options);
+    super(connection, options);
+
+    parentTransaction.state.addChild(this.state);
+
+    if (this.isolationLevel) {
+      throw new Error("cannot set transaction isolation in a nested transaction");
+    }
+
     this.savepointName = savepointName;
   }
 
-  async commit(): Promise<void> {
-    await this.connection.releaseSavepoint(this.savepointName);
-    await super.commit();
+  override materializeBang(): void {
+    this.connection.createSavepoint(this.savepointName);
+    super.materializeBang();
   }
 
-  async rollback(): Promise<void> {
-    await this.connection.rollbackToSavepoint(this.savepointName);
-    await super.rollback();
+  restart(): void {
+    if (!this.isMaterialized()) return;
+    this._instrumenter.finish("restart");
+    this._instrumenter.start();
+    this.connection.rollbackToSavepoint(this.savepointName);
+  }
+
+  override async rollback(): Promise<void> {
+    if (!this.state.isInvalidated()) {
+      if (this.isMaterialized()) {
+        await this.connection.rollbackToSavepoint(this.savepointName);
+      }
+    }
+    this.state.rollbackBang();
+    if (this.isMaterialized()) {
+      this._instrumenter.finish("rollback");
+    }
+  }
+
+  override async commit(): Promise<void> {
+    if (this.isMaterialized()) {
+      await this.connection.releaseSavepoint(this.savepointName);
+    }
+    this.state.commitBang();
+    if (this.isMaterialized()) {
+      this._instrumenter.finish("commit");
+    }
+  }
+
+  override isFullRollback(): boolean {
+    return false;
   }
 }
 
@@ -230,14 +621,65 @@ export class SavepointTransaction extends Transaction {
  * Mirrors: ActiveRecord::ConnectionAdapters::RealTransaction
  */
 export class RealTransaction extends Transaction {
-  async commit(): Promise<void> {
-    await this.connection.commit();
-    await super.commit();
+  override materializeBang(): void {
+    if (this.joinable) {
+      if (this.isolationLevel) {
+        (this.connection as any).beginIsolatedDbTransaction(this.isolationLevel);
+      } else {
+        (this.connection as any).beginDbTransaction();
+      }
+    } else {
+      (this.connection as any).beginDeferredTransaction(this.isolationLevel);
+    }
+    super.materializeBang();
   }
 
-  async rollback(): Promise<void> {
-    await this.connection.rollback();
-    await super.rollback();
+  restart(): void {
+    if (!this.isMaterialized()) return;
+    this._instrumenter.finish("restart");
+
+    if (
+      typeof (this.connection as any).supportsRestartDbTransaction === "function" &&
+      (this.connection as any).supportsRestartDbTransaction()
+    ) {
+      this._instrumenter.start();
+      (this.connection as any).restartDbTransaction();
+    } else {
+      (this.connection as any).rollbackDbTransaction();
+      this.materializeBang();
+    }
+  }
+
+  override async rollback(): Promise<void> {
+    if (this.isMaterialized()) {
+      (this.connection as any).rollbackDbTransaction();
+      if (
+        this.isolationLevel &&
+        typeof (this.connection as any).resetIsolationLevel === "function"
+      ) {
+        (this.connection as any).resetIsolationLevel();
+      }
+    }
+    this.state.fullRollbackBang();
+    if (this.isMaterialized()) {
+      this._instrumenter.finish("rollback");
+    }
+  }
+
+  override async commit(): Promise<void> {
+    if (this.isMaterialized()) {
+      (this.connection as any).commitDbTransaction();
+      if (
+        this.isolationLevel &&
+        typeof (this.connection as any).resetIsolationLevel === "function"
+      ) {
+        (this.connection as any).resetIsolationLevel();
+      }
+    }
+    this.state.fullCommitBang();
+    if (this.isMaterialized()) {
+      this._instrumenter.finish("commit");
+    }
   }
 }
 
@@ -246,53 +688,163 @@ export class RealTransaction extends Transaction {
  */
 export class TransactionManager {
   private _stack: (Transaction | NullTransaction)[] = [];
-  private _adapter: DatabaseAdapter;
+  private _connection: DatabaseAdapter;
+  private _hasUnmaterializedTransactions = false;
+  private _materializingTransactions = false;
+  private _lazyTransactionsEnabled = true;
 
-  constructor(adapter: DatabaseAdapter) {
-    this._adapter = adapter;
+  static readonly NULL_TRANSACTION = Object.freeze(new NullTransaction());
+
+  constructor(connection: DatabaseAdapter) {
+    this._connection = connection;
   }
 
   get currentTransaction(): Transaction | NullTransaction {
-    return this._stack.length > 0 ? this._stack[this._stack.length - 1] : new NullTransaction();
+    return this._stack.length > 0
+      ? this._stack[this._stack.length - 1]
+      : TransactionManager.NULL_TRANSACTION;
   }
 
   get openTransactions(): number {
-    return this._stack.filter((t) => t.open).length;
+    return this._stack.length;
   }
 
   get withinNewTransaction(): boolean {
     return this._stack.length > 0;
   }
 
-  async beginTransaction(options: { joinable?: boolean } = {}): Promise<Transaction> {
+  async beginTransaction(
+    options: { isolation?: string | null; joinable?: boolean; _lazy?: boolean } = {},
+  ): Promise<Transaction> {
+    const { isolation = null, joinable = true, _lazy = true } = options;
+    const current = this.currentTransaction;
+    const runCommitCallbacks = current instanceof Transaction ? !current.joinable : true;
+
     let transaction: Transaction;
 
     if (this._stack.length === 0) {
-      await this._adapter.beginTransaction();
-      transaction = new RealTransaction(this._adapter, options);
+      transaction = new RealTransaction(this._connection, {
+        isolation,
+        joinable,
+        runCommitCallbacks,
+      });
+    } else if (current instanceof Transaction && current.isRestartable()) {
+      transaction = new RestartParentTransaction(this._connection, current, {
+        isolation,
+        joinable,
+        runCommitCallbacks,
+      });
     } else {
-      const savepointName = `active_record_${this._stack.length}`;
-      await this._adapter.createSavepoint(savepointName);
-      transaction = new SavepointTransaction(this._adapter, savepointName, options);
+      const parentTransaction = current instanceof Transaction ? current : undefined;
+      transaction = new SavepointTransaction(
+        this._connection,
+        `active_record_${this._stack.length}`,
+        parentTransaction!,
+        { isolation, joinable, runCommitCallbacks },
+      );
+    }
+
+    if (!transaction.isMaterialized()) {
+      if (
+        typeof (this._connection as any).supportsLazyTransactions === "function" &&
+        (this._connection as any).supportsLazyTransactions() &&
+        this.isLazyTransactionsEnabled() &&
+        _lazy
+      ) {
+        this._hasUnmaterializedTransactions = true;
+      } else {
+        transaction.materializeBang();
+      }
     }
 
     this._stack.push(transaction);
     return transaction;
   }
 
-  async commitTransaction(): Promise<void> {
-    const transaction = this._stack.pop();
-    if (transaction && transaction instanceof Transaction) {
-      await transaction.commit();
-      await transaction.runAfterCommitCallbacks();
+  disableLazyTransactionsBang(): void {
+    this.materializeTransactions();
+    this._lazyTransactionsEnabled = false;
+  }
+
+  enableLazyTransactionsBang(): void {
+    this._lazyTransactionsEnabled = true;
+  }
+
+  isLazyTransactionsEnabled(): boolean {
+    return this._lazyTransactionsEnabled;
+  }
+
+  dirtyCurrentTransaction(): void {
+    const current = this.currentTransaction;
+    if (current instanceof Transaction) {
+      current.dirtyBang();
     }
   }
 
-  async rollbackTransaction(): Promise<void> {
-    const transaction = this._stack.pop();
-    if (transaction && transaction instanceof Transaction) {
-      await transaction.rollback();
-      await transaction.runAfterRollbackCallbacks();
+  restoreTransactions(): boolean {
+    if (!this.isRestorable()) return false;
+    for (const t of this._stack) {
+      if (t instanceof Transaction) {
+        t.restoreBang();
+      }
     }
+    return true;
+  }
+
+  isRestorable(): boolean {
+    return this._stack.every((t) => {
+      if (t instanceof Transaction) return !t.isDirty();
+      return true;
+    });
+  }
+
+  materializeTransactions(): void {
+    if (this._materializingTransactions) return;
+
+    if (this._hasUnmaterializedTransactions) {
+      try {
+        this._materializingTransactions = true;
+        for (const t of this._stack) {
+          if (t instanceof Transaction && !t.isMaterialized()) {
+            t.materializeBang();
+          }
+        }
+      } finally {
+        this._materializingTransactions = false;
+      }
+      this._hasUnmaterializedTransactions = false;
+    }
+  }
+
+  async commitTransaction(): Promise<void> {
+    const transaction = this._stack[this._stack.length - 1];
+    if (!(transaction instanceof Transaction)) return;
+
+    try {
+      await transaction.beforeCommitRecords();
+    } finally {
+      this._stack.pop();
+    }
+
+    if (transaction.isDirty()) {
+      this.dirtyCurrentTransaction();
+    }
+
+    await transaction.commit();
+    await transaction.commitRecords();
+  }
+
+  async rollbackTransaction(transaction?: Transaction): Promise<void> {
+    const txn = transaction || this._stack[this._stack.length - 1];
+    if (!(txn instanceof Transaction)) return;
+
+    try {
+      await txn.rollback();
+    } finally {
+      if (this._stack[this._stack.length - 1] === txn) {
+        this._stack.pop();
+      }
+    }
+    await txn.rollbackRecords();
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -248,14 +248,34 @@ export class TransactionCallback {
 }
 
 /**
+ * Connection interface used by Transaction classes.
+ * Extends DatabaseAdapter with the DatabaseStatements methods that
+ * Transaction classes call. This avoids `as any` casts throughout.
+ */
+export interface TransactionConnection extends DatabaseAdapter {
+  beginDbTransaction?(): void | Promise<void>;
+  beginIsolatedDbTransaction?(isolation: string): void | Promise<void>;
+  beginDeferredTransaction?(isolation?: string | null): void | Promise<void>;
+  commitDbTransaction?(): void | Promise<void>;
+  rollbackDbTransaction?(): void | Promise<void>;
+  restartDbTransaction?(): void | Promise<void>;
+  resetIsolationLevel?(): void | Promise<void>;
+  supportsLazyTransactions?(): boolean;
+  supportsRestartDbTransaction?(): boolean;
+  addTransactionRecord?(record: unknown): void;
+  active?: boolean;
+  currentTransaction?(): Transaction | NullTransaction;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::Transaction
  */
 export class Transaction {
   readonly state = new TransactionState();
   private _callbacks: TransactionCallback[] | null = null;
   private _records: unknown[] | null = null;
-  private _lazyEnrollmentRecords: WeakMap<object, unknown> | null = null;
-  private _connection: DatabaseAdapter;
+  private _lazyEnrollmentRecords: Map<unknown, unknown> | null = null;
+  private _connection: TransactionConnection;
   private _joinable: boolean;
   readonly isolationLevel: string | null;
   private _materialized = false;
@@ -268,7 +288,7 @@ export class Transaction {
   static readonly Callback = TransactionCallback;
 
   constructor(
-    connection: DatabaseAdapter,
+    connection: TransactionConnection,
     options: {
       isolation?: string | null;
       joinable?: boolean;
@@ -288,7 +308,7 @@ export class Transaction {
     });
   }
 
-  get connection(): DatabaseAdapter {
+  get connection(): TransactionConnection {
     return this._connection;
   }
 
@@ -352,14 +372,16 @@ export class Transaction {
     if (ensureFinalize) {
       this._records.push(record);
     } else {
-      if (!this._lazyEnrollmentRecords) this._lazyEnrollmentRecords = new WeakMap();
-      this._lazyEnrollmentRecords.set(record as object, record);
+      if (!this._lazyEnrollmentRecords) this._lazyEnrollmentRecords = new Map();
+      this._lazyEnrollmentRecords.set(record, record);
     }
   }
 
   get records(): unknown[] | null {
     if (this._lazyEnrollmentRecords && this._records) {
-      // WeakMap doesn't have .values() — lazy records are best-effort
+      for (const value of this._lazyEnrollmentRecords.values()) {
+        this._records.push(value);
+      }
       this._lazyEnrollmentRecords = null;
     }
     return this._records;
@@ -390,17 +412,38 @@ export class Transaction {
   }
 
   async rollbackRecords(): Promise<void> {
-    if (this._records) {
-      const ite = this._uniqueRecords();
-      for (const record of ite) {
-        if (typeof (record as any).rolledbackBang === "function") {
-          await (record as any).rolledbackBang({
-            forceRestoreState: this.isFullRollback(),
-            shouldRunCallbacks: true,
-          });
+    const recs = this.records;
+    if (recs) {
+      const ite = this._uniqueRecords(recs);
+      const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+
+      try {
+        while (ite.length > 0) {
+          const record = ite.shift()!;
+          const shouldRunCallbacks =
+            instanceMap.get(record) === record &&
+            typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
+            (record as any).isTriggerTransactionalCallbacks();
+
+          if (typeof (record as any).rolledbackBang === "function") {
+            await (record as any).rolledbackBang({
+              forceRestoreState: this.isFullRollback(),
+              shouldRunCallbacks,
+            });
+          }
+        }
+      } finally {
+        for (const i of ite) {
+          if (typeof (i as any).rolledbackBang === "function") {
+            await (i as any).rolledbackBang({
+              forceRestoreState: this.isFullRollback(),
+              shouldRunCallbacks: false,
+            });
+          }
         }
       }
     }
+
     if (this._callbacks) {
       for (const cb of this._callbacks) {
         await cb.afterRollback();
@@ -410,9 +453,10 @@ export class Transaction {
 
   async beforeCommitRecords(): Promise<void> {
     if (this._runCommitCallbacks) {
-      if (this._records) {
-        const ite = this._uniqueRecords();
-        for (const record of ite) {
+      const recs = this.records;
+      if (recs) {
+        const unique = this._uniqueRecords(recs);
+        for (const record of unique) {
           if (typeof (record as any).beforeCommittedBang === "function") {
             await (record as any).beforeCommittedBang();
           }
@@ -427,19 +471,36 @@ export class Transaction {
   }
 
   async commitRecords(): Promise<void> {
-    if (this._records) {
-      const ite = this._uniqueRecords();
+    const recs = this.records;
+    if (recs) {
+      const ite = this._uniqueRecords(recs);
+
       if (this._runCommitCallbacks) {
-        for (const record of ite) {
-          if (typeof (record as any).committedBang === "function") {
-            await (record as any).committedBang({ shouldRunCallbacks: true });
+        const instanceMap = this._prepareInstancesToRunCallbacksOn(ite);
+
+        try {
+          while (ite.length > 0) {
+            const record = ite.shift()!;
+            const shouldRunCallbacks =
+              instanceMap.get(record) === record &&
+              typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
+              (record as any).isTriggerTransactionalCallbacks();
+
+            if (typeof (record as any).committedBang === "function") {
+              await (record as any).committedBang({ shouldRunCallbacks });
+            }
+          }
+        } finally {
+          for (const i of ite) {
+            if (typeof (i as any).committedBang === "function") {
+              await (i as any).committedBang({ shouldRunCallbacks: false });
+            }
           }
         }
       } else {
-        for (const record of ite) {
-          if (typeof (this._connection as any).addTransactionRecord === "function") {
-            (this._connection as any).addTransactionRecord(record);
-          }
+        while (ite.length > 0) {
+          const record = ite.shift()!;
+          this._connection.addTransactionRecord?.(record);
         }
       }
     }
@@ -451,15 +512,17 @@ export class Transaction {
         }
       }
     } else if (this._callbacks) {
-      const current = (this._connection as any).currentTransaction?.();
-      if (current && typeof current.appendCallbacks === "function") {
+      const current = this._connection.currentTransaction?.();
+      if (current instanceof Transaction) {
         current.appendCallbacks(this._callbacks);
       }
     }
   }
 
   restart(): void {
-    // Subclasses override
+    // Overridden by RealTransaction, SavepointTransaction, RestartParentTransaction.
+    // Base implementation is intentionally empty — only subclasses that represent
+    // actual DB transactions have restart behavior.
   }
 
   isFullRollback(): boolean {
@@ -493,17 +556,58 @@ export class Transaction {
     }
   }
 
-  private _uniqueRecords(): unknown[] {
-    if (!this._records) return [];
+  private _uniqueRecords(recs: unknown[]): unknown[] {
     const seen = new Set<unknown>();
     const result: unknown[] = [];
-    for (const record of this._records) {
+    for (const record of recs) {
       if (!seen.has(record)) {
         seen.add(record);
         result.push(record);
       }
     }
     return result;
+  }
+
+  private _prepareInstancesToRunCallbacksOn(records: unknown[]): Map<unknown, unknown> {
+    const candidates = new Map<unknown, unknown>();
+    for (const record of records) {
+      if (
+        typeof (record as any).isTriggerTransactionalCallbacks === "function" &&
+        !(record as any).isTriggerTransactionalCallbacks()
+      ) {
+        continue;
+      }
+
+      const earlier = candidates.get(record);
+      if (
+        earlier &&
+        typeof (record as any).constructor?.runCommitCallbacksOnFirstSavedInstancesInTransaction !==
+          "undefined" &&
+        (record as any).constructor.runCommitCallbacksOnFirstSavedInstancesInTransaction
+      ) {
+        continue;
+      }
+
+      if (
+        earlier &&
+        typeof (earlier as any).isDestroyed === "function" &&
+        (earlier as any).isDestroyed() &&
+        (typeof (record as any).isDestroyed !== "function" || !(record as any).isDestroyed())
+      ) {
+        continue;
+      }
+
+      if (
+        earlier &&
+        typeof (earlier as any)._newRecordBeforeLastCommit !== "undefined" &&
+        (earlier as any)._newRecordBeforeLastCommit
+      ) {
+        (record as any)._newRecordBeforeLastCommit = true;
+      }
+
+      candidates.set(record, record);
+    }
+    return candidates;
   }
 }
 
@@ -514,7 +618,7 @@ export class RestartParentTransaction extends Transaction {
   private _parent: Transaction;
 
   constructor(
-    connection: DatabaseAdapter,
+    connection: TransactionConnection,
     parentTransaction: Transaction,
     options: { isolation?: string | null; joinable?: boolean; runCommitCallbacks?: boolean } = {},
   ) {
@@ -562,7 +666,7 @@ export class SavepointTransaction extends Transaction {
   readonly savepointName: string;
 
   constructor(
-    connection: DatabaseAdapter,
+    connection: TransactionConnection,
     savepointName: string,
     parentTransaction: Transaction,
     options: { isolation?: string | null; joinable?: boolean; runCommitCallbacks?: boolean } = {},
@@ -585,15 +689,18 @@ export class SavepointTransaction extends Transaction {
 
   restart(): void {
     if (!this.isMaterialized()) return;
+
     this._instrumenter.finish("restart");
     this._instrumenter.start();
+
     this.connection.rollbackToSavepoint(this.savepointName);
   }
 
   override async rollback(): Promise<void> {
     if (!this.state.isInvalidated()) {
-      if (this.isMaterialized()) {
-        await this.connection.rollbackToSavepoint(this.savepointName);
+      const conn = this.connection;
+      if (this.isMaterialized() && conn.active !== false) {
+        await conn.rollbackToSavepoint(this.savepointName);
       }
     }
     this.state.rollbackBang();
@@ -624,40 +731,35 @@ export class RealTransaction extends Transaction {
   override materializeBang(): void {
     if (this.joinable) {
       if (this.isolationLevel) {
-        (this.connection as any).beginIsolatedDbTransaction(this.isolationLevel);
+        this.connection.beginIsolatedDbTransaction?.(this.isolationLevel);
       } else {
-        (this.connection as any).beginDbTransaction();
+        this.connection.beginDbTransaction?.();
       }
     } else {
-      (this.connection as any).beginDeferredTransaction(this.isolationLevel);
+      this.connection.beginDeferredTransaction?.(this.isolationLevel);
     }
     super.materializeBang();
   }
 
   restart(): void {
     if (!this.isMaterialized()) return;
+
     this._instrumenter.finish("restart");
 
-    if (
-      typeof (this.connection as any).supportsRestartDbTransaction === "function" &&
-      (this.connection as any).supportsRestartDbTransaction()
-    ) {
+    if (this.connection.supportsRestartDbTransaction?.()) {
       this._instrumenter.start();
-      (this.connection as any).restartDbTransaction();
+      this.connection.restartDbTransaction?.();
     } else {
-      (this.connection as any).rollbackDbTransaction();
+      this.connection.rollbackDbTransaction?.();
       this.materializeBang();
     }
   }
 
   override async rollback(): Promise<void> {
     if (this.isMaterialized()) {
-      (this.connection as any).rollbackDbTransaction();
-      if (
-        this.isolationLevel &&
-        typeof (this.connection as any).resetIsolationLevel === "function"
-      ) {
-        (this.connection as any).resetIsolationLevel();
+      this.connection.rollbackDbTransaction?.();
+      if (this.isolationLevel) {
+        this.connection.resetIsolationLevel?.();
       }
     }
     this.state.fullRollbackBang();
@@ -668,12 +770,9 @@ export class RealTransaction extends Transaction {
 
   override async commit(): Promise<void> {
     if (this.isMaterialized()) {
-      (this.connection as any).commitDbTransaction();
-      if (
-        this.isolationLevel &&
-        typeof (this.connection as any).resetIsolationLevel === "function"
-      ) {
-        (this.connection as any).resetIsolationLevel();
+      this.connection.commitDbTransaction?.();
+      if (this.isolationLevel) {
+        this.connection.resetIsolationLevel?.();
       }
     }
     this.state.fullCommitBang();
@@ -688,14 +787,14 @@ export class RealTransaction extends Transaction {
  */
 export class TransactionManager {
   private _stack: (Transaction | NullTransaction)[] = [];
-  private _connection: DatabaseAdapter;
+  private _connection: TransactionConnection;
   private _hasUnmaterializedTransactions = false;
   private _materializingTransactions = false;
   private _lazyTransactionsEnabled = true;
 
   static readonly NULL_TRANSACTION = Object.freeze(new NullTransaction());
 
-  constructor(connection: DatabaseAdapter) {
+  constructor(connection: TransactionConnection) {
     this._connection = connection;
   }
 
@@ -707,10 +806,6 @@ export class TransactionManager {
 
   get openTransactions(): number {
     return this._stack.length;
-  }
-
-  get withinNewTransaction(): boolean {
-    return this._stack.length > 0;
   }
 
   async beginTransaction(
@@ -735,19 +830,18 @@ export class TransactionManager {
         runCommitCallbacks,
       });
     } else {
-      const parentTransaction = current instanceof Transaction ? current : undefined;
+      const parentTransaction = current as Transaction;
       transaction = new SavepointTransaction(
         this._connection,
         `active_record_${this._stack.length}`,
-        parentTransaction!,
+        parentTransaction,
         { isolation, joinable, runCommitCallbacks },
       );
     }
 
     if (!transaction.isMaterialized()) {
       if (
-        typeof (this._connection as any).supportsLazyTransactions === "function" &&
-        (this._connection as any).supportsLazyTransactions() &&
+        this._connection.supportsLazyTransactions?.() &&
         this.isLazyTransactionsEnabled() &&
         _lazy
       ) {
@@ -846,5 +940,42 @@ export class TransactionManager {
       }
     }
     await txn.rollbackRecords();
+  }
+
+  async withinNewTransaction<T>(
+    options: { isolation?: string | null; joinable?: boolean },
+    fn: (tx: ActiveRecordTransaction) => Promise<T> | T,
+  ): Promise<T> {
+    const transaction = await this.beginTransaction({
+      isolation: options.isolation,
+      joinable: options.joinable,
+    });
+    let result: T;
+    try {
+      result = await fn(transaction.userTransaction);
+    } catch (e) {
+      await this.rollbackTransaction();
+      if (!transaction.state.isCompleted()) {
+        transaction.incompleteBang();
+      }
+      throw e;
+    }
+
+    try {
+      await this.commitTransaction();
+    } catch (commitError) {
+      if (!transaction.state.isCompleted()) {
+        await this.rollbackTransaction(transaction);
+      }
+      if (!transaction.state.isCompleted()) {
+        transaction.incompleteBang();
+      }
+      throw commitError;
+    }
+
+    if (!transaction.state.isCompleted()) {
+      transaction.incompleteBang();
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## Summary

- Rewrites all classes in `connection-adapters/abstract/transaction.ts` to match the Rails `ConnectionAdapters::Transaction` API with full fidelity
- Takes `connection_adapters/abstract/transaction.rb` from **39% → 100%** in api:compare (59/59 methods)
- Wires `TransactionManager` into `AbstractAdapter` with proper delegation
- All adapter method calls properly awaited (createSavepoint, beginDbTransaction, etc.)

## What changed

**TransactionState**: child tracking with cascading rollback/invalidate, Rails-matching state names and method signatures (`commitBang`, `rollbackBang`, `fullRollbackBang`, `invalidateBang`, `addChild`, etc.)

**Transaction**: lazy materialization (`materializeBang`/`isMaterialized`), dirty tracking, record enrollment with lazy enrollment via Map, isolation level, `userTransaction`, `written`, 3-event `TransactionCallback` (`before_commit`/`after_commit`/`after_rollback`), record lifecycle methods (`rollbackRecords`/`beforeCommitRecords`/`commitRecords`) with `prepareInstancesToRunCallbacksOn` matching Rails' callback dispatch logic, ensure blocks for cleanup on exception

**TransactionCallback**: matches Rails `Callback` class — `beforeCommit()`/`afterCommit()`/`afterRollback()` dispatch by event type

**NullTransaction**: full no-op interface matching Rails (`addRecord`, `isDirty`, `isMaterialized`, `userTransaction`, `beforeCommit`/`afterCommit` execute block, `afterRollback` no-op)

**RestartParentTransaction**: delegates `materializeBang`/`isMaterialized`/`restart` to parent, wires child state, `isFullRollback` returns false

**SavepointTransaction**: materialization-aware `commit`/`rollback`/`restart` with instrumentation, checks `connection.active` before rollback (matching Rails)

**RealTransaction**: materialization dispatches on `joinable`/`isolationLevel`, `restart` supports both `supportsRestartDbTransaction` paths, `fullRollbackBang`/`fullCommitBang` for state, isolation level reset

**TransactionManager**: lazy transaction support (`disableLazyTransactionsBang`/`enableLazyTransactionsBang`/`materializeTransactions`), dirty tracking (`dirtyCurrentTransaction`), restore support (`restoreTransactions`/`isRestorable`), 3-way begin dispatch (Real/RestartParent/Savepoint), `withinNewTransaction` matching Rails `within_new_transaction` with error recovery

**TransactionConnection interface**: typed interface extending `DatabaseAdapter` with the `DatabaseStatements` methods that transaction classes call, eliminating `as any` casts

**AbstractAdapter integration**: `_transactionManager` field initialized on construction, `transactionManager` getter, `currentTransaction()` and `withinNewTransaction()` delegation, `resetTransaction()` with restore support matching Rails

**database-statements.ts**: imports `TransactionManager` for typed `transactionManager()` return

## Test plan

- [x] All 7948 active activerecord tests pass (0 failures)
- [x] All 133 active transaction tests pass
- [x] All 45 active transaction-callback tests pass
- [x] api:compare shows 100% for `connection_adapters/abstract/transaction.rb` (59/59)
- [x] Build and typecheck pass
- [x] Lint passes