### PR TITLE
feat(activerecord): add per-adapter DatabaseTasks classes (Phase 1)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig(
       "packages/activerecord/src/encryption/context.ts",
       "packages/activerecord/src/connection-handling.ts",
       // Task runners shell out to database CLIs — node-only
+      "packages/activerecord/src/tasks/database-tasks.ts",
       "packages/activerecord/src/tasks/sqlite-database-tasks.ts",
       "packages/activerecord/src/tasks/postgresql-database-tasks.ts",
       "packages/activerecord/src/tasks/mysql-database-tasks.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,17 +68,14 @@ export default defineConfig(
       "packages/activesupport/src/fs-adapter.ts",
       "packages/activesupport/src/crypto-adapter.ts",
       "packages/activesupport/src/async-context-adapter.ts",
+      "packages/activesupport/src/child-process-adapter.ts",
+      "packages/activesupport/src/os-adapter.ts",
       // Node-only modules exposed via subpath imports (no browser equivalent)
       "packages/activesupport/src/gzip.ts",
       "packages/rack/src/deflater.ts",
       "packages/activerecord/src/encryption/config.ts",
       "packages/activerecord/src/encryption/context.ts",
       "packages/activerecord/src/connection-handling.ts",
-      // Task runners shell out to database CLIs — node-only
-      "packages/activerecord/src/tasks/database-tasks.ts",
-      "packages/activerecord/src/tasks/sqlite-database-tasks.ts",
-      "packages/activerecord/src/tasks/postgresql-database-tasks.ts",
-      "packages/activerecord/src/tasks/mysql-database-tasks.ts",
     ],
     plugins: {
       blazetrails: { rules: { "no-node-builtins": noNodeBuiltins } },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,6 +74,10 @@ export default defineConfig(
       "packages/activerecord/src/encryption/config.ts",
       "packages/activerecord/src/encryption/context.ts",
       "packages/activerecord/src/connection-handling.ts",
+      // Task runners shell out to database CLIs — node-only
+      "packages/activerecord/src/tasks/sqlite-database-tasks.ts",
+      "packages/activerecord/src/tasks/postgresql-database-tasks.ts",
+      "packages/activerecord/src/tasks/mysql-database-tasks.ts",
     ],
     plugins: {
       blazetrails: { rules: { "no-node-builtins": noNodeBuiltins } },

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -251,7 +251,8 @@ export class SchemaDumper {
     lines.push("// This file is auto-generated from the current state of the database.");
     lines.push("// Instead of editing this file, please use the migrations feature.");
     lines.push("");
-    lines.push("export default async function defineSchema(ctx: any) {");
+    lines.push("/** @param {import('@blazetrails/activerecord').MigrationContext} ctx */");
+    lines.push("export default async function defineSchema(ctx) {");
   }
 
   private trailer(lines: string[]): void {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -200,16 +200,21 @@ function cleanDefault(raw: unknown): unknown {
   return raw;
 }
 
+export type SchemaDumpLanguage = "ts" | "js";
+
 export class SchemaDumper {
   static readonly DEFAULT_DATETIME_PRECISION = 6;
   static ignoreTables: (string | RegExp)[] = [];
 
   private _source: SchemaSource;
   protected _options: Record<string, unknown>;
+  private _language: SchemaDumpLanguage;
 
   constructor(source: SchemaSource, options: Record<string, unknown> = {}) {
     this._source = source;
     this._options = options;
+    const lang = (options.language as SchemaDumpLanguage | undefined) ?? "ts";
+    this._language = lang;
   }
 
   /**
@@ -221,8 +226,11 @@ export class SchemaDumper {
     return new this(source, options);
   }
 
-  static dump(source: SchemaSource): string | Promise<string> {
-    const dumper = this.create(source);
+  static dump(
+    source: SchemaSource,
+    options: Record<string, unknown> = {},
+  ): string | Promise<string> {
+    const dumper = this.create(source, options);
     return dumper.dump();
   }
 
@@ -251,8 +259,14 @@ export class SchemaDumper {
     lines.push("// This file is auto-generated from the current state of the database.");
     lines.push("// Instead of editing this file, please use the migrations feature.");
     lines.push("");
-    lines.push("/** @param {import('@blazetrails/activerecord').MigrationContext} ctx */");
-    lines.push("export default async function defineSchema(ctx) {");
+    if (this._language === "ts") {
+      lines.push(`import type { MigrationContext } from "@blazetrails/activerecord";`);
+      lines.push("");
+      lines.push("export default async function defineSchema(ctx: MigrationContext) {");
+    } else {
+      lines.push("/** @param {import('@blazetrails/activerecord').MigrationContext} ctx */");
+      lines.push("export default async function defineSchema(ctx) {");
+    }
   }
 
   private trailer(lines: string[]): void {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -273,9 +273,12 @@ export class NoDatabaseError extends StatementInvalid {
   }
 }
 
-export class DatabaseAlreadyExists extends ActiveRecordError {
-  constructor(message?: string) {
-    super(message ?? "Database already exists");
+export class DatabaseAlreadyExists extends StatementInvalid {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
+    super(message ?? "Database already exists", options);
     this.name = "DatabaseAlreadyExists";
   }
 }

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -273,6 +273,13 @@ export class NoDatabaseError extends StatementInvalid {
   }
 }
 
+export class DatabaseAlreadyExists extends ActiveRecordError {
+  constructor(message?: string) {
+    super(message ?? "Database already exists");
+    this.name = "DatabaseAlreadyExists";
+  }
+}
+
 export class StaleObjectError extends ActiveRecordError {
   readonly record?: any;
   readonly attemptedAction?: string;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -153,6 +153,7 @@ export {
   ValueTooLong,
   PreparedStatementInvalid,
   NoDatabaseError,
+  DatabaseAlreadyExists,
   AttributeAssignmentError,
   TransactionIsolationError,
   IrreversibleOrderError,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -221,6 +221,15 @@ export { ConnectionPool } from "./connection-adapters/abstract/connection-pool.j
 export { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
 export { DatabaseTasks } from "./tasks/database-tasks.js";
 export type { DatabaseTaskHandler } from "./tasks/database-tasks.js";
+export { SQLiteDatabaseTasks } from "./tasks/sqlite-database-tasks.js";
+export { PostgreSQLDatabaseTasks } from "./tasks/postgresql-database-tasks.js";
+export { MySQLDatabaseTasks } from "./tasks/mysql-database-tasks.js";
+import { SQLiteDatabaseTasks as _SQLiteTasks } from "./tasks/sqlite-database-tasks.js";
+import { PostgreSQLDatabaseTasks as _PGTasks } from "./tasks/postgresql-database-tasks.js";
+import { MySQLDatabaseTasks as _MySQLTasks } from "./tasks/mysql-database-tasks.js";
+_SQLiteTasks.register();
+_PGTasks.register();
+_MySQLTasks.register();
 export { Migrator } from "./migration.js";
 export type { MigrationProxy, MigrationLike } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -221,7 +221,7 @@ export { DatabaseConfigurations } from "./database-configurations.js";
 export { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 export { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
 export { DatabaseTasks } from "./tasks/database-tasks.js";
-export type { DatabaseTaskHandler } from "./tasks/database-tasks.js";
+export type { DatabaseTaskHandler, SchemaFormat } from "./tasks/database-tasks.js";
 export { SQLiteDatabaseTasks } from "./tasks/sqlite-database-tasks.js";
 export { PostgreSQLDatabaseTasks } from "./tasks/postgresql-database-tasks.js";
 export { MySQLDatabaseTasks } from "./tasks/mysql-database-tasks.js";

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -52,21 +52,28 @@ class AdapterSchemaSource implements SchemaSource {
   }
 }
 
+export interface SchemaDumperOptions {
+  /** Output language for the generated schema DSL: "ts" (default) or "js". */
+  language?: "ts" | "js";
+}
+
 export class SchemaDumper {
   private _adapter: DatabaseAdapter;
+  private _options: SchemaDumperOptions;
 
-  constructor(adapter: DatabaseAdapter) {
+  constructor(adapter: DatabaseAdapter, options: SchemaDumperOptions = {}) {
     this._adapter = adapter;
+    this._options = options;
   }
 
-  static async dump(adapter: DatabaseAdapter): Promise<string> {
-    const dumper = new SchemaDumper(adapter);
+  static async dump(adapter: DatabaseAdapter, options: SchemaDumperOptions = {}): Promise<string> {
+    const dumper = new SchemaDumper(adapter, options);
     return dumper.dump();
   }
 
   async dump(): Promise<string> {
     const source = new AdapterSchemaSource(this._adapter);
-    return await AbstractSchemaDumper.dump(source);
+    return await AbstractSchemaDumper.dump(source, { language: this._options.language ?? "ts" });
   }
 
   async dumpWithVersion(): Promise<string> {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -725,3 +725,115 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
   });
 });
+
+describe("DatabaseTasksStructureDumpDispatchTest", () => {
+  beforeEach(() => {
+    DatabaseTasks.clearRegisteredTasks();
+    DatabaseTasks.structureDumpFlags = null;
+    DatabaseTasks.structureLoadFlags = null;
+  });
+
+  afterEach(() => {
+    DatabaseTasks.clearRegisteredTasks();
+    DatabaseTasks.structureDumpFlags = null;
+    DatabaseTasks.structureLoadFlags = null;
+  });
+
+  it("structure_dump dispatches to registered handler", async () => {
+    const calls: Array<{ filename: string; flags: unknown }> = [];
+    DatabaseTasks.registerTask("sqlite", {
+      structureDump: async (_c, filename, flags) => {
+        calls.push({ filename, flags: flags ?? null });
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureDump(config, "out.sql");
+    expect(calls).toEqual([{ filename: "out.sql", flags: null }]);
+  });
+
+  it("structure_load dispatches to registered handler", async () => {
+    const calls: string[] = [];
+    DatabaseTasks.registerTask("sqlite", {
+      structureLoad: async (_c, filename) => {
+        calls.push(filename);
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureLoad(config, "in.sql");
+    expect(calls).toEqual(["in.sql"]);
+  });
+
+  it("structure_dump raises when adapter does not support it", async () => {
+    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await expect(DatabaseTasks.structureDump(config, "out.sql")).rejects.toThrow(
+      /does not support structureDump/,
+    );
+  });
+
+  it("structure_load raises when adapter does not support it", async () => {
+    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await expect(DatabaseTasks.structureLoad(config, "in.sql")).rejects.toThrow(
+      /does not support structureLoad/,
+    );
+  });
+
+  it("structure_dump passes flag string when structureDumpFlags is a string", async () => {
+    let received: unknown = "unset";
+    DatabaseTasks.structureDumpFlags = "--no-tablespaces";
+    DatabaseTasks.registerTask("sqlite", {
+      structureDump: async (_c, _f, flags) => {
+        received = flags;
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureDump(config, "out.sql");
+    expect(received).toBe("--no-tablespaces");
+  });
+
+  it("structure_dump selects adapter-specific flags from a hash", async () => {
+    let received: unknown = "unset";
+    DatabaseTasks.structureDumpFlags = {
+      sqlite3: ["--sqlite-only"],
+      postgresql: ["--pg-only"],
+    };
+    DatabaseTasks.registerTask("sqlite", {
+      structureDump: async (_c, _f, flags) => {
+        received = flags;
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureDump(config, "out.sql");
+    expect(received).toEqual(["--sqlite-only"]);
+  });
+
+  it("structure_load selects adapter-specific flags from a hash", async () => {
+    let received: unknown = "unset";
+    DatabaseTasks.structureLoadFlags = {
+      sqlite3: ["--quiet"],
+      postgresql: ["--verbose"],
+    };
+    DatabaseTasks.registerTask("sqlite", {
+      structureLoad: async (_c, _f, flags) => {
+        received = flags;
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureLoad(config, "in.sql");
+    expect(received).toEqual(["--quiet"]);
+  });
+
+  it("explicit extraFlags argument overrides configured structureDumpFlags", async () => {
+    let received: unknown = "unset";
+    DatabaseTasks.structureDumpFlags = "--default-flag";
+    DatabaseTasks.registerTask("sqlite", {
+      structureDump: async (_c, _f, flags) => {
+        received = flags;
+      },
+    });
+    const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    await DatabaseTasks.structureDump(config, "out.sql", "--explicit");
+    expect(received).toBe("--explicit");
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -72,11 +72,11 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
     /* needs schema cache implementation */
   });
   it("cache dump default filename", () => {
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("db/schema.rb");
+    expect(DatabaseTasks.dumpSchemaFilename()).toBe("db/schema.ts");
   });
   it("cache dump default filename with custom db dir", () => {
     DatabaseTasks.dbDir = "custom_db";
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("custom_db/schema.rb");
+    expect(DatabaseTasks.dumpSchemaFilename()).toBe("custom_db/schema.ts");
   });
   it("cache dump alternate filename", () => {
     process.env.SCHEMA = "alt_schema.rb";
@@ -87,7 +87,7 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
       adapter: "sqlite3",
       database: "animals.db",
     });
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.rb");
+    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.ts");
   });
   it("cache dump filename with path from the argument has precedence", () => {
     process.env.SCHEMA = "override.rb";
@@ -683,7 +683,7 @@ describe("DatabaseTaskCheckTargetVersionTest", () => {
 describe("DatabaseTasksCheckSchemaFileTest", () => {
   it("check schema file", () => {
     expect(() => DatabaseTasks.checkSchemaFile("")).toThrow();
-    expect(() => DatabaseTasks.checkSchemaFile("db/schema.rb")).not.toThrow();
+    expect(() => DatabaseTasks.checkSchemaFile("db/schema.ts")).not.toThrow();
   });
 });
 
@@ -702,7 +702,7 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
   });
 
   it("check dump filename defaults", () => {
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("db/schema.rb");
+    expect(DatabaseTasks.dumpSchemaFilename()).toBe("db/schema.ts");
   });
 
   it("check dump filename with schema env", () => {
@@ -712,7 +712,7 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
 
   it("check dump filename defaults for non primary databases", () => {
     const config = new HashConfig("test", "animals", { adapter: "sqlite3" });
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.rb");
+    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.ts");
   });
 
   it.skip("setting schema dump to nil", () => {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -835,5 +839,78 @@ describe("DatabaseTasksStructureDumpDispatchTest", () => {
     const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
     await DatabaseTasks.structureDump(config, "out.sql", "--explicit");
     expect(received).toBe("--explicit");
+  });
+});
+
+describe("DatabaseTasksDumpSchemaFormatBranchingTest", () => {
+  const originalFormat = DatabaseTasks.schemaFormat;
+  const originalRoot = DatabaseTasks.root;
+
+  beforeEach(() => {
+    DatabaseTasks.clearRegisteredTasks();
+  });
+
+  afterEach(() => {
+    DatabaseTasks.clearRegisteredTasks();
+    DatabaseTasks.schemaFormat = originalFormat;
+    DatabaseTasks.root = originalRoot;
+  });
+
+  it("dump schema delegates to structureDump when schema format is sql", async () => {
+    const calls: Array<{ filename: string }> = [];
+    DatabaseTasks.registerTask("sqlite", {
+      structureDump: async (_c, filename) => {
+        calls.push({ filename });
+      },
+    });
+    DatabaseTasks.schemaFormat = "sql";
+    DatabaseTasks.dbDir = path.join(os.tmpdir(), `trails-dump-${randomUUID()}`);
+    try {
+      const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+      await DatabaseTasks.dumpSchema(config);
+      expect(calls.length).toBe(1);
+      expect(calls[0].filename.endsWith("structure.sql")).toBe(true);
+      expect(fs.existsSync(path.dirname(calls[0].filename))).toBe(true);
+    } finally {
+      fs.rmSync(DatabaseTasks.dbDir, { recursive: true, force: true });
+      DatabaseTasks.dbDir = "db";
+    }
+  });
+});
+
+describe("DatabaseTasksLoadSchemaRubyFormatTest", () => {
+  const originalFormat = DatabaseTasks.schemaFormat;
+  const originalRoot = DatabaseTasks.root;
+
+  afterEach(() => {
+    DatabaseTasks.schemaFormat = originalFormat;
+    DatabaseTasks.root = originalRoot;
+    DatabaseTasks.setAdapter(null);
+  });
+
+  it("load schema imports the schema module for ruby format", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-schema-"));
+    const schemaFile = path.join(dir, "schema.mjs");
+    const markerFile = path.join(dir, "marker.txt");
+    fs.writeFileSync(
+      schemaFile,
+      `export default async function defineSchema() {\n` +
+        `  const fs = await import("node:fs");\n` +
+        `  fs.writeFileSync(${JSON.stringify(markerFile)}, "loaded");\n` +
+        `}\n`,
+    );
+
+    const adapter = createTestAdapter();
+    DatabaseTasks.setAdapter(adapter);
+    DatabaseTasks.schemaFormat = "ruby";
+
+    try {
+      const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+      await DatabaseTasks.loadSchema(config, "ruby", schemaFile);
+      expect(fs.existsSync(markerFile)).toBe(true);
+      expect(fs.readFileSync(markerFile, "utf8")).toBe("loaded");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -878,7 +878,7 @@ describe("DatabaseTasksDumpSchemaFormatBranchingTest", () => {
   });
 });
 
-describe("DatabaseTasksLoadSchemaRubyFormatTest", () => {
+describe("DatabaseTasksLoadSchemaTsFormatTest", () => {
   const originalFormat = DatabaseTasks.schemaFormat;
   const originalRoot = DatabaseTasks.root;
 
@@ -888,7 +888,7 @@ describe("DatabaseTasksLoadSchemaRubyFormatTest", () => {
     DatabaseTasks.setAdapter(null);
   });
 
-  it("load schema imports the schema module for ruby format", async () => {
+  it("load schema imports the schema module for ts format", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-schema-"));
     const schemaFile = path.join(dir, "schema.mjs");
     const markerFile = path.join(dir, "marker.txt");
@@ -902,11 +902,11 @@ describe("DatabaseTasksLoadSchemaRubyFormatTest", () => {
 
     const adapter = createTestAdapter();
     DatabaseTasks.setAdapter(adapter);
-    DatabaseTasks.schemaFormat = "ruby";
+    DatabaseTasks.schemaFormat = "ts";
 
     try {
       const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
-      await DatabaseTasks.loadSchema(config, "ruby", schemaFile);
+      await DatabaseTasks.loadSchema(config, "ts", schemaFile);
       expect(fs.existsSync(markerFile)).toBe(true);
       expect(fs.readFileSync(markerFile, "utf8")).toBe("loaded");
     } finally {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -6,7 +6,7 @@ import { createTestAdapter } from "../test-adapter.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
   it("raises an error when called with protected environment", async () => {
-    await expect(DatabaseTasks.checkProtectedEnvironments("production")).rejects.toThrow(
+    await expect(DatabaseTasks.checkProtectedEnvironmentsBang("production")).rejects.toThrow(
       /production/,
     );
   });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -448,8 +448,10 @@ export class DatabaseTasks {
       return;
     }
 
-    const { pathToFileURL } = await import("node:url");
-    const mod = (await import(pathToFileURL(filename).href)) as {
+    const path = getPath();
+    const absolute = path.isAbsolute(filename) ? filename : path.join(this.root, filename);
+    const href = "file://" + absolute.replace(/\\/g, "/").replace(/^\//, "/");
+    const mod = (await import(href)) as {
       default?: (ctx: unknown) => Promise<void> | void;
     };
     const defineSchema = mod.default ?? (mod as unknown as (ctx: unknown) => Promise<void> | void);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -484,7 +484,8 @@ export class DatabaseTasks {
     const path = getPath();
     const dir = path.dirname(filename);
     fs.mkdirSync(dir, { recursive: true });
-    const output = await SchemaDumper.dump(adapter);
+    const language = this.schemaFormat === "js" ? "js" : "ts";
+    const output = await SchemaDumper.dump(adapter, { language });
     fs.writeFileSync(filename, output);
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,7 +7,7 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs } from "@blazetrails/activesupport";
+import { getFs, getPath } from "@blazetrails/activesupport";
 
 export class DatabaseTasks {
   static get env(): string {
@@ -17,6 +17,10 @@ export class DatabaseTasks {
   static set env(value: string) {
     DatabaseConfigurations.defaultEnv = value;
   }
+
+  static get name(): string {
+    return "primary";
+  }
   static databaseConfiguration: DatabaseConfigurations | null = null;
   static dbDir: string = "db";
   static migrationsPath: string[] = ["db/migrate"];
@@ -25,6 +29,8 @@ export class DatabaseTasks {
   static root: string = process.cwd();
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
   static schemaFormat: "ruby" | "sql" = "ruby";
+  static structureDumpFlags: string | string[] | Record<string, string | string[]> | null = null;
+  static structureLoadFlags: string | string[] | Record<string, string | string[]> | null = null;
 
   private static _registeredTasks: Array<{
     pattern: RegExp | string;
@@ -107,7 +113,7 @@ export class DatabaseTasks {
     if (!this.databaseConfiguration) return;
     const configs = this.eachLocalConfiguration();
     for (const config of configs) {
-      await this.checkProtectedEnvironments(config.envName);
+      await this.checkProtectedEnvironmentsBang(config.envName);
     }
     for (const config of configs) {
       await this.drop(config);
@@ -117,7 +123,7 @@ export class DatabaseTasks {
   static async dropCurrent(environment?: string): Promise<void> {
     const envs = this._environmentsFor(environment);
     for (const env of envs) {
-      await this.checkProtectedEnvironments(env);
+      await this.checkProtectedEnvironmentsBang(env);
       const configs = this.configsFor(env);
       for (const config of configs) {
         await this.drop(config);
@@ -171,7 +177,7 @@ export class DatabaseTasks {
   }
 
   static async purgeCurrent(environment?: string): Promise<void> {
-    await this.checkProtectedEnvironments(environment);
+    await this.checkProtectedEnvironmentsBang(environment);
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     for (const config of configs) {
@@ -183,7 +189,7 @@ export class DatabaseTasks {
     if (!this.databaseConfiguration) return;
     const configs = this.eachLocalConfiguration();
     for (const config of configs) {
-      await this.checkProtectedEnvironments(config.envName);
+      await this.checkProtectedEnvironmentsBang(config.envName);
     }
     for (const config of configs) {
       await this.purge(config);
@@ -191,7 +197,7 @@ export class DatabaseTasks {
   }
 
   static async truncateAll(environment?: string): Promise<void> {
-    await this.checkProtectedEnvironments(environment);
+    await this.checkProtectedEnvironmentsBang(environment);
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     for (const config of configs) {
@@ -265,7 +271,7 @@ export class DatabaseTasks {
     }
   }
 
-  static async checkProtectedEnvironments(environment?: string): Promise<void> {
+  static async checkProtectedEnvironmentsBang(environment?: string): Promise<void> {
     const env = this._normalizeEnv(environment);
     const { Base } = await import("../base.js");
     const protectedEnvs = Base.protectedEnvironments;
@@ -346,6 +352,303 @@ export class DatabaseTasks {
     }
     return [env];
   }
+
+  static async structureDump(
+    config: DatabaseConfig,
+    filename: string,
+    extraFlags?: string | string[] | null,
+  ): Promise<void> {
+    const handler = this._resolveTaskOrThrow(this._adapterFor(config));
+    if (!handler.structureDump) {
+      throw new Error(`Adapter '${this._adapterFor(config)}' does not support structureDump`);
+    }
+    const flags = extraFlags ?? this._flagsFor(this.structureDumpFlags, config.adapter);
+    await handler.structureDump(config, filename, flags);
+  }
+
+  static async structureLoad(
+    config: DatabaseConfig,
+    filename: string,
+    extraFlags?: string | string[] | null,
+  ): Promise<void> {
+    const handler = this._resolveTaskOrThrow(this._adapterFor(config));
+    if (!handler.structureLoad) {
+      throw new Error(`Adapter '${this._adapterFor(config)}' does not support structureLoad`);
+    }
+    const flags = extraFlags ?? this._flagsFor(this.structureLoadFlags, config.adapter);
+    await handler.structureLoad(config, filename, flags);
+  }
+
+  private static _flagsFor(
+    source: typeof DatabaseTasks.structureDumpFlags,
+    adapter?: string,
+  ): string | string[] | null {
+    if (!source) return null;
+    if (Array.isArray(source) || typeof source === "string") return source;
+    if (adapter && typeof source === "object" && adapter in source) {
+      const value = (source as Record<string, string | string[]>)[adapter];
+      return value;
+    }
+    return null;
+  }
+
+  static schemaDumpPath(config?: DatabaseConfig): string {
+    return this.dumpSchemaFilename(config);
+  }
+
+  static async dumpSchema(config: DatabaseConfig): Promise<void> {
+    const filename = this.schemaDumpPath(config);
+    if (this.schemaFormat === "sql") {
+      await this.structureDump(config, filename);
+      return;
+    }
+    const { SchemaDumper } = await import("../schema-dumper.js");
+    const adapter = this._adapterInstance;
+    if (!adapter) {
+      throw new Error("No adapter available for schema dump. Call DatabaseTasks.setAdapter first.");
+    }
+    const fs = getFs();
+    const path = getPath();
+    const dir = path.dirname(filename);
+    fs.mkdirSync(dir, { recursive: true });
+    const output = await SchemaDumper.dump(adapter);
+    fs.writeFileSync(filename, output);
+  }
+
+  static async loadSchema(
+    config: DatabaseConfig,
+    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    file?: string,
+  ): Promise<void> {
+    const filename = file ?? this.schemaDumpPath(config);
+    this.checkSchemaFile(filename);
+
+    if (format === "sql") {
+      await this.structureLoad(config, filename);
+      return;
+    }
+
+    const { pathToFileURL } = await import("node:url");
+    const mod = (await import(pathToFileURL(filename).href)) as {
+      default?: (ctx: unknown) => Promise<void> | void;
+    };
+    const defineSchema = mod.default ?? (mod as unknown as (ctx: unknown) => Promise<void> | void);
+    if (typeof defineSchema !== "function") {
+      throw new Error(`Schema file must export a default function (got ${typeof defineSchema})`);
+    }
+    const adapter = this._adapterInstance;
+    if (!adapter) {
+      throw new Error("No adapter configured. Call DatabaseTasks.setAdapter first.");
+    }
+    const { MigrationContext } = await import("../migration.js");
+    const ctx = new MigrationContext(adapter);
+    await defineSchema(ctx);
+  }
+
+  static async loadSchemaCurrent(
+    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    file?: string,
+    environment?: string,
+  ): Promise<void> {
+    const envs = this._environmentsFor(environment);
+    for (const env of envs) {
+      for (const config of this.configsFor(env)) {
+        await this.loadSchema(config, format, file);
+      }
+    }
+  }
+
+  static async loadSeed(): Promise<void> {
+    if (!this.seedLoader) {
+      throw new Error(
+        "You tried to load seed data, but no seed loader is specified. " +
+          "Set DatabaseTasks.seedLoader = { loadSeed() { ... } }",
+      );
+    }
+    await this.seedLoader.loadSeed();
+  }
+
+  static async migrateStatus(): Promise<
+    Array<{ status: "up" | "down"; version: string; name: string }>
+  > {
+    const adapter = this._adapterInstance;
+    if (!adapter) {
+      throw new Error("No adapter configured. Call DatabaseTasks.setAdapter first.");
+    }
+    const { Migrator } = await import("../migration.js");
+    const migrator = new Migrator(adapter, this._migrations);
+    return migrator.migrationsStatus();
+  }
+
+  static async migrateAll(): Promise<void> {
+    const configs = this.configsFor(this._normalizeEnv());
+    for (const config of configs) {
+      await this.withTemporaryConnection(config, async () => {
+        await this.migrate();
+      });
+    }
+  }
+
+  static async prepareAll(): Promise<void> {
+    const configs = this.configsFor(this._normalizeEnv());
+    for (const config of configs) {
+      try {
+        await this.create(config);
+      } catch {
+        // already exists
+      }
+    }
+    await this.migrateAll();
+    if (this.seedLoader) await this.loadSeed();
+  }
+
+  static async dbConfigsWithVersions(): Promise<Map<string, DatabaseConfig[]>> {
+    const result = new Map<string, DatabaseConfig[]>();
+    const env = this._normalizeEnv();
+    for (const config of this.configsFor(env)) {
+      const key = config.envName;
+      const list = result.get(key) ?? [];
+      list.push(config);
+      result.set(key, list);
+    }
+    return result;
+  }
+
+  static async withTemporaryConnection<T>(
+    config: DatabaseConfig,
+    fn: (adapter: import("../adapter.js").DatabaseAdapter) => Promise<T>,
+  ): Promise<T> {
+    const adapter = await this._connectFor(config);
+    const previous = this._adapterInstance;
+    this._adapterInstance = adapter;
+    try {
+      return await fn(adapter);
+    } finally {
+      this._adapterInstance = previous;
+      const close = (adapter as { close?: () => Promise<void> }).close;
+      if (typeof close === "function") await close.call(adapter);
+    }
+  }
+
+  static async withTemporaryPoolForEach<T>(
+    envName: string,
+    fn: (config: DatabaseConfig) => Promise<T>,
+  ): Promise<void> {
+    for (const config of this.configsFor(envName)) {
+      await this.withTemporaryConnection(config, async () => {
+        await fn(config);
+      });
+    }
+  }
+
+  static async migrationClass(): Promise<typeof import("../base.js").Base> {
+    const { Base } = await import("../base.js");
+    return Base;
+  }
+
+  static migrationConnection(): import("../adapter.js").DatabaseAdapter | null {
+    return this._adapterInstance;
+  }
+
+  static async migrationConnectionPool(): Promise<unknown> {
+    const { Base } = await import("../base.js");
+    const pool = (Base as unknown as { connectionPool?: unknown }).connectionPool;
+    return pool ?? null;
+  }
+
+  static async schemaUpToDate(
+    config: DatabaseConfig,
+    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    file?: string,
+  ): Promise<boolean> {
+    const filename = file ?? this.schemaDumpPath(config);
+    const fs = getFs();
+    if (!fs.existsSync(filename)) return false;
+    void format;
+    void this._adapterInstance;
+    return true;
+  }
+
+  static setupInitialDatabaseYaml(): Record<string, unknown> {
+    return {};
+  }
+
+  static forEach(databases: DatabaseConfigurations, fn: (name: string) => void): void {
+    const env = this.env;
+    const configs = databases.configsFor({ envName: env });
+    if (configs.length <= 1) return;
+    for (const cfg of configs) {
+      fn(cfg.name);
+    }
+  }
+
+  static raiseForMultiDb(environment: string | undefined, opts: { command: string }): void {
+    const envName = this._normalizeEnv(environment);
+    const configs = this.configsFor(envName);
+    if (configs.length > 1) {
+      const list = configs.map((c) => `${opts.command}:${c.name}`).join(", ");
+      throw new Error(
+        `You're using a multiple database application. To use \`${opts.command}\` you must ` +
+          `run the namespaced task with a VERSION. Available tasks are ${list}.`,
+      );
+    }
+  }
+
+  static async truncateTables(config: DatabaseConfig): Promise<void> {
+    const handler = this._resolveTaskOrThrow(this._adapterFor(config));
+    if (handler.truncateAll) {
+      await handler.truncateAll(config);
+    }
+  }
+
+  static async reconstructFromSchema(
+    config: DatabaseConfig,
+    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    file?: string,
+  ): Promise<void> {
+    try {
+      await this.purge(config);
+    } catch {
+      await this.create(config);
+    }
+    await this.loadSchema(config, format, file);
+  }
+
+  private static async _connectFor(
+    config: DatabaseConfig,
+  ): Promise<import("../adapter.js").DatabaseAdapter> {
+    const adapter = config.adapter;
+    if (!adapter) throw new Error("config missing adapter");
+    if (/sqlite/.test(adapter)) {
+      const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+      return new SQLite3Adapter(config.database ?? ":memory:");
+    }
+    if (/postgres/.test(adapter)) {
+      const { PostgreSQLAdapter } = await import("../adapters/postgresql-adapter.js");
+      const c = config.configuration;
+      if (c.url) return new PostgreSQLAdapter(String(c.url));
+      return new PostgreSQLAdapter({
+        host: (c.host as string) ?? "localhost",
+        port: (c.port as number) ?? 5432,
+        database: config.database,
+        user: c.username as string | undefined,
+        password: c.password as string | undefined,
+      });
+    }
+    if (/mysql|trilogy/.test(adapter)) {
+      const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
+      const c = config.configuration;
+      if (c.url) return new Mysql2Adapter(String(c.url));
+      return new Mysql2Adapter({
+        host: (c.host as string) ?? "localhost",
+        port: (c.port as number) ?? 3306,
+        database: config.database,
+        user: c.username as string | undefined,
+        password: c.password as string | undefined,
+      });
+    }
+    throw new Error(`Unsupported adapter: ${adapter}`);
+  }
 }
 
 export interface DatabaseTaskHandler {
@@ -355,4 +658,14 @@ export interface DatabaseTaskHandler {
   truncateAll?(config: DatabaseConfig): Promise<void>;
   charset?(config: DatabaseConfig): Promise<string | null>;
   collation?(config: DatabaseConfig): Promise<string | null>;
+  structureDump?(
+    config: DatabaseConfig,
+    filename: string,
+    extraFlags?: string | string[] | null,
+  ): Promise<void>;
+  structureLoad?(
+    config: DatabaseConfig,
+    filename: string,
+    extraFlags?: string | string[] | null,
+  ): Promise<void>;
 }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -464,6 +464,12 @@ export class DatabaseTasks {
     }
 
     const path = getPath();
+    if (!path.isAbsolute || !path.pathToFileURL) {
+      throw new Error(
+        "DatabaseTasks.loadSchema requires PathAdapter.isAbsolute and pathToFileURL. " +
+          "The configured PathAdapter does not provide them.",
+      );
+    }
     const absolute = path.isAbsolute(filename) ? filename : path.resolve(this.root, filename);
     const href = path.pathToFileURL(absolute).href;
     const mod = (await import(href)) as {
@@ -679,7 +685,13 @@ export class DatabaseTasks {
     if (!adapter) throw new Error("config missing adapter");
     if (/sqlite/.test(adapter)) {
       const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
-      return new SQLite3Adapter(config.database ?? ":memory:");
+      const database = config.database ?? ":memory:";
+      const path = getPath();
+      const resolved =
+        database === ":memory:" || (path.isAbsolute && path.isAbsolute(database))
+          ? database
+          : path.resolve(this.root, database);
+      return new SQLite3Adapter(resolved);
     }
     if (/postgres/.test(adapter)) {
       const { PostgreSQLAdapter } = await import("../adapters/postgresql-adapter.js");

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -73,6 +73,22 @@ export class DatabaseTasks {
 
   static get root(): string {
     if (this._root !== null) return this._root;
+    return DatabaseTasks._resolveCwd();
+  }
+
+  /**
+   * Resolve the process's current working directory.
+   *
+   * Tries the fast synchronous fallback first (`globalThis.process.cwd()`)
+   * so the sync `root` getter works under Node ESM — where the sync
+   * `getOs()` auto-register can't synchronously pull in `node:os`. Falls
+   * through to `getOs().cwd()` only if `process` isn't available, so
+   * custom OsAdapters (e.g. browser / VFS) can still supply a logical
+   * root.
+   */
+  private static _resolveCwd(): string {
+    const proc = (globalThis as { process?: { cwd?: () => string } }).process;
+    if (proc && typeof proc.cwd === "function") return proc.cwd();
     return getOs().cwd();
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -10,6 +10,20 @@ import { ProtectedEnvironmentError } from "../migration.js";
 import { getFs, getPath, getCrypto } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
+/**
+ * Schema file format.
+ *
+ * - `"ts"`: TypeScript DSL module (`db/schema.ts`), default.
+ * - `"js"`: JavaScript DSL module (`db/schema.js`) — for projects without a
+ *   TypeScript toolchain at runtime.
+ * - `"sql"`: Native SQL structure dump (`db/structure.sql`), via the
+ *   adapter's `structureDump`/`structureLoad`.
+ *
+ * Mirrors Rails' `ActiveRecord.schema_format` (`:ruby | :sql`) but swaps
+ * Ruby for TS/JS since trails has no Ruby runtime.
+ */
+export type SchemaFormat = "ts" | "js" | "sql";
+
 export class DatabaseTasks {
   static get env(): string {
     return DatabaseConfigurations.defaultEnv;
@@ -45,7 +59,7 @@ export class DatabaseTasks {
   static fixturesPath: string = "test/fixtures";
   static root: string = process.cwd();
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
-  static schemaFormat: "ruby" | "sql" = "ruby";
+  static schemaFormat: SchemaFormat = "ts";
   static structureDumpFlags: string | string[] | Record<string, string | string[]> | null = null;
   static structureLoadFlags: string | string[] | Record<string, string | string[]> | null = null;
 
@@ -274,9 +288,9 @@ export class DatabaseTasks {
   static dumpSchemaFilename(config?: DatabaseConfig): string {
     const envSchema = process.env.SCHEMA?.trim();
     if (envSchema) return envSchema;
-    const isSql = this.schemaFormat === "sql";
-    const ext = isSql ? "sql" : "ts";
-    const base = isSql ? "structure" : "schema";
+    const format = this.schemaFormat;
+    const ext = format === "sql" ? "sql" : format;
+    const base = format === "sql" ? "structure" : "schema";
     if (config && config.name !== "primary") {
       return `${this.dbDir}/${config.name}_${base}.${ext}`;
     }
@@ -438,7 +452,7 @@ export class DatabaseTasks {
 
   static async loadSchema(
     config: DatabaseConfig,
-    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<void> {
     const filename = file ?? this.schemaDumpPath(config);
@@ -469,7 +483,7 @@ export class DatabaseTasks {
   }
 
   static async loadSchemaCurrent(
-    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
     environment?: string,
   ): Promise<void> {
@@ -582,7 +596,7 @@ export class DatabaseTasks {
 
   static async schemaUpToDate(
     config: DatabaseConfig,
-    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<boolean> {
     void format;
@@ -645,7 +659,7 @@ export class DatabaseTasks {
 
   static async reconstructFromSchema(
     config: DatabaseConfig,
-    format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
+    format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<void> {
     const { NoDatabaseError } = await import("../errors.js");

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -23,8 +23,24 @@ export class DatabaseTasks {
   }
   static databaseConfiguration: DatabaseConfigurations | null = null;
   static dbDir: string = "db";
-  static migrationsPath: string[] = ["db/migrate"];
-  static migrationsPaths: string[] = ["db/migrate"];
+  private static _migrationsPaths: string[] = ["db/migrate"];
+
+  static get migrationsPath(): string[] {
+    return this._migrationsPaths;
+  }
+
+  static set migrationsPath(value: string[]) {
+    this._migrationsPaths = value;
+  }
+
+  static get migrationsPaths(): string[] {
+    return this._migrationsPaths;
+  }
+
+  static set migrationsPaths(value: string[]) {
+    this._migrationsPaths = value;
+  }
+
   static fixturesPath: string = "test/fixtures";
   static root: string = process.cwd();
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
@@ -257,12 +273,13 @@ export class DatabaseTasks {
   static dumpSchemaFilename(config?: DatabaseConfig): string {
     const envSchema = process.env.SCHEMA?.trim();
     if (envSchema) return envSchema;
-    const ext = this.schemaFormat === "sql" ? "structure.sql" : "schema.rb";
+    const isSql = this.schemaFormat === "sql";
+    const ext = isSql ? "sql" : "ts";
+    const base = isSql ? "structure" : "schema";
     if (config && config.name !== "primary") {
-      const base = this.schemaFormat === "sql" ? "structure" : "schema";
-      return `${this.dbDir}/${config.name}_${base}.${this.schemaFormat === "sql" ? "sql" : "rb"}`;
+      return `${this.dbDir}/${config.name}_${base}.${ext}`;
     }
-    return `${this.dbDir}/${ext}`;
+    return `${this.dbDir}/${base}.${ext}`;
   }
 
   static checkSchemaFile(filename: string): void {
@@ -399,6 +416,9 @@ export class DatabaseTasks {
   static async dumpSchema(config: DatabaseConfig): Promise<void> {
     const filename = this.schemaDumpPath(config);
     if (this.schemaFormat === "sql") {
+      const fs = getFs();
+      const path = getPath();
+      fs.mkdirSync(path.dirname(filename), { recursive: true });
       await this.structureDump(config, filename);
       return;
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,7 +7,13 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs, getPath } from "@blazetrails/activesupport";
+import { getFs, getPath, getCrypto } from "@blazetrails/activesupport";
+
+function coercePort(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
 
 export class DatabaseTasks {
   static get env(): string {
@@ -449,8 +455,11 @@ export class DatabaseTasks {
     }
 
     const path = getPath();
-    const absolute = path.isAbsolute(filename) ? filename : path.join(this.root, filename);
-    const href = "file://" + absolute.replace(/\\/g, "/").replace(/^\//, "/");
+    const absolute = path.isAbsolute(filename) ? filename : path.resolve(this.root, filename);
+    const forwardSlashed = absolute.replace(/\\/g, "/");
+    const href = forwardSlashed.startsWith("/")
+      ? `file://${forwardSlashed}`
+      : `file:///${forwardSlashed}`;
     const mod = (await import(href)) as {
       default?: (ctx: unknown) => Promise<void> | void;
     };
@@ -512,12 +521,13 @@ export class DatabaseTasks {
   }
 
   static async prepareAll(): Promise<void> {
+    const { DatabaseAlreadyExists } = await import("../errors.js");
     const configs = this.configsFor(this._normalizeEnv());
     for (const config of configs) {
       try {
         await this.create(config);
-      } catch {
-        // already exists
+      } catch (error) {
+        if (!(error instanceof DatabaseAlreadyExists)) throw error;
       }
     }
     await this.migrateAll();
@@ -583,12 +593,30 @@ export class DatabaseTasks {
     format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<boolean> {
+    void format;
     const filename = file ?? this.schemaDumpPath(config);
     const fs = getFs();
-    if (!fs.existsSync(filename)) return false;
-    void format;
-    void this._adapterInstance;
-    return true;
+    if (!fs.existsSync(filename)) return true;
+
+    const adapter = this._adapterInstance;
+    if (!adapter) return false;
+
+    const { InternalMetadata } = await import("../internal-metadata.js");
+    const metadata = new InternalMetadata(adapter);
+    if (!(await metadata.tableExists())) return false;
+
+    const storedSha1 = await metadata.get("schema_sha1");
+    if (!storedSha1) return false;
+
+    const fileSha1 = this._schemaSha1(filename);
+    return storedSha1 === fileSha1;
+  }
+
+  private static _schemaSha1(filename: string): string {
+    const contents = getFs().readFileSync(filename, "utf-8");
+    const hash = getCrypto().createHash("sha1");
+    hash.update(contents);
+    return hash.digest("hex");
   }
 
   static setupInitialDatabaseYaml(): Record<string, unknown> {
@@ -628,9 +656,11 @@ export class DatabaseTasks {
     format: "ruby" | "sql" = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<void> {
+    const { NoDatabaseError } = await import("../errors.js");
     try {
       await this.purge(config);
-    } catch {
+    } catch (error) {
+      if (!(error instanceof NoDatabaseError)) throw error;
       await this.create(config);
     }
     await this.loadSchema(config, format, file);
@@ -651,7 +681,7 @@ export class DatabaseTasks {
       if (c.url) return new PostgreSQLAdapter(String(c.url));
       return new PostgreSQLAdapter({
         host: (c.host as string) ?? "localhost",
-        port: (c.port as number) ?? 5432,
+        port: coercePort(c.port, 5432),
         database: config.database,
         user: c.username as string | undefined,
         password: c.password as string | undefined,
@@ -663,7 +693,7 @@ export class DatabaseTasks {
       if (c.url) return new Mysql2Adapter(String(c.url));
       return new Mysql2Adapter({
         host: (c.host as string) ?? "localhost",
-        port: (c.port as number) ?? 3306,
+        port: coercePort(c.port, 3306),
         database: config.database,
         user: c.username as string | undefined,
         password: c.password as string | undefined,

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -502,13 +502,20 @@ export class DatabaseTasks {
     }
 
     const path = getPath();
-    if (!path.isAbsolute || !path.pathToFileURL) {
+    if (!path.pathToFileURL) {
       throw new Error(
-        "DatabaseTasks.loadSchema requires PathAdapter.isAbsolute and pathToFileURL. " +
-          "The configured PathAdapter does not provide them.",
+        "DatabaseTasks.loadSchema requires PathAdapter.pathToFileURL. " +
+          "The configured PathAdapter does not provide it.",
       );
     }
-    const absolute = path.isAbsolute(filename) ? filename : path.resolve(this.root, filename);
+    // Missing isAbsolute means the PathAdapter doesn't model relative vs.
+    // absolute (e.g. a VFS) — treat the incoming filename as already
+    // absolute in that case.
+    const absolute = path.isAbsolute
+      ? path.isAbsolute(filename)
+        ? filename
+        : path.resolve(this.root, filename)
+      : filename;
     const href = path.pathToFileURL(absolute).href;
     const mod = (await import(href)) as {
       default?: (ctx: unknown) => Promise<void> | void;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -727,8 +727,10 @@ export class DatabaseTasks {
       const fromUrl = typeof c.url === "string" ? sqliteDatabaseFromUrl(String(c.url)) : undefined;
       const database = config.database ?? fromUrl ?? ":memory:";
       const path = getPath();
+      // Missing isAbsolute means the PathAdapter (e.g. a VFS) doesn't
+      // model relative/absolute — treat as already absolute.
       const resolved =
-        database === ":memory:" || (path.isAbsolute && path.isAbsolute(database))
+        database === ":memory:" || !path.isAbsolute || path.isAbsolute(database)
           ? database
           : path.resolve(this.root, database);
       return new SQLite3Adapter(resolved);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -20,6 +20,10 @@ export class DatabaseTasks {
   static databaseConfiguration: DatabaseConfigurations | null = null;
   static dbDir: string = "db";
   static migrationsPath: string[] = ["db/migrate"];
+  static migrationsPaths: string[] = ["db/migrate"];
+  static fixturesPath: string = "test/fixtures";
+  static root: string = process.cwd();
+  static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
   static schemaFormat: "ruby" | "sql" = "ruby";
 
   private static _registeredTasks: Array<{

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -8,12 +8,7 @@ import type { DatabaseConfig } from "../database-configurations/database-config.
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
 import { getFs, getPath, getCrypto } from "@blazetrails/activesupport";
-
-function coercePort(value: unknown, fallback: number): number {
-  if (value === undefined || value === null || value === "") return fallback;
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : fallback;
-}
+import { coercePort } from "./task-utils.js";
 
 export class DatabaseTasks {
   static get env(): string {
@@ -456,10 +451,7 @@ export class DatabaseTasks {
 
     const path = getPath();
     const absolute = path.isAbsolute(filename) ? filename : path.resolve(this.root, filename);
-    const forwardSlashed = absolute.replace(/\\/g, "/");
-    const href = forwardSlashed.startsWith("/")
-      ? `file://${forwardSlashed}`
-      : `file:///${forwardSlashed}`;
+    const href = path.pathToFileURL(absolute).href;
     const mod = (await import(href)) as {
       default?: (ctx: unknown) => Promise<void> | void;
     };

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,7 +7,7 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs, getPath, getCrypto } from "@blazetrails/activesupport";
+import { getFs, getPath, getCrypto, getOs } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
 /**
@@ -57,7 +57,17 @@ export class DatabaseTasks {
   }
 
   static fixturesPath: string = "test/fixtures";
-  static root: string = process.cwd();
+  private static _root: string | null = null;
+
+  static get root(): string {
+    if (this._root !== null) return this._root;
+    return getOs().cwd();
+  }
+
+  static set root(value: string) {
+    this._root = value;
+  }
+
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
   static schemaFormat: SchemaFormat = "ts";
   static structureDumpFlags: string | string[] | Record<string, string | string[]> | null = null;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -10,6 +10,18 @@ import { ProtectedEnvironmentError } from "../migration.js";
 import { getFs, getPath, getCrypto, getOs } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
+function sqliteDatabaseFromUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const pathname = decodeURIComponent(parsed.pathname);
+    const host = parsed.host;
+    const resolved = host ? `${host}${pathname}` : pathname;
+    return resolved || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Schema file format.
  *
@@ -695,7 +707,9 @@ export class DatabaseTasks {
     if (!adapter) throw new Error("config missing adapter");
     if (/sqlite/.test(adapter)) {
       const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
-      const database = config.database ?? ":memory:";
+      const c = config.configuration;
+      const fromUrl = typeof c.url === "string" ? sqliteDatabaseFromUrl(String(c.url)) : undefined;
+      const database = config.database ?? fromUrl ?? ":memory:";
       const path = getPath();
       const resolved =
         database === ":memory:" || (path.isAbsolute && path.isAbsolute(database))

--- a/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { MySQLDatabaseTasks } from "./mysql-database-tasks.js";
+import { DatabaseTasks } from "./database-tasks.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+
+function config(overrides: Record<string, unknown> = {}): HashConfig {
+  return new HashConfig("development", "primary", {
+    adapter: "mysql2",
+    database: "trails_test",
+    ...overrides,
+  });
+}
+
+describe("MySQLDatabaseTasks", () => {
+  it("test_charset_defaults_to_utf8mb4", () => {
+    expect(new MySQLDatabaseTasks(config()).charset()).toBe("utf8mb4");
+  });
+
+  it("test_charset_reads_encoding_from_config", () => {
+    expect(new MySQLDatabaseTasks(config({ encoding: "latin1" })).charset()).toBe("latin1");
+  });
+
+  it("test_collation_reads_from_config", () => {
+    expect(new MySQLDatabaseTasks(config({ collation: "utf8mb4_general_ci" })).collation()).toBe(
+      "utf8mb4_general_ci",
+    );
+  });
+
+  it("test_collation_returns_null_when_unset", () => {
+    expect(new MySQLDatabaseTasks(config()).collation()).toBeNull();
+  });
+
+  it("test_using_database_configurations_is_true", () => {
+    expect(MySQLDatabaseTasks.usingDatabaseConfigurations()).toBe(true);
+  });
+
+  it("test_registers_mysql_and_trilogy_patterns", () => {
+    DatabaseTasks.clearRegisteredTasks();
+    MySQLDatabaseTasks.register();
+    expect(DatabaseTasks.resolveTask("mysql2")).toBeDefined();
+    expect(DatabaseTasks.resolveTask("trilogy")).toBeDefined();
+  });
+});

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::MySQLDatabaseTasks
  */
 
-import { getFs, getChildProcess, type SpawnSyncResult } from "@blazetrails/activesupport";
+import { getFs, getChildProcessAsync, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
@@ -109,17 +109,17 @@ export class MySQLDatabaseTasks {
     return (this.configurationHash.collation as string) ?? null;
   }
 
-  structureDump(filename: string, extraFlags?: string | string[] | null): void {
+  async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     const args = this.prepareCommandOptions();
     args.push("--result-file", filename, "--no-data", "--routines", "--skip-comments");
     args.push(this.requireDatabaseName());
     if (extraFlags) {
       args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    this.runCmd("mysqldump", args, "dumping");
+    await this.runCmd("mysqldump", args, "dumping");
   }
 
-  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
+  async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     const args = this.prepareCommandOptions();
     args.push("--database", this.requireDatabaseName());
     if (extraFlags) {
@@ -127,7 +127,7 @@ export class MySQLDatabaseTasks {
     }
     const sqlBody = getFs().readFileSync(filename, "utf8");
     const stdin = `SET FOREIGN_KEY_CHECKS = 0;\n${sqlBody}\nSET FOREIGN_KEY_CHECKS = 1;\n`;
-    this.runCmd("mysql", args, "loading", stdin);
+    await this.runCmd("mysql", args, "loading", stdin);
   }
 
   static register(): void {
@@ -240,8 +240,9 @@ export class MySQLDatabaseTasks {
     }
   }
 
-  private runCmd(cmd: string, args: string[], action: string, stdin?: string): void {
-    const result: SpawnSyncResult = getChildProcess().spawnSync(cmd, args, {
+  private async runCmd(cmd: string, args: string[], action: string, stdin?: string): Promise<void> {
+    const childProcess = await getChildProcessAsync();
+    const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, {
       encoding: "utf8",
       input: stdin,
       env: this.commandEnv(),

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::MySQLDatabaseTasks
  */
 
+import * as fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
@@ -11,9 +12,37 @@ import { DatabaseTasks } from "./database-tasks.js";
 
 type ConfigHash = Record<string, unknown>;
 
+interface UrlParts {
+  host?: string;
+  port?: string;
+  username?: string;
+  password?: string;
+  database?: string;
+  socket?: string;
+}
+
+function parseDbUrl(url: string | undefined): UrlParts {
+  if (!url) return {};
+  try {
+    const parsed = new URL(url);
+    const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+    return {
+      host: parsed.hostname || undefined,
+      port: parsed.port || undefined,
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+      database: database || undefined,
+      socket: parsed.searchParams.get("socket") ?? undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 export class MySQLDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
   private readonly configurationHash: ConfigHash;
+  private readonly urlParts: UrlParts;
 
   static usingDatabaseConfigurations(): boolean {
     return true;
@@ -22,6 +51,7 @@ export class MySQLDatabaseTasks {
   constructor(dbConfig: DatabaseConfig) {
     this.dbConfig = dbConfig;
     this.configurationHash = { ...dbConfig.configuration };
+    this.urlParts = parseDbUrl(this.configurationHash.url as string | undefined);
   }
 
   async create(): Promise<void> {
@@ -65,16 +95,13 @@ export class MySQLDatabaseTasks {
 
   structureLoad(filename: string, extraFlags?: string | string[] | null): void {
     const args = this.prepareCommandOptions();
-    args.push(
-      "--execute",
-      `SET FOREIGN_KEY_CHECKS = 0; SOURCE ${filename}; SET FOREIGN_KEY_CHECKS = 1`,
-      "--database",
-      this.requireDatabaseName(),
-    );
+    args.push("--database", this.requireDatabaseName());
     if (extraFlags) {
       args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    this.runCmd("mysql", args, "loading");
+    const sqlBody = fs.readFileSync(filename, "utf8");
+    const stdin = `SET FOREIGN_KEY_CHECKS = 0;\n${sqlBody}\nSET FOREIGN_KEY_CHECKS = 1;\n`;
+    this.runCmd("mysql", args, "loading", stdin);
   }
 
   static register(): void {
@@ -110,24 +137,36 @@ export class MySQLDatabaseTasks {
     return options;
   }
 
+  private resolvedField(name: keyof UrlParts): string | undefined {
+    const c = this.configurationHash;
+    const fromConfig = c[name as string];
+    if (fromConfig !== undefined && fromConfig !== null && fromConfig !== "") {
+      return String(fromConfig);
+    }
+    const fromUrl = this.urlParts[name];
+    return fromUrl !== undefined ? String(fromUrl) : undefined;
+  }
+
   private prepareCommandOptions(): string[] {
-    const mapping: Record<string, string> = {
-      host: "--host",
-      port: "--port",
-      socket: "--socket",
-      username: "--user",
-      password: "--password",
-      encoding: "--default-character-set",
-      sslca: "--ssl-ca",
-      sslcert: "--ssl-cert",
-      sslcapath: "--ssl-capath",
-      sslcipher: "--ssl-cipher",
-      sslkey: "--ssl-key",
-      ssl_mode: "--ssl-mode",
-    };
     const args: string[] = [];
-    for (const [opt, flag] of Object.entries(mapping)) {
-      const value = this.configurationHash[opt];
+    const flagMap: Array<{ flag: string; key: string; fromUrl?: boolean }> = [
+      { flag: "--host", key: "host", fromUrl: true },
+      { flag: "--port", key: "port", fromUrl: true },
+      { flag: "--socket", key: "socket", fromUrl: true },
+      { flag: "--user", key: "username", fromUrl: true },
+      { flag: "--password", key: "password", fromUrl: true },
+      { flag: "--default-character-set", key: "encoding" },
+      { flag: "--ssl-ca", key: "sslca" },
+      { flag: "--ssl-cert", key: "sslcert" },
+      { flag: "--ssl-capath", key: "sslcapath" },
+      { flag: "--ssl-cipher", key: "sslcipher" },
+      { flag: "--ssl-key", key: "sslkey" },
+      { flag: "--ssl-mode", key: "ssl_mode" },
+    ];
+    for (const { flag, key, fromUrl } of flagMap) {
+      const value = fromUrl
+        ? this.resolvedField(key as keyof UrlParts)
+        : (this.configurationHash[key] as string | number | undefined);
       if (value !== undefined && value !== null && value !== "") {
         args.push(`${flag}=${String(value)}`);
       }
@@ -137,15 +176,12 @@ export class MySQLDatabaseTasks {
 
   private async withAdmin<T>(fn: (admin: DatabaseAdapter) => Promise<T>): Promise<T> {
     const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
-    const c = this.configurationHash;
-    const adapter = c.url
-      ? new Mysql2Adapter(String(c.url))
-      : new Mysql2Adapter({
-          host: (c.host as string) ?? "localhost",
-          port: (c.port as number) ?? 3306,
-          user: c.username as string | undefined,
-          password: c.password as string | undefined,
-        });
+    const adapter = new Mysql2Adapter({
+      host: this.resolvedField("host") ?? "localhost",
+      port: Number(this.resolvedField("port") ?? 3306),
+      user: this.resolvedField("username"),
+      password: this.resolvedField("password"),
+    });
     try {
       return await fn(adapter);
     } finally {
@@ -154,20 +190,30 @@ export class MySQLDatabaseTasks {
     }
   }
 
-  private runCmd(cmd: string, args: string[], action: string): void {
-    const result = spawnSync(cmd, args, { encoding: "utf8" });
-    if (result.status !== 0) {
-      const msg =
+  private runCmd(cmd: string, args: string[], action: string, stdin?: string): void {
+    const spawnOpts: Parameters<typeof spawnSync>[2] = { encoding: "utf8" };
+    if (stdin !== undefined) spawnOpts.input = stdin;
+    const result = spawnSync(cmd, args, spawnOpts);
+    if (result.error || result.status !== 0 || result.signal) {
+      const details: string[] = [];
+      if (result.error) details.push(`Error: ${result.error.message}`);
+      if (result.status !== null && result.status !== 0) {
+        details.push(`Exit status: ${result.status}`);
+      }
+      if (result.signal) details.push(`Signal: ${result.signal}`);
+      if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
+      if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
+      throw new Error(
         `failed to execute: \`${cmd}\`\n` +
-        `Please check the output above for any errors and make sure that ` +
-        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n` +
-        `(action: ${action}, stderr: ${result.stderr ?? ""})`;
-      throw new Error(msg);
+          (details.length ? `${details.join("\n\n")}\n\n` : "") +
+          `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
+          `(action: ${action})`,
+      );
     }
   }
 
   private requireDatabaseName(): string {
-    const name = this.dbConfig.database;
+    const name = this.dbConfig.database ?? this.urlParts.database;
     if (!name) throw new Error("MySQL configuration missing 'database'");
     return name;
   }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -4,8 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::MySQLDatabaseTasks
  */
 
-import * as fs from "node:fs";
-import { spawnSync } from "node:child_process";
+import { getFs, getChildProcess, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
@@ -99,7 +98,7 @@ export class MySQLDatabaseTasks {
     if (extraFlags) {
       args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    const sqlBody = fs.readFileSync(filename, "utf8");
+    const sqlBody = getFs().readFileSync(filename, "utf8");
     const stdin = `SET FOREIGN_KEY_CHECKS = 0;\n${sqlBody}\nSET FOREIGN_KEY_CHECKS = 1;\n`;
     this.runCmd("mysql", args, "loading", stdin);
   }
@@ -191,9 +190,10 @@ export class MySQLDatabaseTasks {
   }
 
   private runCmd(cmd: string, args: string[], action: string, stdin?: string): void {
-    const spawnOpts: Parameters<typeof spawnSync>[2] = { encoding: "utf8" };
-    if (stdin !== undefined) spawnOpts.input = stdin;
-    const result = spawnSync(cmd, args, spawnOpts);
+    const result: SpawnSyncResult = getChildProcess().spawnSync(cmd, args, {
+      encoding: "utf8",
+      input: stdin,
+    });
     if (result.error || result.status !== 0 || result.signal) {
       const details: string[] = [];
       if (result.error) details.push(`Error: ${result.error.message}`);

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -9,6 +9,7 @@ import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
+import { coercePort } from "./task-utils.js";
 
 const ER_DB_CREATE_EXISTS = 1007;
 
@@ -172,6 +173,12 @@ export class MySQLDatabaseTasks {
     return fromUrl !== undefined ? String(fromUrl) : undefined;
   }
 
+  /**
+   * Build argv for mysql/mysqldump. The password is deliberately NOT placed
+   * in argv (it would otherwise be visible in `ps` to other local users);
+   * callers should read the password via env (MYSQL_PWD) — set in
+   * {@link commandEnv}.
+   */
   private prepareCommandOptions(): string[] {
     const args: string[] = [];
     const flagMap: Array<{ flag: string; key: string; fromUrl?: boolean }> = [
@@ -179,7 +186,6 @@ export class MySQLDatabaseTasks {
       { flag: "--port", key: "port", fromUrl: true },
       { flag: "--socket", key: "socket", fromUrl: true },
       { flag: "--user", key: "username", fromUrl: true },
-      { flag: "--password", key: "password", fromUrl: true },
       { flag: "--default-character-set", key: "encoding" },
       { flag: "--ssl-ca", key: "sslca" },
       { flag: "--ssl-cert", key: "sslcert" },
@@ -199,14 +205,33 @@ export class MySQLDatabaseTasks {
     return args;
   }
 
+  private commandEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    const password = this.resolvedField("password");
+    if (password !== undefined) env.MYSQL_PWD = password;
+    return env;
+  }
+
   private async withAdmin<T>(fn: (admin: DatabaseAdapter) => Promise<T>): Promise<T> {
     const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
-    const adapter = new Mysql2Adapter({
-      host: this.resolvedField("host") ?? "localhost",
-      port: Number(this.resolvedField("port") ?? 3306),
+    const socket = this.resolvedField("socket");
+    const adminConfig: {
+      host?: string;
+      port?: number;
+      user?: string;
+      password?: string;
+      socketPath?: string;
+    } = {
       user: this.resolvedField("username"),
       password: this.resolvedField("password"),
-    });
+    };
+    if (socket) {
+      adminConfig.socketPath = socket;
+    } else {
+      adminConfig.host = this.resolvedField("host") ?? "localhost";
+      adminConfig.port = coercePort(this.resolvedField("port"), 3306);
+    }
+    const adapter = new Mysql2Adapter(adminConfig);
     try {
       return await fn(adapter);
     } finally {
@@ -219,6 +244,7 @@ export class MySQLDatabaseTasks {
     const result: SpawnSyncResult = getChildProcess().spawnSync(cmd, args, {
       encoding: "utf8",
       input: stdin,
+      env: this.commandEnv(),
     });
     if (result.error || result.status !== 0 || result.signal) {
       const details: string[] = [];

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -206,7 +206,9 @@ export class MySQLDatabaseTasks {
   }
 
   private commandEnv(): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = { ...process.env };
+    const env: NodeJS.ProcessEnv = {
+      ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
+    };
     const password = this.resolvedField("password");
     if (password !== undefined) env.MYSQL_PWD = password;
     return env;

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
 
@@ -25,14 +26,18 @@ export class MySQLDatabaseTasks {
 
   async create(): Promise<void> {
     const opts = this.creationOptions();
-    const charset = opts.charset ? ` CHARACTER SET \`${opts.charset}\`` : "";
-    const collation = opts.collation ? ` COLLATE \`${opts.collation}\`` : "";
-    const sql = `CREATE DATABASE \`${this.requireDatabaseName()}\`${charset}${collation}`;
-    await this.runSystem(sql);
+    const charset = opts.charset ? ` CHARACTER SET \`${this.escapeIdent(opts.charset)}\`` : "";
+    const collation = opts.collation ? ` COLLATE \`${this.escapeIdent(opts.collation)}\`` : "";
+    const sql = `CREATE DATABASE \`${this.escapeIdent(this.requireDatabaseName())}\`${charset}${collation}`;
+    await this.withAdmin((admin) => admin.executeMutation(sql));
   }
 
   async drop(): Promise<void> {
-    await this.runSystem(`DROP DATABASE IF EXISTS \`${this.requireDatabaseName()}\``);
+    await this.withAdmin((admin) =>
+      admin.executeMutation(
+        `DROP DATABASE IF EXISTS \`${this.escapeIdent(this.requireDatabaseName())}\``,
+      ),
+    );
   }
 
   async purge(): Promise<void> {
@@ -79,6 +84,16 @@ export class MySQLDatabaseTasks {
       purge: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).purge(),
       charset: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).charset(),
       collation: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).collation(),
+      structureDump: async (
+        config: DatabaseConfig,
+        filename: string,
+        flags?: string | string[] | null,
+      ) => new MySQLDatabaseTasks(config).structureDump(filename, flags),
+      structureLoad: async (
+        config: DatabaseConfig,
+        filename: string,
+        flags?: string | string[] | null,
+      ) => new MySQLDatabaseTasks(config).structureLoad(filename, flags),
     };
     DatabaseTasks.registerTask(/mysql/, handler);
     DatabaseTasks.registerTask(/trilogy/, handler);
@@ -120,10 +135,23 @@ export class MySQLDatabaseTasks {
     return args;
   }
 
-  private async runSystem(sql: string): Promise<void> {
-    const args = this.prepareCommandOptions();
-    args.push("--execute", sql);
-    this.runCmd("mysql", args, "admin");
+  private async withAdmin<T>(fn: (admin: DatabaseAdapter) => Promise<T>): Promise<T> {
+    const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
+    const c = this.configurationHash;
+    const adapter = c.url
+      ? new Mysql2Adapter(String(c.url))
+      : new Mysql2Adapter({
+          host: (c.host as string) ?? "localhost",
+          port: (c.port as number) ?? 3306,
+          user: c.username as string | undefined,
+          password: c.password as string | undefined,
+        });
+    try {
+      return await fn(adapter);
+    } finally {
+      const close = (adapter as unknown as { close?: () => Promise<void> }).close;
+      if (typeof close === "function") await close.call(adapter);
+    }
   }
 
   private runCmd(cmd: string, args: string[], action: string): void {
@@ -142,5 +170,9 @@ export class MySQLDatabaseTasks {
     const name = this.dbConfig.database;
     if (!name) throw new Error("MySQL configuration missing 'database'");
     return name;
+  }
+
+  private escapeIdent(value: string): string {
+    return value.replace(/`/g, "``");
   }
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -1,0 +1,146 @@
+/**
+ * MySQLDatabaseTasks — MySQL/MariaDB-specific database lifecycle operations.
+ *
+ * Mirrors: ActiveRecord::Tasks::MySQLDatabaseTasks
+ */
+
+import { spawnSync } from "node:child_process";
+import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseTasks } from "./database-tasks.js";
+
+type ConfigHash = Record<string, unknown>;
+
+export class MySQLDatabaseTasks {
+  private readonly dbConfig: DatabaseConfig;
+  private readonly configurationHash: ConfigHash;
+
+  static usingDatabaseConfigurations(): boolean {
+    return true;
+  }
+
+  constructor(dbConfig: DatabaseConfig) {
+    this.dbConfig = dbConfig;
+    this.configurationHash = { ...dbConfig.configuration };
+  }
+
+  async create(): Promise<void> {
+    const opts = this.creationOptions();
+    const charset = opts.charset ? ` CHARACTER SET \`${opts.charset}\`` : "";
+    const collation = opts.collation ? ` COLLATE \`${opts.collation}\`` : "";
+    const sql = `CREATE DATABASE \`${this.requireDatabaseName()}\`${charset}${collation}`;
+    await this.runSystem(sql);
+  }
+
+  async drop(): Promise<void> {
+    await this.runSystem(`DROP DATABASE IF EXISTS \`${this.requireDatabaseName()}\``);
+  }
+
+  async purge(): Promise<void> {
+    await this.drop();
+    await this.create();
+  }
+
+  charset(): string {
+    return String(this.configurationHash.encoding ?? "utf8mb4");
+  }
+
+  collation(): string | null {
+    return (this.configurationHash.collation as string) ?? null;
+  }
+
+  structureDump(filename: string, extraFlags?: string | string[] | null): void {
+    const args = this.prepareCommandOptions();
+    args.push("--result-file", filename, "--no-data", "--routines", "--skip-comments");
+    args.push(this.requireDatabaseName());
+    if (extraFlags) {
+      args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    this.runCmd("mysqldump", args, "dumping");
+  }
+
+  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
+    const args = this.prepareCommandOptions();
+    args.push(
+      "--execute",
+      `SET FOREIGN_KEY_CHECKS = 0; SOURCE ${filename}; SET FOREIGN_KEY_CHECKS = 1`,
+      "--database",
+      this.requireDatabaseName(),
+    );
+    if (extraFlags) {
+      args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    this.runCmd("mysql", args, "loading");
+  }
+
+  static register(): void {
+    const handler = {
+      create: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).create(),
+      drop: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).drop(),
+      purge: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).purge(),
+      charset: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).charset(),
+      collation: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).collation(),
+    };
+    DatabaseTasks.registerTask(/mysql/, handler);
+    DatabaseTasks.registerTask(/trilogy/, handler);
+  }
+
+  private creationOptions(): { charset?: string; collation?: string } {
+    const options: { charset?: string; collation?: string } = {};
+    if (this.configurationHash.encoding !== undefined) {
+      options.charset = String(this.configurationHash.encoding);
+    }
+    if (this.configurationHash.collation !== undefined) {
+      options.collation = String(this.configurationHash.collation);
+    }
+    return options;
+  }
+
+  private prepareCommandOptions(): string[] {
+    const mapping: Record<string, string> = {
+      host: "--host",
+      port: "--port",
+      socket: "--socket",
+      username: "--user",
+      password: "--password",
+      encoding: "--default-character-set",
+      sslca: "--ssl-ca",
+      sslcert: "--ssl-cert",
+      sslcapath: "--ssl-capath",
+      sslcipher: "--ssl-cipher",
+      sslkey: "--ssl-key",
+      ssl_mode: "--ssl-mode",
+    };
+    const args: string[] = [];
+    for (const [opt, flag] of Object.entries(mapping)) {
+      const value = this.configurationHash[opt];
+      if (value !== undefined && value !== null && value !== "") {
+        args.push(`${flag}=${String(value)}`);
+      }
+    }
+    return args;
+  }
+
+  private async runSystem(sql: string): Promise<void> {
+    const args = this.prepareCommandOptions();
+    args.push("--execute", sql);
+    this.runCmd("mysql", args, "admin");
+  }
+
+  private runCmd(cmd: string, args: string[], action: string): void {
+    const result = spawnSync(cmd, args, { encoding: "utf8" });
+    if (result.status !== 0) {
+      const msg =
+        `failed to execute: \`${cmd}\`\n` +
+        `Please check the output above for any errors and make sure that ` +
+        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n` +
+        `(action: ${action}, stderr: ${result.stderr ?? ""})`;
+      throw new Error(msg);
+    }
+  }
+
+  private requireDatabaseName(): string {
+    const name = this.dbConfig.database;
+    if (!name) throw new Error("MySQL configuration missing 'database'");
+    return name;
+  }
+}

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -7,7 +7,22 @@
 import { getFs, getChildProcess, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
+
+const ER_DB_CREATE_EXISTS = 1007;
+
+function isMySQLDatabaseExistsError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: unknown; errno?: unknown; message?: unknown };
+  if (e.code === "ER_DB_CREATE_EXISTS") return true;
+  if (e.errno === ER_DB_CREATE_EXISTS) return true;
+  return (
+    typeof e.message === "string" &&
+    e.message.includes("Can't create database") &&
+    e.message.includes("database exists")
+  );
+}
 
 type ConfigHash = Record<string, unknown>;
 
@@ -57,8 +72,19 @@ export class MySQLDatabaseTasks {
     const opts = this.creationOptions();
     const charset = opts.charset ? ` CHARACTER SET \`${this.escapeIdent(opts.charset)}\`` : "";
     const collation = opts.collation ? ` COLLATE \`${this.escapeIdent(opts.collation)}\`` : "";
-    const sql = `CREATE DATABASE \`${this.escapeIdent(this.requireDatabaseName())}\`${charset}${collation}`;
-    await this.withAdmin((admin) => admin.executeMutation(sql));
+    const dbName = this.requireDatabaseName();
+    const sql = `CREATE DATABASE \`${this.escapeIdent(dbName)}\`${charset}${collation}`;
+    try {
+      await this.withAdmin((admin) => admin.executeMutation(sql));
+    } catch (error) {
+      if (isMySQLDatabaseExistsError(error)) {
+        throw new DatabaseAlreadyExists(`Database '${dbName}' already exists`, {
+          sql,
+          cause: error,
+        });
+      }
+      throw error;
+    }
   }
 
   async drop(): Promise<void> {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -256,7 +256,7 @@ export class MySQLDatabaseTasks {
       if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
       if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
       throw new Error(
-        `failed to execute: \`${cmd}\`\n` +
+        `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
           (details.length ? `${details.join("\n\n")}\n\n` : "") +
           `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
           `(action: ${action})`,

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { PostgreSQLDatabaseTasks } from "./postgresql-database-tasks.js";
+import { DatabaseTasks } from "./database-tasks.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+
+function config(overrides: Record<string, unknown> = {}): HashConfig {
+  return new HashConfig("development", "primary", {
+    adapter: "postgresql",
+    database: "trails_test",
+    ...overrides,
+  });
+}
+
+describe("PostgreSQLDatabaseTasks", () => {
+  it("test_charset_defaults_to_utf8", () => {
+    expect(new PostgreSQLDatabaseTasks(config()).charset()).toBe("utf8");
+  });
+
+  it("test_charset_reads_encoding_from_config", () => {
+    expect(new PostgreSQLDatabaseTasks(config({ encoding: "UTF8" })).charset()).toBe("UTF8");
+  });
+
+  it("test_collation_reads_from_config", () => {
+    expect(new PostgreSQLDatabaseTasks(config({ collation: "C" })).collation()).toBe("C");
+  });
+
+  it("test_collation_returns_null_when_unset", () => {
+    expect(new PostgreSQLDatabaseTasks(config()).collation()).toBeNull();
+  });
+
+  it("test_using_database_configurations_is_true", () => {
+    expect(PostgreSQLDatabaseTasks.usingDatabaseConfigurations()).toBe(true);
+  });
+
+  it("test_registers_with_database_tasks", () => {
+    DatabaseTasks.clearRegisteredTasks();
+    PostgreSQLDatabaseTasks.register();
+    expect(DatabaseTasks.resolveTask("postgresql")).toBeDefined();
+  });
+});

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -6,9 +6,9 @@
 
 import {
   getFs,
-  getOs,
+  getOsAsync,
   getPath,
-  getChildProcess,
+  getChildProcessAsync,
   type SpawnSyncResult,
 } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
@@ -128,7 +128,7 @@ export class PostgreSQLDatabaseTasks {
     await this.create(true);
   }
 
-  structureDump(filename: string, extraFlags?: string | string[] | null): void {
+  async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     // Use --dbname=NAME instead of a positional argument so database names
     // beginning with "-" aren't parsed as pg_dump options.
     const args = [
@@ -142,12 +142,13 @@ export class PostgreSQLDatabaseTasks {
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    this.runCmd("pg_dump", args, "dumping");
-    this.removeSqlHeaderComments(filename);
+    await this.runCmd("pg_dump", args, "dumping");
+    await this.removeSqlHeaderComments(filename);
   }
 
-  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
-    const nullDevice = getOs().platform() === "win32" ? "NUL" : "/dev/null";
+  async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {
+    const os = await getOsAsync();
+    const nullDevice = os.platform() === "win32" ? "NUL" : "/dev/null";
     // --dbname=NAME avoids psql treating a db name starting with "-" as a
     // flag.
     const args = [
@@ -164,7 +165,7 @@ export class PostgreSQLDatabaseTasks {
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    this.runCmd("psql", args, "loading");
+    await this.runCmd("psql", args, "loading");
   }
 
   static register(): void {
@@ -231,8 +232,9 @@ export class PostgreSQLDatabaseTasks {
     return env;
   }
 
-  private runCmd(cmd: string, args: string[], action: string): void {
-    const result = getChildProcess().spawnSync(cmd, args, {
+  private async runCmd(cmd: string, args: string[], action: string): Promise<void> {
+    const childProcess = await getChildProcessAsync();
+    const result = childProcess.spawnSync(cmd, args, {
       env: this.psqlEnv(),
       encoding: "utf8",
     });
@@ -241,10 +243,10 @@ export class PostgreSQLDatabaseTasks {
     }
   }
 
-  private removeSqlHeaderComments(filename: string): void {
+  private async removeSqlHeaderComments(filename: string): Promise<void> {
     const fs = getFs();
     const path = getPath();
-    const os = getOs();
+    const os = await getOsAsync();
     const contents = fs.readFileSync(filename, "utf8");
     const lines = contents.split("\n");
     let i = 0;

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -129,17 +129,27 @@ export class PostgreSQLDatabaseTasks {
   }
 
   structureDump(filename: string, extraFlags?: string | string[] | null): void {
-    const args = ["--schema-only", "--no-privileges", "--no-owner", "--file", filename];
+    // Use --dbname=NAME instead of a positional argument so database names
+    // beginning with "-" aren't parsed as pg_dump options.
+    const args = [
+      "--schema-only",
+      "--no-privileges",
+      "--no-owner",
+      "--file",
+      filename,
+      `--dbname=${this.requireDatabaseName()}`,
+    ];
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    args.push(this.requireDatabaseName());
     this.runCmd("pg_dump", args, "dumping");
     this.removeSqlHeaderComments(filename);
   }
 
   structureLoad(filename: string, extraFlags?: string | string[] | null): void {
     const nullDevice = getOs().platform() === "win32" ? "NUL" : "/dev/null";
+    // --dbname=NAME avoids psql treating a db name starting with "-" as a
+    // flag.
     const args = [
       "--set",
       ON_ERROR_STOP_1,
@@ -149,11 +159,11 @@ export class PostgreSQLDatabaseTasks {
       nullDevice,
       "--file",
       filename,
+      `--dbname=${this.requireDatabaseName()}`,
     ];
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
-    args.push(this.requireDatabaseName());
     this.runCmd("psql", args, "loading");
   }
 
@@ -240,6 +250,12 @@ export class PostgreSQLDatabaseTasks {
     let i = 0;
     while (i < lines.length && (lines[i].startsWith(SQL_COMMENT_BEGIN) || lines[i].trim() === "")) {
       i++;
+    }
+    if (!fs.mkdtempSync) {
+      throw new Error(
+        "PostgreSQLDatabaseTasks.structureDump requires FsAdapter.mkdtempSync. " +
+          "The configured FsAdapter does not provide it.",
+      );
     }
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "uncommented_structure_"));
     const tmp = path.join(tmpDir, "structure.sql");

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -211,7 +211,9 @@ export class PostgreSQLDatabaseTasks {
   }
 
   private psqlEnv(): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = { ...process.env };
+    const env: NodeJS.ProcessEnv = {
+      ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
+    };
     const c = this.configurationHash;
     const host = this.dbConfig.host ?? this.urlParts.host;
     const port = c.port ?? this.urlParts.port;

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -1,0 +1,148 @@
+/**
+ * PostgreSQLDatabaseTasks — PostgreSQL-specific database lifecycle operations.
+ *
+ * Mirrors: ActiveRecord::Tasks::PostgreSQLDatabaseTasks
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseTasks } from "./database-tasks.js";
+
+const DEFAULT_ENCODING = process.env.CHARSET ?? "utf8";
+const ON_ERROR_STOP_1 = "ON_ERROR_STOP=1";
+const SQL_COMMENT_BEGIN = "--";
+
+type ConfigHash = Record<string, unknown>;
+
+export class PostgreSQLDatabaseTasks {
+  private readonly dbConfig: DatabaseConfig;
+  private readonly configurationHash: ConfigHash;
+
+  static usingDatabaseConfigurations(): boolean {
+    return true;
+  }
+
+  constructor(dbConfig: DatabaseConfig) {
+    this.dbConfig = dbConfig;
+    this.configurationHash = { ...dbConfig.configuration };
+  }
+
+  async create(_connectionAlreadyEstablished = false): Promise<void> {
+    const dbName = this.requireDatabaseName();
+    const encoding = String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
+    const sql = `CREATE DATABASE "${dbName}" ENCODING '${encoding}'`;
+    await this.runOnSystemDb(sql);
+  }
+
+  async drop(): Promise<void> {
+    const dbName = this.requireDatabaseName();
+    await this.runOnSystemDb(`DROP DATABASE IF EXISTS "${dbName}"`);
+  }
+
+  charset(): string {
+    return String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
+  }
+
+  collation(): string | null {
+    return (this.configurationHash.collation as string) ?? null;
+  }
+
+  async purge(): Promise<void> {
+    await this.drop();
+    await this.create(true);
+  }
+
+  structureDump(filename: string, extraFlags?: string | string[] | null): void {
+    const args = ["--schema-only", "--no-privileges", "--no-owner", "--file", filename];
+    if (extraFlags) {
+      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    args.push(this.requireDatabaseName());
+    this.runCmd("pg_dump", args, "dumping");
+    this.removeSqlHeaderComments(filename);
+  }
+
+  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
+    const args = [
+      "--set",
+      ON_ERROR_STOP_1,
+      "--quiet",
+      "--no-psqlrc",
+      "--output",
+      "/dev/null",
+      "--file",
+      filename,
+    ];
+    if (extraFlags) {
+      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    args.push(this.requireDatabaseName());
+    this.runCmd("psql", args, "loading");
+  }
+
+  static register(): void {
+    DatabaseTasks.registerTask(/postgres/, {
+      create: async (config) => new PostgreSQLDatabaseTasks(config).create(),
+      drop: async (config) => new PostgreSQLDatabaseTasks(config).drop(),
+      purge: async (config) => new PostgreSQLDatabaseTasks(config).purge(),
+      charset: async (config) => new PostgreSQLDatabaseTasks(config).charset(),
+      collation: async (config) => new PostgreSQLDatabaseTasks(config).collation(),
+    });
+  }
+
+  private psqlEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    const c = this.configurationHash;
+    if (this.dbConfig.host) env.PGHOST = this.dbConfig.host;
+    if (c.port !== undefined) env.PGPORT = String(c.port);
+    if (c.password !== undefined) env.PGPASSWORD = String(c.password);
+    if (c.username !== undefined) env.PGUSER = String(c.username);
+    if (c.sslmode !== undefined) env.PGSSLMODE = String(c.sslmode);
+    if (c.sslcert !== undefined) env.PGSSLCERT = String(c.sslcert);
+    if (c.sslkey !== undefined) env.PGSSLKEY = String(c.sslkey);
+    if (c.sslrootcert !== undefined) env.PGSSLROOTCERT = String(c.sslrootcert);
+    return env;
+  }
+
+  private async runOnSystemDb(sql: string): Promise<void> {
+    const args = ["--dbname", "postgres", "--command", sql];
+    const result = spawnSync("psql", args, { env: this.psqlEnv(), encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error(`failed to execute: psql ${args.join(" ")}\n\n${result.stderr ?? ""}`);
+    }
+  }
+
+  private runCmd(cmd: string, args: string[], action: string): void {
+    const result = spawnSync(cmd, args, { env: this.psqlEnv(), encoding: "utf8" });
+    if (result.status !== 0) {
+      const msg =
+        `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+        `Please check the output above for any errors and make sure that ` +
+        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n` +
+        `(action: ${action})`;
+      throw new Error(msg);
+    }
+  }
+
+  private removeSqlHeaderComments(filename: string): void {
+    const contents = fs.readFileSync(filename, "utf8");
+    const lines = contents.split("\n");
+    let i = 0;
+    while (i < lines.length && (lines[i].startsWith(SQL_COMMENT_BEGIN) || lines[i].trim() === "")) {
+      i++;
+    }
+    const tmp = path.join(os.tmpdir(), `uncommented_structure_${process.pid}.sql`);
+    fs.writeFileSync(tmp, lines.slice(i).join("\n"));
+    fs.copyFileSync(tmp, filename);
+    fs.unlinkSync(tmp);
+  }
+
+  private requireDatabaseName(): string {
+    const name = this.dbConfig.database;
+    if (!name) throw new Error("PostgreSQL configuration missing 'database'");
+    return name;
+  }
+}

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -4,10 +4,13 @@
  * Mirrors: ActiveRecord::Tasks::PostgreSQLDatabaseTasks
  */
 
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
-import { spawnSync } from "node:child_process";
+import {
+  getFs,
+  getOs,
+  getPath,
+  getChildProcess,
+  type SpawnSyncResult,
+} from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
@@ -195,26 +198,19 @@ export class PostgreSQLDatabaseTasks {
   }
 
   private runCmd(cmd: string, args: string[], action: string): void {
-    const result = spawnSync(cmd, args, { env: this.psqlEnv(), encoding: "utf8" });
+    const result = getChildProcess().spawnSync(cmd, args, {
+      env: this.psqlEnv(),
+      encoding: "utf8",
+    });
     if (result.error || result.status !== 0 || result.signal) {
-      const details: string[] = [];
-      if (result.error) details.push(`Error: ${result.error.message}`);
-      if (result.status !== null && result.status !== 0) {
-        details.push(`Exit status: ${result.status}`);
-      }
-      if (result.signal) details.push(`Signal: ${result.signal}`);
-      if (result.stderr) details.push(`stderr:\n${result.stderr.trimEnd()}`);
-      if (result.stdout) details.push(`stdout:\n${result.stdout.trimEnd()}`);
-      throw new Error(
-        `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-          (details.length ? `${details.join("\n\n")}\n\n` : "") +
-          `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
-          `(action: ${action})`,
-      );
+      throw new Error(formatCmdError(cmd, args, result, action));
     }
   }
 
   private removeSqlHeaderComments(filename: string): void {
+    const fs = getFs();
+    const path = getPath();
+    const os = getOs();
     const contents = fs.readFileSync(filename, "utf8");
     const lines = contents.split("\n");
     let i = 0;
@@ -244,4 +240,26 @@ export class PostgreSQLDatabaseTasks {
   private escapeSingle(value: string): string {
     return value.replace(/'/g, "''");
   }
+}
+
+function formatCmdError(
+  cmd: string,
+  args: string[],
+  result: SpawnSyncResult,
+  action: string,
+): string {
+  const details: string[] = [];
+  if (result.error) details.push(`Error: ${result.error.message}`);
+  if (result.status !== null && result.status !== 0) {
+    details.push(`Exit status: ${result.status}`);
+  }
+  if (result.signal) details.push(`Signal: ${result.signal}`);
+  if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
+  if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
+  return (
+    `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+    (details.length ? `${details.join("\n\n")}\n\n` : "") +
+    `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
+    `(action: ${action})`
+  );
 }

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -18,9 +18,43 @@ const SQL_COMMENT_BEGIN = "--";
 
 type ConfigHash = Record<string, unknown>;
 
+interface UrlParts {
+  host?: string;
+  port?: string;
+  username?: string;
+  password?: string;
+  database?: string;
+  sslmode?: string;
+  sslcert?: string;
+  sslkey?: string;
+  sslrootcert?: string;
+}
+
+function parseDbUrl(url: string | undefined): UrlParts {
+  if (!url) return {};
+  try {
+    const parsed = new URL(url);
+    const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+    return {
+      host: parsed.hostname || undefined,
+      port: parsed.port || undefined,
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+      database: database || undefined,
+      sslmode: parsed.searchParams.get("sslmode") ?? undefined,
+      sslcert: parsed.searchParams.get("sslcert") ?? undefined,
+      sslkey: parsed.searchParams.get("sslkey") ?? undefined,
+      sslrootcert: parsed.searchParams.get("sslrootcert") ?? undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 export class PostgreSQLDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
   private readonly configurationHash: ConfigHash;
+  private readonly urlParts: UrlParts;
 
   static usingDatabaseConfigurations(): boolean {
     return true;
@@ -29,6 +63,7 @@ export class PostgreSQLDatabaseTasks {
   constructor(dbConfig: DatabaseConfig) {
     this.dbConfig = dbConfig;
     this.configurationHash = { ...dbConfig.configuration };
+    this.urlParts = parseDbUrl(this.configurationHash.url as string | undefined);
   }
 
   async create(connectionAlreadyEstablished = false): Promise<void> {
@@ -140,26 +175,42 @@ export class PostgreSQLDatabaseTasks {
   private psqlEnv(): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = { ...process.env };
     const c = this.configurationHash;
-    if (this.dbConfig.host) env.PGHOST = this.dbConfig.host;
-    if (c.port !== undefined) env.PGPORT = String(c.port);
-    if (c.password !== undefined) env.PGPASSWORD = String(c.password);
-    if (c.username !== undefined) env.PGUSER = String(c.username);
-    if (c.sslmode !== undefined) env.PGSSLMODE = String(c.sslmode);
-    if (c.sslcert !== undefined) env.PGSSLCERT = String(c.sslcert);
-    if (c.sslkey !== undefined) env.PGSSLKEY = String(c.sslkey);
-    if (c.sslrootcert !== undefined) env.PGSSLROOTCERT = String(c.sslrootcert);
+    const host = this.dbConfig.host ?? this.urlParts.host;
+    const port = c.port ?? this.urlParts.port;
+    const password = c.password ?? this.urlParts.password;
+    const username = c.username ?? this.urlParts.username;
+    if (host) env.PGHOST = String(host);
+    if (port !== undefined) env.PGPORT = String(port);
+    if (password !== undefined) env.PGPASSWORD = String(password);
+    if (username !== undefined) env.PGUSER = String(username);
+    const sslmode = c.sslmode ?? this.urlParts.sslmode;
+    const sslcert = c.sslcert ?? this.urlParts.sslcert;
+    const sslkey = c.sslkey ?? this.urlParts.sslkey;
+    const sslrootcert = c.sslrootcert ?? this.urlParts.sslrootcert;
+    if (sslmode !== undefined) env.PGSSLMODE = String(sslmode);
+    if (sslcert !== undefined) env.PGSSLCERT = String(sslcert);
+    if (sslkey !== undefined) env.PGSSLKEY = String(sslkey);
+    if (sslrootcert !== undefined) env.PGSSLROOTCERT = String(sslrootcert);
     return env;
   }
 
   private runCmd(cmd: string, args: string[], action: string): void {
     const result = spawnSync(cmd, args, { env: this.psqlEnv(), encoding: "utf8" });
-    if (result.status !== 0) {
-      const msg =
+    if (result.error || result.status !== 0 || result.signal) {
+      const details: string[] = [];
+      if (result.error) details.push(`Error: ${result.error.message}`);
+      if (result.status !== null && result.status !== 0) {
+        details.push(`Exit status: ${result.status}`);
+      }
+      if (result.signal) details.push(`Signal: ${result.signal}`);
+      if (result.stderr) details.push(`stderr:\n${result.stderr.trimEnd()}`);
+      if (result.stdout) details.push(`stdout:\n${result.stdout.trimEnd()}`);
+      throw new Error(
         `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-        `Please check the output above for any errors and make sure that ` +
-        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n` +
-        `(action: ${action})`;
-      throw new Error(msg);
+          (details.length ? `${details.join("\n\n")}\n\n` : "") +
+          `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
+          `(action: ${action})`,
+      );
     }
   }
 
@@ -170,14 +221,18 @@ export class PostgreSQLDatabaseTasks {
     while (i < lines.length && (lines[i].startsWith(SQL_COMMENT_BEGIN) || lines[i].trim() === "")) {
       i++;
     }
-    const tmp = path.join(os.tmpdir(), `uncommented_structure_${process.pid}.sql`);
-    fs.writeFileSync(tmp, lines.slice(i).join("\n"));
-    fs.copyFileSync(tmp, filename);
-    fs.unlinkSync(tmp);
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "uncommented_structure_"));
+    const tmp = path.join(tmpDir, "structure.sql");
+    try {
+      fs.writeFileSync(tmp, lines.slice(i).join("\n"));
+      fs.copyFileSync(tmp, filename);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 
   private requireDatabaseName(): string {
-    const name = this.dbConfig.database;
+    const name = this.dbConfig.database ?? this.urlParts.database;
     if (!name) throw new Error("PostgreSQL configuration missing 'database'");
     return name;
   }

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -13,9 +13,24 @@ import {
 } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 
 const DEFAULT_ENCODING = process.env.CHARSET ?? "utf8";
+const DUPLICATE_DATABASE = "42P04";
+
+function coercePort(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function isPGDuplicateDatabaseError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: unknown; message?: unknown };
+  if (e.code === DUPLICATE_DATABASE) return true;
+  return typeof e.message === "string" && e.message.includes("already exists");
+}
 const ON_ERROR_STOP_1 = "ON_ERROR_STOP=1";
 const SQL_COMMENT_BEGIN = "--";
 
@@ -76,6 +91,14 @@ export class PostgreSQLDatabaseTasks {
     const admin = await this.connectAdmin();
     try {
       await admin.executeMutation(sql);
+    } catch (error) {
+      if (isPGDuplicateDatabaseError(error)) {
+        throw new DatabaseAlreadyExists(`Database '${dbName}' already exists`, {
+          sql,
+          cause: error,
+        });
+      }
+      throw error;
     } finally {
       await this.closeAdapter(admin);
     }
@@ -161,7 +184,7 @@ export class PostgreSQLDatabaseTasks {
     }
     return new PostgreSQLAdapter({
       host: (c.host as string) ?? "localhost",
-      port: (c.port as number) ?? 5432,
+      port: coercePort(c.port, 5432),
       database: "postgres",
       user: c.username as string | undefined,
       password: c.password as string | undefined,

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -15,15 +15,10 @@ import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
+import { coercePort } from "./task-utils.js";
 
 const DEFAULT_ENCODING = process.env.CHARSET ?? "utf8";
 const DUPLICATE_DATABASE = "42P04";
-
-function coercePort(value: unknown, fallback: number): number {
-  if (value === undefined || value === null || value === "") return fallback;
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : fallback;
-}
 
 function isPGDuplicateDatabaseError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
 
@@ -30,20 +31,31 @@ export class PostgreSQLDatabaseTasks {
     this.configurationHash = { ...dbConfig.configuration };
   }
 
-  async create(_connectionAlreadyEstablished = false): Promise<void> {
+  async create(connectionAlreadyEstablished = false): Promise<void> {
     const dbName = this.requireDatabaseName();
-    const encoding = String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
-    const sql = `CREATE DATABASE "${dbName}" ENCODING '${encoding}'`;
-    await this.runOnSystemDb(sql);
+    const encoding = this.encoding();
+    const sql = `CREATE DATABASE "${this.escapeIdent(dbName)}" ENCODING '${this.escapeSingle(encoding)}'`;
+    const admin = await this.connectAdmin();
+    try {
+      await admin.executeMutation(sql);
+    } finally {
+      await this.closeAdapter(admin);
+    }
+    void connectionAlreadyEstablished;
   }
 
   async drop(): Promise<void> {
     const dbName = this.requireDatabaseName();
-    await this.runOnSystemDb(`DROP DATABASE IF EXISTS "${dbName}"`);
+    const admin = await this.connectAdmin();
+    try {
+      await admin.executeMutation(`DROP DATABASE IF EXISTS "${this.escapeIdent(dbName)}"`);
+    } finally {
+      await this.closeAdapter(admin);
+    }
   }
 
   charset(): string {
-    return String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
+    return this.encoding();
   }
 
   collation(): string | null {
@@ -90,7 +102,39 @@ export class PostgreSQLDatabaseTasks {
       purge: async (config) => new PostgreSQLDatabaseTasks(config).purge(),
       charset: async (config) => new PostgreSQLDatabaseTasks(config).charset(),
       collation: async (config) => new PostgreSQLDatabaseTasks(config).collation(),
+      structureDump: async (config, filename, flags) =>
+        new PostgreSQLDatabaseTasks(config).structureDump(filename, flags),
+      structureLoad: async (config, filename, flags) =>
+        new PostgreSQLDatabaseTasks(config).structureLoad(filename, flags),
     });
+  }
+
+  private encoding(): string {
+    return String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
+  }
+
+  private async connectAdmin(): Promise<DatabaseAdapter> {
+    const { PostgreSQLAdapter } = await import("../adapters/postgresql-adapter.js");
+    const c = this.configurationHash;
+    if (c.url) {
+      const parsed = new URL(String(c.url));
+      parsed.pathname = "/postgres";
+      return new PostgreSQLAdapter(parsed.toString());
+    }
+    return new PostgreSQLAdapter({
+      host: (c.host as string) ?? "localhost",
+      port: (c.port as number) ?? 5432,
+      database: "postgres",
+      user: c.username as string | undefined,
+      password: c.password as string | undefined,
+    });
+  }
+
+  private async closeAdapter(adapter: DatabaseAdapter): Promise<void> {
+    const maybeClose = (adapter as { close?: () => Promise<void> }).close;
+    if (typeof maybeClose === "function") {
+      await maybeClose.call(adapter);
+    }
   }
 
   private psqlEnv(): NodeJS.ProcessEnv {
@@ -105,14 +149,6 @@ export class PostgreSQLDatabaseTasks {
     if (c.sslkey !== undefined) env.PGSSLKEY = String(c.sslkey);
     if (c.sslrootcert !== undefined) env.PGSSLROOTCERT = String(c.sslrootcert);
     return env;
-  }
-
-  private async runOnSystemDb(sql: string): Promise<void> {
-    const args = ["--dbname", "postgres", "--command", sql];
-    const result = spawnSync("psql", args, { env: this.psqlEnv(), encoding: "utf8" });
-    if (result.status !== 0) {
-      throw new Error(`failed to execute: psql ${args.join(" ")}\n\n${result.stderr ?? ""}`);
-    }
   }
 
   private runCmd(cmd: string, args: string[], action: string): void {
@@ -144,5 +180,13 @@ export class PostgreSQLDatabaseTasks {
     const name = this.dbConfig.database;
     if (!name) throw new Error("PostgreSQL configuration missing 'database'");
     return name;
+  }
+
+  private escapeIdent(value: string): string {
+    return value.replace(/"/g, '""');
+  }
+
+  private escapeSingle(value: string): string {
+    return value.replace(/'/g, "''");
   }
 }

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -17,8 +17,13 @@ import { DatabaseAlreadyExists } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { coercePort } from "./task-utils.js";
 
-const DEFAULT_ENCODING = process.env.CHARSET ?? "utf8";
+const DEFAULT_ENCODING_FALLBACK = "utf8";
 const DUPLICATE_DATABASE = "42P04";
+
+function defaultEncoding(): string {
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  return proc?.env?.CHARSET ?? DEFAULT_ENCODING_FALLBACK;
+}
 
 function isPGDuplicateDatabaseError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
@@ -134,13 +139,14 @@ export class PostgreSQLDatabaseTasks {
   }
 
   structureLoad(filename: string, extraFlags?: string | string[] | null): void {
+    const nullDevice = getOs().platform() === "win32" ? "NUL" : "/dev/null";
     const args = [
       "--set",
       ON_ERROR_STOP_1,
       "--quiet",
       "--no-psqlrc",
       "--output",
-      "/dev/null",
+      nullDevice,
       "--file",
       filename,
     ];
@@ -166,7 +172,7 @@ export class PostgreSQLDatabaseTasks {
   }
 
   private encoding(): string {
-    return String(this.configurationHash.encoding ?? DEFAULT_ENCODING);
+    return String(this.configurationHash.encoding ?? defaultEncoding());
   }
 
   private async connectAdmin(): Promise<DatabaseAdapter> {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -2,13 +2,14 @@ import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 import { SQLiteDatabaseTasks } from "./sqlite-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseAlreadyExists, NoDatabaseError } from "../errors.js";
 
 function tmpDbPath(): string {
-  return path.join(os.tmpdir(), `trails-sqlite-test-${process.pid}-${Date.now()}.sqlite3`);
+  return path.join(os.tmpdir(), `trails-sqlite-test-${process.pid}-${randomUUID()}.sqlite3`);
 }
 
 describe("SQLiteDatabaseTasks", () => {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SQLiteDatabaseTasks } from "./sqlite-database-tasks.js";
+import { DatabaseTasks } from "./database-tasks.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import { DatabaseAlreadyExists, NoDatabaseError } from "../errors.js";
+
+function tmpDbPath(): string {
+  return path.join(os.tmpdir(), `trails-sqlite-test-${process.pid}-${Date.now()}.sqlite3`);
+}
+
+describe("SQLiteDatabaseTasks", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const file of created) {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        // ignore
+      }
+    }
+    created.length = 0;
+  });
+
+  it("test_db_create_creates_file", async () => {
+    const dbPath = tmpDbPath();
+    created.push(dbPath);
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: dbPath,
+    });
+    await new SQLiteDatabaseTasks(config).create();
+    expect(fs.existsSync(dbPath)).toBe(true);
+  });
+
+  it("test_db_create_when_file_exists_raises", async () => {
+    const dbPath = tmpDbPath();
+    created.push(dbPath);
+    fs.writeFileSync(dbPath, "");
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: dbPath,
+    });
+    await expect(new SQLiteDatabaseTasks(config).create()).rejects.toBeInstanceOf(
+      DatabaseAlreadyExists,
+    );
+  });
+
+  it("test_db_drop_removes_file", async () => {
+    const dbPath = tmpDbPath();
+    created.push(dbPath);
+    fs.writeFileSync(dbPath, "");
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: dbPath,
+    });
+    await new SQLiteDatabaseTasks(config).drop();
+    expect(fs.existsSync(dbPath)).toBe(false);
+  });
+
+  it("test_db_drop_missing_raises_no_database_error", async () => {
+    const dbPath = tmpDbPath();
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: dbPath,
+    });
+    await expect(new SQLiteDatabaseTasks(config).drop()).rejects.toBeInstanceOf(NoDatabaseError);
+  });
+
+  it("test_charset_returns_utf8", () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: ":memory:",
+    });
+    expect(new SQLiteDatabaseTasks(config).charset()).toBe("UTF-8");
+  });
+
+  it("test_registers_with_database_tasks", () => {
+    DatabaseTasks.clearRegisteredTasks();
+    SQLiteDatabaseTasks.register();
+    expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
+  });
+});

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -99,9 +99,15 @@ describe("SQLiteDatabaseTasks", () => {
     const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
     const seedAdapter = new SQLite3Adapter(dbPath);
     await seedAdapter.executeMutation(
-      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT)",
     );
     await seedAdapter.executeMutation("CREATE INDEX index_widgets_on_name ON widgets(name)");
+    await seedAdapter.executeMutation(
+      "CREATE TRIGGER touch_widgets AFTER UPDATE ON widgets " +
+        "BEGIN " +
+        "UPDATE widgets SET updated_at = datetime('now') WHERE id = NEW.id; " +
+        "END",
+    );
     await (seedAdapter as unknown as { close(): Promise<void> }).close();
 
     await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
@@ -109,6 +115,7 @@ describe("SQLiteDatabaseTasks", () => {
     const dumped = fs.readFileSync(dumpPath, "utf8");
     expect(dumped).toMatch(/CREATE TABLE widgets/);
     expect(dumped).toMatch(/index_widgets_on_name/);
+    expect(dumped).toMatch(/CREATE TRIGGER touch_widgets/);
 
     const targetConfig = new HashConfig("development", "primary", {
       adapter: "sqlite3",
@@ -127,6 +134,10 @@ describe("SQLiteDatabaseTasks", () => {
         "SELECT name FROM sqlite_master WHERE type='index' AND name='index_widgets_on_name'",
       )) as unknown[];
       expect(idx.length).toBe(1);
+      const trigger = (await loadedAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='touch_widgets'",
+      )) as unknown[];
+      expect(trigger.length).toBe(1);
     } finally {
       await (loadedAdapter as unknown as { close(): Promise<void> }).close();
     }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -84,4 +84,51 @@ describe("SQLiteDatabaseTasks", () => {
     SQLiteDatabaseTasks.register();
     expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
   });
+
+  it("test_structure_dump_and_load_round_trip_via_adapter", async () => {
+    const dbPath = tmpDbPath();
+    const dumpPath = path.join(os.tmpdir(), `trails-sqlite-dump-${randomUUID()}.sql`);
+    const loadDbPath = tmpDbPath();
+    created.push(dbPath, dumpPath, loadDbPath);
+
+    const sourceConfig = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: dbPath,
+    });
+
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    const seedAdapter = new SQLite3Adapter(dbPath);
+    await seedAdapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    );
+    await seedAdapter.executeMutation("CREATE INDEX index_widgets_on_name ON widgets(name)");
+    await (seedAdapter as unknown as { close(): Promise<void> }).close();
+
+    await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
+
+    const dumped = fs.readFileSync(dumpPath, "utf8");
+    expect(dumped).toMatch(/CREATE TABLE widgets/);
+    expect(dumped).toMatch(/index_widgets_on_name/);
+
+    const targetConfig = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: loadDbPath,
+    });
+    fs.writeFileSync(loadDbPath, "");
+    await new SQLiteDatabaseTasks(targetConfig).structureLoad(dumpPath);
+
+    const loadedAdapter = new SQLite3Adapter(loadDbPath);
+    try {
+      const tables = (await loadedAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+      )) as Array<{ name: string }>;
+      expect(tables.map((r) => r.name)).toContain("widgets");
+      const idx = (await loadedAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='index_widgets_on_name'",
+      )) as unknown[];
+      expect(idx.length).toBe(1);
+    } finally {
+      await (loadedAdapter as unknown as { close(): Promise<void> }).close();
+    }
+  });
 });

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -173,10 +173,10 @@ export class SQLiteDatabaseTasks {
 
   private resolveDbPath(): string {
     const path = getPath();
-    const database = this.dbConfig.database;
-    if (!database) {
-      throw new Error("SQLite database configuration missing 'database' path");
-    }
+    // Align with DatabaseTasks._connectFor which defaults missing sqlite
+    // database to ":memory:" — makes create/drop no-ops on in-memory
+    // configs instead of throwing on otherwise-valid setups.
+    const database = this.dbConfig.database ?? ":memory:";
     // Per PathAdapter contract, a missing isAbsolute means the adapter
     // doesn't model relative/absolute distinctions (e.g. a VFS) — treat
     // every path as already absolute.

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -124,7 +124,15 @@ export class SQLiteDatabaseTasks {
           new Set(tablesRows.map((r) => String(r.tbl_name ?? "")).filter(Boolean)),
         );
         const excluded = allTables.filter((name) =>
-          ignoreTables.some((pat) => (pat instanceof RegExp ? pat.test(name) : pat === name)),
+          ignoreTables.some((pat) => {
+            if (pat instanceof RegExp) {
+              // Reset lastIndex so global/sticky regex patterns don't
+              // produce false negatives across repeated .test() calls.
+              pat.lastIndex = 0;
+              return pat.test(name);
+            }
+            return pat === name;
+          }),
         );
         if (excluded.length > 0) {
           const placeholders = excluded.map(() => "?").join(", ");

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -169,8 +169,11 @@ export class SQLiteDatabaseTasks {
     if (!database) {
       throw new Error("SQLite database configuration missing 'database' path");
     }
+    // Per PathAdapter contract, a missing isAbsolute means the adapter
+    // doesn't model relative/absolute distinctions (e.g. a VFS) — treat
+    // every path as already absolute.
     if (database === ":memory:") return database;
-    if (path.isAbsolute && path.isAbsolute(database)) return database;
+    if (!path.isAbsolute || path.isAbsolute(database)) return database;
     return path.join(this.root, database);
   }
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -114,6 +114,7 @@ export class SQLiteDatabaseTasks {
         "CASE type WHEN 'table' THEN 0 WHEN 'view' THEN 1 " +
         "WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 ELSE 4 END";
       let where = "WHERE sql IS NOT NULL";
+      let binds: unknown[] = [];
 
       if (ignoreTables.length > 0) {
         const tablesRows = (await adapter.execute(
@@ -126,13 +127,14 @@ export class SQLiteDatabaseTasks {
           ignoreTables.some((pat) => (pat instanceof RegExp ? pat.test(name) : pat === name)),
         );
         if (excluded.length > 0) {
-          const list = excluded.map((n) => `'${n.replace(/'/g, "''")}'`).join(", ");
-          where += ` AND tbl_name NOT IN (${list})`;
+          const placeholders = excluded.map(() => "?").join(", ");
+          where += ` AND tbl_name NOT IN (${placeholders})`;
+          binds = excluded;
         }
       }
 
       const query = `SELECT sql || ';' AS sql FROM sqlite_master ${where} ORDER BY ${typeOrder}, tbl_name, name`;
-      const rows = (await adapter.execute(query)) as Array<Record<string, unknown>>;
+      const rows = (await adapter.execute(query, binds)) as Array<Record<string, unknown>>;
       const output = rows.map((r) => String(r.sql ?? "")).join("\n");
       getFs().writeFileSync(filename, output);
     } finally {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -1,10 +1,16 @@
 /**
  * SQLiteDatabaseTasks — SQLite-specific database lifecycle operations.
  *
- * Mirrors: ActiveRecord::Tasks::SQLiteDatabaseTasks
+ * Mirrors: ActiveRecord::Tasks::SQLiteDatabaseTasks.
+ *
+ * Unlike Rails (which shells out to the `sqlite3` CLI for structureDump /
+ * structureLoad), trails runs these operations through the SQLite3Adapter so
+ * the same code works under sqlite-wasm + the activesupport vfs adapter — no
+ * subprocess required.
  */
 
-import { getFs, getPath, getChildProcess, type SpawnSyncResult } from "@blazetrails/activesupport";
+import { getFs, getPath } from "@blazetrails/activesupport";
+import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { NoDatabaseError, DatabaseAlreadyExists } from "../errors.js";
@@ -90,26 +96,62 @@ export class SQLiteDatabaseTasks {
     return "UTF-8";
   }
 
-  structureDump(filename: string, extraFlags?: string | string[] | null): void {
-    const args: string[] = [];
-    if (extraFlags) {
-      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+  async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {
+    void extraFlags;
+    const adapter = await this.connectAdapter();
+    try {
+      const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
+      const ignoreTables = SchemaDumper.ignoreTables;
+
+      let query: string;
+      if (ignoreTables.length > 0) {
+        // Resolve patterns against the live table list (Rails does the same —
+        // string names + regex patterns both need the current sqlite_master
+        // row to compare against).
+        const tablesRows = (await adapter.execute(
+          "SELECT tbl_name FROM sqlite_master WHERE type IN ('table','view','index','trigger')",
+        )) as Array<Record<string, unknown>>;
+        const allTables = Array.from(
+          new Set(tablesRows.map((r) => String(r.tbl_name ?? "")).filter(Boolean)),
+        );
+        const excluded = allTables.filter((name) =>
+          ignoreTables.some((pat) => (pat instanceof RegExp ? pat.test(name) : pat === name)),
+        );
+        if (excluded.length > 0) {
+          const list = excluded.map((n) => `'${n.replace(/'/g, "''")}'`).join(", ");
+          query =
+            `SELECT sql || ';' AS sql FROM sqlite_master ` +
+            `WHERE sql IS NOT NULL AND tbl_name NOT IN (${list}) ` +
+            `ORDER BY tbl_name, type DESC, name`;
+        } else {
+          query =
+            `SELECT sql || ';' AS sql FROM sqlite_master ` +
+            `WHERE sql IS NOT NULL ORDER BY tbl_name, type DESC, name`;
+        }
+      } else {
+        query =
+          `SELECT sql || ';' AS sql FROM sqlite_master ` +
+          `WHERE sql IS NOT NULL ORDER BY tbl_name, type DESC, name`;
+      }
+
+      const rows = (await adapter.execute(query)) as Array<Record<string, unknown>>;
+      const output = rows.map((r) => String(r.sql ?? "")).join("\n");
+      getFs().writeFileSync(filename, output);
+    } finally {
+      await this.closeAdapter(adapter);
     }
-    args.push(this.resolveDbPath());
-    args.push(".schema --nosys");
-    this.runCmd("sqlite3", args, filename);
   }
 
-  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
-    const args: string[] = [];
-    if (extraFlags) {
-      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
-    }
-    args.push(this.resolveDbPath());
+  async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {
+    void extraFlags;
     const sql = getFs().readFileSync(filename, "utf8");
-    const result = getChildProcess().spawnSync("sqlite3", args, { input: sql, encoding: "utf8" });
-    if (result.error || result.status !== 0 || result.signal) {
-      throw new Error(this.formatCmdError("sqlite3", args, result, "loading"));
+    const adapter = await this.connectAdapter();
+    try {
+      for (const statement of splitSqlStatements(sql)) {
+        await adapter.executeMutation(statement);
+      }
+    } finally {
+      await this.closeAdapter(adapter);
     }
   }
 
@@ -121,6 +163,16 @@ export class SQLiteDatabaseTasks {
     }
     if (database === ":memory:" || path.isAbsolute(database)) return database;
     return path.join(this.root, database);
+  }
+
+  private async connectAdapter(): Promise<DatabaseAdapter> {
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    return new SQLite3Adapter(this.resolveDbPath());
+  }
+
+  private async closeAdapter(adapter: DatabaseAdapter): Promise<void> {
+    const close = (adapter as { close?: () => Promise<void> }).close;
+    if (typeof close === "function") await close.call(adapter);
   }
 
   static register(): void {
@@ -135,34 +187,63 @@ export class SQLiteDatabaseTasks {
         new SQLiteDatabaseTasks(config).structureLoad(filename, flags),
     });
   }
+}
 
-  private runCmd(cmd: string, args: string[], outFile: string): void {
-    const result = getChildProcess().spawnSync(cmd, args, { encoding: "utf8" });
-    if (result.error || result.status !== 0 || result.signal) {
-      throw new Error(this.formatCmdError(cmd, args, result, "dumping"));
+/**
+ * Split a SQL script into individual statements on semicolon boundaries,
+ * respecting string literals ('...' and "..."), line comments (-- ...) and
+ * block comments (slash-star ... star-slash). Simple enough for
+ * structure-load files (which are DDL the adapter itself produced) but not a
+ * full SQL parser.
+ */
+function splitSqlStatements(sql: string): string[] {
+  const result: string[] = [];
+  let buf = "";
+  let i = 0;
+  const n = sql.length;
+  while (i < n) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+    if (ch === "-" && next === "-") {
+      while (i < n && sql[i] !== "\n") i++;
+      continue;
     }
-    getFs().writeFileSync(outFile, result.stdout ?? "");
-  }
-
-  private formatCmdError(
-    cmd: string,
-    args: string[],
-    result: SpawnSyncResult,
-    action: string,
-  ): string {
-    const details: string[] = [];
-    if (result.error) details.push(`Error: ${result.error.message}`);
-    if (result.status !== null && result.status !== 0) {
-      details.push(`Exit status: ${result.status}`);
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < n - 1 && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
+      i += 2;
+      continue;
     }
-    if (result.signal) details.push(`Signal: ${result.signal}`);
-    if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
-    if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
-    return (
-      `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-      (details.length ? `${details.join("\n\n")}\n\n` : "") +
-      `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
-      `(action: ${action})`
-    );
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      buf += ch;
+      i++;
+      while (i < n) {
+        buf += sql[i];
+        if (sql[i] === quote && sql[i + 1] !== quote) {
+          i++;
+          break;
+        }
+        if (sql[i] === quote && sql[i + 1] === quote) {
+          buf += sql[i + 1];
+          i += 2;
+          continue;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (ch === ";") {
+      const stmt = buf.trim();
+      if (stmt) result.push(stmt);
+      buf = "";
+      i++;
+      continue;
+    }
+    buf += ch;
+    i++;
   }
+  const tail = buf.trim();
+  if (tail) result.push(tail);
+  return result;
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -107,8 +107,8 @@ export class SQLiteDatabaseTasks {
     args.push(this.resolveDbPath());
     const sql = fs.readFileSync(filename, "utf8");
     const result = spawnSync("sqlite3", args, { input: sql, encoding: "utf8" });
-    if (result.status !== 0) {
-      throw new Error(`failed to execute:\nsqlite3 ${args.join(" ")}\n\n${result.stderr ?? ""}`);
+    if (result.error || result.status !== 0 || result.signal) {
+      throw new Error(this.formatCmdError("sqlite3", args, result, "loading"));
     }
   }
 
@@ -136,13 +136,31 @@ export class SQLiteDatabaseTasks {
 
   private runCmd(cmd: string, args: string[], outFile: string): void {
     const result = spawnSync(cmd, args, { encoding: "utf8" });
-    if (result.status !== 0) {
-      const msg =
-        `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
-        `Please check the output above for any errors and make sure that ` +
-        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n`;
-      throw new Error(msg);
+    if (result.error || result.status !== 0 || result.signal) {
+      throw new Error(this.formatCmdError(cmd, args, result, "dumping"));
     }
     fs.writeFileSync(outFile, result.stdout ?? "");
+  }
+
+  private formatCmdError(
+    cmd: string,
+    args: string[],
+    result: ReturnType<typeof spawnSync>,
+    action: string,
+  ): string {
+    const details: string[] = [];
+    if (result.error) details.push(`Error: ${result.error.message}`);
+    if (result.status !== null && result.status !== 0) {
+      details.push(`Exit status: ${result.status}`);
+    }
+    if (result.signal) details.push(`Signal: ${result.signal}`);
+    if (result.stderr) details.push(`stderr:\n${String(result.stderr).trimEnd()}`);
+    if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
+    return (
+      `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+      (details.length ? `${details.join("\n\n")}\n\n` : "") +
+      `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
+      `(action: ${action})`
+    );
   }
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -4,9 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::SQLiteDatabaseTasks
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { spawnSync } from "node:child_process";
+import { getFs, getPath, getChildProcess, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { NoDatabaseError, DatabaseAlreadyExists } from "../errors.js";
@@ -25,6 +23,8 @@ export class SQLiteDatabaseTasks {
   }
 
   async create(): Promise<void> {
+    const fs = getFs();
+    const path = getPath();
     const dbPath = this.resolveDbPath();
     if (dbPath !== ":memory:" && fs.existsSync(dbPath)) {
       throw new DatabaseAlreadyExists(`Database '${dbPath}' already exists`);
@@ -36,6 +36,7 @@ export class SQLiteDatabaseTasks {
   }
 
   async drop(): Promise<void> {
+    const fs = getFs();
     const dbPath = this.resolveDbPath();
     if (dbPath === ":memory:") return;
     try {
@@ -105,14 +106,15 @@ export class SQLiteDatabaseTasks {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
     args.push(this.resolveDbPath());
-    const sql = fs.readFileSync(filename, "utf8");
-    const result = spawnSync("sqlite3", args, { input: sql, encoding: "utf8" });
+    const sql = getFs().readFileSync(filename, "utf8");
+    const result = getChildProcess().spawnSync("sqlite3", args, { input: sql, encoding: "utf8" });
     if (result.error || result.status !== 0 || result.signal) {
       throw new Error(this.formatCmdError("sqlite3", args, result, "loading"));
     }
   }
 
   private resolveDbPath(): string {
+    const path = getPath();
     const database = this.dbConfig.database;
     if (!database) {
       throw new Error("SQLite database configuration missing 'database' path");
@@ -135,17 +137,17 @@ export class SQLiteDatabaseTasks {
   }
 
   private runCmd(cmd: string, args: string[], outFile: string): void {
-    const result = spawnSync(cmd, args, { encoding: "utf8" });
+    const result = getChildProcess().spawnSync(cmd, args, { encoding: "utf8" });
     if (result.error || result.status !== 0 || result.signal) {
       throw new Error(this.formatCmdError(cmd, args, result, "dumping"));
     }
-    fs.writeFileSync(outFile, result.stdout ?? "");
+    getFs().writeFileSync(outFile, result.stdout ?? "");
   }
 
   private formatCmdError(
     cmd: string,
     args: string[],
-    result: ReturnType<typeof spawnSync>,
+    result: SpawnSyncResult,
     action: string,
   ): string {
     const details: string[] = [];

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -167,7 +167,8 @@ export class SQLiteDatabaseTasks {
     if (!database) {
       throw new Error("SQLite database configuration missing 'database' path");
     }
-    if (database === ":memory:" || path.isAbsolute(database)) return database;
+    if (database === ":memory:") return database;
+    if (path.isAbsolute && path.isAbsolute(database)) return database;
     return path.join(this.root, database);
   }
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -103,11 +103,19 @@ export class SQLiteDatabaseTasks {
       const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
       const ignoreTables = SchemaDumper.ignoreTables;
 
-      let query: string;
+      // Order so that dependencies resolve during structure_load: create
+      // tables + views first, then their indexes and triggers (which both
+      // reference those tables). Rails' equivalent orders by `type DESC`
+      // because its CLI path runs through sqlite3's shell which resolves
+      // forward-referenced triggers lazily; when re-executing as a script
+      // through better-sqlite3's `db.exec` the statements are applied
+      // strictly in order, so triggers-before-tables would fail.
+      const typeOrder =
+        "CASE type WHEN 'table' THEN 0 WHEN 'view' THEN 1 " +
+        "WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 ELSE 4 END";
+      let where = "WHERE sql IS NOT NULL";
+
       if (ignoreTables.length > 0) {
-        // Resolve patterns against the live table list (Rails does the same —
-        // string names + regex patterns both need the current sqlite_master
-        // row to compare against).
         const tablesRows = (await adapter.execute(
           "SELECT tbl_name FROM sqlite_master WHERE type IN ('table','view','index','trigger')",
         )) as Array<Record<string, unknown>>;
@@ -119,21 +127,11 @@ export class SQLiteDatabaseTasks {
         );
         if (excluded.length > 0) {
           const list = excluded.map((n) => `'${n.replace(/'/g, "''")}'`).join(", ");
-          query =
-            `SELECT sql || ';' AS sql FROM sqlite_master ` +
-            `WHERE sql IS NOT NULL AND tbl_name NOT IN (${list}) ` +
-            `ORDER BY tbl_name, type DESC, name`;
-        } else {
-          query =
-            `SELECT sql || ';' AS sql FROM sqlite_master ` +
-            `WHERE sql IS NOT NULL ORDER BY tbl_name, type DESC, name`;
+          where += ` AND tbl_name NOT IN (${list})`;
         }
-      } else {
-        query =
-          `SELECT sql || ';' AS sql FROM sqlite_master ` +
-          `WHERE sql IS NOT NULL ORDER BY tbl_name, type DESC, name`;
       }
 
+      const query = `SELECT sql || ';' AS sql FROM sqlite_master ${where} ORDER BY ${typeOrder}, tbl_name, name`;
       const rows = (await adapter.execute(query)) as Array<Record<string, unknown>>;
       const output = rows.map((r) => String(r.sql ?? "")).join("\n");
       getFs().writeFileSync(filename, output);
@@ -147,8 +145,16 @@ export class SQLiteDatabaseTasks {
     const sql = getFs().readFileSync(filename, "utf8");
     const adapter = await this.connectAdapter();
     try {
-      for (const statement of splitSqlStatements(sql)) {
-        await adapter.executeMutation(statement);
+      // SQLite's `db.exec` runs an entire script in one shot, so it's safe
+      // for dumps containing trigger bodies (CREATE TRIGGER ... BEGIN ...;
+      // ...; END) where naive semicolon splitting would break.
+      const exec = (adapter as unknown as { exec?: (sql: string) => void }).exec;
+      if (typeof exec === "function") {
+        exec.call(adapter, sql);
+      } else {
+        for (const statement of splitSqlStatements(sql)) {
+          await adapter.executeMutation(statement);
+        }
       }
     } finally {
       await this.closeAdapter(adapter);

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -56,12 +56,33 @@ export class SQLiteDatabaseTasks {
   }
 
   async purge(): Promise<void> {
+    await this.disconnect();
     try {
       await this.drop();
     } catch (error) {
       if (!(error instanceof NoDatabaseError)) throw error;
     }
     await this.create();
+    await this.reconnect();
+  }
+
+  private async disconnect(): Promise<void> {
+    try {
+      const { Base } = await import("../base.js");
+      const existing = (Base as unknown as { adapter?: { close?: () => Promise<void> } }).adapter;
+      if (existing && typeof existing.close === "function") await existing.close();
+    } catch {
+      // best effort
+    }
+  }
+
+  private async reconnect(): Promise<void> {
+    try {
+      const { Base } = await import("../base.js");
+      await Base.establishConnection({ adapter: "sqlite3", database: this.resolveDbPath() });
+    } catch {
+      // best effort
+    }
   }
 
   charset(): string {
@@ -106,6 +127,10 @@ export class SQLiteDatabaseTasks {
       drop: async (config) => new SQLiteDatabaseTasks(config).drop(),
       purge: async (config) => new SQLiteDatabaseTasks(config).purge(),
       charset: async (config) => new SQLiteDatabaseTasks(config).charset(),
+      structureDump: async (config, filename, flags) =>
+        new SQLiteDatabaseTasks(config).structureDump(filename, flags),
+      structureLoad: async (config, filename, flags) =>
+        new SQLiteDatabaseTasks(config).structureLoad(filename, flags),
     });
   }
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -1,0 +1,123 @@
+/**
+ * SQLiteDatabaseTasks — SQLite-specific database lifecycle operations.
+ *
+ * Mirrors: ActiveRecord::Tasks::SQLiteDatabaseTasks
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import type { DatabaseConfig } from "../database-configurations/database-config.js";
+import { DatabaseTasks } from "./database-tasks.js";
+import { NoDatabaseError, DatabaseAlreadyExists } from "../errors.js";
+
+export class SQLiteDatabaseTasks {
+  private readonly dbConfig: DatabaseConfig;
+  private readonly root: string;
+
+  static usingDatabaseConfigurations(): boolean {
+    return true;
+  }
+
+  constructor(dbConfig: DatabaseConfig, root: string = DatabaseTasks.root) {
+    this.dbConfig = dbConfig;
+    this.root = root;
+  }
+
+  async create(): Promise<void> {
+    const dbPath = this.resolveDbPath();
+    if (dbPath !== ":memory:" && fs.existsSync(dbPath)) {
+      throw new DatabaseAlreadyExists(`Database '${dbPath}' already exists`);
+    }
+    if (dbPath !== ":memory:") {
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      fs.writeFileSync(dbPath, "");
+    }
+  }
+
+  async drop(): Promise<void> {
+    const dbPath = this.resolveDbPath();
+    if (dbPath === ":memory:") return;
+    try {
+      fs.unlinkSync(dbPath);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new NoDatabaseError((error as Error).message);
+      }
+      throw error;
+    }
+    for (const suffix of ["-shm", "-wal"]) {
+      try {
+        fs.unlinkSync(dbPath + suffix);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  async purge(): Promise<void> {
+    try {
+      await this.drop();
+    } catch (error) {
+      if (!(error instanceof NoDatabaseError)) throw error;
+    }
+    await this.create();
+  }
+
+  charset(): string {
+    return "UTF-8";
+  }
+
+  structureDump(filename: string, extraFlags?: string | string[] | null): void {
+    const args: string[] = [];
+    if (extraFlags) {
+      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    args.push(this.resolveDbPath());
+    args.push(".schema --nosys");
+    this.runCmd("sqlite3", args, filename);
+  }
+
+  structureLoad(filename: string, extraFlags?: string | string[] | null): void {
+    const args: string[] = [];
+    if (extraFlags) {
+      args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
+    }
+    args.push(this.resolveDbPath());
+    const sql = fs.readFileSync(filename, "utf8");
+    const result = spawnSync("sqlite3", args, { input: sql, encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error(`failed to execute:\nsqlite3 ${args.join(" ")}\n\n${result.stderr ?? ""}`);
+    }
+  }
+
+  private resolveDbPath(): string {
+    const database = this.dbConfig.database;
+    if (!database) {
+      throw new Error("SQLite database configuration missing 'database' path");
+    }
+    if (database === ":memory:" || path.isAbsolute(database)) return database;
+    return path.join(this.root, database);
+  }
+
+  static register(): void {
+    DatabaseTasks.registerTask(/sqlite/, {
+      create: async (config) => new SQLiteDatabaseTasks(config).create(),
+      drop: async (config) => new SQLiteDatabaseTasks(config).drop(),
+      purge: async (config) => new SQLiteDatabaseTasks(config).purge(),
+      charset: async (config) => new SQLiteDatabaseTasks(config).charset(),
+    });
+  }
+
+  private runCmd(cmd: string, args: string[], outFile: string): void {
+    const result = spawnSync(cmd, args, { encoding: "utf8" });
+    if (result.status !== 0) {
+      const msg =
+        `failed to execute:\n${cmd} ${args.join(" ")}\n\n` +
+        `Please check the output above for any errors and make sure that ` +
+        `\`${cmd}\` is installed in your PATH and has proper permissions.\n\n`;
+      throw new Error(msg);
+    }
+    fs.writeFileSync(outFile, result.stdout ?? "");
+  }
+}

--- a/packages/activerecord/src/tasks/task-utils.ts
+++ b/packages/activerecord/src/tasks/task-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared helpers for DatabaseTasks and the per-adapter task classes.
+ */
+
+export function coercePort(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -55,10 +55,13 @@ type NodeChildProcess = {
 function wrap(cp: NodeChildProcess): ChildProcessAdapter {
   return {
     spawnSync(cmd, args, options) {
+      // Only default encoding when it was left undefined. Preserve an
+      // explicit `null` so callers can opt out of string decoding.
+      const encoding = options && "encoding" in options ? options.encoding : "utf8";
       const result = cp.spawnSync(cmd, args, {
         input: options?.input,
         env: options?.env,
-        encoding: options?.encoding ?? "utf8",
+        encoding,
         cwd: options?.cwd,
       });
       return {
@@ -72,6 +75,16 @@ function wrap(cp: NodeChildProcess): ChildProcessAdapter {
   };
 }
 
+/**
+ * Sync auto-registration of the node implementation.
+ *
+ * Works under CommonJS (where `require` is a global). In pure Node ESM the
+ * sync path cannot synchronously pull in `node:child_process` without a
+ * top-level static import of `node:module` (which would break browser
+ * bundles that consume this package). Consumers running under ESM should
+ * call {@link getChildProcessAsync} instead — it uses dynamic
+ * `import("node:child_process")` and works everywhere.
+ */
 function tryAutoRegisterNode(): boolean {
   if (registry.has("node")) return true;
   if (nodeAttempted) return false;
@@ -80,16 +93,15 @@ function tryAutoRegisterNode(): boolean {
     if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
       return false;
     }
-    const nodeModule =
-      typeof require !== "undefined"
-        ? // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require("node:module")
-        : null;
-    if (!nodeModule) return false;
+    if (typeof require === "undefined") return false;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nodeModule = require("node:module") as {
+      createRequire: (from: string | URL) => NodeRequire;
+    };
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const cp = req("node:child_process") as NodeChildProcess;
+    const cp = req("node:child_process") as unknown as NodeChildProcess;
     registry.set("node", wrap(cp));
     return true;
   } catch {

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -2,7 +2,7 @@
  * Child-process adapter — mirrors the Rails adapter pattern.
  *
  * Exposes a minimal synchronous `spawnSync`-like API so higher-level packages
- * (activerecord tasks, railties CLI) can shell out to external tools without
+ * (activerecord tasks, trailties CLI) can shell out to external tools without
  * taking a direct dependency on `node:child_process`.
  */
 

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -1,0 +1,112 @@
+/**
+ * Child-process adapter — mirrors the Rails adapter pattern.
+ *
+ * Exposes a minimal synchronous `spawnSync`-like API so higher-level packages
+ * (activerecord tasks, railties CLI) can shell out to external tools without
+ * taking a direct dependency on `node:child_process`.
+ */
+
+export interface SpawnSyncOptions {
+  input?: string | Uint8Array;
+  env?: NodeJS.ProcessEnv;
+  encoding?: "utf8" | "utf-8" | null;
+  cwd?: string;
+}
+
+export interface SpawnSyncResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export interface ChildProcessAdapter {
+  spawnSync(cmd: string, args: string[], options?: SpawnSyncOptions): SpawnSyncResult;
+}
+
+const registry = new Map<string, ChildProcessAdapter>();
+let currentAdapterName: string | null = null;
+let resolved: ChildProcessAdapter | null = null;
+
+export function registerChildProcessAdapter(name: string, adapter: ChildProcessAdapter): void {
+  registry.set(name, adapter);
+  if (name === currentAdapterName) resolved = null;
+}
+
+let nodeAttempted = false;
+
+function tryAutoRegisterNode(): boolean {
+  if (registry.has("node")) return true;
+  if (nodeAttempted) return false;
+  nodeAttempted = true;
+  try {
+    if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
+      return false;
+    }
+    const nodeModule =
+      typeof require !== "undefined"
+        ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+          require("node:module")
+        : null;
+    if (!nodeModule) return false;
+    const req = nodeModule.createRequire(
+      typeof __filename !== "undefined" ? __filename : "file:///activesupport",
+    );
+    const cp = req("node:child_process") as {
+      spawnSync: (cmd: string, args: string[], opts?: unknown) => SpawnSyncResult;
+    };
+    registry.set("node", {
+      spawnSync(cmd, args, options) {
+        const result = cp.spawnSync(cmd, args, {
+          input: options?.input,
+          env: options?.env,
+          encoding: options?.encoding ?? "utf8",
+          cwd: options?.cwd,
+        });
+        return {
+          status: result.status,
+          signal: result.signal,
+          stdout: typeof result.stdout === "string" ? result.stdout : String(result.stdout ?? ""),
+          stderr: typeof result.stderr === "string" ? result.stderr : String(result.stderr ?? ""),
+          error: result.error,
+        };
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolve(): ChildProcessAdapter {
+  if (resolved) return resolved;
+  const name = currentAdapterName;
+  if (name) {
+    const reg = registry.get(name);
+    if (!reg) throw new Error(`Child-process adapter "${name}" is not registered.`);
+    resolved = reg;
+    return reg;
+  }
+  if (tryAutoRegisterNode()) {
+    resolved = registry.get("node")!;
+    return resolved;
+  }
+  throw new Error(
+    "No child-process adapter configured. Set ActiveSupport.childProcessAdapter or register a custom adapter.",
+  );
+}
+
+export function getChildProcess(): ChildProcessAdapter {
+  return resolve();
+}
+
+export const childProcessAdapterConfig = {
+  get adapter(): string | null {
+    return currentAdapterName;
+  },
+  set adapter(name: string | null) {
+    currentAdapterName = name;
+    resolved = null;
+  },
+};

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -35,6 +35,31 @@ export function registerChildProcessAdapter(name: string, adapter: ChildProcessA
 }
 
 let nodeAttempted = false;
+let nodeAsyncPromise: Promise<boolean> | null = null;
+
+type NodeChildProcess = {
+  spawnSync: (cmd: string, args: string[], opts?: unknown) => SpawnSyncResult;
+};
+
+function wrap(cp: NodeChildProcess): ChildProcessAdapter {
+  return {
+    spawnSync(cmd, args, options) {
+      const result = cp.spawnSync(cmd, args, {
+        input: options?.input,
+        env: options?.env,
+        encoding: options?.encoding ?? "utf8",
+        cwd: options?.cwd,
+      });
+      return {
+        status: result.status,
+        signal: result.signal,
+        stdout: typeof result.stdout === "string" ? result.stdout : String(result.stdout ?? ""),
+        stderr: typeof result.stderr === "string" ? result.stderr : String(result.stderr ?? ""),
+        error: result.error,
+      };
+    },
+  };
+}
 
 function tryAutoRegisterNode(): boolean {
   if (registry.has("node")) return true;
@@ -53,30 +78,31 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const cp = req("node:child_process") as {
-      spawnSync: (cmd: string, args: string[], opts?: unknown) => SpawnSyncResult;
-    };
-    registry.set("node", {
-      spawnSync(cmd, args, options) {
-        const result = cp.spawnSync(cmd, args, {
-          input: options?.input,
-          env: options?.env,
-          encoding: options?.encoding ?? "utf8",
-          cwd: options?.cwd,
-        });
-        return {
-          status: result.status,
-          signal: result.signal,
-          stdout: typeof result.stdout === "string" ? result.stdout : String(result.stdout ?? ""),
-          stderr: typeof result.stderr === "string" ? result.stderr : String(result.stderr ?? ""),
-          error: result.error,
-        };
-      },
-    });
+    const cp = req("node:child_process") as NodeChildProcess;
+    registry.set("node", wrap(cp));
     return true;
   } catch {
     return false;
   }
+}
+
+function tryAutoRegisterNodeAsync(): Promise<boolean> {
+  if (registry.has("node")) return Promise.resolve(true);
+  if (!nodeAsyncPromise) {
+    nodeAsyncPromise = (async () => {
+      try {
+        if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
+          return false;
+        }
+        const cp = (await import("node:child_process")) as unknown as NodeChildProcess;
+        registry.set("node", wrap(cp));
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  return nodeAsyncPromise;
 }
 
 function resolve(): ChildProcessAdapter {
@@ -97,8 +123,26 @@ function resolve(): ChildProcessAdapter {
   );
 }
 
+async function resolveAsync(): Promise<ChildProcessAdapter> {
+  const name = currentAdapterName;
+  try {
+    return resolve();
+  } catch (error) {
+    if (name) throw error;
+    if (await tryAutoRegisterNodeAsync()) {
+      resolved = registry.get("node")!;
+      return resolved;
+    }
+    throw error;
+  }
+}
+
 export function getChildProcess(): ChildProcessAdapter {
   return resolve();
+}
+
+export async function getChildProcessAsync(): Promise<ChildProcessAdapter> {
+  return resolveAsync();
 }
 
 export const childProcessAdapterConfig = {

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -37,8 +37,19 @@ export function registerChildProcessAdapter(name: string, adapter: ChildProcessA
 let nodeAttempted = false;
 let nodeAsyncPromise: Promise<boolean> | null = null;
 
+// Node's child_process.spawnSync returns stdout/stderr as Buffer|string
+// depending on the encoding option. Keep the Node-side shape permissive and
+// normalize to string at the adapter boundary.
+type NodeSpawnSyncResult = {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: unknown;
+  stderr: unknown;
+  error?: Error;
+};
+
 type NodeChildProcess = {
-  spawnSync: (cmd: string, args: string[], opts?: unknown) => SpawnSyncResult;
+  spawnSync: (cmd: string, args: string[], opts?: unknown) => NodeSpawnSyncResult;
 };
 
 function wrap(cp: NodeChildProcess): ChildProcessAdapter {

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -9,7 +9,12 @@
 export interface SpawnSyncOptions {
   input?: string | Uint8Array;
   env?: NodeJS.ProcessEnv;
-  encoding?: "utf8" | "utf-8" | null;
+  /**
+   * Output encoding for stdout/stderr. The adapter always returns decoded
+   * strings, so only UTF-8 variants are accepted here. If a caller needs
+   * raw bytes they should use `node:child_process` directly.
+   */
+  encoding?: "utf8" | "utf-8";
   cwd?: string;
 }
 
@@ -55,13 +60,10 @@ type NodeChildProcess = {
 function wrap(cp: NodeChildProcess): ChildProcessAdapter {
   return {
     spawnSync(cmd, args, options) {
-      // Only default encoding when it was left undefined. Preserve an
-      // explicit `null` so callers can opt out of string decoding.
-      const encoding = options && "encoding" in options ? options.encoding : "utf8";
       const result = cp.spawnSync(cmd, args, {
         input: options?.input,
         env: options?.env,
-        encoding,
+        encoding: options?.encoding ?? "utf8",
         cwd: options?.cwd,
       });
       return {

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -42,6 +42,7 @@ export interface FsAdapter {
   ): number;
   closeSync(fd: number): void;
   copyFileSync(src: string, dest: string): void;
+  mkdtempSync(prefix: string): string;
 }
 
 export interface PathAdapter {
@@ -50,6 +51,7 @@ export interface PathAdapter {
   basename(p: string): string;
   resolve(...parts: string[]): string;
   extname(p: string): string;
+  isAbsolute(p: string): boolean;
   sep: string;
 }
 

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -42,7 +42,12 @@ export interface FsAdapter {
   ): number;
   closeSync(fd: number): void;
   copyFileSync(src: string, dest: string): void;
-  mkdtempSync(prefix: string): string;
+  /**
+   * Create a unique temp directory (optional — not all filesystems support
+   * atomic uniqueness). Only used by server-side database tasks; custom
+   * adapters may omit it.
+   */
+  mkdtempSync?(prefix: string): string;
 }
 
 export interface PathAdapter {
@@ -51,9 +56,18 @@ export interface PathAdapter {
   basename(p: string): string;
   resolve(...parts: string[]): string;
   extname(p: string): string;
-  isAbsolute(p: string): boolean;
-  /** Convert an absolute filesystem path to a `file://` URL (RFC 8089). */
-  pathToFileURL(p: string): URL;
+  /**
+   * Optional — adapters that don't model absolute paths (e.g. in-memory
+   * VFS) can omit this. When undefined, callers should treat any path as
+   * absolute.
+   */
+  isAbsolute?(p: string): boolean;
+  /**
+   * Optional — convert an absolute filesystem path to a `file://` URL
+   * (RFC 8089). Only used by server-side paths that call dynamic `import()`
+   * on disk files.
+   */
+  pathToFileURL?(p: string): URL;
   sep: string;
 }
 
@@ -92,7 +106,7 @@ function tryAutoRegisterNode(): boolean {
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
     const fs = req("node:fs") as FsAdapter;
-    const nodePath = req("node:path") as Omit<PathAdapter, "pathToFileURL">;
+    const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;
     const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
     const path: PathAdapter = {
       join: (...parts) => nodePath.join(...parts),
@@ -120,9 +134,8 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
           return false;
         }
         const fs = (await import("node:fs")) as unknown as FsAdapter;
-        const nodePath = (await import("node:path")) as unknown as Omit<
-          PathAdapter,
-          "pathToFileURL"
+        const nodePath = (await import("node:path")) as unknown as Required<
+          Omit<PathAdapter, "pathToFileURL">
         >;
         const nodeUrl = (await import("node:url")) as { pathToFileURL(p: string): URL };
         const path: PathAdapter = {

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -52,6 +52,8 @@ export interface PathAdapter {
   resolve(...parts: string[]): string;
   extname(p: string): string;
   isAbsolute(p: string): boolean;
+  /** Convert an absolute filesystem path to a `file://` URL (RFC 8089). */
+  pathToFileURL(p: string): URL;
   sep: string;
 }
 
@@ -90,7 +92,18 @@ function tryAutoRegisterNode(): boolean {
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
     const fs = req("node:fs") as FsAdapter;
-    const path = req("node:path") as PathAdapter;
+    const nodePath = req("node:path") as Omit<PathAdapter, "pathToFileURL">;
+    const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
+    const path: PathAdapter = {
+      join: (...parts) => nodePath.join(...parts),
+      dirname: (p) => nodePath.dirname(p),
+      basename: (p) => nodePath.basename(p),
+      resolve: (...parts) => nodePath.resolve(...parts),
+      extname: (p) => nodePath.extname(p),
+      isAbsolute: (p) => nodePath.isAbsolute(p),
+      pathToFileURL: (p) => nodeUrl.pathToFileURL(p),
+      sep: nodePath.sep,
+    };
     registry.set("node", { fs, path });
     return true;
   } catch {
@@ -107,7 +120,21 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
           return false;
         }
         const fs = (await import("node:fs")) as unknown as FsAdapter;
-        const path = (await import("node:path")) as unknown as PathAdapter;
+        const nodePath = (await import("node:path")) as unknown as Omit<
+          PathAdapter,
+          "pathToFileURL"
+        >;
+        const nodeUrl = (await import("node:url")) as { pathToFileURL(p: string): URL };
+        const path: PathAdapter = {
+          join: (...parts) => nodePath.join(...parts),
+          dirname: (p) => nodePath.dirname(p),
+          basename: (p) => nodePath.basename(p),
+          resolve: (...parts) => nodePath.resolve(...parts),
+          extname: (p) => nodePath.extname(p),
+          isAbsolute: (p) => nodePath.isAbsolute(p),
+          pathToFileURL: (p) => nodeUrl.pathToFileURL(p),
+          sep: nodePath.sep,
+        };
         registry.set("node", { fs, path });
         return true;
       } catch {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -24,9 +24,25 @@ export {
 } from "./async-context-adapter.js";
 export type { AsyncContext, AsyncContextAdapter } from "./async-context-adapter.js";
 
+export {
+  registerChildProcessAdapter,
+  getChildProcess,
+  childProcessAdapterConfig,
+} from "./child-process-adapter.js";
+export type {
+  ChildProcessAdapter,
+  SpawnSyncOptions,
+  SpawnSyncResult,
+} from "./child-process-adapter.js";
+
+export { registerOsAdapter, getOs, osAdapterConfig } from "./os-adapter.js";
+export type { OsAdapter } from "./os-adapter.js";
+
 import { fsAdapterConfig } from "./fs-adapter.js";
 import { cryptoAdapterConfig } from "./crypto-adapter.js";
 import { asyncContextAdapterConfig } from "./async-context-adapter.js";
+import { childProcessAdapterConfig } from "./child-process-adapter.js";
+import { osAdapterConfig } from "./os-adapter.js";
 
 /**
  * ActiveSupport configuration — mirrors Rails' ActiveSupport module.
@@ -62,6 +78,20 @@ export const ActiveSupport = {
   },
   set asyncContextAdapter(name: string | null) {
     asyncContextAdapterConfig.adapter = name;
+  },
+
+  get childProcessAdapter(): string | null {
+    return childProcessAdapterConfig.adapter;
+  },
+  set childProcessAdapter(name: string | null) {
+    childProcessAdapterConfig.adapter = name;
+  },
+
+  get osAdapter(): string | null {
+    return osAdapterConfig.adapter;
+  },
+  set osAdapter(name: string | null) {
+    osAdapterConfig.adapter = name;
   },
 };
 

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -27,6 +27,7 @@ export type { AsyncContext, AsyncContextAdapter } from "./async-context-adapter.
 export {
   registerChildProcessAdapter,
   getChildProcess,
+  getChildProcessAsync,
   childProcessAdapterConfig,
 } from "./child-process-adapter.js";
 export type {
@@ -35,7 +36,7 @@ export type {
   SpawnSyncResult,
 } from "./child-process-adapter.js";
 
-export { registerOsAdapter, getOs, osAdapterConfig } from "./os-adapter.js";
+export { registerOsAdapter, getOs, getOsAsync, osAdapterConfig } from "./os-adapter.js";
 export type { OsAdapter } from "./os-adapter.js";
 
 import { fsAdapterConfig } from "./fs-adapter.js";

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -9,6 +9,12 @@ export interface OsAdapter {
   tmpdir(): string;
   /** Normalized platform id, e.g. "linux", "darwin", "win32". */
   platform(): string;
+  /**
+   * Current working directory. On Node this is `process.cwd()`. Adapters
+   * for non-Node runtimes should return the logical root they'd like
+   * relative paths resolved against.
+   */
+  cwd(): string;
 }
 
 const registry = new Map<string, OsAdapter>();
@@ -21,6 +27,21 @@ export function registerOsAdapter(name: string, adapter: OsAdapter): void {
 }
 
 let nodeAttempted = false;
+let nodeAsyncPromise: Promise<boolean> | null = null;
+
+type NodeOs = { tmpdir: () => string; platform: () => string };
+
+function wrap(os: NodeOs): OsAdapter {
+  return {
+    tmpdir: () => os.tmpdir(),
+    platform: () => os.platform(),
+    cwd: () => {
+      const proc = (globalThis as { process?: { cwd?: () => string } }).process;
+      if (proc && typeof proc.cwd === "function") return proc.cwd();
+      throw new Error("process.cwd() is unavailable in this runtime");
+    },
+  };
+}
 
 function tryAutoRegisterNode(): boolean {
   if (registry.has("node")) return true;
@@ -39,12 +60,31 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const os = req("node:os") as { tmpdir: () => string; platform: () => string };
-    registry.set("node", { tmpdir: () => os.tmpdir(), platform: () => os.platform() });
+    const os = req("node:os") as NodeOs;
+    registry.set("node", wrap(os));
     return true;
   } catch {
     return false;
   }
+}
+
+function tryAutoRegisterNodeAsync(): Promise<boolean> {
+  if (registry.has("node")) return Promise.resolve(true);
+  if (!nodeAsyncPromise) {
+    nodeAsyncPromise = (async () => {
+      try {
+        if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
+          return false;
+        }
+        const os = (await import("node:os")) as unknown as NodeOs;
+        registry.set("node", wrap(os));
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  return nodeAsyncPromise;
 }
 
 function resolve(): OsAdapter {
@@ -65,8 +105,26 @@ function resolve(): OsAdapter {
   );
 }
 
+async function resolveAsync(): Promise<OsAdapter> {
+  const name = currentAdapterName;
+  try {
+    return resolve();
+  } catch (error) {
+    if (name) throw error;
+    if (await tryAutoRegisterNodeAsync()) {
+      resolved = registry.get("node")!;
+      return resolved;
+    }
+    throw error;
+  }
+}
+
 export function getOs(): OsAdapter {
   return resolve();
+}
+
+export async function getOsAsync(): Promise<OsAdapter> {
+  return resolveAsync();
 }
 
 export const osAdapterConfig = {

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -7,6 +7,8 @@
 
 export interface OsAdapter {
   tmpdir(): string;
+  /** Normalized platform id, e.g. "linux", "darwin", "win32". */
+  platform(): string;
 }
 
 const registry = new Map<string, OsAdapter>();
@@ -37,8 +39,8 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const os = req("node:os") as { tmpdir: () => string };
-    registry.set("node", { tmpdir: () => os.tmpdir() });
+    const os = req("node:os") as { tmpdir: () => string; platform: () => string };
+    registry.set("node", { tmpdir: () => os.tmpdir(), platform: () => os.platform() });
     return true;
   } catch {
     return false;

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -1,0 +1,78 @@
+/**
+ * OS adapter — mirrors the Rails adapter pattern.
+ *
+ * Exposes the few `node:os` surfaces higher-level packages need (currently
+ * just `tmpdir`) so they can avoid importing `node:os` directly.
+ */
+
+export interface OsAdapter {
+  tmpdir(): string;
+}
+
+const registry = new Map<string, OsAdapter>();
+let currentAdapterName: string | null = null;
+let resolved: OsAdapter | null = null;
+
+export function registerOsAdapter(name: string, adapter: OsAdapter): void {
+  registry.set(name, adapter);
+  if (name === currentAdapterName) resolved = null;
+}
+
+let nodeAttempted = false;
+
+function tryAutoRegisterNode(): boolean {
+  if (registry.has("node")) return true;
+  if (nodeAttempted) return false;
+  nodeAttempted = true;
+  try {
+    if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
+      return false;
+    }
+    const nodeModule =
+      typeof require !== "undefined"
+        ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+          require("node:module")
+        : null;
+    if (!nodeModule) return false;
+    const req = nodeModule.createRequire(
+      typeof __filename !== "undefined" ? __filename : "file:///activesupport",
+    );
+    const os = req("node:os") as { tmpdir: () => string };
+    registry.set("node", { tmpdir: () => os.tmpdir() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolve(): OsAdapter {
+  if (resolved) return resolved;
+  const name = currentAdapterName;
+  if (name) {
+    const reg = registry.get(name);
+    if (!reg) throw new Error(`OS adapter "${name}" is not registered.`);
+    resolved = reg;
+    return reg;
+  }
+  if (tryAutoRegisterNode()) {
+    resolved = registry.get("node")!;
+    return resolved;
+  }
+  throw new Error(
+    "No OS adapter configured. Set ActiveSupport.osAdapter or register a custom adapter.",
+  );
+}
+
+export function getOs(): OsAdapter {
+  return resolve();
+}
+
+export const osAdapterConfig = {
+  get adapter(): string | null {
+    return currentAdapterName;
+  },
+  set adapter(name: string | null) {
+    currentAdapterName = name;
+    resolved = null;
+  },
+};

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -44,6 +44,15 @@ function wrap(os: NodeOs): OsAdapter {
   };
 }
 
+/**
+ * Sync auto-registration of the node implementation.
+ *
+ * Works under CommonJS. In pure Node ESM the sync path cannot synchronously
+ * pull in `node:os` without a top-level static import of `node:module`
+ * (which would break browser bundles). Consumers running under ESM should
+ * call {@link getOsAsync} instead — it uses dynamic `import("node:os")`
+ * and works everywhere.
+ */
 function tryAutoRegisterNode(): boolean {
   if (registry.has("node")) return true;
   if (nodeAttempted) return false;
@@ -52,12 +61,11 @@ function tryAutoRegisterNode(): boolean {
     if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
       return false;
     }
-    const nodeModule =
-      typeof require !== "undefined"
-        ? // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require("node:module")
-        : null;
-    if (!nodeModule) return false;
+    if (typeof require === "undefined") return false;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nodeModule = require("node:module") as {
+      createRequire: (from: string | URL) => NodeRequire;
+    };
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -1,8 +1,9 @@
 /**
  * OS adapter — mirrors the Rails adapter pattern.
  *
- * Exposes the few `node:os` surfaces higher-level packages need (currently
- * just `tmpdir`) so they can avoid importing `node:os` directly.
+ * Exposes the few runtime surfaces higher-level packages need (`tmpdir`,
+ * `platform`, `cwd`) so they can avoid importing `node:os` / `process`
+ * directly.
  */
 
 export interface OsAdapter {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -328,8 +328,9 @@ describe("schema dump and load", () => {
       const defineSchema = new Function(
         "ctx",
         schema
+          .replace(/\/\*\*[\s\S]*?\*\/\s*/, "")
           .replace(
-            "export default async function defineSchema(ctx: any) {",
+            /export default async function defineSchema\(ctx(?:: any)?\) \{/,
             "return (async () => {",
           )
           .replace(/}$/, "})();"),

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -319,7 +319,9 @@ describe("schema dump and load", () => {
 
       // Dump schema
       const source = new AdapterSchemaSource(sourceAdapter);
-      const schema = await SchemaDumper.dump(source);
+      // Dump as JS so the JSDoc-annotated output is valid input to
+      // `new Function` below (no TS `import type` / annotation syntax).
+      const schema = await SchemaDumper.dump(source, { language: "js" });
       expect(schema).toContain("users");
       expect(schema).toContain("createTable");
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -328,7 +328,11 @@ describe("schema dump and load", () => {
       const defineSchema = new Function(
         "ctx",
         schema
-          .replace(/\/\*\*[\s\S]*?\*\/\s*/, "")
+          // Strip only the header JSDoc (first /** ... */ before the
+          // export statement). Anchored to start-of-string with optional
+          // leading // line comments / blank lines so later block comments
+          // in the body aren't clobbered.
+          .replace(/^(?:\s*\/\/[^\n]*\n)*\s*\/\*\*[\s\S]*?\*\/\s*/, "")
           .replace(
             /export default async function defineSchema\(ctx(?:: any)?\) \{/,
             "return (async () => {",

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -168,15 +168,25 @@ async function runSeed(): Promise<void> {
   console.log("Seeds completed.");
 }
 
+function displayNameFor(config: HashConfig, raw: RawConfig): string {
+  return (
+    config.database ??
+    (raw.database as string | undefined) ??
+    (typeof raw.url === "string" ? raw.url : undefined) ??
+    `${config.adapter ?? "unknown"} database`
+  );
+}
+
 async function runCreate(): Promise<void> {
   const raw = await loadDatabaseConfig();
   const config = toDbConfig(raw);
+  const displayName = displayNameFor(config, raw);
   try {
     await DatabaseTasks.create(config);
-    if (config.database) console.log(`Created database '${config.database}'`);
+    console.log(`Created database '${displayName}'`);
   } catch (error) {
     if (error instanceof DatabaseAlreadyExists) {
-      console.error(`Database '${config.database}' already exists`);
+      console.error(`Database '${displayName}' already exists`);
       return;
     }
     throw error;
@@ -186,12 +196,13 @@ async function runCreate(): Promise<void> {
 async function runDrop(): Promise<void> {
   const raw = await loadDatabaseConfig();
   const config = toDbConfig(raw);
+  const displayName = displayNameFor(config, raw);
   try {
     await DatabaseTasks.drop(config);
-    if (config.database) console.log(`Dropped database '${config.database}'`);
+    console.log(`Dropped database '${displayName}'`);
   } catch (error) {
     if (error instanceof NoDatabaseError) {
-      console.error(`Database '${config.database}' does not exist`);
+      console.error(`Database '${displayName}' does not exist`);
       return;
     }
     throw error;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -168,11 +168,25 @@ async function runSeed(): Promise<void> {
   console.log("Seeds completed.");
 }
 
+/** Strip credentials from a DB URL before we log it. */
+function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) parsed.password = "***";
+    if (parsed.username && parsed.password === "***") {
+      // Keep username visible so operators can still identify the connection.
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 function displayNameFor(config: HashConfig, raw: RawConfig): string {
   return (
     config.database ??
     (raw.database as string | undefined) ??
-    (typeof raw.url === "string" ? raw.url : undefined) ??
+    (typeof raw.url === "string" ? sanitizeUrl(raw.url) : undefined) ??
     `${config.adapter ?? "unknown"} database`
   );
 }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -39,6 +39,31 @@ function migrationsDir(): string {
   return path.join(process.cwd(), "db", "migrations");
 }
 
+function databaseFromUrl(url: string, adapter?: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const protocol = parsed.protocol;
+    const isSqlite =
+      adapter === "sqlite3" ||
+      adapter === "sqlite" ||
+      protocol === "sqlite:" ||
+      protocol === "sqlite3:" ||
+      protocol === "file:";
+    if (isSqlite) {
+      // SQLite URLs carry a filesystem path (often absolute). Preserve the
+      // leading slash and host prefix if any: `sqlite3:///tmp/app.sqlite3`
+      // -> `/tmp/app.sqlite3`; `sqlite3://./rel.sqlite3` -> `./rel.sqlite3`.
+      const host = parsed.host;
+      const pathname = decodeURIComponent(parsed.pathname);
+      return host ? `${host}${pathname}` : pathname;
+    }
+    const name = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+    return name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function inferAdapterFromUrl(url: string): string | undefined {
   try {
     switch (new URL(url).protocol) {
@@ -71,16 +96,25 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
     if (!normalized.adapter) normalized.adapter = "sqlite3";
   }
   if (!normalized.database && typeof normalized.url === "string") {
+    const db = databaseFromUrl(normalized.url, normalized.adapter as string | undefined);
+    if (db) normalized.database = db;
     try {
       const parsed = new URL(normalized.url);
-      const name = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
-      if (name) normalized.database = name;
-      if (!normalized.host && parsed.hostname) normalized.host = parsed.hostname;
-      if (!normalized.username && parsed.username) {
-        normalized.username = decodeURIComponent(parsed.username);
-      }
-      if (!normalized.password && parsed.password) {
-        normalized.password = decodeURIComponent(parsed.password);
+      const protocol = parsed.protocol;
+      const isSqlite =
+        normalized.adapter === "sqlite3" ||
+        normalized.adapter === "sqlite" ||
+        protocol === "sqlite:" ||
+        protocol === "sqlite3:" ||
+        protocol === "file:";
+      if (!isSqlite) {
+        if (!normalized.host && parsed.hostname) normalized.host = parsed.hostname;
+        if (!normalized.username && parsed.username) {
+          normalized.username = decodeURIComponent(parsed.username);
+        }
+        if (!normalized.password && parsed.password) {
+          normalized.password = decodeURIComponent(parsed.password);
+        }
       }
     } catch {
       // leave unparsed url as-is; adapters will surface the error

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -39,9 +39,37 @@ function migrationsDir(): string {
   return path.join(process.cwd(), "db", "migrations");
 }
 
+function inferAdapterFromUrl(url: string): string | undefined {
+  try {
+    switch (new URL(url).protocol) {
+      case "postgres:":
+      case "postgresql:":
+        return "postgresql";
+      case "mysql:":
+      case "mysql2:":
+      case "trilogy:":
+        return "mysql2";
+      case "sqlite:":
+      case "sqlite3:":
+      case "file:":
+        return "sqlite3";
+      default:
+        return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
 function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig {
   const normalized: Record<string, unknown> = { ...raw };
-  if (!normalized.adapter) normalized.adapter = "sqlite3";
+  if (!normalized.adapter) {
+    if (typeof normalized.url === "string") {
+      const inferred = inferAdapterFromUrl(normalized.url);
+      if (inferred) normalized.adapter = inferred;
+    }
+    if (!normalized.adapter) normalized.adapter = "sqlite3";
+  }
   if (!normalized.database && typeof normalized.url === "string") {
     try {
       const parsed = new URL(normalized.url);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -40,7 +40,25 @@ function migrationsDir(): string {
 }
 
 function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig {
-  return new HashConfig(envName, "primary", raw as Record<string, unknown>);
+  const normalized: Record<string, unknown> = { ...raw };
+  if (!normalized.adapter) normalized.adapter = "sqlite3";
+  if (!normalized.database && typeof normalized.url === "string") {
+    try {
+      const parsed = new URL(normalized.url);
+      const name = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+      if (name) normalized.database = name;
+      if (!normalized.host && parsed.hostname) normalized.host = parsed.hostname;
+      if (!normalized.username && parsed.username) {
+        normalized.username = decodeURIComponent(parsed.username);
+      }
+      if (!normalized.password && parsed.password) {
+        normalized.password = decodeURIComponent(parsed.password);
+      }
+    } catch {
+      // leave unparsed url as-is; adapters will surface the error
+    }
+  }
+  return new HashConfig(envName, "primary", normalized);
 }
 
 async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -2,55 +2,27 @@ import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { loadDatabaseConfig, connectAdapter, type DatabaseConfig } from "../database.js";
+import {
+  loadDatabaseConfig,
+  connectAdapter,
+  resolveEnv,
+  type DatabaseConfig as RawConfig,
+} from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import { Migrator, SchemaDumper } from "@blazetrails/activerecord";
+import {
+  DatabaseTasks,
+  HashConfig,
+  Migrator,
+  SchemaDumper,
+  DatabaseAlreadyExists,
+  NoDatabaseError,
+} from "@blazetrails/activerecord";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 import { AdapterSchemaSource } from "../schema-source.js";
 
-// --- Helpers ---
-
-function buildSystemConfig(
-  config: DatabaseConfig,
-  adapterName: string,
-): { systemConfig: DatabaseConfig; dbNameResolved: string } {
-  const isMysql = adapterName === "mysql2" || adapterName === "mysql";
-  const systemDb = isMysql ? undefined : "postgres";
-
-  if (config.url) {
-    const parsed = new URL(config.url);
-    const dbNameResolved = parsed.pathname.replace(/^\//, "");
-    if (!dbNameResolved) {
-      throw new Error(
-        `Could not extract database name from URL. Ensure the URL includes a database path.`,
-      );
-    }
-    parsed.pathname = isMysql ? "/" : "/postgres";
-    return {
-      systemConfig: { ...config, url: parsed.toString(), database: systemDb },
-      dbNameResolved,
-    };
-  }
-
-  const dbNameResolved = config.database!;
-  return {
-    systemConfig: { ...config, url: undefined, database: systemDb },
-    dbNameResolved,
-  };
-}
-
-const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
-
-function validateDbName(name: string): void {
-  if (!VALID_IDENTIFIER.test(name)) {
-    throw new Error(`Invalid database name "${name}". Names must match ${VALID_IDENTIFIER}.`);
-  }
-}
-
 async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
-  if (typeof (adapter as any).close === "function") {
-    await (adapter as any).close();
-  }
+  const maybeClose = (adapter as { close?: () => Promise<void> }).close;
+  if (typeof maybeClose === "function") await maybeClose.call(adapter);
 }
 
 async function withAdapter(fn: (adapter: DatabaseAdapter) => Promise<void>): Promise<void> {
@@ -67,6 +39,10 @@ function migrationsDir(): string {
   return path.join(process.cwd(), "db", "migrations");
 }
 
+function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig {
+  return new HashConfig(envName, "primary", raw as Record<string, unknown>);
+}
+
 async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
@@ -77,14 +53,10 @@ async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Pro
   const migrator = new Migrator(adapter, migrations);
   await migrator.migrate(targetVersion ?? null);
 
-  for (const line of migrator.output) {
-    console.log(line);
-  }
+  for (const line of migrator.output) console.log(line);
 
   const pending = await migrator.pendingMigrations();
-  if (pending.length === 0) {
-    console.log("All migrations are up to date.");
-  }
+  if (pending.length === 0) console.log("All migrations are up to date.");
 }
 
 async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<void> {
@@ -97,9 +69,7 @@ async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<voi
   const migrator = new Migrator(adapter, migrations);
   await migrator.rollback(steps);
 
-  for (const line of migrator.output) {
-    console.log(line);
-  }
+  for (const line of migrator.output) console.log(line);
 }
 
 async function runSeed(): Promise<void> {
@@ -119,65 +89,34 @@ async function runSeed(): Promise<void> {
 }
 
 async function runCreate(): Promise<void> {
-  const config = await loadDatabaseConfig();
-  const adapterName = config.adapter ?? "sqlite3";
-
-  if (adapterName === "sqlite3" || adapterName === "sqlite") {
-    const dbPath = config.database;
-    if (dbPath && dbPath !== ":memory:") {
-      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-      if (!fs.existsSync(dbPath)) {
-        fs.writeFileSync(dbPath, "");
-      }
-      console.log(`Created database '${dbPath}'`);
+  const raw = await loadDatabaseConfig();
+  const config = toDbConfig(raw);
+  try {
+    await DatabaseTasks.create(config);
+    if (config.database) console.log(`Created database '${config.database}'`);
+  } catch (error) {
+    if (error instanceof DatabaseAlreadyExists) {
+      console.error(`Database '${config.database}' already exists`);
+      return;
     }
-  } else {
-    if (!config.database && !config.url) {
-      throw new Error(
-        `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
-      );
-    }
-    const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
-    validateDbName(dbNameResolved);
-    const systemAdapter = await connectAdapter(systemConfig);
-    try {
-      await systemAdapter.executeMutation(`CREATE DATABASE "${dbNameResolved}"`);
-      console.log(`Created database '${dbNameResolved}'`);
-    } finally {
-      await closeAdapter(systemAdapter);
-    }
+    throw error;
   }
 }
 
 async function runDrop(): Promise<void> {
-  const config = await loadDatabaseConfig();
-  const adapterName = config.adapter ?? "sqlite3";
-
-  if (adapterName === "sqlite3" || adapterName === "sqlite") {
-    const dbPath = config.database;
-    if (dbPath && dbPath !== ":memory:" && fs.existsSync(dbPath)) {
-      fs.unlinkSync(dbPath);
-      console.log(`Dropped database '${dbPath}'`);
+  const raw = await loadDatabaseConfig();
+  const config = toDbConfig(raw);
+  try {
+    await DatabaseTasks.drop(config);
+    if (config.database) console.log(`Dropped database '${config.database}'`);
+  } catch (error) {
+    if (error instanceof NoDatabaseError) {
+      console.error(`Database '${config.database}' does not exist`);
+      return;
     }
-  } else {
-    if (!config.database && !config.url) {
-      throw new Error(
-        `No database name specified in config for adapter "${adapterName}". Set the "database" property.`,
-      );
-    }
-    const { systemConfig, dbNameResolved } = buildSystemConfig(config, adapterName);
-    validateDbName(dbNameResolved);
-    const systemAdapter = await connectAdapter(systemConfig);
-    try {
-      await systemAdapter.executeMutation(`DROP DATABASE IF EXISTS "${dbNameResolved}"`);
-      console.log(`Dropped database '${dbNameResolved}'`);
-    } finally {
-      await closeAdapter(systemAdapter);
-    }
+    throw error;
   }
 }
-
-// --- Command definitions ---
 
 export function dbCommand(): Command {
   const cmd = new Command("db");


### PR DESCRIPTION
## Summary

Phase 1 of the full-migration-parity plan. Adds Rails-canonical per-adapter task classes that mirror \`ActiveRecord::Tasks::{SQLite,PostgreSQL,MySQL}DatabaseTasks\`, each self-registering with the \`DatabaseTasks\` module.

- \`SQLiteDatabaseTasks\` — create/drop/purge/charset/structureDump/structureLoad via file ops + \`sqlite3\` CLI
- \`PostgreSQLDatabaseTasks\` — psql/pg_dump with PG* env vars, header-comment stripping
- \`MySQLDatabaseTasks\` — mysqldump/mysql with prepared command options, registers for both mysql and trilogy patterns
- Adds \`DatabaseAlreadyExists\` error class
- Adds \`root\`, \`migrationsPaths\`, \`fixturesPath\`, \`seedLoader\` properties on \`DatabaseTasks\`

## api:compare impact

activerecord: **78.3% → 79.4%** (+30 methods, +3 files at 100%)

- \`tasks/sqlite-database-tasks.ts\`: 8/8 (100%) ✓
- \`tasks/postgresql-database-tasks.ts\`: 9/9 (100%) ✓
- \`tasks/mysql-database-tasks.ts\`: 9/9 (100%) ✓
- \`tasks/database-tasks.ts\`: now 29/53 (55%) — will climb in follow-up PRs

## Scope

This PR is deliberately scoped to the adapter-task extraction only. Follow-ups in the plan:
- Fill missing \`DatabaseTasks\` module methods (\`structureDump\`, \`loadSchema\`, \`dumpSchema\`, \`prepareAll\`, \`migrateAll\`, etc.)
- Refactor \`railties/src/commands/db.ts\` to delegate through \`DatabaseTasks\`
- Add \`db:version\`, \`db:migrate:up\`, \`db:migrate:down\`, \`db:forward\`, \`db:prepare\`, \`db:test:prepare\`, etc.
- Structure dump/load, schema cache persistence, multi-database support

## Test plan

- [x] \`pnpm build\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 16,985 pass / 0 fail
- [x] \`pnpm api:compare --package activerecord\` — 79.4% (up from 78.3%)