### PR TITLE
feat(activerecord): pool pin/unpin with TransactionManager

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -375,6 +375,10 @@ export class AbstractAdapter {
     return this._transactionManager.currentTransaction;
   }
 
+  isTransactionOpen(): boolean {
+    return this._transactionManager.currentTransaction.open;
+  }
+
   async withinNewTransaction<T>(
     opts: { isolation?: string | null; joinable?: boolean },
     fn: (tx?: unknown) => Promise<T> | T,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -375,8 +375,36 @@ export class AbstractAdapter {
     return this._transactionManager.currentTransaction;
   }
 
+  async rollbackTransaction(): Promise<void> {
+    return this._transactionManager.rollbackTransaction();
+  }
+
+  async commitTransaction(): Promise<void> {
+    return this._transactionManager.commitTransaction();
+  }
+
   isTransactionOpen(): boolean {
     return this._transactionManager.currentTransaction.open;
+  }
+
+  get openTransactions(): number {
+    return this._transactionManager.openTransactions;
+  }
+
+  async materializeTransactions(): Promise<void> {
+    return this._transactionManager.materializeTransactions();
+  }
+
+  async disableLazyTransactionsBang(): Promise<void> {
+    return this._transactionManager.disableLazyTransactionsBang();
+  }
+
+  enableLazyTransactionsBang(): void {
+    this._transactionManager.enableLazyTransactionsBang();
+  }
+
+  dirtyCurrentTransaction(): void {
+    this._transactionManager.dirtyCurrentTransaction();
   }
 
   async withinNewTransaction<T>(

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -191,6 +191,8 @@ export class ConnectionPool implements ReapablePool {
   private _leases: LeaseRegistry | null = new LeaseRegistry();
   private _idleTimeout: number | null;
   private _lastCheckinAt = new Map<DatabaseAdapter, number>();
+  private _pinnedConnection: DatabaseAdapter | null = null;
+  private _pinnedConnectionsDepth = 0;
 
   constructor(poolConfig: PoolConfig) {
     this.poolConfig = poolConfig;
@@ -295,9 +297,67 @@ export class ConnectionPool implements ReapablePool {
     return false;
   }
 
+  // --- Pin / Unpin ---
+
+  async pinConnectionBang(_lockThread = false): Promise<void> {
+    if (!this._pinnedConnection) {
+      this._pinnedConnection = this._connectionLease().connection ?? this.checkout();
+    }
+    this._pinnedConnectionsDepth += 1;
+
+    if (this._connections && !this._connections.includes(this._pinnedConnection)) {
+      this._connections.push(this._pinnedConnection);
+    }
+
+    const conn = this._pinnedConnection as any;
+    if (conn.verifyBang) conn.verifyBang();
+    if (conn.transactionManager) {
+      await conn.transactionManager.beginTransaction({ joinable: false, _lazy: false });
+    }
+  }
+
+  async unpinConnectionBang(): Promise<boolean> {
+    if (!this._pinnedConnection) {
+      throw new Error(`There isn't a pinned connection`);
+    }
+
+    let clean = true;
+    this._pinnedConnectionsDepth -= 1;
+    const connection = this._pinnedConnection;
+    if (this._pinnedConnectionsDepth === 0) {
+      this._pinnedConnection = null;
+    }
+
+    const conn = connection as any;
+    if (conn.transactionManager) {
+      if (conn.transactionManager.currentTransaction.open) {
+        await conn.transactionManager.rollbackTransaction();
+      } else {
+        clean = false;
+        if (conn.resetBang) conn.resetBang();
+      }
+    }
+
+    if (this._pinnedConnection === null) {
+      if (conn.stealBang) conn.stealBang();
+      this.checkin(connection);
+    }
+
+    return clean;
+  }
+
   // --- Checkout / Checkin ---
 
   checkout(): DatabaseAdapter {
+    if (this._pinnedConnection) {
+      const conn = this._pinnedConnection as any;
+      if (conn.verifyBang) conn.verifyBang();
+      if (this._connections && !this._connections.includes(this._pinnedConnection)) {
+        this._connections.push(this._pinnedConnection);
+      }
+      return this._pinnedConnection;
+    }
+
     if (this.isDiscarded()) {
       throw new ConnectionNotEstablished("Connection pool has been discarded");
     }
@@ -325,6 +385,7 @@ export class ConnectionPool implements ReapablePool {
   }
 
   checkin(conn: DatabaseAdapter): void {
+    if (this._pinnedConnection === conn) return;
     this._connectionLease().clear(conn);
     if (this._checkedOut.has(conn)) {
       this._checkedOut.delete(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -12,6 +12,17 @@ import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.j
 import { SchemaReflection } from "../schema-cache.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+import type { TransactionManager } from "./transaction.js";
+
+/**
+ * A connection that supports transaction management.
+ * AbstractAdapter satisfies this interface; the pool uses it for pin/unpin.
+ */
+interface TransactionAwareConnection extends DatabaseAdapter {
+  transactionManager: TransactionManager;
+  verifyBang(): void;
+  resetBang(): void;
+}
 
 let _contextIdCounter = 0;
 let _contextStorage: AsyncContext<number> | null = null;
@@ -309,10 +320,12 @@ export class ConnectionPool implements ReapablePool {
       this._connections.push(this._pinnedConnection);
     }
 
-    const conn = this._pinnedConnection as any;
-    if (conn.verifyBang) conn.verifyBang();
-    if (conn.transactionManager) {
-      await conn.transactionManager.beginTransaction({ joinable: false, _lazy: false });
+    if (isTransactionAware(this._pinnedConnection)) {
+      this._pinnedConnection.verifyBang();
+      await this._pinnedConnection.transactionManager.beginTransaction({
+        joinable: false,
+        _lazy: false,
+      });
     }
   }
 
@@ -328,18 +341,16 @@ export class ConnectionPool implements ReapablePool {
       this._pinnedConnection = null;
     }
 
-    const conn = connection as any;
-    if (conn.transactionManager) {
-      if (conn.transactionManager.currentTransaction.open) {
-        await conn.transactionManager.rollbackTransaction();
+    if (isTransactionAware(connection)) {
+      if (connection.transactionManager.currentTransaction.open) {
+        await connection.transactionManager.rollbackTransaction();
       } else {
         clean = false;
-        if (conn.resetBang) conn.resetBang();
+        connection.resetBang();
       }
     }
 
     if (this._pinnedConnection === null) {
-      if (conn.stealBang) conn.stealBang();
       this.checkin(connection);
     }
 
@@ -350,8 +361,9 @@ export class ConnectionPool implements ReapablePool {
 
   checkout(): DatabaseAdapter {
     if (this._pinnedConnection) {
-      const conn = this._pinnedConnection as any;
-      if (conn.verifyBang) conn.verifyBang();
+      if (isTransactionAware(this._pinnedConnection)) {
+        this._pinnedConnection.verifyBang();
+      }
       if (this._connections && !this._connections.includes(this._pinnedConnection)) {
         this._connections.push(this._pinnedConnection);
       }
@@ -461,6 +473,8 @@ export class ConnectionPool implements ReapablePool {
   // --- Lifecycle ---
 
   disconnect(): void {
+    this._pinnedConnection = null;
+    this._pinnedConnectionsDepth = 0;
     if (this._connections) this._connections.length = 0;
     if (this._available) this._available.length = 0;
     this._checkedOut.clear();
@@ -474,6 +488,8 @@ export class ConnectionPool implements ReapablePool {
 
   discardBang(): void {
     if (this.isDiscarded()) return;
+    this._pinnedConnection = null;
+    this._pinnedConnectionsDepth = 0;
     this._connections = null;
     this._available = null;
     this._leases = null;
@@ -563,4 +579,8 @@ export class ConnectionPool implements ReapablePool {
     }
     return this._leases.get(String(executionContextId()));
   }
+}
+
+function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConnection {
+  return "transactionManager" in conn && "verifyBang" in conn && "resetBang" in conn;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -205,7 +205,6 @@ export class ConnectionPool implements ReapablePool {
   private _lastCheckinAt = new Map<DatabaseAdapter, number>();
   private _pinnedConnection: DatabaseAdapter | null = null;
   private _pinnedConnectionsDepth = 0;
-  private _pinnedConnectionCheckedOut = false;
 
   constructor(poolConfig: PoolConfig) {
     this.poolConfig = poolConfig;
@@ -338,7 +337,6 @@ export class ConnectionPool implements ReapablePool {
 
     if (!this._pinnedConnection) {
       this._pinnedConnection = connection;
-      this._pinnedConnectionCheckedOut = newlyCheckedOut;
     }
     this._pinnedConnectionsDepth += 1;
   }
@@ -363,12 +361,8 @@ export class ConnectionPool implements ReapablePool {
     } finally {
       this._pinnedConnectionsDepth -= 1;
       if (this._pinnedConnectionsDepth === 0) {
-        const wasCheckedOut = this._pinnedConnectionCheckedOut;
         this._pinnedConnection = null;
-        this._pinnedConnectionCheckedOut = false;
-        if (wasCheckedOut) {
-          this.checkin(connection);
-        }
+        this.checkin(connection);
       }
     }
 
@@ -493,7 +487,6 @@ export class ConnectionPool implements ReapablePool {
   disconnect(): void {
     this._pinnedConnection = null;
     this._pinnedConnectionsDepth = 0;
-    this._pinnedConnectionCheckedOut = false;
     if (this._connections) this._connections.length = 0;
     if (this._available) this._available.length = 0;
     this._checkedOut.clear();
@@ -509,7 +502,6 @@ export class ConnectionPool implements ReapablePool {
     if (this.isDiscarded()) return;
     this._pinnedConnection = null;
     this._pinnedConnectionsDepth = 0;
-    this._pinnedConnectionCheckedOut = false;
     this._connections = null;
     this._available = null;
     this._leases = null;
@@ -574,6 +566,10 @@ export class ConnectionPool implements ReapablePool {
   }
 
   remove(conn: DatabaseAdapter): void {
+    if (this._pinnedConnection === conn) {
+      this._pinnedConnection = null;
+      this._pinnedConnectionsDepth = 0;
+    }
     this._connectionLease().clear(conn);
     this._checkedOut.delete(conn);
     this._lastCheckinAt.delete(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -205,6 +205,7 @@ export class ConnectionPool implements ReapablePool {
   private _lastCheckinAt = new Map<DatabaseAdapter, number>();
   private _pinnedConnection: DatabaseAdapter | null = null;
   private _pinnedConnectionsDepth = 0;
+  private _pinnedConnectionCheckedOut = false;
 
   constructor(poolConfig: PoolConfig) {
     this.poolConfig = poolConfig;
@@ -337,6 +338,7 @@ export class ConnectionPool implements ReapablePool {
 
     if (!this._pinnedConnection) {
       this._pinnedConnection = connection;
+      this._pinnedConnectionCheckedOut = newlyCheckedOut;
     }
     this._pinnedConnectionsDepth += 1;
   }
@@ -361,8 +363,12 @@ export class ConnectionPool implements ReapablePool {
     } finally {
       this._pinnedConnectionsDepth -= 1;
       if (this._pinnedConnectionsDepth === 0) {
+        const wasCheckedOut = this._pinnedConnectionCheckedOut;
         this._pinnedConnection = null;
-        this.checkin(connection);
+        this._pinnedConnectionCheckedOut = false;
+        if (wasCheckedOut) {
+          this.checkin(connection);
+        }
       }
     }
 
@@ -487,6 +493,7 @@ export class ConnectionPool implements ReapablePool {
   disconnect(): void {
     this._pinnedConnection = null;
     this._pinnedConnectionsDepth = 0;
+    this._pinnedConnectionCheckedOut = false;
     if (this._connections) this._connections.length = 0;
     if (this._available) this._available.length = 0;
     this._checkedOut.clear();
@@ -502,6 +509,7 @@ export class ConnectionPool implements ReapablePool {
     if (this.isDiscarded()) return;
     this._pinnedConnection = null;
     this._pinnedConnectionsDepth = 0;
+    this._pinnedConnectionCheckedOut = false;
     this._connections = null;
     this._available = null;
     this._leases = null;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -312,22 +312,33 @@ export class ConnectionPool implements ReapablePool {
   // --- Pin / Unpin ---
 
   async pinConnectionBang(_lockThread = false): Promise<void> {
+    const leasedConnection = this._connectionLease().connection;
+    const connection = this._pinnedConnection ?? leasedConnection ?? this.checkout();
+    const newlyCheckedOut = this._pinnedConnection === null && leasedConnection == null;
+
+    try {
+      if (this._connections && !this._connections.includes(connection)) {
+        this._connections.push(connection);
+      }
+
+      if (isTransactionAware(connection)) {
+        connection.verifyBang();
+        await connection.transactionManager.beginTransaction({
+          joinable: false,
+          _lazy: false,
+        });
+      }
+    } catch (error) {
+      if (newlyCheckedOut) {
+        this.checkin(connection);
+      }
+      throw error;
+    }
+
     if (!this._pinnedConnection) {
-      this._pinnedConnection = this._connectionLease().connection ?? this.checkout();
+      this._pinnedConnection = connection;
     }
     this._pinnedConnectionsDepth += 1;
-
-    if (this._connections && !this._connections.includes(this._pinnedConnection)) {
-      this._connections.push(this._pinnedConnection);
-    }
-
-    if (isTransactionAware(this._pinnedConnection)) {
-      this._pinnedConnection.verifyBang();
-      await this._pinnedConnection.transactionManager.beginTransaction({
-        joinable: false,
-        _lazy: false,
-      });
-    }
   }
 
   async unpinConnectionBang(): Promise<boolean> {
@@ -335,24 +346,24 @@ export class ConnectionPool implements ReapablePool {
       throw new Error(`There isn't a pinned connection`);
     }
 
-    let clean = true;
-    this._pinnedConnectionsDepth -= 1;
     const connection = this._pinnedConnection;
-    if (this._pinnedConnectionsDepth === 0) {
-      this._pinnedConnection = null;
-    }
+    let clean = true;
 
-    if (isTransactionAware(connection)) {
-      if (connection.transactionManager.currentTransaction.open) {
-        await connection.transactionManager.rollbackTransaction();
-      } else {
-        clean = false;
-        connection.resetBang();
+    try {
+      if (isTransactionAware(connection)) {
+        if (connection.transactionManager.currentTransaction.open) {
+          await connection.transactionManager.rollbackTransaction();
+        } else {
+          clean = false;
+          connection.resetBang();
+        }
       }
-    }
-
-    if (this._pinnedConnection === null) {
-      this.checkin(connection);
+    } finally {
+      this._pinnedConnectionsDepth -= 1;
+      if (this._pinnedConnectionsDepth === 0) {
+        this._pinnedConnection = null;
+        this.checkin(connection);
+      }
     }
 
     return clean;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -16,7 +16,8 @@ import type { TransactionManager } from "./transaction.js";
 
 /**
  * A connection that supports transaction management.
- * AbstractAdapter satisfies this interface; the pool uses it for pin/unpin.
+ * Adapters extending AbstractAdapter and implementing DatabaseAdapter satisfy
+ * this interface; the pool uses it for pin/unpin.
  */
 interface TransactionAwareConnection extends DatabaseAdapter {
   transactionManager: TransactionManager;
@@ -582,5 +583,11 @@ export class ConnectionPool implements ReapablePool {
 }
 
 function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConnection {
-  return "transactionManager" in conn && "verifyBang" in conn && "resetBang" in conn;
+  const c = conn as Partial<TransactionAwareConnection>;
+  return (
+    typeof c.verifyBang === "function" &&
+    typeof c.resetBang === "function" &&
+    typeof c.transactionManager === "object" &&
+    c.transactionManager !== null
+  );
 }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -514,19 +514,26 @@ it("unpin connection returns whether transaction has been rolledback", async () 
 it("pin connection nesting", async () => {
   const pool = makeTransactionAwarePool(5);
   await pool.pinConnectionBang();
-  const conn1 = pool.checkout();
+  const conn1 = pool.checkout() as TransactionAwareTestAdapter;
+  expect(conn1.transactionManager.openTransactions).toBe(1);
+  expect(conn1.transactionManager.currentTransaction.joinable).toBe(false);
 
+  // Nested pin opens a second transaction (savepoint-level in Rails)
   await pool.pinConnectionBang();
   const conn2 = pool.checkout();
   expect(conn1).toBe(conn2);
+  expect(conn1.transactionManager.openTransactions).toBe(2);
 
-  // First unpin doesn't check in the connection
+  // First unpin rolls back the inner transaction but keeps connection pinned
   await pool.unpinConnectionBang();
+  expect(conn1.transactionManager.openTransactions).toBe(1);
+  expect(conn1.transactionManager.currentTransaction.open).toBe(true);
   const conn3 = pool.checkout();
   expect(conn3).toBe(conn1);
 
-  // Second unpin checks it in
+  // Second unpin rolls back the outer transaction and checks in
   await pool.unpinConnectionBang();
+  expect(conn1.transactionManager.openTransactions).toBe(0);
 });
 
 it.skip("pin connection nesting lock", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -5,6 +5,8 @@ import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
 
 function makePool(size: number = 5): ConnectionPool {
   const dbConfig = new HashConfig("test", "primary", {
@@ -15,6 +17,72 @@ function makePool(size: number = 5): ConnectionPool {
   });
   const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
     adapterFactory: createTestAdapter,
+  });
+  return new ConnectionPool(pc);
+}
+
+class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAdapter {
+  override get adapterName() {
+    return "TestTransactionAdapter";
+  }
+  readonly inTransaction = false;
+
+  async execute(_sql: string, _binds?: unknown[]): Promise<Record<string, unknown>[]> {
+    return [];
+  }
+  async executeMutation(_sql: string, _binds?: unknown[]): Promise<number> {
+    return 0;
+  }
+  async beginTransaction(): Promise<void> {}
+  async commit(): Promise<void> {}
+  async rollback(): Promise<void> {}
+  async createSavepoint(_name: string): Promise<void> {}
+  async releaseSavepoint(_name: string): Promise<void> {}
+  async rollbackToSavepoint(_name: string): Promise<void> {}
+  async selectAll(sql: string, _n?: string | null, b?: unknown[]) {
+    return this.execute(sql, b);
+  }
+  async selectOne(sql: string, _n?: string | null, b?: unknown[]) {
+    return (await this.execute(sql, b))[0];
+  }
+  async selectValue(_s: string) {
+    return undefined;
+  }
+  async selectValues(_s: string) {
+    return [];
+  }
+  async selectRows(_s: string) {
+    return [];
+  }
+  async execQuery(sql: string, _n?: string | null, b?: unknown[]) {
+    return this.execute(sql, b);
+  }
+  async execInsert(sql: string, _n?: string | null, b?: unknown[]) {
+    return this.executeMutation(sql, b);
+  }
+  async execDelete(sql: string, _n?: string | null, b?: unknown[]) {
+    return this.executeMutation(sql, b);
+  }
+  async execUpdate(sql: string, _n?: string | null, b?: unknown[]) {
+    return this.executeMutation(sql, b);
+  }
+  isWriteQuery(_sql: string) {
+    return false;
+  }
+  emptyInsertStatementValue() {
+    return "DEFAULT VALUES";
+  }
+}
+
+function makeTransactionAwarePool(size: number = 5): ConnectionPool {
+  const dbConfig = new HashConfig("test", "primary", {
+    adapter: "sqlite3",
+    database: "test.db",
+    pool: size,
+    reapingFrequency: null,
+  });
+  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+    adapterFactory: () => new TransactionAwareTestAdapter(),
   });
   return new ConnectionPool(pc);
 }
@@ -397,36 +465,76 @@ it("role and shard is returned", () => {
   expect(pool.shard).toBe("shard_one");
 });
 
-it.skip("pin connection always returns the same connection", () => {
-  /* needs pin connection */
+it("pin connection always returns the same connection", async () => {
+  const pool = makeTransactionAwarePool(5);
+  await pool.pinConnectionBang();
+  const conn1 = pool.checkout();
+  const conn2 = pool.checkout();
+  expect(conn1).toBe(conn2);
+  await pool.unpinConnectionBang();
 });
 
-it.skip("pin connection connected?", () => {
-  /* needs pin connection */
+it("pin connection connected?", async () => {
+  const pool = makeTransactionAwarePool(5);
+  await pool.pinConnectionBang();
+  expect(pool.isConnected()).toBe(true);
+  await pool.unpinConnectionBang();
 });
 
 it.skip("pin connection synchronize the connection", () => {
-  /* needs pin connection */
+  /* needs thread synchronization */
 });
 
-it.skip("pin connection opens a transaction", () => {
-  /* needs pin connection + transactions */
+it("pin connection opens a transaction", async () => {
+  const pool = makeTransactionAwarePool(5);
+  await pool.pinConnectionBang();
+  const conn = pool.checkout() as TransactionAwareTestAdapter;
+  expect(conn.transactionManager.openTransactions).toBe(1);
+  expect(conn.transactionManager.currentTransaction.open).toBe(true);
+  expect(conn.transactionManager.currentTransaction.joinable).toBe(false);
+  await pool.unpinConnectionBang();
 });
 
-it.skip("unpin connection returns whether transaction has been rolledback", () => {
-  /* needs pin connection + transactions */
+it("unpin connection returns whether transaction has been rolledback", async () => {
+  const pool = makeTransactionAwarePool(5);
+
+  // Clean unpin — transaction is still open, rollback happens → clean = true
+  await pool.pinConnectionBang();
+  const clean = await pool.unpinConnectionBang();
+  expect(clean).toBe(true);
+
+  // Dirty unpin — manually commit the transaction before unpin
+  await pool.pinConnectionBang();
+  const conn = pool.checkout() as TransactionAwareTestAdapter;
+  await conn.transactionManager.commitTransaction();
+  const dirty = await pool.unpinConnectionBang();
+  expect(dirty).toBe(false);
 });
 
-it.skip("pin connection nesting", () => {
-  /* needs pin connection */
+it("pin connection nesting", async () => {
+  const pool = makeTransactionAwarePool(5);
+  await pool.pinConnectionBang();
+  const conn1 = pool.checkout();
+
+  await pool.pinConnectionBang();
+  const conn2 = pool.checkout();
+  expect(conn1).toBe(conn2);
+
+  // First unpin doesn't check in the connection
+  await pool.unpinConnectionBang();
+  const conn3 = pool.checkout();
+  expect(conn3).toBe(conn1);
+
+  // Second unpin checks it in
+  await pool.unpinConnectionBang();
 });
 
 it.skip("pin connection nesting lock", () => {
-  /* needs pin connection + locking */
+  /* needs thread locking */
 });
 
 it.skip("pin connection nesting lock inverse", () => {
-  /* needs pin connection + locking */
+  /* needs thread locking */
 });
 
 it("inspect does not show secrets", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -536,7 +536,7 @@ it("pin connection nesting", async () => {
   expect(conn1.transactionManager.openTransactions).toBe(0);
 });
 
-it("pin connection preserves an existing lease after unpin", async () => {
+it("pin connection reuses leased connection and checks in on unpin", async () => {
   const pool = makeTransactionAwarePool(5);
   const leased = pool.leaseConnection() as TransactionAwareTestAdapter;
 
@@ -550,9 +550,8 @@ it("pin connection preserves an existing lease after unpin", async () => {
   expect(clean).toBe(true);
   expect(leased.transactionManager.openTransactions).toBe(0);
 
-  // Lease should still be intact — activeConnection returns the same connection
-  expect(pool.activeConnection).toBe(leased);
-  pool.releaseConnection();
+  // Pinning takes ownership — connection is checked in on final unpin (matches Rails)
+  expect(pool.stat().idle).toBe(1);
 });
 
 it.skip("pin connection nesting lock", () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -536,6 +536,25 @@ it("pin connection nesting", async () => {
   expect(conn1.transactionManager.openTransactions).toBe(0);
 });
 
+it("pin connection preserves an existing lease after unpin", async () => {
+  const pool = makeTransactionAwarePool(5);
+  const leased = pool.leaseConnection() as TransactionAwareTestAdapter;
+
+  await pool.pinConnectionBang();
+  const pinned = pool.checkout() as TransactionAwareTestAdapter;
+  expect(pinned).toBe(leased);
+  expect(leased.transactionManager.openTransactions).toBe(1);
+  expect(leased.transactionManager.currentTransaction.joinable).toBe(false);
+
+  const clean = await pool.unpinConnectionBang();
+  expect(clean).toBe(true);
+  expect(leased.transactionManager.openTransactions).toBe(0);
+
+  // Lease should still be intact — activeConnection returns the same connection
+  expect(pool.activeConnection).toBe(leased);
+  pool.releaseConnection();
+});
+
 it.skip("pin connection nesting lock", () => {
   /* needs thread locking */
 });


### PR DESCRIPTION
## Summary
- Add `pinConnectionBang`/`unpinConnectionBang` to `ConnectionPool`, matching Rails' `pin_connection!`/`unpin_connection!`
- Pin opens a non-joinable transaction via `TransactionManager.beginTransaction({ joinable: false, _lazy: false })`; unpin checks `transactionOpen` and rolls back (clean) or resets the connection (dirty)
- `checkout`/`checkin` respect the pinned connection — checkout returns it directly, checkin is a no-op
- `disconnect`/`discardBang` clear pinned state
- Add `TransactionAwareConnection` interface and `isTransactionAware` type guard (no `as any` casts)
- Add transaction manager delegation methods to `AbstractAdapter`: `rollbackTransaction`, `commitTransaction`, `isTransactionOpen`, `openTransactions`, `materializeTransactions`, `disableLazyTransactionsBang`, `enableLazyTransactionsBang`, `dirtyCurrentTransaction`
- Unskip 5 pin connection tests: same-connection, connected, opens-transaction, clean/dirty-unpin, nesting

## Test plan
- [x] `vitest run connection-pool.test.ts` — 26 passed, 26 skipped (5 newly unskipped)
- [x] `vitest run transactions.test.ts` — 133 passed, 20 skipped
- [x] `vitest run connection-adapters/` — all passing
- [x] `tsc --build` clean
- [x] `api:compare` — transaction.ts at 100% (59/59)