### PR TITLE
chore: CI type-check TypeScript code blocks in website guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
 
+  guides-typecheck:
+    name: Guides Code Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm guides:typecheck
+
   dx-type-tests:
     name: DX Type Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.tsbuildinfo
 scripts/test-compare/output/
 scripts/api-compare/output/
+scripts/guides-typecheck/.tmp/
 scripts/api-compare/.rack-source
 scripts/api-compare/.rails-source
 .claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "typecheck": "node scripts/typecheck.mjs",
+    "guides:typecheck": "tsx scripts/guides-typecheck/check.ts",
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -69,6 +69,8 @@ each handler, calling it is itself async.
 `validates` / `validate` look the same:
 
 ```ts
+import { Model } from "@blazetrails/activemodel";
+
 class Post extends Model {
   static {
     Post.validates("title", { presence: true, length: { minimum: 3 } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,27 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.3.5)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  scripts/guides-typecheck:
+    dependencies:
+      '@blazetrails/actionpack':
+        specifier: workspace:*
+        version: link:../../packages/actionpack
+      '@blazetrails/activemodel':
+        specifier: workspace:*
+        version: link:../../packages/activemodel
+      '@blazetrails/activerecord':
+        specifier: workspace:*
+        version: link:../../packages/activerecord
+      '@blazetrails/activesupport':
+        specifier: workspace:*
+        version: link:../../packages/activesupport
+      '@blazetrails/arel':
+        specifier: workspace:*
+        version: link:../../packages/arel
+      '@blazetrails/rack':
+        specifier: workspace:*
+        version: link:../../packages/rack
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@blazetrails/actionpack':
         specifier: workspace:*
         version: link:../../packages/actionpack
+      '@blazetrails/actionview':
+        specifier: workspace:*
+        version: link:../../packages/actionview
       '@blazetrails/activemodel':
         specifier: workspace:*
         version: link:../../packages/activemodel
@@ -221,6 +224,9 @@ importers:
       '@blazetrails/rack':
         specifier: workspace:*
         version: link:../../packages/rack
+      '@blazetrails/trailties':
+        specifier: workspace:*
+        version: link:../../packages/trailties
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "scripts/guides-typecheck"

--- a/scripts/guides-typecheck/README.md
+++ b/scripts/guides-typecheck/README.md
@@ -18,6 +18,10 @@ pnpm build && pnpm guides:typecheck
 (Build is required so the `dist/*.d.ts` files exist for type
 resolution via each package's `exports` field.)
 
+Also enforces that every fenced block has a language tag — a bare
+` ``` ` with no language is rejected so nothing gets silently
+excluded from the check.
+
 ## Writing guide examples
 
 Every `ts` block is compiled as its own ES module. The following
@@ -30,6 +34,11 @@ don't need boilerplate:
 For anything else — including your own `Model`/`Base` subclasses —
 import from `@blazetrails/*` explicitly. That's also how real readers
 will copy the code, so it doubles as a sanity check on the example.
+
+**Each block is compiled in isolation.** A `class Post` defined in
+one block is not visible to the next. If two blocks need to share
+setup, either repeat the shared code or inline it with a comment like
+`// assuming Post is defined as above`.
 
 ## Skipping a block
 

--- a/scripts/guides-typecheck/README.md
+++ b/scripts/guides-typecheck/README.md
@@ -1,0 +1,65 @@
+# Guides Code Type Check
+
+Type-checks every ` ```ts ` / ` ```typescript ` code block under
+`packages/website/docs/guides/` against the real published types of
+`@blazetrails/*` packages. Catches:
+
+- Stale imports (package renamed, module removed).
+- Wrong call signatures on real APIs (rename catches up automatically
+  when the guide is out of date).
+- Syntax errors.
+
+Runs in CI on every push. Run locally with:
+
+```sh
+pnpm build && pnpm guides:typecheck
+```
+
+(Build is required so the `dist/*.d.ts` files exist for type
+resolution via each package's `exports` field.)
+
+## Writing guide examples
+
+Every `ts` block is compiled as its own ES module. The following
+illustrative names are declared globally as `any` so short snippets
+don't need boilerplate:
+
+`user`, `post`, `comment`, `tx`, `User`, `Post`, `Comment`,
+`AnyRecord`.
+
+For anything else — including your own `Model`/`Base` subclasses —
+import from `@blazetrails/*` explicitly. That's also how real readers
+will copy the code, so it doubles as a sanity check on the example.
+
+## Skipping a block
+
+Prefix the block with `<!-- typecheck:skip -->` on the line
+immediately before the opening fence. Use sparingly — skipped blocks
+are invisible to the drift-detection that this check exists for.
+
+```md
+<!-- typecheck:skip -->
+
+\`\`\`ts
+// intentionally broken, shown for contrast
+const x: string = 5;
+\`\`\`
+```
+
+## How it works
+
+1. Reads every `.md` file under `packages/website/docs/guides/`.
+2. Extracts each `ts` / `typescript` fenced block. Checks the
+   preceding non-blank line for the `typecheck:skip` marker.
+3. Writes each block to `.tmp/run-*/blocks/` as its own `.ts` file
+   with an `export {}` suffix (makes it a module so top-level
+   `await` works).
+4. Writes a shared `globals.d.ts` that declares the illustrative
+   names.
+5. Runs `tsc --noEmit` across all blocks at once.
+6. Remaps tsc's error paths back to the source guide filename and
+   absolute line number.
+
+The temp dir lives inside this script's own workspace package so
+`@blazetrails/*` resolution walks up to the workspace's symlinked
+`node_modules` naturally.

--- a/scripts/guides-typecheck/check.test.ts
+++ b/scripts/guides-typecheck/check.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { extractBlocks } from "./check.js";
+
+describe("extractBlocks", () => {
+  it("pulls out ts and typescript blocks with correct start lines", () => {
+    const md = [
+      "# Heading", // 1
+      "", // 2
+      "```ts", // 3 <- block starts line 4
+      "const x = 1;", // 4
+      "```", // 5
+      "", // 6
+      "```typescript", // 7 <- block starts line 8
+      "const y = 2;", // 8
+      "```", // 9
+    ].join("\n");
+    const { blocks, untagged } = extractBlocks("a.md", md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].startLine).toBe(4);
+    expect(blocks[0].code).toBe("const x = 1;");
+    expect(blocks[1].startLine).toBe(8);
+    expect(untagged).toHaveLength(0);
+  });
+
+  it("skips non-ts languages", () => {
+    const md = ["```sh", "ls", "```", "", "```ts", "const x = 1;", "```"].join("\n");
+    const { blocks } = extractBlocks("a.md", md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe("const x = 1;");
+  });
+
+  it("flags untagged fenced blocks", () => {
+    const md = ["```", "const x = 1;", "```"].join("\n");
+    const { blocks, untagged } = extractBlocks("a.md", md);
+    expect(blocks).toHaveLength(0);
+    expect(untagged).toHaveLength(1);
+    expect(untagged[0].line).toBe(1);
+  });
+
+  it("honors <!-- typecheck:skip --> on the preceding non-blank line", () => {
+    const md = ["<!-- typecheck:skip -->", "", "```ts", "const x: string = 5;", "```"].join("\n");
+    const { blocks } = extractBlocks("a.md", md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].skip).toBe(true);
+  });
+
+  it("does not apply skip marker when separated by non-blank content", () => {
+    const md = [
+      "<!-- typecheck:skip -->",
+      "",
+      "some prose",
+      "",
+      "```ts",
+      "const x = 1;",
+      "```",
+    ].join("\n");
+    const { blocks } = extractBlocks("a.md", md);
+    expect(blocks[0].skip).toBe(false);
+  });
+
+  it("handles adjacent blocks without bleeding state", () => {
+    const md = ["```ts", "const x = 1;", "```", "```ts", "const y = 2;", "```"].join("\n");
+    const { blocks } = extractBlocks("a.md", md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].code).toBe("const x = 1;");
+    expect(blocks[1].code).toBe("const y = 2;");
+  });
+});

--- a/scripts/guides-typecheck/check.test.ts
+++ b/scripts/guides-typecheck/check.test.ts
@@ -58,6 +58,11 @@ describe("extractBlocks", () => {
     expect(blocks[0].skip).toBe(false);
   });
 
+  it("throws on an unterminated fenced block", () => {
+    const md = ["```ts", "const x = 1;"].join("\n");
+    expect(() => extractBlocks("a.md", md)).toThrow(/Unterminated fenced code block in a\.md/);
+  });
+
   it("handles adjacent blocks without bleeding state", () => {
     const md = ["```ts", "const x = 1;", "```", "```ts", "const y = 2;", "```"].join("\n");
     const { blocks } = extractBlocks("a.md", md);

--- a/scripts/guides-typecheck/check.test.ts
+++ b/scripts/guides-typecheck/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractBlocks } from "./check.js";
+import { type Block, extractBlocks, remapDiagnostics } from "./check.js";
 
 describe("extractBlocks", () => {
   it("pulls out ts and typescript blocks with correct start lines", () => {
@@ -92,5 +92,51 @@ describe("extractBlocks", () => {
     expect(blocks).toHaveLength(2);
     expect(blocks[0].code).toBe("const x = 1;");
     expect(blocks[1].code).toBe("const y = 2;");
+  });
+});
+
+describe("remapDiagnostics", () => {
+  const repoRoot = "/repo";
+  const block: Block = {
+    file: "/repo/packages/website/docs/guides/foo.md",
+    startLine: 42,
+    code: "// irrelevant",
+    skip: false,
+  };
+  const blocksByIdx = new Map<number, Block>([[7, block]]);
+
+  it("rewrites tsc paren-form diagnostics (file.ts(L,C))", () => {
+    const raw =
+      "/tmp/run-X/blocks/packages_website_docs_guides_foo_md__L42__7.ts(3,9): error TS2322: bad type";
+    expect(remapDiagnostics(raw, blocksByIdx, repoRoot)).toBe(
+      "packages/website/docs/guides/foo.md:44:9: error TS2322: bad type",
+    );
+  });
+
+  it("rewrites tsc colon-form diagnostics (file.ts:L:C)", () => {
+    const raw =
+      "/tmp/run-X/blocks/packages_website_docs_guides_foo_md__L42__7.ts:3:9 - error TS2322: bad type";
+    expect(remapDiagnostics(raw, blocksByIdx, repoRoot)).toBe(
+      "packages/website/docs/guides/foo.md:44:9 - error TS2322: bad type",
+    );
+  });
+
+  it("handles paths containing spaces", () => {
+    const raw =
+      "/Users/Jane Doe/repo/.tmp/run-X/blocks/packages_website_docs_guides_foo_md__L42__7.ts(3,9): error TS1234";
+    expect(remapDiagnostics(raw, blocksByIdx, repoRoot)).toBe(
+      "packages/website/docs/guides/foo.md:44:9: error TS1234",
+    );
+  });
+
+  it("leaves unrelated lines untouched", () => {
+    const raw = "some unrelated line\nanother one";
+    expect(remapDiagnostics(raw, blocksByIdx, repoRoot)).toBe(raw);
+  });
+
+  it("leaves matches with unknown idx unchanged", () => {
+    const raw =
+      "/tmp/run-X/blocks/packages_website_docs_guides_foo_md__L42__99.ts(3,9): error TS2322: bad type";
+    expect(remapDiagnostics(raw, blocksByIdx, repoRoot)).toBe(raw);
   });
 });

--- a/scripts/guides-typecheck/check.test.ts
+++ b/scripts/guides-typecheck/check.test.ts
@@ -58,6 +58,29 @@ describe("extractBlocks", () => {
     expect(blocks[0].skip).toBe(false);
   });
 
+  it("extracts indented fenced blocks and strips the fence's indent", () => {
+    const md = [
+      "- A list item with a nested block:", // 1
+      "", // 2
+      "  ```ts", // 3 — content starts on line 4
+      "  const x = 1;", // 4
+      "  ```", // 5
+    ].join("\n");
+    const { blocks, untagged } = extractBlocks("a.md", md);
+    expect(untagged).toHaveLength(0);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe("const x = 1;");
+    expect(blocks[0].startLine).toBe(4);
+  });
+
+  it("accepts a language tag separated from backticks by whitespace", () => {
+    const md = ["``` ts", "const x = 1;", "```"].join("\n");
+    const { blocks, untagged } = extractBlocks("a.md", md);
+    expect(untagged).toHaveLength(0);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe("const x = 1;");
+  });
+
   it("throws on an unterminated fenced block", () => {
     const md = ["```ts", "const x = 1;"].join("\n");
     expect(() => extractBlocks("a.md", md)).toThrow(/Unterminated fenced code block in a\.md/);

--- a/scripts/guides-typecheck/check.test.ts
+++ b/scripts/guides-typecheck/check.test.ts
@@ -81,6 +81,21 @@ describe("extractBlocks", () => {
     expect(blocks[0].code).toBe("const x = 1;");
   });
 
+  it("handles 4+ backtick fences (fence containing ``` inside)", () => {
+    const md = [
+      "````ts", // 1 — content starts on line 2
+      "const s = `hello ${'world'}`;", // 2
+      "const example = '```';", // 3  <- fake 3-backtick closer; must NOT close
+      "````", // 4
+    ].join("\n");
+    const { blocks, untagged } = extractBlocks("a.md", md);
+    expect(untagged).toHaveLength(0);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe(
+      ["const s = `hello ${'world'}`;", "const example = '```';"].join("\n"),
+    );
+  });
+
   it("throws on an unterminated fenced block", () => {
     const md = ["```ts", "const x = 1;"].join("\n");
     expect(() => extractBlocks("a.md", md)).toThrow(/Unterminated fenced code block in a\.md/);

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -74,13 +74,20 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
   let blockLines: string[] = [];
   let blockSkip = false;
   let blockIsTs = false;
+  let blockIndent = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!inBlock) {
-      const openMatch = /^```(\S*)/.exec(line);
+      // CommonMark: fences may be indented up to 3 spaces. In practice
+      // guides nest blocks inside list items at deeper indents, so we
+      // accept any leading whitespace. The language tag is the first
+      // whitespace-separated token after the backticks.
+      const openMatch = /^(\s*)```(.*)$/.exec(line);
       if (openMatch) {
-        const lang = openMatch[1];
+        const indent = openMatch[1].length;
+        const info = openMatch[2].trim();
+        const lang = info.split(/\s+/)[0] ?? "";
         if (!lang) {
           untagged.push({ file: filePath, line: i + 1 });
         }
@@ -89,6 +96,7 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
         blockLines = [];
         blockSkip = false;
         blockIsTs = lang === "ts" || lang === "typescript";
+        blockIndent = indent;
         for (let j = i - 1; j >= 0; j--) {
           const prev = lines[j].trim();
           if (prev === "") continue;
@@ -97,7 +105,7 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
         }
       }
     } else {
-      if (/^```\s*$/.test(line)) {
+      if (/^\s*```\s*$/.test(line)) {
         if (blockIsTs) {
           blocks.push({
             file: filePath,
@@ -108,7 +116,13 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
         }
         inBlock = false;
       } else {
-        blockLines.push(line);
+        // Strip up to `blockIndent` leading spaces from each content
+        // line, matching how Markdown renderers reconstruct the block.
+        const strippedLine =
+          blockIndent > 0 && line.startsWith(" ".repeat(blockIndent))
+            ? line.slice(blockIndent)
+            : line;
+        blockLines.push(strippedLine);
       }
     }
   }

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -214,15 +214,13 @@ function writeTsconfig(tmpDir: string): string {
     extends: path.relative(tmpDir, rootTsconfig),
     compilerOptions: {
       noEmit: true,
-      // Override settings incompatible with a one-off check:
+      // Override settings incompatible with a one-off check. rootDir
+      // and outDir from the root don't matter here because noEmit is
+      // true, so we leave them inherited.
       composite: false,
       declaration: false,
       declarationMap: false,
       sourceMap: false,
-      // rootDir from the root resolves to "."; our files aren't
-      // under it, so clear it.
-      rootDir: null,
-      outDir: null,
     },
     include: ["globals.d.ts", "blocks/**/*.ts"],
     // Root uses `references`; we're a leaf check, clear it.

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -75,18 +75,23 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
   let blockSkip = false;
   let blockIsTs = false;
   let blockIndent = 0;
