### PR TITLE
feat(activerecord): pin connection and async checkout with queue

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -11,6 +11,7 @@ import type { ConnectionDescriptor } from "./connection-descriptor.js";
 import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.js";
 import { SchemaReflection } from "../schema-cache.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
+import { ConnectionLeasingQueue } from "./connection-pool/queue.js";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
 import type { TransactionManager } from "./transaction.js";
 
@@ -23,6 +24,11 @@ interface TransactionAwareConnection extends DatabaseAdapter {
   transactionManager: TransactionManager;
   verifyBang(): void;
   resetBang(): void;
+}
+
+interface PoolManagedConnection {
+  lease?(): void;
+  expire?(): void;
 }
 
 let _contextIdCounter = 0;
@@ -198,13 +204,12 @@ export class ConnectionPool implements ReapablePool {
   checkoutTimeout: number;
 
   private _connections: DatabaseAdapter[] | null = [];
-  private _available: DatabaseAdapter[] | null = [];
+  private _available: ConnectionLeasingQueue | null;
   private _checkedOut = new Set<DatabaseAdapter>();
   private _leases: LeaseRegistry | null = new LeaseRegistry();
   private _idleTimeout: number | null;
   private _lastCheckinAt = new Map<DatabaseAdapter, number>();
-  private _pinnedConnection: DatabaseAdapter | null = null;
-  private _pinnedConnectionsDepth = 0;
+  private _pinnedConnections = new Map<number, { connection: DatabaseAdapter; depth: number }>();
 
   constructor(poolConfig: PoolConfig) {
     this.poolConfig = poolConfig;
@@ -215,6 +220,7 @@ export class ConnectionPool implements ReapablePool {
     this.size = this.dbConfig.pool;
     this.checkoutTimeout = this.dbConfig.checkoutTimeout;
     this._idleTimeout = this.dbConfig.idleTimeout;
+    this._available = new ConnectionLeasingQueue();
 
     this.reaper = new Reaper(this, this.dbConfig.reapingFrequency ?? 0);
     this.reaper.run();
@@ -312,9 +318,19 @@ export class ConnectionPool implements ReapablePool {
   // --- Pin / Unpin ---
 
   async pinConnectionBang(_lockThread = false): Promise<void> {
+    const ctxId = executionContextId();
+    let pin = this._pinnedConnections.get(ctxId);
     const leasedConnection = this._connectionLease().connection;
-    const connection = this._pinnedConnection ?? leasedConnection ?? this.checkout();
-    const newlyCheckedOut = this._pinnedConnection === null && leasedConnection == null;
+    const connection = pin?.connection ?? leasedConnection ?? this._acquireConnection();
+    const newlyCheckedOut = !pin && leasedConnection == null;
+
+    // Record the pin before any async work to prevent concurrent
+    // pinConnectionBang calls in the same context from double-acquiring.
+    if (!pin) {
+      pin = { connection, depth: 0 };
+      this._pinnedConnections.set(ctxId, pin);
+    }
+    pin.depth++;
 
     try {
       if (this._connections && !this._connections.includes(connection)) {
@@ -329,24 +345,25 @@ export class ConnectionPool implements ReapablePool {
         });
       }
     } catch (error) {
-      if (newlyCheckedOut) {
-        this.checkin(connection);
+      pin.depth--;
+      if (pin.depth === 0) {
+        this._pinnedConnections.delete(ctxId);
+        if (newlyCheckedOut) {
+          this.checkin(connection);
+        }
       }
       throw error;
     }
-
-    if (!this._pinnedConnection) {
-      this._pinnedConnection = connection;
-    }
-    this._pinnedConnectionsDepth += 1;
   }
 
   async unpinConnectionBang(): Promise<boolean> {
-    if (!this._pinnedConnection) {
-      throw new Error(`There isn't a pinned connection`);
+    const ctxId = executionContextId();
+    const pin = this._pinnedConnections.get(ctxId);
+    if (!pin) {
+      throw new Error(`There isn't a pinned connection ${this.inspect()}`);
     }
 
-    const connection = this._pinnedConnection;
+    const connection = pin.connection;
     let clean = true;
 
     try {
@@ -359,9 +376,9 @@ export class ConnectionPool implements ReapablePool {
         }
       }
     } finally {
-      this._pinnedConnectionsDepth -= 1;
-      if (this._pinnedConnectionsDepth === 0) {
-        this._pinnedConnection = null;
+      pin.depth--;
+      if (pin.depth === 0) {
+        this._pinnedConnections.delete(ctxId);
         this.checkin(connection);
       }
     }
@@ -372,23 +389,73 @@ export class ConnectionPool implements ReapablePool {
   // --- Checkout / Checkin ---
 
   checkout(): DatabaseAdapter {
-    if (this._pinnedConnection) {
-      if (isTransactionAware(this._pinnedConnection)) {
-        this._pinnedConnection.verifyBang();
+    const pin = this._pinnedConnections.get(executionContextId());
+    if (pin) {
+      if (isTransactionAware(pin.connection)) {
+        pin.connection.verifyBang();
       }
-      if (this._connections && !this._connections.includes(this._pinnedConnection)) {
-        this._connections.push(this._pinnedConnection);
+      if (this._connections && !this._connections.includes(pin.connection)) {
+        this._connections.push(pin.connection);
       }
-      return this._pinnedConnection;
+      return pin.connection;
     }
+    return this._acquireConnection();
+  }
 
+  async checkoutAsync(timeout?: number): Promise<DatabaseAdapter> {
+    const pin = this._pinnedConnections.get(executionContextId());
+    if (pin) {
+      if (isTransactionAware(pin.connection)) {
+        pin.connection.verifyBang();
+      }
+      if (this._connections && !this._connections.includes(pin.connection)) {
+        this._connections.push(pin.connection);
+      }
+      return pin.connection;
+    }
+    const conn = this._tryAcquire();
+    if (conn) return conn;
+
+    const t = timeout ?? this.checkoutTimeout;
+    if (!this._available) {
+      throw new ConnectionNotEstablished("Connection pool has been discarded");
+    }
+    let c: DatabaseAdapter;
+    try {
+      const result = this._available.poll(t);
+      c = result instanceof Promise ? await result : result!;
+    } catch (err) {
+      if (err instanceof ConnectionTimeoutError) {
+        err.setPool(this);
+      }
+      throw err;
+    }
     if (this.isDiscarded()) {
       throw new ConnectionNotEstablished("Connection pool has been discarded");
     }
-    if (this._available && this._available.length > 0) {
-      const conn = this._available.pop()!;
-      this._checkedOut.add(conn);
-      return conn;
+    this._checkedOut.add(c);
+    return c;
+  }
+
+  private _acquireConnection(): DatabaseAdapter {
+    const conn = this._tryAcquire();
+    if (conn) return conn;
+    throw new ConnectionTimeoutError(
+      `Could not obtain a connection from the pool. All ${this.size} connections are in use.`,
+      { connectionPool: this },
+    );
+  }
+
+  private _tryAcquire(): DatabaseAdapter | undefined {
+    if (this.isDiscarded()) {
+      throw new ConnectionNotEstablished("Connection pool has been discarded");
+    }
+    if (this._available) {
+      const conn = this._available.poll();
+      if (conn) {
+        this._checkedOut.add(conn);
+        return conn;
+      }
     }
     if (this._connections && this._connections.length < this.size) {
       if (!this.automaticReconnect) {
@@ -400,20 +467,19 @@ export class ConnectionPool implements ReapablePool {
       const conn = this.newConnection();
       this._connections.push(conn);
       this._checkedOut.add(conn);
+      (conn as unknown as PoolManagedConnection).lease?.();
       return conn;
     }
-    throw new ConnectionTimeoutError(
-      `Could not obtain a connection from the pool. All ${this.size} connections are in use.`,
-      { connectionPool: this },
-    );
+    return undefined;
   }
 
   checkin(conn: DatabaseAdapter): void {
-    if (this._pinnedConnection === conn) return;
+    if (this._isConnectionPinned(conn)) return;
     this._connectionLease().clear(conn);
     if (this._checkedOut.has(conn)) {
       this._checkedOut.delete(conn);
-      this._available?.push(conn);
+      (conn as unknown as PoolManagedConnection).expire?.();
+      this._available?.add(conn);
       this._lastCheckinAt.set(conn, Date.now());
     }
   }
@@ -461,7 +527,7 @@ export class ConnectionPool implements ReapablePool {
   // --- Pool statistics ---
 
   numWaitingInQueue(): number {
-    return 0;
+    return this._available?.numWaiting() ?? 0;
   }
 
   stat(): {
@@ -485,10 +551,12 @@ export class ConnectionPool implements ReapablePool {
   // --- Lifecycle ---
 
   disconnect(): void {
-    this._pinnedConnection = null;
-    this._pinnedConnectionsDepth = 0;
+    this._pinnedConnections.clear();
     if (this._connections) this._connections.length = 0;
-    if (this._available) this._available.length = 0;
+    this._available?.rejectAll(
+      new ConnectionNotEstablished("Connection pool has been disconnected"),
+    );
+    this._available?.clear();
     this._checkedOut.clear();
     this._leases?.clear();
     this._lastCheckinAt.clear();
@@ -500,9 +568,10 @@ export class ConnectionPool implements ReapablePool {
 
   discardBang(): void {
     if (this.isDiscarded()) return;
-    this._pinnedConnection = null;
-    this._pinnedConnectionsDepth = 0;
+    this._pinnedConnections.clear();
     this._connections = null;
+    this._available?.rejectAll(new ConnectionNotEstablished("Connection pool has been discarded"));
+    this._available?.clear();
     this._available = null;
     this._leases = null;
     this._checkedOut.clear();
@@ -531,23 +600,18 @@ export class ConnectionPool implements ReapablePool {
 
     const now = Date.now();
     const minimumIdleMs = minimumIdle * 1000;
-    const toRemove: DatabaseAdapter[] = [];
 
-    for (const conn of this._available) {
-      if (this._checkedOut.has(conn)) continue;
+    const all = this._available.clear();
+    for (const conn of all) {
       const lastCheckin = this._lastCheckinAt.get(conn) ?? 0;
       const idleMs = now - lastCheckin;
       if (idleMs >= minimumIdleMs) {
-        toRemove.push(conn);
+        const connIdx = this._connections.indexOf(conn);
+        if (connIdx >= 0) this._connections.splice(connIdx, 1);
+        this._lastCheckinAt.delete(conn);
+      } else {
+        this._available.add(conn);
       }
-    }
-
-    for (const conn of toRemove) {
-      const availIdx = this._available.indexOf(conn);
-      if (availIdx >= 0) this._available.splice(availIdx, 1);
-      const connIdx = this._connections.indexOf(conn);
-      if (connIdx >= 0) this._connections.splice(connIdx, 1);
-      this._lastCheckinAt.delete(conn);
     }
   }
 
@@ -566,20 +630,33 @@ export class ConnectionPool implements ReapablePool {
   }
 
   remove(conn: DatabaseAdapter): void {
-    if (this._pinnedConnection === conn) {
-      this._pinnedConnection = null;
-      this._pinnedConnectionsDepth = 0;
-    }
     this._connectionLease().clear(conn);
     this._checkedOut.delete(conn);
     this._lastCheckinAt.delete(conn);
-    if (this._available) {
-      const availIdx = this._available.indexOf(conn);
-      if (availIdx >= 0) this._available.splice(availIdx, 1);
+    this._available?.delete(conn);
+
+    for (const [ctxId, pin] of this._pinnedConnections) {
+      if (pin.connection === conn) {
+        this._pinnedConnections.delete(ctxId);
+      }
     }
+
     if (this._connections) {
       const connIdx = this._connections.indexOf(conn);
       if (connIdx >= 0) this._connections.splice(connIdx, 1);
+    }
+
+    const needsNewConnection = this._available?.isAnyWaiting() ?? false;
+    if (
+      needsNewConnection &&
+      this.automaticReconnect &&
+      this._connections &&
+      this._connections.length < this.size
+    ) {
+      const newConn = this.newConnection();
+      this._connections.push(newConn);
+      this._lastCheckinAt.set(newConn, Date.now());
+      this._available?.add(newConn);
     }
   }
 
@@ -588,6 +665,13 @@ export class ConnectionPool implements ReapablePool {
   }
 
   // --- Private ---
+
+  private _isConnectionPinned(conn: DatabaseAdapter): boolean {
+    for (const pin of this._pinnedConnections.values()) {
+      if (pin.connection === conn) return true;
+    }
+    return false;
+  }
 
   private _connectionLease(): Lease {
     if (!this._leases) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts
@@ -323,3 +323,25 @@ describe("ConnectionPool::ConnectionLeasingQueue", () => {
     expect(q.leasedTo(c)).toBeUndefined();
   });
 });
+
+describe("Queue rejectAll", () => {
+  it("rejects all pending waiters with the provided error", async () => {
+    const q = new Queue();
+    const p1 = q.poll(5) as Promise<DatabaseAdapter>;
+    const p2 = q.poll(5) as Promise<DatabaseAdapter>;
+    expect(q.numWaiting()).toBe(2);
+
+    const error = new Error("pool discarded");
+    q.rejectAll(error);
+
+    await expect(p1).rejects.toThrow("pool discarded");
+    await expect(p2).rejects.toThrow("pool discarded");
+    expect(q.numWaiting()).toBe(0);
+  });
+
+  it("rejectAll is a no-op when no waiters exist", () => {
+    const q = new Queue();
+    expect(() => q.rejectAll(new Error("test"))).not.toThrow();
+    expect(q.numWaiting()).toBe(0);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -26,6 +26,8 @@ interface WaiterState {
   container: Array<(conn: DatabaseAdapter) => void>;
   timer: ReturnType<typeof setTimeout> | null;
   settled: boolean;
+  reject?: (err: Error) => void;
+  onSettle?: () => void;
 }
 
 export class BiasedConditionVariable {
@@ -44,23 +46,30 @@ export class BiasedConditionVariable {
     return this._waiters.length;
   }
 
-  wait(timeout: number): Promise<DatabaseAdapter> {
+  wait(timeout: number, onSettle?: () => void): Promise<DatabaseAdapter> {
     return new Promise((resolve, reject) => {
       const state: WaiterState = {
         container: this._waiters,
         timer: null,
         settled: false,
+        reject,
+        onSettle,
+      };
+
+      const settle = () => {
+        const idx = state.container.indexOf(waiter);
+        if (idx >= 0) state.container.splice(idx, 1);
+        if (state.timer != null) {
+          clearTimeout(state.timer);
+          state.timer = null;
+        }
+        state.onSettle?.();
       };
 
       const waiter = (conn: DatabaseAdapter) => {
         if (state.settled) return;
         state.settled = true;
-        if (state.timer != null) {
-          clearTimeout(state.timer);
-          state.timer = null;
-        }
-        const idx = state.container.indexOf(waiter);
-        if (idx >= 0) state.container.splice(idx, 1);
+        settle();
         resolve(conn);
       };
       (waiter as any)._state = state;
@@ -68,8 +77,7 @@ export class BiasedConditionVariable {
       state.timer = setTimeout(() => {
         if (state.settled) return;
         state.settled = true;
-        const idx = state.container.indexOf(waiter);
-        if (idx >= 0) state.container.splice(idx, 1);
+        settle();
         const msg =
           `could not obtain a connection from the pool within ${timeout.toFixed(3)} seconds; ` +
           `all pooled connections were in use`;
@@ -112,6 +120,23 @@ export class BiasedConditionVariable {
       i++;
     }
     return connections.slice(i);
+  }
+
+  rejectAll(error: Error): void {
+    while (this._waiters.length > 0) {
+      const waiter = this._waiters.shift()!;
+      const state = (waiter as any)._state as WaiterState | undefined;
+      if (state && !state.settled) {
+        state.settled = true;
+        if (state.timer != null) {
+          clearTimeout(state.timer);
+          state.timer = null;
+        }
+        state.onSettle?.();
+        state.reject?.(error);
+      }
+    }
+    this._otherCond?.rejectAll(error);
   }
 
   /**
@@ -236,6 +261,10 @@ export class Queue {
     return items;
   }
 
+  rejectAll(error: Error): void {
+    this._cond.rejectAll(error);
+  }
+
   protected internalPoll(timeout?: number): Promise<DatabaseAdapter> | DatabaseAdapter | undefined {
     const conn = this.noWaitPoll();
     if (conn) return conn;
@@ -256,7 +285,7 @@ export class Queue {
 
   private waitPoll(timeout: number): Promise<DatabaseAdapter> {
     this._numWaiting++;
-    return this._cond.wait(timeout).finally(() => {
+    return this._cond.wait(timeout, () => {
       this._numWaiting--;
     });
   }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
+import {
+  ConnectionPool,
+  withExecutionContext,
+} from "./connection-adapters/abstract/connection-pool.js";
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
@@ -183,16 +186,34 @@ it("full pool exception", () => {
   expect(() => pool.checkout()).toThrow(/Could not obtain a connection/);
 });
 
-it.skip("full pool blocks", () => {
-  /* needs async waiting/blocking */
+it("full pool async checkout timeout", async () => {
+  const pool = makePool(1);
+  pool.checkout();
+  await expect(pool.checkoutAsync(0.05)).rejects.toThrow(/could not obtain a connection/);
+});
+
+it("full pool blocks", async () => {
+  const pool = makePool(1);
+  const conn = pool.checkout();
+  const promise = pool.checkoutAsync(1);
+  pool.checkin(conn);
+  const conn2 = await promise;
+  expect(conn2).toBe(conn);
+  pool.checkin(conn2);
 });
 
 it.skip("full pool blocking shares load interlock", () => {
   /* needs thread interlock */
 });
 
-it.skip("removing releases latch", () => {
-  /* needs async waiting */
+it("removing releases latch", async () => {
+  const pool = makePool(1);
+  const conn = pool.checkout();
+  const promise = pool.checkoutAsync(1);
+  pool.remove(conn);
+  const conn2 = await promise;
+  expect(conn2).not.toBe(conn);
+  pool.checkin(conn2);
 });
 
 it("reap and active", () => {
@@ -552,6 +573,38 @@ it("pin connection reuses leased connection and checks in on unpin", async () =>
 
   // Pinning takes ownership — connection is checked in on final unpin (matches Rails)
   expect(pool.stat().idle).toBe(1);
+});
+
+it("pin connection isolation across execution contexts", async () => {
+  const pool = makeTransactionAwarePool(5);
+  let ctx1Conn: DatabaseAdapter | null = null;
+  let ctx2Conn: DatabaseAdapter | null = null;
+
+  await withExecutionContext(async () => {
+    await pool.pinConnectionBang();
+    ctx1Conn = pool.checkout();
+
+    // Nested context gets a different pin
+    await withExecutionContext(async () => {
+      await pool.pinConnectionBang();
+      ctx2Conn = pool.checkout();
+      expect(ctx2Conn).not.toBe(ctx1Conn);
+
+      // Checkin of ctx2's pinned connection is a no-op (still pinned)
+      pool.checkin(ctx2Conn!);
+      expect(pool.checkout()).toBe(ctx2Conn);
+
+      await pool.unpinConnectionBang();
+    });
+
+    // Back in ctx1 — still pinned to ctx1Conn
+    expect(pool.checkout()).toBe(ctx1Conn);
+    await pool.unpinConnectionBang();
+  });
+
+  expect(ctx1Conn).toBeTruthy();
+  expect(ctx2Conn).toBeTruthy();
+  expect(ctx1Conn).not.toBe(ctx2Conn);
 });
 
 it.skip("pin connection nesting lock", () => {


### PR DESCRIPTION
## Summary

Builds on #482's TransactionManager pin/unpin integration.

**Per-context pin connection:**
- Pinned connections tracked per `executionContextId()` via `Map` — parallel async contexts are isolated
- `disconnect`/`discardBang` clear all pinned connections
- `remove` clears pinned mappings referencing removed connections
- `checkin` checks ALL contexts before returning a pinned connection to the pool

**Async checkout:**
- Replaces raw `_available` array with `ConnectionLeasingQueue` (promise-based)
- `checkoutAsync(timeout?)` waits for a connection when pool is at capacity
- `checkin()` signals waiting checkouts via `queue.add()`
- `remove()` creates new connections for waiters (guarded by `automaticReconnect`)
- Timeout errors include pool context via `err.setPool(this)`

**Queue enhancements:**
- `rejectAll(error)` rejects all pending waiters on disconnect/discard
- `onSettle` callback for synchronous `_numWaiting` bookkeeping
- `lease`/`expire` on checkout/checkin

**Tests:**
- Async checkout timeout, full pool blocks, removing releases latch
- 30 pool tests passing, 24 skipped

## Test plan

- [x] 30 pool tests passing (up from 26 on #482)
- [x] Full activerecord suite passes (7969 tests)
- [x] Queue tests passing (25 tests)