### PR TITLE
feat(activerecord): ConnectionHandling module methods matching Rails API

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -464,6 +464,36 @@ export class Base extends Model {
     return ConnectionHandling.establishConnection(this, config);
   }
 
+  // --- ConnectionHandling mixin (static methods, wired via extend() after class) ---
+  declare static connectsTo: typeof ConnectionHandling.connectsTo;
+  declare static connectedTo: typeof ConnectionHandling.connectedTo;
+  declare static connectedToMany: typeof ConnectionHandling.connectedToMany;
+  declare static connectedToAllShards: typeof ConnectionHandling.connectedToAllShards;
+  declare static connectingTo: typeof ConnectionHandling.connectingTo;
+  declare static connectedToQ: typeof ConnectionHandling.connectedToQ;
+  declare static whilePreventingWrites: typeof ConnectionHandling.whilePreventingWrites;
+  declare static prohibitShardSwapping: typeof ConnectionHandling.prohibitShardSwapping;
+  declare static isShardSwappingProhibited: typeof ConnectionHandling.isShardSwappingProhibited;
+  declare static clearQueryCachesForCurrentThread: typeof ConnectionHandling.clearQueryCachesForCurrentThread;
+  declare static leaseConnection: typeof ConnectionHandling.leaseConnection;
+  declare static releaseConnection: typeof ConnectionHandling.releaseConnection;
+  declare static withConnection: typeof ConnectionHandling.withConnection;
+  declare static connectionPool: typeof ConnectionHandling.connectionPool;
+  declare static retrieveConnection: typeof ConnectionHandling.retrieveConnection;
+  declare static connectionDbConfig: typeof ConnectionHandling.connectionDbConfig;
+  static get connectionSpecificationName(): string {
+    return ConnectionHandling.connectionSpecificationName.call(this);
+  }
+  static set connectionSpecificationName(name: string) {
+    (this as any)._connectionSpecificationName = name;
+  }
+  declare static isConnectedQ: typeof ConnectionHandling.isConnectedQ;
+  declare static removeConnection: typeof ConnectionHandling.removeConnection;
+  declare static schemaCache: typeof ConnectionHandling.schemaCache;
+  declare static clearCacheBang: typeof ConnectionHandling.clearCacheBang;
+  declare static shardKeys: typeof ConnectionHandling.shardKeys;
+  declare static isSharded: typeof ConnectionHandling.isSharded;
+
   /**
    * Return the list of column names (attribute names).
    *
@@ -3074,6 +3104,33 @@ function mixin(target: object, methods: Record<string, Function>): void {
     });
   }
 }
+
+// ConnectionHandling: extend Base with static methods (non-enumerable, matching mixin pattern)
+import { extend } from "@blazetrails/activesupport";
+extend(Base, {
+  connectsTo: ConnectionHandling.connectsTo,
+  connectedTo: ConnectionHandling.connectedTo,
+  connectedToMany: ConnectionHandling.connectedToMany,
+  connectedToAllShards: ConnectionHandling.connectedToAllShards,
+  connectingTo: ConnectionHandling.connectingTo,
+  connectedToQ: ConnectionHandling.connectedToQ,
+  whilePreventingWrites: ConnectionHandling.whilePreventingWrites,
+  prohibitShardSwapping: ConnectionHandling.prohibitShardSwapping,
+  isShardSwappingProhibited: ConnectionHandling.isShardSwappingProhibited,
+  clearQueryCachesForCurrentThread: ConnectionHandling.clearQueryCachesForCurrentThread,
+  leaseConnection: ConnectionHandling.leaseConnection,
+  releaseConnection: ConnectionHandling.releaseConnection,
+  withConnection: ConnectionHandling.withConnection,
+  connectionPool: ConnectionHandling.connectionPool,
+  retrieveConnection: ConnectionHandling.retrieveConnection,
+  connectionDbConfig: ConnectionHandling.connectionDbConfig,
+  isConnectedQ: ConnectionHandling.isConnectedQ,
+  removeConnection: ConnectionHandling.removeConnection,
+  schemaCache: ConnectionHandling.schemaCache,
+  clearCacheBang: ConnectionHandling.clearCacheBang,
+  shardKeys: ConnectionHandling.shardKeys,
+  isSharded: ConnectionHandling.isSharded,
+});
 
 mixin(Base.prototype, {
   // Core

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -1,14 +1,194 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "./base.js";
+import { HashConfig } from "./database-configurations/hash-config.js";
+import { createTestAdapter } from "./test-adapter.js";
+import { connectedToStack, currentRole, currentShard, currentPreventingWrites } from "./core.js";
+
+function setupConnection() {
+  const config = new HashConfig("test", "primary", {
+    adapter: "sqlite3",
+    database: "test.db",
+    pool: 5,
+    reapingFrequency: null,
+  });
+  Base.connectionHandler.establishConnection(config, {
+    owner: "Base",
+    adapterFactory: createTestAdapter,
+  });
+}
 
 describe("ConnectionHandlingTest", () => {
-  it.skip("#with_connection lease the connection for the duration of the block", () => {});
-  it.skip("#lease_connection makes the lease permanent even inside #with_connection", () => {});
+  beforeEach(() => {
+    setupConnection();
+  });
+
+  afterEach(() => {
+    connectedToStack().length = 0;
+    Base.connectionHandler.clearAllConnectionsBang();
+  });
+
+  it("#with_connection lease the connection for the duration of the block", () => {
+    const pool = Base.connectionPool();
+    expect(pool.activeConnection).toBeNull();
+    Base.withConnection((conn) => {
+      expect(conn).toBeTruthy();
+      expect(pool.activeConnection).toBeTruthy();
+    });
+  });
+
+  it("#lease_connection makes the lease permanent even inside #with_connection", () => {
+    Base.withConnection(() => {
+      const leased = Base.leaseConnection();
+      expect(leased).toBeTruthy();
+    });
+    // leaseConnection makes sticky=true, so connection persists
+    expect(Base.connectionPool().activeConnection).toBeTruthy();
+    Base.releaseConnection();
+  });
+
   it.skip("#lease_connection makes the lease permanent even inside #with_connection(prevent_permanent_checkout: true)", () => {});
-  it.skip("#with_connection use the already leased connection if available", () => {});
-  it.skip("#with_connection is reentrant", () => {});
+
+  it("#with_connection use the already leased connection if available", () => {
+    const leased = Base.leaseConnection();
+    Base.withConnection((conn) => {
+      expect(conn).toBe(leased);
+    });
+    Base.releaseConnection();
+  });
+
+  it("#with_connection is reentrant", () => {
+    Base.withConnection((outer) => {
+      Base.withConnection((inner) => {
+        expect(inner).toBe(outer);
+      });
+    });
+  });
+
   it.skip("#connection is a soft-deprecated alias to #lease_connection", () => {});
   it.skip("#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated", () => {});
   it.skip("#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed", () => {});
   it.skip("#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)", () => {});
   it.skip("common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed", () => {});
+
+  it("connected_to switches role for block", () => {
+    expect(currentRole.call(Base)).toBe("writing");
+    Base.connectedTo({ role: "reading" }, () => {
+      expect(currentRole.call(Base)).toBe("reading");
+    });
+    expect(currentRole.call(Base)).toBe("writing");
+  });
+
+  it("connected_to switches shard for block", () => {
+    expect(currentShard.call(Base)).toBe("default");
+    Base.connectedTo({ role: "writing", shard: "shard_one" }, () => {
+      expect(currentShard.call(Base)).toBe("shard_one");
+    });
+    expect(currentShard.call(Base)).toBe("default");
+  });
+
+  it("connected_to? checks role and shard", () => {
+    expect(Base.connectedToQ({ role: "writing" })).toBe(true);
+    expect(Base.connectedToQ({ role: "reading" })).toBe(false);
+    Base.connectedTo({ role: "reading" }, () => {
+      expect(Base.connectedToQ({ role: "reading" })).toBe(true);
+    });
+  });
+
+  it("while_preventing_writes", () => {
+    expect(currentPreventingWrites.call(Base)).toBe(false);
+    Base.whilePreventingWrites(() => {
+      expect(currentPreventingWrites.call(Base)).toBe(true);
+    });
+    expect(currentPreventingWrites.call(Base)).toBe(false);
+  });
+
+  it("prohibit_shard_swapping", () => {
+    expect(Base.isShardSwappingProhibited()).toBe(false);
+    Base.prohibitShardSwapping(() => {
+      expect(Base.isShardSwappingProhibited()).toBe(true);
+      expect(() => {
+        Base.connectedTo({ role: "writing", shard: "other" }, () => {});
+      }).toThrow(/cannot swap.*shard/);
+    });
+    expect(Base.isShardSwappingProhibited()).toBe(false);
+  });
+
+  it("connection_specification_name defaults to Base", () => {
+    expect(Base.connectionSpecificationName).toBe("Base");
+  });
+
+  it("shard_keys and sharded?", () => {
+    expect(Base.shardKeys()).toEqual([]);
+    expect(Base.isSharded()).toBe(false);
+  });
+
+  it("lease_connection and release_connection", () => {
+    const conn = Base.leaseConnection();
+    expect(conn).toBeTruthy();
+    expect(Base.connectionPool().activeConnection).toBe(conn);
+    Base.releaseConnection();
+    expect(Base.connectionPool().activeConnection).toBeNull();
+  });
+
+  it("connection_pool returns pool", () => {
+    const pool = Base.connectionPool();
+    expect(pool).toBeTruthy();
+    expect(pool.role).toBe("writing");
+  });
+
+  it("connection_db_config", () => {
+    const config = Base.connectionDbConfig();
+    expect(config.adapter).toBe("sqlite3");
+  });
+
+  it("is_connected?", () => {
+    const pool = Base.connectionPool();
+    pool.leaseConnection();
+    expect(Base.isConnectedQ()).toBe(true);
+    pool.releaseConnection();
+  });
+
+  it("connectsTo rejects both database and shards", () => {
+    expect(() =>
+      Base.connectsTo({
+        database: { writing: "primary" },
+        shards: { default: { writing: "primary" } },
+      }),
+    ).toThrow(/can only accept/);
+  });
+
+  it("connectedTo requires role or shard", () => {
+    expect(() => Base.connectedTo({}, () => {})).toThrow(/must provide/);
+  });
+
+  it("connectingTo pushes onto stack", () => {
+    Base.connectingTo({ role: "reading" });
+    expect(currentRole.call(Base)).toBe("reading");
+    connectedToStack().pop();
+    expect(currentRole.call(Base)).toBe("writing");
+  });
+
+  it("connectedToMany switches for classes", () => {
+    Base.connectedToMany([Base], { role: "reading" }, () => {
+      expect(currentRole.call(Base)).toBe("reading");
+    });
+    expect(currentRole.call(Base)).toBe("writing");
+  });
+
+  it("clear_query_caches_for_current_thread does not throw", () => {
+    expect(() => Base.clearQueryCachesForCurrentThread()).not.toThrow();
+  });
+
+  it("schema_cache and clear_cache_bang do not throw", () => {
+    expect(() => Base.schemaCache()).not.toThrow();
+    expect(() => Base.clearCacheBang()).not.toThrow();
+  });
+
+  it("remove_connection removes the pool", () => {
+    expect(Base.connectionPool()).toBeTruthy();
+    Base.removeConnection();
+    expect(() => Base.connectionPool()).toThrow(/No database connection/);
+    // Re-establish for other tests
+    setupConnection();
+  });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
@@ -9,12 +10,362 @@ import {
   ConnectionNotEstablished,
   ConfigurationError,
 } from "./errors.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  connectedToStack,
+  currentRole as coreCurrentRole,
+  currentShard as coreCurrentShard,
+} from "./core.js";
 
 /**
  * Connection establishment and management for ActiveRecord models.
  *
  * Mirrors: ActiveRecord::ConnectionHandling
  */
