### PR TITLE
feat(activerecord): add DX type tests (vitest typecheck mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
 
+  dx-type-tests:
+    name: DX Type Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test:types
+
   sqlite-tests:
     name: SQLite Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,13 @@ Run it to see current stats per package. Use `--package <name>` for a single pac
 Rails conventions. These need to be moved, not rewritten.
 
 CI runs `api:compare` on every push to track regressions.
+
+## Measuring DX
+
+A secondary signal is `pnpm test:types` — a Vitest typecheck-mode suite in
+`packages/*/dx-tests/` that exercises the public API the way a Rails
+developer would. It pins the current type contract and encodes DX gaps
+(e.g. `Model.where` returning `any`) as assertions. When a gap is closed,
+the assertion flips and signals the test should be tightened.
+
+A dedicated `DX Type Tests` CI job runs on every push.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:types": "pnpm build && vitest run --config vitest.dx-tests.config.ts",
+    "test:types": "vitest run --config vitest.dx-tests.config.ts",
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:types": "pnpm build && vitest run --config vitest.dx-tests.config.ts",
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",

--- a/packages/activerecord/dx-tests/README.md
+++ b/packages/activerecord/dx-tests/README.md
@@ -1,0 +1,24 @@
+# DX type tests
+
+Type-level tests for `@blazetrails/activerecord` that exercise the public
+API the way a Rails developer would use it. They answer: **can someone
+build a Rails app on top of this with good autocomplete and type safety?**
+
+These are NOT runtime tests. They use Vitest's typecheck mode (`*.test-d.ts`)
+and assert types with `expectTypeOf` / `assertType`. Failures here mean the
+published types lie to users.
+
+Run locally:
+
+```bash
+pnpm test:types
+```
+
+CI runs the same command in a dedicated `DX Type Tests` job.
+
+Each file covers a real-world usage scenario:
+
+- `basic-crud.test-d.ts` — defining a model, creating, reading, updating, destroying
+- `associations.test-d.ts` — `belongsTo` / `hasMany` / `hasOne` shapes
+- `query-chaining.test-d.ts` — `where` / `order` / `limit` / thenable chains
+- `edge-cases.test-d.ts` — rough edges where today's types still return `any`

--- a/packages/activerecord/dx-tests/README.md
+++ b/packages/activerecord/dx-tests/README.md
@@ -5,8 +5,8 @@ API the way a Rails developer would use it. They answer: **can someone
 build a Rails app on top of this with good autocomplete and type safety?**
 
 These are NOT runtime tests. They use Vitest's typecheck mode (`*.test-d.ts`)
-and assert types with `expectTypeOf` / `assertType`. Failures here mean the
-published types lie to users.
+with `expectTypeOf` / `assertType`. Failures here mean the published types
+lie to users.
 
 Run locally:
 
@@ -14,11 +14,27 @@ Run locally:
 pnpm test:types
 ```
 
-CI runs the same command in a dedicated `DX Type Tests` job.
+CI runs the same command in a dedicated `DX Type Tests` job. No pre-build
+is required — the dx-tests `tsconfig.json` uses path aliases to resolve
+`@blazetrails/*` imports straight to `src/`.
 
-Each file covers a real-world usage scenario:
+## Files
 
-- `basic-crud.test-d.ts` — defining a model, creating, reading, updating, destroying
+Each file represents a real-world usage scenario:
+
+- `basic-crud.test-d.ts` — defining a model, creating, reading, updating,
+  destroying, serializing.
 - `associations.test-d.ts` — `belongsTo` / `hasMany` / `hasOne` shapes
-- `query-chaining.test-d.ts` — `where` / `order` / `limit` / thenable chains
-- `edge-cases.test-d.ts` — rough edges where today's types still return `any`
+  using the canonical Rails-guides blog domain (Author / Post / Comment /
+  Profile).
+- `query-chaining.test-d.ts` — `where` / `findBy` / ordinal finders /
+  thenable chains on `Relation<T>`.
+- `edge-cases.test-d.ts` — composite keys, enums, scopes, validators,
+  permissive attribute bags.
+
+## Gap-tracking pattern
+
+Some tests are marked `KNOWN GAP:` and assert the current (weaker) shape.
+When the implementation tightens (e.g. `Post.where(...)` starts returning
+`Relation<Post>` instead of `any`), the corresponding assertion flips and
+fails — that's the signal to update the test and promote the assertion.

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -96,9 +96,13 @@ describe("associations DX", () => {
     assertType<HasHasMany>(false as HasHasMany);
   });
 
-  it("KNOWN GAP: association accessors are not typed on the instance", () => {
-    // Ideally: post.author → Promise<Author | null>, author.posts → CollectionProxy<Post>.
-    type HasAuthorAccessor = "author" extends keyof Post ? true : false;
-    assertType<HasAuthorAccessor>(true as HasAuthorAccessor);
+  it("KNOWN GAP: association accessors return `unknown` via Model's index signature", () => {
+    // `Model` declares `[key: string]: unknown`, so `post.author` type-checks
+    // but resolves to `unknown` — no autocomplete, no narrowing. The ideal DX
+    // is `post.author: Promise<Author | null>` and `author.posts: CollectionProxy<Post>`.
+    const post = new Post({ title: "hi", author_id: 1, published: true });
+    expectTypeOf(post.author).toBeUnknown();
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.posts).toBeUnknown();
   });
 });

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -26,7 +26,7 @@ class Author extends Base {
 
 class Post extends Base {
   declare title: string;
-  declare authorId: number;
+  declare author_id: number;
   declare published: boolean;
 
   static {
@@ -40,7 +40,7 @@ class Post extends Base {
 
 class Comment extends Base {
   declare body: string;
-  declare postId: number;
+  declare post_id: number;
 
   static {
     this.attribute("body", "string");
@@ -51,7 +51,7 @@ class Comment extends Base {
 
 class Profile extends Base {
   declare bio: string;
-  declare authorId: number;
+  declare author_id: number;
 
   static {
     this.attribute("bio", "string");

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -1,67 +1,104 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
-import { Base } from "@blazetrails/activerecord";
+import { Base, CollectionProxy } from "@blazetrails/activerecord";
 
-// `belongsTo` / `hasMany` / `hasOne` are mixed into typeof Base at runtime via
-// `extend()`. They are real static methods but not yet statically typed —
-// each `@ts-expect-error` below is a concrete DX improvement waiting to be made.
+// Structural shape of the (currently-runtime-only) association API. Keeping
+// it here makes the casts below readable and the assertions meaningful.
+interface AssocHost {
+  belongsTo(name: string, options?: Record<string, unknown>): void;
+  hasOne(name: string, options?: Record<string, unknown>): void;
+  hasMany(name: string, options?: Record<string, unknown>): void;
+}
+
+// Scenario: blog-style domain — Authors write Posts, Posts have Comments,
+// Authors have a Profile. This is the Rails guides' canonical example.
 
 class Author extends Base {
   declare name: string;
 
   static {
-    // @ts-expect-error hasMany not statically typed on typeof Base
-    this.hasMany("posts");
+    this.attribute("name", "string");
+    // `hasMany` is mixed into typeof Base at runtime via extend().
+    // Until it's statically typed, we invoke through a local cast.
+    (this as unknown as AssocHost).hasMany("posts");
+    (this as unknown as AssocHost).hasOne("profile");
   }
 }
 
 class Post extends Base {
   declare title: string;
   declare authorId: number;
+  declare published: boolean;
 
   static {
-    // @ts-expect-error belongsTo not statically typed on typeof Base
-    this.belongsTo("author");
+    this.attribute("title", "string");
+    this.attribute("author_id", "integer");
+    this.attribute("published", "boolean", { default: false });
+    (this as unknown as AssocHost).belongsTo("author");
+    (this as unknown as AssocHost).hasMany("comments", { dependent: "destroy" });
+  }
+}
+
+class Comment extends Base {
+  declare body: string;
+  declare postId: number;
+
+  static {
+    this.attribute("body", "string");
+    this.attribute("post_id", "integer");
+    (this as unknown as AssocHost).belongsTo("post");
   }
 }
 
 class Profile extends Base {
+  declare bio: string;
   declare authorId: number;
 
   static {
-    // @ts-expect-error hasOne not statically typed on typeof Base
-    this.hasOne("author");
+    this.attribute("bio", "string");
+    this.attribute("author_id", "integer");
+    (this as unknown as AssocHost).belongsTo("author");
   }
 }
 
 describe("associations DX", () => {
-  it("model classes created with associations remain their own type", () => {
-    const post = new Post({ title: "hi", author_id: 1 });
+  it("model classes that declare associations remain their own type", () => {
+    const post = new Post({ title: "hi", author_id: 1, published: true });
     expectTypeOf(post).toEqualTypeOf<Post>();
     const author = new Author({ name: "dean" });
     expectTypeOf(author).toEqualTypeOf<Author>();
-    const profile = new Profile({ author_id: 1 });
+    const profile = new Profile({ author_id: 1, bio: "hi" });
     expectTypeOf(profile).toEqualTypeOf<Profile>();
+    const comment = new Comment({ post_id: 1, body: "nice" });
+    expectTypeOf(comment).toEqualTypeOf<Comment>();
   });
 
-  it("association helpers exist at runtime even though types are missing", () => {
-    // Cast to any so we can at least assert they're present. When the types
-    // are fixed, drop this cast and the `@ts-expect-error` above.
-    const B = Base as unknown as {
-      belongsTo: (name: string, options?: Record<string, unknown>) => void;
-      hasMany: (name: string, options?: Record<string, unknown>) => void;
-      hasOne: (name: string, options?: Record<string, unknown>) => void;
-    };
-    expectTypeOf(B.belongsTo).parameters.toEqualTypeOf<[string, Record<string, unknown>?]>();
-    expectTypeOf(B.hasMany).returns.toEqualTypeOf<void>();
-    expectTypeOf(B.hasOne).returns.toEqualTypeOf<void>();
+  it("association options bag accepts common Rails keys", () => {
+    class Tagged extends Base {
+      static {
+        const klass = this as unknown as AssocHost;
+        klass.belongsTo("author", { className: "Author", foreignKey: "author_id" });
+        klass.belongsTo("post", { optional: true });
+        klass.hasMany("comments", { dependent: "destroy", inverseOf: "tagged" });
+        klass.hasOne("profile", { through: "author" });
+      }
+    }
+    assertType(Tagged);
   });
 
-  it("association accessors are not typed on the instance today", () => {
-    // Ideally: post.author → Promise<Author | null>, author.posts → CollectionProxy.
-    // This test fails the moment someone adds typed accessors (good — time to
-    // replace the runtime cast above with real types).
-    type PostKeys = keyof Post;
-    type HasAuthorAccessor = "author" extends PostKeys ? true : false;
+  it("CollectionProxy is exported (currently non-generic — known gap)", () => {
+    assertType<typeof CollectionProxy>(CollectionProxy);
+  });
+
+  it("KNOWN GAP: belongsTo/hasMany/hasOne are not statically declared on typeof Base", () => {
+    // This test encodes the current shape. When these methods are typed on
+    // `typeof Base`, remove the `AssocHost` cast above and update this test.
+    type HasHasMany = "hasMany" extends keyof typeof Base ? true : false;
+    assertType<HasHasMany>(false as HasHasMany);
+  });
+
+  it("KNOWN GAP: association accessors are not typed on the instance", () => {
+    // Ideally: post.author → Promise<Author | null>, author.posts → CollectionProxy<Post>.
+    type HasAuthorAccessor = "author" extends keyof Post ? true : false;
     assertType<HasAuthorAccessor>(true as HasAuthorAccessor);
   });
 });

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -1,0 +1,67 @@
+import { describe, it, expectTypeOf, assertType } from "vitest";
+import { Base } from "@blazetrails/activerecord";
+
+// `belongsTo` / `hasMany` / `hasOne` are mixed into typeof Base at runtime via
+// `extend()`. They are real static methods but not yet statically typed —
+// each `@ts-expect-error` below is a concrete DX improvement waiting to be made.
+
+class Author extends Base {
+  declare name: string;
+
+  static {
+    // @ts-expect-error hasMany not statically typed on typeof Base
+    this.hasMany("posts");
+  }
+}
+
+class Post extends Base {
+  declare title: string;
+  declare authorId: number;
+
+  static {
+    // @ts-expect-error belongsTo not statically typed on typeof Base
+    this.belongsTo("author");
+  }
+}
+
+class Profile extends Base {
+  declare authorId: number;
+
+  static {
+    // @ts-expect-error hasOne not statically typed on typeof Base
+    this.hasOne("author");
+  }
+}
+
+describe("associations DX", () => {
+  it("model classes created with associations remain their own type", () => {
+    const post = new Post({ title: "hi", author_id: 1 });
+    expectTypeOf(post).toEqualTypeOf<Post>();
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author).toEqualTypeOf<Author>();
+    const profile = new Profile({ author_id: 1 });
+    expectTypeOf(profile).toEqualTypeOf<Profile>();
+  });
+
+  it("association helpers exist at runtime even though types are missing", () => {
+    // Cast to any so we can at least assert they're present. When the types
+    // are fixed, drop this cast and the `@ts-expect-error` above.
+    const B = Base as unknown as {
+      belongsTo: (name: string, options?: Record<string, unknown>) => void;
+      hasMany: (name: string, options?: Record<string, unknown>) => void;
+      hasOne: (name: string, options?: Record<string, unknown>) => void;
+    };
+    expectTypeOf(B.belongsTo).parameters.toEqualTypeOf<[string, Record<string, unknown>?]>();
+    expectTypeOf(B.hasMany).returns.toEqualTypeOf<void>();
+    expectTypeOf(B.hasOne).returns.toEqualTypeOf<void>();
+  });
+
+  it("association accessors are not typed on the instance today", () => {
+    // Ideally: post.author → Promise<Author | null>, author.posts → CollectionProxy.
+    // This test fails the moment someone adds typed accessors (good — time to
+    // replace the runtime cast above with real types).
+    type PostKeys = keyof Post;
+    type HasAuthorAccessor = "author" extends PostKeys ? true : false;
+    assertType<HasAuthorAccessor>(true as HasAuthorAccessor);
+  });
+});

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -1,0 +1,67 @@
+import { describe, it, expectTypeOf, assertType } from "vitest";
+import { Base, Relation } from "@blazetrails/activerecord";
+
+// Note: we don't redeclare `id` because Base defines it as an accessor.
+class User extends Base {
+  declare name: string;
+  declare email: string;
+
+  static {
+    this.attribute("name", "string");
+    this.attribute("email", "string");
+  }
+}
+
+describe("basic CRUD DX", () => {
+  it("new User() returns a User instance with typed declared attributes", () => {
+    const u = new User({ name: "dean", email: "d@example.com" });
+    expectTypeOf(u).toEqualTypeOf<User>();
+    expectTypeOf(u.name).toBeString();
+    expectTypeOf(u.email).toBeString();
+    // `id` on Base is currently typed as `unknown` — DX gap.
+    expectTypeOf(u.id).toBeUnknown();
+  });
+
+  it("User.all() and User.where(...) are callable statics (return `any` today)", () => {
+    assertType(User.all());
+    assertType(User.where({ name: "dean" }));
+  });
+
+  it("awaiting a Relation<User> resolves to User[]", async () => {
+    const rel: Relation<User> = User.all() as Relation<User>;
+    const rows = await rel;
+    expectTypeOf(rows).toEqualTypeOf<User[]>();
+  });
+
+  it("Relation#find(id) resolves to a single User", async () => {
+    const rel: Relation<User> = User.all() as Relation<User>;
+    const found = await rel.find(1);
+    expectTypeOf(found).toEqualTypeOf<User>();
+  });
+
+  it("Relation#find([ids]) resolves to User[]", async () => {
+    const rel: Relation<User> = User.all() as Relation<User>;
+    const many = await rel.find([1, 2, 3]);
+    expectTypeOf(many).toEqualTypeOf<User[]>();
+  });
+
+  it("Relation#findBy returns User | null", async () => {
+    const rel: Relation<User> = User.all() as Relation<User>;
+    const maybe = await rel.findBy({ name: "dean" });
+    expectTypeOf(maybe).toEqualTypeOf<User | null>();
+  });
+
+  it("Relation#first() returns User | null; first(n) returns User[]", async () => {
+    const rel: Relation<User> = User.all() as Relation<User>;
+    expectTypeOf(await rel.first()).toEqualTypeOf<User | null>();
+    expectTypeOf(await rel.first(3)).toEqualTypeOf<User[]>();
+  });
+
+  it("instance persistence methods are callable", () => {
+    const u = new User({ name: "dean" });
+    assertType(u.save());
+    assertType(u.destroy());
+    assertType(u.isNewRecord());
+    assertType(u.isPersisted());
+  });
+});

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -1,67 +1,94 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
 import { Base, Relation } from "@blazetrails/activerecord";
 
-// Note: we don't redeclare `id` because Base defines it as an accessor.
+// Scenario: an app that models users — the ActiveRecord onboarding path.
+// Someone reading the Rails guide should be able to write this verbatim.
 class User extends Base {
   declare name: string;
   declare email: string;
 
   static {
+    this.tableName = "users";
     this.attribute("name", "string");
     this.attribute("email", "string");
+    this.validates("email", { presence: true });
   }
 }
 
-describe("basic CRUD DX", () => {
-  it("new User() returns a User instance with typed declared attributes", () => {
+describe("basic CRUD DX — defining and using a model", () => {
+  it("declaring a model with attribute() and validates() returns void side-effects", () => {
+    expectTypeOf<ReturnType<typeof Base.attribute>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.validates>>().toEqualTypeOf<void>();
+  });
+
+  it("instantiating a model preserves declared property types", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
     expectTypeOf(u).toEqualTypeOf<User>();
     expectTypeOf(u.name).toBeString();
     expectTypeOf(u.email).toBeString();
-    // `id` on Base is currently typed as `unknown` — DX gap.
-    expectTypeOf(u.id).toBeUnknown();
   });
 
-  it("User.all() and User.where(...) are callable statics (return `any` today)", () => {
-    assertType(User.all());
-    assertType(User.where({ name: "dean" }));
+  it("User.create returns a Promise<Base> (should narrow to User — known gap)", () => {
+    expectTypeOf(User.create).returns.resolves.toEqualTypeOf<Base>();
   });
 
-  it("awaiting a Relation<User> resolves to User[]", async () => {
-    const rel: Relation<User> = User.all() as Relation<User>;
+  it("User.create(attrs) accepts a Record<string, unknown>", () => {
+    assertType<Promise<Base>>(User.create({ name: "dean", email: "d@example.com" }));
+  });
+
+  it("User.find resolves — currently typed as `any`, a key DX gap", () => {
+    // In Rails: User.find(1) → User. Here it's declared as returning `any`.
+    expectTypeOf(User.find).returns.resolves.toBeAny();
+  });
+
+  it("User.findBy / findByBang have concrete Base returns", () => {
+    expectTypeOf(User.findBy).returns.resolves.toEqualTypeOf<Base | null>();
+    expectTypeOf(User.findByBang).returns.resolves.toEqualTypeOf<Base>();
+  });
+
+  it("User.count / exists / pluck have concrete return types", () => {
+    expectTypeOf(User.count).returns.resolves.toBeNumber();
+    expectTypeOf(User.exists).returns.resolves.toBeBoolean();
+    expectTypeOf(User.pluck).returns.resolves.toEqualTypeOf<unknown[]>();
+  });
+
+  it("awaiting a typed Relation<User> resolves to User[]", async () => {
+    const rel = {} as Relation<User>;
     const rows = await rel;
     expectTypeOf(rows).toEqualTypeOf<User[]>();
   });
 
-  it("Relation#find(id) resolves to a single User", async () => {
-    const rel: Relation<User> = User.all() as Relation<User>;
-    const found = await rel.find(1);
-    expectTypeOf(found).toEqualTypeOf<User>();
-  });
-
-  it("Relation#find([ids]) resolves to User[]", async () => {
-    const rel: Relation<User> = User.all() as Relation<User>;
-    const many = await rel.find([1, 2, 3]);
-    expectTypeOf(many).toEqualTypeOf<User[]>();
-  });
-
-  it("Relation#findBy returns User | null", async () => {
-    const rel: Relation<User> = User.all() as Relation<User>;
-    const maybe = await rel.findBy({ name: "dean" });
-    expectTypeOf(maybe).toEqualTypeOf<User | null>();
-  });
-
-  it("Relation#first() returns User | null; first(n) returns User[]", async () => {
-    const rel: Relation<User> = User.all() as Relation<User>;
+  it("Relation#find / findBy / first keep the generic T", async () => {
+    const rel = {} as Relation<User>;
+    expectTypeOf(await rel.find(1)).toEqualTypeOf<User>();
+    expectTypeOf(await rel.find([1, 2])).toEqualTypeOf<User[]>();
+    expectTypeOf(await rel.findBy({ email: "d@example.com" })).toEqualTypeOf<User | null>();
     expectTypeOf(await rel.first()).toEqualTypeOf<User | null>();
-    expectTypeOf(await rel.first(3)).toEqualTypeOf<User[]>();
+    expectTypeOf(await rel.first(5)).toEqualTypeOf<User[]>();
   });
 
-  it("instance persistence methods are callable", () => {
+  it("persistence methods on an instance return Promises and sensible scalars", () => {
     const u = new User({ name: "dean" });
-    assertType(u.save());
-    assertType(u.destroy());
-    assertType(u.isNewRecord());
-    assertType(u.isPersisted());
+    expectTypeOf(u.save).returns.resolves.toBeBoolean();
+    expectTypeOf(u.destroy).returns.toBeObject();
+    expectTypeOf(u.isNewRecord()).toBeBoolean();
+    expectTypeOf(u.isPersisted()).toBeBoolean();
+  });
+
+  it("serialization methods expose a JSON-ish shape", () => {
+    const u = new User({ name: "dean", email: "d@example.com" });
+    expectTypeOf(u.toJson()).toBeString();
+    expectTypeOf(u.asJson()).toEqualTypeOf<Record<string, unknown>>();
+    expectTypeOf(u.attributes).toEqualTypeOf<Record<string, unknown>>();
+  });
+
+  it("update / updateBang exist on the instance with attrs bag", () => {
+    const u = new User();
+    assertType<Promise<boolean>>(u.update({ name: "dean2" }));
+    assertType<Promise<true>>(u.updateBang({ name: "dean2" }));
+  });
+
+  it("tableName configured in `static {}` is a string accessor", () => {
+    expectTypeOf(User.tableName).toBeString();
   });
 });

--- a/packages/activerecord/dx-tests/edge-cases.test-d.ts
+++ b/packages/activerecord/dx-tests/edge-cases.test-d.ts
@@ -1,0 +1,45 @@
+import { describe, it, expectTypeOf, assertType } from "vitest";
+import { Base } from "@blazetrails/activerecord";
+
+class Widget extends Base {
+  declare name: string;
+
+  static {
+    this.attribute("name", "string");
+  }
+}
+
+describe("edge cases — rough edges in current DX", () => {
+  it("Widget.where accepts a record OR a SQL string + binds", () => {
+    assertType(Widget.where({ name: "a" }));
+    assertType(Widget.where("name = ?", "a"));
+  });
+
+  it("tableName is a string; primaryKey is string | string[]", () => {
+    expectTypeOf(Widget.tableName).toBeString();
+    expectTypeOf(Widget.primaryKey).toEqualTypeOf<string | string[]>();
+  });
+
+  it("composite primary key assignment type-checks", () => {
+    class Compound extends Base {
+      static {
+        this.primaryKey = ["tenant_id", "id"];
+      }
+    }
+    expectTypeOf(Compound.primaryKey).toEqualTypeOf<string | string[]>();
+  });
+
+  it("new Widget() accepts a partial attributes bag (Rails parity)", () => {
+    // Rails accepts any hash — there is no compile-time filtering of unknown
+    // attributes today. Flagged so we notice if the constructor tightens.
+    assertType(new Widget());
+    assertType(new Widget({}));
+    assertType(new Widget({ name: "ok" }));
+    assertType(new Widget({ totally_unknown_column: 1 }));
+  });
+
+  it("subclasses of Base are assignable to typeof Base", () => {
+    const ctor: typeof Base = Widget;
+    expectTypeOf(ctor).toMatchTypeOf<typeof Base>();
+  });
+});

--- a/packages/activerecord/dx-tests/edge-cases.test-d.ts
+++ b/packages/activerecord/dx-tests/edge-cases.test-d.ts
@@ -1,6 +1,9 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
 import { Base } from "@blazetrails/activerecord";
 
+// Scenario: the rough edges a real app will hit — composite keys, enums,
+// scopes, transactions, and the permissive attributes bag.
+
 class Widget extends Base {
   declare name: string;
 
@@ -10,7 +13,7 @@ class Widget extends Base {
 }
 
 describe("edge cases — rough edges in current DX", () => {
-  it("Widget.where accepts a record OR a SQL string + binds", () => {
+  it("Widget.where is overloaded: record OR SQL + binds", () => {
     assertType(Widget.where({ name: "a" }));
     assertType(Widget.where("name = ?", "a"));
   });
@@ -20,7 +23,7 @@ describe("edge cases — rough edges in current DX", () => {
     expectTypeOf(Widget.primaryKey).toEqualTypeOf<string | string[]>();
   });
 
-  it("composite primary key assignment type-checks", () => {
+  it("composite primary keys type-check as string[]", () => {
     class Compound extends Base {
       static {
         this.primaryKey = ["tenant_id", "id"];
@@ -29,9 +32,7 @@ describe("edge cases — rough edges in current DX", () => {
     expectTypeOf(Compound.primaryKey).toEqualTypeOf<string | string[]>();
   });
 
-  it("new Widget() accepts a partial attributes bag (Rails parity)", () => {
-    // Rails accepts any hash — there is no compile-time filtering of unknown
-    // attributes today. Flagged so we notice if the constructor tightens.
+  it("new Widget() accepts a permissive attributes bag (Rails parity)", () => {
     assertType(new Widget());
     assertType(new Widget({}));
     assertType(new Widget({ name: "ok" }));
@@ -41,5 +42,38 @@ describe("edge cases — rough edges in current DX", () => {
   it("subclasses of Base are assignable to typeof Base", () => {
     const ctor: typeof Base = Widget;
     expectTypeOf(ctor).toMatchTypeOf<typeof Base>();
+  });
+
+  it("enum() defines a typed mapping (Rails: `enum status: {...}`)", () => {
+    class Order extends Base {
+      static {
+        this.enum("status", { pending: 0, shipped: 1, cancelled: 2 });
+      }
+    }
+    assertType(Order);
+    expectTypeOf<ReturnType<typeof Base.enum>>().toEqualTypeOf<void>();
+  });
+
+  it("scope() + defaultScope register query macros", () => {
+    expectTypeOf(Base.scope).toBeFunction();
+    expectTypeOf(Base.defaultScope).toBeFunction();
+    expectTypeOf<ReturnType<typeof Base.defaultScope>>().toEqualTypeOf<void>();
+  });
+
+  it("validates + validatesAssociated + validatesUniqueness are void-returning", () => {
+    expectTypeOf<ReturnType<typeof Base.validates>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.validatesAssociated>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.validatesUniqueness>>().toEqualTypeOf<void>();
+  });
+
+  it("KNOWN GAP: Base.find / Base.all / Base.where are typed as `any`", () => {
+    expectTypeOf(Base.find).returns.resolves.toBeAny();
+    expectTypeOf(Base.all()).toBeAny();
+    expectTypeOf(Base.where({})).toBeAny();
+  });
+
+  it("KNOWN GAP: instance `id` is typed as `unknown`", () => {
+    const w = new Widget({ name: "w" });
+    expectTypeOf(w.id).toBeUnknown();
   });
 });

--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -1,13 +1,18 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
 import { Base, Relation } from "@blazetrails/activerecord";
 
+// Scenario: building a search endpoint — users chain scopes, filters, order,
+// and pagination, then `await` the result.
+
 class Post extends Base {
   declare title: string;
   declare published: boolean;
+  declare createdAt: Date;
 
   static {
     this.attribute("title", "string");
     this.attribute("published", "boolean");
+    this.attribute("created_at", "datetime");
   }
 }
 
@@ -18,24 +23,44 @@ describe("query chaining DX", () => {
     expectTypeOf(rows).toEqualTypeOf<Post[]>();
   });
 
-  it("Relation exposes then/catch/finally (PromiseLike surface)", () => {
+  it("Relation is PromiseLike (then/catch/finally)", () => {
     const rel = {} as Relation<Post>;
     assertType<Relation<Post>["then"]>(rel.then);
     assertType<Relation<Post>["catch"]>(rel.catch);
     assertType<Relation<Post>["finally"]>(rel.finally);
   });
 
-  it("finder methods on Relation keep the generic T", async () => {
+  it("Relation finder methods preserve T through the generic", async () => {
     const rel = {} as Relation<Post>;
     expectTypeOf(await rel.first()).toEqualTypeOf<Post | null>();
     expectTypeOf(await rel.firstBang()).toEqualTypeOf<Post>();
     expectTypeOf(await rel.last()).toEqualTypeOf<Post | null>();
     expectTypeOf(await rel.sole()).toEqualTypeOf<Post>();
     expectTypeOf(await rel.take(5)).toEqualTypeOf<Post[]>();
+    expectTypeOf(await rel.findBy({ published: true })).toEqualTypeOf<Post | null>();
   });
 
-  it("Post.where returns `any` today — known DX gap", () => {
-    // A future improvement would return Relation<Post> so chaining keeps typing.
+  it("Relation ordinal finders (second..fortyTwo) return T | null", async () => {
+    const rel = {} as Relation<Post>;
+    expectTypeOf(await rel.second()).toEqualTypeOf<Post | null>();
+    expectTypeOf(await rel.third()).toEqualTypeOf<Post | null>();
+    expectTypeOf(await rel.fortyTwo()).toEqualTypeOf<Post | null>();
+    expectTypeOf(await rel.secondToLast()).toEqualTypeOf<Post | null>();
+  });
+
+  it("find(id) vs find([ids]) — overload picks scalar vs array", async () => {
+    const rel = {} as Relation<Post>;
+    expectTypeOf(await rel.find(1)).toEqualTypeOf<Post>();
+    expectTypeOf(await rel.find([1, 2, 3])).toEqualTypeOf<Post[]>();
+  });
+
+  it("findOrCreateByBang / createOrFindByBang return T", async () => {
+    const rel = {} as Relation<Post>;
+    expectTypeOf(await rel.findOrCreateByBang({ title: "x" })).toEqualTypeOf<Post>();
+    expectTypeOf(await rel.createOrFindByBang({ title: "x" })).toEqualTypeOf<Post>();
+  });
+
+  it("KNOWN GAP: Post.where returns `any` — ideally Relation<Post>", () => {
     const chain = Post.where({ published: true });
     expectTypeOf(chain).toBeAny();
   });
@@ -44,5 +69,11 @@ describe("query chaining DX", () => {
     const rel = Post.where({ published: true }) as Relation<Post>;
     const rows = await rel;
     expectTypeOf(rows).toEqualTypeOf<Post[]>();
+  });
+
+  it("Post.where accepts a Record or a SQL-string + binds", () => {
+    assertType(Post.where({ title: "x" }));
+    assertType(Post.where("title = ?", "x"));
+    assertType(Post.whereNot({ published: false }));
   });
 });

--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -7,7 +7,7 @@ import { Base, Relation } from "@blazetrails/activerecord";
 class Post extends Base {
   declare title: string;
   declare published: boolean;
-  declare createdAt: Date;
+  declare created_at: Date;
 
   static {
     this.attribute("title", "string");

--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -1,0 +1,48 @@
+import { describe, it, expectTypeOf, assertType } from "vitest";
+import { Base, Relation } from "@blazetrails/activerecord";
+
+class Post extends Base {
+  declare title: string;
+  declare published: boolean;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+  }
+}
+
+describe("query chaining DX", () => {
+  it("a Relation<Post> is awaitable and resolves to Post[]", async () => {
+    const rel = {} as Relation<Post>;
+    const rows = await rel;
+    expectTypeOf(rows).toEqualTypeOf<Post[]>();
+  });
+
+  it("Relation exposes then/catch/finally (PromiseLike surface)", () => {
+    const rel = {} as Relation<Post>;
+    assertType<Relation<Post>["then"]>(rel.then);
+    assertType<Relation<Post>["catch"]>(rel.catch);
+    assertType<Relation<Post>["finally"]>(rel.finally);
+  });
+
+  it("finder methods on Relation keep the generic T", async () => {
+    const rel = {} as Relation<Post>;
+    expectTypeOf(await rel.first()).toEqualTypeOf<Post | null>();
+    expectTypeOf(await rel.firstBang()).toEqualTypeOf<Post>();
+    expectTypeOf(await rel.last()).toEqualTypeOf<Post | null>();
+    expectTypeOf(await rel.sole()).toEqualTypeOf<Post>();
+    expectTypeOf(await rel.take(5)).toEqualTypeOf<Post[]>();
+  });
+
+  it("Post.where returns `any` today — known DX gap", () => {
+    // A future improvement would return Relation<Post> so chaining keeps typing.
+    const chain = Post.where({ published: true });
+    expectTypeOf(chain).toBeAny();
+  });
+
+  it("hand-typed chain via `as Relation<Post>` preserves T through await", async () => {
+    const rel = Post.where({ published: true }) as Relation<Post>;
+    const rows = await rel;
+    expectTypeOf(rows).toEqualTypeOf<Post[]>();
+  });
+});

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "paths": {
+      "@blazetrails/activerecord": ["../src/index.ts"],
+      "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
+      "@blazetrails/arel": ["../../arel/src/index.ts"],
+      "@blazetrails/activesupport": ["../../activesupport/src/index.ts"]
+    }
+  },
+  "include": ["."],
+  "references": [
+    { "path": "../../activerecord" },
+    { "path": "../../activemodel" },
+    { "path": "../../arel" },
+    { "path": "../../activesupport" }
+  ]
+}

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -1,23 +1,25 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": false,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
     "noEmit": true,
-    "rootDir": ".",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
-      "@blazetrails/activesupport": ["../../activesupport/src/index.ts"]
+      "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],
+      "@blazetrails/activesupport/message-verifier": ["../../activesupport/src/message-verifier.ts"]
     }
   },
-  "include": ["."],
-  "references": [
-    { "path": "../../activerecord" },
-    { "path": "../../activemodel" },
-    { "path": "../../arel" },
-    { "path": "../../activesupport" }
-  ]
+  "include": ["."]
 }

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
+    "composite": false,
     "noEmit": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["packages/*/src/**/*.test.ts"],
-    exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**"],
+    exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**", "packages/*/dx-tests/**"],
     setupFiles: process.env.MYSQL_TEST_URL
       ? ["./packages/activerecord/src/test-setup-mysql.ts"]
       : [],

--- a/vitest.dx-tests.config.ts
+++ b/vitest.dx-tests.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+// Separate config for DX type tests. These are type-level assertions — no
+// runtime code runs. Vitest's typecheck mode compiles each *.test-d.ts and
+// reports any type errors as test failures.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
+      "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
+      "@blazetrails/activemodel": path.resolve(__dirname, "packages/activemodel/src/index.ts"),
+      "@blazetrails/activerecord": path.resolve(__dirname, "packages/activerecord/src/index.ts"),
+    },
+  },
+  test: {
+    include: [],
+    typecheck: {
+      enabled: true,
+      only: true,
+      include: ["packages/*/dx-tests/**/*.test-d.ts"],
+      tsconfig: "./packages/activerecord/dx-tests/tsconfig.json",
+    },
+  },
+});

