### PR TITLE
refactor(activerecord): Rails fidelity cleanup

### DIFF
--- a/packages/activerecord/src/associations/preloader/branch.ts
+++ b/packages/activerecord/src/associations/preloader/branch.ts
@@ -1,6 +1,5 @@
 import type { Base } from "../../base.js";
 import type { AbstractReflection } from "../../reflection.js";
-import { _reflectOnAssociation } from "../../reflection.js";
 import { Association } from "./association.js";
 import { ThroughAssociation } from "./through-association.js";
 
@@ -127,7 +126,7 @@ export class Branch {
     const parentClasses = this.parent!.targetClasses();
     const result: AbstractReflection[] = [];
     for (const parentKlass of parentClasses) {
-      const refl = _reflectOnAssociation(parentKlass, this.association!);
+      const refl = parentKlass._reflectOnAssociation(this.association!);
       if (refl) result.push(refl);
     }
     return result;
@@ -155,8 +154,7 @@ export class Branch {
     const h = new Map<AbstractReflection, Base[]>();
 
     for (const record of this.sourceRecords) {
-      const reflection = _reflectOnAssociation(
-        record.constructor as typeof Base,
+      const reflection = (record.constructor as typeof Base)._reflectOnAssociation(
         this.association!,
       );
 
@@ -233,8 +231,7 @@ export class Branch {
     if (this._polymorphic !== undefined) return this._polymorphic;
 
     this._polymorphic = this.sourceRecords.some((record) => {
-      const reflection = _reflectOnAssociation(
-        record.constructor as typeof Base,
+      const reflection = (record.constructor as typeof Base)._reflectOnAssociation(
         this.association!,
       );
       return reflection != null && reflection.isPolymorphic();

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -1,6 +1,5 @@
 import type { Base } from "../../base.js";
 import type { AssociationReflection, ThroughReflection } from "../../reflection.js";
-import { _reflectOnAssociation } from "../../reflection.js";
 import { Association } from "./association.js";
 import { Preloader } from "../preloader.js";
 import { pluralize, singularize } from "@blazetrails/activesupport";
@@ -278,8 +277,7 @@ export class ThroughAssociation extends Association {
     const model = (this.reflection as any).activeRecord;
     const assocDef = model?._associations?.find((a: any) => a.name === this.reflection.name);
     if (assocDef?.options?.through) {
-      return _reflectOnAssociation(
-        model,
+      return model._reflectOnAssociation(
         assocDef.options.through,
       ) as AssociationLikeReflection | null;
     }
@@ -305,7 +303,7 @@ export class ThroughAssociation extends Association {
       if (throughKlass) {
         const candidates = [sourceName, pluralize(sourceName), singularize(sourceName)];
         for (const name of candidates) {
-          const r = _reflectOnAssociation(throughKlass, name) as AssociationLikeReflection | null;
+          const r = throughKlass._reflectOnAssociation(name) as AssociationLikeReflection | null;
           if (r) return r;
         }
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -30,6 +30,10 @@ import {
   AttributeAssignmentError,
 } from "./errors.js";
 import { AssociatedValidator } from "./validations/associated.js";
+import { AbsenceValidator as ARAbsenceValidator } from "./validations/absence.js";
+import { PresenceValidator as ARPresenceValidator } from "./validations/presence.js";
+import { LengthValidator as ARLengthValidator } from "./validations/length.js";
+import { NumericalityValidator as ARNumericalityValidator } from "./validations/numericality.js";
 import { AutosaveAssociation, clearAutosaveState } from "./autosave-association.js";
 import {
   RecordInvalid,
@@ -687,6 +691,62 @@ export class Base extends Model {
    */
   static _reflectOnAssociation(name: string): any {
     return (this as any)._reflections?.[name] ?? null;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Validations.validates
+   *
+   * Overrides Model.validates to use AR-specific validator classes for
+   * presence/absence/length/numericality. These AR validators add
+   * association awareness (filtering destroyed records, column precision).
+   */
+  static override validates(attribute: string, rules: Record<string, unknown>): void {
+    // Swap AM validator classes for AR equivalents that handle associations
+    const arRules = { ...rules };
+    if (arRules.presence) {
+      const opts = arRules.presence === true ? {} : (arRules.presence as Record<string, unknown>);
+      delete arRules.presence;
+      this.validatesWith(ARPresenceValidator, {
+        attributes: [attribute],
+        ...opts,
+        ...extractShared(arRules),
+      });
+    }
+    if (arRules.absence) {
+      const opts = arRules.absence === true ? {} : (arRules.absence as Record<string, unknown>);
+      delete arRules.absence;
+      this.validatesWith(ARAbsenceValidator, {
+        attributes: [attribute],
+        ...opts,
+        ...extractShared(arRules),
+      });
+    }
+    if (arRules.length) {
+      const opts = arRules.length as Record<string, unknown>;
+      delete arRules.length;
+      this.validatesWith(ARLengthValidator, {
+        attributes: [attribute],
+        ...opts,
+        ...extractShared(arRules),
+      });
+    }
+    if (arRules.numericality) {
+      const opts =
+        arRules.numericality === true ? {} : (arRules.numericality as Record<string, unknown>);
+      delete arRules.numericality;
+      this.validatesWith(ARNumericalityValidator, {
+        attributes: [attribute],
+        ...opts,
+        ...extractShared(arRules),
+      });
+    }
+    // Delegate remaining rules (inclusion, exclusion, format, etc.) to Model
+    const hasRemaining = Object.keys(arRules).some(
+      (k) => !["on", "if", "unless", "strict", "allowNil", "allowBlank"].includes(k),
+    );
+    if (hasRemaining) {
+      super.validates(attribute, arRules);
+    }
   }
 
   static validatesAssociated(...args: (string | Record<string, unknown>)[]): void {
@@ -3069,6 +3129,17 @@ export interface Base extends Included<typeof AutosaveAssociation> {}
 // in the class body, so `Base.findBySql` and `Base.connectsTo` carry the
 // exact generics, `this` parameter, and return type of their implementations.
 // ---------------------------------------------------------------------------
+
+function extractShared(rules: Record<string, unknown>): Record<string, unknown> {
+  const shared: Record<string, unknown> = {};
+  if (rules.on !== undefined) shared.on = rules.on;
+  if (rules.if !== undefined) shared.if = rules.if;
+  if (rules.unless !== undefined) shared.unless = rules.unless;
+  if (rules.strict) shared.strict = rules.strict;
+  if (rules.allowNil !== undefined) shared.allowNil = rules.allowNil;
+  if (rules.allowBlank !== undefined) shared.allowBlank = rules.allowBlank;
+  return shared;
+}
 
 extend(Base, ConnectionHandling.ClassMethods);
 extend(Base, Querying);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -679,14 +679,6 @@ export class Base extends Model {
   }
 
   /**
-   * Validate that all named associations are themselves valid.
-   *
-   * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
-   *
-   * Registers AssociatedValidator through validatesWith (matching Rails'
-   * validates_with pattern) so on:/if:/unless:/message: options all work.
-   */
-  /**
    * Mirrors: ActiveRecord::Reflection::ClassMethods#_reflect_on_association
    */
   static _reflectOnAssociation(name: string): any {
@@ -701,44 +693,44 @@ export class Base extends Model {
    * association awareness (filtering destroyed records, column precision).
    */
   static override validates(attribute: string, rules: Record<string, unknown>): void {
-    // Swap AM validator classes for AR equivalents that handle associations
     const arRules = { ...rules };
+    const shared = extractShared(arRules);
+    const { allowNil: sharedAllowNil, allowBlank: sharedAllowBlank, ...sharedRest } = shared;
+
+    // Build options for an AR validator, respecting per-validator allowNil/allowBlank
+    // precedence (only apply shared value when per-validator option is undefined).
+    const buildOpts = (opts: Record<string, unknown>) => ({
+      attributes: [attribute],
+      ...opts,
+      ...sharedRest,
+      ...(opts.allowNil === undefined && sharedAllowNil !== undefined
+        ? { allowNil: sharedAllowNil }
+        : {}),
+      ...(opts.allowBlank === undefined && sharedAllowBlank !== undefined
+        ? { allowBlank: sharedAllowBlank }
+        : {}),
+    });
+
     if (arRules.presence) {
       const opts = arRules.presence === true ? {} : (arRules.presence as Record<string, unknown>);
       delete arRules.presence;
-      this.validatesWith(ARPresenceValidator, {
-        attributes: [attribute],
-        ...opts,
-        ...extractShared(arRules),
-      });
+      this.validatesWith(ARPresenceValidator, buildOpts(opts));
     }
     if (arRules.absence) {
       const opts = arRules.absence === true ? {} : (arRules.absence as Record<string, unknown>);
       delete arRules.absence;
-      this.validatesWith(ARAbsenceValidator, {
-        attributes: [attribute],
-        ...opts,
-        ...extractShared(arRules),
-      });
+      this.validatesWith(ARAbsenceValidator, buildOpts(opts));
     }
     if (arRules.length) {
       const opts = arRules.length as Record<string, unknown>;
       delete arRules.length;
-      this.validatesWith(ARLengthValidator, {
-        attributes: [attribute],
-        ...opts,
-        ...extractShared(arRules),
-      });
+      this.validatesWith(ARLengthValidator, buildOpts(opts));
     }
     if (arRules.numericality) {
       const opts =
         arRules.numericality === true ? {} : (arRules.numericality as Record<string, unknown>);
       delete arRules.numericality;
-      this.validatesWith(ARNumericalityValidator, {
-        attributes: [attribute],
-        ...opts,
-        ...extractShared(arRules),
-      });
+      this.validatesWith(ARNumericalityValidator, buildOpts(opts));
     }
     // Delegate remaining rules (inclusion, exclusion, format, etc.) to Model
     const hasRemaining = Object.keys(arRules).some(
@@ -749,6 +741,11 @@ export class Base extends Model {
     }
   }
 
+  /**
+   * Validates that all named associations are themselves valid.
+   *
+   * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
+   */
   static validatesAssociated(...args: (string | Record<string, unknown>)[]): void {
     const last = args[args.length - 1];
     const opts =

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -700,8 +700,8 @@ export class Base extends Model {
     // Build options for an AR validator, respecting per-validator allowNil/allowBlank
     // precedence (only apply shared value when per-validator option is undefined).
     const buildOpts = (opts: Record<string, unknown>) => ({
-      attributes: [attribute],
       ...opts,
+      attributes: [attribute],
       ...sharedRest,
       ...(opts.allowNil === undefined && sharedAllowNil !== undefined
         ? { allowNil: sharedAllowNil }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -565,8 +565,8 @@ export class AssociationReflection extends MacroReflection {
     const name = this.inverseName();
     if (!name) return null;
     if (this._inverseOfCache !== undefined) return this._inverseOfCache;
-    this._inverseOfCache = _reflectOnAssociation(this.klass, name);
-    return this._inverseOfCache;
+    this._inverseOfCache = this.klass._reflectOnAssociation(name) ?? null;
+    return this._inverseOfCache!;
   }
 
   private _inverseNameCache: string | null | undefined = undefined;
@@ -592,11 +592,11 @@ export class AssociationReflection extends MacroReflection {
 
     let reflection: AssociationReflection | ThroughReflection | null | false;
     try {
-      reflection = _reflectOnAssociation(this.klass, inverseName);
+      reflection = this.klass._reflectOnAssociation(inverseName);
 
       if (!reflection && this.activeRecord.automaticallyInvertPluralAssociations) {
         const pluralInverseName = pluralize(inverseName);
-        reflection = _reflectOnAssociation(this.klass, pluralInverseName);
+        reflection = this.klass._reflectOnAssociation(pluralInverseName);
       }
     } catch (e: unknown) {
       // Rails: rescue NameError => error; raise unless error.name.to_s == class_name
@@ -807,7 +807,7 @@ export class AssociationReflection extends MacroReflection {
     if (this.hasInverse()) {
       const name = this.inverseName();
       if (!name) return null;
-      const inverseRelationship = _reflectOnAssociation(associatedClass, name);
+      const inverseRelationship = associatedClass._reflectOnAssociation(name);
       if (!inverseRelationship) {
         throw new Error(
           `Could not find the inverse association for ${this.name} (:${name} in ${associatedClass.name})`,
@@ -1095,8 +1095,8 @@ export class ThroughReflection extends AbstractReflection {
     if (throughRef) {
       try {
         const singular = singularize(this.name);
-        if (_reflectOnAssociation(throughRef.klass, singular)) return singular;
-        if (_reflectOnAssociation(throughRef.klass, this.name)) return this.name;
+        if (throughRef.klass._reflectOnAssociation(singular)) return singular;
+        if (throughRef.klass._reflectOnAssociation(this.name)) return this.name;
       } catch {
         /* klass resolution may fail */
       }
@@ -1117,8 +1117,8 @@ export class ThroughReflection extends AbstractReflection {
       return null;
     }
     try {
-      this._sourceReflectionCache = _reflectOnAssociation(throughRef.klass, srcName);
-      return this._sourceReflectionCache;
+      this._sourceReflectionCache = throughRef.klass._reflectOnAssociation(srcName) ?? null;
+      return this._sourceReflectionCache!;
     } catch {
       this._sourceReflectionCache = null;
       return null;
@@ -1127,8 +1127,8 @@ export class ThroughReflection extends AbstractReflection {
 
   get throughReflection(): AssociationReflection | ThroughReflection | null {
     if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
-    this._throughReflectionCache = _reflectOnAssociation(this.activeRecord, this.through);
-    return this._throughReflectionCache;
+    this._throughReflectionCache = this.activeRecord._reflectOnAssociation(this.through) ?? null;
+    return this._throughReflectionCache!;
   }
 
   get joinTable(): string | null {
@@ -1224,7 +1224,7 @@ export class ThroughReflection extends AbstractReflection {
     try {
       const singular = singularize(this.name);
       const candidates = [...new Set([singular, this.name])];
-      const matching = candidates.filter((n) => _reflectOnAssociation(throughRef.klass, n) != null);
+      const matching = candidates.filter((n) => throughRef.klass._reflectOnAssociation(n) != null);
 
       if (matching.length > 1) {
         throw new AmbiguousSourceReflectionForThroughAssociation(

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -565,8 +565,9 @@ export class AssociationReflection extends MacroReflection {
     const name = this.inverseName();
     if (!name) return null;
     if (this._inverseOfCache !== undefined) return this._inverseOfCache;
-    this._inverseOfCache = this.klass._reflectOnAssociation(name) ?? null;
-    return this._inverseOfCache!;
+    const result = this.klass._reflectOnAssociation(name) ?? null;
+    this._inverseOfCache = result;
+    return result;
   }
 
   private _inverseNameCache: string | null | undefined = undefined;
@@ -1117,8 +1118,9 @@ export class ThroughReflection extends AbstractReflection {
       return null;
     }
     try {
-      this._sourceReflectionCache = throughRef.klass._reflectOnAssociation(srcName) ?? null;
-      return this._sourceReflectionCache!;
+      const src = throughRef.klass._reflectOnAssociation(srcName) ?? null;
+      this._sourceReflectionCache = src;
+      return src;
     } catch {
       this._sourceReflectionCache = null;
       return null;
@@ -1127,8 +1129,9 @@ export class ThroughReflection extends AbstractReflection {
 
   get throughReflection(): AssociationReflection | ThroughReflection | null {
     if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
-    this._throughReflectionCache = this.activeRecord._reflectOnAssociation(this.through) ?? null;
-    return this._throughReflectionCache!;
+    const through = this.activeRecord._reflectOnAssociation(this.through) ?? null;
+    this._throughReflectionCache = through;
+    return through;
   }
 
   get joinTable(): string | null {


### PR DESCRIPTION
## Summary

Three improvements for closer Rails parity from the loose ends of PRs #500, #501, #504:

**1. Base.validates uses AR-specific validators**
- Overrides `Model.validates` to swap AM validator classes for AR equivalents (Presence, Absence, Length, Numericality) that handle association filtering and column precision/scale
- Matches Rails where AR reopens the helper methods module to register AR-specific validator classes
- Remaining validators (inclusion, exclusion, format, etc.) delegate to `super.validates`

**2. Migrate `_reflectOnAssociation` to class method pattern**
- Internal callers in `reflection.ts` and `preloader/` now use `klass._reflectOnAssociation(name)` instead of the standalone function
- Matches Rails' `klass._reflect_on_association(name)` pattern
- Standalone function preserved in exports for external consumers

**3. Extended<>/Included<> analysis (no code change)**
- `Extended<>` isn't practical for TS static mixins (no `interface typeof Class` merging)
- `Included<>` already applied for AutosaveAssociation; remaining `include()` calls have small method counts where `declare` lines are clearer

## Test plan
- [x] All 16,964 tests pass
- [x] Build and typecheck pass
- [x] api:compare unchanged at 77.9%