### PR TITLE
feat(activerecord): isolate connectedToStack and shardSwapping per async context

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./base.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
-import { connectedToStack, currentRole, currentShard, currentPreventingWrites } from "./core.js";
+import {
+  connectedToStack,
+  currentRole,
+  currentShard,
+  currentPreventingWrites,
+  withIsolatedConnectionState,
+} from "./core.js";
 
 function setupConnection() {
   const config = new HashConfig("test", "primary", {
@@ -190,5 +196,94 @@ describe("ConnectionHandlingTest", () => {
     expect(() => Base.connectionPool()).toThrow(/No database connection/);
     // Re-establish for other tests
     setupConnection();
+  });
+
+  it("connected_to stack is isolated per async context", async () => {
+    let innerRoleBeforeAwait: string | undefined;
+    let innerRoleAfterAwait: string | undefined;
+
+    await withIsolatedConnectionState(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        innerRoleBeforeAwait = currentRole.call(Base);
+        await Promise.resolve();
+        innerRoleAfterAwait = currentRole.call(Base);
+      });
+    });
+
+    const outerRole = currentRole.call(Base);
+
+    expect(innerRoleBeforeAwait).toBe("reading");
+    expect(innerRoleAfterAwait).toBe("reading");
+    expect(outerRole).toBe("writing");
+    expect(connectedToStack()).toHaveLength(0);
+  });
+
+  it("prohibit_shard_swapping is isolated per async context", async () => {
+    let resolveOverlap!: () => void;
+    const overlap = new Promise<void>((resolve) => {
+      resolveOverlap = resolve;
+    });
+    let prohibitedBeforeAwait: boolean | undefined;
+    let prohibitedAfterAwait: boolean | undefined;
+    let concurrentProhibited: boolean | undefined;
+
+    const prohibitedTask = withIsolatedConnectionState(async () => {
+      await Base.prohibitShardSwapping(async () => {
+        prohibitedBeforeAwait = Base.isShardSwappingProhibited();
+        await Promise.resolve();
+        prohibitedAfterAwait = Base.isShardSwappingProhibited();
+        await overlap;
+      });
+    });
+
+    const concurrentTask = withIsolatedConnectionState(async () => {
+      await Promise.resolve();
+      concurrentProhibited = Base.isShardSwappingProhibited();
+      resolveOverlap();
+    });
+
+    await Promise.all([prohibitedTask, concurrentTask]);
+
+    expect(prohibitedBeforeAwait).toBe(true);
+    expect(prohibitedAfterAwait).toBe(true);
+    expect(concurrentProhibited).toBe(false);
+    expect(Base.isShardSwappingProhibited()).toBe(false);
+  });
+
+  it("concurrent async contexts do not interfere", async () => {
+    let resolveTask1!: () => void;
+    const task1Gate = new Promise<void>((r) => {
+      resolveTask1 = r;
+    });
+    let resolveTask2!: () => void;
+    const task2Gate = new Promise<void>((r) => {
+      resolveTask2 = r;
+    });
+    const results: string[] = [];
+
+    const task1 = withIsolatedConnectionState(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        await Promise.resolve();
+        results.push(`task1: ${currentRole.call(Base)}`);
+        resolveTask2();
+        await task1Gate;
+      });
+    });
+
+    const task2 = withIsolatedConnectionState(async () => {
+      await task2Gate;
+      await Base.connectedTo({ role: "writing", shard: "shard_one" }, async () => {
+        await Promise.resolve();
+        results.push(`task2: ${currentRole.call(Base)}`);
+        resolveTask1();
+      });
+    });
+
+    await Promise.all([task1, task2]);
+
+    expect(results).toContain("task1: reading");
+    expect(results).toContain("task2: writing");
+    expect(currentRole.call(Base)).toBe("writing");
+    expect(connectedToStack()).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -16,6 +16,8 @@ import {
   currentRole as coreCurrentRole,
   currentShard as coreCurrentShard,
 } from "./core.js";
+import { getAsyncContext } from "@blazetrails/activesupport";
+import type { AsyncContext } from "@blazetrails/activesupport";
 
 /**
  * Connection establishment and management for ActiveRecord models.
@@ -23,7 +25,17 @@ import {
  * Mirrors: ActiveRecord::ConnectionHandling
  */
 
-let _shardSwappingProhibited = false;
+let _prohibitContext: AsyncContext<boolean> | null = null;
+let _prohibitContextAdapter: ReturnType<typeof getAsyncContext> | null = null;
+
+function getProhibitContext(): AsyncContext<boolean> {
+  const adapter = getAsyncContext();
+  if (!_prohibitContext || _prohibitContextAdapter !== adapter) {
+    _prohibitContextAdapter = adapter;
+    _prohibitContext = adapter.create<boolean>();
+  }
+  return _prohibitContext;
+}
 
 // --- ConnectionHandling module methods (mixed into Base as static methods) ---
 
