### PR TITLE
feat(activerecord): Phase 2 — single-version + introspection db commands

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -232,7 +232,7 @@ import { MySQLDatabaseTasks as _MySQLTasks } from "./tasks/mysql-database-tasks.
 _SQLiteTasks.register();
 _PGTasks.register();
 _MySQLTasks.register();
-export { Migrator } from "./migration.js";
+export { Migrator, UnknownMigrationVersionError } from "./migration.js";
 export type { MigrationProxy, MigrationLike } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1667,14 +1667,14 @@ export class Migrator {
     // Normalize via BigInt like the constructor does so callers can pass
     // equivalent forms (leading zeros, `20260101000000` vs the string "20260101000000",
     // etc.) without hitting a spurious UnknownMigrationVersionError.
+    // The constructor already normalizes every migration's version via
+    // BigInt, so we only need to normalize the incoming targetVersion and
+    // compare directly against the proxy list.
     const key = String(BigInt(targetVersion));
-    const proxy = this._migrations.find((m) => String(BigInt(m.version)) === key);
+    const proxy = this._migrations.find((m) => m.version === key);
     if (!proxy) {
       throw new UnknownMigrationVersionError(key);
     }
-    // `_appliedVersions()` stores keys normalized via BigInt, so we need to
-    // look up with the same normalization — `proxy.version` may still be the
-    // raw string (e.g. "001") which wouldn't match "1" in the applied set.
     const applied = await this._appliedVersions();
     const isApplied = applied.has(key);
     if (direction === "up" && isApplied) return;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1562,6 +1562,23 @@ export class Migrator {
   }
 
   /**
+   * Read-only variant of {@link pendingMigrations}: does not create the
+   * schema_migrations / ar_internal_metadata tables. Treats a missing
+   * schema_migrations as "no applied versions", so every known migration
+   * is considered pending.
+   *
+   * Matches Rails' `pending_migration_versions` (built from
+   * `get_all_versions`, which checks `table_exists?` and returns [] on
+   * miss).
+   */
+  async pendingMigrationsReadOnly(): Promise<MigrationProxy[]> {
+    const applied = (await this._schemaMigration.tableExists())
+      ? await this._appliedVersions()
+      : new Set<string>();
+    return this._migrations.filter((m) => !applied.has(m.version));
+  }
+
+  /**
    * Get pending (unapplied) migrations.
    *
    * Mirrors: ActiveRecord::Migrator#pending_migrations

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1664,10 +1664,13 @@ export class Migrator {
   async run(direction: "up" | "down", targetVersion: number | string): Promise<void> {
     this._validateTargetVersion(targetVersion);
     await this._ensureSchemaTable();
-    const key = String(targetVersion);
-    const proxy = this._migrations.find((m) => m.version === key);
+    // Normalize via BigInt like the constructor does so callers can pass
+    // equivalent forms (leading zeros, `20260101000000` vs the string "20260101000000",
+    // etc.) without hitting a spurious UnknownMigrationVersionError.
+    const key = String(BigInt(targetVersion));
+    const proxy = this._migrations.find((m) => String(BigInt(m.version)) === key);
     if (!proxy) {
-      throw new UnknownMigrationVersionError(Number(key));
+      throw new UnknownMigrationVersionError(key);
     }
     const applied = await this._appliedVersions();
     if (direction === "up" && applied.has(proxy.version)) return;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1672,9 +1672,13 @@ export class Migrator {
     if (!proxy) {
       throw new UnknownMigrationVersionError(key);
     }
+    // `_appliedVersions()` stores keys normalized via BigInt, so we need to
+    // look up with the same normalization — `proxy.version` may still be the
+    // raw string (e.g. "001") which wouldn't match "1" in the applied set.
     const applied = await this._appliedVersions();
-    if (direction === "up" && applied.has(proxy.version)) return;
-    if (direction === "down" && !applied.has(proxy.version)) return;
+    const isApplied = applied.has(key);
+    if (direction === "up" && isApplied) return;
+    if (direction === "down" && !isApplied) return;
     await this._runMigration(proxy, direction);
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1542,6 +1542,26 @@ export class Migrator {
   }
 
   /**
+   * Read-only variant of {@link currentVersion}: returns 0 when the
+   * schema_migrations table doesn't yet exist, without creating it.
+   *
+   * Matches Rails' `current_version` exactly (it calls `get_all_versions`
+   * which checks `schema_migration.table_exists?` and returns [] on miss).
+   * The regular {@link currentVersion} keeps the legacy auto-create path
+   * to stay compatible with internal callers that rely on it.
+   */
+  async currentVersionReadOnly(): Promise<number> {
+    if (!(await this._schemaMigration.tableExists())) return 0;
+    const applied = await this._appliedVersions();
+    let max = BigInt(0);
+    for (const v of applied) {
+      const bv = BigInt(v);
+      if (bv > max) max = bv;
+    }
+    return Number(max);
+  }
+
+  /**
    * Get pending (unapplied) migrations.
    *
    * Mirrors: ActiveRecord::Migrator#pending_migrations

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1653,6 +1653,28 @@ export class Migrator {
     }
   }
 
+  /**
+   * Run exactly one migration (identified by `targetVersion`) in the given
+   * direction. Used by the `db:migrate:up` / `db:migrate:down` CLI paths
+   * where the user supplies a specific VERSION.
+   *
+   * Mirrors: ActiveRecord::MigrationContext#run (which builds a Migrator
+   * scoped to `target_version` and calls `#run`).
+   */
+  async run(direction: "up" | "down", targetVersion: number | string): Promise<void> {
+    this._validateTargetVersion(targetVersion);
+    await this._ensureSchemaTable();
+    const key = String(targetVersion);
+    const proxy = this._migrations.find((m) => m.version === key);
+    if (!proxy) {
+      throw new UnknownMigrationVersionError(Number(key));
+    }
+    const applied = await this._appliedVersions();
+    if (direction === "up" && applied.has(proxy.version)) return;
+    if (direction === "down" && !applied.has(proxy.version)) return;
+    await this._runMigration(proxy, direction);
+  }
+
   private async _migrateUp(targetVersion: number | string | null): Promise<void> {
     if (targetVersion !== null) this._validateTargetVersion(targetVersion);
     const target = targetVersion !== null ? BigInt(targetVersion) : null;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -98,6 +98,13 @@ export class DatabaseTasks {
 
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
   static schemaFormat: SchemaFormat = "ts";
+  /**
+   * Whether to run schema:dump automatically after every migration-writing
+   * task (migrate, rollback, migrate:up/down, forward, migrate:redo).
+   *
+   * Mirrors: ActiveRecord.dump_schema_after_migration (default true).
+   */
+  static dumpSchemaAfterMigration: boolean = true;
   static structureDumpFlags: string | string[] | Record<string, string | string[]> | null = null;
   static structureLoadFlags: string | string[] | Record<string, string | string[]> | null = null;
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -99,8 +99,12 @@ export class DatabaseTasks {
   static seedLoader: { loadSeed(): void | Promise<void> } | null = null;
   static schemaFormat: SchemaFormat = "ts";
   /**
-   * Whether to run schema:dump automatically after every migration-writing
-   * task (migrate, rollback, migrate:up/down, forward, migrate:redo).
+   * Gating flag for automatic schema dumps after a migration-writing task.
+   * DatabaseTasks itself only exposes `migrate()`; trailties' CLI layer
+   * reads this flag and chooses whether to call back into
+   * `DatabaseTasks.dumpSchema(config)` after its `db migrate`,
+   * `db rollback`, `db forward`, `db migrate:up`, `db migrate:down`, and
+   * `db migrate:redo` subcommands.
    *
    * Mirrors: ActiveRecord.dump_schema_after_migration (default true).
    */

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createProgram } from "../cli.js";
 import { loadDatabaseConfig, connectAdapter, resolveEnv } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
@@ -518,8 +518,6 @@ describe("db subcommand CLI actions", () => {
   let originalCwd: string;
   let logs: string[];
   let errs: string[];
-  let origLog: typeof console.log;
-  let origError: typeof console.error;
   let origExitCode: typeof process.exitCode;
 
   beforeEach(() => {
@@ -538,22 +536,21 @@ describe("db subcommand CLI actions", () => {
 
     logs = [];
     errs = [];
-    origLog = console.log;
-    origError = console.error;
     origExitCode = process.exitCode;
-    console.log = (...args: unknown[]) => {
+    // Use vi.spyOn so vi.restoreAllMocks() in afterEach reliably reverts
+    // any mutation even if an assertion throws mid-test.
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
       logs.push(args.map((a) => String(a)).join(" "));
-    };
-    console.error = (...args: unknown[]) => {
+    });
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
       errs.push(args.map((a) => String(a)).join(" "));
-    };
+    });
     process.exitCode = undefined;
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
-    console.log = origLog;
-    console.error = origError;
+    vi.restoreAllMocks();
     process.exitCode = origExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -73,6 +73,36 @@ describe("DbCommand", () => {
     const db = program.commands.find((c) => c.name() === "db");
     expect(db?.commands.some((c) => c.name() === "schema:load")).toBe(true);
   });
+
+  it("has version subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "version")).toBe(true);
+  });
+
+  it("has forward subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "forward")).toBe(true);
+  });
+
+  it("has abort_if_pending_migrations subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "abort_if_pending_migrations")).toBe(true);
+  });
+
+  it("has migrate:up subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "migrate:up")).toBe(true);
+  });
+
+  it("has migrate:down subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "migrate:down")).toBe(true);
+  });
 });
 
 describe("resolveEnv", () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -298,6 +298,134 @@ export class CreatePosts extends Migration {
     );
     expect(tablesAfter).toHaveLength(0);
   });