+
+let _shardSwappingProhibited = false;
+
+// --- ConnectionHandling module methods (mixed into Base as static methods) ---
+
+export function connectsTo(
+  this: typeof Base,
+  options: {
+    database?: Record<string, string>;
+    shards?: Record<string, Record<string, string>>;
+  },
+): ConnectionPool[] {
+  const database = options.database ?? {};
+  const shards = options.shards ?? {};
+
+  if (Object.keys(database).length > 0 && Object.keys(shards).length > 0) {
+    throw new ArgumentError(
+      "`connectsTo` can only accept a `database` or `shards` argument, but not both.",
+    );
+  }
+
+  const connections: ConnectionPool[] = [];
+  const shardEntries = Object.keys(shards).length > 0 ? shards : { default: database };
+
+  (this as any)._shardKeys = Object.keys(shardEntries);
+  (this as any).connectionClass = true;
+
+  const configs = DatabaseConfigurations.fromEnv((this as any).configurations?.toH?.() ?? {});
+
+  for (const [shard, dbKeys] of Object.entries(shardEntries)) {
+    for (const [role, dbKey] of Object.entries(dbKeys)) {
+      const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+      const found = configs.configsFor({ envName: env, name: dbKey });
+      const dbConfig = found[0] ?? new HashConfig(env, dbKey, {});
+      const pool = this.connectionHandler.establishConnection(dbConfig, {
+        owner: this.connectionClassForSelf(),
+        role,
+        shard,
+      });
+      connections.push(pool);
+    }
+  }
+
+  return connections;
+}
+
+export function connectedTo<T>(
+  this: typeof Base,
+  options: { role?: string; shard?: string; preventWrites?: boolean },
+  fn: () => T,
+): T {
+  const { role, shard, preventWrites = false } = options;
+  if (!role && !shard) {
+    throw new ArgumentError("must provide a `shard` and/or `role`.");
+  }
+
+  return withRoleAndShard.call(this, role, shard, preventWrites, fn) as T;
+}
+
+export function connectedToMany<T>(
+  this: typeof Base,
+  classes: (typeof Base)[],
+  options: { role: string; shard?: string; preventWrites?: boolean },
+  fn: () => T,
+): T {
+  const { role, shard, preventWrites = false } = options;
+
+  const klasses = new Set(classes.map((klass) => klass.connectionClassForSelf()));
+  const entry = { role, shard, preventWrites, klasses };
+  appendToConnectedToStack(entry);
+
+  let result: T;
+  try {
+    result = fn();
+  } catch (error) {
+    removeStackEntry(entry);
+    throw error;
+  }
+
+  return withCleanup(result, () => removeStackEntry(entry));
+}
+
+export function connectedToAllShards<T>(
+  this: typeof Base,
+  options: { role?: string; preventWrites?: boolean },
+  fn: () => T,
+): T[] | Promise<Awaited<T>[]> {
+  const keys = shardKeys.call(this);
+  const results: T[] = [];
+
+  for (const shard of keys) {
+    const result = connectedTo.call(
+      this,
+      { shard, role: options.role, preventWrites: options.preventWrites },
+      fn,
+    ) as T;
+
+    if (isThenable(result)) {
+      const asyncResults = async (): Promise<Awaited<T>[]> => {
+        const awaited = results as Awaited<T>[];
+        awaited.push((await result) as Awaited<T>);
+        for (const remaining of keys.slice(keys.indexOf(shard) + 1)) {
+          const r = connectedTo.call(
+            this,
+            { shard: remaining, role: options.role, preventWrites: options.preventWrites },
+            fn,
+          );
+          awaited.push((await r) as Awaited<T>);
+        }
+        return awaited;
+      };
+      return asyncResults();
+    }
+
+    results.push(result);
+  }
+
+  return results;
+}
+
+export function connectingTo(
+  this: typeof Base,
+  options: { role?: string; shard?: string; preventWrites?: boolean },
+): void {
+  const { role = "writing", shard = "default", preventWrites = false } = options;
+  appendToConnectedToStack({
+    role,
+    shard,
+    preventWrites,
+    klasses: new Set([this.connectionClassForSelf()]),
+  });
+}
+
+export function connectedToQ(
+  this: typeof Base,
+  options: { role: string; shard?: string },
+): boolean {
+  return (
+    coreCurrentRole.call(this as any) === options.role &&
+    coreCurrentShard.call(this as any) === (options.shard ?? "default")
+  );
+}
+
+export function whilePreventingWrites<T>(this: typeof Base, fn: () => T, enabled = true): T {
+  return connectedTo.call(
+    this,
+    { role: coreCurrentRole.call(this as any), preventWrites: enabled },
+    fn,
+  ) as T;
+}
+
+export function prohibitShardSwapping<T>(fn: () => T, enabled = true): T {
+  const prev = _shardSwappingProhibited;
+  _shardSwappingProhibited = enabled;
+
+  let result: T;
+  try {
+    result = fn();
+  } catch (error) {
+    _shardSwappingProhibited = prev;
+    throw error;
+  }
+
+  return withCleanup(result, () => {
+    _shardSwappingProhibited = prev;
+  });
+}
+
+export function isShardSwappingProhibited(): boolean {
+  return _shardSwappingProhibited;
+}
+
+export function clearQueryCachesForCurrentThread(this: typeof Base): void {
+  this.connectionHandler.eachConnectionPool(null, (pool) => {
+    const conn = pool.activeConnection;
+    if (conn && typeof (conn as any).clearQueryCache === "function") {
+      (conn as any).clearQueryCache();
+    }
+  });
+}
+
+export function leaseConnection(this: typeof Base): DatabaseAdapter {
+  return connectionPool.call(this).leaseConnection();
+}
+
+export function releaseConnection(this: typeof Base): boolean {
+  return connectionPool.call(this).releaseConnection();
+}
+
+export function withConnection<T>(
+  this: typeof Base,
+  fn: (conn: DatabaseAdapter) => T,
+  options?: { preventPermanentCheckout?: boolean },
+): T {
+  return connectionPool.call(this).withConnection(fn, options);
+}
+
+export function connectionDbConfig(this: typeof Base) {
+  return connectionPool.call(this).dbConfig;
+}
+
+export function connectionPool(this: typeof Base): ConnectionPool {
+  const name = connectionSpecificationName.call(this);
+  return this.connectionHandler.retrieveConnectionPool(name, {
+    role: coreCurrentRole.call(this as any),
+    shard: coreCurrentShard.call(this as any),
+    strict: true,
+  })!;
+}
+
+export function retrieveConnection(this: typeof Base): DatabaseAdapter {
+  const name = connectionSpecificationName.call(this);
+  return this.connectionHandler.retrieveConnection(name, {
+    role: coreCurrentRole.call(this as any),
+    shard: coreCurrentShard.call(this as any),
+  });
+}
+
+export function isConnectedQ(this: typeof Base): boolean {
+  const name = connectionSpecificationName.call(this);
+  return this.connectionHandler.isConnected(name, {
+    role: coreCurrentRole.call(this as any),
+    shard: coreCurrentShard.call(this as any),
+  });
+}
+
+export function removeConnection(this: typeof Base): void {
+  const name = connectionSpecificationName.call(this);
+  if (
+    this.connectionHandler.retrieveConnectionPool(name, {
+      role: coreCurrentRole.call(this as any),
+      shard: coreCurrentShard.call(this as any),
+    })
+  ) {
+    (this as any)._connectionSpecificationName = undefined;
+  }
+  this.connectionHandler.removeConnectionPool(name, {
+    role: coreCurrentRole.call(this as any),
+    shard: coreCurrentShard.call(this as any),
+  });
+}
+
+export function connectionSpecificationName(this: typeof Base): string {
+  if ((this as any)._connectionSpecificationName != null) {
+    return (this as any)._connectionSpecificationName;
+  }
+  if (this.name === "Base") {
+    return "Base";
+  }
+  if ((this as any).connectionClassQ?.()) {
+    return this.name;
+  }
+  const parent = Object.getPrototypeOf(this);
+  if (parent && typeof parent === "function" && parent !== this) {
+    return connectionSpecificationName.call(parent as typeof Base);
+  }
+  return "Base";
+}
+
+export function schemaCache(this: typeof Base) {
+  const pool = connectionPool.call(this);
+  return pool.poolConfig.schemaCache ?? (pool as any).schemaCache;
+}
+
+export function clearCacheBang(this: typeof Base): void {
+  const cache = schemaCache.call(this);
+  if (cache && typeof (cache as any).clearBang === "function") {
+    (cache as any).clearBang();
+  }
+}
+
+export function shardKeys(this: typeof Base): string[] {
+  const connClass = this.connectionClassForSelf();
+  return (connClass as any)._shardKeys ?? [];
+}
+
+export function isSharded(this: typeof Base): boolean {
+  return shardKeys.call(this).length > 0;
+}
+
+// --- Private helpers ---
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return value != null && typeof (value as any).then === "function";
+}
+
+function withCleanup<T>(result: T, cleanup: () => void): T {
+  if (isThenable(result)) {
+    return Promise.resolve(result).finally(cleanup) as T;
+  }
+  cleanup();
+  return result;
+}
+
+function removeStackEntry(entry: object): void {
+  const stack = connectedToStack();
+  const index = stack.lastIndexOf(entry as any);
+  if (index !== -1) stack.splice(index, 1);
+}
+
+function withRoleAndShard<T>(
+  this: typeof Base,
+  role: string | undefined,
+  shard: string | undefined,
+  preventWrites: boolean,
+  fn: () => T,
+): T {
+  const connectionClass = this.connectionClassForSelf();
+  const entry = {
+    role,
+    shard,
+    preventWrites,
+    klasses: new Set([connectionClass]),
+  };
+  appendToConnectedToStack(entry);
+
+  let result: T;
+  try {
+    result = fn();
+  } catch (error) {
+    removeStackEntry(entry);
+    throw error;
+  }
+
+  return withCleanup(result, () => removeStackEntry(entry));
+}
+
+function appendToConnectedToStack(entry: {
+  role?: string;
+  shard?: string;
+  preventWrites?: boolean;
+  klasses: Set<any>;
+}): void {
+  if (_shardSwappingProhibited && entry.shard) {
+    // Check if the shard would actually change
+    for (const klass of entry.klasses) {
+      const current = coreCurrentShard.call(klass);
+      if (current !== entry.shard) {
+        throw new ArgumentError("cannot swap `shard` while shard swapping is prohibited.");
+      }
+    }
+  }
+  connectedToStack().push(entry);
+}
 
 const _adapterCache: Record<string, new (...args: any[]) => DatabaseAdapter> = {};
 

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -47,3 +47,42 @@ export function include(klass: AnyClass, mod: Module): void {
   }
   Object.defineProperties(klass.prototype, descriptors);
 }
