### PR TITLE
refactor(activemodel): route validations through callback chain like Rails

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
+import { CallbackChain } from "./callbacks.js";
 
 describe("CallbacksTest", () => {
   it("after callbacks are not executed if the block returns false", () => {
@@ -65,7 +66,7 @@ describe("CallbacksTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    await (p.constructor as typeof Model)._callbackChain.runAfter("create", p);
+    (p.constructor as typeof Model)._callbackChain.runAfter("create", p);
     expect(log).toEqual(["first", "second"]);
   });
 
@@ -310,24 +311,21 @@ describe("CallbacksTest", () => {
   });
 });
 
-describe("CallbackChain.runAsync", () => {
-  it("runs after callbacks only after the async block completes", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
+describe("CallbackChain.run", () => {
+  it("runs after callbacks only after the block completes", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
     chain.register("after", "save", () => {
       log.push("after");
     });
-    await chain.run("save", {}, async () => {
+    chain.run("save", {}, () => {
       log.push("block:start");
-      await Promise.resolve();
       log.push("block:end");
     });
     expect(log).toEqual(["block:start", "block:end", "after"]);
   });
 
-  it("returns false and skips block when before callback halts", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
+  it("returns false and skips block when before callback halts", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
     chain.register("before", "save", () => {
@@ -337,35 +335,14 @@ describe("CallbackChain.runAsync", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    const result = await chain.run("save", {}, async () => {
+    const result = chain.run("save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
     expect(log).toEqual(["before"]);
   });
 
-  it("around callbacks wrap the async block", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
-    const chain = new CallbackChain();
-    const log: string[] = [];
-    chain.register("around", "save", async (_record: any, proceed: () => void | Promise<void>) => {
-      log.push("around:before");
-      await proceed();
-      log.push("around:after");
-    });
-    chain.register("after", "save", () => {
-      log.push("after");
-    });
-    await chain.run("save", {}, async () => {
-      log.push("block:start");
-      await Promise.resolve();
-      log.push("block:end");
-    });
-    expect(log).toEqual(["around:before", "block:start", "block:end", "around:after", "after"]);
-  });
-
-  it("sync around callback still waits for async block", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
+  it("around callbacks wrap the block", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
     chain.register("around", "save", (_record: any, proceed: () => void) => {
@@ -376,71 +353,41 @@ describe("CallbackChain.runAsync", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    await chain.run("save", {}, async () => {
-      log.push("block:start");
-      await Promise.resolve();
-      log.push("block:end");
+    chain.run("save", {}, () => {
+      log.push("block");
     });
-    expect(log).toEqual(["around:before", "block:start", "around:after", "block:end", "after"]);
+    expect(log).toEqual(["around:before", "block", "around:after", "after"]);
   });
 
-  it("async before callback that resolves to false halts the chain", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
+  it("before callback that returns false halts the chain", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
-    chain.register("before", "save", async () => {
-      await Promise.resolve();
+    chain.register("before", "save", () => {
       log.push("before");
       return false;
     });
     chain.register("after", "save", () => {
       log.push("after");
     });
-    const result = await chain.run("save", {}, async () => {
+    const result = chain.run("save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
     expect(log).toEqual(["before"]);
   });
 
-  it("async after callbacks are awaited in order", async () => {
-    const { CallbackChain } = await import("./callbacks.js");
+  it("after callbacks run in registration order", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
-
-    // Use controlled deferreds so we can prove sequential awaiting.
-    // The second callback's promise resolves before the first's, but
-    // because runAfter awaits sequentially, "after1" must appear
-    // before "after2".
-    let resolveFirst!: () => void;
-    const firstDeferred = new Promise<void>((r) => {
-      resolveFirst = r;
-    });
-    let resolveSecond!: () => void;
-    const secondDeferred = new Promise<void>((r) => {
-      resolveSecond = r;
-    });
-
-    chain.register("after", "save", async () => {
-      await firstDeferred;
+    chain.register("after", "save", () => {
       log.push("after1");
     });
-    chain.register("after", "save", async () => {
-      await secondDeferred;
+    chain.register("after", "save", () => {
       log.push("after2");
     });
-
-    const runPromise = chain.run("save", {}, async () => {
+    chain.run("save", {}, () => {
       log.push("block");
     });
-
-    // Resolve second before first — if callbacks ran concurrently,
-    // "after2" would appear before "after1"
-    resolveSecond();
-    await Promise.resolve();
-    resolveFirst();
-
-    await runPromise;
     expect(log).toEqual(["block", "after1", "after2"]);
   });
 });

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -318,7 +318,7 @@ describe("CallbackChain.run", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    chain.run("save", {}, () => {
+    chain.runCallbacks("save", {}, () => {
       log.push("block:start");
       log.push("block:end");
     });
@@ -335,7 +335,7 @@ describe("CallbackChain.run", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    const result = chain.run("save", {}, () => {
+    const result = chain.runCallbacks("save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
@@ -353,7 +353,7 @@ describe("CallbackChain.run", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    chain.run("save", {}, () => {
+    chain.runCallbacks("save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["around:before", "block", "around:after", "after"]);
@@ -369,7 +369,7 @@ describe("CallbackChain.run", () => {
     chain.register("after", "save", () => {
       log.push("after");
     });
-    const result = chain.run("save", {}, () => {
+    const result = chain.runCallbacks("save", {}, () => {
       log.push("block");
     });
     expect(result).toBe(false);
@@ -385,7 +385,7 @@ describe("CallbackChain.run", () => {
     chain.register("after", "save", () => {
       log.push("after2");
     });
-    chain.run("save", {}, () => {
+    chain.runCallbacks("save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["block", "after1", "after2"]);

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -156,7 +156,7 @@ function resolveCallback(
     throw new ArgumentError(`Callback object must implement ${methodName} or ${camelMethod}`);
   }
   if (timing === "around") {
-    return ((record: AnyRecord, proceed: () => void | Promise<void>) =>
+    return ((record: AnyRecord, proceed: () => void) =>
       method.call(fnOrObject, record, proceed)) as AroundCallbackFn;
   }
   return ((record: AnyRecord) => method.call(fnOrObject, record)) as CallbackFn;
@@ -166,10 +166,7 @@ function resolveCallback(
  * Callback types.
  */
 export type CallbackFn = (record: AnyRecord) => void | boolean | Promise<void | boolean>;
-export type AroundCallbackFn = (
-  record: AnyRecord,
-  proceed: () => void | Promise<void>,
-) => void | Promise<void>;
+export type AroundCallbackFn = (record: AnyRecord, proceed: () => void) => void;
 
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
@@ -189,14 +186,13 @@ interface CallbackEntry {
 }
 
 /**
- * Callbacks mixin — lifecycle hooks on models.
+ * Callbacks — lifecycle hooks on models.
  *
  * Mirrors: ActiveModel::Callbacks
  *
- * The primary API is async (run/runBefore/runAfter) which properly
- * awaits promise-returning callbacks. Sync variants (runSync/
- * runBeforeSync/runAfterSync) exist for contexts that can't be async
- * (constructors, synchronous validation).
+ * All callbacks are synchronous, matching Rails where callbacks
+ * are synchronous Ruby methods. The run/runBefore/runAfter methods
+ * execute callbacks in registration order.
  */
 export class CallbackChain {
   private callbacks: CallbackEntry[] = [];
@@ -235,6 +231,10 @@ export class CallbackChain {
     return true;
   }
 
+  clearEvent(event: CallbackEvent): void {
+    this.callbacks = this.callbacks.filter((c) => c.event !== event);
+  }
+
   clone(): CallbackChain {
     const copy = new CallbackChain();
     copy.callbacks = [...this.callbacks];
@@ -242,64 +242,14 @@ export class CallbackChain {
   }
 
   /**
-   * Run callbacks for a given event around an async block.
-   * Awaits the block and all callbacks. Returns false if a before
-   * callback resolves to false or if an around callback does not
-   * call proceed().
+   * Run callbacks for a given event around a block.
+   * Returns false if a before callback returns false (halting)
+   * or if an around callback does not call proceed().
+   *
+   * Mirrors: ActiveSupport::Callbacks#run_callbacks
    */
-  async run(
-    event: CallbackEvent,
-    record: AnyRecord,
-    block: () => void | Promise<void>,
-  ): Promise<boolean> {
-    if (!(await this.runBefore(event, record))) return false;
-
-    const arounds = this.callbacks.filter(
-      (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
-    );
-
-    let blockExecuted = false;
-    const trackedBlock = async () => {
-      await block();
-      blockExecuted = true;
-    };
-
-    let chain: () => void | Promise<void> = trackedBlock;
-    for (const cb of [...arounds].reverse()) {
-      const prev = chain;
-      chain = async () => {
-        let pendingProceed: Promise<void> | undefined;
-        const wrappedProceed = () => {
-          const result = prev();
-          if (result && typeof (result as Promise<void>).then === "function") {
-            pendingProceed = result as Promise<void>;
-          }
-          return result;
-        };
-        try {
-          await (cb.fn as AroundCallbackFn)(record, wrappedProceed);
-          if (pendingProceed) await pendingProceed;
-        } catch (aroundError) {
-          if (pendingProceed) await pendingProceed.catch(() => {});
-          throw aroundError;
-        }
-      };
-    }
-    await chain();
-
-    if (!blockExecuted) return false;
-
-    await this.runAfter(event, record);
-
-    return true;
-  }
-
-  /**
-   * Synchronous variant of run() for contexts that can't be async
-   * (constructors, synchronous validation). Does not await promises.
-   */
-  runSync(event: CallbackEvent, record: AnyRecord, block: () => void): boolean {
-    if (!this.runBeforeSync(event, record)) return false;
+  run(event: CallbackEvent, record: AnyRecord, block: () => void): boolean {
+    if (!this.runBefore(event, record)) return false;
 
     const arounds = this.callbacks.filter(
       (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
@@ -312,29 +262,18 @@ export class CallbackChain {
     }
     chain();
 
-    this.runAfterSync(event, record);
+    this.runAfter(event, record);
 
     return true;
   }
 
   /**
-   * Run before callbacks, awaiting async callbacks.
-   * Returns false if a callback resolves to false (halting the chain).
+   * Run before callbacks for a given event.
+   * Returns false if any callback returns false (halting the chain).
+   *
+   * Mirrors: ActiveSupport::Callbacks — before filter chain
    */
-  async runBefore(event: CallbackEvent, record: AnyRecord): Promise<boolean> {
-    const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
-    for (const cb of befores) {
-      if (!this._shouldRun(cb, record)) continue;
-      const result = await (cb.fn as CallbackFn)(record);
-      if (result === false) return false;
-    }
-    return true;
-  }
-
-  /**
-   * Synchronous before callbacks. Does not await promises.
-   */
-  runBeforeSync(event: CallbackEvent, record: AnyRecord): boolean {
+  runBefore(event: CallbackEvent, record: AnyRecord): boolean {
     const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
     for (const cb of befores) {
       if (!this._shouldRun(cb, record)) continue;
@@ -345,24 +284,38 @@ export class CallbackChain {
   }
 
   /**
-   * Run after callbacks, awaiting async callbacks.
+   * Run after callbacks for a given event.
+   *
+   * Mirrors: ActiveSupport::Callbacks — after filter chain
    */
-  async runAfter(event: CallbackEvent, record: AnyRecord): Promise<void> {
-    const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
-    for (const cb of afters) {
-      if (!this._shouldRun(cb, record)) continue;
-      await (cb.fn as CallbackFn)(record);
-    }
-  }
-
-  /**
-   * Synchronous after callbacks. Does not await promises.
-   */
-  runAfterSync(event: CallbackEvent, record: AnyRecord): void {
+  runAfter(event: CallbackEvent, record: AnyRecord): void {
     const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
     for (const cb of afters) {
       if (!this._shouldRun(cb, record)) continue;
       (cb.fn as CallbackFn)(record);
+    }
+  }
+
+  // -- Async variants for persistence lifecycle (save/create/update/destroy) --
+  // These exist because activerecord's before_destroy/before_save callbacks
+  // can trigger cascading DB operations (dependent: :destroy) which are
+  // inherently async in Node.js. Validation callbacks use the sync API above.
+
+  async runBeforeAsync(event: CallbackEvent, record: AnyRecord): Promise<boolean> {
+    const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
+    for (const cb of befores) {
+      if (!this._shouldRun(cb, record)) continue;
+      const result = await (cb.fn as CallbackFn)(record);
+      if (result === false) return false;
+    }
+    return true;
+  }
+
+  async runAfterAsync(event: CallbackEvent, record: AnyRecord): Promise<void> {
+    const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
+    for (const cb of afters) {
+      if (!this._shouldRun(cb, record)) continue;
+      await (cb.fn as CallbackFn)(record);
     }
   }
 }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -167,9 +167,9 @@ function resolveCallback(
  *
  * CallbackFn allows Promise returns because the same callback chain serves
  * both sync events (validation, initialize) and async events (save, destroy).
- * The sync API (run/runBefore/runAfter) ignores Promise returns — only use
- * sync callbacks on sync events. The async API (runAsync/runBeforeAsync/
- * runAfterAsync) properly awaits Promises.
+ * The sync API (runCallbacks/runBefore/runAfter) ignores Promise returns —
+ * only use sync callbacks on sync events. The async API
+ * (runCallbacksAsync/runBeforeAsync/runAfterAsync) properly awaits Promises.
  *
  * AroundCallbackFn's proceed() returns void | Promise<void> because the
  * wrapped block may be async (e.g., DB operations in persistence). Around

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -203,9 +203,11 @@ interface CallbackEntry {
  *
  * Mirrors: ActiveModel::Callbacks
  *
- * All callbacks are synchronous, matching Rails where callbacks
- * are synchronous Ruby methods. The run/runBefore/runAfter methods
- * execute callbacks in registration order.
+ * The primary API is synchronous, matching Rails where callbacks are
+ * synchronous Ruby methods. runCallbacks/runBefore/runAfter execute
+ * callbacks in registration order and do not await returned Promises.
+ * For persistence events where callbacks or blocks are asynchronous,
+ * use the async variants (runCallbacksAsync/runBeforeAsync/runAfterAsync).
  */
 export class CallbackChain {
   private callbacks: CallbackEntry[] = [];
@@ -261,7 +263,7 @@ export class CallbackChain {
    *
    * Mirrors: ActiveSupport::Callbacks#run_callbacks
    */
-  run(event: CallbackEvent, record: AnyRecord, block: () => void): boolean {
+  runCallbacks(event: CallbackEvent, record: AnyRecord, block: () => void): boolean {
     if (!this.runBefore(event, record)) return false;
 
     const arounds = this.callbacks.filter(
@@ -322,7 +324,7 @@ export class CallbackChain {
   // can trigger cascading DB operations (dependent: :destroy) which are
   // inherently async in Node.js. Validation callbacks use the sync API above.
 
-  async runAsync(
+  async runCallbacksAsync(
     event: CallbackEvent,
     record: AnyRecord,
     block: () => void | Promise<void>,

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -156,7 +156,7 @@ function resolveCallback(
     throw new ArgumentError(`Callback object must implement ${methodName} or ${camelMethod}`);
   }
   if (timing === "around") {
-    return ((record: AnyRecord, proceed: () => void) =>
+    return ((record: AnyRecord, proceed: () => void | Promise<void>) =>
       method.call(fnOrObject, record, proceed)) as AroundCallbackFn;
   }
   return ((record: AnyRecord) => method.call(fnOrObject, record)) as CallbackFn;
@@ -164,9 +164,22 @@ function resolveCallback(
 
 /**
  * Callback types.
+ *
+ * CallbackFn allows Promise returns because the same callback chain serves
+ * both sync events (validation, initialize) and async events (save, destroy).
+ * The sync API (run/runBefore/runAfter) ignores Promise returns — only use
+ * sync callbacks on sync events. The async API (runAsync/runBeforeAsync/
+ * runAfterAsync) properly awaits Promises.
+ *
+ * AroundCallbackFn's proceed() returns void | Promise<void> because the
+ * wrapped block may be async (e.g., DB operations in persistence). Around
+ * callbacks that wrap async blocks should await proceed().
  */
 export type CallbackFn = (record: AnyRecord) => void | boolean | Promise<void | boolean>;
-export type AroundCallbackFn = (record: AnyRecord, proceed: () => void) => void;
+export type AroundCallbackFn = (
+  record: AnyRecord,
+  proceed: () => void | Promise<void>,
+) => void | Promise<void>;
 
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
@@ -255,12 +268,20 @@ export class CallbackChain {
       (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
     );
 
-    let chain = block;
+    let blockExecuted = false;
+    const trackedBlock = () => {
+      block();
+      blockExecuted = true;
+    };
+
+    let chain: () => void = trackedBlock;
     for (const cb of [...arounds].reverse()) {
       const prev = chain;
       chain = () => (cb.fn as AroundCallbackFn)(record, prev);
     }
     chain();
+
+    if (!blockExecuted) return false;
 
     this.runAfter(event, record);
 
@@ -318,11 +339,29 @@ export class CallbackChain {
       blockExecuted = true;
     };
 
+    // Build the around chain. Each around callback wraps the previous.
+    // The pendingProceed pattern ensures that even if a sync around callback
+    // calls proceed() without awaiting it, the async block's Promise is
+    // still awaited before moving on.
     let chain: () => void | Promise<void> = trackedBlock;
     for (const cb of [...arounds].reverse()) {
       const prev = chain;
       chain = async () => {
-        await (cb.fn as AroundCallbackFn)(record, prev as () => void);
+        let pendingProceed: Promise<void> | undefined;
+        const wrappedProceed = () => {
+          const result = prev();
+          if (result && typeof (result as Promise<void>).then === "function") {
+            pendingProceed = result as Promise<void>;
+          }
+          return result;
+        };
+        try {
+          await (cb.fn as AroundCallbackFn)(record, wrappedProceed);
+          if (pendingProceed) await pendingProceed;
+        } catch (aroundError) {
+          if (pendingProceed) await pendingProceed.catch(() => {});
+          throw aroundError;
+        }
       };
     }
     await chain();

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -301,6 +301,39 @@ export class CallbackChain {
   // can trigger cascading DB operations (dependent: :destroy) which are
   // inherently async in Node.js. Validation callbacks use the sync API above.
 
+  async runAsync(
+    event: CallbackEvent,
+    record: AnyRecord,
+    block: () => void | Promise<void>,
+  ): Promise<boolean> {
+    if (!(await this.runBeforeAsync(event, record))) return false;
+
+    const arounds = this.callbacks.filter(
+      (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
+    );
+
+    let blockExecuted = false;
+    const trackedBlock = async () => {
+      await block();
+      blockExecuted = true;
+    };
+
+    let chain: () => void | Promise<void> = trackedBlock;
+    for (const cb of [...arounds].reverse()) {
+      const prev = chain;
+      chain = async () => {
+        await (cb.fn as AroundCallbackFn)(record, prev as () => void);
+      };
+    }
+    await chain();
+
+    if (!blockExecuted) return false;
+
+    await this.runAfterAsync(event, record);
+
+    return true;
+  }
+
   async runBeforeAsync(event: CallbackEvent, record: AnyRecord): Promise<boolean> {
     const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
     for (const cb of befores) {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -31,7 +31,6 @@ export { PresenceValidator } from "./validations/presence.js";
 export { LengthValidator } from "./validations/length.js";
 export { NumericalityValidator } from "./validations/numericality.js";
 export { AcceptsMultiparameterTime } from "./type/helpers/accepts-multiparameter-time.js";
-export type { ValidatorContract } from "./validator.js";
 export { ModelName } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
 export { CallbackChain } from "./callbacks.js";

--- a/packages/activemodel/src/misc.test.ts
+++ b/packages/activemodel/src/misc.test.ts
@@ -2068,8 +2068,8 @@ describe("ActiveModel", () => {
 
       const p = new Payment({ amount: 100 });
       // Run callbacks manually
-      (Payment as any)._callbackChain.runBeforeSync("process", p);
-      (Payment as any)._callbackChain.runAfterSync("process", p);
+      (Payment as any)._callbackChain.runBefore("process", p);
+      (Payment as any)._callbackChain.runAfter("process", p);
       expect(log).toEqual(["before_process", "after_process"]);
     });
 
@@ -2144,7 +2144,7 @@ describe("ActiveModel", () => {
       );
 
       const u = new User({ name: "Alice" });
-      await (User as any)._callbackChain.runBefore("save", u);
+      (User as any)._callbackChain.runBefore("save", u);
       expect(order).toEqual(["prepended", "first"]);
     });
   });
@@ -2164,12 +2164,12 @@ describe("ActiveModel", () => {
         m.validates("email", { presence: true });
       });
 
-      // The validations should have on: "create" context
-      const validations = (User as any)._validations;
-      const nameV = validations.find((v: any) => v.attribute === "name");
-      const emailV = validations.find((v: any) => v.attribute === "email");
-      expect(nameV.on).toBe("create");
-      expect(emailV.on).toBe("create");
+      // Validations only run with "create" context, not without
+      const user = new User();
+      expect(user.isValid()).toBe(true);
+      expect(user.isValid("create")).toBe(false);
+      expect(user.errors.on("name")).toContain("can't be blank");
+      expect(user.errors.on("email")).toContain("can't be blank");
     });
   });
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -15,7 +15,7 @@ import {
   defineModelCallbacks,
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions } from "./serialization.js";
-import { BlockValidator } from "./validator.js";
+import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
 import {
   AttributeMethodPattern,
   attributeMethodPrefix,
@@ -29,13 +29,8 @@ import {
   attributeWriterMissing as defaultAttributeWriterMissing,
   ArgumentError,
 } from "./attribute-assignment.js";
-import type {
-  ValidatorContract as Validator,
-  ConditionalOptions,
-  ConditionFn,
-  AnyRecord,
-} from "./validator.js";
-import { shouldValidate } from "./validator.js";
+import type { ConditionalOptions, ConditionFn, AnyRecord } from "./validator.js";
+import { evaluateCondition } from "./validator.js";
 import { PresenceValidator } from "./validations/presence.js";
 import { AbsenceValidator } from "./validations/absence.js";
 import { LengthValidator } from "./validations/length.js";
@@ -55,20 +50,6 @@ import {
 } from "./attribute-registration.js";
 import { _toPartialPath } from "./conversion.js";
 
-interface ValidationEntry {
-  attribute: string;
-  validator: Validator;
-  on?: string;
-  strict?: boolean;
-  if?: ConditionFn | ConditionFn[];
-  unless?: ConditionFn | ConditionFn[];
-}
-
-interface CustomValidationEntry {
-  method: string | ((record: AnyRecord) => void);
-  options: ConditionalOptions;
-}
-
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
  * Dirty tracking, Serialization, and Naming.
@@ -87,8 +68,7 @@ export class Model {
   static _attributeAliases: Record<string, string> = {};
   static _aliasesByAttributeName: Map<string, string[]> = new Map();
   static _generatedMethods: Set<string> = new Set();
-  static _validations: ValidationEntry[] = [];
-  static _customValidations: CustomValidationEntry[] = [];
+  static _validators: Array<ValidatorBase | EachValidator> = [];
   static _callbackChain: CallbackChain = new CallbackChain();
   private static _modelName: ModelName | null = null;
 
@@ -265,10 +245,6 @@ export class Model {
   // -- Validations (Phase 1100) --
 
   static validates(attribute: string, rules: Record<string, unknown>): void {
-    if (!Object.prototype.hasOwnProperty.call(this, "_validations")) {
-      this._validations = [...this._validations];
-    }
-
     const onContext = rules.on as string | undefined;
     const ifCond = rules.if as ConditionFn | ConditionFn[] | undefined;
     const unlessCond = rules.unless as ConditionFn | ConditionFn[] | undefined;
@@ -276,28 +252,25 @@ export class Model {
     const sharedAllowNil = rules.allowNil as boolean | undefined;
     const sharedAllowBlank = rules.allowBlank as boolean | undefined;
 
-    const push = (validator: Validator) => {
-      if (typeof (validator as AnyRecord).checkValidityBang === "function") {
-        (validator as AnyRecord).checkValidityBang();
-      }
-      this._validations.push({
-        attribute,
-        validator,
-        on: onContext,
-        ...(isStrict && { strict: true }),
-        ...(ifCond !== undefined && { if: ifCond }),
-        ...(unlessCond !== undefined && { unless: unlessCond }),
-      });
-    };
+    const shared: Record<string, unknown> = {};
+    if (onContext !== undefined) shared.on = onContext;
+    if (ifCond !== undefined) shared.if = ifCond;
+    if (unlessCond !== undefined) shared.unless = unlessCond;
+    if (isStrict) shared.strict = true;
+
+    const validatorSpecs: Array<{
+      klass: new (options: Record<string, unknown>) => ValidatorBase;
+      opts: Record<string, unknown>;
+    }> = [];
 
     if (rules.presence) {
       const opts = rules.presence === true ? {} : (rules.presence as AnyRecord);
-      push(new PresenceValidator(opts));
+      validatorSpecs.push({ klass: PresenceValidator, opts });
     }
 
     if (rules.absence) {
       const opts = rules.absence === true ? {} : (rules.absence as AnyRecord);
-      push(new AbsenceValidator(opts));
+      validatorSpecs.push({ klass: AbsenceValidator, opts });
     }
 
     if (rules.length) {
@@ -306,7 +279,7 @@ export class Model {
         opts.allowNil = sharedAllowNil;
       if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
         opts.allowBlank = sharedAllowBlank;
-      push(new LengthValidator(opts));
+      validatorSpecs.push({ klass: LengthValidator, opts });
     }
 
     if (rules.numericality) {
@@ -315,7 +288,7 @@ export class Model {
         opts.allowNil = sharedAllowNil;
       if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
         opts.allowBlank = sharedAllowBlank;
-      push(new NumericalityValidator(opts));
+      validatorSpecs.push({ klass: NumericalityValidator, opts });
     }
 
     if (rules.inclusion) {
@@ -324,7 +297,7 @@ export class Model {
         opts.allowNil = sharedAllowNil;
       if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
         opts.allowBlank = sharedAllowBlank;
-      push(new InclusionValidator(opts));
+      validatorSpecs.push({ klass: InclusionValidator, opts });
     }
 
     if (rules.exclusion) {
@@ -333,7 +306,7 @@ export class Model {
         opts.allowNil = sharedAllowNil;
       if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
         opts.allowBlank = sharedAllowBlank;
-      push(new ExclusionValidator(opts));
+      validatorSpecs.push({ klass: ExclusionValidator, opts });
     }
 
     if (rules.format) {
@@ -342,7 +315,7 @@ export class Model {
         opts.allowNil = sharedAllowNil;
       if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
         opts.allowBlank = sharedAllowBlank;
-      push(new FormatValidator(opts));
+      validatorSpecs.push({ klass: FormatValidator, opts });
     }
 
     if (rules.acceptance) {
@@ -350,7 +323,7 @@ export class Model {
       if (!this._attributeDefinitions.has(attribute)) {
         this.attribute(attribute, "string", { virtual: true });
       }
-      push(new AcceptanceValidator(opts));
+      validatorSpecs.push({ klass: AcceptanceValidator, opts });
     }
 
     if (rules.confirmation) {
@@ -359,11 +332,15 @@ export class Model {
       if (!this._attributeDefinitions.has(confirmationAttr)) {
         this.attribute(confirmationAttr, "string", { virtual: true });
       }
-      push(new ConfirmationValidator(opts));
+      validatorSpecs.push({ klass: ConfirmationValidator, opts });
     }
 
     if (rules.comparison) {
-      push(new ComparisonValidator(rules.comparison as AnyRecord));
+      validatorSpecs.push({ klass: ComparisonValidator, opts: rules.comparison as AnyRecord });
+    }
+
+    for (const { klass, opts } of validatorSpecs) {
+      this.validatesWith(klass, { ...opts, attributes: [attribute], ...shared });
     }
   }
 
@@ -372,8 +349,9 @@ export class Model {
   }
 
   static clearValidatorsBang(): void {
-    this._validations = [];
-    this._customValidations = [];
+    this._validators = [];
+    this._ensureOwnCallbacks();
+    this._callbackChain.clearEvent("validate");
   }
 
   static isAttributeMethod(attribute: string): boolean {
@@ -384,10 +362,15 @@ export class Model {
     methodOrFn: string | ((record: AnyRecord) => void),
     options: ConditionalOptions = {},
   ): void {
-    if (!Object.prototype.hasOwnProperty.call(this, "_customValidations")) {
-      this._customValidations = [...this._customValidations];
-    }
-    this._customValidations.push({ method: methodOrFn, options });
+    const fn: CallbackFn = (record: AnyRecord) => {
+      if (typeof methodOrFn === "function") {
+        methodOrFn(record);
+      } else if (typeof record[methodOrFn] === "function") {
+        record[methodOrFn]();
+      }
+    };
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("before", "validate", fn, this._buildValidateConditions(options));
   }
 
   /**
@@ -401,9 +384,15 @@ export class Model {
     options: ConditionalOptions = {},
   ): void {
     const validator = new BlockValidator({ attributes, ...options }, fn);
-    this.validate((record: AnyRecord) => {
-      validator.validate(record);
-    }, options);
+    this._ensureOwnValidators();
+    this._validators.push(validator);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "before",
+      "validate",
+      (record: AnyRecord) => validator.validate(record),
+      this._buildValidateConditions(options),
+    );
   }
 
   /**
@@ -414,18 +403,41 @@ export class Model {
    */
   static validatesWith(
     validatorClass: {
-      new (options?: Record<string, unknown>): { validate(record: AnyRecord): void };
+      new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
     },
-    options: ConditionalOptions & { [key: string]: unknown } = {},
+    options: ConditionalOptions & { strict?: boolean; [key: string]: unknown } = {},
   ): void {
-    const { if: ifOpt, unless: unlessOpt, on: onOpt, ...rest } = options;
+    const { if: ifOpt, unless: unlessOpt, on: onOpt, strict: isStrict, ...rest } = options;
     const validator = new validatorClass(rest);
-    this.validate(
-      (record: AnyRecord) => {
-        validator.validate(record);
-      },
-      { if: ifOpt, unless: unlessOpt, on: onOpt },
-    );
+    if (typeof (validator as AnyRecord).checkValidityBang === "function") {
+      (validator as AnyRecord).checkValidityBang();
+    }
+    this._ensureOwnValidators();
+    this._validators.push(validator as ValidatorBase);
+
+    const conditions = this._buildValidateConditions({ if: ifOpt, unless: unlessOpt, on: onOpt });
+
+    let callbackFn: CallbackFn;
+    if (isStrict) {
+      callbackFn = (record: AnyRecord) => {
+        const origErrors = record.errors;
+        const tempErrors = new Errors(record);
+        record.errors = tempErrors;
+        try {
+          validator.validate(record);
+        } finally {
+          record.errors = origErrors;
+        }
+        if (tempErrors.any) {
+          throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
+        }
+      };
+    } else {
+      callbackFn = (record: AnyRecord) => validator.validate(record);
+    }
+
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("before", "validate", callbackFn, conditions);
   }
 
   /**
@@ -433,8 +445,8 @@ export class Model {
    *
    * Mirrors: ActiveModel::Validations.validators
    */
-  static validators(): Array<{ attribute: string; validator: Validator; on?: string }> {
-    return [...this._validations];
+  static validators(): Array<ValidatorBase | EachValidator> {
+    return [...this._validators];
   }
 
   /**
@@ -442,10 +454,13 @@ export class Model {
    *
    * Mirrors: ActiveModel::Validations.validators_on
    */
-  static validatorsOn(attribute: string): Validator[] {
-    return this._validations
-      .filter((entry) => entry.attribute === attribute)
-      .map((entry) => entry.validator);
+  static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
+    return this._validators.filter((v) => {
+      if (v instanceof EachValidator) {
+        return v.attributes.includes(attribute);
+      }
+      return false;
+    });
   }
 
   // -- Individual validator helper methods --
@@ -680,9 +695,45 @@ export class Model {
 
   private static _ensureOwnCallbacks(): void {
     if (!Object.prototype.hasOwnProperty.call(this, "_callbackChain")) {
-      // Clone parent's chain so subclass inherits existing callbacks
       this._callbackChain = this._callbackChain.clone();
     }
+  }
+
+  private static _ensureOwnValidators(): void {
+    if (!Object.prototype.hasOwnProperty.call(this, "_validators")) {
+      this._validators = [...this._validators];
+    }
+  }
+
+  private static _buildValidateConditions(
+    options: ConditionalOptions,
+  ): CallbackConditions | undefined {
+    const parts: Array<(record: AnyRecord) => boolean> = [];
+
+    if (options.on !== undefined) {
+      const onContext = options.on;
+      parts.push((record: AnyRecord) => {
+        const ctx = record._validationContext;
+        if (!ctx) return false;
+        return ctx === onContext;
+      });
+    }
+
+    if (options.if !== undefined) {
+      const conds = Array.isArray(options.if) ? options.if : [options.if];
+      parts.push((record: AnyRecord) => conds.every((c) => evaluateCondition(record, c)));
+    }
+
+    if (options.unless !== undefined) {
+      const conds = Array.isArray(options.unless) ? options.unless : [options.unless];
+      parts.push((record: AnyRecord) => !conds.some((c) => evaluateCondition(record, c)));
+    }
+
+    if (parts.length === 0) return undefined;
+
+    return {
+      if: (record: AnyRecord) => parts.every((fn) => fn(record)),
+    };
   }
 
   /**
@@ -777,7 +828,7 @@ export class Model {
     this._dirty.snapshot(this._attributes);
 
     // Fire after_initialize callbacks
-    ctor._callbackChain.runAfterSync("initialize", this);
+    ctor._callbackChain.runAfter("initialize", this);
   }
 
   // -- Attribute access --
@@ -894,44 +945,23 @@ export class Model {
     this.errors.clear();
     const ctor = this.constructor as typeof Model;
     const contextStr = context instanceof ValidationContext ? context.name : context;
-    const effectiveContext = contextStr ?? this._validationContext;
+    const prevContext = this._validationContext;
+    this._validationContext = contextStr ?? this._validationContext;
 
-    // Run before_validation callbacks
-    if (!ctor._callbackChain.runBeforeSync("validation", this)) return false;
-
-    // Run attribute validations
-    for (const entry of ctor._validations) {
-      // If validation has an `on` context, only run when context matches
-      if (entry.on && entry.on !== effectiveContext) continue;
-      // Check if/unless conditions
-      if (!shouldValidate(this, { if: entry.if, unless: entry.unless })) continue;
-      const value = this.readAttribute(entry.attribute);
-      if (entry.strict) {
-        const tempErrors = new Errors(this);
-        entry.validator.validate(this, entry.attribute, value, tempErrors);
-        if (tempErrors.any) {
-          const msg = tempErrors.fullMessages.join(", ");
-          throw new StrictValidationFailed(`${entry.attribute} ${msg}`);
-        }
-      } else {
-        entry.validator.validate(this, entry.attribute, value, this.errors);
-      }
+    try {
+      const completed = ctor._callbackChain.run("validation", this, () => {
+        this._runValidateCallbacks();
+      });
+      if (!completed) return false;
+      return this.errors.empty;
+    } finally {
+      this._validationContext = prevContext;
     }
+  }
 
-    // Run custom validations
-    for (const entry of ctor._customValidations) {
-      if (!shouldValidate(this, entry.options)) continue;
-      if (typeof entry.method === "function") {
-        entry.method(this);
-      } else if (typeof (this as AnyRecord)[entry.method] === "function") {
-        (this as AnyRecord)[entry.method]();
-      }
-    }
-
-    // Run after_validation callbacks
-    ctor._callbackChain.runAfterSync("validation", this);
-
-    return this.errors.empty;
+  private _runValidateCallbacks(): void {
+    const ctor = this.constructor as typeof Model;
+    ctor._callbackChain.runBefore("validate", this);
   }
 
   /**
@@ -1378,7 +1408,7 @@ export class Model {
   // -- Callbacks helper for subclasses --
 
   runCallbacks(event: string, block: () => void): boolean {
-    return (this.constructor as typeof Model)._callbackChain.runSync(event, this, block);
+    return (this.constructor as typeof Model)._callbackChain.run(event, this, block);
   }
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -424,10 +424,12 @@ export class Model {
       new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
     }>) {
       const validator = new klass(rest);
-      if (typeof (validator as AnyRecord).checkValidity === "function") {
-        (validator as AnyRecord).checkValidity();
-      } else if (typeof (validator as AnyRecord).checkValidityBang === "function") {
-        (validator as AnyRecord).checkValidityBang();
+      if (!(validator instanceof EachValidator)) {
+        if (typeof (validator as AnyRecord).checkValidity === "function") {
+          (validator as AnyRecord).checkValidity();
+        } else if (typeof (validator as AnyRecord).checkValidityBang === "function") {
+          (validator as AnyRecord).checkValidityBang();
+        }
       }
       this._ensureOwnValidators();
       this._validators.push(validator as ValidatorBase);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -424,7 +424,9 @@ export class Model {
       new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
     }>) {
       const validator = new klass(rest);
-      if (typeof (validator as AnyRecord).checkValidityBang === "function") {
+      if (typeof (validator as AnyRecord).checkValidity === "function") {
+        (validator as AnyRecord).checkValidity();
+      } else if (typeof (validator as AnyRecord).checkValidityBang === "function") {
         (validator as AnyRecord).checkValidityBang();
       }
       this._ensureOwnValidators();
@@ -470,10 +472,8 @@ export class Model {
    */
   static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
     return this._validators.filter((v) => {
-      if (v instanceof EachValidator) {
-        return v.attributes.includes(attribute);
-      }
-      return false;
+      const attributes = (v as AnyRecord).attributes;
+      return Array.isArray(attributes) && attributes.includes(attribute);
     });
   }
 
@@ -963,7 +963,7 @@ export class Model {
     this._validationContext = contextStr ?? this._validationContext;
 
     try {
-      const completed = ctor._callbackChain.run("validation", this, () => {
+      const completed = ctor._callbackChain.runCallbacks("validation", this, () => {
         this._runValidateCallbacks();
       });
       if (!completed) return false;
@@ -1422,7 +1422,7 @@ export class Model {
   // -- Callbacks helper for subclasses --
 
   runCallbacks(event: string, block: () => void): boolean {
-    return (this.constructor as typeof Model)._callbackChain.run(event, this, block);
+    return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block);
   }
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -402,42 +402,56 @@ export class Model {
    * Mirrors: ActiveModel::Validations.validates_with
    */
   static validatesWith(
-    validatorClass: {
-      new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
-    },
-    options: ConditionalOptions & { strict?: boolean; [key: string]: unknown } = {},
+    ...args: Array<
+      | {
+          new (
+            options: Record<string, unknown>,
+          ): ValidatorBase | { validate(record: AnyRecord): void };
+        }
+      | (ConditionalOptions & { strict?: boolean; [key: string]: unknown })
+    >
   ): void {
-    const { if: ifOpt, unless: unlessOpt, on: onOpt, strict: isStrict, ...rest } = options;
-    const validator = new validatorClass(rest);
-    if (typeof (validator as AnyRecord).checkValidityBang === "function") {
-      (validator as AnyRecord).checkValidityBang();
-    }
-    this._ensureOwnValidators();
-    this._validators.push(validator as ValidatorBase);
+    const last = args[args.length - 1];
+    const options: ConditionalOptions & { strict?: boolean; [key: string]: unknown } =
+      typeof last === "function"
+        ? {}
+        : ((args.pop() as ConditionalOptions & { strict?: boolean; [key: string]: unknown }) ?? {});
 
+    const { if: ifOpt, unless: unlessOpt, on: onOpt, strict: isStrict, ...rest } = options;
     const conditions = this._buildValidateConditions({ if: ifOpt, unless: unlessOpt, on: onOpt });
 
-    let callbackFn: CallbackFn;
-    if (isStrict) {
-      callbackFn = (record: AnyRecord) => {
-        const origErrors = record.errors;
-        const tempErrors = new Errors(record);
-        record.errors = tempErrors;
-        try {
-          validator.validate(record);
-        } finally {
-          record.errors = origErrors;
-        }
-        if (tempErrors.any) {
-          throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
-        }
-      };
-    } else {
-      callbackFn = (record: AnyRecord) => validator.validate(record);
-    }
+    for (const klass of args as Array<{
+      new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
+    }>) {
+      const validator = new klass(rest);
+      if (typeof (validator as AnyRecord).checkValidityBang === "function") {
+        (validator as AnyRecord).checkValidityBang();
+      }
+      this._ensureOwnValidators();
+      this._validators.push(validator as ValidatorBase);
 
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "validate", callbackFn, conditions);
+      let callbackFn: CallbackFn;
+      if (isStrict) {
+        callbackFn = (record: AnyRecord) => {
+          const origErrors = record.errors;
+          const tempErrors = new Errors(record);
+          record.errors = tempErrors;
+          try {
+            validator.validate(record);
+          } finally {
+            record.errors = origErrors;
+          }
+          if (tempErrors.any) {
+            throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
+          }
+        };
+      } else {
+        callbackFn = (record: AnyRecord) => validator.validate(record);
+      }
+
+      this._ensureOwnCallbacks();
+      this._callbackChain.register("before", "validate", callbackFn, conditions);
+    }
   }
 
   /**

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -1,15 +1,6 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
-
-export interface AbsenceOptions extends ConditionalOptions {
-  message?: string;
-}
 
 /**
  * HelperMethods — shorthand validators (validates_presence_of, etc.)
@@ -31,18 +22,10 @@ export interface HelperMethods {
   validatesPresenceOf(...attributes: string[]): void;
 }
 
-export class AbsenceValidator implements Validator {
-  constructor(private options: AbsenceOptions = {}) {}
-
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+export class AbsenceValidator extends EachValidator {
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (!isBlank(value)) {
-      errs.add(attribute, "present", { message: this.options.message });
+      record.errors.add(attribute, "present", { message: this.options.message });
     }
   }
 }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -1,16 +1,5 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
-
-export interface AcceptanceOptions extends ConditionalOptions {
-  accept?: unknown[];
-  allowNil?: boolean;
-  message?: string;
-}
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 
 /**
  * Manages lazily-defined virtual attributes for acceptance validation.
@@ -39,23 +28,15 @@ export class LazilyDefineAttributes {
   }
 }
 
-export class AcceptanceValidator implements Validator {
+export class AcceptanceValidator extends EachValidator {
   static readonly lazilyDefineAttributes = new LazilyDefineAttributes([]);
 
-  constructor(private options: AcceptanceOptions = {}) {}
-
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
-    const accepted = this.options.accept ?? ["1", "true", true];
+    const accepted = (this.options.accept as unknown[]) ?? ["1", "true", true];
     if (!accepted.includes(value)) {
-      errs.add(attribute, "accepted", { message: this.options.message });
+      record.errors.add(attribute, "accepted", { message: this.options.message });
     }
   }
 

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -1,25 +1,8 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 
-export interface ComparisonOptions extends ConditionalOptions {
-  greaterThan?: unknown | ((record: AnyRecord) => unknown);
-  greaterThanOrEqualTo?: unknown | ((record: AnyRecord) => unknown);
-  lessThan?: unknown | ((record: AnyRecord) => unknown);
-  lessThanOrEqualTo?: unknown | ((record: AnyRecord) => unknown);
-  equalTo?: unknown | ((record: AnyRecord) => unknown);
-  otherThan?: unknown | ((record: AnyRecord) => unknown);
-  message?: string;
-}
-
-export class ComparisonValidator implements Validator {
-  constructor(private options: ComparisonOptions = {}) {}
-
+export class ComparisonValidator extends EachValidator {
   private resolve(opt: unknown | ((record: AnyRecord) => unknown), record: AnyRecord): unknown {
     return typeof opt === "function" ? (opt as (record: AnyRecord) => unknown)(record) : opt;
   }
@@ -31,12 +14,7 @@ export class ComparisonValidator implements Validator {
     return Number(a) - Number(b);
   }
 
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  checkValidityBang(): void {
+  override checkValidity(): void {
     const keys = [
       "greaterThan",
       "greaterThanOrEqualTo",
@@ -52,18 +30,17 @@ export class ComparisonValidator implements Validator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (value === null || value === undefined) return;
     if (typeof value === "string" && isBlank(value)) {
-      errs.add(attribute, "blank", { value, message: this.options.message });
+      record.errors.add(attribute, "blank", { value, message: this.options.message });
       return;
     }
 
     if (this.options.greaterThan !== undefined) {
       const target = this.resolve(this.options.greaterThan, record);
       if (this.compare(value, target) <= 0) {
-        errs.add(attribute, "greater_than", {
+        record.errors.add(attribute, "greater_than", {
           count: target,
           value,
           message: this.options.message,
@@ -73,7 +50,7 @@ export class ComparisonValidator implements Validator {
     if (this.options.greaterThanOrEqualTo !== undefined) {
       const target = this.resolve(this.options.greaterThanOrEqualTo, record);
       if (this.compare(value, target) < 0) {
-        errs.add(attribute, "greater_than_or_equal_to", {
+        record.errors.add(attribute, "greater_than_or_equal_to", {
           count: target,
           value,
           message: this.options.message,
@@ -83,13 +60,17 @@ export class ComparisonValidator implements Validator {
     if (this.options.lessThan !== undefined) {
       const target = this.resolve(this.options.lessThan, record);
       if (this.compare(value, target) >= 0) {
-        errs.add(attribute, "less_than", { count: target, value, message: this.options.message });
+        record.errors.add(attribute, "less_than", {
+          count: target,
+          value,
+          message: this.options.message,
+        });
       }
     }
     if (this.options.lessThanOrEqualTo !== undefined) {
       const target = this.resolve(this.options.lessThanOrEqualTo, record);
       if (this.compare(value, target) > 0) {
-        errs.add(attribute, "less_than_or_equal_to", {
+        record.errors.add(attribute, "less_than_or_equal_to", {
           count: target,
           value,
           message: this.options.message,
@@ -99,13 +80,21 @@ export class ComparisonValidator implements Validator {
     if (this.options.equalTo !== undefined) {
       const target = this.resolve(this.options.equalTo, record);
       if (this.compare(value, target) !== 0) {
-        errs.add(attribute, "equal_to", { count: target, value, message: this.options.message });
+        record.errors.add(attribute, "equal_to", {
+          count: target,
+          value,
+          message: this.options.message,
+        });
       }
     }
     if (this.options.otherThan !== undefined) {
       const target = this.resolve(this.options.otherThan, record);
       if (this.compare(value, target) === 0) {
-        errs.add(attribute, "other_than", { count: target, value, message: this.options.message });
+        record.errors.add(attribute, "other_than", {
+          count: target,
+          value,
+          message: this.options.message,
+        });
       }
     }
   }

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -1,27 +1,9 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { humanize } from "@blazetrails/activesupport";
 
-export interface ConfirmationOptions extends ConditionalOptions {
-  message?: string;
-  caseSensitive?: boolean;
-}
-
-export class ConfirmationValidator implements Validator {
-  constructor(private options: ConfirmationOptions = {}) {}
-
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+export class ConfirmationValidator extends EachValidator {
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const confirmationAttr = `${attribute}Confirmation`;
     const confirmation = record.readAttribute?.(confirmationAttr) ?? record[confirmationAttr];
     if (confirmation == null) return;
@@ -37,7 +19,7 @@ export class ConfirmationValidator implements Validator {
       const humanAttr = modelClass?.humanAttributeName
         ? modelClass.humanAttributeName(attribute)
         : humanize(attribute);
-      errs.add(confirmationAttr, "confirmation", {
+      record.errors.add(confirmationAttr, "confirmation", {
         message: this.options.message,
         attribute: humanAttr,
       });

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -1,42 +1,22 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isExcluded, checkClusivityValidity } from "./clusivity.js";
 
-export interface ExclusionOptions extends ConditionalOptions {
-  in?: Iterable<unknown> | (() => Iterable<unknown>);
-  within?: Iterable<unknown> | (() => Iterable<unknown>);
-  allowNil?: boolean;
-  allowBlank?: boolean;
-  message?: string;
-}
-
-export class ExclusionValidator implements Validator {
-  constructor(private options: ExclusionOptions) {}
-
-  checkValidityBang(): void {
+export class ExclusionValidator extends EachValidator {
+  override checkValidity(): void {
     checkClusivityValidity(this.options);
   }
 
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (this.options.allowNil !== false && (value === null || value === undefined)) return;
-    if (this.options.allowBlank && isBlank(value)) return;
-    const inOpt = this.options.in ?? this.options.within;
+    const inOpt = (this.options.in ?? this.options.within) as
+      | Iterable<unknown>
+      | (() => Iterable<unknown>)
+      | undefined;
     if (!inOpt) return;
     const collection = typeof inOpt === "function" ? inOpt() : inOpt;
     if (isExcluded(collection, value)) {
-      errs.add(attribute, "exclusion", { value, message: this.options.message });
+      record.errors.add(attribute, "exclusion", { value, message: this.options.message });
     }
   }
 }

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -29,10 +29,7 @@ export class FormatValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (value === null || value === undefined) {
-      if (this.options.allowNil) return;
-      return;
-    }
+    if (value === null || value === undefined) return;
     const str = String(value);
     if (this.options.with) {
       const re = this.resolveRegexp(

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -1,23 +1,7 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 
-export interface FormatOptions extends ConditionalOptions {
-  with?: RegExp | ((record: AnyRecord) => RegExp);
-  without?: RegExp | ((record: AnyRecord) => RegExp);
-  allowNil?: boolean;
-  allowBlank?: boolean;
-  message?: string;
-}
-
-export class FormatValidator implements Validator {
-  constructor(private options: FormatOptions) {}
-
+export class FormatValidator extends EachValidator {
   private resolveRegexp(opt: RegExp | ((record: AnyRecord) => RegExp), record: AnyRecord): RegExp {
     const re = typeof opt === "function" ? opt(record) : opt;
     if (re.multiline) {
@@ -28,45 +12,45 @@ export class FormatValidator implements Validator {
     return re;
   }
 
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
-    if (value === null || value === undefined) {
-      if (this.options.allowNil) return;
-      return;
-    }
-    if (this.options.allowBlank && isBlank(value)) return;
-    const str = String(value);
-    if (this.options.with) {
-      const re = this.resolveRegexp(this.options.with, record);
-      if (!re.test(str)) {
-        errs.add(attribute, "invalid", { value, message: this.options.message });
-      }
-    }
-    if (this.options.without) {
-      const re = this.resolveRegexp(this.options.without, record);
-      if (re.test(str)) {
-        errs.add(attribute, "invalid", { value, message: this.options.message });
-      }
-    }
-  }
-
-  checkValidityBang(): void {
-    if (!this.options.with && !this.options.without) {
-      throw new Error("Either :with or :without must be supplied (but not both)");
-    }
-    if (this.options.with && this.options.without) {
-      throw new Error("Either :with or :without must be supplied (but not both)");
-    }
+  override checkValidity(): void {
     const withOpt = this.options.with;
+    const withoutOpt = this.options.without;
+    if (!withOpt && !withoutOpt) {
+      throw new Error("Either :with or :without must be supplied (but not both)");
+    }
+    if (withOpt && withoutOpt) {
+      throw new Error("Either :with or :without must be supplied (but not both)");
+    }
     if (withOpt && withOpt instanceof RegExp && withOpt.multiline) {
       throw new Error(
         "The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \\A and \\z?",
       );
+    }
+  }
+
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+    if (value === null || value === undefined) {
+      if (this.options.allowNil) return;
+      return;
+    }
+    const str = String(value);
+    if (this.options.with) {
+      const re = this.resolveRegexp(
+        this.options.with as RegExp | ((record: AnyRecord) => RegExp),
+        record,
+      );
+      if (!re.test(str)) {
+        record.errors.add(attribute, "invalid", { value, message: this.options.message });
+      }
+    }
+    if (this.options.without) {
+      const re = this.resolveRegexp(
+        this.options.without as RegExp | ((record: AnyRecord) => RegExp),
+        record,
+      );
+      if (re.test(str)) {
+        record.errors.add(attribute, "invalid", { value, message: this.options.message });
+      }
     }
   }
 }

--- a/packages/activemodel/src/validations/inclusion-validation.test.ts
+++ b/packages/activemodel/src/validations/inclusion-validation.test.ts
@@ -187,12 +187,12 @@ describe("InclusionValidationTest", () => {
         this.attribute("tags", "string");
       }
     }
-    const validator = new InclusionValidator({ in: ["a", "b", "c"] });
+    const validator = new InclusionValidator({ in: ["a", "b", "c"], attributes: ["tags"] });
     const r1 = new Item();
-    validator.validateEach(r1, "tags", ["a", "b"], r1.errors);
+    validator.validateEach(r1, "tags", ["a", "b"]);
     expect(r1.errors.size).toBe(0);
     const r2 = new Item();
-    validator.validateEach(r2, "tags", ["a", "z"], r2.errors);
+    validator.validateEach(r2, "tags", ["a", "z"]);
     expect(r2.errors.size).toBeGreaterThan(0);
   });
 

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -1,42 +1,22 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isMember, checkClusivityValidity } from "./clusivity.js";
 
-export interface InclusionOptions extends ConditionalOptions {
-  in?: Iterable<unknown> | (() => Iterable<unknown>);
-  within?: Iterable<unknown> | (() => Iterable<unknown>);
-  allowNil?: boolean;
-  allowBlank?: boolean;
-  message?: string;
-}
-
-export class InclusionValidator implements Validator {
-  constructor(private options: InclusionOptions) {}
-
-  checkValidityBang(): void {
+export class InclusionValidator extends EachValidator {
+  override checkValidity(): void {
     checkClusivityValidity(this.options);
   }
 
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (this.options.allowNil !== false && (value === null || value === undefined)) return;
-    if (this.options.allowBlank && isBlank(value)) return;
-    const inOpt = this.options.in ?? this.options.within;
+    const inOpt = (this.options.in ?? this.options.within) as
+      | Iterable<unknown>
+      | (() => Iterable<unknown>)
+      | undefined;
     if (!inOpt) return;
     const collection = typeof inOpt === "function" ? inOpt() : inOpt;
     if (!isMember(collection, value)) {
-      errs.add(attribute, "inclusion", { value, message: this.options.message });
+      record.errors.add(attribute, "inclusion", { value, message: this.options.message });
     }
   }
 }

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -1,34 +1,8 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 
-export interface LengthOptions extends ConditionalOptions {
-  minimum?: number | (() => number);
-  maximum?: number | (() => number);
-  is?: number | (() => number);
-  in?: [number, number];
-  allowNil?: boolean;
-  allowBlank?: boolean;
-  message?: string;
-  tooShort?: string;
-  tooLong?: string;
-  wrongLength?: string;
-}
-
-export class LengthValidator implements Validator {
-  constructor(private options: LengthOptions = {}) {}
-
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  checkValidityBang(): void {
+export class LengthValidator extends EachValidator {
+  override checkValidity(): void {
     if (
       this.options.minimum === undefined &&
       this.options.maximum === undefined &&
@@ -41,22 +15,16 @@ export class LengthValidator implements Validator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
-    if (!shouldValidate(record, this.options)) return;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (value === null || value === undefined) {
-      // Rails: nil is always skipped for maximum-only validations
       const maximumOnly =
         this.options.maximum !== undefined &&
         this.options.minimum === undefined &&
         this.options.is === undefined &&
         this.options.in === undefined;
       if (this.options.allowNil !== false || maximumOnly) return;
-      // allowNil is explicitly false and not maximum-only — fall through to validate
     }
-    if (this.options.allowBlank && isBlank(value)) return;
 
-    // Rails: handle any object with a length property
     let length: number;
     if (typeof value === "string" || Array.isArray(value)) {
       length = value.length;
@@ -75,37 +43,41 @@ export class LengthValidator implements Validator {
       if (v === undefined) return undefined;
       return typeof v === "function" ? v() : v;
     };
-    let min = this.options.in ? this.options.in[0] : resolveNum(this.options.minimum);
-    const max = this.options.in ? this.options.in[1] : resolveNum(this.options.maximum);
+    const inOpt = this.options.in as [number, number] | undefined;
+    let min = inOpt
+      ? inOpt[0]
+      : resolveNum(this.options.minimum as number | (() => number) | undefined);
+    const max = inOpt
+      ? inOpt[1]
+      : resolveNum(this.options.maximum as number | (() => number) | undefined);
 
-    // Rails: implicit minimum: 1 when allow_blank is false and no explicit constraints
     if (
       min === undefined &&
       max === undefined &&
       this.options.allowBlank === false &&
       this.options.is === undefined &&
-      this.options.in === undefined
+      inOpt === undefined
     ) {
       min = 1;
     }
 
     if (min !== undefined && length < min) {
-      errs.add(attribute, "too_short", {
-        message: this.options.tooShort ?? this.options.message,
+      record.errors.add(attribute, "too_short", {
+        message: (this.options.tooShort ?? this.options.message) as string | undefined,
         count: min,
         value,
       });
     }
     if (max !== undefined && length > max) {
-      errs.add(attribute, "too_long", {
-        message: this.options.tooLong ?? this.options.message,
+      record.errors.add(attribute, "too_long", {
+        message: (this.options.tooLong ?? this.options.message) as string | undefined,
         count: max,
         value,
       });
     }
     if (this.options.is !== undefined && length !== this.options.is) {
-      errs.add(attribute, "wrong_length", {
-        message: this.options.wrongLength ?? this.options.message,
+      record.errors.add(attribute, "wrong_length", {
+        message: (this.options.wrongLength ?? this.options.message) as string | undefined,
         count: this.options.is,
         value,
       });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -1,33 +1,10 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 
 type NumericValue = number | ((record: AnyRecord) => number) | string;
 
-export interface NumericalityOptions extends ConditionalOptions {
-  onlyInteger?: boolean;
-  greaterThan?: NumericValue;
-  greaterThanOrEqualTo?: NumericValue;
-  lessThan?: NumericValue;
-  lessThanOrEqualTo?: NumericValue;
-  equalTo?: NumericValue;
-  otherThan?: NumericValue;
-  in?: [number, number];
-  odd?: boolean;
-  even?: boolean;
-  allowNil?: boolean;
-  allowBlank?: boolean;
-  message?: string;
-}
-
-export class NumericalityValidator implements Validator {
-  constructor(private options: NumericalityOptions = {}) {}
-
+export class NumericalityValidator extends EachValidator {
   private resolveNumeric(val: NumericValue | undefined, record: AnyRecord): number | undefined {
     if (val === undefined) return undefined;
     if (typeof val === "function") return val(record);
@@ -39,12 +16,7 @@ export class NumericalityValidator implements Validator {
     return val;
   }
 
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  checkValidityBang(): void {
+  override checkValidity(): void {
     const compareKeys = [
       "greaterThan",
       "greaterThanOrEqualTo",
@@ -69,61 +41,65 @@ export class NumericalityValidator implements Validator {
     }
   }
 
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (value === null || value === undefined) {
       if (this.options.allowNil !== false) return;
-      errs.add(attribute, "not_a_number", { value, message: this.options.message });
+      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
       return;
     }
     if (this.options.allowBlank && isBlank(value)) return;
 
-    // Rails rejects hex literals (0x...) — JS Number() accepts them
     if (typeof value === "string" && /^\s*[+-]?0x/i.test(value)) {
-      errs.add(attribute, "not_a_number", { value, message: this.options.message });
+      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
       return;
     }
 
     const num = Number(value);
     if (isNaN(num)) {
-      errs.add(attribute, "not_a_number", { value, message: this.options.message });
+      record.errors.add(attribute, "not_a_number", { value, message: this.options.message });
       return;
     }
 
     if (this.options.onlyInteger && !Number.isInteger(num)) {
-      errs.add(attribute, "not_an_integer", { value, message: this.options.message });
+      record.errors.add(attribute, "not_an_integer", { value, message: this.options.message });
       return;
     }
 
     const msg = this.options.message;
-    const gt = this.resolveNumeric(this.options.greaterThan, record);
+    const gt = this.resolveNumeric(this.options.greaterThan as NumericValue | undefined, record);
     if (gt !== undefined && !(num > gt)) {
-      errs.add(attribute, "greater_than", { count: gt, value, message: msg });
+      record.errors.add(attribute, "greater_than", { count: gt, value, message: msg });
     }
-    const gte = this.resolveNumeric(this.options.greaterThanOrEqualTo, record);
+    const gte = this.resolveNumeric(
+      this.options.greaterThanOrEqualTo as NumericValue | undefined,
+      record,
+    );
     if (gte !== undefined && !(num >= gte)) {
-      errs.add(attribute, "greater_than_or_equal_to", { count: gte, value, message: msg });
+      record.errors.add(attribute, "greater_than_or_equal_to", { count: gte, value, message: msg });
     }
-    const lt = this.resolveNumeric(this.options.lessThan, record);
+    const lt = this.resolveNumeric(this.options.lessThan as NumericValue | undefined, record);
     if (lt !== undefined && !(num < lt)) {
-      errs.add(attribute, "less_than", { count: lt, value, message: msg });
+      record.errors.add(attribute, "less_than", { count: lt, value, message: msg });
     }
-    const lte = this.resolveNumeric(this.options.lessThanOrEqualTo, record);
+    const lte = this.resolveNumeric(
+      this.options.lessThanOrEqualTo as NumericValue | undefined,
+      record,
+    );
     if (lte !== undefined && !(num <= lte)) {
-      errs.add(attribute, "less_than_or_equal_to", { count: lte, value, message: msg });
+      record.errors.add(attribute, "less_than_or_equal_to", { count: lte, value, message: msg });
     }
-    const eq = this.resolveNumeric(this.options.equalTo, record);
+    const eq = this.resolveNumeric(this.options.equalTo as NumericValue | undefined, record);
     if (eq !== undefined && num !== eq) {
-      errs.add(attribute, "equal_to", { count: eq, value, message: msg });
+      record.errors.add(attribute, "equal_to", { count: eq, value, message: msg });
     }
-    const ot = this.resolveNumeric(this.options.otherThan, record);
+    const ot = this.resolveNumeric(this.options.otherThan as NumericValue | undefined, record);
     if (ot !== undefined && num === ot) {
-      errs.add(attribute, "other_than", { count: ot, value, message: msg });
+      record.errors.add(attribute, "other_than", { count: ot, value, message: msg });
     }
     if (this.options.in !== undefined) {
-      const [min, max] = this.options.in;
+      const [min, max] = this.options.in as [number, number];
       if (num < min || num > max) {
-        errs.add(attribute, "in", {
+        record.errors.add(attribute, "in", {
           message: msg,
           value,
           count: `${min}..${max}`,
@@ -131,10 +107,10 @@ export class NumericalityValidator implements Validator {
       }
     }
     if (this.options.odd && num % 2 === 0) {
-      errs.add(attribute, "odd", { value, message: msg });
+      record.errors.add(attribute, "odd", { value, message: msg });
     }
     if (this.options.even && num % 2 !== 0) {
-      errs.add(attribute, "even", { value, message: msg });
+      record.errors.add(attribute, "even", { value, message: msg });
     }
   }
 }

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -1,28 +1,11 @@
-import type { Errors } from "../errors.js";
-import type {
-  AnyRecord,
-  ConditionalOptions,
-  ValidatorContract as Validator,
-} from "../validator.js";
-import { shouldValidate } from "../validator.js";
+import { EachValidator } from "../validator.js";
+import type { AnyRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
 
-export interface PresenceOptions extends ConditionalOptions {
-  message?: string | ((record: AnyRecord) => string);
-}
-
-export class PresenceValidator implements Validator {
-  constructor(private options: PresenceOptions = {}) {}
-
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void {
-    if (!shouldValidate(record, this.options)) return;
-    this.validateEach(record, attribute, value, errors);
-  }
-
-  validateEach(record: AnyRecord, attribute: string, value: unknown, errors?: Errors): void {
-    const errs = errors ?? record.errors;
+export class PresenceValidator extends EachValidator {
+  validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (isBlank(value)) {
-      errs.add(attribute, "blank", { message: this.options.message });
+      record.errors.add(attribute, "blank", { message: this.options.message });
     }
   }
 }

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -1,4 +1,3 @@
-import type { Errors } from "./errors.js";
 import { isBlank, underscore } from "@blazetrails/activesupport";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,14 +9,6 @@ export interface ConditionalOptions {
   if?: ConditionFn | ConditionFn[];
   unless?: ConditionFn | ConditionFn[];
   on?: string;
-}
-
-/**
- * Base validator interface — kept for backward compatibility with
- * existing validators that implement this shape.
- */
-export interface ValidatorContract {
-  validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void;
 }
 
 export function evaluateCondition(record: AnyRecord, cond: ConditionFn): boolean {

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -20,7 +20,7 @@ export interface ValidatorContract {
   validate(record: AnyRecord, attribute: string, value: unknown, errors: Errors): void;
 }
 
-function evaluateCondition(record: AnyRecord, cond: ConditionFn): boolean {
+export function evaluateCondition(record: AnyRecord, cond: ConditionFn): boolean {
   if (typeof cond === "function") return cond(record);
   const method = record[cond];
   if (typeof method === "function") return method.call(record);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2129,34 +2129,30 @@ export class Base extends Model {
 
     const wasNewRecord = this._newRecord;
     if (this._newRecord) {
-      if (!(await ctor._callbackChain.runBeforeAsync("create", this))) {
-        this._skipTouch = false;
-        return false;
-      }
-      this._performInsert();
-      if (this._pendingOperation) {
-        await this._pendingOperation;
-        this._pendingOperation = null;
-      }
-      this._previouslyNewRecord = true;
-      this._newRecord = false;
-      this.changesApplied();
-      saved = true;
-      await ctor._callbackChain.runAfterAsync("create", this);
+      const createResult = await ctor._callbackChain.runAsync("create", this, async () => {
+        this._performInsert();
+        if (this._pendingOperation) {
+          await this._pendingOperation;
+          this._pendingOperation = null;
+        }
+        this._previouslyNewRecord = true;
+        this._newRecord = false;
+        this.changesApplied();
+        saved = true;
+      });
+      if (!createResult) saved = false;
     } else {
-      if (!(await ctor._callbackChain.runBeforeAsync("update", this))) {
-        this._skipTouch = false;
-        return false;
-      }
-      this._performUpdate();
-      if (this._pendingOperation) {
-        await this._pendingOperation;
-        this._pendingOperation = null;
-      }
-      this._previouslyNewRecord = false;
-      this.changesApplied();
-      saved = true;
-      await ctor._callbackChain.runAfterAsync("update", this);
+      const updateResult = await ctor._callbackChain.runAsync("update", this, async () => {
+        this._performUpdate();
+        if (this._pendingOperation) {
+          await this._pendingOperation;
+          this._pendingOperation = null;
+        }
+        this._previouslyNewRecord = false;
+        this.changesApplied();
+        saved = true;
+      });
+      if (!updateResult) saved = false;
     }
     this._skipTouch = false;
 
@@ -2391,36 +2387,36 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
-    if (!(await ctor._callbackChain.runBeforeAsync("destroy", this))) return false;
-
-    const table = ctor.arelTable;
-    const pk = this.id;
-    if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
-      const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
-      const lockCol = ctor.lockingColumn;
-      if (ctor.lockingEnabled) {
-        const currentVersion = this.readAttribute(lockCol);
-        if (currentVersion == null) {
-          dm.where(table.get(lockCol).isNull());
-        } else {
-          dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
+    const destroyResult = await ctor._callbackChain.runAsync("destroy", this, async () => {
+      const table = ctor.arelTable;
+      const pk = this.id;
+      if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
+        const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
+        const lockCol = ctor.lockingColumn;
+        if (ctor.lockingEnabled) {
+          const currentVersion = this.readAttribute(lockCol);
+          if (currentVersion == null) {
+            dm.where(table.get(lockCol).isNull());
+          } else {
+            dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
+          }
         }
+
+        const affected = await ctor.adapter.execDelete(dm.toSql(), "Destroy");
+        if (ctor.lockingEnabled && affected === 0) {
+          throw new StaleObjectError(this, "destroy");
+        }
+        didDelete = affected > 0;
       }
 
-      const affected = await ctor.adapter.execDelete(dm.toSql(), "Destroy");
-      if (ctor.lockingEnabled && affected === 0) {
-        throw new StaleObjectError(this, "destroy");
-      }
-      didDelete = affected > 0;
-    }
+      this._destroyed = true;
+      this._frozen = true;
+      this._collectionProxies.clear();
+      this._preloadedAssociations.clear();
+      this._associationInstances.clear();
+    });
 
-    this._destroyed = true;
-    this._frozen = true;
-    this._collectionProxies.clear();
-    this._preloadedAssociations.clear();
-    this._associationInstances.clear();
-
-    await ctor._callbackChain.runAfterAsync("destroy", this);
+    if (!destroyResult) return false;
 
     if (didDelete) {
       this._transactionAction = "destroy";

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2129,7 +2129,7 @@ export class Base extends Model {
 
     const wasNewRecord = this._newRecord;
     if (this._newRecord) {
-      const createResult = await ctor._callbackChain.runAsync("create", this, async () => {
+      const createResult = await ctor._callbackChain.runCallbacksAsync("create", this, async () => {
         this._performInsert();
         if (this._pendingOperation) {
           await this._pendingOperation;
@@ -2142,7 +2142,7 @@ export class Base extends Model {
       });
       if (!createResult) saved = false;
     } else {
-      const updateResult = await ctor._callbackChain.runAsync("update", this, async () => {
+      const updateResult = await ctor._callbackChain.runCallbacksAsync("update", this, async () => {
         this._performUpdate();
         if (this._pendingOperation) {
           await this._pendingOperation;
@@ -2387,7 +2387,7 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
-    const destroyResult = await ctor._callbackChain.runAsync("destroy", this, async () => {
+    const destroyResult = await ctor._callbackChain.runCallbacksAsync("destroy", this, async () => {
       const table = ctor.arelTable;
       const pk = this.id;
       if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
@@ -2427,7 +2427,7 @@ export class Base extends Model {
       await updateCounterCaches(this, "decrement");
     }
 
-    return didDelete || this._destroyed;
+    return true;
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1749,7 +1749,7 @@ export class Base extends Model {
       record._strictLoading = true;
     }
     // Fire after_find callbacks
-    this._callbackChain.runAfterSync("find", record);
+    this._callbackChain.runAfter("find", record);
     return record;
   }
 
@@ -2119,7 +2119,7 @@ export class Base extends Model {
     const { autosaveBelongsTo, autosaveChildren } = await import("./autosave-association.js");
 
     let saved = false;
-    if (!(await ctor._callbackChain.runBefore("save", this))) return false;
+    if (!(await ctor._callbackChain.runBeforeAsync("save", this))) return false;
 
     const belongsToOk = await autosaveBelongsTo(this);
     if (!belongsToOk) {
@@ -2129,40 +2129,43 @@ export class Base extends Model {
 
     const wasNewRecord = this._newRecord;
     if (this._newRecord) {
-      const createResult = await ctor._callbackChain.run("create", this, async () => {
-        this._performInsert();
-        if (this._pendingOperation) {
-          await this._pendingOperation;
-          this._pendingOperation = null;
-        }
-        this._previouslyNewRecord = true;
-        this._newRecord = false;
-        this.changesApplied();
-        saved = true;
-      });
-      if (!createResult) saved = false;
+      if (!(await ctor._callbackChain.runBeforeAsync("create", this))) {
+        this._skipTouch = false;
+        return false;
+      }
+      this._performInsert();
+      if (this._pendingOperation) {
+        await this._pendingOperation;
+        this._pendingOperation = null;
+      }
+      this._previouslyNewRecord = true;
+      this._newRecord = false;
+      this.changesApplied();
+      saved = true;
+      await ctor._callbackChain.runAfterAsync("create", this);
     } else {
-      const updateResult = await ctor._callbackChain.run("update", this, async () => {
-        this._performUpdate();
-        if (this._pendingOperation) {
-          await this._pendingOperation;
-          this._pendingOperation = null;
-        }
-        this._previouslyNewRecord = false;
-        this.changesApplied();
-        saved = true;
-      });
-      if (!updateResult) saved = false;
+      if (!(await ctor._callbackChain.runBeforeAsync("update", this))) {
+        this._skipTouch = false;
+        return false;
+      }
+      this._performUpdate();
+      if (this._pendingOperation) {
+        await this._pendingOperation;
+        this._pendingOperation = null;
+      }
+      this._previouslyNewRecord = false;
+      this.changesApplied();
+      saved = true;
+      await ctor._callbackChain.runAfterAsync("update", this);
     }
     this._skipTouch = false;
 
     if (saved) {
-      // Set transaction action and tracking flags for callback filtering
       this._transactionAction = wasNewRecord ? "create" : "update";
       (this as any)._newRecordBeforeLastCommit = wasNewRecord;
       (this as any)._triggerUpdateCallback = !wasNewRecord;
 
-      await ctor._callbackChain.runAfter("save", this);
+      await ctor._callbackChain.runAfterAsync("save", this);
 
       if (wasNewRecord) {
         const { updateCounterCaches } = await import("./associations.js");
@@ -2388,36 +2391,36 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
-    const halted = !(await ctor._callbackChain.run("destroy", this, async () => {
-      const table = ctor.arelTable;
-      const pk = this.id;
-      if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
-        const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
-        const lockCol = ctor.lockingColumn;
-        if (ctor.lockingEnabled) {
-          const currentVersion = this.readAttribute(lockCol);
-          if (currentVersion == null) {
-            dm.where(table.get(lockCol).isNull());
-          } else {
-            dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
-          }
-        }
+    if (!(await ctor._callbackChain.runBeforeAsync("destroy", this))) return false;
 
-        const affected = await ctor.adapter.execDelete(dm.toSql(), "Destroy");
-        if (ctor.lockingEnabled && affected === 0) {
-          throw new StaleObjectError(this, "destroy");
+    const table = ctor.arelTable;
+    const pk = this.id;
+    if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
+      const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
+      const lockCol = ctor.lockingColumn;
+      if (ctor.lockingEnabled) {
+        const currentVersion = this.readAttribute(lockCol);
+        if (currentVersion == null) {
+          dm.where(table.get(lockCol).isNull());
+        } else {
+          dm.where(table.get(lockCol).eq(Number(currentVersion) || 0));
         }
-        didDelete = affected > 0;
       }
 
-      this._destroyed = true;
-      this._frozen = true;
-      this._collectionProxies.clear();
-      this._preloadedAssociations.clear();
-      this._associationInstances.clear();
-    }));
+      const affected = await ctor.adapter.execDelete(dm.toSql(), "Destroy");
+      if (ctor.lockingEnabled && affected === 0) {
+        throw new StaleObjectError(this, "destroy");
+      }
+      didDelete = affected > 0;
+    }
 
-    if (halted) return false;
+    this._destroyed = true;
+    this._frozen = true;
+    this._collectionProxies.clear();
+    this._preloadedAssociations.clear();
+    this._associationInstances.clear();
+
+    await ctor._callbackChain.runAfterAsync("destroy", this);
 
     if (didDelete) {
       this._transactionAction = "destroy";
@@ -2428,7 +2431,7 @@ export class Base extends Model {
       await updateCounterCaches(this, "decrement");
     }
 
-    return didDelete || !halted;
+    return didDelete || this._destroyed;
   }
 
   /**

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6121,8 +6121,8 @@ describe("CalculationsTest", () => {
     (Order as any).beforeShip(() => log.push("before_ship"));
     (Order as any).afterDeliver(() => log.push("after_deliver"));
     const o = new Order({});
-    (Order as any)._callbackChain.runBeforeSync("ship", o);
-    (Order as any)._callbackChain.runAfterSync("deliver", o);
+    (Order as any)._callbackChain.runBefore("ship", o);
+    (Order as any)._callbackChain.runAfter("deliver", o);
     expect(log).toEqual(["before_ship", "after_deliver"]);
   });
 
@@ -6165,7 +6165,7 @@ describe("CalculationsTest", () => {
       { prepend: true },
     );
     const u = new User({});
-    (User as any)._callbackChain.runBeforeSync("destroy", u);
+    (User as any)._callbackChain.runBefore("destroy", u);
     expect(order[0]).toBe("prepended");
   });
 
@@ -6202,8 +6202,9 @@ describe("CalculationsTest", () => {
       m.validates("name", { presence: true });
       m.validates("email", { presence: true });
     });
-    const validations = (User as any)._validations.filter((v: any) => v.on === "update");
-    expect(validations.length).toBe(2);
+    const user = new User();
+    expect(user.isValid()).toBe(true);
+    expect(user.isValid("update")).toBe(false);
   });
 
   // Rails guide: to_xml — XML serialization

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -35,7 +35,7 @@ export async function touch(this: Base, ...names: string[]): Promise<boolean> {
 
   await this.updateColumns(attrs);
 
-  await ctor._callbackChain.runAfter("touch", this);
+  await ctor._callbackChain.runAfterAsync("touch", this);
   return true;
 }
 

--- a/packages/activerecord/src/validations/absence.ts
+++ b/packages/activerecord/src/validations/absence.ts
@@ -9,13 +9,13 @@ import { AbsenceValidator as BaseAbsenceValidator } from "@blazetrails/activemod
 import { isAssociation, resolveAssociation, filterDestroyed } from "./association-helpers.js";
 
 export class AbsenceValidator extends BaseAbsenceValidator {
-  validate(record: any, attribute: string, value: unknown, errors: any): void {
+  validateEach(record: any, attribute: string, value: unknown): void {
     if (isAssociation(record, attribute)) {
       const resolved = resolveAssociation(record, attribute, value);
       const filtered = filterDestroyed(resolved);
-      super.validate(record, attribute, filtered, errors);
+      super.validateEach(record, attribute, filtered);
       return;
     }
-    super.validate(record, attribute, value, errors);
+    super.validateEach(record, attribute, value);
   }
 }

--- a/packages/activerecord/src/validations/presence.ts
+++ b/packages/activerecord/src/validations/presence.ts
@@ -9,13 +9,13 @@ import { PresenceValidator as BasePresenceValidator } from "@blazetrails/activem
 import { isAssociation, resolveAssociation, filterDestroyed } from "./association-helpers.js";
 
 export class PresenceValidator extends BasePresenceValidator {
-  validate(record: any, attribute: string, value: unknown, errors: any): void {
+  validateEach(record: any, attribute: string, value: unknown): void {
     if (isAssociation(record, attribute)) {
       const resolved = resolveAssociation(record, attribute, value);
       const filtered = filterDestroyed(resolved);
-      super.validate(record, attribute, filtered, errors);
+      super.validateEach(record, attribute, filtered);
       return;
     }
-    super.validate(record, attribute, value, errors);
+    super.validateEach(record, attribute, value);
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `_validations`/`_customValidations` arrays with Rails-style `:validate` callback registration
- All 10 validators now extend `EachValidator` with `validateEach(record, attr, value)` instead of the old 4-arg `ValidatorContract`
- `validates()` → `validatesWith()` → registers `:validate` callback on the chain
- `isValid()` mirrors Rails: `run_callbacks(:validation) { _run_validate_callbacks }`
- `CallbackChain` is sync-primary (`run`/`runBefore`/`runAfter`), with `runBeforeAsync`/`runAfterAsync` for activerecord persistence where callbacks cascade async DB operations
- Net -257 lines

## Test plan

- [x] All 1372 activemodel tests pass
- [x] All 8034 activerecord tests pass (193 PG-only files skipped)
- [x] Builds clean across activemodel, activerecord, activesupport, arel, rack