### PR TITLE
feat(activesupport): add included/extended hooks to include() and extend()

### DIFF
--- a/packages/activesupport/src/concern.test.ts
+++ b/packages/activesupport/src/concern.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { concern, includeConcern, hasConcern } from "./concern.js";
+import { extended } from "./include.js";
 
 describe("Concern", () => {
   it("mixes instance methods into class prototype", () => {
@@ -411,5 +412,41 @@ describe("ConcernTest", () => {
     includeConcern(Base, m);
     expect((Base as any).classMethod()).toBe("class");
     expect(new (Base as any)().instMethod()).toBe("inst");
+  });
+
+  it("fires Symbol extended hook on classMethods when concern is included", () => {
+    const calls: any[] = [];
+    class Base {}
+    const m = concern({
+      classMethods: {
+        classMethod() {
+          return "class";
+        },
+        [extended](base: any) {
+          calls.push(base);
+        },
+      },
+    });
+    includeConcern(Base, m);
+    expect((Base as any).classMethod()).toBe("class");
+    expect(calls).toEqual([Base]);
+  });
+
+  it("fires Symbol extended hook on instanceMethods when concern is included", () => {
+    const calls: any[] = [];
+    class Base {}
+    const m = concern({
+      instanceMethods: {
+        instMethod() {
+          return "inst";
+        },
+        [extended](base: any) {
+          calls.push(base);
+        },
+      },
+    });
+    includeConcern(Base, m);
+    expect(new (Base as any)().instMethod()).toBe("inst");
+    expect(calls).toEqual([Base.prototype]);
   });
 });

--- a/packages/activesupport/src/concern.ts
+++ b/packages/activesupport/src/concern.ts
@@ -39,11 +39,20 @@ const PREPENDED_BLOCK = Symbol("prependedBlock");
  * semantics have no equivalent in the plain include() helper.
  */
 function prependMethods(klass: any, methods: Record<string, Function>): void {
+  const descriptor = {
+    value: undefined as any,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  };
   for (const [name, fn] of Object.entries(methods)) {
-    if (klass.prototype[name]) {
-      klass.prototype[`_super_${name}`] = klass.prototype[name];
+    const existing = klass.prototype[name];
+    if (existing) {
+      descriptor.value = existing;
+      Object.defineProperty(klass.prototype, `_super_${name}`, descriptor);
     }
-    klass.prototype[name] = fn;
+    descriptor.value = fn;
+    Object.defineProperty(klass.prototype, name, descriptor);
   }
 }
 

--- a/packages/activesupport/src/concern.ts
+++ b/packages/activesupport/src/concern.ts
@@ -1,3 +1,5 @@
+import { extend as extendModule } from "./include.js";
+
 export class MultipleIncludedBlocks extends Error {
   constructor() {
     super("Cannot define multiple 'included' blocks for a Concern");
@@ -30,6 +32,21 @@ const INCLUDED_CONCERNS = Symbol("includedConcerns");
 const INCLUDED_BLOCK = Symbol("includedBlock");
 const PREPENDED_BLOCK = Symbol("prependedBlock");
 
+/**
+ * Prepend instance methods onto klass.prototype, saving originals as
+ * _super_<name> so the prepending method can call through.
+ * This is the one path Concern handles directly — Ruby's prepend
+ * semantics have no equivalent in the plain include() helper.
+ */
+function prependMethods(klass: any, methods: Record<string, Function>): void {
+  for (const [name, fn] of Object.entries(methods)) {
+    if (klass.prototype[name]) {
+      klass.prototype[`_super_${name}`] = klass.prototype[name];
+    }
+    klass.prototype[name] = fn;
+  }
+}
+
 export namespace Concern {
   export function define(definition: ConcernDefinition): ConcernMixin {
     return { __concern: true, definition };
@@ -40,10 +57,10 @@ export namespace Concern {
       const inherited: Set<ConcernMixin> | undefined = klass[INCLUDED_CONCERNS];
       klass[INCLUDED_CONCERNS] = inherited ? new Set(inherited) : new Set<ConcernMixin>();
     }
-    const included: Set<ConcernMixin> = klass[INCLUDED_CONCERNS];
+    const includedSet: Set<ConcernMixin> = klass[INCLUDED_CONCERNS];
 
-    if (included.has(mixin)) return;
-    included.add(mixin);
+    if (includedSet.has(mixin)) return;
+    includedSet.add(mixin);
 
     const def = mixin.definition;
 
@@ -54,19 +71,19 @@ export namespace Concern {
     }
 
     if (def.instanceMethods) {
-      for (const [name, fn] of Object.entries(def.instanceMethods)) {
-        if (def.prepend && klass.prototype[name]) {
-          const original = klass.prototype[name];
-          klass.prototype[`_super_${name}`] = original;
-        }
-        klass.prototype[name] = fn;
+      if (def.prepend) {
+        prependMethods(klass, def.instanceMethods);
+      } else {
+        // Concerns overwrite existing methods (TS has no MRO, so this is the
+        // only way to simulate Ruby's ancestor chain insertion). Use
+        // extendModule on the prototype — extend() always overwrites and
+        // fires the extended hook, matching the "methods added" semantic.
+        extendModule(klass.prototype, def.instanceMethods);
       }
     }
 
     if (def.classMethods) {
-      for (const [name, fn] of Object.entries(def.classMethods)) {
-        klass[name] = fn;
-      }
+      extendModule(klass, def.classMethods);
     }
 
     const includedBlock = def.included ?? (mixin as any)[INCLUDED_BLOCK];
@@ -83,8 +100,8 @@ export namespace Concern {
   }
 
   export function hasConcern(klass: any, mixin: ConcernMixin): boolean {
-    const included: Set<ConcernMixin> | undefined = klass[INCLUDED_CONCERNS];
-    return included?.has(mixin) ?? false;
+    const includedSet: Set<ConcernMixin> | undefined = klass[INCLUDED_CONCERNS];
+    return includedSet?.has(mixin) ?? false;
   }
 
   export function setIncludedBlock(target: any, block: (base: any) => void): void {

--- a/packages/activesupport/src/include.test.ts
+++ b/packages/activesupport/src/include.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { include, extend, included, extended } from "./include.js";
+
+describe("include", () => {
+  it("copies instance methods onto the prototype", () => {
+    class User {}
+    const mod = {
+      greet() {
+        return "hello";
+      },
+    };
+    include(User, mod);
+    expect(new (User as any)().greet()).toBe("hello");
+  });
+
+  it("does not replace methods already on the prototype", () => {
+    class User {
+      greet() {
+        return "original";
+      }
+    }
+    include(User, {
+      greet() {
+        return "replaced";
+      },
+    });
+    expect(new User().greet()).toBe("original");
+  });
+
+  it("fires the included callback after methods are copied", () => {
+    const order: string[] = [];
+    class User {}
+    const mod = {
+      greet() {
+        return "hello";
+      },
+      [included](base: any) {
+        order.push("included");
+        expect(base).toBe(User);
+        expect(new base().greet()).toBe("hello");
+      },
+    };
+    include(User, mod);
+    expect(order).toEqual(["included"]);
+  });
+
+  it("does not copy the included symbol onto the prototype", () => {
+    class User {}
+    const mod = {
+      greet() {
+        return "hello";
+      },
+      [included](_base: any) {},
+    };
+    include(User, mod);
+    expect((User.prototype as any)[included]).toBeUndefined();
+  });
+
+  it("works without an included callback", () => {
+    class User {}
+    include(User, {
+      greet() {
+        return "hello";
+      },
+    });
+    expect(new (User as any)().greet()).toBe("hello");
+  });
+});
+
+describe("extend", () => {
+  it("copies methods as static methods on the class", () => {
+    class User {}
+    extend(User, {
+      findByName(name: string) {
+        return `found:${name}`;
+      },
+    });
+    expect((User as any).findByName("dean")).toBe("found:dean");
+  });
+
+  it("fires the extended callback after methods are copied", () => {
+    const order: string[] = [];
+    class User {}
+    const mod = {
+      findByName() {
+        return "found";
+      },
+      [extended](base: any) {
+        order.push("extended");
+        expect(base).toBe(User);
+        expect(base.findByName()).toBe("found");
+      },
+    };
+    extend(User, mod);
+    expect(order).toEqual(["extended"]);
+  });
+
+  it("does not copy the extended symbol onto the class", () => {
+    class User {}
+    const mod = {
+      greet() {
+        return "hello";
+      },
+      [extended](_base: any) {},
+    };
+    extend(User, mod);
+    expect((User as any)[extended]).toBeUndefined();
+  });
+
+  it("works without an extended callback", () => {
+    class User {}
+    extend(User, {
+      findByName() {
+        return "found";
+      },
+    });
+    expect((User as any).findByName()).toBe("found");
+  });
+});

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -26,8 +26,8 @@ type Module = Record<string, Function>;
  * Symbol keys for Ruby's Module#included and Module#extended callbacks.
  * Using symbols avoids collisions with real method names.
  */
-export const included = Symbol("included");
-export const extended = Symbol("extended");
+export const included = Symbol.for("@blazetrails/activesupport:included");
+export const extended = Symbol.for("@blazetrails/activesupport:extended");
 
 /**
  * Derive instance method types from an included module object.
@@ -37,7 +37,12 @@ export const extended = Symbol("extended");
  *   export interface Relation<T> extends Included<typeof QueryMethodBangs> {}
  */
 export type Included<M extends Module> = {
-  [K in keyof M]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
+  [K in keyof M as K extends string ? K : never]: M[K] extends (
+    this: any,
+    ...args: infer A
+  ) => infer R
+    ? (...args: A) => R
+    : never;
 };
 
 export function include(klass: AnyClass, mod: Module): void {
@@ -72,7 +77,12 @@ export function include(klass: AnyClass, mod: Module): void {
  *   const TypedBase = Base as unknown as BaseStatic;
  */
 export type Extended<M extends Module> = {
-  [K in keyof M]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
+  [K in keyof M as K extends string ? K : never]: M[K] extends (
+    this: any,
+    ...args: infer A
+  ) => infer R
+    ? (...args: A) => R
+    : never;
 };
 
 /**

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -23,6 +23,13 @@ type AnyClass = new (...args: any[]) => any;
 type Module = Record<string, Function>;
 
 /**
+ * Symbol keys for Ruby's Module#included and Module#extended callbacks.
+ * Using symbols avoids collisions with real method names.
+ */
+export const included = Symbol("included");
+export const extended = Symbol("extended");
+
+/**
  * Derive instance method types from an included module object.
  * Strips the `this` parameter from each function signature.
  *
@@ -46,6 +53,11 @@ export function include(klass: AnyClass, mod: Module): void {
     };
   }
   Object.defineProperties(klass.prototype, descriptors);
+
+  // Ruby's Module#included(base) — fires after methods are copied
+  if (typeof (mod as any)[included] === "function") {
+    (mod as any)[included](klass);
+  }
 }
 
 /**
@@ -84,5 +96,10 @@ export function extend(klass: AnyClass | object, mod: Module): void {
       configurable: true,
       enumerable: false,
     });
+  }
+
+  // Ruby's Module#extended(base) — fires after methods are copied
+  if (typeof (mod as any)[extended] === "function") {
+    (mod as any)[extended](klass);
   }
 }

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -352,7 +352,7 @@ export {
 } from "./callbacks.js";
 export type { ClassMethods } from "./callbacks.js";
 export { Concern, MultipleIncludedBlocks, MultiplePrependBlocks } from "./concern.js";
-export { include, extend } from "./include.js";
+export { include, extend, included, extended } from "./include.js";
 export type { Included, Extended } from "./include.js";
 export { ClassAttribute } from "./class-attribute.js";
 


### PR DESCRIPTION
## Summary

- Adds `included` and `extended` Symbol-keyed hooks to `include()` and `extend()` in activesupport
- Mirrors Ruby's core `Module#included(base)` and `Module#extended(base)` callbacks — any module can now run setup logic when mixed into a class
- Uses Symbols so hooks are invisible to `Object.keys` and never get copied onto prototypes/classes alongside real methods

## Test plan

- [x] New `include.test.ts` with 9 tests covering both hooks, no-hook case, and verifying symbols aren't leaked
- [x] Existing `concern.test.ts` passes (25 tests)
- [x] `tsc --build` clean