### PR TITLE
docs: Rails deviations guides for arel, activemodel, activerecord

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ See `activesupport/src/include.ts` for the API and
 - Do NOT use subagents unless explicitly requested. Do the work directly.
 - Do use worktrees for any changes. Leave the default worktree for the user.
 - Copilot automatically reviews every PR and every push, so no need to request review.
+  Copilot reviews can be found at `~/.btwhooks/data/github/blazetrailsdev/trails/$PR`.
 - Do open new PRs in draft status.
 - Do NOT add code comments that just describe what the line does. Only add
   comments when they provide additional value — a potential bug hidden, or

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -13,13 +13,17 @@ export default defineConfig({
     siteTitle: "BlazeTrails",
     nav: [
       { text: "Docs", link: "/" },
-      { text: "Guides", link: "/guides/arel-rails-deviations" },
+      { text: "Guides", link: "/guides/" },
       { text: "Website", link: siteRoot },
       { text: "API Reference", link: "/api/@blazetrails/arel/README" },
     ],
 
     sidebar: {
       "/guides/": [
+        {
+          text: "Overview",
+          items: [{ text: "Guides", link: "/guides/" }],
+        },
         {
           text: "Rails Deviations",
           items: [

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -13,11 +13,22 @@ export default defineConfig({
     siteTitle: "BlazeTrails",
     nav: [
       { text: "Docs", link: "/" },
+      { text: "Guides", link: "/guides/arel-rails-deviations" },
       { text: "Website", link: siteRoot },
       { text: "API Reference", link: "/api/@blazetrails/arel/README" },
     ],
 
     sidebar: {
+      "/guides/": [
+        {
+          text: "Rails Deviations",
+          items: [
+            { text: "Arel", link: "/guides/arel-rails-deviations" },
+            { text: "ActiveModel", link: "/guides/activemodel-rails-deviations" },
+            { text: "ActiveRecord", link: "/guides/activerecord-rails-deviations" },
+          ],
+        },
+      ],
       "/api/": [
         {
           text: "Packages",

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -17,7 +17,7 @@ and serialization.
 
 ActiveModel is the heaviest user of the `include` / `extend` /
 `Included` / `Extended` mixin helpers. The full primer lives in the
-guides index: [Module mixins](./#module-mixins). In ActiveModel
+guides index: [Module mixins](./index.md#module-mixins). In ActiveModel
 specifically, the machinery is applied to wire up
 `AttributeMethods`, `Callbacks`, `Validations`, `Dirty`,
 `Serialization`, and friends onto `Model` / `Base`.
@@ -56,7 +56,7 @@ away.
 
 Rails callbacks are Ruby blocks; ours are (possibly-async) functions.
 The shared rationale and signatures live at
-[Block APIs → callback functions](./#block-apis). One ActiveModel-
+[Block APIs → callback functions](./index.md#block-apis). One ActiveModel-
 specific point: `before_save :do_thing` (Rails-style symbol reference
 to a method) is accepted as a method-name string or a direct function
 — either works. This is the module where `runCallbacks` lives
@@ -108,8 +108,8 @@ See `packages/activemodel/src/serialization.ts`.
 
 ## Small, systematic differences
 
-The cross-package conventions — [method casing](./#method-casing),
-[symbols/kwargs](./#symbols-kwargs), and [bang methods](./#bang-methods)
+The cross-package conventions — [method casing](./index.md#method-casing),
+[symbols/kwargs](./index.md#symbols-kwargs), and [bang methods](./index.md#bang-methods)
 — all apply. ActiveModel-specific wrinkles:
 
 - **`try :foo` → `?.`.** TypeScript's optional chaining replaces Ruby's

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -13,41 +13,14 @@ it's also where the Ruby → TypeScript idiom gap shows up most in the shape
 of the API: mixins, callbacks, dirty tracking, attribute method generation,
 and serialization.
 
-## Module mixins: `include`, `extend`, `Included`, `Extended`
+## Module mixins
 
-Ruby modules (`include SomeConcern`, `extend OtherConcern`, with `included
-do ... end` / `extended do ... end` hooks) are the most-used metaprogramming
-feature in Rails. TypeScript has no equivalent, so ActiveSupport ships a set
-of helpers that get as close as the language allows.
-
-- **`include(Klass, mod)`** copies instance methods from `mod` onto
-  `Klass.prototype`. Skips methods already on the prototype. If the module
-  exports a function keyed by the `included` Symbol, it runs that hook with
-  the class as its argument. See `packages/activesupport/src/include.ts`.
-- **`extend(Klass, mod)`** is the class-method equivalent. Copies onto the
-  class itself and runs the `extended` Symbol hook.
-- **`Included<Mod>` / `Extended<Mod>`** are type helpers that translate a
-  module's `this`-typed functions into the method signatures the class will
-  have after mixing. They give consumers the typing they'd otherwise lose.
-
-Differences vs Ruby:
-
-- Hooks use `Symbol.for("@blazetrails/activesupport:included")` rather than
-  a magic method name. The symbol-based hook is imported by name, which
-  plays nicer with TypeScript tooling than stringly-typed method lookup.
-- Mixing is explicit and happens once at class-declaration time, rather
-  than at `include` time as Ruby does inside the class body. The net effect
-  is the same.
-
-For single methods rather than whole modules, the pattern is
-`this`-typed functions assigned directly to a class. See `CLAUDE.md` for
-the spelling; examples live in `attribute-methods.ts`, `validations.ts`,
-`callbacks.ts`, and many more.
-
-ActiveSupport also has `concern.ts`, a port of
-`ActiveSupport::Concern` for cases where we really want the Rails shape
-(class-level DSL blocks nested inside a module). It's less commonly needed
-because `Included<>` usually does the job.
+ActiveModel is the heaviest user of the `include` / `extend` /
+`Included` / `Extended` mixin helpers. The full primer lives in the
+guides index: [Module mixins](./#module-mixins). In ActiveModel
+specifically, the machinery is applied to wire up
+`AttributeMethods`, `Callbacks`, `Validations`, `Dirty`,
+`Serialization`, and friends onto `Model` / `Base`.
 
 ## Attribute methods: generated, not `method_missing`
 
@@ -81,27 +54,14 @@ away.
 
 ## Callbacks: async-capable
 
-Rails callbacks are Ruby blocks. Our callback signatures accept either
-sync or async functions:
-
-```ts
-type CallbackFn = (this: any, ...args: any[]) => void | Promise<void>;
-type AroundCallbackFn = (this: any, fn: () => Promise<void>) => Promise<void>;
-```
-
-(See `packages/activemodel/src/callbacks.ts`.)
-
-Implications:
-
-- `runCallbacks` awaits each callback. Calling it is itself async.
-- `around` callbacks receive a `() => Promise<void>` to invoke the inner
-  chain, not a block with `yield`.
-- `before_save :do_thing` (a symbol naming a method) becomes either a
-  reference to a method name string or a direct function — we accept both.
-
-This is a required deviation: nearly every real callback in an
-ActiveRecord app needs to hit I/O, so callbacks had to be async-aware
-from the start.
+Rails callbacks are Ruby blocks; ours are (possibly-async) functions.
+The shared rationale and signatures live at
+[Block APIs → callback functions](./#block-apis). One ActiveModel-
+specific point: `before_save :do_thing` (Rails-style symbol reference
+to a method) is accepted as a method-name string or a direct function
+— either works. This is the module where `runCallbacks` lives
+(`packages/activemodel/src/callbacks.ts`), and because it awaits
+each handler, calling it is itself async.
 
 ## Validations: sync signature, async reality
 
@@ -148,32 +108,29 @@ See `packages/activemodel/src/serialization.ts`.
 
 ## Small, systematic differences
 
-- **Symbols → strings.** `validates :name, presence: true` becomes
-  `validates("name", { presence: true })`. Ruby symbol literals have no
-  JS equivalent.
-- **Keyword args → options object.** Same story: `validates("name", {
-length: { minimum: 3, maximum: 20 } })`.
-- **snake_case → camelCase.** `record.previous_changes` →
-  `record.previousChanges`.
-- **`try :foo` → `?.`** TypeScript's optional chaining replaces Ruby's
-  safe-navigation helpers.
-- **Range** — Ruby's `Range` becomes a plain `{ begin, end, excludeEnd }`
+The cross-package conventions — [method casing](./#method-casing),
+[symbols/kwargs](./#symbols-kwargs), and [bang methods](./#bang-methods)
+— all apply. ActiveModel-specific wrinkles:
+
+- **`try :foo` → `?.`.** TypeScript's optional chaining replaces Ruby's
+  safe-navigation helper.
+- **Range.** Ruby's `Range` becomes a plain `{ begin, end, excludeEnd }`
   object from `@blazetrails/activesupport`. Relevant to validators like
   `numericality: { within: makeRange(0, 100) }`.
 
 ## Summary
 
-| Area                      | Rails                                | Trails                                                                     |
-| ------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
-| Module inclusion          | `include Mod`, `included do ... end` | `include(Klass, mod)` + `included` symbol hook; `Included<Mod>` for typing |
-| Module extension          | `extend Mod`, `extended do ... end`  | `extend(Klass, mod)` + `extended` symbol hook; `Extended<Mod>` for typing  |
-| Attribute methods         | `method_missing` + `define_method`   | Generated methods in `_generatedMethods`; index signature for reads        |
-| Dirty tracking            | Scattered ivars                      | `DirtyTracker` instance at `_dirtyTracker`                                 |
-| Callbacks                 | Blocks (`before_save do ... end`)    | Async-capable functions; `runCallbacks` is async                           |
-| Validations               | Synchronous                          | Sync signature; async validators collected on `_asyncValidationPromises`   |
-| DSL sugar                 | Block receivers                      | One `Proxy` in `Model.withOptions`                                         |
-| Serialization             | Eager map over ivars                 | Same API, supports lazy attribute stores                                   |
-| Symbols / kwargs / naming | `:symbol`, kwargs, snake_case        | strings, options objects, camelCase                                        |
+| Area              | Rails                              | Trails                                                                   |
+| ----------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| Attribute methods | `method_missing` + `define_method` | Generated methods in `_generatedMethods`; index signature for reads      |
+| Dirty tracking    | Scattered ivars                    | `DirtyTracker` instance at `_dirtyTracker`                               |
+| Callbacks         | Blocks (`before_save do ... end`)  | Async-capable functions; `runCallbacks` is async                         |
+| Validations       | Synchronous                        | Sync signature; async validators collected on `_asyncValidationPromises` |
+| DSL sugar         | Block receivers                    | One `Proxy` in `Model.withOptions`                                       |
+| Serialization     | Eager map over ivars               | Same API, supports lazy attribute stores                                 |
+
+Cross-package deviations (mixins, method casing, bang methods, symbols/
+kwargs) live in the [guides index](./).
 
 The rule of thumb: if a thing is synchronous and pure, ActiveModel looks
 essentially like Rails. The deviations cluster wherever Ruby used a

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -1,0 +1,175 @@
+# ActiveModel: Deviations from Rails
+
+ActiveModel sits between Arel (pure, synchronous) and ActiveRecord (async,
+I/O-heavy). Most of its surface is synchronous in both Rails and Trails, but
+it's also where the Ruby → TypeScript idiom gap shows up most in the shape
+of the API: mixins, callbacks, dirty tracking, attribute method generation,
+and serialization.
+
+## Module mixins: `include`, `extend`, `Included`, `Extended`
+
+Ruby modules (`include SomeConcern`, `extend OtherConcern`, with `included
+do ... end` / `extended do ... end` hooks) are the most-used metaprogramming
+feature in Rails. TypeScript has no equivalent, so ActiveSupport ships a set
+of helpers that get as close as the language allows.
+
+- **`include(Klass, mod)`** copies instance methods from `mod` onto
+  `Klass.prototype`. Skips methods already on the prototype. If the module
+  exports a function keyed by the `included` Symbol, it runs that hook with
+  the class as its argument. See `packages/activesupport/src/include.ts`.
+- **`extend(Klass, mod)`** is the class-method equivalent. Copies onto the
+  class itself and runs the `extended` Symbol hook.
+- **`Included<Mod>` / `Extended<Mod>`** are type helpers that translate a
+  module's `this`-typed functions into the method signatures the class will
+  have after mixing. They give consumers the typing they'd otherwise lose.
+
+Differences vs Ruby:
+
+- Hooks use `Symbol.for("@blazetrails/activesupport:included")` rather than
+  a magic method name. The symbol-based hook is imported by name, which
+  plays nicer with TypeScript tooling than stringly-typed method lookup.
+- Mixing is explicit and happens once at class-declaration time, rather
+  than at `include` time as Ruby does inside the class body. The net effect
+  is the same.
+
+For single methods rather than whole modules, the pattern is
+`this`-typed functions assigned directly to a class. See `CLAUDE.md` for
+the spelling; examples live in `attribute-methods.ts`, `validations.ts`,
+`callbacks.ts`, and many more.
+
+ActiveSupport also has `concern.ts`, a port of
+`ActiveSupport::Concern` for cases where we really want the Rails shape
+(class-level DSL blocks nested inside a module). It's less commonly needed
+because `Included<>` usually does the job.
+
+## Attribute methods: generated, not `method_missing`
+
+Rails' `ActiveModel::AttributeMethods` registers method *patterns*
+(`_changed?`, `_was`, `reset_`, etc.) and routes calls through
+`method_missing`. We can't do that in TypeScript without blinding the type
+checker, so Trails generates the methods at class-definition time and
+tracks them in a `_generatedMethods` Set.
+
+- `AttributeMethodPattern` (`packages/activemodel/src/attribute-methods.ts`)
+  holds the same prefix/suffix/proxy-target concept as Rails.
+- `match()` still exists for the cases where we need to split a method name
+  back into its attribute.
+- The `[key: string]: unknown` index signature on `Base` means plain
+  attribute access (`user.name`) doesn't need a proxy — it's just a
+  property. The price is that TypeScript can't type it without a per-model
+  declaration; consumers usually declare their fields explicitly.
+
+Net effect: no `method_missing`, no `Proxy`, no runtime lookup on every
+access. Slightly less dynamic than Rails, significantly friendlier to the
+type checker.
+
+## Dirty tracking: encapsulated in `DirtyTracker`
+
+Rails scatters `@changed_attributes`, `@previously_changed`, etc. across
+instance variables. Trails puts them on a `DirtyTracker` instance held at
+`record._dirtyTracker` (`packages/activemodel/src/dirty.ts`). Accessors
+like `record.changed`, `record.changes`, `record.previousChanges`
+delegate. The public API is the same; the internals are one indirection
+away.
+
+## Callbacks: async-capable
+
+Rails callbacks are Ruby blocks. Our callback signatures accept either
+sync or async functions:
+
+```ts
+type CallbackFn       = (this: any, ...args: any[]) => void | Promise<void>;
+type AroundCallbackFn = (this: any, fn: () => Promise<void>) => Promise<void>;
+```
+
+(See `packages/activemodel/src/callbacks.ts`.)
+
+Implications:
+
+- `runCallbacks` awaits each callback. Calling it is itself async.
+- `around` callbacks receive a `() => Promise<void>` to invoke the inner
+  chain, not a block with `yield`.
+- `before_save :do_thing` (a symbol naming a method) becomes either a
+  reference to a method name string or a direct function — we accept both.
+
+This is a required deviation: nearly every real callback in an
+ActiveRecord app needs to hit I/O, so callbacks had to be async-aware
+from the start.
+
+## Validations: sync signature, async reality
+
+`validates` / `validate` look the same:
+
+```ts
+class Post extends Model {
+  static {
+    Post.validates("title", { presence: true, length: { minimum: 3 } });
+  }
+}
+```
+
+The deviation surfaces when a validator needs I/O. `uniqueness` is the
+canonical case (it has to hit the DB), and it lives in ActiveRecord, not
+ActiveModel, but ActiveModel is where the machinery that supports it
+lives. `isValid()` stays synchronous for back-compat with Rails'
+signature, and async validators push their `Promise`s onto
+`record._asyncValidationPromises` for the caller to await. `save()`
+awaits these automatically; bare `isValid()` callers have to do it
+themselves.
+
+See `packages/activerecord/src/validations/uniqueness.ts` for the
+pattern; ActiveModel contributes the validator registration and error
+accumulation.
+
+## `withOptions`: one of the few Proxies
+
+ActiveModel uses `Proxy` exactly once, in `Model.withOptions(defaults,
+fn)`. Inside `fn`, calls to `validates` are rewritten to merge in the
+defaults. This is pure sugar — a one-proxy convenience for a Rails-style
+DSL block. See `packages/activemodel/src/model.ts`. Everything else in
+ActiveModel is proxy-free.
+
+## Serialization
+
+`serializableHash()` produces the same shape as Rails'
+`serializable_hash`. The one deviation: it understands attribute stores
+with lazy `fetchValue()`, not just plain `Map`/object. Rails always
+materializes attributes eagerly; we don't, because TypeScript makes lazy
+stores easy and some of our adapters want them.
+
+See `packages/activemodel/src/serialization.ts`.
+
+## Small, systematic differences
+
+- **Symbols → strings.** `validates :name, presence: true` becomes
+  `validates("name", { presence: true })`. Ruby symbol literals have no
+  JS equivalent.
+- **Keyword args → options object.** Same story: `validates("name", {
+  length: { minimum: 3, maximum: 20 } })`.
+- **snake_case → camelCase.** `record.previous_changes` →
+  `record.previousChanges`.
+- **`try :foo` → `?.`** TypeScript's optional chaining replaces Ruby's
+  safe-navigation helpers.
+- **Range** — Ruby's `Range` becomes a plain `{ begin, end, excludeEnd }`
+  object from `@blazetrails/activesupport`. Relevant to validators like
+  `numericality: { within: makeRange(0, 100) }`.
+
+## Summary
+
+| Area | Rails | Trails |
+| --- | --- | --- |
+| Module inclusion | `include Mod`, `included do ... end` | `include(Klass, mod)` + `included` symbol hook; `Included<Mod>` for typing |
+| Module extension | `extend Mod`, `extended do ... end` | `extend(Klass, mod)` + `extended` symbol hook; `Extended<Mod>` for typing |
+| Attribute methods | `method_missing` + `define_method` | Generated methods in `_generatedMethods`; index signature for reads |
+| Dirty tracking | Scattered ivars | `DirtyTracker` instance at `_dirtyTracker` |
+| Callbacks | Blocks (`before_save do ... end`) | Async-capable functions; `runCallbacks` is async |
+| Validations | Synchronous | Sync signature; async validators collected on `_asyncValidationPromises` |
+| DSL sugar | Block receivers | One `Proxy` in `Model.withOptions` |
+| Serialization | Eager map over ivars | Same API, supports lazy attribute stores |
+| Symbols / kwargs / naming | `:symbol`, kwargs, snake_case | strings, options objects, camelCase |
+
+The rule of thumb: if a thing is synchronous and pure, ActiveModel looks
+essentially like Rails. The deviations cluster wherever Ruby used a
+language feature (blocks, symbols, `method_missing`) that TypeScript
+doesn't have, or where the downstream consumer (ActiveRecord) needs
+async support.

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -1,4 +1,11 @@
+---
+title: "ActiveModel: Deviations from Rails"
+description: Module mixins via include/extend and Included/Extended, generated attribute methods, async-capable callbacks, encapsulated dirty tracking.
+---
+
 # ActiveModel: Deviations from Rails
+
+> **See also:** [Guides index](./index.md) · [Arel deviations](./arel-rails-deviations.md) · [ActiveRecord deviations](./activerecord-rails-deviations.md)
 
 ActiveModel sits between Arel (pure, synchronous) and ActiveRecord (async,
 I/O-heavy). Most of its surface is synchronous in both Rails and Trails, but
@@ -44,7 +51,7 @@ because `Included<>` usually does the job.
 
 ## Attribute methods: generated, not `method_missing`
 
-Rails' `ActiveModel::AttributeMethods` registers method *patterns*
+Rails' `ActiveModel::AttributeMethods` registers method _patterns_
 (`_changed?`, `_was`, `reset_`, etc.) and routes calls through
 `method_missing`. We can't do that in TypeScript without blinding the type
 checker, so Trails generates the methods at class-definition time and
@@ -78,7 +85,7 @@ Rails callbacks are Ruby blocks. Our callback signatures accept either
 sync or async functions:
 
 ```ts
-type CallbackFn       = (this: any, ...args: any[]) => void | Promise<void>;
+type CallbackFn = (this: any, ...args: any[]) => void | Promise<void>;
 type AroundCallbackFn = (this: any, fn: () => Promise<void>) => Promise<void>;
 ```
 
@@ -145,7 +152,7 @@ See `packages/activemodel/src/serialization.ts`.
   `validates("name", { presence: true })`. Ruby symbol literals have no
   JS equivalent.
 - **Keyword args → options object.** Same story: `validates("name", {
-  length: { minimum: 3, maximum: 20 } })`.
+length: { minimum: 3, maximum: 20 } })`.
 - **snake_case → camelCase.** `record.previous_changes` →
   `record.previousChanges`.
 - **`try :foo` → `?.`** TypeScript's optional chaining replaces Ruby's
@@ -156,17 +163,17 @@ See `packages/activemodel/src/serialization.ts`.
 
 ## Summary
 
-| Area | Rails | Trails |
-| --- | --- | --- |
-| Module inclusion | `include Mod`, `included do ... end` | `include(Klass, mod)` + `included` symbol hook; `Included<Mod>` for typing |
-| Module extension | `extend Mod`, `extended do ... end` | `extend(Klass, mod)` + `extended` symbol hook; `Extended<Mod>` for typing |
-| Attribute methods | `method_missing` + `define_method` | Generated methods in `_generatedMethods`; index signature for reads |
-| Dirty tracking | Scattered ivars | `DirtyTracker` instance at `_dirtyTracker` |
-| Callbacks | Blocks (`before_save do ... end`) | Async-capable functions; `runCallbacks` is async |
-| Validations | Synchronous | Sync signature; async validators collected on `_asyncValidationPromises` |
-| DSL sugar | Block receivers | One `Proxy` in `Model.withOptions` |
-| Serialization | Eager map over ivars | Same API, supports lazy attribute stores |
-| Symbols / kwargs / naming | `:symbol`, kwargs, snake_case | strings, options objects, camelCase |
+| Area                      | Rails                                | Trails                                                                     |
+| ------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| Module inclusion          | `include Mod`, `included do ... end` | `include(Klass, mod)` + `included` symbol hook; `Included<Mod>` for typing |
+| Module extension          | `extend Mod`, `extended do ... end`  | `extend(Klass, mod)` + `extended` symbol hook; `Extended<Mod>` for typing  |
+| Attribute methods         | `method_missing` + `define_method`   | Generated methods in `_generatedMethods`; index signature for reads        |
+| Dirty tracking            | Scattered ivars                      | `DirtyTracker` instance at `_dirtyTracker`                                 |
+| Callbacks                 | Blocks (`before_save do ... end`)    | Async-capable functions; `runCallbacks` is async                           |
+| Validations               | Synchronous                          | Sync signature; async validators collected on `_asyncValidationPromises`   |
+| DSL sugar                 | Block receivers                      | One `Proxy` in `Model.withOptions`                                         |
+| Serialization             | Eager map over ivars                 | Same API, supports lazy attribute stores                                   |
+| Symbols / kwargs / naming | `:symbol`, kwargs, snake_case        | strings, options objects, camelCase                                        |
 
 The rule of thumb: if a thing is synchronous and pure, ActiveModel looks
 essentially like Rails. The deviations cluster wherever Ruby used a

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -34,10 +34,11 @@ tracks them in a `_generatedMethods` Set.
   holds the same prefix/suffix/proxy-target concept as Rails.
 - `match()` still exists for the cases where we need to split a method name
   back into its attribute.
-- The `[key: string]: unknown` index signature on `Base` means plain
-  attribute access (`user.name`) doesn't need a proxy — it's just a
-  property. The price is that TypeScript can't type it without a per-model
-  declaration; consumers usually declare their fields explicitly.
+- The `[key: string]: unknown` index signature on `Model`
+  (`packages/activemodel/src/model.ts:62`) means plain attribute access
+  (`user.name`) doesn't need a proxy — it's just a property. The price
+  is that TypeScript can't type it without a per-model declaration;
+  consumers usually declare their fields explicitly.
 
 Net effect: no `method_missing`, no `Proxy`, no runtime lookup on every
 access. Slightly less dynamic than Rails, significantly friendlier to the

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -149,10 +149,7 @@ Trails, each `Base` subclass holds its own `_connectionHandler`, and
 pools are acquired per query rather than checked out per thread.
 `establishConnection` / `connectsTo` shape mirrors Rails; the
 underlying pool model is different because there are no threads to
-pool over. See `packages/activerecord/src/connection-handling.ts` and
-the [connections and pools
-notes](https://github.com/blazetrailsdev/trails/blob/main/docs/activerecord-connections-and-pools.md)
-for the full story.
+pool over. See `packages/activerecord/src/connection-handling.ts`.
 
 ## 5. Relation `method_missing` → typed `Proxy`
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -1,0 +1,265 @@
+# ActiveRecord: Deviations from Rails
+
+ActiveRecord is where JavaScript's async single-threaded model has the
+biggest impact. Almost every DB-touching method in Rails is synchronous;
+in Trails, almost every DB-touching method is async. This document
+catalogs the differences so readers don't have to rediscover them one
+test at a time.
+
+Everything in the [ActiveModel deviations](./activemodel-rails-deviations.md)
+doc applies here too (mixins, callbacks, attribute methods, etc.). This
+doc focuses on what's new or amplified in ActiveRecord.
+
+## 1. Async everywhere DB is touched
+
+This is the single biggest deviation. Rails:
+
+```ruby
+user = User.find(1)        # sync
+user.name = "Dean"
+user.save                  # sync
+posts = user.posts.to_a    # sync
+```
+
+Trails:
+
+```ts
+const user  = await User.find(1);
+user.name   = "Dean";
+await user.save();
+const posts = await user.posts.toArray();
+```
+
+Every read and every write is a `Promise`. Concretely:
+
+- **Finders**: `find`, `findBy`, `first`, `last`, `take`, `exists?`,
+  `count`, `sum`, `minimum`, `maximum`, `pluck`, `ids`, `each`,
+  `findEach`, `findInBatches`, `inBatches` — all async. See
+  `packages/activerecord/src/relation/finder-methods.ts`.
+- **Relation materialization**: `toArray()` replaces Rails' `to_a`/
+  implicit `each`, and is async. Relations are lazy like in Rails, but
+  you have to explicitly await the terminal operation.
+- **Persistence**: `save`, `save!`, `create`, `update`, `update!`,
+  `destroy`, `destroy!`, `toggle!`, `touch`, `updateColumn`,
+  `updateColumns`, `increment!`, `decrement!` — all async. See
+  `packages/activerecord/src/persistence.ts`.
+- **Associations**: `user.posts`, `post.author` return relations/
+  promises — accessing them is async because loading them is.
+- **Schema / connection calls**: every adapter method (`executeQuery`,
+  `selectAll`, `insert`, `executeMutation`, `beginTransaction`,
+  `commit`, `rollback`) returns `Promise`.
+
+There is no synchronous escape hatch. Browser and Node both expose DB
+access through async drivers.
+
+### Practical consequences
+
+- `if (user.valid?)` in Rails becomes `if (record.isValid())` in
+  Trails — still synchronous — **but** if any uniqueness validator
+  fired, you must `await` its pending promise before trusting
+  `record.errors`. `save()` does this for you; manual `isValid()`
+  callers don't get it for free. See
+  `packages/activerecord/src/validations/uniqueness.ts`.
+- Sequencing matters. `user.posts.toArray()` and `user.posts.count()`
+  are separate round-trips unless you preload. Accidentally awaiting
+  the same relation twice issues two queries.
+- Iteration is async: `for await (const record of Model.findEach())`
+  rather than `Model.find_each do |record| ... end`.
+
+## 2. Transactions: function, not block
+
+Rails:
+
+```ruby
+User.transaction do
+  user.save!
+  post.save!
+end
+```
+
+Trails:
+
+```ts
+await User.transaction(async (tx) => {
+  await user.save();
+  await post.save();
+});
+```
+
+The shape is intentionally close: both pass a body that runs inside a
+transaction and rolls back on any thrown error. The differences:
+
+- The body is an **async function**, not a block.
+- **Transaction state rides on `AsyncLocalStorage`**, not a thread
+  local. Nested `await`s see the correct surrounding transaction
+  because the async context propagates automatically. See
+  `packages/activerecord/src/transactions.ts` and the async-context
+  adapter in `@blazetrails/activesupport`.
+- Options (`isolation`, `requiresNew`, `joinable`) are passed as a
+  third argument rather than as keyword args.
+
+## 3. Async-context state instead of thread locals
+
+Rails uses `Thread.current` / `ActiveSupport::IsolatedExecutionState`
+for per-request state: current transaction, query cache, connection
+handler role, `Current` attributes. Node has no threads in the Rails
+sense, so Trails uses `AsyncLocalStorage` (with a browser fallback)
+wrapped by `@blazetrails/activesupport`'s `getAsyncContext()`.
+
+Current uses:
+
+- **Current transaction** — `packages/activerecord/src/transactions.ts`.
+- **Query-prohibit scopes** — `connection-handling.ts` uses an
+  `AsyncContext<boolean>` to track `whileDisconnecting` and friends.
+- **Current attributes** — `current-attributes.ts` in ActiveSupport.
+
+The behavior matches Rails for any code that stays in a single
+async flow. If you spawn unattached work (`setTimeout`, `queueMicrotask`
+without `await`), you lose the context the same way Rails loses thread
+locals when you spawn a new thread.
+
+## 4. Connection handling: no implicit global
+
+Rails leans on `ActiveRecord::Base.connection` as a near-global. In
+Trails, each `Base` subclass holds its own `_connectionHandler`, and
+pools are acquired per query rather than checked out per thread.
+`establishConnection` / `connectsTo` shape mirrors Rails; the
+underlying pool model is different because there are no threads to
+pool over. See `packages/activerecord/src/connection-handling.ts` and
+`docs/activerecord-connections-and-pools.md` for the full story.
+
+## 5. Relation `method_missing` → typed `Proxy`
+
+Rails' `ActiveRecord::Relation` uses `method_missing` to forward
+unknown calls to the model class (for named scopes and class-method
+delegation). We do the same thing with a `Proxy` wrapper
+(`wrapWithScopeProxy` in
+`packages/activerecord/src/relation/delegation.ts`). Every relation
+returned by `all()`, `where()`, `order()`, etc. is wrapped so that
+`User.where({ active: true }).published()` resolves `published`
+against the model's registered scopes.
+
+This is one of very few places we reach for `Proxy`. We use it here
+because the set of methods is genuinely dynamic (scopes are
+user-defined) and TypeScript's structural typing lets consumers
+declare the scope signatures on their Relation type.
+
+## 6. Named scopes: stored, not metaprogrammed
+
+`scope("published", (rel) => rel.where({ published: true }))` stores
+the function in a `_scopes` Map on the class and defines a static
+method that delegates through `all()`. The Relation proxy above picks
+the scope up on relation instances. See
+`packages/activerecord/src/scoping/named.ts`.
+
+## 7. Enums: explicit `defineProperty`, async bang methods
+
+Rails' `enum status: [:draft, :published]` generates `draft?`,
+`published?`, `draft!`, `published!`, and scopes. Trails does the same
+but:
+
+- Generation happens in `defineEnum`
+  (`packages/activerecord/src/enum.ts`) via `Object.defineProperty`,
+  not `define_method`.
+- The **bang methods are async** because persisting the change hits
+  the DB:
+
+  ```ts
+  await post.draftBang();    // Rails: post.draft!
+  ```
+
+  `post.isDraft()` and `post.draft()` (setter without persist) stay
+  synchronous.
+
+## 8. Ranges: plain object
+
+Ruby's `Range` (`1..10`, `1...10`, `Date.new(..)..Date.new(..)`) has
+no JS equivalent, so ActiveSupport exposes a plain typed object
+`{ begin, end, excludeEnd }` and helper functions. `where({ age:
+makeRange(18, 65) })` lowers to the right SQL via Arel. Rails passes
+real `Range` instances; we pass this struct.
+
+See `packages/activesupport/src/range-ext.ts`.
+
+## 9. Numeric types
+
+JavaScript has only `number` and `bigint`. Rails distinguishes
+`Integer`, `Float`, `BigDecimal`. Trails maps them as:
+
+- `Integer` → `number` (or `bigint` where 64-bit IDs demand it).
+- `Float`, `Decimal` → `number` (full `BigDecimal` arithmetic is not
+  attempted — this is a known lossy area; specific columns that need
+  exact decimal math will need a Decimal type later).
+- `Date`, `DateTime`, `Time` → JS `Date`.
+
+If this matters for your use case, treat the column as a string and
+parse it yourself. We intentionally don't ship a half-implemented
+`BigDecimal`.
+
+## 10. Adapters (beyond the DB): `fs` and `crypto`
+
+Rails uses `File`, `FileUtils`, `OpenSSL`, and `SecureRandom`
+directly. That is fine on servers and impossible in browsers.
+ActiveSupport ships two adapters consumed by ActiveRecord:
+
+- **`fs-adapter.ts`** — `FsAdapter` interface with `readFileSync`,
+  `writeFileSync`, `existsSync`, `mkdirSync`, etc. Auto-registers
+  `node:fs` + `node:path` at runtime when available. A browser host
+  registers an in-memory or OPFS-backed implementation.
+- **`crypto-adapter.ts`** — `CryptoAdapter` with `randomBytes`,
+  `randomUUID`, `createHash`, `createHmac`, `createCipheriv`,
+  `pbkdf2Sync`, `timingSafeEqual`. Auto-registers a Node-crypto
+  wrapper; browsers register a `window.crypto`-based adapter.
+
+Callers always go through `getFs()` / `getCrypto()` rather than
+importing `node:fs` / `node:crypto` directly. This is how signed IDs,
+message verifiers, schema cache persistence, and migration file I/O
+all keep working in the browser.
+
+More adapters are likely coming (e.g., process/env, timers) as
+browser surface area grows.
+
+## 11. Callbacks: async all the way down
+
+Already covered in the [ActiveModel doc](./activemodel-rails-deviations.md#callbacks-async-capable),
+but worth emphasizing here: because ActiveRecord callbacks commonly
+need to hit the DB (`beforeSave` cascading to related records, etc.),
+they are almost always async. Always `await` them when composing
+manually; `save()` / `destroy()` / etc. do it for you.
+
+## 12. Naming / keyword args / symbols
+
+- `Model.where(name: "dean", active: true)` →
+  `Model.where({ name: "dean", active: true })`.
+- `has_many :posts, dependent: :destroy` →
+  `Model.hasMany("posts", { dependent: "destroy" })`. String literals
+  replace symbols throughout the options surface.
+- snake_case → camelCase everywhere.
+
+These are systematic, not per-method.
+
+## Summary
+
+| Area | Rails | Trails |
+| --- | --- | --- |
+| Finders / reads | Sync | Async (`await` required) |
+| Persistence | Sync | Async |
+| Relation iteration | `to_a`, `each` (sync) | `toArray()`, `for await` |
+| Transactions | `transaction do ... end` | `await transaction(async (tx) => { ... })` |
+| Per-flow state | `Thread.current` | `AsyncLocalStorage` via `getAsyncContext()` |
+| Connection pool | Thread-checkout model | Per-handler pools, per-query acquisition |
+| Relation method dispatch | `method_missing` | `Proxy` wrapper (`wrapWithScopeProxy`) |
+| Scopes | Generated via `define_singleton_method` | `_scopes` Map + delegation |
+| Enum bang methods | Sync | Async (`draftBang()` hits DB) |
+| Ranges | `Range` | Plain `{ begin, end, excludeEnd }` |
+| Numerics | `Integer`/`Float`/`BigDecimal` | `number`/`bigint` only |
+| File / crypto access | Direct stdlib | Pluggable adapters for browser support |
+| Callbacks | Ruby blocks | Async functions |
+| Uniqueness validation | Sync DB hit | Async, coordinated via `_asyncValidationPromises` |
+
+If something in Rails surprises you with its absence here, the most
+common cause is: "it was synchronous in Ruby and the JavaScript
+equivalent is async, so the signature changed." The second most
+common is: "Ruby had a language feature (symbol, block, Range,
+`method_missing`) and TypeScript doesn't, so we expressed the same
+idea differently."

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -221,7 +221,7 @@ parse it yourself. We intentionally don't ship a half-implemented
 
 ## 10. Adapters (beyond the DB): `fs` and `crypto`
 
-See [Browser support via adapters](./#adapters) for the shared
+See [Browser support via adapters](./index.md#adapters) for the shared
 `FsAdapter` / `CryptoAdapter` primer. ActiveRecord is the heaviest
 consumer: signed IDs, message verifiers, schema cache persistence, and
 migration file I/O all route through `getFs()` / `getCrypto()` so they
@@ -229,7 +229,7 @@ keep working in the browser.
 
 ## 11. Callbacks: async all the way down
 
-See [Block APIs → callback functions](./#block-apis) for the shared
+See [Block APIs → callback functions](./index.md#block-apis) for the shared
 callback story. Worth emphasizing in ActiveRecord specifically: because
 callbacks here commonly need to hit the DB (`beforeSave` cascading to
 related records, etc.), they are almost always async. Always `await`
@@ -239,8 +239,8 @@ you.
 ## 12. Naming, bang methods, keyword args, symbols
 
 All cross-package — see the index for
-[method casing](./#method-casing), [bang methods](./#bang-methods),
-and [symbols/kwargs](./#symbols-kwargs). Every ActiveRecord API
+[method casing](./index.md#method-casing), [bang methods](./index.md#bang-methods),
+and [symbols/kwargs](./index.md#symbols-kwargs). Every ActiveRecord API
 follows them.
 
 ## Summary

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -37,19 +37,27 @@ await user.save();
 const posts = await user.posts.toArray();
 ```
 
+> The examples below import `transaction` from `@blazetrails/activerecord`
+> and pass the model class explicitly. Rails' `User.transaction do ... end`
+> is a class method; Trails exports a module-level function instead.
+
 Every read and every write is a `Promise`. Concretely:
 
-- **Finders**: `find`, `findBy`, `first`, `last`, `take`, `exists?`,
+- **Finders**: `find`, `findBy`, `first`, `last`, `take`, `exists`,
   `count`, `sum`, `minimum`, `maximum`, `pluck`, `ids`, `each`,
   `findEach`, `findInBatches`, `inBatches` — all async. See
-  `packages/activerecord/src/relation/finder-methods.ts`.
+  `packages/activerecord/src/relation/finder-methods.ts` and
+  `packages/activerecord/src/relation.ts` (`exists`, `findEach`).
 - **Relation materialization**: `toArray()` replaces Rails' `to_a`/
   implicit `each`, and is async. Relations are lazy like in Rails, but
   you have to explicitly await the terminal operation.
-- **Persistence**: `save`, `save!`, `create`, `update`, `update!`,
-  `destroy`, `destroy!`, `toggle!`, `touch`, `updateColumn`,
-  `updateColumns`, `increment!`, `decrement!` — all async. See
-  `packages/activerecord/src/persistence.ts`.
+- **Persistence**: `save`, `saveBang`, `create`, `update`, `updateBang`,
+  `destroy`, `destroyBang`, `toggleBang`, `touch`, `updateColumn`,
+  `updateColumns`, `incrementBang`, `decrementBang` — all async. See
+  `packages/activerecord/src/base.ts` and
+  `packages/activerecord/src/persistence.ts`. The Rails bang
+  convention (`save!`, `destroy!`) becomes a `Bang` suffix because `!`
+  isn't a legal identifier character in JS/TS.
 - **Associations**: `user.posts`, `post.author` return relations/
   promises — accessing them is async because loading them is.
 - **Schema / connection calls**: every adapter method (`executeQuery`,
@@ -70,8 +78,10 @@ access through async drivers.
 - Sequencing matters. `user.posts.toArray()` and `user.posts.count()`
   are separate round-trips unless you preload. Accidentally awaiting
   the same relation twice issues two queries.
-- Iteration is async: `for await (const record of Model.findEach())`
-  rather than `Model.find_each do |record| ... end`.
+- Iteration is async: `for await (const record of Model.all().findEach())`
+  rather than `Model.find_each do |record| ... end`. `findEach` lives on
+  `Relation`, not `Base`, so you start from `.all()` (or any other
+  relation-returning call).
 
 ## 2. Transactions: function, not block
 
@@ -87,9 +97,11 @@ end
 Trails:
 
 ```ts
-await User.transaction(async (tx) => {
-  await user.save();
-  await post.save();
+import { transaction } from "@blazetrails/activerecord";
+
+await transaction(User, async (tx) => {
+  await user.saveBang();
+  await post.saveBang();
 });
 ```
 
@@ -97,6 +109,11 @@ The shape is intentionally close: both pass a body that runs inside a
 transaction and rolls back on any thrown error. The differences:
 
 - The body is an **async function**, not a block.
+- There's no static `User.transaction`. The module-level `transaction`
+  function takes the model class as its first argument so it can find
+  the right adapter. An instance-level `record.transaction(fn)` is also
+  available (mirrors `ActiveRecord::Base#transaction`, see
+  `packages/activerecord/src/base.ts`).
 - **Transaction state rides on `AsyncLocalStorage`**, not a thread
   local. Nested `await`s see the correct surrounding transaction
   because the async context propagates automatically. See
@@ -133,7 +150,9 @@ pools are acquired per query rather than checked out per thread.
 `establishConnection` / `connectsTo` shape mirrors Rails; the
 underlying pool model is different because there are no threads to
 pool over. See `packages/activerecord/src/connection-handling.ts` and
-`docs/activerecord-connections-and-pools.md` for the full story.
+the [connections and pools
+notes](https://github.com/blazetrailsdev/trails/blob/main/docs/activerecord-connections-and-pools.md)
+for the full story.
 
 ## 5. Relation `method_missing` → typed `Proxy`
 
@@ -205,45 +224,27 @@ parse it yourself. We intentionally don't ship a half-implemented
 
 ## 10. Adapters (beyond the DB): `fs` and `crypto`
 
-Rails uses `File`, `FileUtils`, `OpenSSL`, and `SecureRandom`
-directly. That is fine on servers and impossible in browsers.
-ActiveSupport ships two adapters consumed by ActiveRecord:
-
-- **`fs-adapter.ts`** — `FsAdapter` interface with `readFileSync`,
-  `writeFileSync`, `existsSync`, `mkdirSync`, etc. Auto-registers
-  `node:fs` + `node:path` at runtime when available. A browser host
-  registers an in-memory or OPFS-backed implementation.
-- **`crypto-adapter.ts`** — `CryptoAdapter` with `randomBytes`,
-  `randomUUID`, `createHash`, `createHmac`, `createCipheriv`,
-  `pbkdf2Sync`, `timingSafeEqual`. Auto-registers a Node-crypto
-  wrapper; browsers register a `window.crypto`-based adapter.
-
-Callers always go through `getFs()` / `getCrypto()` rather than
-importing `node:fs` / `node:crypto` directly. This is how signed IDs,
-message verifiers, schema cache persistence, and migration file I/O
-all keep working in the browser.
-
-More adapters are likely coming (e.g., process/env, timers) as
-browser surface area grows.
+See [Browser support via adapters](./#adapters) for the shared
+`FsAdapter` / `CryptoAdapter` primer. ActiveRecord is the heaviest
+consumer: signed IDs, message verifiers, schema cache persistence, and
+migration file I/O all route through `getFs()` / `getCrypto()` so they
+keep working in the browser.
 
 ## 11. Callbacks: async all the way down
 
-Already covered in the [ActiveModel doc](./activemodel-rails-deviations.md#callbacks-async-capable),
-but worth emphasizing here: because ActiveRecord callbacks commonly
-need to hit the DB (`beforeSave` cascading to related records, etc.),
-they are almost always async. Always `await` them when composing
-manually; `save()` / `destroy()` / etc. do it for you.
+See [Block APIs → callback functions](./#block-apis) for the shared
+callback story. Worth emphasizing in ActiveRecord specifically: because
+callbacks here commonly need to hit the DB (`beforeSave` cascading to
+related records, etc.), they are almost always async. Always `await`
+them when composing manually; `save()` / `destroy()` / etc. do it for
+you.
 
-## 12. Naming / keyword args / symbols
+## 12. Naming, bang methods, keyword args, symbols
 
-- `Model.where(name: "dean", active: true)` →
-  `Model.where({ name: "dean", active: true })`.
-- `has_many :posts, dependent: :destroy` →
-  `Model.hasMany("posts", { dependent: "destroy" })`. String literals
-  replace symbols throughout the options surface.
-- snake_case → camelCase everywhere.
-
-These are systematic, not per-method.
+All cross-package — see the index for
+[method casing](./#method-casing), [bang methods](./#bang-methods),
+and [symbols/kwargs](./#symbols-kwargs). Every ActiveRecord API
+follows them.
 
 ## Summary
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -1,4 +1,11 @@
+---
+title: "ActiveRecord: Deviations from Rails"
+description: Async finders and persistence, transactions as async functions, AsyncLocalStorage for per-flow state, Proxy-based scope dispatch, pluggable fs/crypto adapters.
+---
+
 # ActiveRecord: Deviations from Rails
+
+> **See also:** [Guides index](./index.md) · [Arel deviations](./arel-rails-deviations.md) · [ActiveModel deviations](./activemodel-rails-deviations.md)
 
 ActiveRecord is where JavaScript's async single-threaded model has the
 biggest impact. Almost every DB-touching method in Rails is synchronous;
@@ -24,8 +31,8 @@ posts = user.posts.to_a    # sync
 Trails:
 
 ```ts
-const user  = await User.find(1);
-user.name   = "Dean";
+const user = await User.find(1);
+user.name = "Dean";
 await user.save();
 const posts = await user.posts.toArray();
 ```
@@ -165,7 +172,7 @@ but:
   the DB:
 
   ```ts
-  await post.draftBang();    // Rails: post.draft!
+  await post.draftBang(); // Rails: post.draft!
   ```
 
   `post.isDraft()` and `post.draft()` (setter without persist) stay
@@ -240,22 +247,22 @@ These are systematic, not per-method.
 
 ## Summary
 
-| Area | Rails | Trails |
-| --- | --- | --- |
-| Finders / reads | Sync | Async (`await` required) |
-| Persistence | Sync | Async |
-| Relation iteration | `to_a`, `each` (sync) | `toArray()`, `for await` |
-| Transactions | `transaction do ... end` | `await transaction(async (tx) => { ... })` |
-| Per-flow state | `Thread.current` | `AsyncLocalStorage` via `getAsyncContext()` |
-| Connection pool | Thread-checkout model | Per-handler pools, per-query acquisition |
-| Relation method dispatch | `method_missing` | `Proxy` wrapper (`wrapWithScopeProxy`) |
-| Scopes | Generated via `define_singleton_method` | `_scopes` Map + delegation |
-| Enum bang methods | Sync | Async (`draftBang()` hits DB) |
-| Ranges | `Range` | Plain `{ begin, end, excludeEnd }` |
-| Numerics | `Integer`/`Float`/`BigDecimal` | `number`/`bigint` only |
-| File / crypto access | Direct stdlib | Pluggable adapters for browser support |
-| Callbacks | Ruby blocks | Async functions |
-| Uniqueness validation | Sync DB hit | Async, coordinated via `_asyncValidationPromises` |
+| Area                     | Rails                                   | Trails                                            |
+| ------------------------ | --------------------------------------- | ------------------------------------------------- |
+| Finders / reads          | Sync                                    | Async (`await` required)                          |
+| Persistence              | Sync                                    | Async                                             |
+| Relation iteration       | `to_a`, `each` (sync)                   | `toArray()`, `for await`                          |
+| Transactions             | `transaction do ... end`                | `await transaction(async (tx) => { ... })`        |
+| Per-flow state           | `Thread.current`                        | `AsyncLocalStorage` via `getAsyncContext()`       |
+| Connection pool          | Thread-checkout model                   | Per-handler pools, per-query acquisition          |
+| Relation method dispatch | `method_missing`                        | `Proxy` wrapper (`wrapWithScopeProxy`)            |
+| Scopes                   | Generated via `define_singleton_method` | `_scopes` Map + delegation                        |
+| Enum bang methods        | Sync                                    | Async (`draftBang()` hits DB)                     |
+| Ranges                   | `Range`                                 | Plain `{ begin, end, excludeEnd }`                |
+| Numerics                 | `Integer`/`Float`/`BigDecimal`          | `number`/`bigint` only                            |
+| File / crypto access     | Direct stdlib                           | Pluggable adapters for browser support            |
+| Callbacks                | Ruby blocks                             | Async functions                                   |
+| Uniqueness validation    | Sync DB hit                             | Async, coordinated via `_asyncValidationPromises` |
 
 If something in Rails surprises you with its absence here, the most
 common cause is: "it was synchronous in Ruby and the JavaScript

--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -1,4 +1,11 @@
+---
+title: "Arel: Deviations from Rails"
+description: How Trails' Arel package differs from Rails Arel — naming, symbol branding, typed generics. No async deviations.
+---
+
 # Arel: Deviations from Rails
+
+> **See also:** [Guides index](./index.md) · [ActiveModel deviations](./activemodel-rails-deviations.md) · [ActiveRecord deviations](./activerecord-rails-deviations.md)
 
 Arel is the least-deviating package in Trails. It is a pure SQL AST builder
 with no I/O, so JavaScript's async/single-threaded model has almost no impact.
@@ -65,7 +72,7 @@ writing queries in Trails feels safer than in Rails.
 Arel is 100% synchronous in both Rails and Trails. Nothing in `packages/arel`
 returns a `Promise`. I/O happens in ActiveRecord's adapters, not here.
 
-## What is *not* different
+## What is _not_ different
 
 - AST node shape and naming (`Nodes::SelectStatement` → `SelectStatement`,
   same fields).
@@ -77,11 +84,11 @@ returns a `Promise`. I/O happens in ActiveRecord's adapters, not here.
 
 ## Summary
 
-| Area | Rails | Trails |
-| --- | --- | --- |
-| Method names | snake_case | camelCase |
-| Arguments | Ruby keyword args / symbols | Option objects / strings |
-| Node identity | `is_a?` / `respond_to?` | `Symbol.for` brands |
-| Dynamic attr access | `method_missing` on `Table` | Explicit `table.get("id")` |
-| Async | N/A (sync) | Same — still sync |
-| Typing | Dynamic | Generic `SelectManager<T>`, `Attribute<T>` |
+| Area                | Rails                       | Trails                                     |
+| ------------------- | --------------------------- | ------------------------------------------ |
+| Method names        | snake_case                  | camelCase                                  |
+| Arguments           | Ruby keyword args / symbols | Option objects / strings                   |
+| Node identity       | `is_a?` / `respond_to?`     | `Symbol.for` brands                        |
+| Dynamic attr access | `method_missing` on `Table` | Explicit `table.get("id")`                 |
+| Async               | N/A (sync)                  | Same — still sync                          |
+| Typing              | Dynamic                     | Generic `SelectManager<T>`, `Attribute<T>` |

--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -19,15 +19,11 @@ visitors, and so on.
 
 ## Naming and arguments
 
-- **snake_case → camelCase.** Every method is renamed (`project` stays
-  `project`, `take` stays `take`, but `order_by` → `orderBy`, `from_clause`
-  → `fromClause`, etc.). This is systematic across the whole codebase and
-  not called out individually elsewhere.
-- **Keyword args → options objects.** Ruby's `Arel::Table.new(:users, as: "u")`
-  becomes `new Table("users", { as: "u" })`. No `**opts` splatting.
-- **Symbols → strings.** Ruby passes `:users` to `Arel::Table.new`; we pass
-  `"users"`. JavaScript has a `Symbol` primitive but no `:foo` literal, and
-  symbols-as-identifiers is not idiomatic TS.
+Arel inherits the cross-cutting conventions described in the guides
+index: [method casing](./#method-casing) (camelCase everywhere) and
+[symbols/kwargs → options objects](./#symbols-kwargs). So Ruby's
+`Arel::Table.new(:users, as: "u")` becomes `new Table("users", { as:
+"u" })`. Nothing Arel-specific about this.
 
 ## Symbol branding instead of class checks
 
@@ -47,17 +43,19 @@ This is a pure-TS concern; Rails never needs it.
 
 Rails Arel uses `method_missing` in a few places (notably for attribute
 access on `Arel::Table`: `users[:id]`). We don't use `Proxy` anywhere in
-Arel. `Table#[]` is a real method that takes a string and returns an
-`Attribute`. The call site is:
+Arel. TypeScript can't express a `Table#[]` method the way Ruby does, so
+`Table` exposes explicit accessors that take a string and return an
+`Attribute`:
 
 ```ts
 // Rails:  users[:id]
-// Trails: users.get("id")   // or: users.attribute("id")
+// Trails: users.get("id")   // or: users.attr("id")
 ```
 
-We considered a `Proxy`-backed `Table` that would make `users.id` work, but
-chose the explicit accessor because the Proxy would defeat TypeScript's
-property checking on the surrounding class. Typing wins over syntax.
+Both are defined in `packages/arel/src/table.ts`. We considered a
+`Proxy`-backed `Table` that would make `users.id` work, but chose the
+explicit accessor because the Proxy would defeat TypeScript's property
+checking on the surrounding class. Typing wins over syntax.
 
 ## Generic typing of nodes
 
@@ -84,11 +82,11 @@ returns a `Promise`. I/O happens in ActiveRecord's adapters, not here.
 
 ## Summary
 
-| Area                | Rails                       | Trails                                     |
-| ------------------- | --------------------------- | ------------------------------------------ |
-| Method names        | snake_case                  | camelCase                                  |
-| Arguments           | Ruby keyword args / symbols | Option objects / strings                   |
-| Node identity       | `is_a?` / `respond_to?`     | `Symbol.for` brands                        |
-| Dynamic attr access | `method_missing` on `Table` | Explicit `table.get("id")`                 |
-| Async               | N/A (sync)                  | Same — still sync                          |
-| Typing              | Dynamic                     | Generic `SelectManager<T>`, `Attribute<T>` |
+| Area                | Rails                       | Trails                                          |
+| ------------------- | --------------------------- | ----------------------------------------------- |
+| Method names        | snake_case                  | camelCase                                       |
+| Arguments           | Ruby keyword args / symbols | Option objects / strings                        |
+| Node identity       | `is_a?` / `respond_to?`     | `Symbol.for` brands                             |
+| Dynamic attr access | `method_missing` on `Table` | Explicit `table.get("id")` / `table.attr("id")` |
+| Async               | N/A (sync)                  | Same — still sync                               |
+| Typing              | Dynamic                     | Generic `SelectManager<T>`, `Attribute<T>`      |

--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -1,0 +1,87 @@
+# Arel: Deviations from Rails
+
+Arel is the least-deviating package in Trails. It is a pure SQL AST builder
+with no I/O, so JavaScript's async/single-threaded model has almost no impact.
+The deviations here are mostly about Ruby idioms that don't translate
+(symbols, `method_missing`, keyword args) and TypeScript features we use to
+add safety Rails can't.
+
+If you know Rails Arel, you already know Trails Arel. The shapes are
+intentionally identical: `Table`, `SelectManager`, `Nodes`, `Attribute`,
+visitors, and so on.
+
+## Naming and arguments
+
+- **snake_case → camelCase.** Every method is renamed (`project` stays
+  `project`, `take` stays `take`, but `order_by` → `orderBy`, `from_clause`
+  → `fromClause`, etc.). This is systematic across the whole codebase and
+  not called out individually elsewhere.
+- **Keyword args → options objects.** Ruby's `Arel::Table.new(:users, as: "u")`
+  becomes `new Table("users", { as: "u" })`. No `**opts` splatting.
+- **Symbols → strings.** Ruby passes `:users` to `Arel::Table.new`; we pass
+  `"users"`. JavaScript has a `Symbol` primitive but no `:foo` literal, and
+  symbols-as-identifiers is not idiomatic TS.
+
+## Symbol branding instead of class checks
+
+Rails Arel relies on Ruby's class system (`is_a?`) and duck typing
+(`respond_to?`) to identify node kinds. We can't rely on `instanceof` across
+module boundaries (multiple copies of a class can coexist across bundles), so
+core node types are branded with `Symbol.for(...)` and detected by symbol
+presence.
+
+- See `packages/arel/src/nodes/binary.ts` for the `ATTRIBUTE_BRAND`
+  pattern. `isAttribute(node)` checks the branded symbol rather than
+  `instanceof Attribute`.
+
+This is a pure-TS concern; Rails never needs it.
+
+## No `method_missing`, no Proxy
+
+Rails Arel uses `method_missing` in a few places (notably for attribute
+access on `Arel::Table`: `users[:id]`). We don't use `Proxy` anywhere in
+Arel. `Table#[]` is a real method that takes a string and returns an
+`Attribute`. The call site is:
+
+```ts
+// Rails:  users[:id]
+// Trails: users.get("id")   // or: users.attribute("id")
+```
+
+We considered a `Proxy`-backed `Table` that would make `users.id` work, but
+chose the explicit accessor because the Proxy would defeat TypeScript's
+property checking on the surrounding class. Typing wins over syntax.
+
+## Generic typing of nodes
+
+TypeScript lets us parameterize nodes where Rails just stores `Object`. A
+`SelectManager<T>` knows the row shape it eventually produces, `Attribute<T>`
+carries its column type, and visitor return types are inferred. This is
+purely additive — Rails behavior is unchanged — and is the main reason
+writing queries in Trails feels safer than in Rails.
+
+## Sync vs async
+
+Arel is 100% synchronous in both Rails and Trails. Nothing in `packages/arel`
+returns a `Promise`. I/O happens in ActiveRecord's adapters, not here.
+
+## What is *not* different
+
+- AST node shape and naming (`Nodes::SelectStatement` → `SelectStatement`,
+  same fields).
+- Visitor pattern (`ToSql`, per-dialect subclasses).
+- `Table`, `SelectManager`, `InsertManager`, `UpdateManager`,
+  `DeleteManager` all have the same roles.
+- Predicate factories on `Attribute` (`eq`, `notEq`, `in`, `matches`, etc.)
+  mirror Rails method for method.
+
+## Summary
+
+| Area | Rails | Trails |
+| --- | --- | --- |
+| Method names | snake_case | camelCase |
+| Arguments | Ruby keyword args / symbols | Option objects / strings |
+| Node identity | `is_a?` / `respond_to?` | `Symbol.for` brands |
+| Dynamic attr access | `method_missing` on `Table` | Explicit `table.get("id")` |
+| Async | N/A (sync) | Same — still sync |
+| Typing | Dynamic | Generic `SelectManager<T>`, `Attribute<T>` |

--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -20,8 +20,8 @@ visitors, and so on.
 ## Naming and arguments
 
 Arel inherits the cross-cutting conventions described in the guides
-index: [method casing](./#method-casing) (camelCase everywhere) and
-[symbols/kwargs → options objects](./#symbols-kwargs). So Ruby's
+index: [method casing](./index.md#method-casing) (camelCase everywhere) and
+[symbols/kwargs → options objects](./index.md#symbols-kwargs). So Ruby's
 `Arel::Table.new(:users, as: "u")` becomes `new Table("users", { as:
 "u" })`. Nothing Arel-specific about this.
 

--- a/packages/website/docs/guides/index.md
+++ b/packages/website/docs/guides/index.md
@@ -1,0 +1,62 @@
+---
+title: Guides
+description: Conceptual guides for Trails — how the TypeScript port relates to Rails, where it deviates, and why.
+---
+
+# Guides
+
+Conceptual guides for Trails. The API reference tells you _what_ exists;
+these guides tell you _why_ it looks the way it does.
+
+## Rails deviations
+
+Trails mirrors the Rails API as closely as TypeScript allows, but some
+things can't (or shouldn't) cross the language gap unchanged. JavaScript
+is async and single-threaded. Ruby modules have no direct equivalent.
+Ruby symbols, keyword args, and blocks don't exist in TS. We also want
+to run in the browser, which Rails does not. These guides document those
+divergences per package so you don't have to rediscover them one test at
+a time.
+
+- [**Arel**](./arel-rails-deviations.md) — the least-deviating package.
+  SQL AST building is purely synchronous; deviations are limited to
+  naming, symbol branding, and added TypeScript generics.
+- [**ActiveModel**](./activemodel-rails-deviations.md) — mixin helpers
+  (`include`/`extend` with `Included`/`Extended` type helpers), generated
+  attribute methods instead of `method_missing`, async-capable callbacks,
+  encapsulated dirty tracking.
+- [**ActiveRecord**](./activerecord-rails-deviations.md) — the biggest
+  diff. Async propagation through finders, persistence, transactions,
+  and enums; `AsyncLocalStorage` instead of thread locals; `Proxy`-based
+  scope dispatch; pluggable `fs` and `crypto` adapters for browser
+  support.
+
+## Common themes
+
+Three themes cut across all three packages; each guide points back to
+the same root causes:
+
+**Async propagation.** Every I/O call in Rails (DB, file system, crypto,
+HTTP) is synchronous. Every equivalent in JavaScript is async. That one
+fact propagates into finders, persistence, validations, callbacks,
+transactions, and even enum bang methods.
+
+**Module mixins.** Rails relies heavily on `include`/`extend` with
+`included`/`extended` hooks. TypeScript has no equivalent, so
+`@blazetrails/activesupport` ships `include(Klass, mod)`,
+`extend(Klass, mod)`, and the `Included<Mod>` / `Extended<Mod>` type
+helpers. Plus the `this`-typed function pattern (see `CLAUDE.md`) for
+single-method mixing.
+
+**Browser support via adapters.** Rails reaches for `File`, `OpenSSL`,
+`SecureRandom` directly. Trails routes those through
+`@blazetrails/activesupport`'s `FsAdapter` and `CryptoAdapter`, which
+auto-register Node implementations and let browsers register their own.
+More adapters will follow.
+
+## Where to go next
+
+- [**API reference**](/api/@blazetrails/arel/README) — generated from the
+  source, one page per module per package.
+- [**GitHub**](https://github.com/blazetrailsdev/trails) — source, issues,
+  contribution notes.

--- a/packages/website/docs/guides/index.md
+++ b/packages/website/docs/guides/index.md
@@ -14,45 +14,170 @@ Trails mirrors the Rails API as closely as TypeScript allows, but some
 things can't (or shouldn't) cross the language gap unchanged. JavaScript
 is async and single-threaded. Ruby modules have no direct equivalent.
 Ruby symbols, keyword args, and blocks don't exist in TS. We also want
-to run in the browser, which Rails does not. These guides document those
-divergences per package so you don't have to rediscover them one test at
-a time.
+to run in the browser, which Rails does not.
+
+The rest of this page covers the deviations that show up in every
+package. The per-package guides cover the ones specific to each:
 
 - [**Arel**](./arel-rails-deviations.md) — the least-deviating package.
   SQL AST building is purely synchronous; deviations are limited to
   naming, symbol branding, and added TypeScript generics.
-- [**ActiveModel**](./activemodel-rails-deviations.md) — mixin helpers
-  (`include`/`extend` with `Included`/`Extended` type helpers), generated
-  attribute methods instead of `method_missing`, async-capable callbacks,
-  encapsulated dirty tracking.
+- [**ActiveModel**](./activemodel-rails-deviations.md) — generated
+  attribute methods instead of `method_missing`, async-capable
+  callbacks, encapsulated dirty tracking.
 - [**ActiveRecord**](./activerecord-rails-deviations.md) — the biggest
   diff. Async propagation through finders, persistence, transactions,
   and enums; `AsyncLocalStorage` instead of thread locals; `Proxy`-based
-  scope dispatch; pluggable `fs` and `crypto` adapters for browser
-  support.
+  scope dispatch; pluggable `fs` and `crypto` adapters.
 
-## Common themes
+## Cross-cutting deviations
 
-Three themes cut across all three packages; each guide points back to
-the same root causes:
+These apply to every package and are referenced from each per-package
+guide. Anchored headings so those links resolve.
 
-**Async propagation.** Every I/O call in Rails (DB, file system, crypto,
-HTTP) is synchronous. Every equivalent in JavaScript is async. That one
-fact propagates into finders, persistence, validations, callbacks,
-transactions, and even enum bang methods.
+### Async propagation {#async-propagation}
 
-**Module mixins.** Rails relies heavily on `include`/`extend` with
-`included`/`extended` hooks. TypeScript has no equivalent, so
-`@blazetrails/activesupport` ships `include(Klass, mod)`,
-`extend(Klass, mod)`, and the `Included<Mod>` / `Extended<Mod>` type
-helpers. Plus the `this`-typed function pattern (see `CLAUDE.md`) for
-single-method mixing.
+Every I/O call in Rails (DB, file system, crypto, HTTP) is synchronous.
+Every equivalent in JavaScript is async. That one fact propagates into
+finders, persistence, validations, callbacks, transactions, uniqueness
+checks, connection management, and even enum bang methods. `isValid()`
+stays synchronous for signature parity with Rails, but DB-backed
+validators (`uniqueness`) collect `Promise`s on
+`record._asyncValidationPromises` for the caller to await.
 
-**Browser support via adapters.** Rails reaches for `File`, `OpenSSL`,
-`SecureRandom` directly. Trails routes those through
-`@blazetrails/activesupport`'s `FsAdapter` and `CryptoAdapter`, which
-auto-register Node implementations and let browsers register their own.
-More adapters will follow.
+There is no synchronous escape hatch. Browsers and Node both expose DB
+access through async drivers.
+
+### Method casing: snake_case → camelCase {#method-casing}
+
+Every Trails method is the camelCase form of its Rails counterpart:
+
+| Rails                  | Trails                |
+| ---------------------- | --------------------- |
+| `before_save`          | `beforeSave`          |
+| `has_many`             | `hasMany`             |
+| `primary_key`          | `primaryKey`          |
+| `find_each`            | `findEach`            |
+| `previous_changes`     | `previousChanges`     |
+| `establish_connection` | `establishConnection` |
+| `default_scope`        | `defaultScope`        |
+
+This is systematic across every package and not called out per-method
+in the per-package guides.
+
+### Bang methods: `!` → `Bang` suffix {#bang-methods}
+
+Ruby uses `!` on a method name to signal "throws instead of returning
+false on failure." `!` isn't a legal identifier character in
+JavaScript, so Trails uses a `Bang` suffix:
+
+| Rails        | Trails          |
+| ------------ | --------------- |
+| `save!`      | `saveBang`      |
+| `update!`    | `updateBang`    |
+| `destroy!`   | `destroyBang`   |
+| `toggle!`    | `toggleBang`    |
+| `increment!` | `incrementBang` |
+| `decrement!` | `decrementBang` |
+| `draft!`     | `draftBang`     |
+
+The non-bang version (`save`, `destroy`) returns `Promise<boolean>` and
+doesn't throw on validation/constraint failure, matching Rails. The
+bang version throws and returns `Promise<true>` / `Promise<this>`.
+
+Predicate methods (Rails' `name?`, `published?`) drop the `?` and
+typically use an `is` prefix: `isPublished()`, `isDraft()`,
+`isPersisted()`, `isNewRecord()`.
+
+### Module mixins: `include` / `extend` / `Included` / `Extended` {#module-mixins}
+
+Ruby modules (`include SomeConcern`, `extend OtherConcern`, with
+`included do ... end` / `extended do ... end` hooks) are the
+most-used metaprogramming feature in Rails. TypeScript has no
+equivalent, so `@blazetrails/activesupport` ships a set of helpers that
+get as close as the language allows.
+
+- **`include(Klass, mod)`** copies instance methods from `mod` onto
+  `Klass.prototype`. Skips methods already on the prototype. If the
+  module exports a function keyed by the `included` `Symbol`, it runs
+  that hook with the class as its argument. See
+  `packages/activesupport/src/include.ts`.
+- **`extend(Klass, mod)`** is the class-method equivalent. Copies onto
+  the class itself and runs the `extended` `Symbol` hook.
+- **`Included<Mod>` / `Extended<Mod>`** are type helpers that translate
+  a module's `this`-typed functions into the method signatures the
+  class will have after mixing. They give consumers the typing they'd
+  otherwise lose.
+
+Differences vs Ruby:
+
+- Hooks use `Symbol.for("@blazetrails/activesupport:included")` rather
+  than a magic method name. Symbol-based hooks play nicer with
+  TypeScript tooling than stringly-typed method lookup.
+- Mixing happens once at class-declaration time in TS, rather than
+  at `include` time inside the class body as in Ruby. Net effect is
+  the same.
+
+For single methods rather than whole modules, the pattern is
+`this`-typed functions assigned directly to a class. See
+[`CLAUDE.md`](https://github.com/blazetrailsdev/trails/blob/main/CLAUDE.md)
+for the spelling; examples live across `attribute-methods.ts`,
+`validations.ts`, `callbacks.ts`, and many more. ActiveSupport also
+has `concern.ts` (a port of `ActiveSupport::Concern`) for cases where
+we really want the Rails shape; `Included<>` usually does the job.
+
+### Symbols, keyword args, options objects {#symbols-kwargs}
+
+Ruby has `:symbol` literals, keyword arguments, and implicit blocks.
+JavaScript has none of those. Systematically:
+
+| Rails                                  | Trails                                       |
+| -------------------------------------- | -------------------------------------------- |
+| `validates :name, presence: true`      | `validates("name", { presence: true })`      |
+| `where(name: "dean", active: true)`    | `where({ name: "dean", active: true })`      |
+| `has_many :posts, dependent: :destroy` | `hasMany("posts", { dependent: "destroy" })` |
+| `:draft`, `:published`                 | `"draft"`, `"published"`                     |
+
+Ruby symbols become strings. Keyword args become a single options
+object. This is systematic and not called out per-API.
+
+### Block APIs → callback functions {#block-apis}
+
+Rails leans heavily on blocks (`Post.transaction do ... end`,
+`posts.each { |p| ... }`, `before_save { |record| ... }`). JS has no
+blocks, so these become callback functions — and because almost every
+such callback ends up touching I/O, they're typed to accept both sync
+and async functions:
+
+```ts
+type CallbackFn = (this: any, ...args: any[]) => void | Promise<void>;
+type AroundCallbackFn = (this: any, fn: () => Promise<void>) => Promise<void>;
+```
+
+`around` callbacks receive `() => Promise<void>` to invoke the inner
+chain, rather than a block with Ruby's `yield`. See
+`packages/activemodel/src/callbacks.ts`.
+
+### Browser support via adapters {#adapters}
+
+Rails reaches for `File`, `FileUtils`, `OpenSSL`, `SecureRandom`
+directly. That is fine on servers and impossible in browsers.
+`@blazetrails/activesupport` ships two adapters consumed by the rest
+of the stack:
+
+- **`FsAdapter`** (`fs-adapter.ts`) — `readFileSync`, `writeFileSync`,
+  `existsSync`, `mkdirSync`, etc. Auto-registers `node:fs` + `node:path`
+  at runtime when available; a browser host registers an in-memory or
+  OPFS-backed implementation. Callers use `getFs()`.
+- **`CryptoAdapter`** (`crypto-adapter.ts`) — `randomBytes`,
+  `randomUUID`, `createHash`, `createHmac`, `createCipheriv`,
+  `pbkdf2Sync`, `timingSafeEqual`. Auto-registers a Node-crypto wrapper;
+  browsers register a `window.crypto`-based adapter. Callers use
+  `getCrypto()`.
+
+Signed IDs, message verifiers, schema cache persistence, and migration
+file I/O all route through these. More adapters are likely as browser
+surface area grows.
 
 ## Where to go next
 

--- a/packages/website/docs/guides/index.md
+++ b/packages/website/docs/guides/index.md
@@ -150,12 +150,17 @@ such callback ends up touching I/O, they're typed to accept both sync
 and async functions:
 
 ```ts
-type CallbackFn = (this: any, ...args: any[]) => void | Promise<void>;
-type AroundCallbackFn = (this: any, fn: () => Promise<void>) => Promise<void>;
+type CallbackFn = (record: AnyRecord) => void | boolean | Promise<void | boolean>;
+type AroundCallbackFn = (
+  record: AnyRecord,
+  proceed: () => void | Promise<void>,
+) => void | Promise<void>;
 ```
 
-`around` callbacks receive `() => Promise<void>` to invoke the inner
-chain, rather than a block with Ruby's `yield`. See
+The record is passed in explicitly (Ruby callbacks get it via `self`).
+`around` callbacks receive a `proceed` thunk to invoke the inner chain,
+rather than a block with Ruby's `yield`. Returning `false` from a
+`before` callback halts the chain, matching Rails. See
 `packages/activemodel/src/callbacks.ts`.
 
 ### Browser support via adapters {#adapters}

--- a/packages/website/docs/index.md
+++ b/packages/website/docs/index.md
@@ -6,6 +6,9 @@ hero:
   tagline: TypeScript packages that mirror the Rails API. trails is the CLI.
   actions:
     - theme: brand
+      text: Guides
+      link: /guides/
+    - theme: alt
       text: API Reference
       link: /api/@blazetrails/arel/README
     - theme: alt
@@ -24,4 +27,8 @@ features:
     details: Web server interface, middleware, request/response handling.
   - title: ActionPack
     details: Routing, controllers, cookies, and sessions (ActionDispatch + ActionController).
+  - title: Rails deviations
+    details: Where Trails diverges from Rails and why — async propagation, mixin helpers, browser adapters.
+    link: /guides/
+    linkText: Read the guides
 ---

--- a/packages/website/docs/index.md
+++ b/packages/website/docs/index.md
@@ -27,7 +27,7 @@ features:
     details: Web server interface, middleware, request/response handling.
   - title: ActionPack
     details: Routing, controllers, cookies, and sessions (ActionDispatch + ActionController).
-  - title: Rails deviations
+  - title: Rails Deviations
     details: Where Trails diverges from Rails and why — async propagation, mixin helpers, browser adapters.
     link: /guides/
     linkText: Read the guides


### PR DESCRIPTION
## Summary
- Add three guides under `packages/website/docs/guides/` documenting how Trails diverges from Rails in `arel`, `activemodel`, and `activerecord` — covering async propagation, mixin patterns (`include`/`extend`, `Included`/`Extended`), fs/crypto adapters for browser support, typed `Proxy` usage, and Ruby→TS idiom gaps (symbols, keyword args, blocks).
- A `/guides/` index landing page hosts the cross-package deviations once; per-package guides link back to its anchors.
- Wire the new section into VitePress: a "Guides" top-level nav entry landing on the index, and a "Rails Deviations" sidebar group alongside the existing API reference.

## Test plan
- [ ] `pnpm --filter @blazetrails/website docs:build` renders the index, the three per-package pages, and the sidebar group.
- [ ] "Guides" nav entry lands on `/guides/` (the index).
- [ ] Cross-links from each per-package page (`./index.md#bang-methods`, etc.) resolve to the correct anchors on the index.