@@ -174,24 +186,11 @@ export function whilePreventingWrites<T>(this: typeof Base, fn: () => T, enabled
 }
 
 export function prohibitShardSwapping<T>(fn: () => T, enabled = true): T {
-  const prev = _shardSwappingProhibited;
-  _shardSwappingProhibited = enabled;
-
-  let result: T;
-  try {
-    result = fn();
-  } catch (error) {
-    _shardSwappingProhibited = prev;
-    throw error;
-  }
-
-  return withCleanup(result, () => {
-    _shardSwappingProhibited = prev;
-  });
+  return getProhibitContext().run(enabled, fn);
 }
 
 export function isShardSwappingProhibited(): boolean {
-  return _shardSwappingProhibited;
+  return getProhibitContext().getStore() ?? false;
 }
 
 export function clearQueryCachesForCurrentThread(this: typeof Base): void {
@@ -355,7 +354,7 @@ function appendToConnectedToStack(entry: {
   preventWrites?: boolean;
   klasses: Set<any>;
 }): void {
-  if (_shardSwappingProhibited && entry.shard) {
+  if (isShardSwappingProhibited() && entry.shard) {
     // Check if the shard would actually change
     for (const klass of entry.klasses) {
       const current = coreCurrentShard.call(klass);

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -4,7 +4,8 @@
  * Mirrors: ActiveRecord::Core
  */
 
-import { Notifications, ParameterFilter } from "@blazetrails/activesupport";
+import { Notifications, ParameterFilter, getAsyncContext } from "@blazetrails/activesupport";
+import type { AsyncContext } from "@blazetrails/activesupport";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 
 /**
@@ -217,19 +218,41 @@ export function isApplicationRecordClass(this: CoreHost): boolean {
 }
 
 // Rails uses ActiveSupport::IsolatedExecutionState for per-fiber/thread
-// storage. This is currently process-global; AsyncLocalStorage isolation
-// is a future improvement.
-type ConnectedToEntry = {
+// storage. We use AsyncLocalStorage for per-context isolation when a
+// store has been established via withIsolatedConnectionState(). Callers
+// outside that wrapper fall back to a process-global stack, so
+// per-request isolation requires wrapping the request handler.
+export type ConnectedToEntry = {
   role?: string;
   shard?: string;
   klasses: Set<any>;
   preventWrites?: boolean;
 };
 
-const _connectedToStack: ConnectedToEntry[] = [];
+const _fallbackStack: ConnectedToEntry[] = [];
+let _stackContext: AsyncContext<ConnectedToEntry[]> | null = null;
+let _stackContextAdapter: ReturnType<typeof getAsyncContext> | null = null;
+
+function getStackContext(): AsyncContext<ConnectedToEntry[]> {
+  const adapter = getAsyncContext();
+  if (!_stackContext || _stackContextAdapter !== adapter) {
+    _stackContextAdapter = adapter;
+    _stackContext = adapter.create<ConnectedToEntry[]>();
+  }
+  return _stackContext;
+}
 
 export function connectedToStack(): ConnectedToEntry[] {
-  return _connectedToStack;
+  return getStackContext().getStore() ?? _fallbackStack;
+}
+
+/**
+ * Run a callback with an isolated connected-to stack.
+ * Nested connectedTo/connectedToMany calls inside will not affect
+ * the outer context's stack.
+ */
+export function withIsolatedConnectionState<T>(fn: () => T): T {
+  return getStackContext().run([], fn);
 }
 
 function klassesInclude(klasses: Set<any>, target: any): boolean {
@@ -246,8 +269,9 @@ function matchesStack(entry: ConnectedToEntry, connClass: CoreHost): boolean {
 
 export function currentRole(this: CoreHost): string {
   const connClass = connectionClassForSelf.call(this);
-  for (let i = _connectedToStack.length - 1; i >= 0; i--) {
-    const entry = _connectedToStack[i];
+  const stack = connectedToStack();
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const entry = stack[i];
     if (entry.role && matchesStack(entry, connClass)) {
       return entry.role;
     }
@@ -257,8 +281,9 @@ export function currentRole(this: CoreHost): string {
 
 export function currentShard(this: CoreHost): string {
   const connClass = connectionClassForSelf.call(this);
-  for (let i = _connectedToStack.length - 1; i >= 0; i--) {
-    const entry = _connectedToStack[i];
+  const stack = connectedToStack();
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const entry = stack[i];
     if (entry.shard && matchesStack(entry, connClass)) {
       return entry.shard;
     }
@@ -268,8 +293,9 @@ export function currentShard(this: CoreHost): string {
 
 export function currentPreventingWrites(this: CoreHost): boolean {
   const connClass = connectionClassForSelf.call(this);
-  for (let i = _connectedToStack.length - 1; i >= 0; i--) {
-    const entry = _connectedToStack[i];
+  const stack = connectedToStack();
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const entry = stack[i];
     if (entry.preventWrites !== undefined && matchesStack(entry, connClass)) {
       return entry.preventWrites;
     }
@@ -278,8 +304,9 @@ export function currentPreventingWrites(this: CoreHost): boolean {
 }
 
 export function isPreventingWrites(this: CoreHost, className?: string): boolean {
-  for (let i = _connectedToStack.length - 1; i >= 0; i--) {
-    const entry = _connectedToStack[i];
+  const stack = connectedToStack();
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const entry = stack[i];
     if (entry.preventWrites === undefined) continue;
     if (klassesInclude(entry.klasses, "Base")) return entry.preventWrites;
     if (className) {


### PR DESCRIPTION
## Summary

Fixes the A- from PR #486 — `connectedToStack` and `_shardSwappingProhibited` were process-global, causing cross-request leakage in concurrent async scenarios.

**Changes:**

- `connectedToStack()` now reads from `AsyncLocalStorage` via `getAsyncContext().create<ConnectedToEntry[]>()`. Each async context gets its own stack. Falls back to a module-level array when running outside `AsyncLocalStorage` (backward compat).

- `_shardSwappingProhibited` replaced with `AsyncContext<boolean>`. `prohibitShardSwapping(fn)` uses `context.run(enabled, fn)` — inherently async-safe, no manual set/restore needed.

- Added `withIsolatedConnectionState(fn)` — runs a callback with a fresh, isolated connection stack. Use in request handlers to prevent cross-request role/shard/preventWrites leakage.

**Tests:**
- Stack isolation across async contexts
- Shard prohibition isolation across async contexts
- Concurrent async contexts don't interfere (`Promise.all` with different roles)

## Test plan

- [x] 25 connection-handling tests passing (3 new isolation tests)
- [x] Full activerecord suite passes (8011 tests)