### PR TITLE
refactor(activerecord): convert ModelSchema delegates to this-typed mixins

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -282,7 +282,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.table_name
    */
   static get tableName(): string {
-    return ModelSchema.resolveTableName(this);
+    return ModelSchema.resolveTableName.call(this);
   }
 
   static set tableName(name: string) {
@@ -332,11 +332,11 @@ export class Base extends Model {
    * Quote a single value for use in SQL.
    */
   static _buildPkWhere(idValue: unknown): string {
-    return ModelSchema.buildPkWhere(this, idValue);
+    return ModelSchema.buildPkWhere.call(this, idValue);
   }
 
   static _buildPkWhereNode(idValue: unknown): InstanceType<typeof Nodes.Node> {
-    return ModelSchema.buildPkWhereNode(this, idValue);
+    return ModelSchema.buildPkWhereNode.call(this, idValue);
   }
 
   /**
@@ -370,10 +370,9 @@ export class Base extends Model {
    * between tests.
    *
    * This is a test/development helper — in production, use migrations.
+   * Wired via extend() after class.
    */
-  static async createTable(): Promise<void> {
-    return ModelSchema.createTable(this);
-  }
+  declare static createTable: typeof ModelSchema.createTable;
 
   /**
    * Set the database adapter for this model class.
@@ -493,26 +492,12 @@ export class Base extends Model {
   declare static shardKeys: typeof ConnectionHandling.shardKeys;
   declare static isSharded: typeof ConnectionHandling.isSharded;
 
-  /**
-   * Return the list of column names (attribute names).
-   *
-   * Mirrors: ActiveRecord::Base.column_names
-   */
-  static columnNames(): string[] {
-    return ModelSchema.columnNames(this);
-  }
-
-  static hasAttributeDefinition(name: string): boolean {
-    return ModelSchema.hasAttributeDefinition(this, name);
-  }
-
-  static columnsHash(): Record<string, { name: string; type: string; default: unknown }> {
-    return ModelSchema.columnsHash(this);
-  }
-
-  static contentColumns(): string[] {
-    return ModelSchema.contentColumns(this);
-  }
+  // --- ModelSchema mixin (wired via extend() after class) ---
+  // Mirrors: ActiveRecord::ModelSchema::ClassMethods
+  declare static columnNames: typeof ModelSchema.columnNames;
+  declare static hasAttributeDefinition: typeof ModelSchema.hasAttributeDefinition;
+  declare static columnsHash: typeof ModelSchema.columnsHash;
+  declare static contentColumns: typeof ModelSchema.contentColumns;
 
   /**
    * Return the STI inheritance column name, if STI is enabled.
@@ -979,7 +964,7 @@ export class Base extends Model {
             [],
           );
         }
-        const whereNodes = tuples.map((tuple) => ModelSchema.buildPkWhereNode(this, tuple));
+        const whereNodes = tuples.map((tuple) => ModelSchema.buildPkWhereNode.call(this, tuple));
         const orCondition = whereNodes.reduce((left, right) => new Nodes.Or(left, right));
         const records = await this.all().where(new Nodes.Grouping(orCondition)).toArray();
         if (records.length !== tuples.length) {
@@ -3057,6 +3042,7 @@ extend(Base, ReadonlyAttributes.ClassMethods);
 extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
+extend(Base, ModelSchema.ClassMethods);
 
 include(Base, {
   // Core

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -498,6 +498,20 @@ export class Base extends Model {
   declare static hasAttributeDefinition: typeof ModelSchema.hasAttributeDefinition;
   declare static columnsHash: typeof ModelSchema.columnsHash;
   declare static contentColumns: typeof ModelSchema.contentColumns;
+  declare static deriveJoinTableName: typeof ModelSchema.deriveJoinTableName;
+  declare static quotedTableName: typeof ModelSchema.quotedTableName;
+  declare static resetTableName: typeof ModelSchema.resetTableName;
+  declare static fullTableNamePrefix: typeof ModelSchema.fullTableNamePrefix;
+  declare static fullTableNameSuffix: typeof ModelSchema.fullTableNameSuffix;
+  declare static resetSequenceName: typeof ModelSchema.resetSequenceName;
+  declare static isPrefetchPrimaryKey: typeof ModelSchema.isPrefetchPrimaryKey;
+  declare static nextSequenceValue: typeof ModelSchema.nextSequenceValue;
+  declare static attributesBuilder: typeof ModelSchema.attributesBuilder;
+  declare static columns: typeof ModelSchema.columns;
+  declare static yamlEncoder: typeof ModelSchema.yamlEncoder;
+  declare static columnForAttribute: typeof ModelSchema.columnForAttribute;
+  declare static symbolColumnToString: typeof ModelSchema.symbolColumnToString;
+  declare static resetColumnInformation: typeof ModelSchema.resetColumnInformation;
 
   /**
    * Return the STI inheritance column name, if STI is enabled.

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -97,12 +97,11 @@ export {
   lockingEnabled,
   LockingType,
 } from "./locking/optimistic.js";
-export {
-  columnNames as schemaColumnNames,
-  columnsHash as schemaColumnsHash,
-  contentColumns as schemaContentColumns,
-  createTable as schemaCreateTable,
-} from "./model-schema.js";
+// ModelSchema is consumed via the Base mixins — `User.columnNames()`,
+// `User.columnsHash()`, `User.contentColumns()`, `User.createTable()`, etc.
+// (mixed in via activesupport `extend()`). The underlying functions are
+// no longer exported as standalone free functions — their `this:`-typed
+// signatures are only callable on a Base subclass.
 export {
   store,
   storeAccessor,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -24,14 +24,14 @@ import { detectAdapterName } from "./adapter-name.js";
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#table_name
  */
-export function resolveTableName(modelClass: typeof Base): string {
-  if ((modelClass as any)._tableName != null) return (modelClass as any)._tableName;
-  if (isStiSubclass(modelClass)) {
-    return resolveTableName(getStiBase(modelClass));
+export function resolveTableName(this: typeof Base): string {
+  if ((this as any)._tableName != null) return (this as any)._tableName;
+  if (isStiSubclass(this)) {
+    return resolveTableName.call(getStiBase(this));
   }
-  const prefix = (modelClass as any)._tableNamePrefix ?? "";
-  const suffix = (modelClass as any)._tableNameSuffix ?? "";
-  const inferred = pluralize(underscore(modelClass.name));
+  const prefix = (this as any)._tableNamePrefix ?? "";
+  const suffix = (this as any)._tableNameSuffix ?? "";
+  const inferred = pluralize(underscore(this.name));
   return `${prefix}${inferred}${suffix}`;
 }
 
@@ -44,9 +44,9 @@ export function resolveTableName(modelClass: typeof Base): string {
  *
  * Mirrors: used throughout ActiveRecord persistence internals
  */
-export function buildPkWhere(modelClass: typeof Base, idValue: unknown): string {
-  const pk = modelClass.primaryKey;
-  const adapter = detectAdapterName(modelClass.adapter);
+export function buildPkWhere(this: typeof Base, idValue: unknown): string {
+  const pk = this.primaryKey;
+  const adapter = detectAdapterName(this.adapter);
   if (Array.isArray(pk)) {
     if (!Array.isArray(idValue) || idValue.length !== pk.length) return "1=0";
     const conditions: string[] = [];
@@ -67,11 +67,11 @@ export function buildPkWhere(modelClass: typeof Base, idValue: unknown): string 
  * Mirrors: used with Arel managers for type-safe SQL generation
  */
 export function buildPkWhereNode(
-  modelClass: typeof Base,
+  this: typeof Base,
   idValue: unknown,
 ): InstanceType<typeof Nodes.Node> {
-  const table = modelClass.arelTable;
-  const pk = modelClass.primaryKey;
+  const table = this.arelTable;
+  const pk = this.primaryKey;
   if (Array.isArray(pk)) {
     if (!Array.isArray(idValue) || idValue.length !== pk.length) return arelSql("1=0");
     const values = idValue;
@@ -98,9 +98,9 @@ export function buildPkWhereNode(
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_names
  */
-export function columnNames(modelClass: typeof Base): string[] {
-  const ignored = new Set(modelClass.ignoredColumns ?? []);
-  return Array.from(modelClass._attributeDefinitions.keys()).filter((name) => !ignored.has(name));
+export function columnNames(this: typeof Base): string[] {
+  const ignored = new Set(this.ignoredColumns ?? []);
+  return Array.from(this._attributeDefinitions.keys()).filter((name) => !ignored.has(name));
 }
 
 /**
@@ -108,8 +108,8 @@ export function columnNames(modelClass: typeof Base): string[] {
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#has_attribute?
  */
-export function hasAttributeDefinition(modelClass: typeof Base, name: string): boolean {
-  return modelClass._attributeDefinitions.has(name);
+export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
+  return this._attributeDefinitions.has(name);
 }
 
 /**
@@ -118,13 +118,13 @@ export function hasAttributeDefinition(modelClass: typeof Base, name: string): b
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
  */
 export function columnsHash(
-  modelClass: typeof Base,
+  this: typeof Base,
 ): Record<string, { name: string; type: string; default: unknown }> {
-  if (modelClass.abstractClass) {
-    throw new Error(`Cannot call columnsHash on abstract class ${modelClass.name}`);
+  if (this.abstractClass) {
+    throw new Error(`Cannot call columnsHash on abstract class ${this.name}`);
   }
   const result: Record<string, { name: string; type: string; default: unknown }> = {};
-  for (const [name, def] of modelClass._attributeDefinitions) {
+  for (const [name, def] of this._attributeDefinitions) {
     result[name] = { name, type: def.type.name, default: def.defaultValue ?? null };
   }
   return result;
@@ -135,9 +135,9 @@ export function columnsHash(
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#content_columns
  */
-export function contentColumns(modelClass: typeof Base): string[] {
-  const pk = modelClass.primaryKey;
-  return columnNames(modelClass).filter((col) => {
+export function contentColumns(this: typeof Base): string[] {
+  const pk = this.primaryKey;
+  return columnNames.call(this).filter((col) => {
     if (col === pk) return false;
     if (col.endsWith("_id")) return false;
     if (col === "created_at" || col === "updated_at") return false;
@@ -234,19 +234,15 @@ export function sqlTypeFor(typeName: string, adapterName?: string): string {
  *
  * Mirrors: used by test infrastructure, not a direct Rails API
  */
-export async function createTable(modelClass: typeof Base): Promise<void> {
-  const table = resolveTableName(modelClass);
-  const pks = Array.isArray(modelClass.primaryKey)
-    ? modelClass.primaryKey
-    : [modelClass.primaryKey];
-  const adapterName = detectAdapterName(modelClass.adapter);
+export async function createTable(this: typeof Base): Promise<void> {
+  const table = resolveTableName.call(this);
+  const pks = Array.isArray(this.primaryKey) ? this.primaryKey : [this.primaryKey];
+  const adapterName = detectAdapterName(this.adapter);
   const isMysql = adapterName === "mysql";
   const isPg = adapterName === "postgres";
   const pkSet = new Set(pks);
 
-  await modelClass.adapter.executeMutation(
-    `DROP TABLE IF EXISTS ${quoteTableName(table, adapterName)}`,
-  );
+  await this.adapter.executeMutation(`DROP TABLE IF EXISTS ${quoteTableName(table, adapterName)}`);
 
   const colDefs: string[] = [];
   if (pks.length === 1) {
@@ -259,13 +255,13 @@ export async function createTable(modelClass: typeof Base): Promise<void> {
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
-      const pkDef = modelClass._attributeDefinitions.get(pk);
+      const pkDef = this._attributeDefinitions.get(pk);
       const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
       colDefs.push(`${quoteIdentifier(pk, adapterName)} ${pkType} NOT NULL`);
     }
   }
 
-  for (const [name, def] of modelClass._attributeDefinitions) {
+  for (const [name, def] of this._attributeDefinitions) {
     if (pkSet.has(name)) continue;
     const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
     colDefs.push(`${quoteIdentifier(name, adapterName)} ${sqlType}`);
@@ -275,7 +271,7 @@ export async function createTable(modelClass: typeof Base): Promise<void> {
     colDefs.push(`PRIMARY KEY (${pks.map((pk) => quoteIdentifier(pk, adapterName)).join(", ")})`);
   }
 
-  await modelClass.adapter.executeMutation(
+  await this.adapter.executeMutation(
     `CREATE TABLE IF NOT EXISTS ${quoteTableName(table, adapterName)} (${colDefs.join(", ")})`,
   );
 }
@@ -329,7 +325,7 @@ export function resetTableName(this: SchemaHost): string {
       return this._tableName!;
     }
   }
-  const name = resolveTableName(this as any);
+  const name = resolveTableName.call(this as any);
   this._tableName = name;
   return name;
 }
@@ -455,3 +451,29 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
   if (typeof ch === "function") return ch.call(host) ?? {};
   return {};
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ *
+ * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention: a Concern
+ * module exposes a `ClassMethods` object whose members become class methods
+ * on any class that includes the Concern. Grouping them here keeps the
+ * mixin surface colocated with the implementations.
+ *
+ * Not included: `resolveTableName`, `buildPkWhere`, `buildPkWhereNode` —
+ * these are internal helpers (resolveTableName backs the `tableName` getter;
+ * the two `buildPkWhere*` functions back the underscored `_buildPkWhere*`
+ * accessors on Base). They use the `this:` convention for internal
+ * consistency but are not surfaced as Rails-style class methods.
+ * Also not (yet) included: the 16 `this: SchemaHost`-typed helpers below
+ * (`deriveJoinTableName`, `quotedTableName`, `resetTableName`, etc.) that
+ * Rails exposes as class methods but aren't currently wired onto Base.
+ * Exposing them will follow in a separate PR.
+ */
+export const ClassMethods = {
+  columnNames,
+  hasAttributeDefinition,
+  columnsHash,
+  contentColumns,
+  createTable,
+};

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -460,20 +460,35 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * on any class that includes the Concern. Grouping them here keeps the
  * mixin surface colocated with the implementations.
  *
- * Not included: `resolveTableName`, `buildPkWhere`, `buildPkWhereNode` —
- * these are internal helpers (resolveTableName backs the `tableName` getter;
- * the two `buildPkWhere*` functions back the underscored `_buildPkWhere*`
- * accessors on Base). They use the `this:` convention for internal
- * consistency but are not surfaced as Rails-style class methods.
- * Also not (yet) included: the 16 `this: SchemaHost`-typed helpers below
- * (`deriveJoinTableName`, `quotedTableName`, `resetTableName`, etc.) that
- * Rails exposes as class methods but aren't currently wired onto Base.
- * Exposing them will follow in a separate PR.
+ * Not included:
+ * - `resolveTableName`, `buildPkWhere`, `buildPkWhereNode` — internal helpers
+ *   that back the `tableName` getter and the underscore-prefixed
+ *   `_buildPkWhere*` accessors. They use the `this:` convention for internal
+ *   consistency but aren't Rails-style class methods.
+ * - `realInheritanceColumn` — internal setter alias; `Base` already exposes
+ *   `inheritanceColumn` as a getter/setter.
+ * - `loadSchema` — private lifecycle hook in Rails; called automatically
+ *   rather than by user code.
  */
 export const ClassMethods = {
+  // Mirrors: ActiveRecord::ModelSchema::ClassMethods
   columnNames,
   hasAttributeDefinition,
   columnsHash,
   contentColumns,
   createTable,
+  deriveJoinTableName,
+  quotedTableName,
+  resetTableName,
+  fullTableNamePrefix,
+  fullTableNameSuffix,
+  resetSequenceName,
+  isPrefetchPrimaryKey,
+  nextSequenceValue,
+  attributesBuilder,
+  columns,
+  yamlEncoder,
+  columnForAttribute,
+  symbolColumnToString,
+  resetColumnInformation,
 };

--- a/packages/activerecord/src/table-metadata.ts
+++ b/packages/activerecord/src/table-metadata.ts
@@ -34,7 +34,7 @@ export class TableMetadata {
 
   hasColumn(columnName: string): boolean {
     if (!this._klass) return false;
-    const hash = columnsHash(this._klass);
+    const hash = columnsHash.call(this._klass);
     return columnName in hash;
   }
 


### PR DESCRIPTION
## Summary

Convert the first-arg-`modelClass` functions in `model-schema.ts` to the `this: typeof Base` convention so they can be wired via activesupport's `extend()`, and simultaneously expose the full Rails `ActiveRecord::ModelSchema::ClassMethods` surface on `Base`. Continues the pattern from #492 and #495.

## Mixed in via `extend(Base, ModelSchema.ClassMethods)`

**Newly converted (first-arg → `this:`)**:
- `columnNames` — Rails `#column_names`
- `hasAttributeDefinition` — Rails `#has_attribute?`
- `columnsHash` — Rails `#columns_hash`
- `contentColumns` — Rails `#content_columns`
- `createTable` — test/dev helper (no direct Rails equivalent; Rails uses migrations)

**Already `this:`-typed, newly surfaced on Base** (pure additive Rails fidelity):
- `deriveJoinTableName` — Rails `#derive_join_table_name`
- `quotedTableName` — Rails `#quoted_table_name`
- `resetTableName` — Rails `#reset_table_name`
- `fullTableNamePrefix` — Rails `#full_table_name_prefix`
- `fullTableNameSuffix` — Rails `#full_table_name_suffix`
- `resetSequenceName` — Rails `#reset_sequence_name`
- `isPrefetchPrimaryKey` — Rails `#prefetch_primary_key?`
- `nextSequenceValue` — Rails `#next_sequence_value`
- `attributesBuilder` — Rails `#attributes_builder`
- `columns` — Rails `#columns`
- `yamlEncoder` — Rails `#yaml_encoder`
- `columnForAttribute` — Rails `#column_for_attribute`
- `symbolColumnToString` — Rails `#symbol_column_to_string`
- `resetColumnInformation` — Rails `#reset_column_information`

**Total**: 19 class methods, all mirroring Rails' `ModelSchema::ClassMethods`. This exception to the 20-method PR limit is explicitly "very simple" — the 14 additive exposures are pure `declare static X: typeof ModelSchema.X` + `ClassMethods` object additions, zero logic changes.

## Signature-only conversions (not surfaced on Base)

- `resolveTableName` — backs the `tableName` getter delegate
- `buildPkWhere` — backs `_buildPkWhere` underscore accessor (internal)
- `buildPkWhereNode` — backs `_buildPkWhereNode` underscore accessor (internal)

These aren't Rails-facing class methods. Converted to `this:` for internal consistency. Their callers in `base.ts` switch from `ModelSchema.fn(this, ...)` to `ModelSchema.fn.call(this, ...)`.

## Intentionally excluded

- **`realInheritanceColumn`** — internal setter alias. `Base` already exposes `inheritanceColumn` as a getter/setter directly.
- **`loadSchema`** — private lifecycle hook in Rails, called automatically rather than by user code. Keeps our internal semantics aligned with Rails' `load_schema` privacy.

## Breaking changes (public API)

The `this:`-typed conversion makes these functions only callable via a class receiver. The intended public API is the class form — `User.columnNames()`, `User.columnsHash()`, etc. — via the Base mixins.

- **Package-root re-exports removed**: `schemaColumnNames`, `schemaColumnsHash`, `schemaContentColumns`, and `schemaCreateTable` (the `schema*` aliases in `index.ts`) are no longer exported from `@blazetrails/activerecord`'s root entrypoint. Any caller who was invoking them as free functions (e.g. `schemaColumnNames(User)`) would have gotten a silent runtime failure after the signature change — hard removal surfaces the issue as a compile error instead. Per CLAUDE.md we delete rather than alias.

## Call-site updates

- `table-metadata.ts`: `columnsHash(this._klass)` → `columnsHash.call(this._klass)`.
- Inside `model-schema.ts`: recursive call in `resolveTableName` and internal use in `createTable` / `contentColumns` updated to the `.call` form.

## Test plan
- [x] `tsc --build packages/activerecord` — clean
- [x] Full activerecord vitest suite — 8024 passed, 3733 skipped, 0 failed
- [x] Pre-commit hooks (eslint, prettier, build, typecheck) — clean