+  let blockFence = "";
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!inBlock) {
-      // CommonMark: fences may be indented up to 3 spaces. In practice
-      // guides nest blocks inside list items at deeper indents, so we
-      // accept any leading whitespace. The language tag is the first
-      // whitespace-separated token after the backticks.
-      const openMatch = /^(\s*)```(.*)$/.exec(line);
+      // CommonMark: fences use 3+ backticks (or tildes); opener and
+      // closer must share the same char and the closer length >= opener.
+      // We only handle backtick fences — guides don't use tilde fences.
+      // Fences may be indented up to 3 spaces per CommonMark; real
+      // guides nest under list items at deeper indents, so we accept
+      // any leading whitespace. The language is the first
+      // whitespace-separated token after the fence.
+      const openMatch = /^(\s*)(`{3,})(.*)$/.exec(line);
       if (openMatch) {
         const indent = openMatch[1].length;
-        const info = openMatch[2].trim();
+        const fence = openMatch[2];
+        const info = openMatch[3].trim();
         const lang = info.split(/\s+/)[0] ?? "";
         if (!lang) {
           untagged.push({ file: filePath, line: i + 1 });
@@ -97,6 +102,7 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
         blockSkip = false;
         blockIsTs = lang === "ts" || lang === "typescript";
         blockIndent = indent;
+        blockFence = fence;
         for (let j = i - 1; j >= 0; j--) {
           const prev = lines[j].trim();
           if (prev === "") continue;
@@ -105,7 +111,11 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
         }
       }
     } else {
-      if (/^\s*```\s*$/.test(line)) {
+      // Closer: same fence char, length >= opener, nothing but
+      // whitespace after.
+      const closeMatch = /^(\s*)(`{3,})\s*$/.exec(line);
+      const isCloser = closeMatch !== null && closeMatch[2].length >= blockFence.length;
+      if (isCloser) {
         if (blockIsTs) {
           blocks.push({
             file: filePath,
@@ -196,25 +206,27 @@ export function remapDiagnostics(
 
 function writeTsconfig(tmpDir: string): string {
   const tsconfigPath = path.join(tmpDir, "tsconfig.json");
-  // Match the root tsconfig.json so guide snippets type-check under
-  // the same module/resolution semantics as the real packages.
-  // Divergence here (e.g. "bundler" vs "Node16") risks snippets that
-  // pass CI but fail for real consumers.
+  // Extend the root tsconfig so guide snippets type-check under
+  // exactly the same compilerOptions as the real packages.
+  // Manually-duplicated options drift; inheriting is safer.
+  const rootTsconfig = path.join(REPO_ROOT, "tsconfig.json");
   const config = {
+    extends: path.relative(tmpDir, rootTsconfig),
     compilerOptions: {
-      target: "ES2022",
-      module: "Node16",
-      moduleResolution: "Node16",
-      strict: true,
       noEmit: true,
-      skipLibCheck: true,
-      esModuleInterop: true,
-      resolveJsonModule: true,
-      allowSyntheticDefaultImports: true,
-      isolatedModules: true,
-      typeRoots: [path.join(REPO_ROOT, "node_modules/@types")],
+      // Override settings incompatible with a one-off check:
+      composite: false,
+      declaration: false,
+      declarationMap: false,
+      sourceMap: false,
+      // rootDir from the root resolves to "."; our files aren't
+      // under it, so clear it.
+      rootDir: null,
+      outDir: null,
     },
     include: ["globals.d.ts", "blocks/**/*.ts"],
+    // Root uses `references`; we're a leaf check, clear it.
+    references: [],
   };
   fs.writeFileSync(tsconfigPath, JSON.stringify(config, null, 2));
   return tsconfigPath;

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -55,24 +55,40 @@ interface Block {
   skip: boolean;
 }
 
-function extractBlocks(filePath: string): Block[] {
-  const content = fs.readFileSync(filePath, "utf8");
+interface UntaggedBlock {
+  file: string;
+  line: number;
+}
+
+interface ExtractResult {
+  blocks: Block[];
+  untagged: UntaggedBlock[];
+}
+
+export function extractBlocks(filePath: string, content: string): ExtractResult {
   const lines = content.split("\n");
   const blocks: Block[] = [];
+  const untagged: UntaggedBlock[] = [];
   let inBlock = false;
   let blockStart = 0;
   let blockLines: string[] = [];
   let blockSkip = false;
+  let blockIsTs = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!inBlock) {
-      const m = /^```(ts|typescript)(\s|$)/.exec(line);
-      if (m) {
+      const openMatch = /^```(\S*)/.exec(line);
+      if (openMatch) {
+        const lang = openMatch[1];
+        if (!lang) {
+          untagged.push({ file: filePath, line: i + 1 });
+        }
         inBlock = true;
-        blockStart = i + 1;
+        blockStart = i + 2;
         blockLines = [];
         blockSkip = false;
+        blockIsTs = lang === "ts" || lang === "typescript";
         for (let j = i - 1; j >= 0; j--) {
           const prev = lines[j].trim();
           if (prev === "") continue;
@@ -82,19 +98,51 @@ function extractBlocks(filePath: string): Block[] {
       }
     } else {
       if (/^```\s*$/.test(line)) {
-        blocks.push({
-          file: filePath,
-          startLine: blockStart,
-          code: blockLines.join("\n"),
-          skip: blockSkip,
-        });
+        if (blockIsTs) {
+          blocks.push({
+            file: filePath,
+            startLine: blockStart,
+            code: blockLines.join("\n"),
+            skip: blockSkip,
+          });
+        }
         inBlock = false;
       } else {
         blockLines.push(line);
       }
     }
   }
-  return blocks;
+  return { blocks, untagged };
+}
+
+function validatePackageCoverage(): void {
+  const packagesDir = path.join(REPO_ROOT, "packages");
+  const discovered: string[] = [];
+  for (const entry of fs.readdirSync(packagesDir)) {
+    const pkgJsonPath = path.join(packagesDir, entry, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as {
+      name?: string;
+      private?: boolean;
+    };
+    if (!pkg.name || !pkg.name.startsWith("@blazetrails/")) continue;
+    discovered.push(pkg.name);
+  }
+
+  const selfPkgPath = path.join(SCRIPT_DIR, "package.json");
+  const self = JSON.parse(fs.readFileSync(selfPkgPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  const declared = new Set(Object.keys(self.dependencies ?? {}));
+  const missing = discovered.filter(
+    (name) => !declared.has(name) && name !== "@blazetrails/website",
+  );
+  if (missing.length > 0) {
+    console.error(`✗ scripts/guides-typecheck/package.json is missing workspace deps for:`);
+    for (const m of missing) console.error(`  ${m}`);
+    console.error(`Add them as "workspace:*" so guide code blocks can import them, then re-run.`);
+    process.exit(1);
+  }
 }
 
 function writeTsconfig(tmpDir: string): string {
@@ -125,14 +173,28 @@ function main(): void {
     process.exit(1);
   }
 
+  validatePackageCoverage();
+
   const mdFiles = fs
     .readdirSync(GUIDES_DIR)
     .filter((f) => f.endsWith(".md"))
     .map((f) => path.join(GUIDES_DIR, f));
 
   const allBlocks: Block[] = [];
+  const allUntagged: UntaggedBlock[] = [];
   for (const file of mdFiles) {
-    allBlocks.push(...extractBlocks(file));
+    const { blocks, untagged } = extractBlocks(file, fs.readFileSync(file, "utf8"));
+    allBlocks.push(...blocks);
+    allUntagged.push(...untagged);
+  }
+
+  if (allUntagged.length > 0) {
+    console.error("✗ Found fenced code blocks without a language tag:");
+    for (const u of allUntagged) {
+      console.error(`  ${path.relative(REPO_ROOT, u.file)}:${u.line}`);
+    }
+    console.error("Every fenced block in a guide must declare its language (e.g. ```ts, ```sh).");
+    process.exit(1);
   }
 
   const checked = allBlocks.filter((b) => !b.skip);
@@ -194,4 +256,6 @@ function main(): void {
   process.exit(result.status ?? 1);
 }
 
-main();
+const isMainEntrypoint =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMainEntrypoint) main();

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -196,11 +196,15 @@ export function remapDiagnostics(
 
 function writeTsconfig(tmpDir: string): string {
   const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+  // Match the root tsconfig.json so guide snippets type-check under
+  // the same module/resolution semantics as the real packages.
+  // Divergence here (e.g. "bundler" vs "Node16") risks snippets that
+  // pass CI but fail for real consumers.
   const config = {
     compilerOptions: {
       target: "ES2022",
-      module: "ESNext",
-      moduleResolution: "bundler",
+      module: "Node16",
+      moduleResolution: "Node16",
       strict: true,
       noEmit: true,
       skipLibCheck: true,

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -112,6 +112,11 @@ export function extractBlocks(filePath: string, content: string): ExtractResult 
       }
     }
   }
+  if (inBlock) {
+    throw new Error(
+      `Unterminated fenced code block in ${filePath} starting at line ${blockStart - 1}.`,
+    );
+  }
   return { blocks, untagged };
 }
 
@@ -175,10 +180,15 @@ function main(): void {
 
   validatePackageCoverage();
 
-  const mdFiles = fs
-    .readdirSync(GUIDES_DIR)
-    .filter((f) => f.endsWith(".md"))
-    .map((f) => path.join(GUIDES_DIR, f));
+  const mdFiles: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith(".md")) mdFiles.push(full);
+    }
+  };
+  walk(GUIDES_DIR);
 
   const allBlocks: Block[] = [];
   const allUntagged: UntaggedBlock[] = [];
@@ -215,13 +225,13 @@ function main(): void {
   fs.writeFileSync(path.join(tmpRoot, "globals.d.ts"), GLOBALS_DTS);
   writeTsconfig(tmpRoot);
 
-  const blockPaths: { block: Block; tmpPath: string }[] = [];
+  const blocksByIdx = new Map<number, Block>();
   checked.forEach((block, idx) => {
     const rel = path.relative(REPO_ROOT, block.file).replace(/[^\w]/g, "_");
     const tmpName = `${rel}__L${block.startLine}__${idx}.ts`;
     const tmpPath = path.join(blocksDir, tmpName);
     fs.writeFileSync(tmpPath, block.code + BLOCK_SUFFIX);
-    blockPaths.push({ block, tmpPath });
+    blocksByIdx.set(idx, block);
   });
 
   console.log(
@@ -240,12 +250,13 @@ function main(): void {
   }
 
   const remappedOutput = output.replace(
-    /(?:\S+[\/\\])?blocks[\/\\](\S+?)__L(\d+)__\d+\.ts(\((\d+),(\d+)\))?/g,
-    (_match, _name, originalStart, _paren, lineOffsetStr, col) => {
+    /(?:\S+[\/\\])?blocks[\/\\](\S+?)__L(\d+)__(\d+)\.ts(\((\d+),(\d+)\))?/g,
+    (_match, _name, _startStr, idxStr, _paren, lineOffsetStr, col) => {
       const lineOffset = lineOffsetStr ? parseInt(lineOffsetStr, 10) : 1;
-      const absoluteLine = parseInt(originalStart, 10) + lineOffset - 1;
-      const match = blockPaths.find((p) => p.tmpPath.includes(`__L${originalStart}__`));
-      const guide = match ? path.relative(REPO_ROOT, match.block.file) : "<unknown>";
+      const block = blocksByIdx.get(parseInt(idxStr, 10));
+      if (!block) return _match;
+      const absoluteLine = block.startLine + lineOffset - 1;
+      const guide = path.relative(REPO_ROOT, block.file);
       return col ? `${guide}:${absoluteLine}:${col}` : `${guide}:${absoluteLine}`;
     },
   );

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -48,7 +48,7 @@ export {};
 
 const BLOCK_SUFFIX = "\nexport {};\n";
 
-interface Block {
+export interface Block {
   file: string;
   startLine: number;
   code: string;
@@ -164,6 +164,36 @@ function validatePackageCoverage(): void {
   }
 }
 
+/**
+ * Rewrite tsc diagnostic locations so they point back at the source
+ * guide file and absolute line number. Handles both `foo.ts(L,C):`
+ * (tsc's default) and `foo.ts:L:C:` (tsc --pretty) forms.
+ */
+export function remapDiagnostics(
+  output: string,
+  blocksByIdx: Map<number, Block>,
+  repoRoot: string,
+): string {
+  // Matches both `path/blocks/<name>__L<start>__<idx>.ts(L,C)` and
+  // `path/blocks/<name>__L<start>__<idx>.ts:L:C`. `:L:C` is captured as
+  // groups 5/6; `(L,C)` as groups 7/8. Either group pair may be undefined.
+  const pattern =
+    /(?:[^\n]*?[\/\\])?blocks[\/\\]([^\n]*?)__L(\d+)__(\d+)\.ts(?::(\d+):(\d+)|\((\d+),(\d+)\))?/g;
+  return output.replace(
+    pattern,
+    (match, _name, _startStr, idxStr, colonL, colonC, parenL, parenC) => {
+      const block = blocksByIdx.get(parseInt(idxStr, 10));
+      if (!block) return match;
+      const lineOffsetStr = colonL ?? parenL;
+      const colStr = colonC ?? parenC;
+      const guide = path.relative(repoRoot, block.file);
+      if (!lineOffsetStr) return guide;
+      const absoluteLine = block.startLine + parseInt(lineOffsetStr, 10) - 1;
+      return colStr ? `${guide}:${absoluteLine}:${colStr}` : `${guide}:${absoluteLine}`;
+    },
+  );
+}
+
 function writeTsconfig(tmpDir: string): string {
   const tsconfigPath = path.join(tmpDir, "tsconfig.json");
   const config = {
@@ -252,9 +282,20 @@ function main(): void {
     `Type-checking ${checked.length} code block${checked.length === 1 ? "" : "s"} from ${mdFiles.length} guide${mdFiles.length === 1 ? "" : "s"}${skipped ? ` (${skipped} skipped)` : ""}…`,
   );
 
-  const result = spawnSync(TSC, ["-p", path.join(tmpRoot, "tsconfig.json")], {
+  // --pretty false forces the classic `file.ts(L,C):` diagnostic format
+  // so remapDiagnostics has a stable input to rewrite.
+  const result = spawnSync(TSC, ["-p", path.join(tmpRoot, "tsconfig.json"), "--pretty", "false"], {
     encoding: "utf8",
   });
+
+  if (result.error) {
+    console.error(`✗ Failed to start TypeScript compiler.`);
+    console.error(`  TSC: ${TSC}`);
+    console.error(`  cwd: ${process.cwd()}`);
+    console.error(`  ${result.error.name}: ${result.error.message}`);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    process.exit(1);
+  }
 
   const output = (result.stdout ?? "") + (result.stderr ?? "");
   if (result.status === 0) {
@@ -263,19 +304,7 @@ function main(): void {
     return;
   }
 
-  const remappedOutput = output.replace(
-    /(?:[^\n]*?[\/\\])?blocks[\/\\]([^\n]*?)__L(\d+)__(\d+)\.ts(\((\d+),(\d+)\))?/g,
-    (_match, _name, _startStr, idxStr, _paren, lineOffsetStr, col) => {
-      const lineOffset = lineOffsetStr ? parseInt(lineOffsetStr, 10) : 1;
-      const block = blocksByIdx.get(parseInt(idxStr, 10));
-      if (!block) return _match;
-      const absoluteLine = block.startLine + lineOffset - 1;
-      const guide = path.relative(REPO_ROOT, block.file);
-      return col ? `${guide}:${absoluteLine}:${col}` : `${guide}:${absoluteLine}`;
-    },
-  );
-
-  console.error(remappedOutput);
+  console.error(remapDiagnostics(output, blocksByIdx, REPO_ROOT));
   console.error(`✗ Guide code block type-check failed.`);
   fs.rmSync(tmpRoot, { recursive: true, force: true });
   process.exit(result.status ?? 1);

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -264,7 +264,7 @@ function main(): void {
   }
 
   const remappedOutput = output.replace(
-    /(?:\S+[\/\\])?blocks[\/\\](\S+?)__L(\d+)__(\d+)\.ts(\((\d+),(\d+)\))?/g,
+    /(?:[^\n]*?[\/\\])?blocks[\/\\]([^\n]*?)__L(\d+)__(\d+)\.ts(\((\d+),(\d+)\))?/g,
     (_match, _name, _startStr, idxStr, _paren, lineOffsetStr, col) => {
       const lineOffset = lineOffsetStr ? parseInt(lineOffsetStr, 10) : 1;
       const block = blocksByIdx.get(parseInt(idxStr, 10));

--- a/scripts/guides-typecheck/check.ts
+++ b/scripts/guides-typecheck/check.ts
@@ -1,0 +1,197 @@
+/**
+ * Type-check TypeScript code blocks in website guides.
+ *
+ * Walks `packages/website/docs/guides/**\/*.md`, extracts every
+ * ```ts / ```typescript fenced block, injects a preamble that
+ * declares common illustrative names (user, post, User, Post, etc.)
+ * so short snippets don't need boilerplate, and compiles each block
+ * with `tsc --noEmit` against real @blazetrails/* types.
+ *
+ * Blocks preceded by an HTML comment `<!-- typecheck:skip -->` on
+ * the immediately preceding non-blank line are skipped.
+ *
+ * Exit code is non-zero if any block fails to compile.
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
+const GUIDES_DIR = path.join(REPO_ROOT, "packages/website/docs/guides");
+const TSC = path.join(
+  REPO_ROOT,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsc.cmd" : "tsc",
+);
+
+/**
+ * Ambient declarations shared across all blocks. Written once as a
+ * .d.ts file so they don't conflict when multiple blocks are compiled
+ * together.
+ */
+const GLOBALS_DTS = `
+declare global {
+  const user: any;
+  const post: any;
+  const comment: any;
+  const tx: any;
+  const User: any;
+  const Post: any;
+  const Comment: any;
+  type AnyRecord = any;
+}
+export {};
+`.trimStart();
+
+const BLOCK_SUFFIX = "\nexport {};\n";
+
+interface Block {
+  file: string;
+  startLine: number;
+  code: string;
+  skip: boolean;
+}
+
+function extractBlocks(filePath: string): Block[] {
+  const content = fs.readFileSync(filePath, "utf8");
+  const lines = content.split("\n");
+  const blocks: Block[] = [];
+  let inBlock = false;
+  let blockStart = 0;
+  let blockLines: string[] = [];
+  let blockSkip = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!inBlock) {
+      const m = /^```(ts|typescript)(\s|$)/.exec(line);
+      if (m) {
+        inBlock = true;
+        blockStart = i + 1;
+        blockLines = [];
+        blockSkip = false;
+        for (let j = i - 1; j >= 0; j--) {
+          const prev = lines[j].trim();
+          if (prev === "") continue;
+          if (prev.includes("<!-- typecheck:skip -->")) blockSkip = true;
+          break;
+        }
+      }
+    } else {
+      if (/^```\s*$/.test(line)) {
+        blocks.push({
+          file: filePath,
+          startLine: blockStart,
+          code: blockLines.join("\n"),
+          skip: blockSkip,
+        });
+        inBlock = false;
+      } else {
+        blockLines.push(line);
+      }
+    }
+  }
+  return blocks;
+}
+
+function writeTsconfig(tmpDir: string): string {
+  const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+  const config = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      esModuleInterop: true,
+      resolveJsonModule: true,
+      allowSyntheticDefaultImports: true,
+      isolatedModules: true,
+      typeRoots: [path.join(REPO_ROOT, "node_modules/@types")],
+    },
+    include: ["globals.d.ts", "blocks/**/*.ts"],
+  };
+  fs.writeFileSync(tsconfigPath, JSON.stringify(config, null, 2));
+  return tsconfigPath;
+}
+
+function main(): void {
+  if (!fs.existsSync(GUIDES_DIR)) {
+    console.error(`Guides directory not found: ${GUIDES_DIR}`);
+    process.exit(1);
+  }
+
+  const mdFiles = fs
+    .readdirSync(GUIDES_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => path.join(GUIDES_DIR, f));
+
+  const allBlocks: Block[] = [];
+  for (const file of mdFiles) {
+    allBlocks.push(...extractBlocks(file));
+  }
+
+  const checked = allBlocks.filter((b) => !b.skip);
+  const skipped = allBlocks.length - checked.length;
+
+  if (checked.length === 0) {
+    console.log(
+      `No TypeScript code blocks to check. (${allBlocks.length} total, ${skipped} skipped.)`,
+    );
+    return;
+  }
+
+  const tmpParent = path.join(SCRIPT_DIR, ".tmp");
+  fs.mkdirSync(tmpParent, { recursive: true });
+  const tmpRoot = fs.mkdtempSync(path.join(tmpParent, "run-"));
+  const blocksDir = path.join(tmpRoot, "blocks");
+  fs.mkdirSync(blocksDir);
+  fs.writeFileSync(path.join(tmpRoot, "globals.d.ts"), GLOBALS_DTS);
+  writeTsconfig(tmpRoot);
+
+  const blockPaths: { block: Block; tmpPath: string }[] = [];
+  checked.forEach((block, idx) => {
+    const rel = path.relative(REPO_ROOT, block.file).replace(/[^\w]/g, "_");
+    const tmpName = `${rel}__L${block.startLine}__${idx}.ts`;
+    const tmpPath = path.join(blocksDir, tmpName);
+    fs.writeFileSync(tmpPath, block.code + BLOCK_SUFFIX);
+    blockPaths.push({ block, tmpPath });
+  });
+
+  console.log(
+    `Type-checking ${checked.length} code block${checked.length === 1 ? "" : "s"} from ${mdFiles.length} guide${mdFiles.length === 1 ? "" : "s"}${skipped ? ` (${skipped} skipped)` : ""}…`,
+  );
+
+  const result = spawnSync(TSC, ["-p", path.join(tmpRoot, "tsconfig.json")], {
+    encoding: "utf8",
+  });
+
+  const output = (result.stdout ?? "") + (result.stderr ?? "");
+  if (result.status === 0) {
+    console.log(`✓ All ${checked.length} code blocks type-check cleanly.`);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    return;
+  }
+
+  const remappedOutput = output.replace(
+    /(?:\S+[\/\\])?blocks[\/\\](\S+?)__L(\d+)__\d+\.ts(\((\d+),(\d+)\))?/g,
+    (_match, _name, originalStart, _paren, lineOffsetStr, col) => {
+      const lineOffset = lineOffsetStr ? parseInt(lineOffsetStr, 10) : 1;
+      const absoluteLine = parseInt(originalStart, 10) + lineOffset - 1;
+      const match = blockPaths.find((p) => p.tmpPath.includes(`__L${originalStart}__`));
+      const guide = match ? path.relative(REPO_ROOT, match.block.file) : "<unknown>";
+      return col ? `${guide}:${absoluteLine}:${col}` : `${guide}:${absoluteLine}`;
+    },
+  );
+
+  console.error(remappedOutput);
+  console.error(`✗ Guide code block type-check failed.`);
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -10,6 +10,8 @@
     "@blazetrails/activesupport": "workspace:*",
     "@blazetrails/arel": "workspace:*",
     "@blazetrails/rack": "workspace:*",
-    "@blazetrails/actionpack": "workspace:*"
+    "@blazetrails/actionpack": "workspace:*",
+    "@blazetrails/actionview": "workspace:*",
+    "@blazetrails/trailties": "workspace:*"
   }
 }

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@blazetrails/guides-typecheck",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Type-checks TypeScript code blocks in the website guides.",
+  "dependencies": {
+    "@blazetrails/activemodel": "workspace:*",
+    "@blazetrails/activerecord": "workspace:*",
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/arel": "workspace:*",
+    "@blazetrails/rack": "workspace:*",
+    "@blazetrails/actionpack": "workspace:*"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ["packages/*/src/**/*.test.ts"],
+    include: ["packages/*/src/**/*.test.ts", "scripts/guides-typecheck/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**", "packages/*/dx-tests/**"],
     setupFiles: process.env.MYSQL_TEST_URL
       ? ["./packages/activerecord/src/test-setup-mysql.ts"]


### PR DESCRIPTION
## Summary
First deliverable from **Phase 0** of the [Rails Guides migration plan](../blob/main/docs/rails-guides-migration-plan.md). Introduces a CI check that type-checks every `ts` / `typescript` fenced block under `packages/website/docs/guides/` against the real `@blazetrails/*` package types.

This catches drift between guides and code automatically: if an API is renamed, every guide still using the old name fails the check. Required because docs examples rot silently otherwise — Rails runs a similar check on guide code.

## Design
- Each block is compiled as its own ES module with an `export {}` suffix so top-level `await` works.
- A shared `globals.d.ts` declares common illustrative names (`user`, `post`, `User`, `Post`, `AnyRecord`, etc.) as `any` — short snippets don't need boilerplate, but imports from `@blazetrails/*` still type-check against real signatures.
- `<!-- typecheck:skip -->` on the line before a fence opts out (for intentionally broken contrast examples).
- The check script lives in a workspace package (`scripts/guides-typecheck/`) that depends on every `@blazetrails/*` so pnpm resolves them normally from `node_modules`.
- Error output remaps tmp paths back to the real guide filename and absolute line.

## Changes
- `scripts/guides-typecheck/{check.ts,package.json,README.md}`: the check, its workspace manifest, contributor docs.
- `pnpm-workspace.yaml`: add the new workspace member.
- `package.json`: `pnpm guides:typecheck` script.
- `.github/workflows/ci.yml`: new **Guides Code Type Check** job (runs `pnpm build && pnpm guides:typecheck`).
- `packages/website/docs/guides/activemodel-rails-deviations.md`: snippet gains an explicit `import { Model } from "@blazetrails/activemodel"` so it type-checks cleanly.
- `.gitignore`: ignore the script's `.tmp/` scratch dir.

## Test plan
- [x] `pnpm build && pnpm guides:typecheck` — all 5 existing blocks across 4 guides pass.
- [x] Verified `<!-- typecheck:skip -->` skips blocks (tested with a deliberately broken snippet).
- [x] Verified a real type error (e.g., `await transaction()` missing args) fails the check with a remapped error pointing at the source guide line.