### PR TITLE
feat(activerecord): implement QueryCache module matching Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -84,6 +84,13 @@ export class AbstractAdapter {
 
   // --- QueryCache mixin (mirrors ActiveRecord::ConnectionAdapters::QueryCache) ---
 
+  private _ensureQueryCache(): Store {
+    if (!this._queryCache) {
+      this._queryCache = new Store();
+    }
+    return this._queryCache;
+  }
+
   get queryCache(): Store | null {
     return this._queryCache;
   }
@@ -101,8 +108,7 @@ export class AbstractAdapter {
     if (pool?.enableQueryCache) {
       return pool.enableQueryCache(fn);
     }
-    const qc = this._queryCache;
-    if (!qc) return fn() as Promise<T>;
+    const qc = this._ensureQueryCache();
     const oldEnabled = qc.enabled;
     const oldDirties = qc.dirties;
     qc.enabled = true;
@@ -121,10 +127,9 @@ export class AbstractAdapter {
       pool.enableQueryCacheBang();
       return;
     }
-    if (this._queryCache) {
-      this._queryCache.enabled = true;
-      this._queryCache.dirties = true;
-    }
+    const qc = this._ensureQueryCache();
+    qc.enabled = true;
+    qc.dirties = true;
   }
 
   async uncached<T>(fn: () => T | Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
@@ -133,8 +138,7 @@ export class AbstractAdapter {
     if (pool?.disableQueryCache) {
       return pool.disableQueryCache(fn, { dirties });
     }
-    const qc = this._queryCache;
-    if (!qc) return fn() as Promise<T>;
+    const qc = this._ensureQueryCache();
     const oldEnabled = qc.enabled;
     const oldDirties = qc.dirties;
     qc.enabled = false;
@@ -153,10 +157,9 @@ export class AbstractAdapter {
       pool.disableQueryCacheBang();
       return;
     }
-    if (this._queryCache) {
-      this._queryCache.enabled = false;
-      this._queryCache.dirties = true;
-    }
+    const qc = this._ensureQueryCache();
+    qc.enabled = false;
+    qc.dirties = true;
   }
 
   clearQueryCache(): void {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -14,7 +14,16 @@ import {
   type Transaction,
   type NullTransaction,
 } from "./abstract/transaction.js";
-import { Store } from "./abstract/query-cache.js";
+import {
+  Store,
+  queryCacheEnabled as queryCacheEnabledGet,
+  cache as cacheMixin,
+  enableQueryCacheBang as enableQueryCacheBangMixin,
+  uncached as uncachedMixin,
+  disableQueryCacheBang as disableQueryCacheBangMixin,
+  clearQueryCache as clearQueryCacheMixin,
+  type QueryCacheHost,
+} from "./abstract/query-cache.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -83,6 +92,7 @@ export class AbstractAdapter {
   lock: unknown = null;
 
   // --- QueryCache mixin (mirrors ActiveRecord::ConnectionAdapters::QueryCache) ---
+  // Single source of truth lives in abstract/query-cache.ts; these delegate.
 
   private _ensureQueryCache(): Store {
     if (!this._queryCache) {
@@ -100,75 +110,31 @@ export class AbstractAdapter {
   }
 
   get queryCacheEnabled(): boolean {
-    return this._queryCache?.enabled ?? false;
+    return queryCacheEnabledGet.call(this as unknown as QueryCacheHost);
   }
 
   async cache<T>(fn: () => T | Promise<T>): Promise<T> {
-    const pool = this.pool as any;
-    if (pool?.enableQueryCache) {
-      return pool.enableQueryCache(fn);
-    }
-    const qc = this._ensureQueryCache();
-    const oldEnabled = qc.enabled;
-    const oldDirties = qc.dirties;
-    qc.enabled = true;
-    qc.dirties = true;
-    try {
-      return await fn();
-    } finally {
-      qc.enabled = oldEnabled;
-      qc.dirties = oldDirties;
-    }
+    this._ensureQueryCache();
+    return cacheMixin.call(this as unknown as QueryCacheHost, fn) as Promise<T>;
   }
 
   enableQueryCacheBang(): void {
-    const pool = this.pool as any;
-    if (pool?.enableQueryCacheBang) {
-      pool.enableQueryCacheBang();
-      return;
-    }
-    const qc = this._ensureQueryCache();
-    qc.enabled = true;
-    qc.dirties = true;
+    this._ensureQueryCache();
+    enableQueryCacheBangMixin.call(this as unknown as QueryCacheHost);
   }
 
   async uncached<T>(fn: () => T | Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
-    const { dirties = true } = options;
-    const pool = this.pool as any;
-    if (pool?.disableQueryCache) {
-      return pool.disableQueryCache(fn, { dirties });
-    }
-    const qc = this._ensureQueryCache();
-    const oldEnabled = qc.enabled;
-    const oldDirties = qc.dirties;
-    qc.enabled = false;
-    qc.dirties = dirties;
-    try {
-      return await fn();
-    } finally {
-      qc.enabled = oldEnabled;
-      qc.dirties = oldDirties;
-    }
+    this._ensureQueryCache();
+    return uncachedMixin.call(this as unknown as QueryCacheHost, fn, options) as Promise<T>;
   }
 
   disableQueryCacheBang(): void {
-    const pool = this.pool as any;
-    if (pool?.disableQueryCacheBang) {
-      pool.disableQueryCacheBang();
-      return;
-    }
-    const qc = this._ensureQueryCache();
-    qc.enabled = false;
-    qc.dirties = true;
+    this._ensureQueryCache();
+    disableQueryCacheBangMixin.call(this as unknown as QueryCacheHost);
   }
 
   clearQueryCache(): void {
-    const pool = this.pool as any;
-    if (pool?.clearQueryCache) {
-      pool.clearQueryCache();
-      return;
-    }
-    this._queryCache?.clear();
+    clearQueryCacheMixin.call(this as unknown as QueryCacheHost);
   }
 
   // --- End QueryCache mixin ---

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -14,6 +14,7 @@ import {
   type Transaction,
   type NullTransaction,
 } from "./abstract/transaction.js";
+import { Store } from "./abstract/query-cache.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -75,9 +76,99 @@ export class AbstractAdapter {
   protected _config: Record<string, unknown> = {};
   _transactionManager: TransactionManager = new TransactionManager(this as any);
 
+  _queryCache: Store | null = null;
+
   pool: unknown = null;
   logger: unknown = null;
   lock: unknown = null;
+
+  // --- QueryCache mixin (mirrors ActiveRecord::ConnectionAdapters::QueryCache) ---
+
+  get queryCache(): Store | null {
+    return this._queryCache;
+  }
+
+  set queryCache(value: Store | null) {
+    this._queryCache = value;
+  }
+
+  get queryCacheEnabled(): boolean {
+    return this._queryCache?.enabled ?? false;
+  }
+
+  async cache<T>(fn: () => T | Promise<T>): Promise<T> {
+    const pool = this.pool as any;
+    if (pool?.enableQueryCache) {
+      return pool.enableQueryCache(fn);
+    }
+    const qc = this._queryCache;
+    if (!qc) return fn() as Promise<T>;
+    const oldEnabled = qc.enabled;
+    const oldDirties = qc.dirties;
+    qc.enabled = true;
+    qc.dirties = true;
+    try {
+      return await fn();
+    } finally {
+      qc.enabled = oldEnabled;
+      qc.dirties = oldDirties;
+    }
+  }
+
+  enableQueryCacheBang(): void {
+    const pool = this.pool as any;
+    if (pool?.enableQueryCacheBang) {
+      pool.enableQueryCacheBang();
+      return;
+    }
+    if (this._queryCache) {
+      this._queryCache.enabled = true;
+      this._queryCache.dirties = true;
+    }
+  }
+
+  async uncached<T>(fn: () => T | Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
+    const { dirties = true } = options;
+    const pool = this.pool as any;
+    if (pool?.disableQueryCache) {
+      return pool.disableQueryCache(fn, { dirties });
+    }
+    const qc = this._queryCache;
+    if (!qc) return fn() as Promise<T>;
+    const oldEnabled = qc.enabled;
+    const oldDirties = qc.dirties;
+    qc.enabled = false;
+    qc.dirties = dirties;
+    try {
+      return await fn();
+    } finally {
+      qc.enabled = oldEnabled;
+      qc.dirties = oldDirties;
+    }
+  }
+
+  disableQueryCacheBang(): void {
+    const pool = this.pool as any;
+    if (pool?.disableQueryCacheBang) {
+      pool.disableQueryCacheBang();
+      return;
+    }
+    if (this._queryCache) {
+      this._queryCache.enabled = false;
+      this._queryCache.dirties = true;
+    }
+  }
+
+  clearQueryCache(): void {
+    const pool = this.pool as any;
+    if (pool?.clearQueryCache) {
+      pool.clearQueryCache();
+      return;
+    }
+    this._queryCache?.clear();
+  }
+
+  // --- End QueryCache mixin ---
 
   get inUse(): boolean {
     return this._inUse;

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,5 +1,5 @@
 import { QueryCacheStore } from "../../query-cache.js";
-import { selectAll as baseSelectAll, type DatabaseStatementsHost } from "./database-statements.js";
+import type { DatabaseStatementsHost } from "./database-statements.js";
 
 const DEFAULT_SIZE = 100;
 
@@ -140,7 +140,7 @@ export class ConnectionPoolConfiguration {
 
   get queryCache(): Store {
     return this._threadQueryCaches.computeIfAbsent("default", () => {
-      return new Store(this._queryCacheMaxSize ?? undefined);
+      return new Store(this._queryCacheMaxSize ?? 0);
     });
   }
 }
@@ -257,29 +257,43 @@ export function clearQueryCache(this: QueryCacheHost): void {
 }
 
 /**
- * Cached override for selectAll. When the query cache is enabled and the
- * query is not locked (FOR UPDATE), results are served from cache.
+ * Creates a cached selectAll that wraps the original. When the query cache
+ * is enabled and the query is not locked (FOR UPDATE), results are served
+ * from cache. Otherwise delegates to the original.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#select_all
  */
-export async function selectAll(
+export function selectAll(
+  original: (
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+  ) => Promise<Record<string, unknown>[]>,
+): (
   this: QueryCacheHost,
   sql: string,
   name?: string | null,
   binds?: unknown[],
-): Promise<Record<string, unknown>[]> {
-  const qc = this._queryCache;
-  if (qc?.enabled) {
-    if (/\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b/i.test(sql)) {
-      return baseSelectAll.call(this, sql, name, binds);
-    }
+) => Promise<Record<string, unknown>[]> {
+  return async function cachedSelectAll(
+    this: QueryCacheHost,
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+  ): Promise<Record<string, unknown>[]> {
+    const qc = this._queryCache;
+    if (qc?.enabled) {
+      if (/\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b/i.test(sql)) {
+        return original.call(this, sql, name, binds);
+      }
 
-    const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
-    return qc.computeIfAbsent(key, async () => {
-      return baseSelectAll.call(this, sql, name, binds);
-    });
-  }
-  return baseSelectAll.call(this, sql, name, binds);
+      const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
+      return qc.computeIfAbsent(key, async () => {
+        return original.call(this, sql, name, binds);
+      });
+    }
+    return original.call(this, sql, name, binds);
+  };
 }
 
 /**
@@ -299,8 +313,8 @@ export function dirtiesQueryCache(
     if (typeof original !== "function") continue;
 
     _base.prototype[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
-      if ((this.pool as any)?.dirtiesQueryCache) {
-        this._queryCache?.clear();
+      if (this._queryCache?.dirties) {
+        this._queryCache.clear();
       }
       return original.apply(this, args);
     };

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,4 +1,5 @@
 import { QueryCacheStore } from "../../query-cache.js";
+import { selectAll as baseSelectAll, type DatabaseStatementsHost } from "./database-statements.js";
 
 const DEFAULT_SIZE = 100;
 
@@ -41,19 +42,18 @@ export class QueryCacheRegistry {
 /**
  * Host interface for QueryCache connection-level mixin methods.
  */
-export interface QueryCacheHost {
-  pool?: {
-    enableQueryCache?<T>(fn: () => T | Promise<T>): T | Promise<T>;
-    disableQueryCache?<T>(fn: () => T | Promise<T>, opts?: { dirties?: boolean }): T | Promise<T>;
-    enableQueryCacheBang?(): void;
-    disableQueryCacheBang?(): void;
-    clearQueryCache?(): void;
-    queryCache?: Store;
-    queryCacheEnabled?: boolean;
-    dirtiesQueryCache?: boolean;
-  };
-  queryCache: Store | null;
-  selectAll?(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
+export interface QueryCachePool {
+  enableQueryCache?<T>(fn: () => T | Promise<T>): T | Promise<T>;
+  disableQueryCache?<T>(fn: () => T | Promise<T>, opts?: { dirties?: boolean }): T | Promise<T>;
+  enableQueryCacheBang?(): void;
+  disableQueryCacheBang?(): void;
+  clearQueryCache?(): void;
+  dirtiesQueryCache?: boolean;
+}
+
+export interface QueryCacheHost extends DatabaseStatementsHost {
+  _queryCache: Store | null;
+  pool?: DatabaseStatementsHost["pool"] & QueryCachePool;
 }
 
 /**
@@ -76,8 +76,8 @@ export class ConnectionPoolConfiguration {
   }
 
   checkoutAndVerify(connection: QueryCacheHost): QueryCacheHost {
-    if (!connection.queryCache) {
-      connection.queryCache = this.queryCache;
+    if (!connection._queryCache) {
+      connection._queryCache = this.queryCache;
     }
     return connection;
   }
@@ -154,14 +154,14 @@ export class ConnectionPoolConfiguration {
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#query_cache (attr_accessor)
  */
 export function queryCache(this: QueryCacheHost): Store | null {
-  return this.queryCache;
+  return this._queryCache;
 }
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#query_cache_enabled
  */
 export function queryCacheEnabled(this: QueryCacheHost): boolean {
-  return this.queryCache?.enabled ?? false;
+  return this._queryCache?.enabled ?? false;
 }
 
 /**
@@ -173,7 +173,7 @@ export async function cache<T>(this: QueryCacheHost, fn: () => T | Promise<T>): 
   if (this.pool?.enableQueryCache) {
     return this.pool.enableQueryCache(fn) as Promise<T>;
   }
-  const qc = this.queryCache;
+  const qc = this._queryCache;
   if (!qc) return fn() as Promise<T>;
   const oldEnabled = qc.enabled;
   const oldDirties = qc.dirties;
@@ -195,7 +195,7 @@ export function enableQueryCacheBang(this: QueryCacheHost): void {
     this.pool.enableQueryCacheBang();
     return;
   }
-  const qc = this.queryCache;
+  const qc = this._queryCache;
   if (qc) {
     qc.enabled = true;
     qc.dirties = true;
@@ -216,7 +216,7 @@ export async function uncached<T>(
   if (this.pool?.disableQueryCache) {
     return this.pool.disableQueryCache(fn, { dirties }) as Promise<T>;
   }
-  const qc = this.queryCache;
+  const qc = this._queryCache;
   if (!qc) return fn() as Promise<T>;
   const oldEnabled = qc.enabled;
   const oldDirties = qc.dirties;
@@ -238,7 +238,7 @@ export function disableQueryCacheBang(this: QueryCacheHost): void {
     this.pool.disableQueryCacheBang();
     return;
   }
-  const qc = this.queryCache;
+  const qc = this._queryCache;
   if (qc) {
     qc.enabled = false;
     qc.dirties = true;
@@ -253,7 +253,7 @@ export function clearQueryCache(this: QueryCacheHost): void {
     this.pool.clearQueryCache();
     return;
   }
-  this.queryCache?.clear();
+  this._queryCache?.clear();
 }
 
 /**
@@ -263,30 +263,46 @@ export function clearQueryCache(this: QueryCacheHost): void {
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#select_all
  */
 export async function selectAll(
-  this: QueryCacheHost & { selectAll?: (...args: unknown[]) => Promise<unknown> },
+  this: QueryCacheHost,
   sql: string,
   name?: string | null,
   binds?: unknown[],
-): Promise<unknown> {
-  const qc = this.queryCache;
+): Promise<Record<string, unknown>[]> {
+  const qc = this._queryCache;
   if (qc?.enabled) {
     if (/\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b/i.test(sql)) {
-      return this.selectAll!(sql, name, binds);
+      return baseSelectAll.call(this, sql, name, binds);
     }
 
     const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
     return qc.computeIfAbsent(key, async () => {
-      return (await this.selectAll!(sql, name, binds)) as Record<string, unknown>[];
+      return baseSelectAll.call(this, sql, name, binds);
     });
   }
-  return this.selectAll!(sql, name, binds);
+  return baseSelectAll.call(this, sql, name, binds);
 }
 
 /**
+ * Wraps adapter methods to clear query caches before execution when
+ * the dirties flag is set. In Rails this uses class_eval to monkey-patch
+ * each method; in TypeScript the cache invalidation is handled by the
+ * QueryCacheAdapter wrapper's executeMutation/rollback methods.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache.dirties_query_cache
  */
-export function dirtiesQueryCache(_base: unknown, ..._methodNames: string[]): void {
-  // In Rails this monkey-patches methods to clear query caches before execution.
-  // In TS, cache invalidation is handled by the QueryCacheAdapter wrapper and
-  // materializeTransactions wiring. This function exists for API parity.
+export function dirtiesQueryCache(
+  _base: { prototype: Record<string, unknown> },
+  ...methodNames: string[]
+): void {
+  for (const methodName of methodNames) {
+    const original = _base.prototype[methodName];
+    if (typeof original !== "function") continue;
+
+    _base.prototype[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
+      if ((this.pool as any)?.dirtiesQueryCache) {
+        this._queryCache?.clear();
+      }
+      return original.apply(this, args);
+    };
+  }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,21 +1,15 @@
 import { QueryCacheStore } from "../../query-cache.js";
 
-/**
- * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache
- */
-export interface QueryCache {
-  enableQueryCache(): void;
-  disableQueryCache(): void;
-  clearQueryCache(): void;
-  queryCacheEnabled: boolean;
-}
+const DEFAULT_SIZE = 100;
 
 /**
- * Store — query cache storage.
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::Store
  */
-export class Store extends QueryCacheStore {}
+export class Store extends QueryCacheStore {
+  isDirties(): boolean {
+    return this.dirties;
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::QueryCacheRegistry
@@ -23,27 +17,276 @@ export class Store extends QueryCacheStore {}
 export class QueryCacheRegistry {
   private _caches = new Map<string, Store>();
 
-  getCache(key: string): Store {
+  computeIfAbsent(key: string, create: () => Store): Store {
     let cache = this._caches.get(key);
     if (!cache) {
-      cache = new Store();
+      cache = create();
       this._caches.set(key, cache);
     }
     return cache;
   }
 
-  clearAll(): void {
+  getCache(key: string): Store {
+    return this.computeIfAbsent(key, () => new Store());
+  }
+
+  clear(): void {
     for (const cache of this._caches.values()) {
       cache.clear();
     }
+    this._caches.clear();
   }
 }
 
 /**
- * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::ConnectionPoolConfiguration
+ * Host interface for QueryCache connection-level mixin methods.
  */
-export interface ConnectionPoolConfiguration {
-  enableQueryCache(): void;
-  disableQueryCache(): void;
-  clearQueryCache(): void;
+export interface QueryCacheHost {
+  pool?: {
+    enableQueryCache?<T>(fn: () => T | Promise<T>): T | Promise<T>;
+    disableQueryCache?<T>(fn: () => T | Promise<T>, opts?: { dirties?: boolean }): T | Promise<T>;
+    enableQueryCacheBang?(): void;
+    disableQueryCacheBang?(): void;
+    clearQueryCache?(): void;
+    queryCache?: Store;
+    queryCacheEnabled?: boolean;
+    dirtiesQueryCache?: boolean;
+  };
+  queryCache: Store | null;
+  selectAll?(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::ConnectionPoolConfiguration
+ *
+ * Mixin for connection pools that manages the per-thread query cache.
+ */
+export class ConnectionPoolConfiguration {
+  private _threadQueryCaches = new QueryCacheRegistry();
+  private _queryCacheMaxSize: number | null;
+
+  constructor(queryCacheConfig?: number | false | null) {
+    if (queryCacheConfig === 0 || queryCacheConfig === false) {
+      this._queryCacheMaxSize = null;
+    } else if (typeof queryCacheConfig === "number") {
+      this._queryCacheMaxSize = queryCacheConfig;
+    } else {
+      this._queryCacheMaxSize = DEFAULT_SIZE;
+    }
+  }
+
+  checkoutAndVerify(connection: QueryCacheHost): QueryCacheHost {
+    if (!connection.queryCache) {
+      connection.queryCache = this.queryCache;
+    }
+    return connection;
+  }
+
+  async disableQueryCache<T>(
+    fn: () => T | Promise<T>,
+    options: { dirties?: boolean } = {},
+  ): Promise<T> {
+    const { dirties = true } = options;
+    const qc = this.queryCache;
+    const oldEnabled = qc.enabled;
+    const oldDirties = qc.dirties;
+    qc.enabled = false;
+    qc.dirties = dirties;
+    try {
+      return await fn();
+    } finally {
+      qc.enabled = oldEnabled;
+      qc.dirties = oldDirties;
+    }
+  }
+
+  async enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
+    const qc = this.queryCache;
+    const oldEnabled = qc.enabled;
+    const oldDirties = qc.dirties;
+    qc.enabled = true;
+    qc.dirties = true;
+    try {
+      return await fn();
+    } finally {
+      qc.enabled = oldEnabled;
+      qc.dirties = oldDirties;
+    }
+  }
+
+  enableQueryCacheBang(): void {
+    const qc = this.queryCache;
+    qc.enabled = true;
+    qc.dirties = true;
+  }
+
+  disableQueryCacheBang(): void {
+    const qc = this.queryCache;
+    qc.enabled = false;
+    qc.dirties = true;
+  }
+
+  get queryCacheEnabled(): boolean {
+    return this.queryCache.enabled;
+  }
+
+  get dirtiesQueryCache(): boolean {
+    return this.queryCache.dirties;
+  }
+
+  clearQueryCache(): void {
+    this.queryCache.clear();
+  }
+
+  get queryCache(): Store {
+    return this._threadQueryCaches.computeIfAbsent("default", () => {
+      return new Store(this._queryCacheMaxSize ?? undefined);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection-level mixin functions
+// Mirrors: ActiveRecord::ConnectionAdapters::QueryCache (module mixed into connection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#query_cache (attr_accessor)
+ */
+export function queryCache(this: QueryCacheHost): Store | null {
+  return this.queryCache;
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#query_cache_enabled
+ */
+export function queryCacheEnabled(this: QueryCacheHost): boolean {
+  return this.queryCache?.enabled ?? false;
+}
+
+/**
+ * Enable the query cache within the block.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#cache
+ */
+export async function cache<T>(this: QueryCacheHost, fn: () => T | Promise<T>): Promise<T> {
+  if (this.pool?.enableQueryCache) {
+    return this.pool.enableQueryCache(fn) as Promise<T>;
+  }
+  const qc = this.queryCache;
+  if (!qc) return fn() as Promise<T>;
+  const oldEnabled = qc.enabled;
+  const oldDirties = qc.dirties;
+  qc.enabled = true;
+  qc.dirties = true;
+  try {
+    return await fn();
+  } finally {
+    qc.enabled = oldEnabled;
+    qc.dirties = oldDirties;
+  }
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#enable_query_cache!
+ */
+export function enableQueryCacheBang(this: QueryCacheHost): void {
+  if (this.pool?.enableQueryCacheBang) {
+    this.pool.enableQueryCacheBang();
+    return;
+  }
+  const qc = this.queryCache;
+  if (qc) {
+    qc.enabled = true;
+    qc.dirties = true;
+  }
+}
+
+/**
+ * Disable the query cache within the block.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#uncached
+ */
+export async function uncached<T>(
+  this: QueryCacheHost,
+  fn: () => T | Promise<T>,
+  options: { dirties?: boolean } = {},
+): Promise<T> {
+  const { dirties = true } = options;
+  if (this.pool?.disableQueryCache) {
+    return this.pool.disableQueryCache(fn, { dirties }) as Promise<T>;
+  }
+  const qc = this.queryCache;
+  if (!qc) return fn() as Promise<T>;
+  const oldEnabled = qc.enabled;
+  const oldDirties = qc.dirties;
+  qc.enabled = false;
+  qc.dirties = dirties;
+  try {
+    return await fn();
+  } finally {
+    qc.enabled = oldEnabled;
+    qc.dirties = oldDirties;
+  }
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#disable_query_cache!
+ */
+export function disableQueryCacheBang(this: QueryCacheHost): void {
+  if (this.pool?.disableQueryCacheBang) {
+    this.pool.disableQueryCacheBang();
+    return;
+  }
+  const qc = this.queryCache;
+  if (qc) {
+    qc.enabled = false;
+    qc.dirties = true;
+  }
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#clear_query_cache
+ */
+export function clearQueryCache(this: QueryCacheHost): void {
+  if (this.pool?.clearQueryCache) {
+    this.pool.clearQueryCache();
+    return;
+  }
+  this.queryCache?.clear();
+}
+
+/**
+ * Cached override for selectAll. When the query cache is enabled and the
+ * query is not locked (FOR UPDATE), results are served from cache.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#select_all
+ */
+export async function selectAll(
+  this: QueryCacheHost & { selectAll?: (...args: unknown[]) => Promise<unknown> },
+  sql: string,
+  name?: string | null,
+  binds?: unknown[],
+): Promise<unknown> {
+  const qc = this.queryCache;
+  if (qc?.enabled) {
+    if (/\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b/i.test(sql)) {
+      return this.selectAll!(sql, name, binds);
+    }
+
+    const key = binds && binds.length > 0 ? JSON.stringify([sql, binds]) : sql;
+    return qc.computeIfAbsent(key, async () => {
+      return (await this.selectAll!(sql, name, binds)) as Record<string, unknown>[];
+    });
+  }
+  return this.selectAll!(sql, name, binds);
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache.dirties_query_cache
+ */
+export function dirtiesQueryCache(_base: unknown, ..._methodNames: string[]): void {
+  // In Rails this monkey-patches methods to clear query caches before execution.
+  // In TS, cache invalidation is handled by the QueryCacheAdapter wrapper and
+  // materializeTransactions wiring. This function exists for API parity.
 }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -76,9 +76,7 @@ export class ConnectionPoolConfiguration {
   }
 
   checkoutAndVerify(connection: QueryCacheHost): QueryCacheHost {
-    if (!connection._queryCache) {
-      connection._queryCache = this.queryCache;
-    }
+    connection._queryCache = this.queryCache;
     return connection;
   }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -21,6 +21,7 @@ export class QueryCacheStore {
   private _map = new Map<string, Record<string, unknown>[]>();
   private _maxSize: number;
   enabled = false;
+  dirties = true;
 
   constructor(maxSize: number = DEFAULT_MAX_SIZE) {
     this._maxSize = maxSize;

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -211,7 +211,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
 
   async executeMutation(sql: string, binds?: unknown[]): Promise<number> {
     this._queryCount++;
-    this.cache.clear();
+    if (this.cache.dirties) this.cache.clear();
     return this.inner.executeMutation(sql, binds);
   }
 
@@ -224,7 +224,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   }
 
   async rollback(): Promise<void> {
-    this.cache.clear();
+    if (this.cache.dirties) this.cache.clear();
     return this.inner.rollback();
   }
 
@@ -237,7 +237,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   }
 
   async rollbackToSavepoint(name: string): Promise<void> {
-    this.cache.clear();
+    if (this.cache.dirties) this.cache.clear();
     return this.inner.rollbackToSavepoint(name);
   }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -188,7 +188,7 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     const isSelect = trimmed.startsWith("SELECT");
     const isReadOnlyCte = trimmed.startsWith("WITH") && !/\b(INSERT|UPDATE|DELETE)\b/.test(trimmed);
     if (!isSelect && !isReadOnlyCte) {
-      this.cache.clear();
+      if (this.cache.dirties) this.cache.clear();
       return this.inner.execute(sql, binds);
     }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -126,11 +126,14 @@ export class QueryCacheAdapter implements DatabaseAdapter {
    */
   async withCache<T>(fn: () => Promise<T>): Promise<T> {
     const wasEnabled = this.cache.enabled;
+    const wasDirties = this.cache.dirties;
     this.cache.enabled = true;
+    this.cache.dirties = true;
     try {
       return await fn();
     } finally {
       this.cache.enabled = wasEnabled;
+      this.cache.dirties = wasDirties;
     }
   }
 
@@ -138,13 +141,17 @@ export class QueryCacheAdapter implements DatabaseAdapter {
    * Disable the query cache within a callback.
    * Mirrors: ActiveRecord::Base.uncached { ... }
    */
-  async uncached<T>(fn: () => Promise<T>): Promise<T> {
+  async uncached<T>(fn: () => Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
+    const { dirties = true } = options;
     const wasEnabled = this.cache.enabled;
+    const wasDirties = this.cache.dirties;
     this.cache.enabled = false;
+    this.cache.dirties = dirties;
     try {
       return await fn();
     } finally {
       this.cache.enabled = wasEnabled;
+      this.cache.dirties = wasDirties;
     }
   }
 
@@ -172,10 +179,6 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   async execute(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]> {
     this._queryCount++;
 
-    if (!this.cache.enabled) {
-      return this.inner.execute(sql, binds);
-    }
-
     // Strip leading SQL comments (e.g. from QueryLogs prepend) before detecting statement type
     const trimmed = sql
       .trimStart()
@@ -183,12 +186,17 @@ export class QueryCacheAdapter implements DatabaseAdapter {
       .trimStart()
       .toUpperCase();
 
-    // Only cache SELECT and read-only WITH (CTE) queries.
-    // WITH can prefix write CTEs (WITH ... INSERT/UPDATE/DELETE), so check for those.
     const isSelect = trimmed.startsWith("SELECT");
     const isReadOnlyCte = trimmed.startsWith("WITH") && !/\b(INSERT|UPDATE|DELETE)\b/.test(trimmed);
+
+    // Write statements clear the cache regardless of whether caching is enabled,
+    // preventing stale results when the cache is re-enabled later.
     if (!isSelect && !isReadOnlyCte) {
       if (this.cache.dirties) this.cache.clear();
+      return this.inner.execute(sql, binds);
+    }
+
+    if (!this.cache.enabled) {
       return this.inner.execute(sql, binds);
     }
 


### PR DESCRIPTION
## Summary

- Rewrites `connection-adapters/abstract/query-cache.ts` to match the Rails `ConnectionAdapters::QueryCache` API
- Takes `connection_adapters/abstract/query_cache.rb` from **48% → 100%** in api:compare (21/21 methods)
- Wires QueryCache mixin methods into `AbstractAdapter`

## What changed

**QueryCacheStore** (`query-cache.ts`): add `dirties` property matching Rails `attr_accessor :dirties`

**Store**: add `isDirties()` getter matching Rails `dirties?` alias

**QueryCacheRegistry**: add `computeIfAbsent()` and `clear()` matching Rails

**ConnectionPoolConfiguration**: convert from interface to class — `checkoutAndVerify`, `enableQueryCache`/`disableQueryCache` (block forms with dirties), `enableQueryCacheBang`/`disableQueryCacheBang`, `queryCacheEnabled`, `dirtiesQueryCache`, `clearQueryCache`, `queryCache` getter

**Connection-level mixin functions**: `queryCache` (reads `_queryCache` backing field), `queryCacheEnabled`, `cache` (block form delegating to pool), `enableQueryCacheBang`, `uncached` (with dirties option), `disableQueryCacheBang`, `clearQueryCache`, `selectAll` (cached override calling `baseSelectAll` for uncached path, bypasses FOR UPDATE), `dirtiesQueryCache` (real method-wrapping matching Rails `class_eval` pattern)

**AbstractAdapter integration**: `_queryCache` field, all QueryCache mixin methods assigned as instance methods

## Test plan

- [x] All 27 active query-cache tests pass
- [x] All 7952 active activerecord tests pass
- [x] api:compare shows 100% for `connection_adapters/abstract/query_cache.rb`
- [x] Build and typecheck pass