### PR TITLE
refactor(activerecord): counter_cache delegates to Relation via Arel

### DIFF
--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -94,7 +94,8 @@ function buildPkPredicate(
       const conditions = pk.map((col, i) => table.get(col).eq(tuple[i]));
       groupings.push(new Nodes.Grouping(new Nodes.And(conditions)));
     }
-    return groupings.reduce((left, right) => new Nodes.Or(left, right));
+    if (groupings.length === 1) return groupings[0];
+    return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));
   }
 
   const attr = table.get(pk);

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -100,6 +100,7 @@ function buildPkPredicate(
   const attr = table.get(pk);
   if (Array.isArray(id)) {
     if (id.length === 0) return arelSql("1=0");
+    if (id.some((value) => value === null || value === undefined)) return arelSql("1=0");
     return attr.in(id);
   }
   if (id === null || id === undefined) return arelSql("1=0");

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { Nodes } from "@blazetrails/arel";
+import { Nodes, sql as arelSql } from "@blazetrails/arel";
 
 /**
  * Counter cache operations for ActiveRecord models.
@@ -70,6 +70,10 @@ export async function updateCounters(
  * - single PK, array of ids → `"id" IN (5, 6, 7)`
  * - composite PK, one tuple → `("a" = 1 AND "b" = 2)`
  * - composite PK, array of tuples → `("a" = 1 AND "b" = 2) OR ("a" = 3 AND "b" = 4)`
+ *
+ * Returns the always-false `1=0` sentinel (matching
+ * `ModelSchema.buildPkWhereNode`) when the id list is empty, when a
+ * composite tuple has the wrong arity, or when any value is null/undefined.
  */
 function buildPkPredicate(
   modelClass: typeof Base,
@@ -79,17 +83,27 @@ function buildPkPredicate(
   const pk = modelClass.primaryKey;
 
   if (Array.isArray(pk)) {
+    if (!Array.isArray(id)) return arelSql("1=0");
     const ids = id as unknown[];
+    if (ids.length === 0) return arelSql("1=0");
     const tuples = Array.isArray(ids[0]) ? (ids as unknown[][]) : [ids];
-    const groupings: InstanceType<typeof Nodes.Node>[] = tuples.map((tuple) => {
+    const groupings: InstanceType<typeof Nodes.Node>[] = [];
+    for (const tuple of tuples) {
+      if (!Array.isArray(tuple) || tuple.length !== pk.length) return arelSql("1=0");
+      if (tuple.some((v) => v === null || v === undefined)) return arelSql("1=0");
       const conditions = pk.map((col, i) => table.get(col).eq(tuple[i]));
-      return new Nodes.Grouping(new Nodes.And(conditions));
-    });
+      groupings.push(new Nodes.Grouping(new Nodes.And(conditions)));
+    }
     return groupings.reduce((left, right) => new Nodes.Or(left, right));
   }
 
   const attr = table.get(pk);
-  return Array.isArray(id) ? attr.in(id) : attr.eq(id);
+  if (Array.isArray(id)) {
+    if (id.length === 0) return arelSql("1=0");
+    return attr.in(id);
+  }
+  if (id === null || id === undefined) return arelSql("1=0");
+  return attr.eq(id);
 }
 
 /**

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { quoteIdentifier } from "./connection-adapters/abstract/quoting.js";
+import { Nodes } from "@blazetrails/arel";
 
 /**
  * Counter cache operations for ActiveRecord models.
@@ -8,45 +8,49 @@ import { quoteIdentifier } from "./connection-adapters/abstract/quoting.js";
  */
 
 /**
- * Increment counter columns for a record by primary key.
+ * Increment a counter column for a record (or records) by primary key.
  *
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#increment_counter
+ *
+ * Rails delegates through `unscoped.where!(primary_key => id).update_counters(...)`,
+ * letting `Relation#update_counters` handle the Arel UPDATE construction.
+ * We do the same — see `Relation#updateCounters`.
  */
 export async function incrementCounter(
   this: typeof Base,
-  attribute: string,
+  counterName: string,
   id: unknown,
   by: number = 1,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  const table = this.arelTable;
-  const touchClause = buildTouchClause(options?.touch);
-  const quotedAttr = quoteIdentifier(attribute);
-  const idBinds = Array.isArray(id) ? id : [id];
-  const binds: unknown[] = [by, ...idBinds];
-  const sql = `UPDATE ${quoteIdentifier(table.name)} SET ${quotedAttr} = COALESCE(${quotedAttr}, 0) + ?${touchClause} WHERE ${buildPkPlaceholder(this)}`;
-  return this.adapter.executeMutation(sql, binds);
+  return updateCounters.call(this, id, { [counterName]: by }, options);
 }
 
 /**
- * Decrement counter columns for a record by primary key.
+ * Decrement a counter column for a record (or records) by primary key.
  *
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#decrement_counter
  */
 export async function decrementCounter(
   this: typeof Base,
-  attribute: string,
+  counterName: string,
   id: unknown,
   by: number = 1,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  return incrementCounter.call(this, attribute, id, -by, options);
+  return updateCounters.call(this, id, { [counterName]: -by }, options);
 }
 
 /**
- * Update counter columns for one or more records.
+ * Update one or more counter columns for records matching the given id(s).
  *
- * Mirrors: ActiveRecord::CounterCache::ClassMethods#update_counters
+ * Mirrors: ActiveRecord::CounterCache::ClassMethods#update_counters, which
+ * in Rails reads:
+ *
+ *   unscoped.where!(primary_key => id).update_counters(counters)
+ *
+ * The actual SQL construction lives on `Relation#updateCounters`, which
+ * uses Arel's `UpdateManager` with `COALESCE("col", 0) + N` expressions.
  */
 export async function updateCounters(
   this: typeof Base,
@@ -54,43 +58,38 @@ export async function updateCounters(
   counters: Record<string, number>,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  const table = this.arelTable;
-  const touchClause = buildTouchClause(options?.touch);
-  const binds: unknown[] = [];
-  const setClause =
-    Object.entries(counters)
-      .map(([attr, amount]) => {
-        const q = quoteIdentifier(attr);
-        binds.push(amount);
-        return `${q} = COALESCE(${q}, 0) + ?`;
-      })
-      .join(", ") + touchClause;
-  const tableName = quoteIdentifier(table.name);
+  const relation = this.unscoped().where(buildPkPredicate(this, id));
+  return relation.updateCounters(counters, options);
+}
 
-  const ids = Array.isArray(id) ? id : [id];
-  if (Array.isArray(this.primaryKey)) {
-    const tuples = Array.isArray(ids[0]) ? (ids as unknown[][]) : [ids as unknown[]];
-    const whereParts = tuples.map((t) => {
-      const pk = this.primaryKey as string[];
-      return `(${pk
-        .map((col) => {
-          binds.push(t[pk.indexOf(col)]);
-          return `${quoteIdentifier(col)} = ?`;
-        })
-        .join(" AND ")})`;
+/**
+ * Build an Arel WHERE predicate matching the given id(s) against the
+ * primary key. Handles four cases:
+ *
+ * - single PK, scalar id → `"id" = 5`
+ * - single PK, array of ids → `"id" IN (5, 6, 7)`
+ * - composite PK, one tuple → `("a" = 1 AND "b" = 2)`
+ * - composite PK, array of tuples → `("a" = 1 AND "b" = 2) OR ("a" = 3 AND "b" = 4)`
+ */
+function buildPkPredicate(
+  modelClass: typeof Base,
+  id: unknown | unknown[],
+): InstanceType<typeof Nodes.Node> {
+  const table = modelClass.arelTable;
+  const pk = modelClass.primaryKey;
+
+  if (Array.isArray(pk)) {
+    const ids = id as unknown[];
+    const tuples = Array.isArray(ids[0]) ? (ids as unknown[][]) : [ids];
+    const groupings: InstanceType<typeof Nodes.Node>[] = tuples.map((tuple) => {
+      const conditions = pk.map((col, i) => table.get(col).eq(tuple[i]));
+      return new Nodes.Grouping(new Nodes.And(conditions));
     });
-    const sql = `UPDATE ${tableName} SET ${setClause} WHERE ${whereParts.join(" OR ")}`;
-    return this.adapter.executeMutation(sql, binds);
+    return groupings.reduce((left, right) => new Nodes.Or(left, right));
   }
 
-  const placeholders = ids
-    .map(() => {
-      return "?";
-    })
-    .join(", ");
-  binds.push(...ids);
-  const sql = `UPDATE ${tableName} SET ${setClause} WHERE ${quoteIdentifier(this.primaryKey as string)} IN (${placeholders})`;
-  return this.adapter.executeMutation(sql, binds);
+  const attr = table.get(pk);
+  return Array.isArray(id) ? attr.in(id) : attr.eq(id);
 }
 
 /**
@@ -139,22 +138,6 @@ export async function resetCounters(
     const count = await countHasMany(record, assoc.name, assoc.options);
     await record.updateColumn(counterColumn, count);
   }
-}
-
-function buildPkPlaceholder(modelClass: typeof Base): string {
-  const pk = modelClass.primaryKey;
-  if (Array.isArray(pk)) {
-    return pk.map((col) => `${quoteIdentifier(col)} = ?`).join(" AND ");
-  }
-  return `${quoteIdentifier(pk)} = ?`;
-}
-
-function buildTouchClause(touch?: boolean | string | string[]): string {
-  if (!touch) return "";
-  if (touch === true) return `, ${quoteIdentifier("updated_at")} = CURRENT_TIMESTAMP`;
-  const cols = Array.isArray(touch) ? touch : [touch];
-  if (cols.length === 0) return "";
-  return cols.map((c) => `, ${quoteIdentifier(c)} = CURRENT_TIMESTAMP`).join("");
 }
 
 /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2735,6 +2735,11 @@ export class Relation<T extends Base> {
       }
     }
 
+    // Nothing to update (e.g. `updateCounters({})` or
+    // `updateCounters({}, { touch: [] })`) — skip updateAll, which would
+    // otherwise build an UPDATE with no SET clause and produce invalid SQL.
+    if (Object.keys(updates).length === 0) return 0;
+
     return this.updateAll(updates);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2730,7 +2730,7 @@ export class Relation<T extends Base> {
         const names = options.touch === true ? [] : ([] as string[]).concat(options.touch);
         const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names);
         for (const [col, time] of Object.entries(touchUpdates)) {
-          updates[col] = arelSql(`'${time.toISOString()}'`);
+          updates[col] = new Nodes.Quoted(time);
         }
       }
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -37,6 +37,7 @@ import { FromClause } from "./relation/from-clause.js";
 import { TableMetadata } from "./table-metadata.js";
 import { WhereClause, predicatesWithWrappedSqlLiterals } from "./relation/where-clause.js";
 import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
+import { touchAttributesWithTime } from "./timestamp.js";
 
 /**
  * Relation — the lazy, chainable query interface.
@@ -2686,25 +2687,49 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Update counters on matching records.
+   * Increment/decrement counter columns for all records matching this
+   * relation. Values can be positive (increment) or negative (decrement).
    *
-   * Mirrors: ActiveRecord::Relation#update_counters
+   * If `options.touch` is given, updates the named timestamp columns
+   * (and `updated_at`/`updated_on` by default) at the same time — matching
+   * Rails' `Relation#update_counters(counters, touch:)` behavior.
+   *
+   * Mirrors: ActiveRecord::Relation#update_counters. For each counter
+   * column, builds an Arel `COALESCE("col", 0) + N` expression via
+   * `NamedFunction` + `UnqualifiedColumn` + `Addition`. The COALESCE
+   * wrapper keeps NULL counters from propagating through the arithmetic.
    */
-  async updateCounters(counters: Record<string, number>): Promise<number> {
+  async updateCounters(
+    counters: Record<string, number>,
+    options?: { touch?: boolean | string | string[] },
+  ): Promise<number> {
     if (this._isNone) return 0;
+
     const table = this._modelClass.arelTable;
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = Object.entries(counters).map(
-      ([key, val]) => {
-        const col = table.get(key);
-        const coalesced = new Nodes.NamedFunction("COALESCE", [col, new Nodes.Quoted(0)]);
-        return [col, new Nodes.Addition(coalesced, new Nodes.Quoted(val))];
-      },
-    );
-    const um = new UpdateManager().table(table).set(updateValues);
-    for (const cond of this._buildWhereStrings(table)) {
-      um.where(arelSql(cond));
+    const updates: Record<string, unknown> = {};
+
+    for (const [counterName, value] of Object.entries(counters)) {
+      const unqual = new Nodes.UnqualifiedColumn(table.get(counterName));
+      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
+      updates[counterName] = new Nodes.Addition(coalesced, new Nodes.Quoted(value));
     }
-    return this._modelClass.adapter.executeMutation(um.toSql());
+
+    if (options?.touch) {
+      // `touch: []` is an explicit "skip timestamp updates" signal. Rails'
+      // counter_cache test `update counters doesn't touch timestamps with
+      // touch: []` asserts this behavior (its Rails implementation is
+      // incidentally a no-op because the test never reloads the record).
+      const isEmptyArray = Array.isArray(options.touch) && options.touch.length === 0;
+      if (!isEmptyArray) {
+        const names = options.touch === true ? [] : ([] as string[]).concat(options.touch);
+        const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names);
+        for (const [col, time] of Object.entries(touchUpdates)) {
+          updates[col] = arelSql(`'${time.toISOString()}'`);
+        }
+      }
+    }
+
+    return this.updateAll(updates);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2708,10 +2708,16 @@ export class Relation<T extends Base> {
     const table = this._modelClass.arelTable;
     const updates: Record<string, unknown> = {};
 
+    // Mirrors Rails' `_increment_attribute` — wrap the column in a COALESCE
+    // (treating NULL as 0) and then add/subtract the binding. Rails uses
+    // `Subtraction` for negative values and `Addition` for positive ones so
+    // the generated SQL reads `col - 3` rather than `col + -3`.
     for (const [counterName, value] of Object.entries(counters)) {
       const unqual = new Nodes.UnqualifiedColumn(table.get(counterName));
       const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
-      updates[counterName] = new Nodes.Addition(coalesced, new Nodes.Quoted(value));
+      const bind = new Nodes.Quoted(Math.abs(value));
+      updates[counterName] =
+        value < 0 ? new Nodes.Subtraction(coalesced, bind) : new Nodes.Addition(coalesced, bind);
     }
 
     if (options?.touch) {

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -37,6 +37,43 @@ describe("UpdateManagerTest", () => {
     });
   });
 
+  describe("UnqualifiedColumn", () => {
+    it("renders without a table qualifier on the RHS of an UPDATE SET", () => {
+      // Mirrors Rails' ActiveRecord::CounterCache pattern:
+      //   SET "counter" = COALESCE("counter", 0) + 1
+      // without a `"posts"."counter"` table prefix on the RHS, which some
+      // adapters reject inside UPDATE statements.
+      const posts = new Table("posts");
+      const counter = posts.get("counter");
+      const unqual = new Nodes.UnqualifiedColumn(counter);
+      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
+      const expr = new Nodes.Addition(coalesced, new Nodes.Quoted(1));
+
+      const um = new UpdateManager();
+      um.table(posts);
+      um.set([[counter, expr]]);
+      const sql = um.toSql();
+
+      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) + 1`);
+      expect(sql).not.toContain(`"posts"."counter", 0`);
+    });
+
+    it("supports Subtraction for negative counter deltas", () => {
+      const posts = new Table("posts");
+      const counter = posts.get("counter");
+      const unqual = new Nodes.UnqualifiedColumn(counter);
+      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
+      const expr = new Nodes.Subtraction(coalesced, new Nodes.Quoted(3));
+
+      const um = new UpdateManager();
+      um.table(posts);
+      um.set([[counter, expr]]);
+      const sql = um.toSql();
+
+      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) - 3`);
+    });
+  });
+
   describe("set", () => {
     it("updates with null", () => {
       const mgr = new UpdateManager();

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1194,7 +1194,10 @@ export class ToSql implements NodeVisitor<SQLString> {
   private visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
     // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
     // qualifier so `SET col = col + 1` works in UPDATE statements.
-    const attr = node.attribute as Nodes.Attribute;
+    const attr = node.attribute as Partial<Nodes.Attribute> | undefined;
+    if (!attr || typeof attr.name !== "string") {
+      throw new UnsupportedVisitError("UnqualifiedColumn must wrap an Attribute node with a name");
+    }
     this.collector.append(`"${attr.name}"`);
     return this.collector;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -157,6 +157,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     if (node instanceof Nodes.SqlLiteral) return this.visitSqlLiteral(node);
     if (node instanceof Nodes.Quoted) return this.visitQuoted(node);
     if (node instanceof Nodes.Casted) return this.visitCasted(node);
+    if (node instanceof Nodes.UnqualifiedColumn) return this.visitUnqualifiedColumn(node);
     if (node instanceof Nodes.Attribute) return this.visitAttribute(node);
     if (node instanceof Nodes.ValuesList) return this.visitValuesList(node);
     if (node instanceof Table) return this.visitTable(node);
@@ -1187,6 +1188,14 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   private visitAttribute(node: Nodes.Attribute): SQLString {
     this.collector.append(`"${node.relation.tableAlias || node.relation.name}"."${node.name}"`);
+    return this.collector;
+  }
+
+  private visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
+    // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
+    // qualifier so `SET col = col + 1` works in UPDATE statements.
+    const attr = node.attribute as Nodes.Attribute;
+    this.collector.append(`"${attr.name}"`);
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary

Bring `ActiveRecord::CounterCache` in line with Rails' architecture. Rails splits counter cache into two layers:

1. `CounterCache::ClassMethods#update_counters(id, counters)` does PK resolution and delegates through `unscoped.where!(primary_key => id).update_counters(counters)`.
2. `Relation#update_counters(counters)` builds the actual UPDATE via Arel (`InfixOperation` + `UnqualifiedColumn`) and calls `update_all`.

Our previous implementation skipped the Relation layer entirely and hand-rolled raw `UPDATE ... SET col = COALESCE(col, 0) + ?` SQL strings inside the class method — tracked as a follow-up in #495.

## Changes

### `counter-cache.ts`
- `incrementCounter` / `decrementCounter` become one-line delegates to `updateCounters`, matching Rails' thin wrappers.
- `updateCounters` builds an Arel PK predicate (scalar id, array of ids, composite PK tuple, or array of tuples) and calls `this.unscoped().where(pred).updateCounters(counters, options)`.
- Removes ~90 lines of raw SQL construction plus the `buildPkPlaceholder` / `buildTouchClause` helpers.

### `relation.ts`
- `Relation#updateCounters` already existed but had two problems: it used a bare Attribute on the RHS (rendering `"tbl"."col"` inside a `SET` expression — tolerated by SQLite but non-idiomatic), and it didn't support the `touch:` option. Rewritten to wrap the Attribute in `Nodes.UnqualifiedColumn` so the RHS renders as `"col"`, and to merge in timestamp updates via `touchAttributesWithTime` when `options.touch` is set. Single code path for counter_cache's class method and for `belongs_to` association counter bookkeeping, which was already using `Relation#updateCounters`.
- **`touch: []` edge case**: Rails' test `update counters doesn't touch timestamps with touch: []` asserts that an empty `touch` array is a no-op. Rails' implementation is incidentally a no-op because the test never reloads the record, so the broken assertion never fires; our equivalent test reloads and checks the DB row directly. Implemented an explicit `touch: []` short-circuit so our stricter test stays green.

### `arel/visitors/to-sql.ts`
- Add `visitUnqualifiedColumn` dispatch. Mirrors Arel's `visit_Arel_Nodes_UnqualifiedColumn` — renders the column name without the table qualifier (`"col"` instead of `"tbl"."col"`), which is what makes `SET col = COALESCE(col, 0) + 1` well-formed.

## Test plan
- [x] `tsc --build packages/activerecord` — clean
- [x] \`counter-cache.test.ts\` — 73 passed, 28 skipped
- [x] Full activerecord vitest suite — 8024 passed, 3733 skipped, 0 failed
- [x] Pre-commit hooks (eslint, prettier, build, typecheck) — clean