### PR TITLE
feat(activerecord): implement Result class matching Rails API

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -1,3 +1,5 @@
+import type { Result } from "./result.js";
+
 /**
  * Database adapter interface — pluggable backends.
  *
@@ -67,11 +69,7 @@ export interface DatabaseAdapter {
   // Mirrors ActiveRecord::ConnectionAdapters::DatabaseStatements.
   // Default implementations delegate to execute()/executeMutation().
 
-  selectAll(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]>;
+  selectAll(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   selectOne(
     sql: string,
     name?: string | null,
@@ -80,11 +78,7 @@ export interface DatabaseAdapter {
   selectValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   selectValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   selectRows(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
-  execQuery(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]>;
+  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   execInsert(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2531,9 +2531,10 @@ export class Base extends Model {
   async reload(): Promise<this> {
     const ctor = this.constructor as typeof Base;
     const sm = ctor.arelTable.project(arelStar).where(ctor._buildPkWhereNode(this.id));
-    const rows = await ctor.adapter.selectAll(sm.toSql(), "Reload");
+    const result = await ctor.adapter.selectAll(sm.toSql(), "Reload");
+    const row = result.first();
 
-    if (rows.length === 0) {
+    if (row === undefined) {
       throw new RecordNotFound(
         `${ctor.name} with ${ctor.primaryKey}=${this.id} not found`,
         ctor.name,
@@ -2542,7 +2543,7 @@ export class Base extends Model {
       );
     }
 
-    for (const [key, value] of Object.entries(rows[0])) {
+    for (const [key, value] of Object.entries(row)) {
       this._attributes.set(key, value);
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -8,6 +8,7 @@ import { sql as arelSql, Nodes } from "@blazetrails/arel";
 import { TransactionIsolationError } from "../../errors.js";
 import { quote, quoteTableName, quoteColumnName } from "./quoting.js";
 import { TransactionManager } from "./transaction.js";
+import { Result } from "../../result.js";
 
 /**
  * Host interface for DatabaseStatements mixin methods that need adapter context.
@@ -22,7 +23,7 @@ export interface DatabaseStatementsHost {
   ): Promise<Record<string, unknown>[]>;
   internalExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
   rawExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
-  castResult?(rawResult: unknown): { rows: unknown[][] };
+  castResult?(rawResult: unknown): Result;
   affectedRows?(rawResult: unknown): number;
   isWriteQuery?(sql: string): boolean;
   currentTransaction?(): {
@@ -237,7 +238,7 @@ export async function query(
   binds?: unknown[],
 ): Promise<unknown[][]> {
   const result = await internalExecQuery.call(this, sql, name ?? "SQL", binds);
-  return (result as any).rows ?? [];
+  return result.rows;
 }
 
 /**
@@ -269,7 +270,7 @@ export function execQuery(
   sql: string,
   name: string = "SQL",
   binds: unknown[] = [],
-): Promise<unknown> {
+): Promise<Result> {
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name, binds);
 }
 
@@ -283,7 +284,7 @@ export function execInsert(
   sql: string,
   name?: string | null,
   binds: unknown[] = [],
-): Promise<unknown> {
+): Promise<Result> {
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name ?? "SQL", binds);
 }
 
@@ -342,7 +343,7 @@ export function execInsertAll(
   this: DatabaseStatementsHost | void,
   sql: string,
   name: string = "SQL",
-): Promise<unknown> {
+): Promise<Result> {
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name);
 }
 
@@ -897,7 +898,7 @@ export async function rawExecQuery(
   sql: string,
   name?: string | null,
   binds?: unknown[],
-): Promise<unknown> {
+): Promise<Result> {
   if (!this.rawExecute) {
     throw new Error("rawExecQuery requires rawExecute on the adapter");
   }
@@ -906,7 +907,7 @@ export async function rawExecQuery(
   const tm = (this as any)._transactionManager as TransactionManager | undefined;
   if (tm) await tm.materializeTransactions();
   const rawResult = await this.rawExecute(sql, name ?? "SQL", binds);
-  return this.castResult ? this.castResult(rawResult) : rawResult;
+  return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
 }
 
 /**
@@ -920,13 +921,13 @@ export async function internalExecQuery(
   sql: string,
   name?: string | null,
   binds?: unknown[],
-): Promise<unknown> {
+): Promise<Result> {
   // Materialize lazy transactions before executing SQL
   const tm = (this as any)._transactionManager as TransactionManager | undefined;
   if (tm) await tm.materializeTransactions();
   if (this?.internalExecute) {
     const rawResult = await this.internalExecute(sql, name ?? "SQL", binds);
-    return this.castResult ? this.castResult(rawResult) : rawResult;
+    return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
   }
   if (binds && binds.length > 0) {
     throw new Error(
@@ -941,27 +942,35 @@ export async function internalExecQuery(
 
 // --- Private helpers ---
 
-function normalizeResult(result: unknown): { rows: unknown[][] } {
+function normalizeResult(result: unknown): Result {
+  if (result instanceof Result) return result;
   if (
     typeof result === "object" &&
     result !== null &&
     "rows" in result &&
     Array.isArray((result as any).rows)
   ) {
-    return result as { rows: unknown[][] };
+    const r = result as { rows: unknown[][]; columns?: string[] };
+    return new Result(r.columns ?? [], r.rows);
   }
   if (Array.isArray(result)) {
-    return {
-      rows: result.map((row) =>
-        Array.isArray(row)
-          ? row
-          : typeof row === "object" && row !== null
-            ? Object.values(row)
-            : [row],
-      ),
-    };
+    const rows = result.map((row) =>
+      Array.isArray(row)
+        ? row
+        : typeof row === "object" && row !== null
+          ? Object.values(row)
+          : [row],
+    );
+    const columns =
+      result.length > 0 &&
+      typeof result[0] === "object" &&
+      result[0] !== null &&
+      !Array.isArray(result[0])
+        ? Object.keys(result[0] as Record<string, unknown>)
+        : [];
+    return new Result(columns, rows);
   }
-  return { rows: [] };
+  return new Result([], []);
 }
 
 function singleValueFromRows(rows: unknown[][]): unknown {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -376,7 +376,11 @@ export async function insert(
   const host = this as DatabaseStatementsHost;
   const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
   const result = await execInsert.call(this, sql, name, resolvedBinds);
-  return idValue ?? host?.lastInsertedId?.(result);
+  if (idValue !== undefined && idValue !== null) return idValue;
+  if (!host?.lastInsertedId) {
+    throw new Error("adapter must implement lastInsertedId(result) to use insert()");
+  }
+  return host.lastInsertedId(result);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -25,6 +25,7 @@ export interface DatabaseStatementsHost {
   rawExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
   castResult?(rawResult: unknown): Result;
   affectedRows?(rawResult: unknown): number;
+  lastInsertedId?(result: Result): unknown;
   isWriteQuery?(sql: string): boolean;
   currentTransaction?(): {
     open: boolean;
@@ -372,9 +373,10 @@ export async function insert(
   _sequenceName?: string | null,
   binds: unknown[] = [],
 ): Promise<unknown> {
+  const host = this as DatabaseStatementsHost;
   const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
-  const value = await execInsert.call(this, sql, name, resolvedBinds);
-  return idValue ?? value;
+  const result = await execInsert.call(this, sql, name, resolvedBinds);
+  return idValue ?? host?.lastInsertedId?.(result);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -16,11 +16,7 @@ import { Result } from "../../result.js";
 export interface DatabaseStatementsHost {
   preparedStatements?: boolean;
   execute?(sql: string, name?: string | null): Promise<unknown>;
-  selectAll?(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]>;
+  selectAll?(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   internalExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
   rawExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
   castResult?(rawResult: unknown): Result;
@@ -133,11 +129,7 @@ export function cacheableQuery(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_all
  */
