### PR TITLE
refactor(activerecord): use activesupport include/extend for Base mixins

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -61,6 +61,7 @@ import * as LockingPessimistic from "./locking/pessimistic.js";
 import * as Translation from "./translation.js";
 import { sanitizeSqlArray, sanitizeSqlLike } from "./sanitization.js";
 import * as Querying from "./querying.js";
+import { include, extend } from "@blazetrails/activesupport";
 import {
   hasAttribute as _hasAttribute,
   attributePresent as _attributePresent,
@@ -1715,10 +1716,11 @@ export class Base extends Model {
     return record;
   }
 
-  static findBySql = Querying.findBySql;
-  static asyncFindBySql = Querying.asyncFindBySql;
-  static countBySql = Querying.countBySql;
-  static asyncCountBySql = Querying.asyncCountBySql;
+  // --- Querying mixin (static methods, wired via extend() after class) ---
+  declare static findBySql: typeof Querying.findBySql;
+  declare static asyncFindBySql: typeof Querying.asyncFindBySql;
+  declare static countBySql: typeof Querying.countBySql;
+  declare static asyncCountBySql: typeof Querying.asyncCountBySql;
 
   /**
    * Increment counter columns for a record by primary key.
@@ -3089,51 +3091,23 @@ export class Base extends Model {
 }
 
 // ---------------------------------------------------------------------------
-// Mixin: attach extracted module functions directly to Base.prototype.
-// This is the TS equivalent of Ruby's `include Module` — the real
-// implementation lives in the module file, Base just wires it up.
-// Uses defineProperty to match class method behavior (non-enumerable).
+// Ruby-style mixin wiring — one `extend` per module, mirroring Rails:
+//
+//   class Base
+//     extend ConnectionHandling  # via ClassMethods in connection-handling.ts
+//     extend Querying
+//     include Core, Integration, AttributeMethods, PrimaryKey
+//   end
+//
+// Per-method types chain from the source modules via `declare static` lines
+// in the class body, so `Base.findBySql` and `Base.connectsTo` carry the
+// exact generics, `this` parameter, and return type of their implementations.
 // ---------------------------------------------------------------------------
 
-function mixin(target: object, methods: Record<string, Function>): void {
-  for (const [name, fn] of Object.entries(methods)) {
-    Object.defineProperty(target, name, {
-      value: fn,
-      writable: true,
-      configurable: true,
-      enumerable: false,
-    });
-  }
-}
+extend(Base, ConnectionHandling.ClassMethods);
+extend(Base, Querying);
 
-// ConnectionHandling: extend Base with static methods (non-enumerable, matching mixin pattern)
-import { extend } from "@blazetrails/activesupport";
-extend(Base, {
-  connectsTo: ConnectionHandling.connectsTo,
-  connectedTo: ConnectionHandling.connectedTo,
-  connectedToMany: ConnectionHandling.connectedToMany,
-  connectedToAllShards: ConnectionHandling.connectedToAllShards,
-  connectingTo: ConnectionHandling.connectingTo,
-  connectedToQ: ConnectionHandling.connectedToQ,
-  whilePreventingWrites: ConnectionHandling.whilePreventingWrites,
-  prohibitShardSwapping: ConnectionHandling.prohibitShardSwapping,
-  isShardSwappingProhibited: ConnectionHandling.isShardSwappingProhibited,
-  clearQueryCachesForCurrentThread: ConnectionHandling.clearQueryCachesForCurrentThread,
-  leaseConnection: ConnectionHandling.leaseConnection,
-  releaseConnection: ConnectionHandling.releaseConnection,
-  withConnection: ConnectionHandling.withConnection,
-  connectionPool: ConnectionHandling.connectionPool,
-  retrieveConnection: ConnectionHandling.retrieveConnection,
-  connectionDbConfig: ConnectionHandling.connectionDbConfig,
-  isConnectedQ: ConnectionHandling.isConnectedQ,
-  removeConnection: ConnectionHandling.removeConnection,
-  schemaCache: ConnectionHandling.schemaCache,
-  clearCacheBang: ConnectionHandling.clearCacheBang,
-  shardKeys: ConnectionHandling.shardKeys,
-  isSharded: ConnectionHandling.isSharded,
-});
-
-mixin(Base.prototype, {
+include(Base, {
   // Core
   inspect: _inspect,
   attributeForInspect: _attributeForInspect,

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -616,3 +616,38 @@ export function adapterNameFromUrl(url: string): string {
       `or pass { adapter: "postgresql", url: "..." }`,
   );
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ *
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention: a Concern
+ * module exposes a `ClassMethods` object whose members become class methods
+ * on any class that includes the Concern. Grouping them here keeps the
+ * mixin surface colocated with the implementations, so adding a new class
+ * method only requires touching this file — `base.ts` wires the whole
+ * object in one line.
+ */
+export const ClassMethods = {
+  connectsTo,
+  connectedTo,
+  connectedToMany,
+  connectedToAllShards,
+  connectingTo,
+  connectedToQ,
+  whilePreventingWrites,
+  prohibitShardSwapping,
+  isShardSwappingProhibited,
+  clearQueryCachesForCurrentThread,
+  leaseConnection,
+  releaseConnection,
+  withConnection,
+  connectionDbConfig,
+  connectionPool,
+  retrieveConnection,
+  isConnectedQ,
+  removeConnection,
+  schemaCache,
+  clearCacheBang,
+  shardKeys,
+  isSharded,
+};


### PR DESCRIPTION
## Summary

Consolidate `Base`'s mixin wiring onto the activesupport `include` / `extend` primitives and apply Rails' `ActiveSupport::Concern#ClassMethods` idiom to the `ConnectionHandling` module.

- **Remove duplicate `mixin()` helper in `base.ts`.** It was a byte-for-byte duplicate of `include()` from activesupport. Replaced with `include(Base, { ... })`.
- **Introduce `ConnectionHandling.ClassMethods`.** Rails' `Concern` pattern groups the methods that become class methods on the target into an inner `ClassMethods` module. We do the same: a single `ClassMethods` object lives next to the 22 mixed-in implementations in `connection-handling.ts`, so adding a new class method only touches that file.
- **One `extend` per module, Rails-style.** The post-class wiring is now:
  ```ts
  extend(Base, ConnectionHandling.ClassMethods);
  extend(Base, Querying);
  ```
  mirroring Rails' `extend ConnectionHandling; extend Querying`.
- **Querying statics move to `declare static`.** The 4 in-class assignments (`static findBySql = Querying.findBySql`) become `declare static findBySql: typeof Querying.findBySql`, matching the existing `ConnectionHandling` pattern. Per-method types chain through from the source module — generics, `this` parameter, return type, async-ness — all preserved.
- **Hoist the activesupport import.** Moved from a late import right before its single use to the top of the file with the rest of the imports.

### Type fidelity

`Base.findBySql`, `User.findBySql`, `Base.connectsTo`, `User.connectsTo`, etc. all resolve with the exact signature from the source module, including subclass static inheritance. I investigated a more aggressive approach (const + intersection-type export to eliminate the `declare static` lines entirely) but it ran into cross-file circular type resolution between `base.ts` and `connection-handling.ts` — the per-method `declare static` lines are the canonical TypeScript pattern for this and give full type chaining without the circularity.

### What's intentionally left alone

- The `establishConnection` static wrapper and `connectionSpecificationName` getter on `Base` stay hand-rolled — `establishConnection` uses a first-arg-`modelClass` convention rather than `this:`, and `connectionSpecificationName` is exposed as a property accessor. Neither fits the `extend` mixin shape without a separate refactor.
- Other module delegates on `Base` (`CounterCache`, `Timestamp`, `LockingOptimistic`, etc.) use an older first-arg-`this` convention and are out of scope.

## Test plan
- [x] `tsc --build packages/activerecord` — clean
- [x] Full activerecord vitest suite — 8024 passed, 0 failed
- [x] Pre-commit hooks (eslint, prettier, build, typecheck) — clean