### PR TITLE
feat(activerecord): ConnectionHandler methods matching Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -12,7 +12,8 @@ import { DatabaseConfigurations } from "../../database-configurations.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
 import type { DatabaseAdapter } from "../../adapter.js";
-import { AdapterNotSpecified } from "../../errors.js";
+import { AdapterNotSpecified, ConnectionNotDefined } from "../../errors.js";
+import type { QueryCachePool } from "./query-cache.js";
 import { Notifications } from "@blazetrails/activesupport";
 
 export { ConnectionDescriptor };
@@ -20,6 +21,15 @@ export type { ConnectionOwner };
 
 export class ConnectionHandler {
   private _connectionNameToPoolManager = new Map<string, PoolManager>();
+  private _preventWrites = false;
+
+  get preventWrites(): boolean {
+    return this._preventWrites;
+  }
+
+  set preventWrites(value: boolean) {
+    this._preventWrites = value;
+  }
 
   /**
    * Normalize an owner into a form suitable for PoolConfig.connectionDescriptor=.
@@ -34,6 +44,38 @@ export class ConnectionHandler {
       return new ConnectionDescriptor(owner);
     }
     return owner;
+  }
+
+  connectionPoolNames(): string[] {
+    return [...this._connectionNameToPoolManager.keys()];
+  }
+
+  connectionPoolList(role?: string | null): ConnectionPool[] {
+    const effectiveRole = role === "all" ? null : role;
+    const pools: ConnectionPool[] = [];
+    for (const manager of this._connectionNameToPoolManager.values()) {
+      const configs =
+        effectiveRole == null ? manager.poolConfigs() : manager.poolConfigs(effectiveRole);
+      for (const pc of configs) {
+        pools.push(pc.pool);
+      }
+    }
+    return pools;
+  }
+
+  get connectionPools(): ConnectionPool[] {
+    return this.connectionPoolList();
+  }
+
+  eachConnectionPool(role: string | null | undefined, cb: (pool: ConnectionPool) => void): void {
+    const effectiveRole = role === "all" ? null : role;
+    for (const manager of this._connectionNameToPoolManager.values()) {
+      const configs =
+        effectiveRole == null ? manager.poolConfigs() : manager.poolConfigs(effectiveRole);
+      for (const pc of configs) {
+        cb(pc.pool);
+      }
+    }
   }
 
   establishConnection(
@@ -79,63 +121,118 @@ export class ConnectionHandler {
     poolManager.setPoolConfig(role, shard, poolConfig);
 
     Notifications.instrument("!connection.active_record", {
-      spec_name: poolKey,
+      connection_name: poolKey,
+      role,
       shard,
+      config: dbConfig.configuration,
     });
 
     return poolConfig.pool;
   }
 
-  retrieveConnectionPool(
-    owner: string,
-    options?: { role?: string; shard?: string },
-  ): ConnectionPool | undefined {
-    const role = options?.role ?? "writing";
-    const shard = options?.shard ?? "default";
-    const poolManager = this._getPoolManager(owner);
-    return poolManager?.getPoolConfig(role, shard)?.pool;
-  }
-
-  get connectionPools(): ConnectionPool[] {
-    const pools: ConnectionPool[] = [];
-    for (const manager of this._connectionNameToPoolManager.values()) {
-      for (const poolConfig of manager.poolConfigs()) {
-        if (poolConfig.poolInitialized) {
-          pools.push(poolConfig.pool);
-        }
-      }
-    }
-    return pools;
+  activeConnectionsQ(role?: string | null): boolean {
+    const pools = this.connectionPoolList(role);
+    return pools.some((pool) => pool.activeConnection != null);
   }
 
   get activeConnections(): boolean {
-    for (const manager of this._connectionNameToPoolManager.values()) {
-      for (const poolConfig of manager.poolConfigs()) {
-        if (poolConfig.poolInitialized && poolConfig.pool.activeConnection) return true;
-      }
-    }
-    return false;
+    return this.activeConnectionsQ();
   }
 
-  removeConnection(owner: string, options?: { role?: string; shard?: string }): void {
+  clearActiveConnectionsBang(role?: string | null): void {
+    this.eachConnectionPool(role, (pool) => {
+      pool.releaseConnection();
+      (pool as unknown as QueryCachePool).disableQueryCacheBang?.();
+    });
+  }
+
+  clearReloadableConnectionsBang(role?: string | null): void {
+    this.eachConnectionPool(role, (pool) => {
+      pool.clearReloadableConnectionsBang();
+    });
+  }
+
+  clearAllConnectionsBang(role?: string | null): void {
+    this.eachConnectionPool(role, (pool) => {
+      pool.disconnectBang();
+    });
+  }
+
+  flushIdleConnectionsBang(role?: string | null): void {
+    this.eachConnectionPool(role, (pool) => {
+      pool.flushBang();
+    });
+  }
+
+  retrieveConnection(
+    connectionName: string,
+    options?: { role?: string; shard?: string },
+  ): DatabaseAdapter {
+    const pool = this.retrieveConnectionPool(connectionName, {
+      role: options?.role,
+      shard: options?.shard,
+      strict: true,
+    });
+    return pool!.leaseConnection();
+  }
+
+  isConnected(connectionName: string, options?: { role?: string; shard?: string }): boolean {
+    const pool = this.retrieveConnectionPool(connectionName, {
+      role: options?.role,
+      shard: options?.shard,
+    });
+    return pool != null && pool.isConnected();
+  }
+
+  removeConnectionPool(connectionName: string, options?: { role?: string; shard?: string }): void {
     const role = options?.role ?? "writing";
     const shard = options?.shard ?? "default";
-    const poolManager = this._getPoolManager(owner);
+    const poolManager = this._getPoolManager(connectionName);
     if (poolManager) {
       this._disconnectPoolFromPoolManager(poolManager, role, shard);
       if (poolManager.roleNames.length === 0) {
-        this._connectionNameToPoolManager.delete(owner);
+        this._connectionNameToPoolManager.delete(connectionName);
       }
     }
   }
 
-  clearAllConnections(): void {
-    for (const manager of this._connectionNameToPoolManager.values()) {
-      for (const poolConfig of manager.poolConfigs()) {
-        poolConfig.disconnect();
-      }
+  retrieveConnectionPool(
+    owner: string,
+    options?: { role?: string; shard?: string; strict?: boolean },
+  ): ConnectionPool | undefined {
+    const role = options?.role ?? "writing";
+    const shard = options?.shard ?? "default";
+    const strict = options?.strict ?? false;
+    const poolManager = this._getPoolManager(owner);
+    const pool = poolManager?.getPoolConfig(role, shard)?.pool;
+
+    if (strict && !pool) {
+      const parts: string[] = [];
+      if (shard !== "default") parts.push(`'${shard}' shard`);
+      if (role !== "writing") parts.push(`'${role}' role`);
+      const selector = parts.join(" and ");
+      const prefix = owner !== "Base" ? owner : "";
+      const full = [prefix, selector].filter(Boolean).join(" with ");
+      const suffix = full ? ` for ${full}` : "";
+      const message = `No database connection defined${suffix}.`;
+      throw new ConnectionNotDefined(message, {
+        connectionName: owner,
+        shard,
+        role,
+      });
     }
-    this._connectionNameToPoolManager.clear();
+
+    return pool;
+  }
+
+  /** @deprecated Use removeConnectionPool */
+  removeConnection(owner: string, options?: { role?: string; shard?: string }): void {
+    this.removeConnectionPool(owner, options);
+  }
+
+  /** @deprecated Use clearAllConnectionsBang */
+  clearAllConnections(): void {
+    this.clearAllConnectionsBang();
   }
 
   private _getPoolManager(connectionName: string): PoolManager | undefined {

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -293,4 +293,173 @@ describe("ConnectionHandlerTest", () => {
   it.skip("pool from any process for uses most recent spec", () => {
     /* needs process forking */
   });
+
+  it("connection pool names", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    expect(handler.connectionPoolNames()).toContain("primary");
+  });
+
+  it("each connection pool", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pools: unknown[] = [];
+    handler.eachConnectionPool(null, (pool) => pools.push(pool));
+    expect(pools).toHaveLength(1);
+  });
+
+  it("clear active connections bang", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pool = handler.retrieveConnectionPool("primary")!;
+    pool.leaseConnection();
+    expect(pool.activeConnection).toBeTruthy();
+    handler.clearActiveConnectionsBang();
+    expect(pool.activeConnection).toBeNull();
+  });
+
+  it("clear all connections bang", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pool = handler.retrieveConnectionPool("primary")!;
+    pool.leaseConnection();
+    handler.clearAllConnectionsBang();
+    expect(pool.isConnected()).toBe(false);
+  });
+
+  it("prevent writes", () => {
+    expect(handler.preventWrites).toBe(false);
+    handler.preventWrites = true;
+    expect(handler.preventWrites).toBe(true);
+    handler.preventWrites = false;
+  });
+
+  it("retrieve connection returns a connection", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const conn = handler.retrieveConnection("primary");
+    expect(conn).toBeTruthy();
+    expect(conn.adapterName).toBeTruthy();
+    handler.retrieveConnectionPool("primary")!.releaseConnection();
+  });
+
+  it("retrieve connection strict throws for missing pool", () => {
+    expect(() => handler.retrieveConnection("nonexistent")).toThrow(/No database connection/);
+  });
+
+  it("is connected", () => {
+    expect(handler.isConnected("primary")).toBe(false);
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pool = handler.retrieveConnectionPool("primary")!;
+    pool.leaseConnection();
+    expect(handler.isConnected("primary")).toBe(true);
+    pool.releaseConnection();
+  });
+
+  it("remove connection pool", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    expect(handler.retrieveConnectionPool("primary")).toBeTruthy();
+    handler.removeConnectionPool("primary");
+    expect(handler.retrieveConnectionPool("primary")).toBeUndefined();
+  });
+
+  it("flush idle connections bang", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pool = handler.retrieveConnectionPool("primary")!;
+    pool.leaseConnection();
+    pool.releaseConnection();
+    expect(pool.stat().idle).toBe(1);
+    handler.flushIdleConnectionsBang();
+    expect(pool.stat().connections).toBe(0);
+  });
+
+  it("connection pool list filtered by role", () => {
+    const config1 = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    const config2 = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev-read.db",
+    });
+    handler.establishConnection(config1, {
+      owner: "primary",
+      role: "writing",
+      adapterFactory: createTestAdapter,
+    });
+    handler.establishConnection(config2, {
+      owner: "primary",
+      role: "reading",
+      adapterFactory: createTestAdapter,
+    });
+    expect(handler.connectionPoolList("writing")).toHaveLength(1);
+    expect(handler.connectionPoolList("reading")).toHaveLength(1);
+    expect(handler.connectionPoolList("all")).toHaveLength(2);
+    expect(handler.connectionPoolList()).toHaveLength(2);
+  });
+
+  it("active connections filtered by role", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, {
+      owner: "primary",
+      role: "writing",
+      adapterFactory: createTestAdapter,
+    });
+    const pool = handler.retrieveConnectionPool("primary", { role: "writing" })!;
+    pool.leaseConnection();
+    expect(handler.activeConnectionsQ("writing")).toBe(true);
+    expect(handler.activeConnectionsQ("reading")).toBe(false);
+    pool.releaseConnection();
+  });
+
+  it("retrieve connection pool strict mode with role and shard", () => {
+    expect(() =>
+      handler.retrieveConnectionPool("primary", {
+        role: "reading",
+        shard: "shard_one",
+        strict: true,
+      }),
+    ).toThrow(/No database connection defined.*'shard_one' shard.*'reading' role/);
+  });
+
+  it("each connection pool with null role", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "dev.db",
+    });
+    handler.establishConnection(config, { owner: "primary", adapterFactory: createTestAdapter });
+    const pools: unknown[] = [];
+    handler.eachConnectionPool(null, (pool) => pools.push(pool));
+    expect(pools).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