+
+/**
+ * Derive static method types from an extended module object.
+ * Strips the `this` parameter from each function signature.
+ *
+ * Usage:
+ *   interface BaseStatic extends Extended<typeof ConnectionHandlingMethods> {
+ *     new (...args: any[]): Base;
+ *   }
+ *   extend(Base, ConnectionHandlingMethods);
+ *   const TypedBase = Base as unknown as BaseStatic;
+ */
+export type Extended<M extends Module> = {
+  [K in keyof M]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
+};
+
+/**
+ * Ruby-style `extend` for mixing module methods onto a class as static methods.
+ *
+ * In Ruby, `extend SomeModule` copies the module's methods onto the
+ * object itself (not its prototype). When used on a class, this makes
+ * the methods available as class-level (static) methods.
+ *
+ * Mirrors: Ruby's Object#extend (core language feature)
+ *
+ * Usage:
+ *   extend(Base, ConnectionHandlingMethods);
+ *   // Now Base.connectedTo(...) works
+ */
+export function extend(klass: AnyClass | object, mod: Module): void {
+  for (const key of Object.keys(mod)) {
+    Object.defineProperty(klass, key, {
+      value: mod[key],
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -352,8 +352,8 @@ export {
 } from "./callbacks.js";
 export type { ClassMethods } from "./callbacks.js";
 export { Concern, MultipleIncludedBlocks, MultiplePrependBlocks } from "./concern.js";
-export { include } from "./include.js";
-export type { Included } from "./include.js";
+export { include, extend } from "./include.js";
+export type { Included, Extended } from "./include.js";
 export { ClassAttribute } from "./class-attribute.js";
 
 export {


### PR DESCRIPTION
## Summary

Implements 22 ConnectionHandling methods as functions mixed into Base via `extend()`:

**Multi-DB:**
- `connectsTo({ database, shards })` — establishes multi-DB connections
- `connectedTo({ role, shard, preventWrites }, fn)` — switches role/shard for block
- `connectedToMany(classes, { role, shard }, fn)` — switches for multiple classes
- `connectedToAllShards({ role }, fn)` — iterates all configured shards (sequential for async)
- `connectingTo({ role, shard })` — persistent role switch (no block)
- `connectedToQ({ role, shard })` — checks current role/shard
- `whilePreventingWrites(fn)` — prevents writes for block
- `prohibitShardSwapping(fn)` — blocks shard changes in block
- `isShardSwappingProhibited()` — checks prohibition state

**Connection access:**
- `leaseConnection()`, `releaseConnection()`, `withConnection(fn)` — delegate to pool
- `connectionPool()` — resolves pool via handler with strict mode
- `retrieveConnection()` — leases via handler
- `connectionDbConfig()` — pool's db config
- `connectionSpecificationName` — getter/setter, walks class hierarchy
- `isConnectedQ()` — checks if pool has connections
- `removeConnection()` — removes pool and resets spec name

**Schema/cache:**
- `schemaCache()`, `clearCacheBang()`, `clearQueryCachesForCurrentThread()`

**Shard info:**
- `shardKeys()`, `isSharded()`

**activesupport:** Added `extend()` function (Ruby's `Object#extend`) and `Extended<>` type helper.

Note: `connectedToStack` and `_shardSwappingProhibited` are process-global, matching Rails' main-thread model. Per-async-context isolation via `AsyncLocalStorage` is a future improvement.

## Test plan

- [x] 22 connection-handling tests passing, 6 skipped
- [x] Full activerecord suite passes (8001 tests)
- [x] api:compare: connection_handling 4% → 85% (23/27)