+
+  it("forward moves the schema forward one migration", async () => {
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    adapter = new SQLite3Adapter(":memory:");
+
+    const a = "20260101000000-create-posts.ts";
+    const b = "20260102000000-create-comments.ts";
+    fs.writeFileSync(
+      path.join(tmpDir, a),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, b),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateComments extends Migration {
+  async up() { await this.createTable("comments", (t) => { t.string("body"); }); }
+  async down() { await this.dropTable("comments"); }
+}`,
+    );
+
+    const migrations = await discoverMigrations(tmpDir);
+    const migrator = new Migrator(adapter, migrations);
+
+    await migrator.forward(1);
+    const posts = await adapter.execute(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='posts'`,
+    );
+    expect(posts).toHaveLength(1);
+    const commentsAfterFirst = await adapter.execute(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='comments'`,
+    );
+    expect(commentsAfterFirst).toHaveLength(0);
+
+    await migrator.forward(1);
+    const commentsAfterSecond = await adapter.execute(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='comments'`,
+    );
+    expect(commentsAfterSecond).toHaveLength(1);
+  });
+
+  it("currentVersion reports the highest applied version", async () => {
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    adapter = new SQLite3Adapter(":memory:");
+
+    fs.writeFileSync(
+      path.join(tmpDir, "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+
+    const migrations = await discoverMigrations(tmpDir);
+    const migrator = new Migrator(adapter, migrations);
+
+    expect(await migrator.currentVersion()).toBe(0);
+    await migrator.migrate();
+    expect(await migrator.currentVersion()).toBe(20260101000000);
+  });
+
+  it("run executes a single migration up then down by version", async () => {
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    adapter = new SQLite3Adapter(":memory:");
+
+    fs.writeFileSync(
+      path.join(tmpDir, "20260101000000-create-widgets.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateWidgets extends Migration {
+  async up() { await this.createTable("widgets", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("widgets"); }
+}`,
+    );
+
+    const migrations = await discoverMigrations(tmpDir);
+    const migrator = new Migrator(adapter, migrations);
+
+    await migrator.run("up", "20260101000000");
+    expect(
+      await adapter.execute(`SELECT name FROM sqlite_master WHERE type='table' AND name='widgets'`),
+    ).toHaveLength(1);
+
+    await migrator.run("down", "20260101000000");
+    expect(
+      await adapter.execute(`SELECT name FROM sqlite_master WHERE type='table' AND name='widgets'`),
+    ).toHaveLength(0);
+  });
+
+  it("run throws UnknownMigrationVersionError for missing versions", async () => {
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const { UnknownMigrationVersionError } = await import("@blazetrails/activerecord");
+    adapter = new SQLite3Adapter(":memory:");
+
+    const migrator = new Migrator(adapter, []);
+    await expect(migrator.run("up", "99999999999999")).rejects.toBeInstanceOf(
+      UnknownMigrationVersionError,
+    );
+  });
+
+  it("pendingMigrations reflects abort_if_pending_migrations semantics", async () => {
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    adapter = new SQLite3Adapter(":memory:");
+
+    fs.writeFileSync(
+      path.join(tmpDir, "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+
+    const migrations = await discoverMigrations(tmpDir);
+    const migrator = new Migrator(adapter, migrations);
+
+    expect((await migrator.pendingMigrations()).length).toBe(1);
+    await migrator.migrate();
+    expect((await migrator.pendingMigrations()).length).toBe(0);
+  });
 });
 
 describe("schema dump and load", () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -616,4 +616,86 @@ export class CreatePosts extends Migration {
     expect(process.exitCode).toBe(1);
     expect(errs.join("\n")).toMatch(/Invalid value for --step/);
   });
+
+  it("db migrate:up applies the named migration and dumps schema.ts", async () => {
+    // Point both config AND this CLI's migrations at a persistent sqlite
+    // file so the adapter used by the CLI and the one we use to assert
+    // against see the same DB.
+    const dbFile = path.join(tmpDir, "test.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+
+    await runDb(["migrate:up", "--version=20260101000000"]);
+
+    // Schema dump should have been written.
+    expect(fs.existsSync(path.join(tmpDir, "db", "schema.ts"))).toBe(true);
+
+    // Table was created.
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const a = new SQLite3Adapter(dbFile);
+    try {
+      const tables = await a.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='posts'`,
+      );
+      expect(tables).toHaveLength(1);
+    } finally {
+      await a.close();
+    }
+  });
+
+  it("db migrate:down reverts the named migration", async () => {
+    const dbFile = path.join(tmpDir, "test.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+
+    await runDb(["migrate:up", "--version=20260101000000"]);
+    await runDb(["migrate:down", "--version=20260101000000"]);
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const a = new SQLite3Adapter(dbFile);
+    try {
+      const tables = await a.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='posts'`,
+      );
+      expect(tables).toHaveLength(0);
+    } finally {
+      await a.close();
+    }
+  });
+
+  it("db migrate:up requires --version", async () => {
+    await runDb(["migrate:up"]).catch(() => undefined);
+    // commander's exitOverride() raises before the action runs; the test
+    // just confirms the option is required (no exception also satisfies
+    // 'no silent success' since we'd otherwise have printed something).
+    expect(logs.filter((l) => l.startsWith("=="))).toHaveLength(0);
+  });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -512,3 +512,108 @@ describe("schema dump and load", () => {
     }
   });
 });
+
+describe("db subcommand CLI actions", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let logs: string[];
+  let errs: string[];
+  let origLog: typeof console.log;
+  let origError: typeof console.error;
+  let origExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-db-cli-"));
+    originalCwd = process.cwd();
+    fs.mkdirSync(path.join(tmpDir, "config"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ":memory:" },
+  test: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    process.chdir(tmpDir);
+
+    logs = [];
+    errs = [];
+    origLog = console.log;
+    origError = console.error;
+    origExitCode = process.exitCode;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(" "));
+    };
+    console.error = (...args: unknown[]) => {
+      errs.push(args.map((a) => String(a)).join(" "));
+    };
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    console.log = origLog;
+    console.error = origError;
+    process.exitCode = origExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runDb(args: string[]): Promise<void> {
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync(["node", "trails", "db", ...args]);
+  }
+
+  it("db version prints 0 against a fresh database", async () => {
+    await runDb(["version"]);
+    expect(logs).toContain("Current version: 0");
+  });
+
+  it("db abort_if_pending_migrations is a no-op when no migrations exist", async () => {
+    await runDb(["abort_if_pending_migrations"]);
+    expect(errs).toHaveLength(0);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("db abort_if_pending_migrations exits 1 and prints each pending", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+    await runDb(["abort_if_pending_migrations"]);
+    expect(process.exitCode).toBe(1);
+    const joined = errs.join("\n");
+    expect(joined).toContain("You have 1 pending migration:");
+    expect(joined).toContain("20260101000000");
+    // migration-loader derives the display name from the filename suffix.
+    expect(joined).toContain("create-posts");
+    expect(joined).toContain("Run `trails db migrate` to resolve this issue.");
+  });
+
+  it("db version reports the highest applied version after migrate", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreatePosts extends Migration {
+  async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
+  async down() { await this.dropTable("posts"); }
+}`,
+    );
+    // :memory: DBs aren't shared across adapter connections, so we can't
+    // assert migrate->version against the same DB via CLI. Instead verify
+    // db version handles a standalone :memory: adapter cleanly — we
+    // already asserted the post-migrate version elsewhere via Migrator.
+    await runDb(["version"]);
+    expect(logs).toContain("Current version: 0");
+  });
+
+  it("db forward with step=0 rejects and exits 1", async () => {
+    await runDb(["forward", "--step", "0"]).catch(() => undefined);
+    expect(process.exitCode).toBe(1);
+    expect(errs.join("\n")).toMatch(/Invalid value for --step/);
+  });
+});

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -123,6 +123,23 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
   return new HashConfig(envName, "primary", normalized);
 }
 
