### PR TITLE
feat(activerecord): implement remaining SchemaStatements methods matching Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -105,9 +105,7 @@ export class SchemaCreation {
       if (change.defaultValue == null) {
         parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
       } else {
-        parts.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${quoteDefaultExpression(change.defaultValue)}`,
-        );
+        parts.push(`ALTER COLUMN ${col} SET${quoteDefaultExpression(change.defaultValue)}`);
       }
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -13,6 +13,7 @@ import {
   type ReferentialAction,
   ColumnDefinition,
   AddColumnDefinition,
+  AlterTable,
   CreateIndexDefinition,
   ForeignKeyDefinition,
   CheckConstraintDefinition,
@@ -22,6 +23,7 @@ import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "./quoti
 
 type Definition =
   | TableDefinition
+  | AlterTable
   | ColumnDefinition
   | AddColumnDefinition
   | CreateIndexDefinition
@@ -41,6 +43,7 @@ export class SchemaCreation {
 
   accept(o: Definition): string {
     if (o instanceof TableDefinition) return this.visitTableDefinition(o);
+    if (o instanceof AlterTable) return this.visitAlterTable(o);
     if (o instanceof AddColumnDefinition) return this.visitAddColumnDefinition(o);
     if (o instanceof ColumnDefinition) return this.visitColumnDefinition(o);
     if (o instanceof CreateIndexDefinition) return this.visitCreateIndexDefinition(o);
@@ -73,6 +76,42 @@ export class SchemaCreation {
 
   protected visitAddColumnDefinition(o: AddColumnDefinition): string {
     return `ADD ${this.accept(o.column)}`;
+  }
+
+  protected visitAlterTable(o: AlterTable): string {
+    const table = quoteTableName(o.name, this.adapterName);
+    const parts: string[] = [];
+
+    for (const add of o.adds) {
+      parts.push(this.visitAddColumnDefinition(add));
+    }
+    for (const fk of o.foreignKeyAdds) {
+      parts.push(`ADD ${this.visitForeignKeyDefinition(fk)}`);
+    }
+    for (const name of o.foreignKeyDrops) {
+      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+    }
+    for (const chk of o.checkConstraintAdds) {
+      parts.push(`ADD ${this.visitCheckConstraintDefinition(chk)}`);
+    }
+    for (const name of o.checkConstraintDrops) {
+      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+    }
+    for (const name of o.constraintDrops) {
+      parts.push(`DROP CONSTRAINT ${quoteIdentifier(name, this.adapterName)}`);
+    }
+    for (const change of o.columnDefaultChanges) {
+      const col = quoteIdentifier(change.columnName, this.adapterName);
+      if (change.defaultValue == null) {
+        parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
+      } else {
+        parts.push(
+          `ALTER COLUMN ${col} SET DEFAULT ${quoteDefaultExpression(change.defaultValue)}`,
+        );
+      }
+    }
+
+    return `ALTER TABLE ${table} ${parts.join(", ")}`;
   }
 
   protected visitCreateIndexDefinition(o: CreateIndexDefinition): string {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -207,6 +207,11 @@ export class AlterTable {
   readonly foreignKeyDrops: string[] = [];
   readonly checkConstraintAdds: CheckConstraintDefinition[] = [];
   readonly checkConstraintDrops: string[] = [];
+  readonly constraintDrops: string[] = [];
+  readonly columnDefaultChanges: Array<{
+    columnName: string;
+    defaultValue: unknown;
+  }> = [];
 
   constructor(name: string) {
     this.name = name;
@@ -230,6 +235,14 @@ export class AlterTable {
 
   dropCheckConstraint(name: string): void {
     this.checkConstraintDrops.push(name);
+  }
+
+  dropConstraint(name: string): void {
+    this.constraintDrops.push(name);
+  }
+
+  changeColumnDefault(columnName: string, defaultValue: unknown): void {
+    this.columnDefaultChanges.push({ columnName, defaultValue });
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1196,14 +1196,23 @@ export class SchemaStatements {
   indexAlgorithm(algorithm?: string): string | undefined {
     if (!algorithm) return undefined;
     const normalized = algorithm.toLowerCase();
-    const valid = ["default", "concurrently"];
-    if (!valid.includes(normalized)) {
-      throw new Error(
-        `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
-      );
-    }
     if (normalized === "default") return undefined;
-    return normalized;
+
+    const adapterAlgorithms =
+      typeof (this.adapter as any).indexAlgorithms === "function"
+        ? ((this.adapter as any).indexAlgorithms() as Record<string, string>)
+        : null;
+
+    if (adapterAlgorithms && normalized in adapterAlgorithms) {
+      return adapterAlgorithms[normalized];
+    }
+
+    const valid = adapterAlgorithms
+      ? ["default", ...Object.keys(adapterAlgorithms)]
+      : ["default", "concurrently"];
+    throw new Error(
+      `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
+    );
   }
 
   quotedColumnsForIndex(columnNames: string[], _options: Record<string, unknown> = {}): string {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -864,15 +864,19 @@ export class SchemaStatements {
     } = {},
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
-    const hasCustomPk = options.primaryKey && options.id !== false;
+    if (Array.isArray(options.primaryKey)) {
+      throw new Error("Composite primary keys are not yet supported by buildCreateTableDefinition");
+    }
+    const hasCustomPk = typeof options.primaryKey === "string" && options.id !== false;
     const td = new TableDefinition(tableName, {
       id: hasCustomPk ? false : options.id,
       adapterName: this.adapterName,
     });
     if (hasCustomPk) {
-      const pkName = typeof options.primaryKey === "string" ? options.primaryKey : "id";
       const pkType = (typeof options.id === "string" ? options.id : "primary_key") as ColumnType;
-      td.columns.unshift(new ColumnDefinition(pkName, pkType, { primaryKey: true }));
+      td.columns.unshift(
+        new ColumnDefinition(options.primaryKey as string, pkType, { primaryKey: true }),
+      );
     }
     if (fn) fn(td);
     return td;
@@ -1020,7 +1024,7 @@ export class SchemaStatements {
       const unqualifiedFrom = (fromTable.split(".").at(-1) ?? fromTable).replace(/\./g, "_");
       const cols = Array.isArray(result.column) ? result.column : [result.column];
       const fullName = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
-      if (fullName.length > 62) {
+      if (fullName.length > this.maxIndexNameSize()) {
         // Truncate and append a simple hash to stay within identifier limits
         const hash = Array.from(fullName).reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
         const hex = Math.abs(hash).toString(16).slice(0, 10);
@@ -1034,7 +1038,7 @@ export class SchemaStatements {
   }
 
   async checkConstraints(_tableName: string): Promise<CheckConstraintDefinition[]> {
-    throw new Error("checkConstraints is not implemented for this adapter");
+    throw new Error("NotImplementedError: checkConstraints is not implemented");
   }
 
   checkConstraintOptions(
@@ -1070,7 +1074,7 @@ export class SchemaStatements {
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
-    const smTable = (this as any).pool?.schemaMigration;
+    const smTable = (this.adapter as any).pool?.schemaMigration;
     if (!smTable) return null;
     const versions: string[] =
       typeof smTable.versions === "function" ? await smTable.versions() : (smTable.versions ?? []);
@@ -1089,13 +1093,12 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    const verStr = String(version);
-    if (typeof version === "string" && !/^\d+$/.test(verStr)) {
+    const ver = String(version);
+    if (!/^\d+$/.test(ver)) {
       throw new Error(`Invalid migration version: ${version}`);
     }
-    const ver = typeof version === "number" ? version : parseInt(version, 10);
 
-    const smMigration = (this as any).pool?.schemaMigration;
+    const smMigration = (this.adapter as any).pool?.schemaMigration;
     const smTableName = smMigration?.tableName ?? "schema_migrations";
     const smTable = this._qt(smTableName);
 
@@ -1107,22 +1110,22 @@ export class SchemaStatements {
     }
 
     // Insert the target version if not already recorded
-    const escapedVer = String(ver).replace(/'/g, "''");
-    if (!existing.has(String(ver))) {
+    const escapedVer = ver.replace(/'/g, "''");
+    if (!existing.has(ver)) {
       await this.adapter.executeMutation(
         `INSERT INTO ${smTable} (version) VALUES ('${escapedVer}')`,
       );
     }
 
     // If pool has migration context, also insert all migration versions below this one
-    const migrationContext = (this as any).pool?.migrationContext;
+    const migrationContext = (this.adapter as any).pool?.migrationContext;
     if (migrationContext) {
-      const allVersions: number[] = (migrationContext.migrations ?? []).map(
-        (m: { version: number }) => m.version,
+      const allVersions: string[] = (migrationContext.migrations ?? []).map(
+        (m: { version: number | string }) => String(m.version),
       );
-      const toInsert = allVersions.filter((v) => v < ver && !existing.has(String(v)));
+      const toInsert = allVersions.filter((v) => BigInt(v) < BigInt(ver) && !existing.has(v));
       for (const v of toInsert) {
-        const vStr = String(v).replace(/'/g, "''");
+        const vStr = v.replace(/'/g, "''");
         await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${vStr}')`);
       }
     }
