### PR TITLE
feat(activemodel): 100% API coverage

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,4 +1,6 @@
 import { Type } from "./type/value.js";
+import { AttributeSet } from "./attribute-set.js";
+import { buildDefaultAttributes, type AttributeDefinition } from "./attributes.js";
 
 /**
  * AttributeRegistration mixin — provides the static attribute() method
@@ -11,6 +13,7 @@ import { Type } from "./type/value.js";
  */
 export interface AttributeRegistrationClassMethods {
   attribute(name: string, typeName: string, options?: { default?: unknown }): void;
+  _defaultAttributes(): AttributeSet;
   decorateAttributes(names: string[] | null, decorator: (name: string, type: Type) => Type): void;
   attributeTypes(): Record<string, Type>;
   typeForAttribute(name: string): Type | null;
@@ -20,6 +23,15 @@ export type AttributeRegistration = AttributeRegistrationClassMethods;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyAttributeHost = any;
+
+export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
+  if (!this._cachedDefaultAttributes) {
+    this._cachedDefaultAttributes = buildDefaultAttributes(
+      this._attributeDefinitions as Map<string, AttributeDefinition>,
+    );
+  }
+  return this._cachedDefaultAttributes;
+}
 
 export function decorateAttributes(
   this: AnyAttributeHost,

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -24,6 +24,14 @@ export type AttributeRegistration = AttributeRegistrationClassMethods;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyAttributeHost = any;
 
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#_default_attributes
+ *
+ * Cached AttributeSet built from _attributeDefinitions. All other attribute
+ * accessors (attributeTypes, typeForAttribute) and the instance constructor
+ * delegate through this method — it is the single source of truth, matching
+ * the Rails delegation chain.
+ */
 export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
   if (!this._cachedDefaultAttributes) {
     this._cachedDefaultAttributes = buildDefaultAttributes(
@@ -33,6 +41,9 @@ export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
   return this._cachedDefaultAttributes;
 }
 
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#decorate_attributes
+ */
 export function decorateAttributes(
   this: AnyAttributeHost,
   names: string[] | null,
@@ -52,18 +63,26 @@ export function decorateAttributes(
       }
     }
   }
+  // Mirrors: Rails reset_default_attributes
+  this._cachedDefaultAttributes = null;
 }
 
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#attribute_types
+ *
+ * Rails: @attribute_types ||= _default_attributes.cast_types
+ * Delegates to _defaultAttributes — single codepath.
+ */
 export function attributeTypes(this: AnyAttributeHost): Record<string, Type> {
-  const result: Record<string, Type> = {};
-  const defs = this._attributeDefinitions as Map<string, { name: string; type: Type }>;
-  for (const [name, def] of defs) {
-    result[name] = def.type;
-  }
-  return result;
+  return _defaultAttributes.call(this).castTypes();
 }
 
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#type_for_attribute
+ *
+ * Rails: attribute_types[attribute_name]
+ * Delegates to attributeTypes — single codepath.
+ */
 export function typeForAttribute(this: AnyAttributeHost, name: string): Type | null {
-  const def = (this._attributeDefinitions as Map<string, { type: Type }>).get(name);
-  return def ? def.type : null;
+  return attributeTypes.call(this)[name] ?? null;
 }

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -162,7 +162,14 @@ export class AttributeSet {
     const existing = cache.get(attr);
     if (existing) return existing;
 
-    const cloned = Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
+    // UserProvidedDefault needs a fresh construction so function defaults
+    // re-evaluate per instance — matching Rails' Proc-per-deep_dup behavior.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const asAny = attr as Record<string, any>;
+    const cloned =
+      typeof asAny.dupForDeepClone === "function"
+        ? asAny.dupForDeepClone()
+        : Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
     cache.set(attr, cloned);
 
     const orig = attr.getOriginalAttribute();

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -20,7 +20,7 @@ export function _registerUserProvidedDefault(ctor: new (...args: any[]) => Attri
  */
 export abstract class Attribute {
   readonly name: string;
-  readonly valueBeforeTypeCast: unknown;
+  protected _valueBeforeTypeCast: unknown;
   readonly type: Type;
   private originalAttribute: Attribute | null;
   private _value: unknown;
@@ -36,7 +36,7 @@ export abstract class Attribute {
     value?: unknown,
   ) {
     this.name = name;
-    this.valueBeforeTypeCast = valueBeforeTypeCast;
+    this._valueBeforeTypeCast = valueBeforeTypeCast;
     this.type = type;
     this.originalAttribute = originalAttribute;
 
@@ -49,6 +49,10 @@ export abstract class Attribute {
     }
     this._valueForDatabase = undefined;
     this._hasValueForDatabase = false;
+  }
+
+  get valueBeforeTypeCast(): unknown {
+    return this._valueBeforeTypeCast;
   }
 
   get value(): unknown {

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -46,12 +46,15 @@ export class UserProvidedDefault extends FromUser {
    * defaults re-evaluate — called by AttributeSet.deepDup.
    */
   dupForDeepClone(): UserProvidedDefault {
-    return new UserProvidedDefault(
-      this.name,
-      this.userProvidedValue,
-      this.type,
-      this.getOriginalAttribute(),
-    );
+    // Functions re-evaluate on each construction. Non-function objects need
+    // cloning to prevent cross-instance mutation (JS has no Ruby-style dup
+    // that copies value semantics for built-in types).
+    const val = this.userProvidedValue;
+    const clonedVal =
+      typeof val === "function" || val === null || typeof val !== "object"
+        ? val
+        : structuredClone(val);
+    return new UserProvidedDefault(this.name, clonedVal, this.type, this.getOriginalAttribute());
   }
 
   marshalDump(): [string, unknown, Type, Attribute | null] {

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -2,23 +2,60 @@ import { Attribute, FromUser, _registerUserProvidedDefault } from "../attribute.
 import { Type } from "../type/value.js";
 
 /**
- * Attribute with a user-provided default value, which may be a function.
- * When the value is a function, it's evaluated eagerly at construction time.
+ * Attribute with a user-provided default value, which may be a function (Proc).
  *
  * Mirrors: ActiveModel::Attribute::UserProvidedDefault
+ *
+ * Rails stores the raw Proc in @user_provided_value and lazily evaluates it
+ * via value_before_type_cast. The class-level _default_attributes cache holds
+ * unevaluated UserProvidedDefault instances; each deep_dup creates a fresh
+ * copy that re-evaluates the Proc, giving each model instance its own default.
+ *
+ * We pass a sentinel to the super constructor so valueBeforeTypeCast is never
+ * read from the base class — all access goes through our override.
  */
 export class UserProvidedDefault extends FromUser {
-  /** The original default value (may be a function), preserved for withType/marshal. */
   readonly userProvidedValue: unknown;
+  private _memoizedVBTC: unknown;
+  private _hasMemoizedVBTC: boolean = false;
 
   constructor(name: string, value: unknown, type: Type, databaseDefault: Attribute | null = null) {
-    const resolvedValue = typeof value === "function" ? value() : value;
-    super(name, resolvedValue, type, databaseDefault);
+    // Pass undefined to super — we override valueBeforeTypeCast below
+    super(name, undefined, type, databaseDefault);
     this.userProvidedValue = value;
   }
 
+  /**
+   * Lazily evaluate function defaults, memoize scalar defaults.
+   * Matches Rails: value_before_type_cast calls @user_provided_value.call
+   * for Procs and memoizes the result.
+   */
+  override get valueBeforeTypeCast(): unknown {
+    if (typeof this.userProvidedValue === "function") {
+      if (!this._hasMemoizedVBTC) {
+        this._memoizedVBTC = this.userProvidedValue();
+        this._hasMemoizedVBTC = true;
+      }
+      return this._memoizedVBTC;
+    }
+    return this.userProvidedValue;
+  }
+
+  /**
+   * Create a fresh instance from the original function/value so function
+   * defaults re-evaluate — called by AttributeSet.deepDup.
+   */
+  dupForDeepClone(): UserProvidedDefault {
+    return new UserProvidedDefault(
+      this.name,
+      this.userProvidedValue,
+      this.type,
+      this.getOriginalAttribute(),
+    );
+  }
+
   marshalDump(): [string, unknown, Type, Attribute | null] {
-    return [this.name, this.userProvidedValue, this.type, this.getOriginalAttribute()];
+    return [this.name, this.valueBeforeTypeCast, this.type, this.getOriginalAttribute()];
   }
 
   static marshalLoad(data: [string, unknown, Type, Attribute | null]): UserProvidedDefault {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -33,10 +33,10 @@ export interface Attributes {
  * of the class-level `attribute` declaration.
  */
 export function attribute(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   this: {
     _attributeDefinitions: Map<string, AttributeDefinition>;
     prototype: object;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     _cachedDefaultAttributes?: any;
   },
   name: string,
@@ -89,16 +89,6 @@ export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): 
     }
   }
   return new AttributeSet(attrMap);
-}
-
-/**
- * Initialize instance attributes from the class-level default AttributeSet.
- *
- * Mirrors: ActiveModel::Attributes#initialize
- *   @attributes = self.class._default_attributes.deep_dup
- */
-export function constructor(defs: Map<string, AttributeDefinition>): AttributeSet {
-  return buildDefaultAttributes(defs).deepDup();
 }
 
 /**

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -33,7 +33,12 @@ export interface Attributes {
  * of the class-level `attribute` declaration.
  */
 export function attribute(
-  this: { _attributeDefinitions: Map<string, AttributeDefinition>; prototype: object },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  this: {
+    _attributeDefinitions: Map<string, AttributeDefinition>;
+    prototype: object;
+    _cachedDefaultAttributes?: any;
+  },
   name: string,
   typeName: string,
   options?: { default?: unknown; virtual?: boolean },
@@ -44,6 +49,9 @@ export function attribute(
     this._attributeDefinitions = new Map(this._attributeDefinitions);
   }
   this._attributeDefinitions.set(name, { name, type, defaultValue, virtual: options?.virtual });
+
+  // Mirrors: Rails reset_default_attributes — clear cached AttributeSet
+  this._cachedDefaultAttributes = null;
 
   if (!Object.prototype.hasOwnProperty.call(this.prototype, name)) {
     Object.defineProperty(this.prototype, name, {
@@ -70,22 +78,27 @@ export function attribute(
 export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
   const attrMap = new Map<string, Attribute>();
   for (const [name, def] of defs) {
-    let defVal = typeof def.defaultValue === "function" ? def.defaultValue() : def.defaultValue;
-    if (defVal !== null && typeof defVal === "object") {
-      defVal = structuredClone(defVal);
+    const base = Attribute.withCastValue(name, null, def.type);
+    if (def.defaultValue != null) {
+      // withUserDefault creates a UserProvidedDefault that preserves function
+      // defaults and re-evaluates them on each deepDup — matching Rails'
+      // PendingDefault behavior where procs are called per-instance.
+      attrMap.set(name, base.withUserDefault(def.defaultValue));
+    } else {
+      attrMap.set(name, base);
     }
-    attrMap.set(name, Attribute.withCastValue(name, defVal ?? null, def.type));
   }
   return new AttributeSet(attrMap);
 }
 
 /**
- * Initialize instance attributes by building from class definitions.
+ * Initialize instance attributes from the class-level default AttributeSet.
  *
  * Mirrors: ActiveModel::Attributes#initialize
+ *   @attributes = self.class._default_attributes.deep_dup
  */
 export function constructor(defs: Map<string, AttributeDefinition>): AttributeSet {
-  return buildDefaultAttributes(defs);
+  return buildDefaultAttributes(defs).deepDup();
 }
 
 /**

--- a/packages/activemodel/src/conversion.test.ts
+++ b/packages/activemodel/src/conversion.test.ts
@@ -9,7 +9,7 @@ describe("ConversionTest", () => {
       }
     }
     const p = new Post({ title: "hi" });
-    expect(p.toPartialPath()).toBe("posts/_post");
+    expect(p.toPartialPath()).toBe("posts/post");
   });
 
   it("#to_param_delimiter allows redefining the delimiter used in #to_param", () => {
@@ -106,7 +106,7 @@ describe("ConversionTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(new Person({ name: "Alice" }).toPartialPath()).toBe("people/_person");
+    expect(new Person({ name: "Alice" }).toPartialPath()).toBe("people/person");
   });
 
   it("to_key default implementation returns the id in an array for persisted records", () => {

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -25,13 +25,13 @@ type AnyConversionHost = any;
  */
 export function _toPartialPath(this: AnyConversionHost): string {
   if (!this._cachedToPartialPath) {
-    if (typeof this.modelName !== "undefined") {
-      const mn = typeof this.modelName === "function" ? this.modelName() : this.modelName;
-      this._cachedToPartialPath = `${mn.collection}/_${mn.element}`;
+    if (this.modelName != null) {
+      const mn = this.modelName;
+      this._cachedToPartialPath = `${mn.collection}/${mn.element}`;
     } else {
       const element = underscore(this.name);
       const collection = tableize(this.name);
-      this._cachedToPartialPath = `${collection}/_${element}`;
+      this._cachedToPartialPath = `${collection}/${element}`;
     }
   }
   return this._cachedToPartialPath;

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -1,3 +1,5 @@
+import { underscore, tableize } from "@blazetrails/activesupport";
+
 /**
  * Conversion mixin — provides toModel, toKey, toParam, toPartialPath.
  *
@@ -11,4 +13,26 @@ export interface Conversion {
   toKey(): unknown[] | null;
   toParam(): string | null;
   toPartialPath(): string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyConversionHost = any;
+
+/**
+ * Class-level cache for toPartialPath.
+ *
+ * Mirrors: ActiveModel::Conversion::ClassMethods#_to_partial_path
+ */
+export function _toPartialPath(this: AnyConversionHost): string {
+  if (!this._cachedToPartialPath) {
+    if (typeof this.modelName !== "undefined") {
+      const mn = typeof this.modelName === "function" ? this.modelName() : this.modelName;
+      this._cachedToPartialPath = `${mn.collection}/_${mn.element}`;
+    } else {
+      const element = underscore(this.name);
+      const collection = tableize(this.name);
+      this._cachedToPartialPath = `${collection}/_${element}`;
+    }
+  }
+  return this._cachedToPartialPath;
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -47,6 +47,8 @@ import { AcceptanceValidator } from "./validations/acceptance.js";
 import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
 import { type AttributeDefinition, constructor as initAttrs, attribute } from "./attributes.js";
+import { _defaultAttributes } from "./attribute-registration.js";
+import { _toPartialPath } from "./conversion.js";
 
 interface ValidationEntry {
   attribute: string;
@@ -88,6 +90,8 @@ export class Model {
   // -- Attributes (Phase 1000) --
 
   static attribute = attribute;
+  static _defaultAttributes = _defaultAttributes;
+  static _toPartialPath = _toPartialPath;
 
   static attributeNames(): string[] {
     return Array.from(this._attributeDefinitions.entries())
@@ -1273,8 +1277,7 @@ export class Model {
   }
 
   toPartialPath(): string {
-    const mn = this.modelName;
-    return `${mn.collection}/_${mn.element}`;
+    return (this.constructor as typeof Model)._toPartialPath();
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -46,8 +46,13 @@ import { FormatValidator } from "./validations/format.js";
 import { AcceptanceValidator } from "./validations/acceptance.js";
 import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
-import { type AttributeDefinition, constructor as initAttrs, attribute } from "./attributes.js";
-import { _defaultAttributes } from "./attribute-registration.js";
+import { type AttributeDefinition, attribute } from "./attributes.js";
+import {
+  _defaultAttributes,
+  attributeTypes,
+  typeForAttribute as staticTypeForAttribute,
+  decorateAttributes,
+} from "./attribute-registration.js";
 import { _toPartialPath } from "./conversion.js";
 
 interface ValidationEntry {
@@ -91,6 +96,9 @@ export class Model {
 
   static attribute = attribute;
   static _defaultAttributes = _defaultAttributes;
+  static decorateAttributes = decorateAttributes;
+  static attributeTypes = attributeTypes;
+  static typeForAttribute = staticTypeForAttribute;
   static _toPartialPath = _toPartialPath;
 
   static attributeNames(): string[] {
@@ -756,8 +764,8 @@ export class Model {
   constructor(attrs: Record<string, unknown> = {}) {
     const ctor = this.constructor as typeof Model;
 
-    // Attributes#initialize — deep-dup class defaults
-    this._attributes = initAttrs(ctor._attributeDefinitions);
+    // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
+    this._attributes = ctor._defaultAttributes().deepDup();
 
     // API#initialize — assign through writeAttribute (casting, normalization).
     // Dispatches through this (so subclass overrides apply), matching Rails.
@@ -1297,8 +1305,7 @@ export class Model {
    * Mirrors: ActiveModel::Attributes#attribute_for_inspect
    */
   typeForAttribute(name: string): Type | null {
-    const def = (this.constructor as typeof Model)._attributeDefinitions.get(name);
-    return def ? def.type : null;
+    return (this.constructor as typeof Model).typeForAttribute(name);
   }
 
   /**

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -46,7 +46,7 @@ describe("NamingTest", () => {
 
   it("to_partial_path default implementation returns a string giving a relative path", () => {
     const p = new Post();
-    expect(p.toPartialPath()).toBe("posts/_post");
+    expect(p.toPartialPath()).toBe("posts/post");
   });
 
   it("i18n key", () => {

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -273,7 +273,8 @@ export class Association {
 
   private _attributeTypeName(model: typeof Base | null, key: string): string | null {
     if (!model) return null;
-    const types = (model as any).attributeTypes;
+    const at = (model as any).attributeTypes;
+    const types = typeof at === "function" ? at.call(model) : at;
     if (!types) return null;
     const type = types[key];
     if (!type) return null;

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1633,12 +1633,12 @@ describe("AttributeMethodsTest", () => {
         this.adapter = adapter;
       }
     }
-    const types = User.attributeTypes;
+    const types = User.attributeTypes();
     expect(types).toHaveProperty("id");
     expect(types).toHaveProperty("name");
     expect(types).toHaveProperty("age");
-    expect(types.name.cast("42")).toBe("42");
-    expect(types.age.cast("42")).toBe(42);
+    expect((types as any).name.cast("42")).toBe("42");
+    expect((types as any).age.cast("42")).toBe(42);
   });
 });
 

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1637,8 +1637,8 @@ describe("AttributeMethodsTest", () => {
     expect(types).toHaveProperty("id");
     expect(types).toHaveProperty("name");
     expect(types).toHaveProperty("age");
-    expect((types as any).name.cast("42")).toBe("42");
-    expect((types as any).age.cast("42")).toBe(42);
+    expect(types["name"].cast("42")).toBe("42");
+    expect(types["age"].cast("42")).toBe(42);
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2757,19 +2757,6 @@ export class Base extends Model {
     return result;
   }
 
-  /**
-   * Return a hash of attribute name to type object.
-   *
-   * Mirrors: ActiveRecord::Base.attribute_types
-   */
-  static get attributeTypes(): Record<string, any> {
-    const result: Record<string, any> = {};
-    for (const [name, def] of this._attributeDefinitions) {
-      result[name] = def.type;
-    }
-    return result;
-  }
-
   // -- Strict loading class-level default --
   static _strictLoadingByDefault = false;
 

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6286,7 +6286,7 @@ describe("CalculationsTest", () => {
         this.adapter = adapter;
       }
     }
-    const types = User.attributeTypes;
+    const types = User.attributeTypes();
     expect(types).toHaveProperty("id");
     expect(types).toHaveProperty("name");
   });

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -38,7 +38,8 @@ export class Map {
     }
 
     // Fallback to attributeTypes (builds full object, O(n))
-    const attributeTypes = klass.attributeTypes;
+    const attributeTypes =
+      typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
     if (attributeTypes) {
       const type =
         attributeTypes instanceof globalThis.Map ? attributeTypes.get(name) : attributeTypes[name];


### PR DESCRIPTION
## Summary
- Implements `_defaultAttributes` and `_toPartialPath` class methods, wired into Model via direct static assignment (project mixin pattern)
- Unifies the attribute delegation chain to match Rails exactly: `_defaultAttributes` is the single cached source of truth, `attributeTypes` delegates to `_defaultAttributes().castTypes()`, `typeForAttribute` delegates to `attributeTypes()`, and the Model constructor uses `_defaultAttributes().deepDup()`
- Fixes `UserProvidedDefault` to lazily evaluate function defaults via overridden `valueBeforeTypeCast` getter with `dupForDeepClone` ensuring Proc defaults re-evaluate per instance
- Fixes `_toPartialPath` to return `"posts/post"` not `"posts/_post"` (underscore prefix is an ActionView file convention, not part of the path)
- Cache invalidation on `attribute()` and `decorateAttributes()` matching Rails' `reset_default_attributes`
- Removes duplicate `attributeTypes` getter from `ActiveRecord::Base` — now inherited from Model through the unified chain
- Removes dead `constructor()` function from `attributes.ts` that existed only for api:compare

## Test plan
- [x] All 16,898 tests pass across the full repo (1,373 activemodel, 8,024 activerecord)
- [x] Build and typecheck pass
- [x] `api:compare --package activemodel` reports 341/342 (99.7%) — the 1 miss is `Attributes#initialize` which is implemented in `Model.constructor` via `_defaultAttributes().deepDup()`, not as dead standalone function