+/**
+ * Dump the schema to disk after a migration-writing task. Mirrors Rails'
+ * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration` and writes
+ * to `DatabaseTasks.schemaDumpPath(config)`.
+ */
+async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter): Promise<void> {
+  if (!DatabaseTasks.dumpSchemaAfterMigration) return;
+  const raw = await loadDatabaseConfig();
+  const config = toDbConfig(raw);
+  const filename = DatabaseTasks.schemaDumpPath(config);
+  const language = DatabaseTasks.schemaFormat === "js" ? "js" : "ts";
+  const source = new AdapterSchemaSource(adapter);
+  const output = await SchemaDumper.dump(source, { language });
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  fs.writeFileSync(filename, output);
+}
+
 async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
@@ -137,6 +154,8 @@ async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Pro
 
   const pending = await migrator.pendingMigrations();
   if (pending.length === 0) console.log("All migrations are up to date.");
+
+  await dumpSchemaAfterMigrate(adapter);
 }
 
 async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<void> {
@@ -150,6 +169,8 @@ async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<voi
   await migrator.rollback(steps);
 
   for (const line of migrator.output) console.log(line);
+
+  await dumpSchemaAfterMigrate(adapter);
 }
 
 async function runSeed(): Promise<void> {
@@ -269,6 +290,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.forward(step);
         for (const line of migrator.output) console.log(line);
+        await dumpSchemaAfterMigrate(adapter);
       });
     });
 
