### PR TITLE
feat(activerecord): extend IndexDefinition and improve schema statement fidelity

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -122,15 +122,22 @@ export class SchemaCreation {
     parts.push(
       `${quoteIdentifier(index.name, this.adapterName)} ON ${quoteTableName(index.table, this.adapterName)}`,
     );
+    if (index.using) parts.push(`USING ${index.using}`);
     const columnsSql = index.columns.map((c) => {
       let col = quoteIdentifier(c, this.adapterName);
+      if (index.lengths[c]) col += `(${index.lengths[c]})`;
       if (this.supportsIndexSortOrder()) {
         const order = index.orders[c];
         if (order) col += ` ${order.toUpperCase()}`;
       }
+      if (index.opclasses[c]) col += ` ${index.opclasses[c]}`;
       return col;
     });
     parts.push(`(${columnsSql.join(", ")})`);
+    if (index.include && index.include.length > 0) {
+      const includeCols = index.include.map((c) => quoteIdentifier(c, this.adapterName));
+      parts.push(`INCLUDE (${includeCols.join(", ")})`);
+    }
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -41,6 +41,18 @@ export class SchemaCreation {
     return this.adapterName !== "mysql";
   }
 
+  protected supportsIndexUsing(): boolean {
+    return this.adapterName === "postgres" || this.adapterName === "mysql";
+  }
+
+  protected supportsIndexInclude(): boolean {
+    return this.adapterName === "postgres";
+  }
+
+  protected supportsNullsNotDistinct(): boolean {
+    return this.adapterName === "postgres";
+  }
+
   accept(o: Definition): string {
     if (o instanceof TableDefinition) return this.visitTableDefinition(o);
     if (o instanceof AlterTable) return this.visitAlterTable(o);
@@ -115,18 +127,15 @@ export class SchemaCreation {
   protected visitCreateIndexDefinition(o: CreateIndexDefinition): string {
     const index = o.index;
     const parts: string[] = ["CREATE"];
-    if (index.type) {
-      parts.push(index.type.toUpperCase());
-    } else if (index.unique) {
-      parts.push("UNIQUE");
-    }
+    if (index.unique) parts.push("UNIQUE");
     parts.push("INDEX");
     if (o.algorithm) parts.push(o.algorithm);
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
+    if (index.type) parts.push(index.type.toUpperCase());
     parts.push(
       `${quoteIdentifier(index.name, this.adapterName)} ON ${quoteTableName(index.table, this.adapterName)}`,
     );
-    if (index.using) parts.push(`USING ${index.using}`);
+    if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     const columnsSql = index.columns.map((c) => {
       let col = quoteIdentifier(c, this.adapterName);
       if (index.lengths[c]) col += `(${index.lengths[c]})`;
@@ -134,15 +143,15 @@ export class SchemaCreation {
         const order = index.orders[c];
         if (order) col += ` ${order.toUpperCase()}`;
       }
-      if (index.opclasses[c]) col += ` ${index.opclasses[c]}`;
+      if (this.adapterName === "postgres" && index.opclasses[c]) col += ` ${index.opclasses[c]}`;
       return col;
     });
     parts.push(`(${columnsSql.join(", ")})`);
-    if (index.include && index.include.length > 0) {
+    if (this.supportsIndexInclude() && index.include && index.include.length > 0) {
       const includeCols = index.include.map((c) => quoteIdentifier(c, this.adapterName));
       parts.push(`INCLUDE (${includeCols.join(", ")})`);
     }
-    if (index.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
+    if (this.supportsNullsNotDistinct() && index.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -115,7 +115,11 @@ export class SchemaCreation {
   protected visitCreateIndexDefinition(o: CreateIndexDefinition): string {
     const index = o.index;
     const parts: string[] = ["CREATE"];
-    if (index.unique) parts.push("UNIQUE");
+    if (index.type) {
+      parts.push(index.type.toUpperCase());
+    } else if (index.unique) {
+      parts.push("UNIQUE");
+    }
     parts.push("INDEX");
     if (o.algorithm) parts.push(o.algorithm);
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
@@ -138,6 +142,7 @@ export class SchemaCreation {
       const includeCols = index.include.map((c) => quoteIdentifier(c, this.adapterName));
       parts.push(`INCLUDE (${includeCols.join(", ")})`);
     }
+    if (index.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -112,21 +112,47 @@ export class IndexDefinition {
   readonly columns: string[];
   readonly where?: string;
   readonly orders: Record<string, string>;
+  readonly lengths: Record<string, number>;
+  readonly opclasses: Record<string, string>;
+  readonly type?: string;
+  readonly using?: string;
+  readonly include?: string[];
+  readonly nullsNotDistinct?: boolean;
+  readonly comment?: string;
+  readonly valid: boolean;
 
   constructor(
     table: string,
     name: string,
     unique: boolean = false,
     columns: string[] = [],
-    where?: string,
-    orders: Record<string, string> = {},
+    options: {
+      where?: string;
+      orders?: Record<string, string>;
+      lengths?: Record<string, number>;
+      opclasses?: Record<string, string>;
+      type?: string;
+      using?: string;
+      include?: string[];
+      nullsNotDistinct?: boolean;
+      comment?: string;
+      valid?: boolean;
+    } = {},
   ) {
     this.table = table;
     this.name = name;
     this.unique = unique;
     this.columns = columns;
-    this.where = where;
-    this.orders = orders;
+    this.where = options.where;
+    this.orders = options.orders ?? {};
+    this.lengths = options.lengths ?? {};
+    this.opclasses = options.opclasses ?? {};
+    this.type = options.type;
+    this.using = options.using;
+    this.include = options.include;
+    this.nullsNotDistinct = options.nullsNotDistinct;
+    this.comment = options.comment;
+    this.valid = options.valid ?? true;
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1164,11 +1164,7 @@ export class SchemaStatements {
     if (!pk) return relation;
 
     const pkColumns = Array.isArray(pk) ? pk : [pk];
-    const quotedPkColumns = pkColumns.map((col) => this._qi(col));
-    const values = this.columnsForDistinct(
-      quotedPkColumns,
-      (relation.orderValues as string[]) ?? [],
-    );
+    const values = this.columnsForDistinct(pkColumns, (relation.orderValues as string[]) ?? []);
 
     let limited: any = relation;
     const selectValues = Array.isArray(values) ? values : [values];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1143,7 +1143,7 @@ export class SchemaStatements {
     }
   }
 
-  columnsForDistinct(columns: string, _orders?: string[]): string {
+  columnsForDistinct(columns: string | string[], _orders?: string[]): string | string[] {
     return columns;
   }
 
@@ -1165,12 +1165,13 @@ export class SchemaStatements {
     const pkColumns = Array.isArray(pk) ? pk : [pk];
     const quotedPkColumns = pkColumns.map((col) => this._qi(col));
     const values = this.columnsForDistinct(
-      quotedPkColumns.join(", "),
+      quotedPkColumns,
       (relation.orderValues as string[]) ?? [],
     );
 
     let limited: any = relation;
-    if (limited.reselect) limited = limited.reselect(values);
+    const selectValues = Array.isArray(values) ? values : [values];
+    if (limited.reselect) limited = limited.reselect(...selectValues);
     if (limited.distinctBang) limited.distinctBang();
 
     // Execute the limited distinct query to get IDs

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -152,19 +152,21 @@ export class SchemaStatements {
       name?: string;
       where?: string;
       order?: Record<string, string>;
+      using?: string;
+      type?: string;
+      comment?: string;
       ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
     const indexName = options.name ?? this.indexName(tableName, { column: cols });
-    const indexDef = new IndexDefinition(
-      tableName,
-      indexName,
-      options.unique ?? false,
-      cols,
-      options.where,
-      options.order ?? {},
-    );
+    const indexDef = new IndexDefinition(tableName, indexName, options.unique ?? false, cols, {
+      where: options.where,
+      orders: options.order ?? {},
+      using: options.using as string | undefined,
+      type: options.type as string | undefined,
+      comment: options.comment as string | undefined,
+    });
     const createDef = new CreateIndexDefinition(indexDef, options.ifNotExists ?? false);
     await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
   }
@@ -980,13 +982,18 @@ export class SchemaStatements {
   ): CreateIndexDefinition {
     const columnNames = Array.isArray(columnName) ? columnName : [columnName];
     const indexName = options.name ?? this.indexName(tableName, { column: columnNames });
-    const idx = new IndexDefinition(
-      tableName,
-      indexName,
-      !!options.unique,
-      columnNames,
-      options.where,
-    );
+    this._validateIndexLength(tableName, indexName);
+    const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
+      where: options.where as string | undefined,
+      orders: (options.order ?? {}) as Record<string, string>,
+      lengths: (options.length ?? {}) as Record<string, number>,
+      opclasses: (options.opclass ?? {}) as Record<string, string>,
+      type: options.type as string | undefined,
+      using: options.using as string | undefined,
+      include: options.include as string[] | undefined,
+      nullsNotDistinct: options.nullsNotDistinct as boolean | undefined,
+      comment: options.comment as string | undefined,
+    });
     return new CreateIndexDefinition(idx, !!options.ifNotExists, options.algorithm);
   }
 
@@ -1140,12 +1147,18 @@ export class SchemaStatements {
     return columns;
   }
 
-  distinctRelationForPrimaryKey(relation: {
+  async distinctRelationForPrimaryKey(relation: {
     primaryKey?: string | string[];
+    table?: { [key: string]: unknown };
     orderValues?: unknown[];
     reselect?: (...cols: unknown[]) => unknown;
     distinctBang?: () => unknown;
-  }): unknown {
+    noneBang?: () => void;
+    where?: (conditions: Record<string, unknown>) => unknown;
+    limitValue?: number | null;
+    offsetValue?: number | null;
+    arel?: unknown;
+  }): Promise<unknown> {
     const pk = relation.primaryKey;
     if (!pk) return relation;
 
@@ -1160,7 +1173,36 @@ export class SchemaStatements {
     if (limited.reselect) limited = limited.reselect(values);
     if (limited.distinctBang) limited.distinctBang();
 
-    return limited;
+    // Execute the limited distinct query to get IDs
+    const arel = limited.arel ?? limited;
+    const sql = typeof arel === "string" ? arel : (arel?.toSql?.() ?? String(arel));
+    const rows = await this.adapter.execute(sql);
+    const pkLen = pkColumns.length;
+
+    const limitedIds: unknown[][] = rows.map((row: Record<string, unknown>) => {
+      const vals = Object.values(row);
+      return vals.slice(-pkLen);
+    });
+
+    if (limitedIds.length === 0) {
+      if (typeof (relation as any).noneBang === "function") {
+        (relation as any).noneBang();
+      }
+    } else {
+      // Build {pk_col => [id1, id2, ...]} conditions
+      const transposed: unknown[][] = pkColumns.map((_, i) => limitedIds.map((row) => row[i]));
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < pkColumns.length; i++) {
+        conditions[pkColumns[i]] = transposed[i];
+      }
+      if (typeof (relation as any).where === "function") {
+        relation = (relation as any).where(conditions);
+      }
+    }
+
+    (relation as any).limitValue = null;
+    (relation as any).offsetValue = null;
+    return relation;
   }
 
   updateTableDefinition(tableName: string, base?: unknown): Table {
@@ -1183,14 +1225,24 @@ export class SchemaStatements {
     } = {},
   ): [IndexDefinition, string | undefined, boolean] {
     const columnNames = Array.isArray(columnName) ? columnName : [columnName];
-    const indexName = options.name ?? this.indexName(tableName, { column: columnNames });
-    const idx = new IndexDefinition(
-      tableName,
-      indexName,
-      !!options.unique,
-      columnNames,
-      options.where,
-    );
+    const indexName =
+      options.name?.toString() ?? this.indexName(tableName, { column: columnNames });
+
+    if (!options.internal) {
+      this._validateIndexLength(tableName, indexName);
+    }
+
+    const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
+      where: options.where,
+      using: options.using,
+      type: options.type,
+      lengths: (options.length ?? {}) as Record<string, number>,
+      orders: (options.order ?? {}) as Record<string, string>,
+      opclasses: (options.opclass ?? {}) as Record<string, string>,
+      include: options.include as string[] | undefined,
+      nullsNotDistinct: options.nullsNotDistinct as boolean | undefined,
+      comment: options.comment as string | undefined,
+    });
     return [idx, this.indexAlgorithm(options.algorithm), !!options.ifNotExists];
   }
 
@@ -1326,5 +1378,14 @@ export class SchemaStatements {
 
   maxIndexNameSize(): number {
     return 62;
+  }
+
+  private _validateIndexLength(tableName: string, indexName: string): void {
+    const limit = this.maxIndexNameSize();
+    if (indexName.length > limit) {
+      throw new Error(
+        `Index name '${indexName}' on table '${tableName}' is too long; the limit is ${limit} characters`,
+      );
+    }
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -160,6 +160,7 @@ export class SchemaStatements {
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
     const indexName = options.name ?? this.indexName(tableName, { column: cols });
+    this._validateIndexLength(tableName, indexName);
     const indexDef = new IndexDefinition(tableName, indexName, options.unique ?? false, cols, {
       where: options.where,
       orders: options.order ?? {},
@@ -1175,7 +1176,7 @@ export class SchemaStatements {
     if (limited.distinctBang) limited.distinctBang();
 
     // Execute the limited distinct query to get IDs
-    const arel = limited.arel ?? limited;
+    const arel = typeof limited.arel === "function" ? limited.arel() : limited;
     const sql = typeof arel === "string" ? arel : (arel?.toSql?.() ?? String(arel));
     const rows = await this.adapter.execute(sql);
     const pkLen = pkColumns.length;
@@ -1201,8 +1202,16 @@ export class SchemaStatements {
       }
     }
 
-    (relation as any).limitValue = null;
-    (relation as any).offsetValue = null;
+    if (typeof (relation as any).limitBang === "function") {
+      (relation as any).limitBang(null);
+    } else {
+      (relation as any)._limitValue = null;
+    }
+    if (typeof (relation as any).offsetBang === "function") {
+      (relation as any).offsetBang(null);
+    } else {
+      (relation as any)._offsetValue = null;
+    }
     return relation;
   }
 


### PR DESCRIPTION
## Summary

Closes the remaining 3 fidelity gaps from PR #481's SchemaStatements implementation.

## What changed

**IndexDefinition** (schema-definitions.ts): Added `lengths`, `opclasses`, `type`, `using`, `include`, `nullsNotDistinct`, `comment`, `valid` fields matching Rails. Constructor refactored to use options object.

**SchemaCreation** (schema-creation.ts): `visitCreateIndexDefinition` now generates `USING` clause, column length suffixes, opclass annotations, and `INCLUDE` clause from the new IndexDefinition fields.

**buildCreateIndexDefinition**: Passes through all index options (length, order, opclass, type, using, include, nullsNotDistinct, comment). Calls `_validateIndexLength` matching Rails' `validate_index_length!`.

**addIndexOptions**: Same — passes through all options, validates index name length (skipped for internal indexes).

**addIndex**: Accepts `using`, `type`, `comment` options.

**distinctRelationForPrimaryKey**: Implements full Rails cycle — executes the distinct reselect query via adapter, extracts limited IDs, applies `where` conditions to rebuild the relation, clears limit/offset.

**_validateIndexLength**: Throws when index name exceeds `maxIndexNameSize()`, matching Rails' `validate_index_length!`.

## Test plan

- [x] All 7972 active activerecord tests pass (12 more than before)
- [x] api:compare 100% for schema_statements.rb maintained
- [x] Build and typecheck pass