### PR TITLE
refactor(activerecord): convert module delegates to this-typed mixins

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2513,9 +2513,9 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Locking::Pessimistic#lock! and #with_lock.
    * Wired via include() after class. The module functions use
-   * `<T extends Base>(this: T, ...)` generics so subclasses see
-   * `this`-polymorphic types — `User.lockBang()` returns `Promise<User>`,
-   * `User.withLock(cb)` gives `cb` a `User` record.
+   * `<T extends Base>(this: T, ...)` generics so subclass instances see
+   * `this`-polymorphic types — `user.lockBang()` returns `Promise<User>`
+   * (when `user: User`), and `user.withLock(cb)` gives `cb` a `User` record.
    */
   declare lockBang: typeof LockingPessimistic.lockBang;
   declare withLock: typeof LockingPessimistic.withLock;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2508,18 +2508,14 @@ export class Base extends Model {
   }
 
   /**
-   * Reload the record with a pessimistic lock (SELECT ... FOR UPDATE).
-   * `with_lock` wraps a block in a transaction and locks the record first.
+   * Reload the record with a pessimistic lock (SELECT ... FOR UPDATE), and
+   * `with_lock` wraps a block in a transaction that first locks the record.
    *
-   * Mirrors: ActiveRecord::Base#lock! and ActiveRecord::Base#with_lock.
-   * Wired via include() after class. Declared with `this` return polymorphism
-   * so chained calls and `withLock` callbacks see the subclass type.
-   */
-  /**
+   * Mirrors: ActiveRecord::Locking::Pessimistic#lock! and #with_lock.
    * Wired via include() after class. The module functions use
    * `<T extends Base>(this: T, ...)` generics so subclasses see
-   * `this`-polymorphic types — User.lockBang() returns Promise<User>,
-   * User.withLock(cb) gives cb a User record.
+   * `this`-polymorphic types — `User.lockBang()` returns `Promise<User>`,
+   * `User.withLock(cb)` gives `cb` a `User` record.
    */
   declare lockBang: typeof LockingPessimistic.lockBang;
   declare withLock: typeof LockingPessimistic.withLock;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -90,7 +90,7 @@ import {
 import { ScopeRegistry } from "./scoping.js";
 
 import { Default as DefaultScoping } from "./scoping/default.js";
-import { Named as NamedScoping } from "./scoping/named.js";
+import * as NamedScoping from "./scoping/named.js";
 import { AssociationNotFoundError } from "./associations/errors.js";
 import { BelongsToAssociation } from "./associations/belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./associations/belongs-to-polymorphic-association.js";
@@ -148,12 +148,10 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
  * Mirrors: ActiveRecord::Base
  */
 export class Base extends Model {
+  // --- Translation mixin (wired via extend() after class) ---
+  declare static lookupAncestors: typeof Translation.lookupAncestors;
   static get i18nScope(): string {
-    return Translation.i18nScope(this);
-  }
-
-  static lookupAncestors(): Array<typeof Base> {
-    return Translation.lookupAncestors(this);
+    return Translation.i18nScope.call(this);
   }
 
   // -- Class-level configuration --
@@ -640,14 +638,8 @@ export class Base extends Model {
   // -- Readonly attributes --
   static _readonlyAttributes: Set<string> = new Set();
 
-  /**
-   * Mark attributes as readonly — they can be set on create but not on update.
-   *
-   * Mirrors: ActiveRecord::Base.attr_readonly
-   */
-  static attrReadonly(...attributes: string[]): void {
-    ReadonlyAttributes.attrReadonly(this, ...attributes);
-  }
+  // --- ReadonlyAttributes mixin (wired via extend() after class) ---
+  declare static attrReadonly: typeof ReadonlyAttributes.attrReadonly;
 
   /**
    * Return the list of readonly attribute names.
@@ -655,7 +647,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.readonly_attributes
    */
   static get readonlyAttributes(): string[] {
-    return ReadonlyAttributes.readonlyAttributes(this);
+    return ReadonlyAttributes.readonlyAttributes.call(this);
   }
 
   // -- Encrypted attributes --
@@ -912,15 +904,10 @@ export class Base extends Model {
    * The extension object adds extra methods to the returned relation
    * when the scope is invoked.
    *
-   * Mirrors: ActiveRecord::Base.scope (with extension block)
+   * Mirrors: ActiveRecord::Base.scope (with extension block).
+   * Wired via extend() after class.
    */
-  static scope(
-    name: string,
-    fn: (rel: any, ...args: any[]) => any,
-    extension?: Record<string, Function>,
-  ): void {
-    NamedScoping.defineScope(this, name, fn, extension);
-  }
+  declare static scope: typeof NamedScoping.scope;
 
   // -- Scoping --
 
@@ -1304,11 +1291,9 @@ export class Base extends Model {
   /**
    * Touch all records matching conditions (update timestamps).
    *
-   * Mirrors: ActiveRecord::Relation#touch_all
+   * Mirrors: ActiveRecord::Relation#touch_all. Wired via extend() after class.
    */
-  static async touchAll(...names: string[]): Promise<number> {
-    return Timestamp.touchAll(this, ...names);
-  }
+  declare static touchAll: typeof Timestamp.touchAll;
 
   /**
    * Return the second record.
@@ -1725,52 +1710,13 @@ export class Base extends Model {
   /**
    * Increment counter columns for a record by primary key.
    *
-   * Mirrors: ActiveRecord::Base.increment_counter
+   * Mirrors: ActiveRecord::Base.increment_counter / decrement_counter /
+   * update_counters / reset_counters. Wired via extend() after class.
    */
-  static async incrementCounter(
-    attribute: string,
-    id: unknown,
-    by: number = 1,
-    options?: { touch?: boolean | string | string[] },
-  ): Promise<number> {
-    return CounterCache.incrementCounter(this, attribute, id, by, options);
-  }
-
-  /**
-   * Decrement counter columns for a record by primary key.
-   *
-   * Mirrors: ActiveRecord::Base.decrement_counter
-   */
-  static async decrementCounter(
-    attribute: string,
-    id: unknown,
-    by: number = 1,
-    options?: { touch?: boolean | string | string[] },
-  ): Promise<number> {
-    return CounterCache.decrementCounter(this, attribute, id, by, options);
-  }
-
-  /**
-   * Update counter columns for one or more records.
-   *
-   * Mirrors: ActiveRecord::Base.update_counters
-   */
-  static async updateCounters(
-    id: unknown | unknown[],
-    counters: Record<string, number>,
-    options?: { touch?: boolean | string | string[] },
-  ): Promise<number> {
-    return CounterCache.updateCounters(this, id, counters, options);
-  }
-
-  /**
-   * Reset counter caches by recounting the actual associated records.
-   *
-   * Mirrors: ActiveRecord::Base.reset_counters
-   */
-  static async resetCounters(id: unknown, ...counterNames: string[]): Promise<void> {
-    return CounterCache.resetCounters(this, id, ...counterNames);
-  }
+  declare static incrementCounter: typeof CounterCache.incrementCounter;
+  declare static decrementCounter: typeof CounterCache.decrementCounter;
+  declare static updateCounters: typeof CounterCache.updateCounters;
+  declare static resetCounters: typeof CounterCache.resetCounters;
 
   /**
    * Instantiate a model from a database row (marks it as persisted).
@@ -2558,22 +2504,20 @@ export class Base extends Model {
 
   /**
    * Reload the record with a pessimistic lock (SELECT ... FOR UPDATE).
+   * `with_lock` wraps a block in a transaction and locks the record first.
    *
-   * Mirrors: ActiveRecord::Base#lock!
+   * Mirrors: ActiveRecord::Base#lock! and ActiveRecord::Base#with_lock.
+   * Wired via include() after class. Declared with `this` return polymorphism
+   * so chained calls and `withLock` callbacks see the subclass type.
    */
-  async lockBang(lockClause: string = "FOR UPDATE"): Promise<this> {
-    await LockingPessimistic.lockBang(this, lockClause);
-    return this;
-  }
-
-  async withLock(lock: string, fn: (record: this) => Promise<void> | void): Promise<void>;
-  async withLock(fn: (record: this) => Promise<void> | void): Promise<void>;
-  async withLock(
-    lockOrFn?: string | ((record: this) => Promise<void> | void),
-    fn?: (record: this) => Promise<void> | void,
-  ): Promise<void> {
-    return LockingPessimistic.withLock(this, lockOrFn as any, fn as any);
-  }
+  /**
+   * Wired via include() after class. The module functions use
+   * `<T extends Base>(this: T, ...)` generics so subclasses see
+   * `this`-polymorphic types — User.lockBang() returns Promise<User>,
+   * User.withLock(cb) gives cb a User record.
+   */
+  declare lockBang: typeof LockingPessimistic.lockBang;
+  declare withLock: typeof LockingPessimistic.withLock;
 
   declare toParam: () => string | null;
 
@@ -2665,11 +2609,9 @@ export class Base extends Model {
    * columns) without changing other attributes. Skips validations
    * and callbacks.
    *
-   * Mirrors: ActiveRecord::Base#touch
+   * Mirrors: ActiveRecord::Base#touch. Wired via include() after class.
    */
-  async touch(...names: string[]): Promise<boolean> {
-    return Timestamp.touch(this, ...names);
-  }
+  declare touch: typeof Timestamp.touch;
 
   /**
    * Update a single attribute and save, skipping validations.
@@ -3106,6 +3048,11 @@ export class Base extends Model {
 
 extend(Base, ConnectionHandling.ClassMethods);
 extend(Base, Querying);
+extend(Base, Translation.ClassMethods);
+extend(Base, ReadonlyAttributes.ClassMethods);
+extend(Base, CounterCache.ClassMethods);
+extend(Base, Timestamp.ClassMethods);
+extend(Base, NamedScoping.ClassMethods);
 
 include(Base, {
   // Core
@@ -3126,3 +3073,5 @@ include(Base, {
   // PrimaryKey
   toKey: _toKey,
 });
+include(Base, LockingPessimistic.InstanceMethods);
+include(Base, Timestamp.InstanceMethods);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -640,6 +640,7 @@ export class Base extends Model {
 
   // --- ReadonlyAttributes mixin (wired via extend() after class) ---
   declare static attrReadonly: typeof ReadonlyAttributes.attrReadonly;
+  declare static readonlyAttributeQ: typeof ReadonlyAttributes.readonlyAttributeQ;
 
   /**
    * Return the list of readonly attribute names.
@@ -904,10 +905,13 @@ export class Base extends Model {
    * The extension object adds extra methods to the returned relation
    * when the scope is invoked.
    *
-   * Mirrors: ActiveRecord::Base.scope (with extension block).
-   * Wired via extend() after class.
+   * Mirrors: ActiveRecord::Scoping::Named::ClassMethods. Wired via extend()
+   * after class.
    */
   declare static scope: typeof NamedScoping.scope;
+  declare static scopeForAssociation: typeof NamedScoping.scopeForAssociation;
+  declare static defaultScoped: typeof NamedScoping.defaultScoped;
+  declare static defaultExtensions: typeof NamedScoping.defaultExtensions;
 
   // -- Scoping --
 
@@ -1710,13 +1714,14 @@ export class Base extends Model {
   /**
    * Increment counter columns for a record by primary key.
    *
-   * Mirrors: ActiveRecord::Base.increment_counter / decrement_counter /
-   * update_counters / reset_counters. Wired via extend() after class.
+   * Mirrors: ActiveRecord::CounterCache::ClassMethods. Wired via extend()
+   * after class.
    */
   declare static incrementCounter: typeof CounterCache.incrementCounter;
   declare static decrementCounter: typeof CounterCache.decrementCounter;
   declare static updateCounters: typeof CounterCache.updateCounters;
   declare static resetCounters: typeof CounterCache.resetCounters;
+  declare static counterCacheColumnQ: typeof CounterCache.counterCacheColumnQ;
 
   /**
    * Instantiate a model from a database row (marks it as persisted).

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1295,7 +1295,10 @@ export class Base extends Model {
   /**
    * Touch all records matching conditions (update timestamps).
    *
-   * Mirrors: ActiveRecord::Relation#touch_all. Wired via extend() after class.
+   * Mirrors: ActiveRecord::Base.touch_all — a class-level entry point that
+   * delegates to `all().touchAll(...)` (Rails wires it up through
+   * `Querying::QUERYING_METHODS`, whose implementation lives on Relation).
+   * Wired via extend() after class.
    */
   declare static touchAll: typeof Timestamp.touchAll;
 

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -158,23 +158,26 @@ function buildTouchClause(touch?: boolean | string | string[]): string {
 }
 
 /**
- * Mirrors: ActiveRecord::CounterCache::ClassMethods#counter_cache_column?
+ * Check whether a column is a counter-cache column — i.e. any belongs_to
+ * association on this class was declared with `counter_cache:` that
+ * resolves to this column name.
  *
- * Rails: _counter_cache_columns.include?(name)
- * Checks associations for belongs_to with counter_cache.
+ * Mirrors: ActiveRecord::CounterCache::ClassMethods#counter_cache_column?
+ * (The `Q` suffix mirrors Ruby's `?` predicate convention.)
  */
-export function isCounterCacheColumn(modelClass: typeof Base, columnName: string): boolean {
-  const counterCols = getCounterCacheColumns(modelClass);
+export function counterCacheColumnQ(this: typeof Base, columnName: string): boolean {
+  const counterCols = getCounterCacheColumns(this);
   return counterCols.has(columnName);
 }
 
 /**
- * Rails: populates _counter_cache_columns from belongs_to reflections
- * that have counter_cache enabled.
+ * Populate the cached set of counter-cache columns from `belongs_to`
+ * reflections that have `counter_cache` enabled. Invoked lazily by
+ * `counterCacheColumnQ`; exposed for Rails parity with
+ * `ActiveRecord::CounterCache#load_schema!`.
  */
-export function loadSchemaBang(modelClass: typeof Base): void {
-  // Force population of counter cache columns set
-  getCounterCacheColumns(modelClass);
+export function loadSchemaBang(this: typeof Base): void {
+  getCounterCacheColumns(this);
 }
 
 function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
@@ -204,4 +207,5 @@ export const ClassMethods = {
   decrementCounter,
   updateCounters,
   resetCounters,
+  counterCacheColumnQ,
 };

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -171,10 +171,15 @@ export function counterCacheColumnQ(this: typeof Base, columnName: string): bool
 }
 
 /**
- * Populate the cached set of counter-cache columns from `belongs_to`
- * reflections that have `counter_cache` enabled. Invoked lazily by
- * `counterCacheColumnQ`; exposed for Rails parity with
- * `ActiveRecord::CounterCache#load_schema!`.
+ * Eagerly populate the cached set of counter-cache columns from
+ * `belongs_to` reflections that have `counter_cache` enabled.
+ *
+ * Mirrors the column-set bookkeeping that Rails'
+ * `ActiveRecord::CounterCache#load_schema!` performs (a private extension
+ * point inside `ClassMethods`). Not currently part of `ClassMethods`
+ * because, like in Rails, it's an internal hook into the schema loader
+ * rather than a user-facing class method — `counterCacheColumnQ` lazily
+ * primes the same cache via `getCounterCacheColumns` on first read.
  */
 export function loadSchemaBang(this: typeof Base): void {
   getCounterCacheColumns(this);

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -13,19 +13,19 @@ import { quoteIdentifier } from "./connection-adapters/abstract/quoting.js";
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#increment_counter
  */
 export async function incrementCounter(
-  modelClass: typeof Base,
+  this: typeof Base,
   attribute: string,
   id: unknown,
   by: number = 1,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  const table = modelClass.arelTable;
+  const table = this.arelTable;
   const touchClause = buildTouchClause(options?.touch);
   const quotedAttr = quoteIdentifier(attribute);
   const idBinds = Array.isArray(id) ? id : [id];
   const binds: unknown[] = [by, ...idBinds];
-  const sql = `UPDATE ${quoteIdentifier(table.name)} SET ${quotedAttr} = COALESCE(${quotedAttr}, 0) + ?${touchClause} WHERE ${buildPkPlaceholder(modelClass)}`;
-  return modelClass.adapter.executeMutation(sql, binds);
+  const sql = `UPDATE ${quoteIdentifier(table.name)} SET ${quotedAttr} = COALESCE(${quotedAttr}, 0) + ?${touchClause} WHERE ${buildPkPlaceholder(this)}`;
+  return this.adapter.executeMutation(sql, binds);
 }
 
 /**
@@ -34,13 +34,13 @@ export async function incrementCounter(
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#decrement_counter
  */
 export async function decrementCounter(
-  modelClass: typeof Base,
+  this: typeof Base,
   attribute: string,
   id: unknown,
   by: number = 1,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  return incrementCounter(modelClass, attribute, id, -by, options);
+  return incrementCounter.call(this, attribute, id, -by, options);
 }
 
 /**
@@ -49,12 +49,12 @@ export async function decrementCounter(
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#update_counters
  */
 export async function updateCounters(
-  modelClass: typeof Base,
+  this: typeof Base,
   id: unknown | unknown[],
   counters: Record<string, number>,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  const table = modelClass.arelTable;
+  const table = this.arelTable;
   const touchClause = buildTouchClause(options?.touch);
   const binds: unknown[] = [];
   const setClause =
@@ -68,10 +68,10 @@ export async function updateCounters(
   const tableName = quoteIdentifier(table.name);
 
   const ids = Array.isArray(id) ? id : [id];
-  if (Array.isArray(modelClass.primaryKey)) {
+  if (Array.isArray(this.primaryKey)) {
     const tuples = Array.isArray(ids[0]) ? (ids as unknown[][]) : [ids as unknown[]];
     const whereParts = tuples.map((t) => {
-      const pk = modelClass.primaryKey as string[];
+      const pk = this.primaryKey as string[];
       return `(${pk
         .map((col) => {
           binds.push(t[pk.indexOf(col)]);
@@ -80,7 +80,7 @@ export async function updateCounters(
         .join(" AND ")})`;
     });
     const sql = `UPDATE ${tableName} SET ${setClause} WHERE ${whereParts.join(" OR ")}`;
-    return modelClass.adapter.executeMutation(sql, binds);
+    return this.adapter.executeMutation(sql, binds);
   }
 
   const placeholders = ids
@@ -89,8 +89,8 @@ export async function updateCounters(
     })
     .join(", ");
   binds.push(...ids);
-  const sql = `UPDATE ${tableName} SET ${setClause} WHERE ${quoteIdentifier(modelClass.primaryKey as string)} IN (${placeholders})`;
-  return modelClass.adapter.executeMutation(sql, binds);
+  const sql = `UPDATE ${tableName} SET ${setClause} WHERE ${quoteIdentifier(this.primaryKey as string)} IN (${placeholders})`;
+  return this.adapter.executeMutation(sql, binds);
 }
 
 /**
@@ -99,12 +99,12 @@ export async function updateCounters(
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#reset_counters
  */
 export async function resetCounters(
-  modelClass: typeof Base,
+  this: typeof Base,
   id: unknown,
   ...counterNames: string[]
 ): Promise<void> {
-  const record = await modelClass.find(id);
-  const assocDefs = (modelClass as any)._associations as
+  const record = await this.find(id);
+  const assocDefs = (this as any)._associations as
     | Array<{ type: string; name: string; options: any }>
     | undefined;
   const hasManyAssocs = assocDefs?.filter((a) => a.type === "hasMany") ?? [];
@@ -114,14 +114,14 @@ export async function resetCounters(
     let counterColumn: string;
 
     if (assoc) {
-      counterColumn = resolveCounterColumn(modelClass, assoc, counterName);
+      counterColumn = resolveCounterColumn(this, assoc, counterName);
     } else {
       if (counterName.endsWith("_count")) {
         assoc = hasManyAssocs.find((a) => a.name === counterName.slice(0, -6));
       }
       if (!assoc) {
         for (const candidate of hasManyAssocs) {
-          const col = resolveCounterColumn(modelClass, candidate, candidate.name);
+          const col = resolveCounterColumn(this, candidate, candidate.name);
           if (col === counterName) {
             assoc = candidate;
             break;
@@ -130,10 +130,10 @@ export async function resetCounters(
       }
       if (!assoc) {
         throw new Error(
-          `'${counterName}' is not a valid counter name or hasMany association on ${modelClass.name}`,
+          `'${counterName}' is not a valid counter name or hasMany association on ${this.name}`,
         );
       }
-      counterColumn = resolveCounterColumn(modelClass, assoc, assoc.name);
+      counterColumn = resolveCounterColumn(this, assoc, assoc.name);
     }
 
     const count = await countHasMany(record, assoc.name, assoc.options);
@@ -159,8 +159,7 @@ function buildTouchClause(touch?: boolean | string | string[]): string {
 
 /**
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#counter_cache_column?
- */
-/**
+ *
  * Rails: _counter_cache_columns.include?(name)
  * Checks associations for belongs_to with counter_cache.
  */
@@ -195,3 +194,14 @@ function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
   (modelClass as any)._counterCacheColumns = cols;
   return cols;
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
+ */
+export const ClassMethods = {
+  incrementCounter,
+  decrementCounter,
+  updateCounters,
+  resetCounters,
+};

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -83,10 +83,12 @@ export {
 } from "./inheritance.js";
 // hasSecurePassword requires node:crypto — use subpath: @blazetrails/activerecord/secure-password
 // CounterCache, ReadonlyAttributes, Timestamp, Locking::Pessimistic, and
-// Translation are consumed via `User.incrementCounter(...)`, `User.touch()`,
-// etc. on the Base class (mixed in via activesupport extend/include) and are
-// no longer exported as standalone free functions — their `this:`-typed
-// signatures are only callable as methods on a Base subclass.
+// Translation are consumed via the Base mixins — class methods like
+// `User.incrementCounter(...)`, `User.touchAll(...)`, `User.attrReadonly(...)`,
+// and instance methods like `user.touch()`, `user.lockBang()`,
+// `user.withLock(cb)`. They are no longer exported as standalone free
+// functions — their `this:`-typed signatures are only callable on a Base
+// subclass (statics) or a Base instance (instance methods).
 // establishConnection requires node:fs — use subpath: @blazetrails/activerecord/connection-handling
 // signedId requires MessageVerifier (node:crypto) — use subpath: @blazetrails/activerecord/signed-id
 export {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -82,14 +82,11 @@ export {
   findStiClass,
 } from "./inheritance.js";
 // hasSecurePassword requires node:crypto — use subpath: @blazetrails/activerecord/secure-password
-export {
-  incrementCounter,
-  decrementCounter,
-  updateCounters,
-  resetCounters,
-} from "./counter-cache.js";
-export { attrReadonly, readonlyAttributes, readonlyAttributeQ } from "./readonly-attributes.js";
-export { touch, touchAll } from "./timestamp.js";
+// CounterCache, ReadonlyAttributes, Timestamp, Locking::Pessimistic, and
+// Translation are consumed via `User.incrementCounter(...)`, `User.touch()`,
+// etc. on the Base class (mixed in via activesupport extend/include) and are
+// no longer exported as standalone free functions — their `this:`-typed
+// signatures are only callable as methods on a Base subclass.
 // establishConnection requires node:fs — use subpath: @blazetrails/activerecord/connection-handling
 // signedId requires MessageVerifier (node:crypto) — use subpath: @blazetrails/activerecord/signed-id
 export {
@@ -98,8 +95,6 @@ export {
   lockingEnabled,
   LockingType,
 } from "./locking/optimistic.js";
-export { lockBang, withLock } from "./locking/pessimistic.js";
-export { i18nScope, lookupAncestors } from "./translation.js";
 export {
   columnNames as schemaColumnNames,
   columnsHash as schemaColumnsHash,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -88,7 +88,7 @@ export {
   updateCounters,
   resetCounters,
 } from "./counter-cache.js";
-export { attrReadonly, readonlyAttributes, readonlyAttribute } from "./readonly-attributes.js";
+export { attrReadonly, readonlyAttributes, readonlyAttributeQ } from "./readonly-attributes.js";
 export { touch, touchAll } from "./timestamp.js";
 // establishConnection requires node:fs — use subpath: @blazetrails/activerecord/connection-handling
 // signedId requires MessageVerifier (node:crypto) — use subpath: @blazetrails/activerecord/signed-id

--- a/packages/activerecord/src/locking/pessimistic.ts
+++ b/packages/activerecord/src/locking/pessimistic.ts
@@ -14,34 +14,37 @@ import { star as arelStar } from "@blazetrails/arel";
  *
  * Mirrors: ActiveRecord::Locking::Pessimistic#lock!
  */
-export async function lockBang(instance: Base, lockClause: string = "FOR UPDATE"): Promise<Base> {
-  if (instance.changed) {
-    const dirtyAttrs = instance.changedAttributes.map((a) => `"${a}"`).join(", ");
+export async function lockBang<T extends Base>(
+  this: T,
+  lockClause: string = "FOR UPDATE",
+): Promise<T> {
+  if (this.changed) {
+    const dirtyAttrs = this.changedAttributes.map((a) => `"${a}"`).join(", ");
     throw new Error(
       `Locking a record with unpersisted changes is not supported. Changed attributes: ${dirtyAttrs}. Use save to persist the changes, or reload to discard them explicitly.`,
     );
   }
-  const ctor = instance.constructor as typeof Base;
+  const ctor = this.constructor as typeof Base;
   const sm = ctor.arelTable
     .project(arelStar)
-    .where((ctor as any)._buildPkWhereNode(instance.id))
+    .where((ctor as any)._buildPkWhereNode(this.id))
     .lock(lockClause);
   const rows = await ctor.adapter.execute(sm.toSql());
 
   if (rows.length === 0) {
     throw new RecordNotFound(
-      `${ctor.name} with ${ctor.primaryKey}=${instance.id} not found`,
+      `${ctor.name} with ${ctor.primaryKey}=${this.id} not found`,
       ctor.name,
       ctor.primaryKey as string,
-      instance.id,
+      this.id,
     );
   }
 
   for (const [key, value] of Object.entries(rows[0])) {
-    (instance as any)._attributes.set(key, value);
+    (this as any)._attributes.set(key, value);
   }
-  (instance as any)._dirty.snapshot((instance as any)._attributes);
-  return instance;
+  (this as any)._dirty.snapshot((this as any)._attributes);
+  return this;
 }
 
 /**
@@ -49,10 +52,10 @@ export async function lockBang(instance: Base, lockClause: string = "FOR UPDATE"
  *
  * Mirrors: ActiveRecord::Locking::Pessimistic#with_lock
  */
-export async function withLock(
-  instance: Base,
-  lockOrFn: string | ((record: Base) => Promise<void> | void),
-  fn?: (record: Base) => Promise<void> | void,
+export async function withLock<T extends Base>(
+  this: T,
+  lockOrFn: string | ((record: T) => Promise<void> | void),
+  fn?: (record: T) => Promise<void> | void,
 ): Promise<void> {
   let lockClause = "FOR UPDATE";
   let callback = fn;
@@ -68,9 +71,19 @@ export async function withLock(
   }
 
   const cb = callback;
+  const instance = this;
   const { transaction } = await import("../transactions.js");
   await transaction(instance.constructor as typeof Base, async () => {
-    await lockBang(instance, lockClause);
+    await lockBang.call(instance, lockClause);
     await cb(instance);
   });
 }
+
+/**
+ * Instance methods wired onto Base.prototype via `include()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern` instance-level mixin.
+ */
+export const InstanceMethods = {
+  lockBang,
+  withLock,
+};

--- a/packages/activerecord/src/locking/pessimistic.ts
+++ b/packages/activerecord/src/locking/pessimistic.ts
@@ -50,8 +50,19 @@ export async function lockBang<T extends Base>(
 /**
  * Wraps a block in a transaction, reloading the record with a lock.
  *
- * Mirrors: ActiveRecord::Locking::Pessimistic#with_lock
+ * Mirrors: ActiveRecord::Locking::Pessimistic#with_lock. Like Rails,
+ * the block is required — calling `withLock("FOR UPDATE")` with no
+ * callback is a compile error (and a runtime error, as a safety net).
  */
+export async function withLock<T extends Base>(
+  this: T,
+  fn: (record: T) => Promise<void> | void,
+): Promise<void>;
+export async function withLock<T extends Base>(
+  this: T,
+  lockClause: string,
+  fn: (record: T) => Promise<void> | void,
+): Promise<void>;
 export async function withLock<T extends Base>(
   this: T,
   lockOrFn: string | ((record: T) => Promise<void> | void),

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -38,8 +38,9 @@ export function readonlyAttributes(this: typeof Base): string[] {
  * Check if a specific attribute is readonly.
  *
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#readonly_attribute?
+ * (The `Q` suffix mirrors Ruby's `?` predicate convention.)
  */
-export function readonlyAttribute(this: typeof Base, attribute: string): boolean {
+export function readonlyAttributeQ(this: typeof Base, attribute: string): boolean {
   return ((this as any)._readonlyAttributes as Set<string> | undefined)?.has(attribute) ?? false;
 }
 
@@ -48,9 +49,11 @@ export function readonlyAttribute(this: typeof Base, attribute: string): boolean
  * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
  *
  * Note: `readonlyAttributes` is exposed on Base as a getter for ergonomic
- * property access, so it stays as a hand-rolled delegate in base.ts rather
- * than being mixed in here. `readonlyAttribute` is not yet wired onto Base.
+ * property access (TS idiom for what Rails exposes as a bare method call),
+ * so it stays as a hand-rolled delegate in base.ts rather than being mixed
+ * in here.
  */
 export const ClassMethods = {
   attrReadonly,
+  readonlyAttributeQ,
 };

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -6,8 +6,8 @@ import type { Base } from "./base.js";
  * Mirrors: ActiveRecord::ReadonlyAttributes
  *
  * Usage:
- *   attrReadonly(User, 'email', 'username')
- *   readonlyAttributes(User) // => ['email', 'username']
+ *   User.attrReadonly('email', 'username')
+ *   User.readonlyAttributes // => ['email', 'username']
  */
 
 /**
@@ -16,12 +16,12 @@ import type { Base } from "./base.js";
  *
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#attr_readonly
  */
-export function attrReadonly(modelClass: typeof Base, ...attributes: string[]): void {
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_readonlyAttributes")) {
-    (modelClass as any)._readonlyAttributes = new Set((modelClass as any)._readonlyAttributes);
+export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
+  if (!Object.prototype.hasOwnProperty.call(this, "_readonlyAttributes")) {
+    (this as any)._readonlyAttributes = new Set((this as any)._readonlyAttributes);
   }
   for (const attr of attributes) {
-    (modelClass as any)._readonlyAttributes.add(attr);
+    (this as any)._readonlyAttributes.add(attr);
   }
 }
 
@@ -30,8 +30,8 @@ export function attrReadonly(modelClass: typeof Base, ...attributes: string[]): 
  *
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#readonly_attributes
  */
-export function readonlyAttributes(modelClass: typeof Base): string[] {
-  return Array.from((modelClass as any)._readonlyAttributes ?? []);
+export function readonlyAttributes(this: typeof Base): string[] {
+  return Array.from((this as any)._readonlyAttributes ?? []);
 }
 
 /**
@@ -39,8 +39,18 @@ export function readonlyAttributes(modelClass: typeof Base): string[] {
  *
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#readonly_attribute?
  */
-export function readonlyAttribute(modelClass: typeof Base, attribute: string): boolean {
-  return (
-    ((modelClass as any)._readonlyAttributes as Set<string> | undefined)?.has(attribute) ?? false
-  );
+export function readonlyAttribute(this: typeof Base, attribute: string): boolean {
+  return ((this as any)._readonlyAttributes as Set<string> | undefined)?.has(attribute) ?? false;
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
+ *
+ * Note: `readonlyAttributes` is exposed on Base as a getter for ergonomic
+ * property access, so it stays as a hand-rolled delegate in base.ts rather
+ * than being mixed in here. `readonlyAttribute` is not yet wired onto Base.
+ */
+export const ClassMethods = {
+  attrReadonly,
+};

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -1,36 +1,43 @@
+import type { Base } from "../base.js";
+
 /**
  * Named scope handling — defines named scopes on model classes
  * and registers them as static methods.
  *
  * Mirrors: ActiveRecord::Scoping::Named
  */
-export class Named {
-  static defineScope(
-    modelClass: any,
-    name: string,
-    fn: (rel: any, ...args: any[]) => any,
-    extension?: Record<string, Function>,
-  ): void {
-    if (!Object.prototype.hasOwnProperty.call(modelClass, "_scopes")) {
-      modelClass._scopes = new Map(modelClass._scopes);
-    }
-    modelClass._scopes.set(name, fn);
 
-    if (extension) {
-      if (!Object.prototype.hasOwnProperty.call(modelClass, "_scopeExtensions")) {
-        modelClass._scopeExtensions = new Map(modelClass._scopeExtensions);
-      }
-      modelClass._scopeExtensions.set(name, extension);
-    }
-
-    Object.defineProperty(modelClass, name, {
-      value: function (...args: any[]) {
-        return (this as any).all()[name](...args);
-      },
-      writable: true,
-      configurable: true,
-    });
+/**
+ * Define a named scope on a model class. Called via `Base.scope(name, body)`.
+ *
+ * Mirrors: ActiveRecord::Scoping::Named::ClassMethods#scope
+ */
+export function scope(
+  this: typeof Base,
+  name: string,
+  fn: (rel: any, ...args: any[]) => any,
+  extension?: Record<string, Function>,
+): void {
+  const modelClass = this as any;
+  if (!Object.prototype.hasOwnProperty.call(modelClass, "_scopes")) {
+    modelClass._scopes = new Map(modelClass._scopes);
   }
+  modelClass._scopes.set(name, fn);
+
+  if (extension) {
+    if (!Object.prototype.hasOwnProperty.call(modelClass, "_scopeExtensions")) {
+      modelClass._scopeExtensions = new Map(modelClass._scopeExtensions);
+    }
+    modelClass._scopeExtensions.set(name, extension);
+  }
+
+  Object.defineProperty(modelClass, name, {
+    value: function (...args: any[]) {
+      return (this as any).all()[name](...args);
+    },
+    writable: true,
+    configurable: true,
+  });
 }
 
 interface NamedHost {
@@ -69,3 +76,11 @@ export function defaultExtensions(this: NamedHost): any[] {
   const scope = scopeForAssociation.call(this) ?? defaultScoped.call(this);
   return scope?.extensions ?? [];
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
+ */
+export const ClassMethods = {
+  scope,
+};

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -83,4 +83,7 @@ export function defaultExtensions(this: NamedHost): any[] {
  */
 export const ClassMethods = {
   scope,
+  scopeForAssociation,
+  defaultScoped,
+  defaultExtensions,
 };

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -14,15 +14,15 @@ import { ReadOnlyRecord } from "./errors.js";
  *
  * Mirrors: ActiveRecord::Timestamp#touch
  */
-export async function touch(instance: Base, ...names: string[]): Promise<boolean> {
-  if (instance.isReadonly()) {
-    throw new ReadOnlyRecord(`${instance.constructor.name} is marked as readonly`);
+export async function touch(this: Base, ...names: string[]): Promise<boolean> {
+  if (this.isReadonly()) {
+    throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
   }
-  if (!instance.isPersisted()) return false;
+  if (!this.isPersisted()) return false;
   const now = new Date();
   const attrs: Record<string, unknown> = {};
 
-  const ctor = instance.constructor as typeof Base;
+  const ctor = this.constructor as typeof Base;
   if (ctor._attributeDefinitions.has("updated_at")) {
     attrs.updated_at = now;
   }
@@ -33,9 +33,9 @@ export async function touch(instance: Base, ...names: string[]): Promise<boolean
 
   if (Object.keys(attrs).length === 0) return false;
 
-  await instance.updateColumns(attrs);
+  await this.updateColumns(attrs);
 
-  await ctor._callbackChain.runAfter("touch", instance);
+  await ctor._callbackChain.runAfter("touch", this);
   return true;
 }
 
@@ -44,8 +44,8 @@ export async function touch(instance: Base, ...names: string[]): Promise<boolean
  *
  * Mirrors: ActiveRecord::Base.touch_all
  */
-export async function touchAll(modelClass: typeof Base, ...names: string[]): Promise<number> {
-  return modelClass.all().touchAll(...names);
+export async function touchAll(this: typeof Base, ...names: string[]): Promise<number> {
+  return this.all().touchAll(...names);
 }
 
 // ---------------------------------------------------------------------------
@@ -106,3 +106,18 @@ export function allTimestampAttributesInModel(this: TimestampHost): string[] {
 export function currentTimeFromProperTimezone(): Date {
   return new Date();
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
+ */
+export const ClassMethods = {
+  touchAll,
+};
+
+/**
+ * Instance methods wired onto Base.prototype via `include()` in base.ts.
+ */
+export const InstanceMethods = {
+  touch,
+};

--- a/packages/activerecord/src/translation.ts
+++ b/packages/activerecord/src/translation.ts
@@ -11,7 +11,7 @@ import type { Base } from "./base.js";
  *
  * Mirrors: ActiveRecord::Translation#i18n_scope
  */
-export function i18nScope(_modelClass: typeof Base): string {
+export function i18nScope(this: typeof Base): string {
   return "activerecord";
 }
 
@@ -22,15 +22,15 @@ export function i18nScope(_modelClass: typeof Base): string {
  *
  * Mirrors: ActiveRecord::Translation#lookup_ancestors
  */
-export function lookupAncestors(modelClass: typeof Base): Array<typeof Base> {
+export function lookupAncestors(this: typeof Base): Array<typeof Base> {
   const ancestors: Array<typeof Base> = [];
-  let klass: any = modelClass;
+  let klass: any = this;
   while (klass) {
     const parent = Object.getPrototypeOf(klass);
     if (!parent || !("_attributeDefinitions" in parent)) {
       // klass is Base (its parent is Model which doesn't have _attributeDefinitions).
-      // Only include Base if it was the original modelClass.
-      if (klass === modelClass) ancestors.push(klass);
+      // Only include Base if it was the original receiver.
+      if (klass === this) ancestors.push(klass);
       break;
     }
     ancestors.push(klass);
@@ -38,3 +38,11 @@ export function lookupAncestors(modelClass: typeof Base): Array<typeof Base> {
   }
   return ancestors;
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
+ */
+export const ClassMethods = {
+  lookupAncestors,
+};


### PR DESCRIPTION
## Summary

Convert six ActiveRecord module delegates (`Translation`, `ReadonlyAttributes`, `CounterCache`, `Timestamp`, `Locking::Pessimistic`, `Scoping::Named`) from the older first-arg-`modelClass` / first-arg-`instance` convention to the `this:`-typed convention, so they can be wired via activesupport's `extend()` and `include()` primitives — matching the pattern established in #492 for `ConnectionHandling` and `Querying`.

### What changes in each module

- **Translation** — `lookupAncestors` → `ClassMethods` (mixed via `extend`). `i18nScope` stays as a hand-rolled getter delegate (it's exposed on `Base` as a property accessor, like `connectionSpecificationName`).
- **ReadonlyAttributes** — `attrReadonly` and `readonlyAttributeQ` → `ClassMethods`. `readonlyAttributes` stays as a getter delegate. Every class method Rails exposes from `ActiveRecord::ReadonlyAttributes::ClassMethods` is now on `Base`.
- **CounterCache** — `incrementCounter`, `decrementCounter`, `updateCounters`, `resetCounters`, `counterCacheColumnQ` → `ClassMethods` (5 methods, matching the full Rails surface).
- **Timestamp** — `touchAll` → `ClassMethods`; `touch` → `InstanceMethods` (mixed via `include`).
- **Locking::Pessimistic** — `lockBang`, `withLock` → `InstanceMethods`. Both use `<T extends Base>(this: T, ...)` generics so subclasses see `this`-polymorphic types: `User.lockBang()` returns `Promise<User>`, `User.withLock(cb)` hands `cb` a `User` record. `withLock` also has explicit TS overloads so calling it without a callback is a compile error (matching Rails' `LocalJumpError` behavior when `with_lock` is called without a block).
- **Scoping::Named** — the `class Named { static defineScope }` wrapper becomes a free function `scope(this: typeof Base, …)`, matching Rails' method name (`ActiveRecord::Scoping::Named::ClassMethods#scope`). `scopeForAssociation`, `defaultScoped`, and `defaultExtensions` are also now exposed on `Base`, matching the full Rails `ClassMethods` surface.

### Breaking changes (public API)

The `this:`-typed conversion makes these functions only callable via a class receiver. The intended public API is the class form — `User.attrReadonly('email')`, `user.touch()`, `user.lockBang()`, etc. — via the Base mixins.

- **Package-root re-exports removed**: `attrReadonly`, `readonlyAttributes`, `readonlyAttributeQ`, `touch`, `touchAll`, `lockBang`, `withLock`, `i18nScope`, `lookupAncestors`, `incrementCounter`, `decrementCounter`, `updateCounters`, `resetCounters` are no longer exported from `@blazetrails/activerecord`'s root entrypoint. Any caller who was invoking them as free functions (e.g. `attrReadonly(User, 'email')`) would have gotten a silent runtime failure after the signature change — hard removal surfaces the issue as a compile error instead. Per CLAUDE.md we delete rather than alias.
- **Predicate renames**: `readonlyAttribute` → `readonlyAttributeQ`, `isCounterCacheColumn` → `counterCacheColumnQ`. The new names follow our `Q`-suffix predicate convention (`connectedToQ`, `isConnectedQ`, `primaryClassQ`) that mirrors Ruby's `?`. The old names had no internal callers.

### Type chaining

Every mixed-in method's type chains through from its source module via `declare static X: typeof Module.X` / `declare X: typeof Module.X` in the class body, preserving generics, `this` parameter, return type, and async-ness. Same pattern as PR #492.

### Out of scope

- **LockingOptimistic** — all three functions are exposed as getters/setters on `Base` (`lockingColumn`, `lockingEnabled`), so they have to stay as hand-rolled property delegates. Pure signature conversion would be churn without an extend win.
- **Scoping::Default** — the `unscoped` / `buildDefaultScope` wrappers capture `_RelationCtor` and `_wrapWithScopeProxy` local closures from `base.ts`. They can't be cleanly moved to the module without restructuring how the Relation constructor is exposed.
- **CounterCache Arel refactor** — Rails' `update_counters` delegates to `Relation` which uses Arel's `UpdateManager`; our TS port reimplements the UPDATE SQL in the class method directly. This is a pre-existing implementation detail orthogonal to the mixin conversion and will be filed as a separate follow-up.
- **ModelSchema** — planned as PR 2 (larger, ~8 methods, touches schema/CPK/column introspection).
- **Inheritance** — uses a different exported-function convention already; no delegate wrappers to remove.

## Test plan
- [x] `tsc --build packages/activerecord` — clean
- [x] Full activerecord vitest suite — 8024 passed, 3733 skipped, 0 failed
- [x] Pre-commit hooks (eslint, prettier, build, typecheck) — clean