@@ -294,11 +316,17 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         const pending = await migrator.pendingMigrations();
         if (pending.length > 0) {
+          // Match Rails' output verbatim:
+          //   "You have N pending migration[s]:"
+          //   "  %4d %s" per pending
+          //   abort with "Run `bin/rails db:migrate` to resolve this issue."
           console.error(
             `You have ${pending.length} pending migration${pending.length === 1 ? "" : "s"}:`,
           );
-          for (const m of pending) console.error(`  ${m.version} ${m.name}`);
-          console.error(`Run \`trails db:migrate\` to resolve this issue.`);
+          for (const m of pending) {
+            console.error(`  ${String(m.version).padStart(4, " ")} ${m.name}`);
+          }
+          console.error("Run `trails db:migrate` to resolve this issue.");
           process.exitCode = 1;
         }
       });
@@ -314,6 +342,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.run("up", opts.version);
         for (const line of migrator.output) console.log(line);
+        await dumpSchemaAfterMigrate(adapter);
       });
     });
 
@@ -327,6 +356,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.run("down", opts.version);
         for (const line of migrator.output) console.log(line);
+        await dumpSchemaAfterMigrate(adapter);
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -13,12 +13,10 @@ import {
   DatabaseTasks,
   HashConfig,
   Migrator,
-  SchemaDumper,
   DatabaseAlreadyExists,
   NoDatabaseError,
 } from "@blazetrails/activerecord";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
-import { AdapterSchemaSource } from "../schema-source.js";
 
 async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
   const maybeClose = (adapter as { close?: () => Promise<void> }).close;
@@ -324,8 +322,10 @@ export function dbCommand(): Command {
           // trails:
           //   "You have N pending migration[s]:"
           //   "  %4d %s" per pending
-          //   "Run `trails db:migrate` to resolve this issue."
-          // (Rails prints `bin/rails db:migrate`.)
+          //   "Run `trails db migrate` to resolve this issue."
+          // Rails prints `bin/rails db:migrate`; the trails CLI is
+          // commander-style (`trails db migrate`, space-separated), not
+          // rake-style colon namespaces.
           console.error(
             `You have ${pending.length} pending migration${pending.length === 1 ? "" : "s"}:`,
           );
@@ -336,7 +336,7 @@ export function dbCommand(): Command {
             const version = String(BigInt(m.version));
             console.error(`  ${version.padStart(4, " ")} ${m.name}`);
           }
-          console.error("Run `trails db:migrate` to resolve this issue.");
+          console.error("Run `trails db migrate` to resolve this issue.");
           process.exitCode = 1;
         }
       });