Implements 11 missing ConnectionHandler methods to match Rails API:

- `preventWrites` getter/setter
- `connectionPoolNames()` — returns pool manager keys
- `connectionPoolList(role?)` — returns pools, optionally filtered by role
- `eachConnectionPool(role?, cb)` — iterates pools
- `clearActiveConnectionsBang(role?)` — releases leased connections
- `clearReloadableConnectionsBang(role?)` — clears reloadable connections
- `clearAllConnectionsBang(role?)` — disconnects all pools
- `flushIdleConnectionsBang(role?)` — flushes idle connections
- `retrieveConnection(name, role, shard)` — leases a connection (strict mode)
- `isConnected(name, role, shard)` — checks if pool has connections
- `removeConnectionPool(name, role, shard)` — removes and disconnects a pool
- `activeConnectionsQ(role?)` — checks for active connections with role filter
- `retrieveConnectionPool` now supports `strict: true` throwing `ConnectionNotDefined`

Renames: `removeConnection` → `removeConnectionPool`, `clearAllConnections` → `clearAllConnectionsBang` (deprecated aliases kept).

PR 6 of 7 in the [connection pool infrastructure plan](docs/activerecord-connections-and-pools.md).

## Test plan

- [x] 28 handler tests passing (up from 18), 13 skipped
- [x] Full activerecord suite passes (7982 tests)
- [x] api:compare: connection_handler 20% → 93% (14/15)