### PR TITLE
feat(activerecord): implement remaining SchemaDefinitions methods matching Rails API

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -368,9 +368,10 @@ export class TableDefinition {
     primaryKey?: string,
     _options: Record<string, unknown> = {},
   ): void {
-    // Remove any existing PK columns
-    const existingPkIdx = this.columns.findIndex((c) => c.options.primaryKey);
-    if (existingPkIdx >= 0) this.columns.splice(existingPkIdx, 1);
+    // Remove all existing PK columns
+    for (let i = this.columns.length - 1; i >= 0; i--) {
+      if (this.columns[i].options.primaryKey) this.columns.splice(i, 1);
+    }
 
     if (id === false) return;
 
@@ -406,11 +407,19 @@ export class TableDefinition {
       new CheckConstraintDefinition(
         this.tableName,
         expression,
-        options.name ?? `chk_${this.tableName}_${expression.slice(0, 20)}`,
+        options.name ?? this._checkConstraintName(expression),
         options.validate ?? true,
       ),
     );
     return this;
+  }
+
+  private _checkConstraintName(expression: string): string {
+    let hash = 0;
+    for (let i = 0; i < expression.length; i++) {
+      hash = ((hash << 5) - hash + expression.charCodeAt(i)) | 0;
+    }
+    return `chk_rails_${(hash >>> 0).toString(16).padStart(8, "0")}`;
   }
 
   newForeignKeyDefinition(
@@ -422,7 +431,8 @@ export class TableDefinition {
       toTable,
       options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_id`,
       options.primaryKey ?? "id",
-      options.name ?? `fk_${this.tableName}_${toTable}`,
+      options.name ??
+        `fk_${this.tableName}_${options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_id`}`,
       options.onDelete,
       options.onUpdate,
     );
@@ -435,7 +445,7 @@ export class TableDefinition {
     return new CheckConstraintDefinition(
       this.tableName,
       expression,
-      options.name ?? `chk_${this.tableName}_${expression.slice(0, 20)}`,
+      options.name ?? this._checkConstraintName(expression),
       options.validate ?? true,
     );
   }
@@ -756,7 +766,7 @@ export class Table {
   }
 
   async isColumnExists(columnName: string, type?: ColumnType): Promise<boolean> {
-    return this._schema.columnExists!(this._tableName, columnName, type);
+    return this._require("columnExists").call(this._schema, this._tableName, columnName, type);
   }
 
   private _require<K extends keyof SchemaStatementsLike>(
@@ -823,12 +833,11 @@ export class Table {
     toTableOrOptions?: string | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    return this._require("removeForeignKey").call(
-      this._schema,
-      this._tableName,
-      toTableOrOptions,
-      options,
-    );
+    const merged =
+      typeof toTableOrOptions === "string" && options
+        ? { ...options, toTable: toTableOrOptions }
+        : toTableOrOptions;
+    return this._require("removeForeignKey").call(this._schema, this._tableName, merged);
   }
 
   async isForeignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
@@ -848,12 +857,11 @@ export class Table {
     expressionOrOptions?: string | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    return this._require("removeCheckConstraint").call(
-      this._schema,
-      this._tableName,
-      expressionOrOptions,
-      options,
-    );
+    const merged =
+      typeof expressionOrOptions === "string" && options
+        ? { ...options, expression: expressionOrOptions }
+        : expressionOrOptions;
+    return this._require("removeCheckConstraint").call(this._schema, this._tableName, merged);
   }
 
   async isCheckConstraintExists(options?: Record<string, unknown>): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -419,7 +419,7 @@ export class TableDefinition {
     const { index, ...colOpts } = options;
     this.columns.push(new ColumnDefinition(name, type, colOpts as ColumnOptions));
     if (index) {
-      const indexOpts: { unique?: boolean; name?: string } = typeof index === "object" ? index : {};
+      const indexOpts: AddIndexOptions = typeof index === "object" ? index : {};
       this.index([name], indexOpts);
     }
     return this;
@@ -594,9 +594,21 @@ export class TableDefinition {
     return this;
   }
 
-  index(columns: string[], options: { unique?: boolean; name?: string } = {}): this {
+  index(columns: string[], options: AddIndexOptions = {}): this {
     const name = options.name ?? `index_${this.tableName}_on_${columns.join("_and_")}`;
-    this.indexes.push(new IndexDefinition(this.tableName, name, options.unique ?? false, columns));
+    this.indexes.push(
+      new IndexDefinition(this.tableName, name, options.unique ?? false, columns, {
+        where: options.where,
+        orders: options.order,
+        lengths: options.length,
+        opclasses: options.opclass,
+        type: options.type,
+        using: options.using,
+        include: options.include,
+        nullsNotDistinct: options.nullsNotDistinct,
+        comment: options.comment,
+      }),
+    );
     return this;
   }
 
@@ -710,10 +722,24 @@ export class TableDefinition {
     if (this.as) {
       sql += ` AS ${this.as}`;
     } else {
-      sql += ` (${columnDefs.join(", ")})`;
+      const tableElements = [...columnDefs];
+      for (const chk of this.checkConstraints) {
+        tableElements.push(
+          `CONSTRAINT ${quoteIdentifier(chk.name, this._adapterName)} CHECK (${chk.expression})`,
+        );
+      }
+      for (const fk of this.foreignKeys) {
+        tableElements.push(
+          `CONSTRAINT ${quoteIdentifier(fk.name, this._adapterName)} FOREIGN KEY (${quoteIdentifier(fk.column, this._adapterName)}) REFERENCES ${quoteTableName(fk.toTable, this._adapterName)} (${quoteIdentifier(fk.primaryKey, this._adapterName)})`,
+        );
+      }
+      sql += ` (${tableElements.join(", ")})`;
     }
 
     if (this.options) sql += ` ${this.options}`;
+    if (this.comment && this._adapterName === "mysql") {
+      sql += ` COMMENT ${quoteDefaultExpression(this.comment)}`;
+    }
 
     return sql;
   }
@@ -799,8 +825,8 @@ export class Table {
     }
   }
 
-  async isColumnExists(columnName: string, type?: ColumnType): Promise<boolean> {
-    return this._require("columnExists").call(this._schema, this._tableName, columnName, type);
+  async isColumnExists(columnName: string): Promise<boolean> {
+    return this._require("columnExists").call(this._schema, this._tableName, columnName);
   }
 
   private _require<K extends keyof SchemaStatementsLike>(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -442,7 +442,7 @@ export class TableDefinition {
     for (let i = 0; i < expression.length; i++) {
       hash = ((hash << 5) - hash + expression.charCodeAt(i)) | 0;
     }
-    return `chk_rails_${(hash >>> 0).toString(16).padStart(8, "0")}`;
+    return `chk_${this.tableName}_${(hash >>> 0).toString(16).padStart(8, "0")}`;
   }
 
   newForeignKeyDefinition(
@@ -701,7 +701,21 @@ export class TableDefinition {
       return parts.join(" ");
     });
 
-    return `CREATE TABLE ${quoteTableName(this.tableName, this._adapterName)} (${columnDefs.join(", ")})`;
+    let sql = "CREATE";
+    if (this.temporary) sql += " TEMPORARY";
+    sql += " TABLE";
+    if (this.ifNotExists) sql += " IF NOT EXISTS";
+    sql += ` ${quoteTableName(this.tableName, this._adapterName)}`;
+
+    if (this.as) {
+      sql += ` AS ${this.as}`;
+    } else {
+      sql += ` (${columnDefs.join(", ")})`;
+    }
+
+    if (this.options) sql += ` ${this.options}`;
+
+    return sql;
   }
 }
 
@@ -845,7 +859,7 @@ export class Table {
     return this._require("removeReference").call(this._schema, this._tableName, name, options);
   }
 
-  async foreignKey(toTable: string, options?: Record<string, unknown>): Promise<void> {
+  async foreignKey(toTable: string, options?: Partial<AddForeignKeyOptions>): Promise<void> {
     return this._require("addForeignKey").call(this._schema, this._tableName, toTable, options);
   }
 
@@ -874,14 +888,21 @@ export class Table {
   }
 
   async removeCheckConstraint(
-    expressionOrOptions?: string | Record<string, unknown>,
-    options?: Record<string, unknown>,
+    expressionOrOptions?: string | { name?: string },
+    options?: { name?: string },
   ): Promise<void> {
-    const merged =
-      typeof expressionOrOptions === "string" && options
-        ? { ...options, expression: expressionOrOptions }
-        : expressionOrOptions;
-    return this._require("removeCheckConstraint").call(this._schema, this._tableName, merged);
+    if (typeof expressionOrOptions === "string") {
+      return this._require("removeCheckConstraint").call(
+        this._schema,
+        this._tableName,
+        options?.name ? options : expressionOrOptions,
+      );
+    }
+    return this._require("removeCheckConstraint").call(
+      this._schema,
+      this._tableName,
+      expressionOrOptions,
+    );
   }
 
   async isCheckConstraintExists(options?: Record<string, unknown>): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -460,13 +460,14 @@ export class TableDefinition {
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
   ): ForeignKeyDefinition {
+    const pk = options.primaryKey ?? "id";
+    const col = options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_${pk}`;
     return new ForeignKeyDefinition(
       this.tableName,
       toTable,
-      options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_id`,
-      options.primaryKey ?? "id",
-      options.name ??
-        `fk_${this.tableName}_${options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_id`}`,
+      col,
+      pk,
+      options.name ?? `fk_${this.tableName}_${col}`,
       options.onDelete,
       options.onUpdate,
     );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -144,6 +144,8 @@ export class IndexDefinition {
   readonly nullsNotDistinct?: boolean;
   readonly comment?: string;
   readonly valid: boolean;
+  readonly algorithm?: string;
+  readonly ifNotExists?: boolean;
 
   constructor(
     table: string,
@@ -158,6 +160,8 @@ export class IndexDefinition {
       type?: string;
       using?: string;
       include?: string[];
+      algorithm?: string;
+      ifNotExists?: boolean;
       nullsNotDistinct?: boolean;
       comment?: string;
       valid?: boolean;
@@ -177,6 +181,8 @@ export class IndexDefinition {
     this.nullsNotDistinct = options.nullsNotDistinct;
     this.comment = options.comment;
     this.valid = options.valid ?? true;
+    this.algorithm = options.algorithm;
+    this.ifNotExists = options.ifNotExists;
   }
 
   columnOptions(): {
@@ -607,6 +613,8 @@ export class TableDefinition {
         include: options.include,
         nullsNotDistinct: options.nullsNotDistinct,
         comment: options.comment,
+        algorithm: options.algorithm,
+        ifNotExists: options.ifNotExists,
       }),
     );
     return this;
@@ -724,14 +732,19 @@ export class TableDefinition {
     } else {
       const tableElements = [...columnDefs];
       for (const chk of this.checkConstraints) {
-        tableElements.push(
-          `CONSTRAINT ${quoteIdentifier(chk.name, this._adapterName)} CHECK (${chk.expression})`,
-        );
+        let chkSql = `CONSTRAINT ${quoteIdentifier(chk.name, this._adapterName)} CHECK (${chk.expression})`;
+        if (!chk.validate && this._adapterName === "postgres") {
+          chkSql += " NOT VALID";
+        }
+        tableElements.push(chkSql);
       }
       for (const fk of this.foreignKeys) {
-        tableElements.push(
-          `CONSTRAINT ${quoteIdentifier(fk.name, this._adapterName)} FOREIGN KEY (${quoteIdentifier(fk.column, this._adapterName)}) REFERENCES ${quoteTableName(fk.toTable, this._adapterName)} (${quoteIdentifier(fk.primaryKey, this._adapterName)})`,
-        );
+        let fkSql = `CONSTRAINT ${quoteIdentifier(fk.name, this._adapterName)} FOREIGN KEY (${quoteIdentifier(fk.column, this._adapterName)}) REFERENCES ${quoteTableName(fk.toTable, this._adapterName)} (${quoteIdentifier(fk.primaryKey, this._adapterName)})`;
+        if (fk.onDelete)
+          fkSql += ` ON DELETE ${fk.onDelete.toUpperCase().replace("NULLIFY", "SET NULL").replace("NO_ACTION", "NO ACTION")}`;
+        if (fk.onUpdate)
+          fkSql += ` ON UPDATE ${fk.onUpdate.toUpperCase().replace("NULLIFY", "SET NULL").replace("NO_ACTION", "NO ACTION")}`;
+        tableElements.push(fkSql);
       }
       sql += ` (${tableElements.join(", ")})`;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,4 +1,5 @@
 import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "./quoting.js";
+import { singularize } from "@blazetrails/activesupport";
 
 /**
  * Column type mapping.
@@ -389,10 +390,10 @@ export class TableDefinition {
   column(
     name: string,
     type: ColumnType,
-    options: ColumnOptions & { index?: boolean | Record<string, unknown> } = {},
+    options: Omit<ColumnOptions, "index"> & { index?: boolean | Record<string, unknown> } = {},
   ): this {
     const { index, ...colOpts } = options;
-    this.columns.push(new ColumnDefinition(name, type, colOpts));
+    this.columns.push(new ColumnDefinition(name, type, colOpts as ColumnOptions));
     if (index) {
       const indexOpts = typeof index === "object" ? index : {};
       this.index([name], indexOpts as { unique?: boolean; name?: string });
@@ -419,7 +420,7 @@ export class TableDefinition {
     return new ForeignKeyDefinition(
       this.tableName,
       toTable,
-      options.column ?? `${toTable.replace(/s$/, "")}_id`,
+      options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_id`,
       options.primaryKey ?? "id",
       options.name ?? `fk_${this.tableName}_${toTable}`,
       options.onDelete,
@@ -744,10 +745,10 @@ export class Table {
   async column(
     columnName: string,
     type: ColumnType,
-    options: ColumnOptions & { index?: boolean | Record<string, unknown> } = {},
+    options: Omit<ColumnOptions, "index"> & { index?: boolean | Record<string, unknown> } = {},
   ): Promise<void> {
     const { index: indexOpt, ...colOpts } = options;
-    await this._schema.addColumn(this._tableName, columnName, type, colOpts);
+    await this._schema.addColumn(this._tableName, columnName, type, colOpts as ColumnOptions);
     if (indexOpt) {
       const opts = typeof indexOpt === "object" ? indexOpt : {};
       await this._schema.addIndex(this._tableName, columnName, opts);
@@ -758,69 +759,109 @@ export class Table {
     return this._schema.columnExists!(this._tableName, columnName, type);
   }
 
+  private _require<K extends keyof SchemaStatementsLike>(
+    method: K,
+  ): NonNullable<SchemaStatementsLike[K]> {
+    const fn = this._schema[method];
+    if (!fn) throw new Error(`${method} is not supported by the current schema backend`);
+    return fn as NonNullable<SchemaStatementsLike[K]>;
+  }
+
   async isIndexExists(
     columnName: string | string[],
     options?: Record<string, unknown>,
   ): Promise<boolean> {
-    return this._schema.indexExists!(this._tableName, columnName, options);
+    return this._require("indexExists").call(this._schema, this._tableName, columnName, options);
   }
 
   async renameIndex(oldName: string, newName: string): Promise<void> {
-    return this._schema.renameIndex!(this._tableName, oldName, newName);
+    return this._require("renameIndex").call(this._schema, this._tableName, oldName, newName);
   }
 
   async change(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {
-    return this._schema.changeColumn!(this._tableName, columnName, type, options);
+    return this._require("changeColumn").call(
+      this._schema,
+      this._tableName,
+      columnName,
+      type,
+      options,
+    );
   }
 
   async changeDefault(columnName: string, defaultOrChanges: unknown): Promise<void> {
-    return this._schema.changeColumnDefault!(this._tableName, columnName, defaultOrChanges);
+    return this._require("changeColumnDefault").call(
+      this._schema,
+      this._tableName,
+      columnName,
+      defaultOrChanges,
+    );
   }
 
   async changeNull(columnName: string, isNull: boolean, defaultValue?: unknown): Promise<void> {
-    return this._schema.changeColumnNull!(this._tableName, columnName, isNull, defaultValue);
+    return this._require("changeColumnNull").call(
+      this._schema,
+      this._tableName,
+      columnName,
+      isNull,
+      defaultValue,
+    );
   }
 
   async removeTimestamps(options?: ColumnOptions): Promise<void> {
-    return this._schema.removeTimestamps!(this._tableName, options);
+    return this._require("removeTimestamps").call(this._schema, this._tableName, options);
   }
 
   async removeReferences(name: string, options?: Record<string, unknown>): Promise<void> {
-    return this._schema.removeReference!(this._tableName, name, options);
+    return this._require("removeReference").call(this._schema, this._tableName, name, options);
   }
 
   async foreignKey(toTable: string, options?: Record<string, unknown>): Promise<void> {
-    return this._schema.addForeignKey!(this._tableName, toTable, options);
+    return this._require("addForeignKey").call(this._schema, this._tableName, toTable, options);
   }
 
   async removeForeignKey(
     toTableOrOptions?: string | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    return this._schema.removeForeignKey!(this._tableName, toTableOrOptions, options);
+    return this._require("removeForeignKey").call(
+      this._schema,
+      this._tableName,
+      toTableOrOptions,
+      options,
+    );
   }
 
   async isForeignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
-    return this._schema.foreignKeyExists!(this._tableName, toTableOrOptions);
+    return this._require("foreignKeyExists").call(this._schema, this._tableName, toTableOrOptions);
   }
 
   async checkConstraint(expression: string, options?: Record<string, unknown>): Promise<void> {
-    return this._schema.addCheckConstraint!(this._tableName, expression, options);
+    return this._require("addCheckConstraint").call(
+      this._schema,
+      this._tableName,
+      expression,
+      options,
+    );
   }
 
   async removeCheckConstraint(
     expressionOrOptions?: string | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    return this._schema.removeCheckConstraint!(this._tableName, expressionOrOptions, options);
+    return this._require("removeCheckConstraint").call(
+      this._schema,
+      this._tableName,
+      expressionOrOptions,
+      options,
+    );
   }
 
   async isCheckConstraintExists(options?: Record<string, unknown>): Promise<boolean> {
-    return this._schema.isCheckConstraintExists!(this._tableName, options);
+    return this._require("isCheckConstraintExists").call(this._schema, this._tableName, options);
   }
 
   async primaryKey(): Promise<string | null> {
-    return this._schema.primaryKey!(this._tableName);
+    return this._require("primaryKey").call(this._schema, this._tableName);
   }
 
   async add(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -103,6 +103,29 @@ export interface ColumnOptions {
   array?: boolean;
 }
 
+export interface AddIndexOptions {
+  unique?: boolean;
+  name?: string;
+  where?: string;
+  order?: Record<string, string>;
+  using?: string;
+  type?: string;
+  comment?: string;
+  ifNotExists?: boolean;
+  length?: Record<string, number>;
+  opclass?: Record<string, string>;
+  include?: string[];
+  nullsNotDistinct?: boolean;
+  algorithm?: string;
+}
+
+export interface AddReferenceOptions extends ColumnOptions {
+  polymorphic?: boolean;
+  foreignKey?: boolean;
+  type?: ColumnType;
+  index?: boolean;
+}
+
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::IndexDefinition
  */
@@ -391,13 +414,13 @@ export class TableDefinition {
   column(
     name: string,
     type: ColumnType,
-    options: Omit<ColumnOptions, "index"> & { index?: boolean | Record<string, unknown> } = {},
+    options: Omit<ColumnOptions, "index"> & { index?: boolean | AddIndexOptions } = {},
   ): this {
     const { index, ...colOpts } = options;
     this.columns.push(new ColumnDefinition(name, type, colOpts as ColumnOptions));
     if (index) {
-      const indexOpts = typeof index === "object" ? index : {};
-      this.index([name], indexOpts as { unique?: boolean; name?: string });
+      const indexOpts: { unique?: boolean; name?: string } = typeof index === "object" ? index : {};
+      this.index([name], indexOpts);
     }
     return this;
   }
@@ -732,16 +755,13 @@ export class Table {
   async rename(oldName: string, newName: string): Promise<void> {
     await this._schema.renameColumn(this._tableName, oldName, newName);
   }
-  async index(
-    columns: string | string[],
-    options?: { unique?: boolean; name?: string },
-  ): Promise<void> {
+  async index(columns: string | string[], options?: AddIndexOptions): Promise<void> {
     await this._schema.addIndex(this._tableName, columns, options);
   }
   async removeIndex(options: { column?: string | string[]; name?: string }): Promise<void> {
     await this._schema.removeIndex(this._tableName, options);
   }
-  async references(name: string, options?: Record<string, unknown>): Promise<void> {
+  async references(name: string, options?: AddReferenceOptions): Promise<void> {
     await this._schema.addReference(this._tableName, name, options);
   }
   async timestamps(options?: ColumnOptions): Promise<void> {
@@ -755,12 +775,12 @@ export class Table {
   async column(
     columnName: string,
     type: ColumnType,
-    options: Omit<ColumnOptions, "index"> & { index?: boolean | Record<string, unknown> } = {},
+    options: Omit<ColumnOptions, "index"> & { index?: boolean | AddIndexOptions } = {},
   ): Promise<void> {
     const { index: indexOpt, ...colOpts } = options;
     await this._schema.addColumn(this._tableName, columnName, type, colOpts as ColumnOptions);
     if (indexOpt) {
-      const opts = typeof indexOpt === "object" ? indexOpt : {};
+      const opts: AddIndexOptions = typeof indexOpt === "object" ? indexOpt : {};
       await this._schema.addIndex(this._tableName, columnName, opts);
     }
   }
@@ -821,7 +841,7 @@ export class Table {
     return this._require("removeTimestamps").call(this._schema, this._tableName, options);
   }
 
-  async removeReferences(name: string, options?: Record<string, unknown>): Promise<void> {
+  async removeReferences(name: string, options?: AddReferenceOptions): Promise<void> {
     return this._require("removeReference").call(this._schema, this._tableName, name, options);
   }
 
@@ -894,25 +914,13 @@ export interface SchemaStatementsLike {
     options?: { ifExists?: boolean },
   ): Promise<void>;
   renameColumn(tableName: string, oldName: string, newName: string): Promise<void>;
-  addIndex(
-    tableName: string,
-    columns: string | string[],
-    options?: Record<string, unknown>,
-  ): Promise<void>;
+  addIndex(tableName: string, columns: string | string[], options?: AddIndexOptions): Promise<void>;
   removeIndex(
     tableName: string,
     options?: { column?: string | string[]; name?: string },
   ): Promise<void>;
-  addReference(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void>;
-  removeReference(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void>;
+  addReference(tableName: string, refName: string, options?: AddReferenceOptions): Promise<void>;
+  removeReference(tableName: string, refName: string, options?: AddReferenceOptions): Promise<void>;
   addTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
   removeTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
   columnExists?(tableName: string, columnName: string, type?: ColumnType): Promise<boolean>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -154,6 +154,49 @@ export class IndexDefinition {
     this.comment = options.comment;
     this.valid = options.valid ?? true;
   }
+
+  columnOptions(): {
+    length: Record<string, number>;
+    order: Record<string, string>;
+    opclass: Record<string, string>;
+  } {
+    return {
+      length: this.lengths,
+      order: this.orders,
+      opclass: this.opclasses,
+    };
+  }
+
+  isDefinedFor(
+    columns?: string | string[],
+    options: {
+      name?: string;
+      unique?: boolean;
+      valid?: boolean;
+      include?: string[];
+      nullsNotDistinct?: boolean;
+    } = {},
+  ): boolean {
+    if (options.name && this.name !== options.name) return false;
+    if (options.unique !== undefined && this.unique !== options.unique) return false;
+    if (options.valid !== undefined && this.valid !== options.valid) return false;
+    if (options.include !== undefined) {
+      const a = (this.include ?? []).slice().sort();
+      const b = options.include.slice().sort();
+      if (a.length !== b.length || a.some((v, i) => v !== b[i])) return false;
+    }
+    if (
+      options.nullsNotDistinct !== undefined &&
+      this.nullsNotDistinct !== options.nullsNotDistinct
+    )
+      return false;
+    if (columns !== undefined) {
+      const cols = Array.isArray(columns) ? columns : [columns];
+      if (this.columns.length !== cols.length || this.columns.some((c, i) => c !== cols[i]))
+        return false;
+    }
+    return true;
+  }
 }
 
 /**
@@ -281,20 +324,136 @@ export class TableDefinition {
   readonly tableName: string;
   readonly columns: ColumnDefinition[] = [];
   readonly indexes: IndexDefinition[] = [];
+  readonly foreignKeys: ForeignKeyDefinition[] = [];
+  readonly checkConstraints: CheckConstraintDefinition[] = [];
+  readonly temporary: boolean;
+  readonly ifNotExists: boolean;
+  readonly as?: string;
+  readonly options?: string;
+  readonly comment?: string;
   private _id: boolean | PrimaryKeyType;
   private _adapterName: "sqlite" | "postgres" | "mysql";
 
   constructor(
     tableName: string,
-    options: { id?: boolean | PrimaryKeyType; adapterName?: "sqlite" | "postgres" | "mysql" } = {},
+    tdOptions: {
+      id?: boolean | PrimaryKeyType;
+      adapterName?: "sqlite" | "postgres" | "mysql";
+      temporary?: boolean;
+      ifNotExists?: boolean;
+      as?: string;
+      options?: string;
+      comment?: string;
+    } = {},
   ) {
     this.tableName = tableName;
-    this._adapterName = options.adapterName ?? "sqlite";
-    this._id = options.id ?? true;
+    this._adapterName = tdOptions.adapterName ?? "sqlite";
+    this._id = tdOptions.id ?? true;
+    this.temporary = tdOptions.temporary ?? false;
+    this.ifNotExists = tdOptions.ifNotExists ?? false;
+    this.as = tdOptions.as;
+    this.options = tdOptions.options;
+    this.comment = tdOptions.comment;
 
     if (this._id !== false) {
       const pkType = (typeof this._id === "string" ? this._id : "primary_key") as ColumnType;
       this.columns.push(new ColumnDefinition("id", pkType, { primaryKey: true }));
+    }
+  }
+
+  setPrimaryKey(
+    _tableName: string,
+    id: ColumnType | false,
+    primaryKey?: string,
+    _options: Record<string, unknown> = {},
+  ): void {
+    // Remove any existing PK columns
+    const existingPkIdx = this.columns.findIndex((c) => c.options.primaryKey);
+    if (existingPkIdx >= 0) this.columns.splice(existingPkIdx, 1);
+
+    if (id === false) return;
+
+    const pkName = primaryKey ?? "id";
+    const pkType = (typeof id === "string" ? id : "primary_key") as ColumnType;
+    this.columns.unshift(new ColumnDefinition(pkName, pkType, { primaryKey: true }));
+  }
+
+  primaryKeys(name?: string): string[] {
+    if (name) {
+      const col = this.columns.find((c) => c.name === name && c.options.primaryKey);
+      return col ? [col.name] : [];
+    }
+    return this.columns.filter((c) => c.options.primaryKey).map((c) => c.name);
+  }
+
+  column(
+    name: string,
+    type: ColumnType,
+    options: ColumnOptions & { index?: boolean | Record<string, unknown> } = {},
+  ): this {
+    const { index, ...colOpts } = options;
+    this.columns.push(new ColumnDefinition(name, type, colOpts));
+    if (index) {
+      const indexOpts = typeof index === "object" ? index : {};
+      this.index([name], indexOpts as { unique?: boolean; name?: string });
+    }
+    return this;
+  }
+
+  checkConstraint(expression: string, options: { name?: string; validate?: boolean } = {}): this {
+    this.checkConstraints.push(
+      new CheckConstraintDefinition(
+        this.tableName,
+        expression,
+        options.name ?? `chk_${this.tableName}_${expression.slice(0, 20)}`,
+        options.validate ?? true,
+      ),
+    );
+    return this;
+  }
+
+  newForeignKeyDefinition(
+    toTable: string,
+    options: Partial<AddForeignKeyOptions> = {},
+  ): ForeignKeyDefinition {
+    return new ForeignKeyDefinition(
+      this.tableName,
+      toTable,
+      options.column ?? `${toTable.replace(/s$/, "")}_id`,
+      options.primaryKey ?? "id",
+      options.name ?? `fk_${this.tableName}_${toTable}`,
+      options.onDelete,
+      options.onUpdate,
+    );
+  }
+
+  newCheckConstraintDefinition(
+    expression: string,
+    options: { name?: string; validate?: boolean } = {},
+  ): CheckConstraintDefinition {
+    return new CheckConstraintDefinition(
+      this.tableName,
+      expression,
+      options.name ?? `chk_${this.tableName}_${expression.slice(0, 20)}`,
+      options.validate ?? true,
+    );
+  }
+
+  static defineColumnMethods(...columnTypes: string[]): void {
+    // In Rails, this dynamically defines type-specific column methods.
+    // In TypeScript, these are defined statically on the class.
+    // This method exists for API parity — the column methods (string, text,
+    // integer, etc.) are already declared as instance methods above.
+    for (const type of columnTypes) {
+      if (!(type in TableDefinition.prototype)) {
+        (TableDefinition.prototype as any)[type] = function (
+          this: TableDefinition,
+          name: string,
+          options: ColumnOptions = {},
+        ) {
+          return this.column(name, type as ColumnType, options);
+        };
+      }
     }
   }
 
@@ -571,14 +730,101 @@ export class Table {
   async removeIndex(options: { column?: string | string[]; name?: string }): Promise<void> {
     await this._schema.removeIndex(this._tableName, options);
   }
-  async references(
-    name: string,
-    options?: ColumnOptions & { polymorphic?: boolean; foreignKey?: boolean },
-  ): Promise<void> {
+  async references(name: string, options?: Record<string, unknown>): Promise<void> {
     await this._schema.addReference(this._tableName, name, options);
   }
   async timestamps(options?: ColumnOptions): Promise<void> {
     await this._schema.addTimestamps(this._tableName, options);
+  }
+
+  get name(): string {
+    return this._tableName;
+  }
+
+  async column(
+    columnName: string,
+    type: ColumnType,
+    options: ColumnOptions & { index?: boolean | Record<string, unknown> } = {},
+  ): Promise<void> {
+    const { index: indexOpt, ...colOpts } = options;
+    await this._schema.addColumn(this._tableName, columnName, type, colOpts);
+    if (indexOpt) {
+      const opts = typeof indexOpt === "object" ? indexOpt : {};
+      await this._schema.addIndex(this._tableName, columnName, opts);
+    }
+  }
+
+  async isColumnExists(columnName: string, type?: ColumnType): Promise<boolean> {
+    return this._schema.columnExists!(this._tableName, columnName, type);
+  }
+
+  async isIndexExists(
+    columnName: string | string[],
+    options?: Record<string, unknown>,
+  ): Promise<boolean> {
+    return this._schema.indexExists!(this._tableName, columnName, options);
+  }
+
+  async renameIndex(oldName: string, newName: string): Promise<void> {
+    return this._schema.renameIndex!(this._tableName, oldName, newName);
+  }
+
+  async change(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {
+    return this._schema.changeColumn!(this._tableName, columnName, type, options);
+  }
+
+  async changeDefault(columnName: string, defaultOrChanges: unknown): Promise<void> {
+    return this._schema.changeColumnDefault!(this._tableName, columnName, defaultOrChanges);
+  }
+
+  async changeNull(columnName: string, isNull: boolean, defaultValue?: unknown): Promise<void> {
+    return this._schema.changeColumnNull!(this._tableName, columnName, isNull, defaultValue);
+  }
+
+  async removeTimestamps(options?: ColumnOptions): Promise<void> {
+    return this._schema.removeTimestamps!(this._tableName, options);
+  }
+
+  async removeReferences(name: string, options?: Record<string, unknown>): Promise<void> {
+    return this._schema.removeReference!(this._tableName, name, options);
+  }
+
+  async foreignKey(toTable: string, options?: Record<string, unknown>): Promise<void> {
+    return this._schema.addForeignKey!(this._tableName, toTable, options);
+  }
+
+  async removeForeignKey(
+    toTableOrOptions?: string | Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    return this._schema.removeForeignKey!(this._tableName, toTableOrOptions, options);
+  }
+
+  async isForeignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
+    return this._schema.foreignKeyExists!(this._tableName, toTableOrOptions);
+  }
+
+  async checkConstraint(expression: string, options?: Record<string, unknown>): Promise<void> {
+    return this._schema.addCheckConstraint!(this._tableName, expression, options);
+  }
+
+  async removeCheckConstraint(
+    expressionOrOptions?: string | Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<void> {
+    return this._schema.removeCheckConstraint!(this._tableName, expressionOrOptions, options);
+  }
+
+  async isCheckConstraintExists(options?: Record<string, unknown>): Promise<boolean> {
+    return this._schema.isCheckConstraintExists!(this._tableName, options);
+  }
+
+  async primaryKey(): Promise<string | null> {
+    return this._schema.primaryKey!(this._tableName);
+  }
+
+  async add(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {
+    return this._schema.addColumn(this._tableName, columnName, type, options);
   }
 }
 
@@ -602,7 +848,7 @@ export interface SchemaStatementsLike {
   addIndex(
     tableName: string,
     columns: string | string[],
-    options?: { unique?: boolean; name?: string },
+    options?: Record<string, unknown>,
   ): Promise<void>;
   removeIndex(
     tableName: string,
@@ -611,12 +857,63 @@ export interface SchemaStatementsLike {
   addReference(
     tableName: string,
     refName: string,
-    options?: ColumnOptions & {
-      polymorphic?: boolean;
-      foreignKey?: boolean;
-      type?: ColumnType;
-      index?: boolean;
-    },
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  removeReference(
+    tableName: string,
+    refName: string,
+    options?: Record<string, unknown>,
   ): Promise<void>;
   addTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
+  removeTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
+  columnExists?(tableName: string, columnName: string, type?: ColumnType): Promise<boolean>;
+  indexExists?(
+    tableName: string,
+    columnName: string | string[],
+    options?: Record<string, unknown>,
+  ): Promise<boolean>;
+  renameIndex?(tableName: string, oldName: string, newName: string): Promise<void>;
+  changeColumn?(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions,
+  ): Promise<void>;
+  changeColumnDefault?(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): Promise<void>;
+  changeColumnNull?(
+    tableName: string,
+    columnName: string,
+    isNull: boolean,
+    defaultValue?: unknown,
+  ): Promise<void>;
+  addForeignKey?(
+    tableName: string,
+    toTable: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  removeForeignKey?(
+    tableName: string,
+    toTableOrOptions?: string | Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  foreignKeyExists?(
+    tableName: string,
+    toTableOrOptions?: string | Record<string, unknown>,
+  ): Promise<boolean>;
+  addCheckConstraint?(
+    tableName: string,
+    expression: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  removeCheckConstraint?(
+    tableName: string,
+    expressionOrOptions?: string | Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  isCheckConstraintExists?(tableName: string, options?: Record<string, unknown>): Promise<boolean>;
+  primaryKey?(tableName: string): Promise<string | null>;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -451,6 +451,11 @@ export class TableDefinition {
     return `chk_${this.tableName}_${(hash >>> 0).toString(16).padStart(8, "0")}`;
   }
 
+  foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): this {
+    this.foreignKeys.push(this.newForeignKeyDefinition(toTable, options));
+    return this;
+  }
+
   newForeignKeyDefinition(
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
@@ -940,7 +945,9 @@ export class Table {
     );
   }
 
-  async isCheckConstraintExists(options?: Record<string, unknown>): Promise<boolean> {
+  async isCheckConstraintExists(
+    options: { name?: string; expression?: string } = {},
+  ): Promise<boolean> {
     return this._require("isCheckConstraintExists").call(this._schema, this._tableName, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -738,7 +738,8 @@ export class TableDefinition {
 
     if (this.options) sql += ` ${this.options}`;
     if (this.comment && this._adapterName === "mysql") {
-      sql += ` COMMENT ${quoteDefaultExpression(this.comment)}`;
+      const escaped = this.comment.replace(/'/g, "''");
+      sql += ` COMMENT '${escaped}'`;
     }
 
     return sql;
@@ -890,14 +891,9 @@ export class Table {
   }
 
   async removeForeignKey(
-    toTableOrOptions?: string | Record<string, unknown>,
-    options?: Record<string, unknown>,
+    toTableOrOptions?: string | { column?: string; name?: string },
   ): Promise<void> {
-    const merged =
-      typeof toTableOrOptions === "string" && options
-        ? { ...options, toTable: toTableOrOptions }
-        : toTableOrOptions;
-    return this._require("removeForeignKey").call(this._schema, this._tableName, merged);
+    return this._require("removeForeignKey").call(this._schema, this._tableName, toTableOrOptions);
   }
 
   async isForeignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -738,7 +738,10 @@ export class TableDefinition {
       const tableElements = [...columnDefs];
       for (const chk of this.checkConstraints) {
         let chkSql = `CONSTRAINT ${quoteIdentifier(chk.name, this._adapterName)} CHECK (${chk.expression})`;
-        if (!chk.validate && this._adapterName === "postgres") {
+        if (!chk.validate) {
+          if (this._adapterName !== "postgres") {
+            throw new Error("Check constraint validate: false is only supported on PostgreSQL");
+          }
           chkSql += " NOT VALID";
         }
         tableElements.push(chkSql);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -100,7 +100,19 @@ export class SchemaStatements {
     await this.adapter.executeMutation(td.toSql());
 
     for (const idx of td.indexes) {
-      await this.addIndex(name, idx.columns, { unique: idx.unique, name: idx.name });
+      await this.addIndex(name, idx.columns, {
+        unique: idx.unique,
+        name: idx.name,
+        where: idx.where,
+        order: idx.orders,
+        using: idx.using,
+        type: idx.type,
+        comment: idx.comment,
+        length: idx.lengths,
+        opclass: idx.opclasses,
+        include: idx.include,
+        nullsNotDistinct: idx.nullsNotDistinct,
+      });
     }
   }
 
@@ -156,6 +168,10 @@ export class SchemaStatements {
       type?: string;
       comment?: string;
       ifNotExists?: boolean;
+      length?: Record<string, number>;
+      opclass?: Record<string, string>;
+      include?: string[];
+      nullsNotDistinct?: boolean;
     } = {},
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -112,6 +112,8 @@ export class SchemaStatements {
         opclass: idx.opclasses,
         include: idx.include,
         nullsNotDistinct: idx.nullsNotDistinct,
+        algorithm: idx.algorithm,
+        ifNotExists: idx.ifNotExists,
       });
     }
   }
@@ -172,6 +174,7 @@ export class SchemaStatements {
       opclass?: Record<string, string>;
       include?: string[];
       nullsNotDistinct?: boolean;
+      algorithm?: string;
     } = {},
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
@@ -180,11 +183,19 @@ export class SchemaStatements {
     const indexDef = new IndexDefinition(tableName, indexName, options.unique ?? false, cols, {
       where: options.where,
       orders: options.order ?? {},
-      using: options.using as string | undefined,
-      type: options.type as string | undefined,
-      comment: options.comment as string | undefined,
+      lengths: options.length ?? {},
+      opclasses: options.opclass ?? {},
+      using: options.using,
+      type: options.type,
+      comment: options.comment,
+      include: options.include,
+      nullsNotDistinct: options.nullsNotDistinct,
     });
-    const createDef = new CreateIndexDefinition(indexDef, options.ifNotExists ?? false);
+    const createDef = new CreateIndexDefinition(
+      indexDef,
+      options.ifNotExists ?? false,
+      options.algorithm,
+    );
     await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -181,7 +181,7 @@ export class SchemaStatements {
     const createDef = new CreateIndexDefinition(
       indexDef,
       options.ifNotExists ?? false,
-      options.algorithm,
+      this.indexAlgorithm(options.algorithm),
     );
     await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
   }
@@ -362,8 +362,8 @@ export class SchemaStatements {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    const column = options.column ?? this.foreignKeyColumnFor(toTable, "id");
     const pk = options.primaryKey ?? "id";
+    const column = options.column ?? this.foreignKeyColumnFor(toTable, pk);
     const name = options.name ?? `fk_${fromTable}_${column}`;
     const fkDef = new ForeignKeyDefinition(
       fromTable,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -20,6 +20,7 @@ import {
   ForeignKeyDefinition,
   CheckConstraintDefinition,
   type AddForeignKeyOptions,
+  type AddIndexOptions,
   type ColumnType,
   type ColumnOptions,
 } from "./schema-definitions.js";
@@ -161,21 +162,7 @@ export class SchemaStatements {
   async addIndex(
     tableName: string,
     columns: string | string[],
-    options: {
-      unique?: boolean;
-      name?: string;
-      where?: string;
-      order?: Record<string, string>;
-      using?: string;
-      type?: string;
-      comment?: string;
-      ifNotExists?: boolean;
-      length?: Record<string, number>;
-      opclass?: Record<string, string>;
-      include?: string[];
-      nullsNotDistinct?: boolean;
-      algorithm?: string;
-    } = {},
+    options: AddIndexOptions = {},
   ): Promise<void> {
     const cols = Array.isArray(columns) ? columns : [columns];
     const indexName = options.name ?? this.indexName(tableName, { column: cols });
@@ -375,7 +362,7 @@ export class SchemaStatements {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    const column = options.column ?? `${toTable.replace(/s$/, "")}_id`;
+    const column = options.column ?? this.foreignKeyColumnFor(toTable, "id");
     const pk = options.primaryKey ?? "id";
     const name = options.name ?? `fk_${fromTable}_${column}`;
     const fkDef = new ForeignKeyDefinition(


### PR DESCRIPTION
## Summary

- Adds all 28 missing methods to `IndexDefinition`, `TableDefinition`, and `Table` matching the Rails `ConnectionAdapters::SchemaDefinitions` API
- Takes `connection_adapters/abstract/schema_definitions.rb` from **59% → 100%** in api:compare (68/68 methods)

## What changed

**IndexDefinition**: `columnOptions()` (returns length/order/opclass), `isDefinedFor()` (match by columns/name/unique/valid/include/nullsNotDistinct)

**TableDefinition**: `temporary`, `ifNotExists`, `as`, `options`, `comment` properties. `foreignKeys`/`checkConstraints` arrays. `setPrimaryKey`, `primaryKeys`, `column` (generic with index option), `checkConstraint`, `newForeignKeyDefinition`, `newCheckConstraintDefinition`, static `defineColumnMethods`

**Table**: `column`, `isColumnExists`, `isIndexExists`, `renameIndex`, `change`, `changeDefault`, `changeNull`, `removeTimestamps`, `removeReferences`, `foreignKey`, `removeForeignKey`, `isForeignKeyExists`, `checkConstraint`, `removeCheckConstraint`, `isCheckConstraintExists`, `primaryKey`, `add` — all delegating to SchemaStatementsLike

**SchemaStatementsLike**: expanded with all methods Table delegates to

## Test plan

- [x] All 7986 active activerecord tests pass (14 more than before)
- [x] api:compare shows 100% for `connection_adapters/abstract/schema_definitions.rb`
- [x] Build and typecheck pass