--- a/vitest.dx-tests.config.ts
+++ b/vitest.dx-tests.config.ts
@@ -1,24 +1,23 @@
 import { defineConfig } from "vitest/config";
-import path from "path";
+import baseVitestConfig from "./vitest.config.js";
 
 // Separate config for DX type tests. These are type-level assertions — no
 // runtime code runs. Vitest's typecheck mode compiles each *.test-d.ts and
 // reports any type errors as test failures.
+//
+// Aliases are reused from the root runtime config so additions don't have to
+// be kept in sync across two files.
+const alias =
+  (baseVitestConfig as { resolve?: { alias?: Record<string, string> } }).resolve?.alias ?? {};
+
 export default defineConfig({
-  resolve: {
-    alias: {
-      "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
-      "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
-      "@blazetrails/activemodel": path.resolve(__dirname, "packages/activemodel/src/index.ts"),
-      "@blazetrails/activerecord": path.resolve(__dirname, "packages/activerecord/src/index.ts"),
-    },
-  },
+  resolve: { alias },
   test: {
     include: [],
     typecheck: {
       enabled: true,
       only: true,
-      include: ["packages/*/dx-tests/**/*.test-d.ts"],
+      include: ["packages/activerecord/dx-tests/**/*.test-d.ts"],
       tsconfig: "./packages/activerecord/dx-tests/tsconfig.json",
     },
   },

--- a/vitest.dx-tests.config.ts
+++ b/vitest.dx-tests.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import baseVitestConfig from "./vitest.config.js";
+import baseVitestConfig from "./vitest.config";
 
 // Separate config for DX type tests. These are type-level assertions — no
 // runtime code runs. Vitest's typecheck mode compiles each *.test-d.ts and


### PR DESCRIPTION
## Summary
- Adds `packages/activerecord/dx-tests/` — type-level tests exercising the public API the way a Rails developer would, using Vitest's typecheck mode.
- Four scenario files totalling 37 tests: `basic-crud`, `associations`, `query-chaining`, `edge-cases`.
- `pnpm test:types` runs the dedicated vitest config (no pre-build required — path aliases resolve `@blazetrails/*` straight to `src/`).
- Separate **DX Type Tests** CI job.
- Regular `pnpm test` excludes `packages/*/dx-tests/**` so runtime tests stay fast.

## Why
These tests answer a different question than the runtime suite: *can someone build a Rails app on top of this with good autocomplete and type safety?* They pin the current contract of the public surface and surface DX gaps as concrete assertions — e.g.:

- `Post.where(...)` currently returns `any` (ideally `Relation<Post>`).
- `belongsTo` / `hasMany` / `hasOne` are runtime-mixed and not statically typed on `typeof Base`.
- `id` on Base is typed as `unknown`.
- `post.author` type-checks (via Model's `[key: string]: unknown` index signature) but resolves to `unknown`.

Each gap is encoded as a passing assertion today; if the types are tightened later, the assertion fails and flags that it's time to update the documented contract.

## Test plan
- [x] `pnpm test:types` passes locally (37/37)
- [x] `pnpm lint` / `pnpm format:check` / `pnpm typecheck` / `pnpm build` all green
- [ ] New `DX Type Tests` CI job goes green
- [ ] Regular `pnpm test` still runs without picking up `.test-d.ts` files