### PR TITLE
feat(activerecord): type Base#id and wire belongsTo/hasOne/hasMany onto Base

### DIFF
--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -1,14 +1,6 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
 import { Base, CollectionProxy } from "@blazetrails/activerecord";
 
-// Structural shape of the (currently-runtime-only) association API. Keeping
-// it here makes the casts below readable and the assertions meaningful.
-interface AssocHost {
-  belongsTo(name: string, options?: Record<string, unknown>): void;
-  hasOne(name: string, options?: Record<string, unknown>): void;
-  hasMany(name: string, options?: Record<string, unknown>): void;
-}
-
 // Scenario: blog-style domain — Authors write Posts, Posts have Comments,
 // Authors have a Profile. This is the Rails guides' canonical example.
 
@@ -17,10 +9,8 @@ class Author extends Base {
 
   static {
     this.attribute("name", "string");
-    // `hasMany` is mixed into typeof Base at runtime via extend().
-    // Until it's statically typed, we invoke through a local cast.
-    (this as unknown as AssocHost).hasMany("posts");
-    (this as unknown as AssocHost).hasOne("profile");
+    this.hasMany("posts");
+    this.hasOne("profile");
   }
 }
 
@@ -33,8 +23,8 @@ class Post extends Base {
     this.attribute("title", "string");
     this.attribute("author_id", "integer");
     this.attribute("published", "boolean", { default: false });
-    (this as unknown as AssocHost).belongsTo("author");
-    (this as unknown as AssocHost).hasMany("comments", { dependent: "destroy" });
+    this.belongsTo("author");
+    this.hasMany("comments", { dependent: "destroy" });
   }
 }
 
@@ -45,7 +35,7 @@ class Comment extends Base {
   static {
     this.attribute("body", "string");
     this.attribute("post_id", "integer");
-    (this as unknown as AssocHost).belongsTo("post");
+    this.belongsTo("post");
   }
 }
 