@@ -1202,7 +1205,9 @@ export class SchemaStatements {
     _tableName: string,
     _commentOrChanges: string | null | { from?: string; to?: string },
   ): Promise<void> {
-    throw new Error(`${this.adapterName} does not support changing table comments`);
+    throw new Error(
+      `NotImplementedError: ${this.adapterName} does not support changing table comments`,
+    );
   }
 
   async changeColumnComment(
@@ -1210,7 +1215,9 @@ export class SchemaStatements {
     _columnName: string,
     _commentOrChanges: string | null | { from?: string; to?: string },
   ): Promise<void> {
-    throw new Error(`${this.adapterName} does not support changing column comments`);
+    throw new Error(
+      `NotImplementedError: ${this.adapterName} does not support changing column comments`,
+    );
   }
 
   createSchemaDumper(options: Record<string, unknown> = {}): SchemaDumper {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1025,9 +1025,17 @@ export class SchemaStatements {
       const cols = Array.isArray(result.column) ? result.column : [result.column];
       const fullName = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
       if (fullName.length > this.maxIndexNameSize()) {
-        // Truncate and append a simple hash to stay within identifier limits
-        const hash = Array.from(fullName).reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
-        const hex = Math.abs(hash).toString(16).slice(0, 10);
+        // Deterministic hash matching Rails' fk_rails_<digest> pattern
+        let h1 = 0x811c9dc5;
+        let h2 = 0x01000193;
+        for (let i = 0; i < fullName.length; i++) {
+          const c = fullName.charCodeAt(i);
+          h1 = Math.imul(h1 ^ c, 0x01000193);
+          h2 = Math.imul(h2 ^ c, 0x1000193b);
+        }
+        const hex = ((h1 >>> 0).toString(16) + (h2 >>> 0).toString(16))
+          .padStart(16, "0")
+          .slice(0, 10);
         result.name = `fk_rails_${hex}`;
       } else {
         result.name = fullName;
@@ -1145,8 +1153,9 @@ export class SchemaStatements {
     if (!pk) return relation;
 
     const pkColumns = Array.isArray(pk) ? pk : [pk];
+    const quotedPkColumns = pkColumns.map((col) => this._qi(col));
     const values = this.columnsForDistinct(
-      pkColumns.join(", "),
+      quotedPkColumns.join(", "),
       (relation.orderValues as string[]) ?? [],
     );
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -832,7 +832,7 @@ export class SchemaStatements {
   }
 
   protected tableAliasLength(): number {
-    return 255;
+    return 64;
   }
 
   async dataSources(): Promise<string[]> {
@@ -843,8 +843,8 @@ export class SchemaStatements {
 
   async isDataSourceExists(name: string): Promise<boolean> {
     if (!name) return false;
-    const sources = await this.dataSources();
-    return sources.includes(name);
+    if (await this.tableExists(name)) return true;
+    return this.viewExists(name);
   }
 
   buildCreateTableDefinition(
@@ -912,7 +912,8 @@ export class SchemaStatements {
   }
 
   private _referenceNameForTable(tableName: string): string {
-    return singularize(tableName.replace(/^.*_/, ""));
+    const unqualified = tableName.split(".").at(-1) ?? tableName;
+    return singularize(unqualified);
   }
 
   async buildAddColumnDefinition(
@@ -1042,7 +1043,7 @@ export class SchemaStatements {
 
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
     const sql = `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(constraintName)}`;
-    await this.adapter.execute(sql);
+    await this.adapter.executeMutation(sql);
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
@@ -1065,26 +1066,27 @@ export class SchemaStatements {
     const ver = typeof version === "number" ? version : parseInt(version, 10);
     const smTable = this._qi("schema_migrations");
 
+    // Query existing versions to avoid duplicates (cross-adapter compatible)
+    const existing = new Set<string>();
+    const rows = await this.adapter.execute(`SELECT version FROM ${smTable}`);
+    for (const row of rows) {
+      existing.add(String((row as Record<string, unknown>).version));
+    }
+
     // Insert the target version if not already recorded
-    await this.adapter.execute(
-      `INSERT INTO ${smTable} (version) VALUES ('${ver}') ON CONFLICT DO NOTHING`,
-    );
+    if (!existing.has(String(ver))) {
+      await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${ver}')`);
+    }
 
     // If pool has migration context, also insert all migration versions below this one
     const migrationContext = (this as any).pool?.migrationContext;
     if (migrationContext) {
-      const migrated: number[] =
-        typeof migrationContext.getAllVersions === "function"
-          ? await migrationContext.getAllVersions()
-          : [];
       const allVersions: number[] = (migrationContext.migrations ?? []).map(
         (m: { version: number }) => m.version,
       );
-      const toInsert = allVersions.filter((v) => v < ver && !migrated.includes(v));
+      const toInsert = allVersions.filter((v) => v < ver && !existing.has(String(v)));
       for (const v of toInsert) {
-        await this.adapter.execute(
-          `INSERT INTO ${smTable} (version) VALUES ('${v}') ON CONFLICT DO NOTHING`,
-        );
+        await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${v}')`);
       }
     }
   }
@@ -1213,7 +1215,7 @@ export class SchemaStatements {
         }
       } else {
         if (sqlFragments.length > 0) {
-          await this.adapter.execute(
+          await this.adapter.executeMutation(
             `ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`,
           );
           sqlFragments.length = 0;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -24,7 +24,7 @@ import {
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
-import { quoteIdentifier, quoteDefaultExpression } from "./quoting.js";
+import { quoteIdentifier, quoteDefaultExpression, quoteTableName } from "./quoting.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
@@ -51,10 +51,7 @@ export class SchemaStatements {
   }
 
   protected _qt(tableName: string): string {
-    return tableName
-      .split(".")
-      .map((part) => this._qi(part))
-      .join(".");
+    return quoteTableName(tableName, this.adapterName);
   }
 
   async createTable(
@@ -1220,7 +1217,7 @@ export class SchemaStatements {
   }
 
   createSchemaDumper(options: Record<string, unknown> = {}): SchemaDumper {
-    return SchemaDumper.create(this as any, options);
+    return SchemaDumper.create(this as Parameters<typeof SchemaDumper.create>[0], options);
   }
 
   isUseForeignKeys(): boolean {
@@ -1234,7 +1231,7 @@ export class SchemaStatements {
 
   async bulkChangeTable(
     tableName: string,
-    operations: Array<[string, ...unknown[]]>,
+    operations: Array<[string, string, ...unknown[]]>,
   ): Promise<void> {
     const sqlFragments: string[] = [];
     const nonCombinable: Array<() => Promise<void>> = [];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -12,6 +12,7 @@ import type { DatabaseAdapter } from "../../adapter.js";
 import {
   TableDefinition,
   Table,
+  AlterTable,
   IndexDefinition,
   ColumnDefinition,
   AddColumnDefinition,
@@ -933,19 +934,21 @@ export class SchemaStatements {
     columnName: string,
     type: ColumnType,
     options: ColumnOptions & { ifNotExists?: boolean } = {},
-  ): Promise<AddColumnDefinition | null> {
+  ): Promise<AlterTable | null> {
     if (options.ifNotExists && (await this.columnExists(tableName, columnName))) {
       return null;
     }
     const { ifNotExists: _, ...colOpts } = options;
-    return new AddColumnDefinition(new ColumnDefinition(columnName, type, colOpts));
+    const at = new AlterTable(tableName);
+    at.addColumn(columnName, type, colOpts);
+    return at;
   }
 
   buildChangeColumnDefaultDefinition(
     tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
-  ): { tableName: string; columnName: string; newDefault: unknown } {
+  ): AlterTable {
     let newDefault: unknown;
     if (
       defaultOrChanges != null &&
@@ -956,7 +959,9 @@ export class SchemaStatements {
     } else {
       newDefault = defaultOrChanges;
     }
-    return { tableName, columnName, newDefault };
+    const at = new AlterTable(tableName);
+    at.changeColumnDefault(columnName, newDefault);
+    return at;
   }
 
   buildCreateIndexDefinition(
@@ -1062,8 +1067,9 @@ export class SchemaStatements {
   }
 
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
-    const sql = `ALTER TABLE ${this._qt(tableName)} DROP CONSTRAINT ${this._qi(constraintName)}`;
-    await this.adapter.executeMutation(sql);
+    const at = new AlterTable(tableName);
+    at.dropConstraint(constraintName);
+    await this.adapter.executeMutation(this.schemaCreation.accept(at));
   }
 
   async dumpSchemaInformation(): Promise<string | null> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -855,16 +855,13 @@ export class SchemaStatements {
     tableName: string,
     options: {
       id?: boolean | "uuid" | false;
-      primaryKey?: string | string[];
+      primaryKey?: string;
       force?: boolean;
       [key: string]: unknown;
     } = {},
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
-    if (Array.isArray(options.primaryKey)) {
-      throw new Error("Composite primary keys are not yet supported by buildCreateTableDefinition");
-    }
-    const hasCustomPk = typeof options.primaryKey === "string" && options.id !== false;
+    const hasCustomPk = !!options.primaryKey && options.id !== false;
     const td = new TableDefinition(tableName, {
       id: hasCustomPk ? false : options.id,
       adapterName: this.adapterName,
@@ -904,7 +901,8 @@ export class SchemaStatements {
   }
 
   private _findJoinTableName(table1: string, table2: string): string {
-    const [t1, t2] = [table1, table2].sort();
+    const unqualify = (name: string) => (name.split(".").at(-1) ?? name).replace(/\./g, "_");
+    const [t1, t2] = [unqualify(table1), unqualify(table2)].sort();
     const parts1 = t1.split("_");
     const parts2 = t2.split("_");
     // Remove common prefix (Rails dedup: music_artists + music_records → music_artists_records)
@@ -1115,9 +1113,9 @@ export class SchemaStatements {
     // If pool has migration context, also insert all migration versions below this one
     const migrationContext = (this.adapter as any).pool?.migrationContext;
     if (migrationContext) {
-      const allVersions: string[] = (migrationContext.migrations ?? []).map(
-        (m: { version: number | string }) => String(m.version),
-      );
+      const allVersions: string[] = (migrationContext.migrations ?? [])
+        .map((m: { version: number | string }) => String(m.version))
+        .filter((v: string) => /^\d+$/.test(v));
       const toInsert = allVersions.filter((v) => BigInt(v) < BigInt(ver) && !existing.has(v));
       for (const v of toInsert) {
         const vStr = v.replace(/'/g, "''");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1190,6 +1190,12 @@ export class SchemaStatements {
 
   indexAlgorithm(algorithm?: string): string | undefined {
     if (!algorithm) return undefined;
+    const valid = ["default", "concurrently"];
+    if (!valid.includes(algorithm.toLowerCase())) {
+      throw new Error(
+        `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
+      );
+    }
     return algorithm;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -25,7 +25,7 @@ import {
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { detectAdapterName } from "../../adapter-name.js";
-import { quoteIdentifier, quoteDefaultExpression, quoteTableName } from "./quoting.js";
+import { quoteIdentifier, quoteDefaultExpression, quoteTableName, quote } from "./quoting.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
@@ -1079,13 +1079,16 @@ export class SchemaStatements {
     const versions: string[] =
       typeof smTable.versions === "function" ? await smTable.versions() : (smTable.versions ?? []);
     if (versions.length === 0) return null;
-    const tableName = this._qt(smTable.tableName ?? "schema_migrations");
-    return versions
-      .map((v: string) => {
-        const escaped = String(v).replace(/'/g, "''");
-        return `INSERT INTO ${tableName} (version) VALUES ('${escaped}');`;
-      })
-      .join("\n");
+    return this._insertVersionsSql(smTable.tableName ?? "schema_migrations", versions);
+  }
+
+  private _insertVersionsSql(tableName: string, versions: string | string[]): string {
+    const smTable = this._qt(tableName);
+    if (Array.isArray(versions)) {
+      const rows = versions.reverse().map((v) => `(${quote(v)})`);
+      return `INSERT INTO ${smTable} (version) VALUES\n${rows.join(",\n")};`;
+    }
+    return `INSERT INTO ${smTable} (version) VALUES (${quote(versions)});`;
   }
 
   internalStringOptionsForPrimaryKey(): Record<string, unknown> {
@@ -1097,41 +1100,39 @@ export class SchemaStatements {
     if (!/^\d+$/.test(ver)) {
       throw new Error(`Invalid migration version: ${version}`);
     }
+    const verNum = parseInt(ver, 10);
 
-    const smMigration = (this.adapter as any).pool?.schemaMigration;
-    const smTableName = smMigration?.tableName ?? "schema_migrations";
+    const pool = (this.adapter as any).pool;
+    const smTableName = pool?.schemaMigration?.tableName ?? "schema_migrations";
     const smTable = this._qt(smTableName);
 
-    // Query existing versions to avoid duplicates (cross-adapter compatible)
-    const existing = new Set<string>();
-    const rows = await this.adapter.execute(`SELECT version FROM ${smTable}`);
-    for (const row of rows) {
-      existing.add(String((row as Record<string, unknown>).version));
+    const migrationContext = pool?.migrationContext;
+    const migrated: number[] = migrationContext
+      ? typeof migrationContext.getAllVersions === "function"
+        ? await migrationContext.getAllVersions()
+        : []
+      : [];
+    const allVersions: number[] = migrationContext
+      ? (migrationContext.migrations ?? []).map((m: { version: number }) => m.version)
+      : [];
+
+    // Insert the target version if not already migrated
+    if (!migrated.includes(verNum)) {
+      await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES (${quote(ver)})`);
     }
 
-    // Insert the target version if not already recorded
-    const escapedVer = ver.replace(/'/g, "''");
-    if (!existing.has(ver)) {
-      await this.adapter.executeMutation(
-        `INSERT INTO ${smTable} (version) VALUES ('${escapedVer}')`,
-      );
-      existing.add(ver);
-    }
-
-    // If pool has migration context, also insert all migration versions below this one
-    const migrationContext = (this.adapter as any).pool?.migrationContext;
-    if (migrationContext) {
-      const allVersions: string[] = (migrationContext.migrations ?? [])
-        .map((m: { version: number | string }) => String(m.version))
-        .filter((v: string) => /^\d+$/.test(v));
-      const toInsert = [...new Set(allVersions)].filter(
-        (v) => BigInt(v) < BigInt(ver) && !existing.has(v),
-      );
-      for (const v of toInsert) {
-        const vStr = v.replace(/'/g, "''");
-        await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${vStr}')`);
-        existing.add(v);
+    // Insert all known migration versions below the target that haven't been run
+    const inserting = allVersions.filter((v) => v < verNum && !migrated.includes(v));
+    if (inserting.length > 0) {
+      const duplicate = inserting.find((v) => inserting.filter((x) => x === v).length > 1);
+      if (duplicate !== undefined) {
+        throw new Error(
+          `Duplicate migration ${duplicate}. Please renumber your migrations to resolve the conflict.`,
+        );
       }
+      await this.adapter.executeMutation(
+        this._insertVersionsSql(smTableName, inserting.map(String)),
+      );
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -807,4 +807,320 @@ export class SchemaStatements {
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     return this.schemaCreation.typeToSql(type, options);
   }
+
+  // ---------------------------------------------------------------------------
+  // Methods below match the Rails SchemaStatements API surface.
+  // ---------------------------------------------------------------------------
+
+  nativeDatabaseTypes(): Record<string, unknown> {
+    return {};
+  }
+
+  tableOptions(_tableName: string): Record<string, unknown> | null {
+    return null;
+  }
+
+  tableComment(_tableName: string): string | null {
+    return null;
+  }
+
+  tableAliasFor(tableName: string): string {
+    const maxLen = this.tableAliasLength();
+    return tableName.slice(0, maxLen).replace(/\./g, "_");
+  }
+
+  protected tableAliasLength(): number {
+    return 255;
+  }
+
+  async dataSources(): Promise<string[]> {
+    const t = await this.tables();
+    const v = await this.views();
+    return [...new Set([...t, ...v])];
+  }
+
+  async isDataSourceExists(name: string): Promise<boolean> {
+    if (!name) return false;
+    const sources = await this.dataSources();
+    return sources.includes(name);
+  }
+
+  buildCreateTableDefinition(
+    tableName: string,
+    options: {
+      id?: boolean | "uuid" | false;
+      primaryKey?: string | string[];
+      force?: boolean;
+      [key: string]: unknown;
+    } = {},
+    fn?: (td: TableDefinition) => void,
+  ): TableDefinition {
+    const td = new TableDefinition(tableName, {
+      id: options.id,
+      adapterName: this.adapterName,
+    });
+    if (fn) fn(td);
+    return td;
+  }
+
+  buildCreateJoinTableDefinition(
+    table1: string,
+    table2: string,
+    options: { columnOptions?: Record<string, unknown>; [key: string]: unknown } = {},
+    fn?: (td: TableDefinition) => void,
+  ): TableDefinition {
+    const joinTableName = [table1, table2].sort().join("_");
+    const { columnOptions = {}, ...rest } = options;
+
+    return this.buildCreateTableDefinition(joinTableName, { ...rest, id: false }, (td) => {
+      td.references(table1.replace(/s$/, ""), { null: false, index: false, ...columnOptions });
+      td.references(table2.replace(/s$/, ""), { null: false, index: false, ...columnOptions });
+      if (fn) fn(td);
+    });
+  }
+
+  async buildAddColumnDefinition(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options: ColumnOptions & { ifNotExists?: boolean } = {},
+  ): Promise<AddColumnDefinition | null> {
+    if (options.ifNotExists && (await this.columnExists(tableName, columnName))) {
+      return null;
+    }
+    const { ifNotExists: _, ...colOpts } = options;
+    return new AddColumnDefinition(new ColumnDefinition(columnName, type, colOpts));
+  }
+
+  buildChangeColumnDefaultDefinition(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): { tableName: string; columnName: string; newDefault: unknown } {
+    let newDefault: unknown;
+    if (
+      defaultOrChanges != null &&
+      typeof defaultOrChanges === "object" &&
+      "to" in (defaultOrChanges as Record<string, unknown>)
+    ) {
+      newDefault = (defaultOrChanges as { to: unknown }).to;
+    } else {
+      newDefault = defaultOrChanges;
+    }
+    return { tableName, columnName, newDefault };
+  }
+
+  buildCreateIndexDefinition(
+    tableName: string,
+    columnName: string | string[],
+    options: {
+      name?: string;
+      unique?: boolean;
+      where?: string;
+      using?: string;
+      type?: string;
+      algorithm?: string;
+      ifNotExists?: boolean;
+      [key: string]: unknown;
+    } = {},
+  ): CreateIndexDefinition {
+    const columnNames = Array.isArray(columnName) ? columnName : [columnName];
+    const indexName = options.name ?? this.indexName(tableName, { column: columnNames });
+    const idx = new IndexDefinition(
+      tableName,
+      indexName,
+      !!options.unique,
+      columnNames,
+      options.where,
+    );
+    return new CreateIndexDefinition(idx, !!options.ifNotExists, options.algorithm);
+  }
+
+  async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {
+    const idxs = await this.indexes(tableName);
+    return idxs.some((idx) => idx.name === indexName);
+  }
+
+  foreignKeyColumnFor(tableName: string, columnName = "id"): string {
+    const name = tableName.replace(/^.*\./, "");
+    const singular = name.replace(/s$/, "");
+    return `${singular}_${columnName}`;
+  }
+
+  foreignKeyOptions(
+    _fromTable: string,
+    toTable: string,
+    options: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    const result = { ...options };
+    if (!result.column) {
+      result.column = this.foreignKeyColumnFor(toTable, "id");
+    }
+    return result;
+  }
+
+  async checkConstraints(_tableName: string): Promise<CheckConstraintDefinition[]> {
+    throw new Error("checkConstraints is not implemented for this adapter");
+  }
+
+  checkConstraintOptions(
+    _tableName: string,
+    _expression: string,
+    options: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return { ...options };
+  }
+
+  async isCheckConstraintExists(
+    tableName: string,
+    options: { name?: string; expression?: string },
+  ): Promise<boolean> {
+    if (!options.name && !options.expression) {
+      throw new Error("At least one of :name or :expression must be supplied");
+    }
+    try {
+      const constraints = await this.checkConstraints(tableName);
+      return constraints.some((c) => {
+        if (options.name && c.name === options.name) return true;
+        if (options.expression && c.expression === options.expression) return true;
+        return false;
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  async removeConstraint(tableName: string, constraintName: string): Promise<void> {
+    const sql = `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(constraintName)}`;
+    await this.adapter.execute(sql);
+  }
+
+  dumpSchemaInformation(): string | null {
+    return null;
+  }
+
+  internalStringOptionsForPrimaryKey(): Record<string, unknown> {
+    return { primaryKey: true };
+  }
+
+  async assumeMigratedUptoVersion(version: number | string): Promise<void> {
+    const ver = typeof version === "string" ? parseInt(version, 10) : version;
+    const smTable = this._qi("schema_migrations");
+    await this.adapter.execute(
+      `INSERT INTO ${smTable} (version) VALUES ('${ver}') ON CONFLICT DO NOTHING`,
+    );
+  }
+
+  columnsForDistinct(columns: string, _orders?: string[]): string {
+    return columns;
+  }
+
+  distinctRelationForPrimaryKey(relation: unknown): unknown {
+    return relation;
+  }
+
+  updateTableDefinition(tableName: string, base: unknown): Table {
+    return new Table(tableName, base as SchemaStatements);
+  }
+
+  addIndexOptions(
+    tableName: string,
+    columnName: string | string[],
+    options: {
+      name?: string;
+      ifNotExists?: boolean;
+      internal?: boolean;
+      unique?: boolean;
+      where?: string;
+      using?: string;
+      type?: string;
+      algorithm?: string;
+      [key: string]: unknown;
+    } = {},
+  ): [IndexDefinition, string | undefined, boolean] {
+    const columnNames = Array.isArray(columnName) ? columnName : [columnName];
+    const indexName = options.name ?? this.indexName(tableName, { column: columnNames });
+    const idx = new IndexDefinition(
+      tableName,
+      indexName,
+      !!options.unique,
+      columnNames,
+      options.where,
+    );
+    return [idx, this.indexAlgorithm(options.algorithm), !!options.ifNotExists];
+  }
+
+  indexAlgorithm(algorithm?: string): string | undefined {
+    if (!algorithm) return undefined;
+    return algorithm;
+  }
+
+  quotedColumnsForIndex(columnNames: string[], _options: Record<string, unknown> = {}): string {
+    return columnNames.map((name) => this._qi(name)).join(", ");
+  }
+
+  isOptionsIncludeDefault(options: Record<string, unknown>): boolean {
+    return "default" in options && !(options.null === false && options.default == null);
+  }
+
+  async changeTableComment(
+    _tableName: string,
+    _commentOrChanges: string | null | { from?: string; to?: string },
+  ): Promise<void> {
+    throw new Error(`${this.adapterName} does not support changing table comments`);
+  }
+
+  async changeColumnComment(
+    _tableName: string,
+    _columnName: string,
+    _commentOrChanges: string | null | { from?: string; to?: string },
+  ): Promise<void> {
+    throw new Error(`${this.adapterName} does not support changing column comments`);
+  }
+
+  createSchemaDumper(_options: Record<string, unknown> = {}): unknown {
+    return null;
+  }
+
+  isUseForeignKeys(): boolean {
+    return true;
+  }
+
+  async bulkChangeTable(
+    tableName: string,
+    operations: Array<[string, ...unknown[]]>,
+  ): Promise<void> {
+    for (const [command, ...args] of operations) {
+      const method = (this as any)[command];
+      if (typeof method === "function") {
+        await method.call(this, ...args);
+      }
+    }
+  }
+
+  validTableDefinitionOptions(): string[] {
+    return ["temporary", "ifNotExists", "options", "as", "comment", "charset", "collation"];
+  }
+
+  validColumnDefinitionOptions(): string[] {
+    return [
+      "limit",
+      "precision",
+      "scale",
+      "default",
+      "null",
+      "collation",
+      "comment",
+      "primaryKey",
+      "ifNotExists",
+    ];
+  }
+
+  validPrimaryKeyOptions(): string[] {
+    return ["limit", "default", "precision"];
+  }
+
+  maxIndexNameSize(): number {
+    return 62;
+  }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -998,13 +998,15 @@ export class SchemaStatements {
       }
     } else {
       if (!result.column) {
-        result.column = this.foreignKeyColumnFor(toTable, "id");
+        const pk = typeof result.primaryKey === "string" ? result.primaryKey : "id";
+        result.column = this.foreignKeyColumnFor(toTable, pk);
       }
     }
 
     if (!result.name) {
+      const unqualifiedFrom = (fromTable.split(".").at(-1) ?? fromTable).replace(/\./g, "_");
       const cols = Array.isArray(result.column) ? result.column : [result.column];
-      result.name = `fk_rails_${fromTable}_${(cols as string[]).join("_")}`;
+      result.name = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
     }
 
     return result;
@@ -1054,7 +1056,10 @@ export class SchemaStatements {
     if (versions.length === 0) return null;
     const tableName = this._qi(smTable.tableName ?? "schema_migrations");
     return versions
-      .map((v: string) => `INSERT INTO ${tableName} (version) VALUES ('${v}');`)
+      .map((v: string) => {
+        const escaped = String(v).replace(/'/g, "''");
+        return `INSERT INTO ${tableName} (version) VALUES ('${escaped}');`;
+      })
       .join("\n");
   }
 
@@ -1064,6 +1069,9 @@ export class SchemaStatements {
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
     const ver = typeof version === "number" ? version : parseInt(version, 10);
+    if (Number.isNaN(ver)) {
+      throw new Error(`Invalid migration version: ${version}`);
+    }
     const smTable = this._qi("schema_migrations");
 
     // Query existing versions to avoid duplicates (cross-adapter compatible)
@@ -1074,8 +1082,9 @@ export class SchemaStatements {
     }
 
     // Insert the target version if not already recorded
+    const verStr = String(ver).replace(/'/g, "''");
     if (!existing.has(String(ver))) {
-      await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${ver}')`);
+      await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${verStr}')`);
     }
 
     // If pool has migration context, also insert all migration versions below this one
@@ -1086,7 +1095,8 @@ export class SchemaStatements {
       );
       const toInsert = allVersions.filter((v) => v < ver && !existing.has(String(v)));
       for (const v of toInsert) {
-        await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${v}')`);
+        const vStr = String(v).replace(/'/g, "''");
+        await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${vStr}')`);
       }
     }
   }
@@ -1231,7 +1241,9 @@ export class SchemaStatements {
     }
 
     if (sqlFragments.length > 0) {
-      await this.adapter.execute(`ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`);
+      await this.adapter.executeMutation(
+        `ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`,
+      );
     }
     for (const proc of nonCombinable) await proc();
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1151,8 +1151,8 @@ export class SchemaStatements {
     return limited;
   }
 
-  updateTableDefinition(tableName: string, base: unknown): Table {
-    return new Table(tableName, base as SchemaStatements);
+  updateTableDefinition(tableName: string, base?: unknown): Table {
+    return new Table(tableName, (base ?? this) as SchemaStatements);
   }
 
   addIndexOptions(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -28,6 +28,8 @@ import { quoteIdentifier, quoteDefaultExpression } from "./quoting.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
+import { singularize } from "@blazetrails/activesupport";
+import { SchemaDumper } from "./schema-dumper.js";
 
 export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
@@ -866,17 +868,51 @@ export class SchemaStatements {
   buildCreateJoinTableDefinition(
     table1: string,
     table2: string,
-    options: { columnOptions?: Record<string, unknown>; [key: string]: unknown } = {},
+    options: {
+      columnOptions?: Record<string, unknown>;
+      tableName?: string;
+      [key: string]: unknown;
+    } = {},
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
-    const joinTableName = [table1, table2].sort().join("_");
-    const { columnOptions = {}, ...rest } = options;
+    const joinTableName = options.tableName ?? this._findJoinTableName(table1, table2);
+    const { columnOptions = {}, tableName: _, ...rest } = options;
+    const mergedColOpts = { null: false, index: false, ...columnOptions };
+
+    const t1Ref = this._referenceNameForTable(table1);
+    const t2Ref = this._referenceNameForTable(table2);
 
     return this.buildCreateTableDefinition(joinTableName, { ...rest, id: false }, (td) => {
-      td.references(table1.replace(/s$/, ""), { null: false, index: false, ...columnOptions });
-      td.references(table2.replace(/s$/, ""), { null: false, index: false, ...columnOptions });
+      td.references(t1Ref, mergedColOpts);
+      td.references(t2Ref, mergedColOpts);
       if (fn) fn(td);
     });
+  }
+
+  private _findJoinTableName(table1: string, table2: string): string {
+    const [t1, t2] = [table1, table2].sort();
+    const parts1 = t1.split("_");
+    const parts2 = t2.split("_");
+    // Remove common prefix (Rails dedup: music_artists + music_records → music_artists_records)
+    let commonLen = 0;
+    while (
+      commonLen < parts1.length - 1 &&
+      commonLen < parts2.length - 1 &&
+      parts1[commonLen] === parts2[commonLen]
+    ) {
+      commonLen++;
+    }
+    if (commonLen > 0) {
+      const prefix = parts1.slice(0, commonLen).join("_");
+      const suffix1 = parts1.slice(commonLen).join("_");
+      const suffix2 = parts2.slice(commonLen).join("_");
+      return `${prefix}_${suffix1}_${suffix2}`;
+    }
+    return `${t1}_${t2}`;
+  }
+
+  private _referenceNameForTable(tableName: string): string {
+    return singularize(tableName.replace(/^.*_/, ""));
   }
 
   async buildAddColumnDefinition(
@@ -943,19 +979,33 @@ export class SchemaStatements {
 
   foreignKeyColumnFor(tableName: string, columnName = "id"): string {
     const name = tableName.replace(/^.*\./, "");
-    const singular = name.replace(/s$/, "");
-    return `${singular}_${columnName}`;
+    return `${singularize(name)}_${columnName}`;
   }
 
   foreignKeyOptions(
-    _fromTable: string,
+    fromTable: string,
     toTable: string,
     options: Record<string, unknown> = {},
   ): Record<string, unknown> {
     const result = { ...options };
-    if (!result.column) {
-      result.column = this.foreignKeyColumnFor(toTable, "id");
+
+    if (Array.isArray(result.primaryKey)) {
+      if (!result.column) {
+        result.column = (result.primaryKey as string[]).map((pk) =>
+          this.foreignKeyColumnFor(toTable, pk),
+        );
+      }
+    } else {
+      if (!result.column) {
+        result.column = this.foreignKeyColumnFor(toTable, "id");
+      }
     }
+
+    if (!result.name) {
+      const cols = Array.isArray(result.column) ? result.column : [result.column];
+      result.name = `fk_rails_${fromTable}_${(cols as string[]).join("_")}`;
+    }
+
     return result;
   }
 
@@ -995,8 +1045,16 @@ export class SchemaStatements {
     await this.adapter.execute(sql);
   }
 
-  dumpSchemaInformation(): string | null {
-    return null;
+  async dumpSchemaInformation(): Promise<string | null> {
+    const smTable = (this as any).pool?.schemaMigration;
+    if (!smTable) return null;
+    const versions: string[] =
+      typeof smTable.versions === "function" ? await smTable.versions() : (smTable.versions ?? []);
+    if (versions.length === 0) return null;
+    const tableName = this._qi(smTable.tableName ?? "schema_migrations");
+    return versions
+      .map((v: string) => `INSERT INTO ${tableName} (version) VALUES ('${v}');`)
+      .join("\n");
   }
 
   internalStringOptionsForPrimaryKey(): Record<string, unknown> {
@@ -1004,19 +1062,62 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    const ver = typeof version === "string" ? parseInt(version, 10) : version;
+    const ver = typeof version === "number" ? version : parseInt(version, 10);
     const smTable = this._qi("schema_migrations");
+
+    // Insert the target version if not already recorded
     await this.adapter.execute(
       `INSERT INTO ${smTable} (version) VALUES ('${ver}') ON CONFLICT DO NOTHING`,
     );
+
+    // If pool has migration context, also insert all migration versions below this one
+    const migrationContext = (this as any).pool?.migrationContext;
+    if (migrationContext) {
+      const migrated: number[] =
+        typeof migrationContext.getAllVersions === "function"
+          ? await migrationContext.getAllVersions()
+          : [];
+      const allVersions: number[] = (migrationContext.migrations ?? []).map(
+        (m: { version: number }) => m.version,
+      );
+      const toInsert = allVersions.filter((v) => v < ver && !migrated.includes(v));
+      for (const v of toInsert) {
+        await this.adapter.execute(
+          `INSERT INTO ${smTable} (version) VALUES ('${v}') ON CONFLICT DO NOTHING`,
+        );
+      }
+    }
   }
 
   columnsForDistinct(columns: string, _orders?: string[]): string {
     return columns;
   }
 
-  distinctRelationForPrimaryKey(relation: unknown): unknown {
-    return relation;
+  async distinctRelationForPrimaryKey(relation: {
+    primaryKey?: string | string[];
+    table?: { [key: string]: unknown };
+    orderValues?: unknown[];
+    reselect?: (...cols: unknown[]) => unknown;
+    distinctBang?: () => unknown;
+    noneBang?: () => void;
+    where?: (conditions: Record<string, unknown>) => unknown;
+    limitValue?: number | null;
+    offsetValue?: number | null;
+  }): Promise<unknown> {
+    const pk = relation.primaryKey;
+    if (!pk) return relation;
+
+    const pkColumns = Array.isArray(pk) ? pk : [pk];
+    const values = this.columnsForDistinct(
+      pkColumns.join(", "),
+      (relation.orderValues as string[]) ?? [],
+    );
+
+    let limited: any = relation;
+    if (limited.reselect) limited = limited.reselect(values);
+    if (limited.distinctBang) limited.distinctBang();
+
+    return limited;
   }
 
   updateTableDefinition(tableName: string, base: unknown): Table {
@@ -1078,24 +1179,59 @@ export class SchemaStatements {
     throw new Error(`${this.adapterName} does not support changing column comments`);
   }
 
-  createSchemaDumper(_options: Record<string, unknown> = {}): unknown {
-    return null;
+  createSchemaDumper(options: Record<string, unknown> = {}): SchemaDumper {
+    return SchemaDumper.create(this as any, options);
   }
 
   isUseForeignKeys(): boolean {
-    return true;
+    const adapter = this.adapter as any;
+    const supportsForeignKeys =
+      typeof adapter.supportsForeignKeys === "function" ? adapter.supportsForeignKeys() : true;
+    const foreignKeysEnabled =
+      typeof adapter.foreignKeysEnabled === "function" ? adapter.foreignKeysEnabled() : true;
+    return supportsForeignKeys && foreignKeysEnabled;
   }
 
   async bulkChangeTable(
     tableName: string,
     operations: Array<[string, ...unknown[]]>,
   ): Promise<void> {
+    const sqlFragments: string[] = [];
+    const nonCombinable: Array<() => Promise<void>> = [];
+
     for (const [command, ...args] of operations) {
-      const method = (this as any)[command];
-      if (typeof method === "function") {
-        await method.call(this, ...args);
+      const forAlterMethod = (this as any)[`${command}ForAlter`];
+      if (typeof forAlterMethod === "function") {
+        const result = forAlterMethod.call(this, ...args);
+        const results = Array.isArray(result) ? result : [result];
+        for (const r of results) {
+          if (typeof r === "string") {
+            sqlFragments.push(r);
+          } else if (typeof r === "function") {
+            nonCombinable.push(r);
+          }
+        }
+      } else {
+        if (sqlFragments.length > 0) {
+          await this.adapter.execute(
+            `ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`,
+          );
+          sqlFragments.length = 0;
+        }
+        for (const proc of nonCombinable) await proc();
+        nonCombinable.length = 0;
+
+        const method = (this as any)[command];
+        if (typeof method === "function") {
+          await method.call(this, ...args);
+        }
       }
     }
+
+    if (sqlFragments.length > 0) {
+      await this.adapter.execute(`ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`);
+    }
+    for (const proc of nonCombinable) await proc();
   }
 
   validTableDefinitionOptions(): string[] {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -50,6 +50,13 @@ export class SchemaStatements {
     return quoteIdentifier(name, this.adapterName);
   }
 
+  protected _qt(tableName: string): string {
+    return tableName
+      .split(".")
+      .map((part) => this._qi(part))
+      .join(".");
+  }
+
   async createTable(
     name: string,
     optionsOrFn?:
@@ -857,10 +864,16 @@ export class SchemaStatements {
     } = {},
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
+    const hasCustomPk = options.primaryKey && options.id !== false;
     const td = new TableDefinition(tableName, {
-      id: options.id,
+      id: hasCustomPk ? false : options.id,
       adapterName: this.adapterName,
     });
+    if (hasCustomPk) {
+      const pkName = typeof options.primaryKey === "string" ? options.primaryKey : "id";
+      const pkType = (typeof options.id === "string" ? options.id : "primary_key") as ColumnType;
+      td.columns.unshift(new ColumnDefinition(pkName, pkType, { primaryKey: true }));
+    }
     if (fn) fn(td);
     return td;
   }
@@ -1006,7 +1019,15 @@ export class SchemaStatements {
     if (!result.name) {
       const unqualifiedFrom = (fromTable.split(".").at(-1) ?? fromTable).replace(/\./g, "_");
       const cols = Array.isArray(result.column) ? result.column : [result.column];
-      result.name = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
+      const fullName = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
+      if (fullName.length > 62) {
+        // Truncate and append a simple hash to stay within identifier limits
+        const hash = Array.from(fullName).reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
+        const hex = Math.abs(hash).toString(16).slice(0, 10);
+        result.name = `fk_rails_${hex}`;
+      } else {
+        result.name = fullName;
+      }
     }
 
     return result;
@@ -1044,7 +1065,7 @@ export class SchemaStatements {
   }
 
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
-    const sql = `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(constraintName)}`;
+    const sql = `ALTER TABLE ${this._qt(tableName)} DROP CONSTRAINT ${this._qi(constraintName)}`;
     await this.adapter.executeMutation(sql);
   }
 
@@ -1054,7 +1075,7 @@ export class SchemaStatements {
     const versions: string[] =
       typeof smTable.versions === "function" ? await smTable.versions() : (smTable.versions ?? []);
     if (versions.length === 0) return null;
-    const tableName = this._qi(smTable.tableName ?? "schema_migrations");
+    const tableName = this._qt(smTable.tableName ?? "schema_migrations");
     return versions
       .map((v: string) => {
         const escaped = String(v).replace(/'/g, "''");
@@ -1068,11 +1089,15 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    const ver = typeof version === "number" ? version : parseInt(version, 10);
-    if (Number.isNaN(ver)) {
+    const verStr = String(version);
+    if (typeof version === "string" && !/^\d+$/.test(verStr)) {
       throw new Error(`Invalid migration version: ${version}`);
     }
-    const smTable = this._qi("schema_migrations");
+    const ver = typeof version === "number" ? version : parseInt(version, 10);
+
+    const smMigration = (this as any).pool?.schemaMigration;
+    const smTableName = smMigration?.tableName ?? "schema_migrations";
+    const smTable = this._qt(smTableName);
 
     // Query existing versions to avoid duplicates (cross-adapter compatible)
     const existing = new Set<string>();
@@ -1082,9 +1107,11 @@ export class SchemaStatements {
     }
 
     // Insert the target version if not already recorded
-    const verStr = String(ver).replace(/'/g, "''");
+    const escapedVer = String(ver).replace(/'/g, "''");
     if (!existing.has(String(ver))) {
-      await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${verStr}')`);
+      await this.adapter.executeMutation(
+        `INSERT INTO ${smTable} (version) VALUES ('${escapedVer}')`,
+      );
     }
 
     // If pool has migration context, also insert all migration versions below this one
@@ -1105,17 +1132,12 @@ export class SchemaStatements {
     return columns;
   }
 
-  async distinctRelationForPrimaryKey(relation: {
+  distinctRelationForPrimaryKey(relation: {
     primaryKey?: string | string[];
-    table?: { [key: string]: unknown };
     orderValues?: unknown[];
     reselect?: (...cols: unknown[]) => unknown;
     distinctBang?: () => unknown;
-    noneBang?: () => void;
-    where?: (conditions: Record<string, unknown>) => unknown;
-    limitValue?: number | null;
-    offsetValue?: number | null;
-  }): Promise<unknown> {
+  }): unknown {
     const pk = relation.primaryKey;
     if (!pk) return relation;
 
@@ -1226,7 +1248,7 @@ export class SchemaStatements {
       } else {
         if (sqlFragments.length > 0) {
           await this.adapter.executeMutation(
-            `ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`,
+            `ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`,
           );
           sqlFragments.length = 0;
         }
@@ -1236,13 +1258,15 @@ export class SchemaStatements {
         const method = (this as any)[command];
         if (typeof method === "function") {
           await method.call(this, ...args);
+        } else {
+          throw new Error(`Unknown bulk change command: ${command}`);
         }
       }
     }
 
     if (sqlFragments.length > 0) {
       await this.adapter.executeMutation(
-        `ALTER TABLE ${this._qi(tableName)} ${sqlFragments.join(", ")}`,
+        `ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`,
       );
     }
     for (const proc of nonCombinable) await proc();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -28,7 +28,7 @@ import { quoteIdentifier, quoteDefaultExpression } from "./quoting.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
-import { singularize } from "@blazetrails/activesupport";
+import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 
 export class SchemaStatements {
@@ -1025,17 +1025,7 @@ export class SchemaStatements {
       const cols = Array.isArray(result.column) ? result.column : [result.column];
       const fullName = `fk_rails_${unqualifiedFrom}_${(cols as string[]).join("_")}`;
       if (fullName.length > this.maxIndexNameSize()) {
-        // Deterministic hash matching Rails' fk_rails_<digest> pattern
-        let h1 = 0x811c9dc5;
-        let h2 = 0x01000193;
-        for (let i = 0; i < fullName.length; i++) {
-          const c = fullName.charCodeAt(i);
-          h1 = Math.imul(h1 ^ c, 0x01000193);
-          h2 = Math.imul(h2 ^ c, 0x1000193b);
-        }
-        const hex = ((h1 >>> 0).toString(16) + (h2 >>> 0).toString(16))
-          .padStart(16, "0")
-          .slice(0, 10);
+        const hex = getCrypto().createHash("sha256").update(fullName).digest("hex").slice(0, 10);
         result.name = `fk_rails_${hex}`;
       } else {
         result.name = fullName;
@@ -1249,10 +1239,10 @@ export class SchemaStatements {
     const sqlFragments: string[] = [];
     const nonCombinable: Array<() => Promise<void>> = [];
 
-    for (const [command, ...args] of operations) {
+    for (const [command, table, ...arguments_] of operations) {
       const forAlterMethod = (this as any)[`${command}ForAlter`];
       if (typeof forAlterMethod === "function") {
-        const result = forAlterMethod.call(this, ...args);
+        const result = forAlterMethod.call(this, table, ...arguments_);
         const results = Array.isArray(result) ? result : [result];
         for (const r of results) {
           if (typeof r === "string") {
@@ -1273,7 +1263,7 @@ export class SchemaStatements {
 
         const method = (this as any)[command];
         if (typeof method === "function") {
-          await method.call(this, ...args);
+          await method.call(this, table, ...arguments_);
         } else {
           throw new Error(`Unknown bulk change command: ${command}`);
         }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1061,8 +1061,9 @@ export class SchemaStatements {
         if (options.expression && c.expression === options.expression) return true;
         return false;
       });
-    } catch {
-      return false;
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("NotImplementedError")) return false;
+      throw e;
     }
   }
 
@@ -1114,6 +1115,7 @@ export class SchemaStatements {
       await this.adapter.executeMutation(
         `INSERT INTO ${smTable} (version) VALUES ('${escapedVer}')`,
       );
+      existing.add(ver);
     }
 
     // If pool has migration context, also insert all migration versions below this one
@@ -1122,10 +1124,13 @@ export class SchemaStatements {
       const allVersions: string[] = (migrationContext.migrations ?? [])
         .map((m: { version: number | string }) => String(m.version))
         .filter((v: string) => /^\d+$/.test(v));
-      const toInsert = allVersions.filter((v) => BigInt(v) < BigInt(ver) && !existing.has(v));
+      const toInsert = [...new Set(allVersions)].filter(
+        (v) => BigInt(v) < BigInt(ver) && !existing.has(v),
+      );
       for (const v of toInsert) {
         const vStr = v.replace(/'/g, "''");
         await this.adapter.executeMutation(`INSERT INTO ${smTable} (version) VALUES ('${vStr}')`);
+        existing.add(v);
       }
     }
   }
@@ -1190,13 +1195,15 @@ export class SchemaStatements {
 
   indexAlgorithm(algorithm?: string): string | undefined {
     if (!algorithm) return undefined;
+    const normalized = algorithm.toLowerCase();
     const valid = ["default", "concurrently"];
-    if (!valid.includes(algorithm.toLowerCase())) {
+    if (!valid.includes(normalized)) {
       throw new Error(
         `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
       );
     }
-    return algorithm;
+    if (normalized === "default") return undefined;
+    return normalized;
   }
 
   quotedColumnsForIndex(columnNames: string[], _options: Record<string, unknown> = {}): string {


### PR DESCRIPTION
## Summary

- Adds all 37 missing methods to `SchemaStatements` class matching the Rails `ConnectionAdapters::SchemaStatements` API
- Takes `connection_adapters/abstract/schema_statements.rb` from **51% → 100%** in api:compare (76/76 methods)
- No stubs — all methods have real implementations matching Rails behavior

## What changed

**Simple getters/defaults**: `nativeDatabaseTypes` (returns {}), `tableOptions` (returns null), `tableComment` (returns null), `internalStringOptionsForPrimaryKey`, `columnsForDistinct`, `maxIndexNameSize` (62), `validTableDefinitionOptions`, `validColumnDefinitionOptions`, `validPrimaryKeyOptions`, `isOptionsIncludeDefault`

**String/name helpers**: `tableAliasFor` (truncate + tr), `foreignKeyColumnFor` (uses activesupport `singularize()`), `indexAlgorithm`, `quotedColumnsForIndex`

**Data source queries**: `dataSources` (tables + views union), `isDataSourceExists`

**Builder methods**: `buildCreateTableDefinition` (delegates to TableDefinition), `buildCreateJoinTableDefinition` (prefix deduplication + singularize for references), `buildAddColumnDefinition` (wraps ColumnDefinition, handles ifNotExists), `buildChangeColumnDefaultDefinition` (extracts from/to changes), `buildCreateIndexDefinition`

**Index/constraint queries**: `isIndexNameExists` (delegates to indexes), `isCheckConstraintExists` (validates args, queries constraints), `checkConstraints` (throws NotImplementedError like Rails), `checkConstraintOptions`

**Foreign key helpers**: `foreignKeyOptions` (handles composite PKs, generates default name), `isUseForeignKeys` (checks adapter capabilities)

**Schema operations**: `removeConstraint` (ALTER TABLE DROP CONSTRAINT), `dumpSchemaInformation` (queries schema_migration versions, returns INSERT SQL), `assumeMigratedUptoVersion` (inserts target + all versions below via migration context), `changeTableComment`/`changeColumnComment` (throw NotImplementedError like Rails), `bulkChangeTable` (SQL fragment batching with *ForAlter methods), `updateTableDefinition` (creates Table), `addIndexOptions`

**Relation/misc**: `distinctRelationForPrimaryKey` (reselect + distinct via Relation API), `createSchemaDumper` (uses SchemaDumper.create())

## Test plan

- [x] All 7960 active activerecord tests pass
- [x] api:compare shows 100% for `connection_adapters/abstract/schema_statements.rb`
- [x] Build and typecheck pass