-export function selectAll(
-  sql: string,
-  _name?: string | null,
-  _binds?: unknown[],
-): Promise<Record<string, unknown>[]> {
+export function selectAll(sql: string, _name?: string | null, _binds?: unknown[]): Promise<Result> {
   throw new Error("selectAll must be implemented by adapter subclass");
 }
 
@@ -146,14 +138,15 @@ export function selectAll(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_one
  */
-export function selectOne(
+export async function selectOne(
   this: DatabaseStatementsHost | void,
   sql: string,
   name?: string | null,
   binds?: unknown[],
 ): Promise<Record<string, unknown> | undefined> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  return doSelect(sql, name, binds).then((rows) => rows[0]);
+  const result = await doSelect(sql, name, binds);
+  return result.first();
 }
 
 /**
@@ -189,14 +182,15 @@ export function selectValues(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_rows
  */
-export function selectRows(
+export async function selectRows(
   this: DatabaseStatementsHost | void,
   sql: string,
   name?: string | null,
   binds?: unknown[],
 ): Promise<unknown[][]> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  return doSelect(sql, name, binds).then((rows) => rows.map((row) => Object.values(row)));
+  const result = await doSelect(sql, name, binds);
+  return result.rows;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -956,21 +956,14 @@ function normalizeResult(result: unknown): Result {
     return new Result(r.columns ?? [], r.rows);
   }
   if (Array.isArray(result)) {
-    const rows = result.map((row) =>
-      Array.isArray(row)
-        ? row
-        : typeof row === "object" && row !== null
-          ? Object.values(row)
-          : [row],
-    );
-    const columns =
-      result.length > 0 &&
-      typeof result[0] === "object" &&
-      result[0] !== null &&
-      !Array.isArray(result[0])
-        ? Object.keys(result[0] as Record<string, unknown>)
-        : [];
-    return new Result(columns, rows);
+    if (result.length === 0) return new Result([], []);
+    const first = result[0];
+    const isHashRow = typeof first === "object" && first !== null && !Array.isArray(first);
+    if (isHashRow) {
+      return Result.fromRowHashes(result as Record<string, unknown>[]);
+    }
+    const rows = result.map((row) => (Array.isArray(row) ? row : [row]));
+    return new Result([], rows);
   }
   return new Result([], []);
 }

--- a/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
+++ b/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
@@ -8,6 +8,7 @@
  */
 
 import { isWriteQuerySql } from "./sql-classification.js";
+import { Result } from "../result.js";
 
 /**
  * Minimum interface required by the mixin — the base class must provide
@@ -31,12 +32,9 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 
 export function DatabaseStatementsMixin<T extends Constructor<any>>(Base: T) {
   return class extends Base {
-    async selectAll(
-      sql: string,
-      _name?: string | null,
-      binds?: unknown[],
-    ): Promise<Record<string, unknown>[]> {
-      return (this as unknown as ExecutionMethods).execute(sql, binds);
+    async selectAll(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+      const rows = await (this as unknown as ExecutionMethods).execute(sql, binds);
+      return Result.fromRowHashes(rows);
     }
 
     async selectOne(
@@ -70,12 +68,9 @@ export function DatabaseStatementsMixin<T extends Constructor<any>>(Base: T) {
       return rows.map((row) => keys.map((key) => row[key]));
     }
 
-    async execQuery(
-      sql: string,
-      _name?: string | null,
-      binds?: unknown[],
-    ): Promise<Record<string, unknown>[]> {
-      return (this as unknown as ExecutionMethods).execute(sql, binds);
+    async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+      const rows = await (this as unknown as ExecutionMethods).execute(sql, binds);
+      return Result.fromRowHashes(rows);
     }
 
     async execInsert(sql: string, _name?: string | null, binds?: unknown[]): Promise<number> {

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -4,12 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements (module)
  */
 
+import type { Result } from "../../result.js";
+
 export interface DatabaseStatements {
-  execQuery(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]>;
+  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,12 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
+import type { Result } from "../../result.js";
+
 export interface DatabaseStatements {
-  execQuery(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]>;
+  execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execInsert(

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -4,8 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements
  */
 
+import type { Result } from "../../result.js";
+
 export interface DatabaseStatements {
-  execQuery(sql: string, name?: string | null): Promise<Record<string, unknown>[]>;
+  execQuery(sql: string, name?: string | null): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -10,6 +10,7 @@ import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { Result } from "./result.js";
 
 function makePool(size: number = 5): ConnectionPool {
   const dbConfig = new HashConfig("test", "primary", {
@@ -43,7 +44,7 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   async releaseSavepoint(_name: string): Promise<void> {}
   async rollbackToSavepoint(_name: string): Promise<void> {}
   async selectAll(sql: string, _n?: string | null, b?: unknown[]) {
-    return this.execute(sql, b);
+    return Result.fromRowHashes(await this.execute(sql, b));
   }
   async selectOne(sql: string, _n?: string | null, b?: unknown[]) {
     return (await this.execute(sql, b))[0];
@@ -58,7 +59,7 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
     return [];
   }
   async execQuery(sql: string, _n?: string | null, b?: unknown[]) {
-    return this.execute(sql, b);
+    return Result.fromRowHashes(await this.execute(sql, b));
   }
   async execInsert(sql: string, _n?: string | null, b?: unknown[]) {
     return this.executeMutation(sql, b);

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -1,4 +1,6 @@
 export { Base } from "./base.js";
+export { Result, IndexedRow } from "./result.js";
+export type { ColumnType as ResultColumnType, ColumnTypes as ResultColumnTypes } from "./result.js";
 export * as Type from "./type.js";
 export { Relation, Range } from "./relation.js";
 export { QueryAttribute } from "./relation/query-attribute.js";

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -10,6 +10,7 @@
  */
 
 import type { DatabaseAdapter } from "./adapter.js";
+import { Result } from "./result.js";
 
 const DEFAULT_MAX_SIZE = 100;
 
@@ -264,12 +265,9 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   // Read methods go through this.execute() to leverage the query cache.
   // Write methods go through this.executeMutation() to clear the cache.
 
-  async selectAll(
-    sql: string,
-    _name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]> {
-    return this.execute(sql, binds);
+  async selectAll(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+    const rows = await this.execute(sql, binds);
+    return Result.fromRowHashes(rows);
   }
 
   async selectOne(
@@ -303,12 +301,9 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return rows.map((row) => keys.map((key) => row[key]));
   }
 
-  async execQuery(
-    sql: string,
-    _name?: string | null,
-    binds?: unknown[],
-  ): Promise<Record<string, unknown>[]> {
-    return this.execute(sql, binds);
+  async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+    const rows = await this.execute(sql, binds);
+    return Result.fromRowHashes(rows);
   }
 
   async execInsert(sql: string, _name?: string | null, binds?: unknown[]): Promise<number> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1446,8 +1446,8 @@ export class Relation<T extends Base> {
       await this._executeEagerLoad();
     } else {
       const sql = this._toSql();
-      const rows = await this._modelClass.adapter.selectAll(sql, "Load");
-      this._records = rows.map((row) => this._modelClass._instantiate(row) as T);
+      const result = await this._modelClass.adapter.selectAll(sql, "Load");
+      this._records = result.toArray().map((row) => this._modelClass._instantiate(row) as T);
     }
     this._loaded = true;
 
@@ -1481,8 +1481,8 @@ export class Relation<T extends Base> {
       !this._fromClause.isEmpty()
     ) {
       const sql = this._toSql();
-      const rows = await this._modelClass.adapter.selectAll(sql, "Eager Load");
-      this._records = rows.map((row) => this._modelClass._instantiate(row) as T);
+      const result = await this._modelClass.adapter.selectAll(sql, "Eager Load");
+      this._records = result.toArray().map((row) => this._modelClass._instantiate(row) as T);
       await this._preloadAssociationsForRecords(this._records, this._eagerLoadAssociations);
       return;
     }

--- a/packages/activerecord/src/result.test.ts
+++ b/packages/activerecord/src/result.test.ts
@@ -1,17 +1,167 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { Result, type ColumnTypes } from "./result.js";
+
+function buildResult(): Result {
+  return new Result(
+    ["col_1", "col_2"],
+    [
+      ["row 1 col 1", "row 1 col 2"],
+      ["row 2 col 1", "row 2 col 2"],
+      ["row 3 col 1", "row 3 col 2"],
+    ],
+  );
+}
+
+const integerType = {
+  deserialize(value: unknown): number {
+    return parseInt(String(value), 10);
+  },
+};
+
+const floatType = {
+  deserialize(value: unknown): number {
+    return parseFloat(String(value));
+  },
+};
 
 describe("ResultTest", () => {
-  it.skip("includes_column?", () => {});
-  it.skip("length", () => {});
-  it.skip("to_a returns row_hashes", () => {});
-  it.skip("first returns first row as a hash", () => {});
-  it.skip("last returns last row as a hash", () => {});
-  it.skip("each with block returns row hashes", () => {});
-  it.skip("each without block returns an enumerator", () => {});
-  it.skip("each without block returns a sized enumerator", () => {});
-  it.skip("cast_values returns rows after type casting", () => {});
-  it.skip("cast_values uses identity type for unknown types", () => {});
-  it.skip("cast_values returns single dimensional array if single column", () => {});
-  it.skip("cast_values can receive types to use instead", () => {});
-  it.skip("each when two columns have the same name", () => {});
+  it("includes_column?", () => {
+    const result = buildResult();
+    expect(result.includesColumn("col_1")).toBe(true);
+    expect(result.includesColumn("foo")).toBe(false);
+  });
+
+  it("length", () => {
+    expect(buildResult().length).toBe(3);
+  });
+
+  it("to_a returns row_hashes", () => {
+    expect(buildResult().toArray()).toEqual([
+      { col_1: "row 1 col 1", col_2: "row 1 col 2" },
+      { col_1: "row 2 col 1", col_2: "row 2 col 2" },
+      { col_1: "row 3 col 1", col_2: "row 3 col 2" },
+    ]);
+  });
+
+  it("first returns first row as a hash", () => {
+    const result = buildResult();
+    expect(result.first()).toEqual({ col_1: "row 1 col 1", col_2: "row 1 col 2" });
+    expect(result.first(1)).toEqual([{ col_1: "row 1 col 1", col_2: "row 1 col 2" }]);
+    expect(result.first(2)).toEqual([
+      { col_1: "row 1 col 1", col_2: "row 1 col 2" },
+      { col_1: "row 2 col 1", col_2: "row 2 col 2" },
+    ]);
+    expect(result.first(3)).toEqual([
+      { col_1: "row 1 col 1", col_2: "row 1 col 2" },
+      { col_1: "row 2 col 1", col_2: "row 2 col 2" },
+      { col_1: "row 3 col 1", col_2: "row 3 col 2" },
+    ]);
+  });
+
+  it("last returns last row as a hash", () => {
+    const result = buildResult();
+    expect(result.last()).toEqual({ col_1: "row 3 col 1", col_2: "row 3 col 2" });
+    expect(result.last(1)).toEqual([{ col_1: "row 3 col 1", col_2: "row 3 col 2" }]);
+    expect(result.last(2)).toEqual([
+      { col_1: "row 2 col 1", col_2: "row 2 col 2" },
+      { col_1: "row 3 col 1", col_2: "row 3 col 2" },
+    ]);
+    expect(result.last(3)).toEqual([
+      { col_1: "row 1 col 1", col_2: "row 1 col 2" },
+      { col_1: "row 2 col 1", col_2: "row 2 col 2" },
+      { col_1: "row 3 col 1", col_2: "row 3 col 2" },
+    ]);
+  });
+
+  it("each with block returns row hashes", () => {
+    buildResult().each((row) => {
+      expect(Object.keys(row)).toEqual(["col_1", "col_2"]);
+    });
+  });
+
+  it("each without block returns an enumerator", () => {
+    const iter = buildResult().each();
+    let index = 0;
+    for (const row of iter) {
+      expect(Object.keys(row)).toEqual(["col_1", "col_2"]);
+      expect(Number.isInteger(index)).toBe(true);
+      index++;
+    }
+    expect(index).toBe(3);
+  });
+
+  it("each without block returns a sized enumerator", () => {
+    expect(buildResult().each().size).toBe(3);
+  });
+
+  it("cast_values returns rows after type casting", () => {
+    const values = [
+      ["1.1", "2.2"],
+      ["3.3", "4.4"],
+    ];
+    const columns = ["col1", "col2"];
+    const types: ColumnTypes = { col1: integerType, col2: floatType };
+    const result = new Result(columns, values, types);
+
+    expect(result.castValues()).toEqual([
+      [1, 2.2],
+      [3, 4.4],
+    ]);
+  });
+
+  it("cast_values uses identity type for unknown types", () => {
+    const values = [
+      ["1.1", "2.2"],
+      ["3.3", "4.4"],
+    ];
+    const columns = ["col1", "col2"];
+    const types: ColumnTypes = { col1: integerType };
+    const result = new Result(columns, values, types);
+
+    expect(result.castValues()).toEqual([
+      [1, "2.2"],
+      [3, "4.4"],
+    ]);
+  });
+
+  it("cast_values returns single dimensional array if single column", () => {
+    const values = [["1.1"], ["3.3"]];
+    const columns = ["col1"];
+    const types: ColumnTypes = { col1: integerType };
+    const result = new Result(columns, values, types);
+
+    expect(result.castValues()).toEqual([1, 3]);
+  });
+
+  it("cast_values can receive types to use instead", () => {
+    const values = [
+      ["1.1", "2.2"],
+      ["3.3", "4.4"],
+    ];
+    const columns = ["col1", "col2"];
+    const types: ColumnTypes = { col1: integerType, col2: floatType };
+    const result = new Result(columns, values, types);
+
+    expect(result.castValues({ col1: floatType })).toEqual([
+      [1.1, 2.2],
+      [3.3, 4.4],
+    ]);
+  });
+
+  it("each when two columns have the same name", () => {
+    const result = new Result(
+      ["foo", "foo"],
+      [
+        ["col 1", "col 2"],
+        ["col 1", "col 2"],
+        ["col 1", "col 2"],
+      ],
+    );
+
+    expect(result.columns.length).toBe(2);
+    result.each((row) => {
+      expect(Object.keys(row).length).toBe(1);
+      expect(row["foo"]).toBe("col 2");
+    });
+  });
 });

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -33,13 +33,33 @@ export class IndexedRow {
     return Object.keys(this.#columnIndexes).length;
   }
 
+  get length(): number {
+    return this.size;
+  }
+
   keys(): string[] {
     return Object.keys(this.#columnIndexes);
+  }
+
+  eachKey(block: (key: string) => void): void {
+    for (const key of Object.keys(this.#columnIndexes)) block(key);
+  }
+
+  hasKey(column: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.#columnIndexes, column);
   }
 
   get(column: string): unknown {
     const i = this.#columnIndexes[column];
     return i === undefined ? undefined : this.#row[i];
+  }
+
+  fetch(column: string, fallback?: () => unknown): unknown {
+    if (Object.prototype.hasOwnProperty.call(this.#columnIndexes, column)) {
+      return this.#row[this.#columnIndexes[column]];
+    }
+    if (fallback) return fallback();
+    throw new Error(`key not found: "${column}"`);
   }
 
   toHash(): Record<string, unknown> {
@@ -48,6 +68,20 @@ export class IndexedRow {
       out[key] = this.#row[index];
     }
     return out;
+  }
+
+  equals(other: unknown): boolean {
+    if (other instanceof IndexedRow) {
+      return this.#row === other.#row && this.#columnIndexes === other.#columnIndexes;
+    }
+    if (other && typeof other === "object") {
+      const hash = this.toHash();
+      const otherObj = other as Record<string, unknown>;
+      const keys = Object.keys(hash);
+      if (keys.length !== Object.keys(otherObj).length) return false;
+      return keys.every((k) => hash[k] === otherObj[k]);
+    }
+    return false;
   }
 }
 
@@ -68,6 +102,22 @@ export class Result {
 
   static empty(): Result {
     return EMPTY;
+  }
+
+  /**
+   * Builds a Result from the row-hash shape returned by our driver-level
+   * `execute()` methods. Column order is taken from the keys of the first
+   * row; empty inputs produce an empty Result.
+   */
+  static fromRowHashes(rows: Record<string, unknown>[]): Result {
+    if (rows.length === 0) return new Result([], []);
+    const columns = Object.keys(rows[0]);
+    const rowArrays = rows.map((row) => columns.map((col) => row[col]));
+    return new Result(columns, rowArrays);
+  }
+
+  [Symbol.iterator](): IterableIterator<Record<string, unknown>> {
+    return this.#getHashRows()[Symbol.iterator]();
   }
 
   includesColumn(name: string): boolean {
@@ -101,6 +151,11 @@ export class Result {
 
   toArray(): Record<string, unknown>[] {
     return this.#getHashRows();
+  }
+
+  at(idx: number): Record<string, unknown> | undefined {
+    const rows = this.#getHashRows();
+    return idx < 0 ? rows[rows.length + idx] : rows[idx];
   }
 
   first(): Record<string, unknown> | undefined;

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -184,17 +184,16 @@ export class Result {
 
   castValues(typeOverrides: ColumnTypes | ColumnType[] = {}): unknown[] {
     const overridesArray = Array.isArray(typeOverrides) ? typeOverrides : null;
+    const overridesHash = overridesArray ? EMPTY_COLUMN_TYPES : (typeOverrides as ColumnTypes);
 
     if (this.columns.length === 1) {
-      const type = overridesArray
-        ? overridesArray[0]
-        : this.#columnType(this.columns[0], 0, typeOverrides as ColumnTypes);
+      const type = overridesArray?.[0] ?? this.#columnType(this.columns[0], 0, overridesHash);
       return this.rows.map((row) => type.deserialize(row[0]));
     }
 
-    const types = overridesArray
-      ? overridesArray
-      : this.columns.map((name, i) => this.#columnType(name, i, typeOverrides as ColumnTypes));
+    const types = this.columns.map(
+      (name, i) => overridesArray?.[i] ?? this.#columnType(name, i, overridesHash),
+    );
 
     return this.rows.map((row) => row.map((value, i) => types[i].deserialize(value)));
   }

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -218,10 +218,10 @@ export class Result {
 
   #getHashRows(): Record<string, unknown>[] {
     if (this.#hashRows) return this.#hashRows;
-    const idx = this.columnIndexes;
+    const entries = Object.entries(this.columnIndexes);
     this.#hashRows = this.rows.map((row) => {
       const obj: Record<string, unknown> = {};
-      for (const [key, i] of Object.entries(idx)) obj[key] = row[i];
+      for (const [key, i] of entries) obj[key] = row[i];
       return obj;
     });
     return this.#hashRows;

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -235,4 +235,6 @@ export class Result {
   }
 }
 
-const EMPTY = new Result([], [], EMPTY_COLUMN_TYPES);
+const EMPTY_COLUMNS = Object.freeze([]) as unknown as string[];
+const EMPTY_ROWS = Object.freeze([]) as unknown as unknown[][];
+const EMPTY = Object.freeze(new Result(EMPTY_COLUMNS, EMPTY_ROWS, EMPTY_COLUMN_TYPES)) as Result;

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -184,16 +184,17 @@ export class Result {
 
   castValues(typeOverrides: ColumnTypes | ColumnType[] = {}): unknown[] {
     const overridesArray = Array.isArray(typeOverrides) ? typeOverrides : null;
-    const overridesHash = overridesArray ? EMPTY_COLUMN_TYPES : (typeOverrides as ColumnTypes);
 
     if (this.columns.length === 1) {
-      const type = overridesArray?.[0] ?? this.#columnType(this.columns[0], 0, overridesHash);
+      const type = overridesArray
+        ? overridesArray[0]
+        : this.#columnType(this.columns[0], 0, typeOverrides as ColumnTypes);
       return this.rows.map((row) => type.deserialize(row[0]));
     }
 
-    const types = this.columns.map(
-      (name, i) => overridesArray?.[i] ?? this.#columnType(name, i, overridesHash),
-    );
+    const types = overridesArray
+      ? overridesArray
+      : this.columns.map((name, i) => this.#columnType(name, i, typeOverrides as ColumnTypes));
 
     return this.rows.map((row) => row.map((value, i) => types[i].deserialize(value)));
   }

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -1,0 +1,183 @@
+/**
+ * Encapsulates a result returned from a database adapter's execQuery.
+ *
+ * Mirrors: ActiveRecord::Result
+ */
+
+export type ColumnType = { deserialize(value: unknown): unknown };
+export type ColumnTypes = Record<string | number, ColumnType>;
+
+const EMPTY_COLUMN_TYPES: ColumnTypes = Object.freeze({}) as ColumnTypes;
+
+const IDENTITY_TYPE: ColumnType = {
+  deserialize(value: unknown) {
+    return value;
+  },
+};
+
+/**
+ * Read-only hash-like view over a single result row.
+ *
+ * Mirrors: ActiveRecord::Result::IndexedRow
+ */
+export class IndexedRow {
+  readonly #columnIndexes: Record<string, number>;
+  readonly #row: unknown[];
+
+  constructor(columnIndexes: Record<string, number>, row: unknown[]) {
+    this.#columnIndexes = columnIndexes;
+    this.#row = row;
+  }
+
+  get size(): number {
+    return Object.keys(this.#columnIndexes).length;
+  }
+
+  keys(): string[] {
+    return Object.keys(this.#columnIndexes);
+  }
+
+  get(column: string): unknown {
+    const i = this.#columnIndexes[column];
+    return i === undefined ? undefined : this.#row[i];
+  }
+
+  toHash(): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [key, index] of Object.entries(this.#columnIndexes)) {
+      out[key] = this.#row[index];
+    }
+    return out;
+  }
+}
+
+export class Result {
+  readonly columns: string[];
+  readonly rows: unknown[][];
+  readonly columnTypes: ColumnTypes;
+
+  #hashRows: Record<string, unknown>[] | null = null;
+  #columnIndexes: Record<string, number> | null = null;
+  #indexedRows: IndexedRow[] | null = null;
+
+  constructor(columns: string[], rows: unknown[][], columnTypes: ColumnTypes | null = null) {
+    this.columns = columns;
+    this.rows = rows;
+    this.columnTypes = columnTypes ?? EMPTY_COLUMN_TYPES;
+  }
+
+  static empty(): Result {
+    return EMPTY;
+  }
+
+  includesColumn(name: string): boolean {
+    return this.columns.includes(name);
+  }
+
+  get length(): number {
+    return this.rows.length;
+  }
+
+  isEmpty(): boolean {
+    return this.rows.length === 0;
+  }
+
+  each(block: (row: Record<string, unknown>) => void): void;
+  each(): IterableIterator<Record<string, unknown>> & { size: number };
+  each(
+    block?: (row: Record<string, unknown>) => void,
+  ): (IterableIterator<Record<string, unknown>> & { size: number }) | void {
+    const rows = this.#getHashRows();
+    if (block) {
+      for (const row of rows) block(row);
+      return;
+    }
+    const iter = rows[Symbol.iterator]() as unknown as IterableIterator<Record<string, unknown>> & {
+      size: number;
+    };
+    Object.defineProperty(iter, "size", { value: this.rows.length });
+    return iter;
+  }
+
+  toArray(): Record<string, unknown>[] {
+    return this.#getHashRows();
+  }
+
+  first(): Record<string, unknown> | undefined;
+  first(n: number): Record<string, unknown>[];
+  first(n?: number): Record<string, unknown> | Record<string, unknown>[] | undefined {
+    const rows = this.#getHashRows();
+    if (n === undefined) return rows[0];
+    return rows.slice(0, n);
+  }
+
+  last(): Record<string, unknown> | undefined;
+  last(n: number): Record<string, unknown>[];
+  last(n?: number): Record<string, unknown> | Record<string, unknown>[] | undefined {
+    const rows = this.#getHashRows();
+    if (n === undefined) return rows[rows.length - 1];
+    return n >= rows.length ? rows.slice() : rows.slice(rows.length - n);
+  }
+
+  result(): Result {
+    return this;
+  }
+
+  cancel(): Result {
+    return this;
+  }
+
+  castValues(typeOverrides: ColumnTypes | ColumnType[] = {}): unknown[] {
+    const overridesArray = Array.isArray(typeOverrides) ? typeOverrides : null;
+
+    if (this.columns.length === 1) {
+      const type = overridesArray
+        ? overridesArray[0]
+        : this.#columnType(this.columns[0], 0, typeOverrides as ColumnTypes);
+      return this.rows.map((row) => type.deserialize(row[0]));
+    }
+
+    const types = overridesArray
+      ? overridesArray
+      : this.columns.map((name, i) => this.#columnType(name, i, typeOverrides as ColumnTypes));
+
+    return this.rows.map((row) => row.map((value, i) => types[i].deserialize(value)));
+  }
+
+  get columnIndexes(): Record<string, number> {
+    if (this.#columnIndexes) return this.#columnIndexes;
+    const hash: Record<string, number> = {};
+    for (let i = 0; i < this.columns.length; i++) {
+      hash[this.columns[i]] = i;
+    }
+    this.#columnIndexes = hash;
+    return hash;
+  }
+
+  get indexedRows(): IndexedRow[] {
+    if (this.#indexedRows) return this.#indexedRows;
+    const idx = this.columnIndexes;
+    this.#indexedRows = this.rows.map((row) => new IndexedRow(idx, row));
+    return this.#indexedRows;
+  }
+
+  #getHashRows(): Record<string, unknown>[] {
+    if (this.#hashRows) return this.#hashRows;
+    const idx = this.columnIndexes;
+    this.#hashRows = this.rows.map((row) => {
+      const obj: Record<string, unknown> = {};
+      for (const [key, i] of Object.entries(idx)) obj[key] = row[i];
+      return obj;
+    });
+    return this.#hashRows;
+  }
+
+  #columnType(name: string, index: number, typeOverrides: ColumnTypes): ColumnType {
+    if (typeOverrides && name in typeOverrides) return typeOverrides[name];
+    if (index in this.columnTypes) return this.columnTypes[index as unknown as string];
+    if (name in this.columnTypes) return this.columnTypes[name];
+    return IDENTITY_TYPE;
+  }
+}
+
+const EMPTY = new Result([], [], EMPTY_COLUMN_TYPES);

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -72,7 +72,7 @@ export class IndexedRow {
 
   equals(other: unknown): boolean {
     if (other instanceof IndexedRow) {
-      return this.#row === other.#row && this.#columnIndexes === other.#columnIndexes;
+      return this === other;
     }
     if (other && typeof other === "object") {
       const hash = this.toHash();
@@ -163,6 +163,7 @@ export class Result {
   first(n?: number): Record<string, unknown> | Record<string, unknown>[] | undefined {
     const rows = this.#getHashRows();
     if (n === undefined) return rows[0];
+    if (n < 0) throw new Error("negative array size");
     return rows.slice(0, n);
   }
 
@@ -171,6 +172,7 @@ export class Result {
   last(n?: number): Record<string, unknown> | Record<string, unknown>[] | undefined {
     const rows = this.#getHashRows();
     if (n === undefined) return rows[rows.length - 1];
+    if (n < 0) throw new Error("negative array size");
     return n >= rows.length ? rows.slice() : rows.slice(rows.length - n);
   }
 


### PR DESCRIPTION
## Summary
- Ports `ActiveRecord::Result` with the full Rails public surface: `columns`, `rows`, `columnTypes`, `includesColumn`, `length`, `each` (block and sized iterator), `isEmpty`, `toArray`, `first`/`last` (optional `n`), `result`, `cancel`, `castValues` (per-column overrides + array form), `columnIndexes`, `indexedRows`, plus the `IndexedRow` inner class. Duplicate-column handling matches Rails (last-write-wins in `columnIndexes`).
- Integrates `Result` into the real query path: `DatabaseAdapter.selectAll` and `execQuery` now return `Result` (matching Rails). `DatabaseStatementsMixin` and `QueryCache` build `Result` via `Result.fromRowHashes` from the row-hash output of `execute()`. The per-adapter `DatabaseStatements` interfaces (mysql, postgresql, sqlite3) are updated to match.
- Three real call sites now consume `Result`: `Relation#toArray` (Load and Eager Load paths) and `Base#reload` (via `result.first()`, matching the Rails idiom).
- `Result` also gains `.at(idx)`, `Symbol.iterator`, and a `fromRowHashes` factory for constructing from driver output. `IndexedRow` is fleshed out with `fetch`, `hasKey`, `eachKey`, `equals`, `length` to match the Rails inner class more completely.
- `DatabaseStatements#insert` now extracts the inserted id via a new optional `host.lastInsertedId(result)` hook, matching Rails' `id_value || last_inserted_id(value)`. The abstract helper throws loudly if neither `idValue` nor `lastInsertedId` is available (matching Rails' NoMethodError).
- The shared `Result.empty()` singleton is frozen (instance + `columns`/`rows` arrays) so consumer mutation cannot leak across callers.
- All 13 Rails `ResultTest` cases ported verbatim and passing.

## Stats
- `result.rb`: **0/15 → 15/15 (100%)**
- activerecord overall: **75.6% → 76.1%**

## Out of scope / follow-ups
- The abstract `database-statements.ts` helpers (`internalExecQuery`, `rawExecQuery`, etc.) remain a parallel Rails-port that no production code calls. They've been updated to return `Result` for internal consistency, but wiring them to real adapters is preexisting tech debt unrelated to this PR.
- `columnTypes` is always empty on `Result` objects built from the driver — populating type metadata would require changing the `execute()` contract and is a broader refactor.
- Adding generic typing (`Result<Row>`) is a separate ergonomic improvement best done after typed attributes land on `Base`.

## Test plan
- [x] `pnpm test packages/activerecord/src/result.test.ts` — 13/13
- [x] `pnpm test packages/activerecord` — 8021 passing, no regressions
- [x] `pnpm -w build` — clean
- [x] `pnpm run api:compare --package activerecord` — result.rb 15/15