@@ -56,11 +46,19 @@ class Profile extends Base {
   static {
     this.attribute("bio", "string");
     this.attribute("author_id", "integer");
-    (this as unknown as AssocHost).belongsTo("author");
+    this.belongsTo("author");
   }
 }
 
 describe("associations DX", () => {
+  it("belongsTo / hasMany / hasOne are statically typed on typeof Base", () => {
+    expectTypeOf(Base.belongsTo).toBeFunction();
+    expectTypeOf(Base.hasOne).toBeFunction();
+    expectTypeOf(Base.hasMany).toBeFunction();
+    expectTypeOf(Base.hasAndBelongsToMany).toBeFunction();
+    expectTypeOf<ReturnType<typeof Base.belongsTo>>().toEqualTypeOf<void>();
+  });
+
   it("model classes that declare associations remain their own type", () => {
     const post = new Post({ title: "hi", author_id: 1, published: true });
     expectTypeOf(post).toEqualTypeOf<Post>();
@@ -75,11 +73,10 @@ describe("associations DX", () => {
   it("association options bag accepts common Rails keys", () => {
     class Tagged extends Base {
       static {
-        const klass = this as unknown as AssocHost;
-        klass.belongsTo("author", { className: "Author", foreignKey: "author_id" });
-        klass.belongsTo("post", { optional: true });
-        klass.hasMany("comments", { dependent: "destroy", inverseOf: "tagged" });
-        klass.hasOne("profile", { through: "author" });
+        this.belongsTo("author", { className: "Author", foreignKey: "author_id" });
+        this.belongsTo("post", { optional: true });
+        this.hasMany("comments", { dependent: "destroy", inverseOf: "tagged" });
+        this.hasOne("profile", { through: "author" });
       }
     }
     assertType(Tagged);
@@ -87,13 +84,6 @@ describe("associations DX", () => {
 
   it("CollectionProxy is exported (currently non-generic — known gap)", () => {
     assertType<typeof CollectionProxy>(CollectionProxy);
-  });
-
-  it("KNOWN GAP: belongsTo/hasMany/hasOne are not statically declared on typeof Base", () => {
-    // This test encodes the current shape. When these methods are typed on
-    // `typeof Base`, remove the `AssocHost` cast above and update this test.
-    type HasHasMany = "hasMany" extends keyof typeof Base ? true : false;
-    assertType<HasHasMany>(false as HasHasMany);
   });
 
   it("KNOWN GAP: association accessors return `unknown` via Model's index signature", () => {

--- a/packages/activerecord/dx-tests/edge-cases.test-d.ts
+++ b/packages/activerecord/dx-tests/edge-cases.test-d.ts
@@ -79,8 +79,18 @@ describe("edge cases — rough edges in current DX", () => {
     >();
   });
 
-  it("KNOWN GAP: instance `id` is typed as `unknown`", () => {
-    const w = new Widget({ name: "w" });
-    expectTypeOf(w.id).toBeUnknown();
+  it("instance `id` is typed as PrimaryKeyValue (string | number | array | null | undefined)", () => {
+    expectTypeOf<Widget["id"]>().toEqualTypeOf<
+      import("@blazetrails/activerecord").PrimaryKeyValue
+    >();
+    // PrimaryKeyValue includes scalar IDs and CPK tuples — narrow at the use
+    // site (e.g. `w.id as number`) when you know the PK type.
+  });
+
+  it("belongsTo / hasMany / hasOne are statically typed on typeof Base", () => {
+    expectTypeOf<ReturnType<typeof Base.belongsTo>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.hasMany>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.hasOne>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.hasAndBelongsToMany>>().toEqualTypeOf<void>();
   });
 });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7828,4 +7828,38 @@ describe("CollectionProxyDelegation", () => {
     const rel = proxy.select("body");
     expect(typeof rel.toSql).toBe("function");
   });
+
+  it("associations mixed onto Base: this.belongsTo / hasOne / hasMany / hasAndBelongsToMany work", () => {
+    const adapter = createTestAdapter();
+    class BtBlog extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        this.hasMany("posts");
+      }
+    }
+    class BtPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("bt_blog_id", "integer");
+        this.adapter = adapter;
+        this.belongsTo("bt_blog");
+      }
+    }
+    class BtAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.hasOne("bt_post");
+        this.hasAndBelongsToMany("bt_tags");
+      }
+    }
+    registerModel(BtBlog);
+    registerModel(BtPost);
+    registerModel(BtAuthor);
+
+    expect(reflectOnAllAssociations(BtBlog).map((r) => r.name)).toContain("posts");
+    expect(reflectOnAllAssociations(BtPost).map((r) => r.name)).toContain("bt_blog");
+    expect(reflectOnAllAssociations(BtAuthor).map((r) => r.name)).toContain("bt_post");
+  });
 });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7861,5 +7861,6 @@ describe("CollectionProxyDelegation", () => {
     expect(reflectOnAllAssociations(BtBlog).map((r) => r.name)).toContain("posts");
     expect(reflectOnAllAssociations(BtPost).map((r) => r.name)).toContain("bt_blog");
     expect(reflectOnAllAssociations(BtAuthor).map((r) => r.name)).toContain("bt_post");
+    expect(reflectOnAllAssociations(BtAuthor).map((r) => r.name)).toContain("bt_tags");
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -129,17 +129,30 @@ export function quoteSqlValue(v: unknown, asArray = false): string {
 }
 
 /**
+ * A single column of a primary key.
+ *
+ * - `string` / `number` — the common scalar PK types (auto-increment ids, UUIDs).
+ * - `null` / `undefined` — column unset (e.g. a new record, or an unassigned
+ *   CPK column).
+ */
+export type PrimaryKeyScalar = string | number | null | undefined;
+
+/**
  * Value of a primary key on a persisted (or to-be-persisted) record.
  *
- * - `number` / `string` — the common scalar PK types (auto-increment ids, UUIDs).
- * - `Array<string | number>` — composite primary key tuple.
- * - `null` / `undefined` — unpersisted record, PK not yet assigned.
+ * - `PrimaryKeyScalar` — single-column primary key.
+ * - `PrimaryKeyScalar[]` — composite primary key tuple. Individual columns
+ *   may be null/undefined when the record isn't fully persisted
+ *   (e.g. `readAttribute` returned `null` for an unset CPK column).
  *
- * Subclasses with a known PK type can narrow this via `declare id: number`.
+ * When the concrete PK type is known, narrow at the use site (e.g.
+ * `record.id as number`) rather than redeclaring `id` on a subclass —
+ * `Base#id` is an accessor, and TS forbids overriding it with a
+ * differently-typed instance property.
  *
  * Mirrors: the value returned by `ActiveRecord::Base#id`.
  */
-export type PrimaryKeyValue = string | number | Array<string | number> | null | undefined;
+export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
 
 // Late-bound Relation constructor to break circular dependency.
 // Set by relation.ts when it loads.
@@ -2047,8 +2060,10 @@ export class Base extends Model {
   }
 
   /**
-   * The primary key value. Narrow to a more specific type via
-   * `declare id: number` (or similar) on subclasses when the PK type is known.
+   * The primary key value. When the concrete PK type is known, narrow it at
+   * the use site (e.g. `record.id as number`) rather than redeclaring `id`
+   * on a subclass — `id` is defined here as an accessor and TS forbids
+   * overriding an accessor with a differently-typed instance property.
    *
    * Mirrors: ActiveRecord::Base#id
    */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2076,7 +2076,7 @@ export class Base extends Model {
     return this.readAttribute(pk) as PrimaryKeyValue;
   }
 
-  set id(value: unknown) {
+  set id(value: PrimaryKeyValue) {
     const ctor = this.constructor as typeof Base;
     const pk = ctor.primaryKey;
     if (Array.isArray(pk)) {
@@ -2085,7 +2085,7 @@ export class Base extends Model {
           `Expected an array for composite primary key [${pk.join(", ")}], got ${value === null ? "null" : typeof value}`,
         );
       }
-      pk.forEach((col, i) => this.writeAttribute(col, (value as unknown[])[i]));
+      pk.forEach((col, i) => this.writeAttribute(col, value[i]));
     } else {
       this.writeAttribute(pk, value);
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -106,6 +106,7 @@ import { ScopeRegistry } from "./scoping.js";
 import { Default as DefaultScoping } from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
 import { AssociationNotFoundError } from "./associations/errors.js";
+import { Associations as _Associations } from "./associations.js";
 import { BelongsToAssociation } from "./associations/belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./associations/belongs-to-polymorphic-association.js";
 import { HasOneAssociation } from "./associations/has-one-association.js";
@@ -126,6 +127,19 @@ export function quoteSqlValue(v: unknown, asArray = false): string {
   if (typeof v === "object") return `'${JSON.stringify(v).replace(/'/g, "''")}'`;
   return `'${String(v).replace(/'/g, "''")}'`;
 }
+
+/**
+ * Value of a primary key on a persisted (or to-be-persisted) record.
+ *
+ * - `number` / `string` — the common scalar PK types (auto-increment ids, UUIDs).
+ * - `Array<string | number>` — composite primary key tuple.
+ * - `null` / `undefined` — unpersisted record, PK not yet assigned.
+ *
+ * Subclasses with a known PK type can narrow this via `declare id: number`.
+ *
+ * Mirrors: the value returned by `ActiveRecord::Base#id`.
+ */
+export type PrimaryKeyValue = string | number | Array<string | number> | null | undefined;
 
 // Late-bound Relation constructor to break circular dependency.
 // Set by relation.ts when it loads.
@@ -157,6 +171,12 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
 export class Base extends Model {
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
+
+  // --- Associations (wired below after class body) ---
+  declare static belongsTo: typeof _Associations.belongsTo;
+  declare static hasOne: typeof _Associations.hasOne;
+  declare static hasMany: typeof _Associations.hasMany;
+  declare static hasAndBelongsToMany: typeof _Associations.hasAndBelongsToMany;
   static get i18nScope(): string {
     return Translation.i18nScope.call(this);
   }
@@ -1126,7 +1146,7 @@ export class Base extends Model {
         .toArray();
       // Ensure all IDs were found
       if (records.length !== castIds.length) {
-        const foundIds = new Set(records.map((r: Base) => r.id));
+        const foundIds = new Set<unknown>(records.map((r: Base) => r.id));
         const missing = castIds.filter((i) => !foundIds.has(i));
         throw new RecordNotFound(
           `${this.name} with ${this.primaryKey} in [${missing.join(", ")}] not found`,
@@ -2027,15 +2047,18 @@ export class Base extends Model {
   }
 
   /**
-   * The primary key value.
+   * The primary key value. Narrow to a more specific type via
+   * `declare id: number` (or similar) on subclasses when the PK type is known.
+   *
+   * Mirrors: ActiveRecord::Base#id
    */
-  get id(): unknown {
+  get id(): PrimaryKeyValue {
     const ctor = this.constructor as typeof Base;
     const pk = ctor.primaryKey;
     if (Array.isArray(pk)) {
-      return pk.map((col) => this.readAttribute(col));
+      return pk.map((col) => this.readAttribute(col)) as PrimaryKeyValue;
     }
-    return this.readAttribute(pk);
+    return this.readAttribute(pk) as PrimaryKeyValue;
   }
 
   set id(value: unknown) {
@@ -3211,6 +3234,12 @@ function extractShared(rules: Record<string, unknown>): Record<string, unknown> 
 
 extend(Base, ConnectionHandling.ClassMethods);
 extend(Base, Querying);
+extend(Base, {
+  belongsTo: _Associations.belongsTo,
+  hasOne: _Associations.hasOne,
+  hasMany: _Associations.hasMany,
+  hasAndBelongsToMany: _Associations.hasAndBelongsToMany,
+});
 extend(Base, Translation.ClassMethods);
 extend(Base, ReadonlyAttributes.ClassMethods);
 extend(Base, CounterCache.ClassMethods);

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -1,4 +1,5 @@
 export { Base } from "./base.js";
+export type { PrimaryKeyValue } from "./base.js";
 export { Result, IndexedRow } from "./result.js";
 export type { ColumnType as ResultColumnType, ColumnTypes as ResultColumnTypes } from "./result.js";
 export * as Type from "./type.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -1,5 +1,5 @@
 export { Base } from "./base.js";
-export type { PrimaryKeyValue } from "./base.js";
+export type { PrimaryKeyScalar, PrimaryKeyValue } from "./base.js";
 export { Result, IndexedRow } from "./result.js";
 export type { ColumnType as ResultColumnType, ColumnTypes as ResultColumnTypes } from "./result.js";
 export * as Type from "./type.js";


### PR DESCRIPTION
## Summary
Closes two DX gaps surfaced by the dx-tests.

### 1. `Base#id` typed as `PrimaryKeyValue` instead of `unknown`
Exports a new public type:
```ts
export type PrimaryKeyValue =
  | string
  | number
  | Array<string | number>
  | null
  | undefined;
```
covers: scalar auto-increment/UUID ids, composite-key tuples, and unpersisted records. CPK users still get a useful union; scalar users narrow at the use site (`record.id as number`). No attempt is made to let subclasses `declare id: number` override the accessor — TS forbids that shape, and CPK support relies on the accessor.

### 2. `belongsTo` / `hasOne` / `hasMany` / `hasAndBelongsToMany` statically visible on `typeof Base`
`Associations` was a separate class holding these methods but they were never wired onto `Base` — so `class User extends Base { static { this.hasMany("posts"); } }` was broken at both the static-type level (dx-tests had to cast via `AssocHost`) and at runtime. This PR:
- Adds `declare static` signatures on `Base` that reference `_Associations.belongsTo` etc.
- `extend(Base, { belongsTo, hasOne, hasMany, hasAndBelongsToMany })` in the mixin block.

Rails-idiomatic now: `User.hasMany(:posts)` works with no cast, matching the Rails class-methods mixin.

### dx-tests
- Dropped the `AssocHost` cast in `associations.test-d.ts`.
- Added positive assertions for `Base.belongsTo/hasOne/hasMany/hasAndBelongsToMany`.
- Flipped the `id is unknown` KNOWN GAP to assert `PrimaryKeyValue`.
- 43/43 DX tests pass.

## Test plan
- [x] `pnpm build` + `pnpm typecheck` green
- [x] `pnpm test` green (17023 tests)
- [x] `pnpm test:types` green (43/43)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green