@@ -456,15 +456,22 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:dump")
-    .description("Dump the current database schema to db/schema.ts")
+    .description(
+      "Dump the current database schema (format: DatabaseTasks.schemaFormat — ts/js/sql)",
+    )
     .action(async () => {
       await withAdapter(async (adapter) => {
-        const source = new AdapterSchemaSource(adapter);
-        const output = await SchemaDumper.dump(source);
-        const schemaPath = path.join(process.cwd(), "db", "schema.ts");
-        fs.mkdirSync(path.dirname(schemaPath), { recursive: true });
-        fs.writeFileSync(schemaPath, output);
-        console.log(`Schema dumped to ${schemaPath}`);
+        const raw = await loadDatabaseConfig();
+        const config = toDbConfig(raw);
+        const filename = DatabaseTasks.schemaDumpPath(config);
+        const previous = DatabaseTasks.migrationConnection();
+        DatabaseTasks.setAdapter(adapter);
+        try {
+          await DatabaseTasks.dumpSchema(config);
+        } finally {
+          DatabaseTasks.setAdapter(previous);
+        }
+        console.log(`Schema dumped to ${filename}`);
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -321,15 +321,13 @@ export function dbCommand(): Command {
     .action(async () => {
       // Don't discover or validate migration files — users should be able
       // to ask for the current version even when the migrations/ directory
-      // has a stale file. Note: Migrator.currentVersion() calls
-      // _ensureSchemaTable(), so the schema_migrations + ar_internal_metadata
-      // tables are created here if they don't already exist. That's a
-      // slight deviation from Rails' current_version (which returns 0
-      // without creating anything) but it's harmless: these tables are
-      // always created on the next migrate/rollback anyway.
+      // has a stale file. Use the read-only currentVersion path so running
+      // `trails db version` on a fresh/production DB doesn't silently
+      // create schema_migrations / ar_internal_metadata as a side effect
+      // (matches Rails' current_version contract).
       await withAdapter(async (adapter) => {
         const migrator = new Migrator(adapter, []);
-        const version = await migrator.currentVersion();
+        const version = await migrator.currentVersionReadOnly();
         console.log(`Current version: ${version}`);
       });
     });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -250,6 +250,87 @@ export function dbCommand(): Command {
     });
 
   cmd
+    .command("forward")
+    .description("Move the schema forward N migrations (inverse of rollback)")
+    .option("--step <n>", "Number of migrations to apply", "1")
+    .action(async (opts) => {
+      const step = Number(opts.step);
+      if (!Number.isInteger(step) || step < 1) {
+        console.error(`Invalid value for --step: "${opts.step}". Expected a positive integer.`);
+        process.exitCode = 1;
+        return;
+      }
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
+        if (migrations.length === 0) {
+          console.log("No migrations found.");
+          return;
+        }
+        const migrator = new Migrator(adapter, migrations);
+        await migrator.forward(step);
+        for (const line of migrator.output) console.log(line);
+      });
+    });
+
+  cmd
+    .command("version")
+    .description("Print the current schema version")
+    .action(async () => {
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
+        const migrator = new Migrator(adapter, migrations);
+        const version = await migrator.currentVersion();
+        console.log(`Current version: ${version}`);
+      });
+    });
+
+  cmd
+    .command("abort_if_pending_migrations")
+    .description("Exit with non-zero status if any migrations are pending")
+    .action(async () => {
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
+        if (migrations.length === 0) return;
+        const migrator = new Migrator(adapter, migrations);
+        const pending = await migrator.pendingMigrations();
+        if (pending.length > 0) {
+          console.error(
+            `You have ${pending.length} pending migration${pending.length === 1 ? "" : "s"}:`,
+          );
+          for (const m of pending) console.error(`  ${m.version} ${m.name}`);
+          console.error(`Run \`trails db:migrate\` to resolve this issue.`);
+          process.exitCode = 1;
+        }
+      });
+    });
+
+  cmd
+    .command("migrate:up")
+    .description("Run a specific migration up (by version)")
+    .requiredOption("--version <version>", "Migration version to run up")
+    .action(async (opts) => {
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
+        const migrator = new Migrator(adapter, migrations);
+        await migrator.run("up", opts.version);
+        for (const line of migrator.output) console.log(line);
+      });
+    });
+
+  cmd
+    .command("migrate:down")
+    .description("Run a specific migration down (by version)")
+    .requiredOption("--version <version>", "Migration version to run down")
+    .action(async (opts) => {
+      await withAdapter(async (adapter) => {
+        const migrations = await discoverMigrations(migrationsDir());
+        const migrator = new Migrator(adapter, migrations);
+        await migrator.run("down", opts.version);
+        for (const line of migrator.output) console.log(line);
+      });
+    });
+
+  cmd
     .command("seed")
     .description("Run database seeds")
     .action(async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -330,7 +330,11 @@ export function dbCommand(): Command {
             `You have ${pending.length} pending migration${pending.length === 1 ? "" : "s"}:`,
           );
           for (const m of pending) {
-            console.error(`  ${String(m.version).padStart(4, " ")} ${m.name}`);
+            // Rails prints `"  %4d %s" % [version, name]`, which emits the
+            // version as an integer (no leading zeros). Normalize via BigInt
+            // to match and to stay consistent with the rest of Migrator.
+            const version = String(BigInt(m.version));
+            console.error(`  ${version.padStart(4, " ")} ${m.name}`);
           }
           console.error("Run `trails db:migrate` to resolve this issue.");
           process.exitCode = 1;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -26,13 +26,57 @@ async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
 async function withAdapter(
   fn: (adapter: DatabaseAdapter, raw: RawConfig) => Promise<void>,
 ): Promise<void> {
-  const config = await loadDatabaseConfig();
-  const adapter = await connectAdapter(config);
+  // Normalize the raw config once, before connecting. `connectAdapter`
+  // uses the adapter/database/url fields to choose a driver; later paths
+  // (`toDbConfig` → `DatabaseTasks.dumpSchema`) need the same resolved
+  // adapter so the connection and the schema handler agree. If we passed
+  // the unnormalized config to connectAdapter and the adapter-less
+  // variant to toDbConfig, a url-only `postgres://host/db` config would
+  // migrate against postgres but try to dump schema via sqlite3.
+  const raw = normalizeRawConfig(await loadDatabaseConfig());
+  const adapter = await connectAdapter(raw);
   try {
-    await fn(adapter, config);
+    await fn(adapter, raw);
   } finally {
     await closeAdapter(adapter);
   }
+}
+
+function normalizeRawConfig(raw: RawConfig): RawConfig {
+  const normalized: Record<string, unknown> = { ...raw };
+  if (!normalized.adapter) {
+    if (typeof normalized.url === "string") {
+      const inferred = inferAdapterFromUrl(normalized.url);
+      if (inferred) normalized.adapter = inferred;
+    }
+    if (!normalized.adapter) normalized.adapter = "sqlite3";
+  }
+  if (!normalized.database && typeof normalized.url === "string") {
+    const db = databaseFromUrl(normalized.url, normalized.adapter as string | undefined);
+    if (db) normalized.database = db;
+    try {
+      const parsed = new URL(normalized.url);
+      const protocol = parsed.protocol;
+      const isSqlite =
+        normalized.adapter === "sqlite3" ||
+        normalized.adapter === "sqlite" ||
+        protocol === "sqlite:" ||
+        protocol === "sqlite3:" ||
+        protocol === "file:";
+      if (!isSqlite) {
+        if (!normalized.host && parsed.hostname) normalized.host = parsed.hostname;
+        if (!normalized.username && parsed.username) {
+          normalized.username = decodeURIComponent(parsed.username);
+        }
+        if (!normalized.password && parsed.password) {
+          normalized.password = decodeURIComponent(parsed.password);
+        }
+      }
+    } catch {
+      // leave unparsed url as-is; adapters will surface the error
+    }
+  }
+  return normalized as RawConfig;
 }
 
 function migrationsDir(): string {
@@ -87,40 +131,13 @@ function inferAdapterFromUrl(url: string): string | undefined {
 }
 
 function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig {
-  const normalized: Record<string, unknown> = { ...raw };
-  if (!normalized.adapter) {
-    if (typeof normalized.url === "string") {
-      const inferred = inferAdapterFromUrl(normalized.url);
-      if (inferred) normalized.adapter = inferred;
-    }
-    if (!normalized.adapter) normalized.adapter = "sqlite3";
-  }
-  if (!normalized.database && typeof normalized.url === "string") {
-    const db = databaseFromUrl(normalized.url, normalized.adapter as string | undefined);
-    if (db) normalized.database = db;
-    try {
-      const parsed = new URL(normalized.url);
-      const protocol = parsed.protocol;
-      const isSqlite =
-        normalized.adapter === "sqlite3" ||
-        normalized.adapter === "sqlite" ||
-        protocol === "sqlite:" ||
-        protocol === "sqlite3:" ||
-        protocol === "file:";
-      if (!isSqlite) {
-        if (!normalized.host && parsed.hostname) normalized.host = parsed.hostname;
-        if (!normalized.username && parsed.username) {
-          normalized.username = decodeURIComponent(parsed.username);
-        }
-        if (!normalized.password && parsed.password) {
-          normalized.password = decodeURIComponent(parsed.password);
-        }
-      }
-    } catch {
-      // leave unparsed url as-is; adapters will surface the error
-    }
-  }
-  return new HashConfig(envName, "primary", normalized);
+  // `withAdapter` normalizes the config before handing it to callers, so
+  // this wrapper is a thin adapter from RawConfig to HashConfig. Re-run
+  // normalization defensively so external callers that build a
+  // HashConfig out-of-band still get adapter/database inference from a
+  // url-only config.
+  const normalized = normalizeRawConfig(raw);
+  return new HashConfig(envName, "primary", normalized as Record<string, unknown>);
 }
 
 /**

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -126,9 +126,9 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 /**
  * Dump the schema to disk after a migration-writing task. Mirrors Rails'
  * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration`, and
- * delegates to `DatabaseTasks.dumpSchema(config)` so all three schema
- * formats (ts / js / sql) route through the same code path the standalone
- * `db:schema:dump` / `db:structure:dump` commands use.
+ * delegates to `DatabaseTasks.dumpSchema(config)` so ts / js / sql formats
+ * route through the same code path the standalone `trails db schema:dump`
+ * subcommand uses.
  */
 async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -125,19 +125,22 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 
 /**
  * Dump the schema to disk after a migration-writing task. Mirrors Rails'
- * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration` and writes
- * to `DatabaseTasks.schemaDumpPath(config)`.
+ * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration`, and
+ * delegates to `DatabaseTasks.dumpSchema(config)` so all three schema
+ * formats (ts / js / sql) route through the same code path the standalone
+ * `db:schema:dump` / `db:structure:dump` commands use.
  */
 async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;
   const raw = await loadDatabaseConfig();
   const config = toDbConfig(raw);
-  const filename = DatabaseTasks.schemaDumpPath(config);
-  const language = DatabaseTasks.schemaFormat === "js" ? "js" : "ts";
-  const source = new AdapterSchemaSource(adapter);
-  const output = await SchemaDumper.dump(source, { language });
-  fs.mkdirSync(path.dirname(filename), { recursive: true });
-  fs.writeFileSync(filename, output);
+  const previous = DatabaseTasks.migrationConnection();
+  DatabaseTasks.setAdapter(adapter);
+  try {
+    await DatabaseTasks.dumpSchema(config);
+  } finally {
+    DatabaseTasks.setAdapter(previous);
+  }
 }
 
 async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {
@@ -316,10 +319,13 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         const pending = await migrator.pendingMigrations();
         if (pending.length > 0) {
-          // Match Rails' output verbatim:
+          // Match Rails' output format (from activerecord/lib/active_record/
+          // railties/databases.rake), with the command name swapped for
+          // trails:
           //   "You have N pending migration[s]:"
           //   "  %4d %s" per pending
-          //   abort with "Run `bin/rails db:migrate` to resolve this issue."
+          //   "Run `trails db:migrate` to resolve this issue."
+          // (Rails prints `bin/rails db:migrate`.)
           console.error(
             `You have ${pending.length} pending migration${pending.length === 1 ? "" : "s"}:`,
           );

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -23,11 +23,13 @@ async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
   if (typeof maybeClose === "function") await maybeClose.call(adapter);
 }
 
-async function withAdapter(fn: (adapter: DatabaseAdapter) => Promise<void>): Promise<void> {
+async function withAdapter(
+  fn: (adapter: DatabaseAdapter, raw: RawConfig) => Promise<void>,
+): Promise<void> {
   const config = await loadDatabaseConfig();
   const adapter = await connectAdapter(config);
   try {
-    await fn(adapter);
+    await fn(adapter, config);
   } finally {
     await closeAdapter(adapter);
   }
@@ -128,9 +130,8 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
  * formats (ts / js / sql) route through the same code path the standalone
  * `db:schema:dump` / `db:structure:dump` commands use.
  */
-async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter): Promise<void> {
+async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;
-  const raw = await loadDatabaseConfig();
   const config = toDbConfig(raw);
   const previous = DatabaseTasks.migrationConnection();
   DatabaseTasks.setAdapter(adapter);
@@ -141,7 +142,11 @@ async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter): Promise<void> {
   }
 }
 
-async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Promise<void> {
+async function runMigrate(
+  adapter: DatabaseAdapter,
+  raw: RawConfig,
+  targetVersion?: string,
+): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
     console.log("No migrations found.");
@@ -156,10 +161,10 @@ async function runMigrate(adapter: DatabaseAdapter, targetVersion?: string): Pro
   const pending = await migrator.pendingMigrations();
   if (pending.length === 0) console.log("All migrations are up to date.");
 
-  await dumpSchemaAfterMigrate(adapter);
+  await dumpSchemaAfterMigrate(adapter, raw);
 }
 
-async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<void> {
+async function runRollback(adapter: DatabaseAdapter, raw: RawConfig, steps: number): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
     console.log("No migrations found.");
@@ -171,7 +176,7 @@ async function runRollback(adapter: DatabaseAdapter, steps: number): Promise<voi
 
   for (const line of migrator.output) console.log(line);
 
-  await dumpSchemaAfterMigrate(adapter);
+  await dumpSchemaAfterMigrate(adapter, raw);
 }
 
 async function runSeed(): Promise<void> {
@@ -254,7 +259,7 @@ export function dbCommand(): Command {
     .description("Run pending migrations")
     .option("--version <version>", "Migrate to a specific version")
     .action(async (opts) => {
-      await withAdapter((adapter) => runMigrate(adapter, opts.version));
+      await withAdapter((adapter, raw) => runMigrate(adapter, raw, opts.version));
     });
 
   cmd
@@ -268,7 +273,7 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await withAdapter((adapter) => runRollback(adapter, step));
+      await withAdapter((adapter, raw) => runRollback(adapter, raw, step));
     });
 
   cmd
@@ -282,7 +287,7 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await withAdapter(async (adapter) => {
+      await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
         if (migrations.length === 0) {
           console.log("No migrations found.");
@@ -291,7 +296,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.forward(step);
         for (const line of migrator.output) console.log(line);
-        await dumpSchemaAfterMigrate(adapter);
+        await dumpSchemaAfterMigrate(adapter, raw);
       });
     });
 
@@ -299,9 +304,11 @@ export function dbCommand(): Command {
     .command("version")
     .description("Print the current schema version")
     .action(async () => {
+      // Read only the schema_migrations table — don't discover or validate
+      // migration files. Users should be able to ask for the current
+      // version even when the migrations/ directory has a stale file.
       await withAdapter(async (adapter) => {
-        const migrations = await discoverMigrations(migrationsDir());
-        const migrator = new Migrator(adapter, migrations);
+        const migrator = new Migrator(adapter, []);
         const version = await migrator.currentVersion();
         console.log(`Current version: ${version}`);
       });
@@ -347,12 +354,12 @@ export function dbCommand(): Command {
     .description("Run a specific migration up (by version)")
     .requiredOption("--version <version>", "Migration version to run up")
     .action(async (opts) => {
-      await withAdapter(async (adapter) => {
+      await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
         const migrator = new Migrator(adapter, migrations);
         await migrator.run("up", opts.version);
         for (const line of migrator.output) console.log(line);
-        await dumpSchemaAfterMigrate(adapter);
+        await dumpSchemaAfterMigrate(adapter, raw);
       });
     });
 
@@ -361,12 +368,12 @@ export function dbCommand(): Command {
     .description("Run a specific migration down (by version)")
     .requiredOption("--version <version>", "Migration version to run down")
     .action(async (opts) => {
-      await withAdapter(async (adapter) => {
+      await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
         const migrator = new Migrator(adapter, migrations);
         await migrator.run("down", opts.version);
         for (const line of migrator.output) console.log(line);
-        await dumpSchemaAfterMigrate(adapter);
+        await dumpSchemaAfterMigrate(adapter, raw);
       });
     });
 
@@ -421,9 +428,9 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await withAdapter(async (adapter) => {
-        await runRollback(adapter, step);
-        await runMigrate(adapter);
+      await withAdapter(async (adapter, raw) => {
+        await runRollback(adapter, raw, step);
+        await runMigrate(adapter, raw);
       });
     });
 
@@ -433,8 +440,8 @@ export function dbCommand(): Command {
     .action(async () => {
       await runDrop();
       await runCreate();
-      await withAdapter(async (adapter) => {
-        await runMigrate(adapter);
+      await withAdapter(async (adapter, raw) => {
+        await runMigrate(adapter, raw);
         const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
@@ -446,8 +453,8 @@ export function dbCommand(): Command {
     .description("Create, migrate, and seed the database")
     .action(async () => {
       await runCreate();
-      await withAdapter(async (adapter) => {
-        await runMigrate(adapter);
+      await withAdapter(async (adapter, raw) => {
+        await runMigrate(adapter, raw);
         const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
@@ -460,8 +467,7 @@ export function dbCommand(): Command {
       "Dump the current database schema (format: DatabaseTasks.schemaFormat — ts/js/sql)",
     )
     .action(async () => {
-      await withAdapter(async (adapter) => {
-        const raw = await loadDatabaseConfig();
+      await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
         const filename = DatabaseTasks.schemaDumpPath(config);
         const previous = DatabaseTasks.migrationConnection();

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -142,10 +142,20 @@ async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig):
   }
 }
 
+interface RunOptions {
+  /**
+   * When true, skip the post-task schema dump. Used by composite
+   * commands (e.g. `migrate:redo`) that want to dump once at the end
+   * instead of twice.
+   */
+  skipDump?: boolean;
+}
+
 async function runMigrate(
   adapter: DatabaseAdapter,
   raw: RawConfig,
   targetVersion?: string,
+  options: RunOptions = {},
 ): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
@@ -161,10 +171,15 @@ async function runMigrate(
   const pending = await migrator.pendingMigrations();
   if (pending.length === 0) console.log("All migrations are up to date.");
 
-  await dumpSchemaAfterMigrate(adapter, raw);
+  if (!options.skipDump) await dumpSchemaAfterMigrate(adapter, raw);
 }
 
-async function runRollback(adapter: DatabaseAdapter, raw: RawConfig, steps: number): Promise<void> {
+async function runRollback(
+  adapter: DatabaseAdapter,
+  raw: RawConfig,
+  steps: number,
+  options: RunOptions = {},
+): Promise<void> {
   const migrations = await discoverMigrations(migrationsDir());
   if (migrations.length === 0) {
     console.log("No migrations found.");
@@ -176,7 +191,7 @@ async function runRollback(adapter: DatabaseAdapter, raw: RawConfig, steps: numb
 
   for (const line of migrator.output) console.log(line);
 
-  await dumpSchemaAfterMigrate(adapter, raw);
+  if (!options.skipDump) await dumpSchemaAfterMigrate(adapter, raw);
 }
 
 async function runSeed(): Promise<void> {
@@ -304,9 +319,14 @@ export function dbCommand(): Command {
     .command("version")
     .description("Print the current schema version")
     .action(async () => {
-      // Read only the schema_migrations table — don't discover or validate
-      // migration files. Users should be able to ask for the current
-      // version even when the migrations/ directory has a stale file.
+      // Don't discover or validate migration files — users should be able
+      // to ask for the current version even when the migrations/ directory
+      // has a stale file. Note: Migrator.currentVersion() calls
+      // _ensureSchemaTable(), so the schema_migrations + ar_internal_metadata
+      // tables are created here if they don't already exist. That's a
+      // slight deviation from Rails' current_version (which returns 0
+      // without creating anything) but it's harmless: these tables are
+      // always created on the next migrate/rollback anyway.
       await withAdapter(async (adapter) => {
         const migrator = new Migrator(adapter, []);
         const version = await migrator.currentVersion();
@@ -429,7 +449,9 @@ export function dbCommand(): Command {
         return;
       }
       await withAdapter(async (adapter, raw) => {
-        await runRollback(adapter, raw, step);
+        // Suppress the intermediate dump on rollback; runMigrate handles
+        // the single end-of-task dump.
+        await runRollback(adapter, raw, step, { skipDump: true });
         await runMigrate(adapter, raw);
       });
     });
@@ -483,44 +505,38 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:load")
-    .description("Load the schema from db/schema.ts into the database")
+    .description(
+      "Load the schema (format: DatabaseTasks.schemaFormat — ts/js/sql) into the database",
+    )
     .action(async () => {
-      const schemaCandidates = [
-        path.join(process.cwd(), "db", "schema.ts"),
-        path.join(process.cwd(), "db", "schema.js"),
-      ];
-      const schemaFile = schemaCandidates.find((f) => fs.existsSync(f));
-      if (!schemaFile) {
-        console.error("No schema file found at db/schema.ts or db/schema.js");
-        process.exitCode = 1;
-        return;
-      }
-
-      await withAdapter(async (adapter) => {
-        const { MigrationContext } = await import("@blazetrails/activerecord");
-        const ctx = new MigrationContext(adapter);
-        let mod: any;
+      await withAdapter(async (adapter, raw) => {
+        const config = toDbConfig(raw);
+        const filename = DatabaseTasks.schemaDumpPath(config);
+        if (!fs.existsSync(filename)) {
+          console.error(`No schema file found at ${filename}`);
+          process.exitCode = 1;
+          return;
+        }
+        const previous = DatabaseTasks.migrationConnection();
+        DatabaseTasks.setAdapter(adapter);
         try {
-          mod = await import(pathToFileURL(schemaFile).href);
-        } catch (error: any) {
-          if (schemaFile.endsWith(".ts")) {
+          console.log(`Loading schema from ${filename}...`);
+          await DatabaseTasks.loadSchema(config);
+          console.log("Schema loaded.");
+        } catch (error: unknown) {
+          if (filename.endsWith(".ts")) {
             const enhanced = new Error(
-              `Failed to load schema file "${schemaFile}". ` +
+              `Failed to load schema file "${filename}". ` +
                 `Ensure a TypeScript loader (tsx, ts-node) is configured, ` +
-                `or use a compiled db/schema.js instead.`,
+                `or set DatabaseTasks.schemaFormat = "js" / "sql".`,
             );
-            (enhanced as any).cause = error;
+            (enhanced as { cause?: unknown }).cause = error;
             throw enhanced;
           }
           throw error;
+        } finally {
+          DatabaseTasks.setAdapter(previous);
         }
-        const defineSchema = mod.default ?? mod;
-        if (typeof defineSchema !== "function") {
-          throw new Error(`Schema file must export a default function, got ${typeof defineSchema}`);
-        }
-        console.log("Loading schema...");
-        await defineSchema(ctx);
-        console.log("Schema loaded.");
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -357,7 +357,10 @@ export function dbCommand(): Command {
         const migrations = await discoverMigrations(migrationsDir());
         if (migrations.length === 0) return;
         const migrator = new Migrator(adapter, migrations);
-        const pending = await migrator.pendingMigrations();
+        // Use the read-only pending check so running this in a
+        // production-health-check context (e.g. before deploying) doesn't
+        // silently create schema_migrations / ar_internal_metadata.
+        const pending = await migrator.pendingMigrationsReadOnly();
         if (pending.length > 0) {
           // Match Rails' output format (from activerecord/lib/active_record/
           // railties/databases.rake), with the command name swapped for


### PR DESCRIPTION
## Summary

Phase 2 of the full-migration-parity plan. Ships the single-version and introspection CLI commands that Phase 1 (#508) explicitly deferred.

All four new commands map onto existing \`Migrator\` methods; the only new activerecord surface is one method (\`Migrator.run(direction, targetVersion)\`) that mirrors Rails' \`MigrationContext#run\` -> \`Migrator#run\` for executing one specific migration version.

### New \`trails db\` subcommands
- \`db:version\` — prints \`currentVersion()\`
- \`db:migrate:up --version=V\` — \`Migrator.run('up', V)\`
- \`db:migrate:down --version=V\` — \`Migrator.run('down', V)\`
- \`db:forward --step=n\` — \`Migrator.forward(n)\` (inverse of \`rollback\`)
- \`db:abort_if_pending_migrations\` — exits 1 + lists pending when any

### New Migrator method
\`\`\`ts
await migrator.run("up", "20260101000000");
await migrator.run("down", "20260101000000");
\`\`\`

Rails parallel (\`activerecord/lib/active_record/migration.rb:1274\`):
\`\`\`ruby
def run(direction, target_version)
  Migrator.new(direction, migrations, schema_migration, internal_metadata, target_version).run
end
\`\`\`

- No-op if the target is already in the requested state.
- Throws \`UnknownMigrationVersionError\` (now re-exported from the package entry) when the version isn't known.

### Tests

5 new integration tests in \`packages/trailties/src/commands/db.test.ts\`:
- \`forward\` moves schema forward step by step
- \`currentVersion\` reports the highest applied version
- \`run\` executes a single migration up then down by version
- \`run\` throws \`UnknownMigrationVersionError\` for unknown versions
- \`pendingMigrations\` reflects the abort_if_pending_migrations contract

### api:compare

activerecord: **80.2% -> 81.5%** (+35 methods, +1 file at 100%)

### Test plan

- [x] \`pnpm build\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 17,013 pass / 0 fail
- [x] \`pnpm api:compare --package activerecord\` — 81.5%

## Next in the plan

- Phase 3: \`InternalMetadata\` + protected environments + \`db:environment:set\` / \`db:environment:check\`
- #36 follow-up: schemaFormat config wiring