### PR TITLE
feat(activerecord): polymorphic this on all finder/CRUD statics

### DIFF
--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -72,6 +72,15 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(await User.secondToLast()).toEqualTypeOf<User | null>();
   });
 
+  it("findSigned / findSignedBang and underscore aliases carry User through", async () => {
+    expectTypeOf(await User.findSigned("tok")).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.findSignedBang("tok")).toEqualTypeOf<User>();
+    expectTypeOf(await User.first_()).toEqualTypeOf<User>();
+    expectTypeOf(await User.last_()).toEqualTypeOf<User>();
+    expectTypeOf(await User.take_()).toEqualTypeOf<User>();
+    expectTypeOf(await User.findBy_({ name: "dean" })).toEqualTypeOf<User>();
+  });
+
   it("find_or / destroyBy / destroyAll / update / destroy all preserve User", async () => {
     expectTypeOf(await User.findOrCreateBy({ name: "a" })).toEqualTypeOf<User>();
     expectTypeOf(await User.findOrInitializeBy({ name: "a" })).toEqualTypeOf<User>();

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -28,12 +28,12 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(u.email).toBeString();
   });
 
-  it("User.create returns a Promise<Base> (should narrow to User — known gap)", () => {
-    expectTypeOf(User.create).returns.resolves.toEqualTypeOf<Base>();
-  });
-
-  it("User.create(attrs) accepts a Record<string, unknown>", () => {
-    assertType<Promise<Base>>(User.create({ name: "dean", email: "d@example.com" }));
+  it("User.create / createBang / new resolve to a User (polymorphic `this`)", async () => {
+    const u = await User.create({ name: "dean", email: "d@example.com" });
+    expectTypeOf(u).toEqualTypeOf<User>();
+    const u2 = await User.createBang({ name: "x" });
+    expectTypeOf(u2).toEqualTypeOf<User>();
+    expectTypeOf(User.new({ name: "y" })).toEqualTypeOf<User>();
   });
 
   it("User.find(id) resolves to a single User", async () => {
@@ -49,9 +49,39 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(users).toEqualTypeOf<User | User[]>();
   });
 
-  it("User.findBy / findByBang have concrete Base returns", () => {
-    expectTypeOf(User.findBy).returns.resolves.toEqualTypeOf<Base | null>();
-    expectTypeOf(User.findByBang).returns.resolves.toEqualTypeOf<Base>();
+  it("User.findBy / findByBang / findSoleBy resolve to User (nullable variant for findBy)", async () => {
+    expectTypeOf(await User.findBy({ email: "d@example.com" })).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.findByBang({ email: "d@example.com" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.findSoleBy({ email: "d@example.com" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.findByAttribute("name", "dean")).toEqualTypeOf<User | null>();
+  });
+
+  it("ordinal + cardinality finders all carry User through", async () => {
+    expectTypeOf(await User.first()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.first(5)).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.firstBang()).toEqualTypeOf<User>();
+    expectTypeOf(await User.last()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.last(5)).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.lastBang()).toEqualTypeOf<User>();
+    expectTypeOf(await User.take()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.take(3)).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.sole()).toEqualTypeOf<User>();
+    expectTypeOf(await User.second()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.third()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.fortyTwo()).toEqualTypeOf<User | null>();
+    expectTypeOf(await User.secondToLast()).toEqualTypeOf<User | null>();
+  });
+
+  it("find_or / destroyBy / destroyAll / update / destroy all preserve User", async () => {
+    expectTypeOf(await User.findOrCreateBy({ name: "a" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.findOrInitializeBy({ name: "a" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.createOrFindBy({ name: "a" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.createOrFindByBang({ name: "a" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.destroyBy({ name: "a" })).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.destroyAll()).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.update(1, { name: "b" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.updateBang(1, { name: "b" })).toEqualTypeOf<User>();
+    expectTypeOf(await User.destroy(1)).toEqualTypeOf<User | User[]>();
   });
 
   it("User.count / exists / pluck have concrete return types", () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1194,7 +1194,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_by
    */
-  static async findBy(conditions: Record<string, unknown>): Promise<Base | null> {
+  static async findBy<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown>,
+  ): Promise<InstanceType<T> | null> {
     const table = this.arelTable;
     const manager = table.project("*");
 
@@ -1211,7 +1214,7 @@ export class Base extends Model {
     const row = await this.adapter.selectOne(sql, "Find");
     if (!row) return null;
 
-    return this._instantiate(row);
+    return this._instantiate(row) as InstanceType<T>;
   }
 
   /**
@@ -1219,7 +1222,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_by!
    */
-  static async findByBang(conditions: Record<string, unknown>): Promise<Base> {
+  static async findByBang<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown>,
+  ): Promise<InstanceType<T>> {
     const record = await this.findBy(conditions);
     if (!record) {
       throw new RecordNotFound(`${this.name} not found`, this.name);
@@ -1233,7 +1239,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_by_* dynamic finders
    */
-  static async findByAttribute(attribute: string, value: unknown): Promise<Base | null> {
+  static async findByAttribute<T extends typeof Base>(
+    this: T,
+    attribute: string,
+    value: unknown,
+  ): Promise<InstanceType<T> | null> {
     return this.findBy({ [attribute]: value });
   }
 
@@ -1259,7 +1269,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_sole_by
    */
-  static async findSoleBy(conditions: Record<string, unknown>): Promise<Base> {
+  static async findSoleBy<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown>,
+  ): Promise<InstanceType<T>> {
     return this.all().where(conditions).sole();
   }
 
@@ -1381,7 +1394,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.destroy_by
    */
-  static async destroyBy(conditions: Record<string, unknown>): Promise<Base[]> {
+  static async destroyBy<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown>,
+  ): Promise<InstanceType<T>[]> {
     return this.all().where(conditions).destroyAll();
   }
 
@@ -1399,7 +1415,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.update(id, attrs)
    */
-  static async update(id: unknown, attrs: Record<string, unknown>): Promise<Base> {
+  static async update<T extends typeof Base>(
+    this: T,
+    id: unknown,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>> {
     const record = await this.find(id);
     await record.update(attrs);
     return record;
@@ -1410,7 +1430,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.destroy(id)
    */
-  static async destroy(id: unknown | unknown[]): Promise<Base | Base[]> {
+  static async destroy<T extends typeof Base>(
+    this: T,
+    id: unknown | unknown[],
+  ): Promise<InstanceType<T> | InstanceType<T>[]> {
     if (Array.isArray(id)) {
       const found = await this.find(id);
       const records = Array.isArray(found) ? found : [found];
@@ -1429,7 +1452,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.destroy_all
    */
-  static async destroyAll(): Promise<Base[]> {
+  static async destroyAll<T extends typeof Base>(this: T): Promise<InstanceType<T>[]> {
     return this.all().destroyAll();
   }
 
@@ -1438,7 +1461,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.update!
    */
-  static async updateBang(id: unknown, attrs: Record<string, unknown>): Promise<Base> {
+  static async updateBang<T extends typeof Base>(
+    this: T,
+    id: unknown,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>> {
     const record = await this.find(id);
     await record.updateBang(attrs);
     return record;
@@ -1458,7 +1485,7 @@ export class Base extends Model {
    * Return the second record.
    * Mirrors: ActiveRecord::Base.second
    */
-  static async second(): Promise<Base | null> {
+  static async second<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().second();
   }
 
@@ -1466,7 +1493,7 @@ export class Base extends Model {
    * Return the third record.
    * Mirrors: ActiveRecord::Base.third
    */
-  static async third(): Promise<Base | null> {
+  static async third<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().third();
   }
 
@@ -1474,7 +1501,7 @@ export class Base extends Model {
    * Return the fourth record.
    * Mirrors: ActiveRecord::Base.fourth
    */
-  static async fourth(): Promise<Base | null> {
+  static async fourth<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().fourth();
   }
 
@@ -1482,7 +1509,7 @@ export class Base extends Model {
    * Return the fifth record.
    * Mirrors: ActiveRecord::Base.fifth
    */
-  static async fifth(): Promise<Base | null> {
+  static async fifth<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().fifth();
   }
 
@@ -1490,7 +1517,7 @@ export class Base extends Model {
    * Return the forty-second record.
    * Mirrors: ActiveRecord::Base.forty_two
    */
-  static async fortyTwo(): Promise<Base | null> {
+  static async fortyTwo<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().fortyTwo();
   }
 
@@ -1498,7 +1525,7 @@ export class Base extends Model {
    * Return the second-to-last record.
    * Mirrors: ActiveRecord::Base.second_to_last
    */
-  static async secondToLast(): Promise<Base | null> {
+  static async secondToLast<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().secondToLast();
   }
 
@@ -1506,7 +1533,7 @@ export class Base extends Model {
    * Return the third-to-last record.
    * Mirrors: ActiveRecord::Base.third_to_last
    */
-  static async thirdToLast(): Promise<Base | null> {
+  static async thirdToLast<T extends typeof Base>(this: T): Promise<InstanceType<T> | null> {
     return this.all().thirdToLast();
   }
 
@@ -1614,7 +1641,12 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.first
    */
-  static async first(n?: number): Promise<Base | Base[] | null> {
+  static async first<T extends typeof Base>(this: T): Promise<InstanceType<T> | null>;
+  static async first<T extends typeof Base>(this: T, n: number): Promise<InstanceType<T>[]>;
+  static async first<T extends typeof Base>(
+    this: T,
+    n?: number,
+  ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
     return this.all().first(n as any);
   }
 
@@ -1623,7 +1655,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.first!
    */
-  static async firstBang(): Promise<Base> {
+  static async firstBang<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
     return this.all().firstBang();
   }
 
@@ -1632,7 +1664,12 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.last
    */
-  static async last(n?: number): Promise<Base | Base[] | null> {
+  static async last<T extends typeof Base>(this: T): Promise<InstanceType<T> | null>;
+  static async last<T extends typeof Base>(this: T, n: number): Promise<InstanceType<T>[]>;
+  static async last<T extends typeof Base>(
+    this: T,
+    n?: number,
+  ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
     return this.all().last(n as any);
   }
 
@@ -1641,7 +1678,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.last!
    */
-  static async lastBang(): Promise<Base> {
+  static async lastBang<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
     return this.all().lastBang();
   }
 
@@ -1650,7 +1687,12 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.take
    */
-  static async take(n?: number): Promise<Base | Base[] | null> {
+  static async take<T extends typeof Base>(this: T): Promise<InstanceType<T> | null>;
+  static async take<T extends typeof Base>(this: T, n: number): Promise<InstanceType<T>[]>;
+  static async take<T extends typeof Base>(
+    this: T,
+    n?: number,
+  ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
     return this.all().take(n as any);
   }
 
@@ -1659,7 +1701,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.sole
    */
-  static async sole(): Promise<Base> {
+  static async sole<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
     return this.all().sole();
   }
 
@@ -1770,10 +1812,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_or_create_by
    */
-  static async findOrCreateBy(
+  static async findOrCreateBy<T extends typeof Base>(
+    this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
-  ): Promise<Base> {
+  ): Promise<InstanceType<T>> {
     const record = await this.findBy(conditions);
     if (record) return record;
     return this.create({ ...conditions, ...extra });
@@ -1784,13 +1827,14 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_or_initialize_by
    */
-  static async findOrInitializeBy(
+  static async findOrInitializeBy<T extends typeof Base>(
+    this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
-  ): Promise<Base> {
+  ): Promise<InstanceType<T>> {
     const record = await this.findBy(conditions);
     if (record) return record;
-    return new this({ ...conditions, ...extra });
+    return new this({ ...conditions, ...extra }) as InstanceType<T>;
   }
 
   /**
@@ -1799,10 +1843,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.create_or_find_by
    */
-  static async createOrFindBy(
+  static async createOrFindBy<T extends typeof Base>(
+    this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
-  ): Promise<Base> {
+  ): Promise<InstanceType<T>> {
     try {
       return await this.create({ ...conditions, ...extra });
     } catch {
@@ -1818,10 +1863,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.create_or_find_by!
    */
-  static async createOrFindByBang(
+  static async createOrFindByBang<T extends typeof Base>(
+    this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
-  ): Promise<Base> {
+  ): Promise<InstanceType<T>> {
     try {
       return await this.createBang({ ...conditions, ...extra });
     } catch (e) {
@@ -1837,8 +1883,8 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.new (Ruby convention)
    */
-  static new(attrs: Record<string, unknown> = {}): Base {
-    return new this(attrs);
+  static new<T extends typeof Base>(this: T, attrs: Record<string, unknown> = {}): InstanceType<T> {
+    return new this(attrs) as InstanceType<T>;
   }
 
   /**
@@ -1855,8 +1901,11 @@ export class Base extends Model {
     return attrs;
   }
 
-  static async create(attrs: Record<string, unknown> = {}): Promise<Base> {
-    const record = new this(this._mergeCurrentScopeAttrs(attrs));
+  static async create<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> = {},
+  ): Promise<InstanceType<T>> {
+    const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
     await record.save();
     return record;
   }
@@ -1866,8 +1915,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.create!
    */
-  static async createBang(attrs: Record<string, unknown> = {}): Promise<Base> {
-    const record = new this(this._mergeCurrentScopeAttrs(attrs));
+  static async createBang<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> = {},
+  ): Promise<InstanceType<T>> {
+    const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
     await record.saveBang();
     return record;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3000,9 +3000,13 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::SignedId.find_signed
    */
-  static async findSigned(signedId: string, options?: { purpose?: string }): Promise<Base | null> {
+  static async findSigned<T extends typeof Base>(
+    this: T,
+    signedId: string,
+    options?: { purpose?: string },
+  ): Promise<InstanceType<T> | null> {
     const SignedIdModule = await loadSignedId();
-    return SignedIdModule.findSigned(this, signedId, options);
+    return SignedIdModule.findSigned(this, signedId, options) as Promise<InstanceType<T> | null>;
   }
 
   /**
@@ -3011,9 +3015,13 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::SignedId.find_signed!
    */
-  static async findSignedBang(signedId: string, options?: { purpose?: string }): Promise<Base> {
+  static async findSignedBang<T extends typeof Base>(
+    this: T,
+    signedId: string,
+    options?: { purpose?: string },
+  ): Promise<InstanceType<T>> {
     const SignedIdModule = await loadSignedId();
-    return SignedIdModule.findSignedBang(this, signedId, options);
+    return SignedIdModule.findSignedBang(this, signedId, options) as Promise<InstanceType<T>>;
   }
 
   /**
@@ -3237,25 +3245,28 @@ export class Base extends Model {
   }
 
   // Underscore aliases for bang methods (Rails uses ! suffix, TS uses _ suffix)
-  static async first_(): Promise<Base> {
-    return (this as any).firstBang();
+  static async first_<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
+    return this.firstBang();
   }
-  static async last_(): Promise<Base> {
-    return (this as any).lastBang();
+  static async last_<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
+    return this.lastBang();
   }
-  static async take_(): Promise<Base> {
-    const r = await (this as any).all().take();
+  static async take_<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
+    const r = await this.all().take();
     if (!r)
       throw new RecordNotFound(
-        `${(this as any).name} record not found`,
-        (this as any).name,
-        (this as any).primaryKey,
+        `${this.name} record not found`,
+        this.name,
+        String(this.primaryKey),
         null,
       );
-    return r;
+    return r as InstanceType<T>;
   }
-  static async findBy_(conditions: Record<string, unknown>): Promise<Base> {
-    return (this as any).findByBang(conditions);
+  static async findBy_<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown>,
+  ): Promise<InstanceType<T>> {
+    return this.findByBang(conditions);
   }
 
   previouslyNewRecord(): boolean {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1214,7 +1214,7 @@ export class Base extends Model {
     const row = await this.adapter.selectOne(sql, "Find");
     if (!row) return null;
 
-    return this._instantiate(row) as InstanceType<T>;
+    return this._instantiate(row);
   }
 
   /**
@@ -1647,7 +1647,7 @@ export class Base extends Model {
     this: T,
     n?: number,
   ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
-    return this.all().first(n as any);
+    return n === undefined ? this.all().first() : this.all().first(n);
   }
 
   /**
@@ -1670,7 +1670,7 @@ export class Base extends Model {
     this: T,
     n?: number,
   ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
-    return this.all().last(n as any);
+    return n === undefined ? this.all().last() : this.all().last(n);
   }
 
   /**
@@ -1693,7 +1693,7 @@ export class Base extends Model {
     this: T,
     n?: number,
   ): Promise<InstanceType<T> | InstanceType<T>[] | null> {
-    return this.all().take(n as any);
+    return n === undefined ? this.all().take() : this.all().take(n);
   }
 
   /**
@@ -1945,15 +1945,18 @@ export class Base extends Model {
   /**
    * Instantiate a model from a database row (marks it as persisted).
    */
-  static _instantiate(row: Record<string, unknown>): Base {
+  static _instantiate<T extends typeof Base>(
+    this: T,
+    row: Record<string, unknown>,
+  ): InstanceType<T> {
     // If STI is enabled, delegate to the correct subclass
     const stiBase = getStiBase(this);
     const inheritanceCol = getInheritanceColumn(stiBase);
     if (inheritanceCol && row[inheritanceCol] && row[inheritanceCol] !== this.name) {
-      return instantiateSti(stiBase, row);
+      return instantiateSti(stiBase, row) as InstanceType<T>;
     }
 
-    const record = new this();
+    const record = new this() as InstanceType<T>;
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {
       record._attributes.writeFromDatabase(key, value);
@@ -3006,7 +3009,7 @@ export class Base extends Model {
     options?: { purpose?: string },
   ): Promise<InstanceType<T> | null> {
     const SignedIdModule = await loadSignedId();
-    return SignedIdModule.findSigned(this, signedId, options) as Promise<InstanceType<T> | null>;
+    return SignedIdModule.findSigned(this, signedId, options);
   }
 
   /**
@@ -3021,7 +3024,7 @@ export class Base extends Model {
     options?: { purpose?: string },
   ): Promise<InstanceType<T>> {
     const SignedIdModule = await loadSignedId();
-    return SignedIdModule.findSignedBang(this, signedId, options) as Promise<InstanceType<T>>;
+    return SignedIdModule.findSignedBang(this, signedId, options);
   }
 
   /**
@@ -3260,7 +3263,7 @@ export class Base extends Model {
         String(this.primaryKey),
         null,
       );
-    return r as InstanceType<T>;
+    return r;
   }
   static async findBy_<T extends typeof Base>(
     this: T,

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -98,11 +98,11 @@ export function signedId(
  *
  * Mirrors: ActiveRecord::SignedId::ClassMethods#find_signed
  */
-export async function findSigned(
-  modelClass: typeof Base,
+export async function findSigned<T extends typeof Base>(
+  modelClass: T,
   token: string,
   options?: { purpose?: string },
-): Promise<Base | null> {
+): Promise<InstanceType<T> | null> {
   const verifier = signedIdVerifier(modelClass);
   const id = verifier.verified(token, {
     purpose: combinePurposes(modelClass, options?.purpose),
@@ -125,11 +125,11 @@ export async function findSigned(
  *
  * Mirrors: ActiveRecord::SignedId::ClassMethods#find_signed!
  */
-export async function findSignedBang(
-  modelClass: typeof Base,
+export async function findSignedBang<T extends typeof Base>(
+  modelClass: T,
   token: string,
   options?: { purpose?: string },
-): Promise<Base> {
+): Promise<InstanceType<T>> {
   const verifier = signedIdVerifier(modelClass);
   const id = verifier.verify(token, {
     purpose: combinePurposes(modelClass, options?.purpose),


### PR DESCRIPTION
## Summary
Follow-up to PR #513. Extends polymorphic `this` — `<T extends typeof Base>(this: T, ...)` returning `InstanceType<T>` — to every remaining Base static method that was still returning plain `Base`.

Now typed:
- **Finders:** `findBy`, `findByBang`, `findByAttribute`, `findSoleBy`
- **Cardinality:** `first`, `firstBang`, `last`, `lastBang`, `take`, `sole`
- **Ordinals:** `second`, `third`, `fourth`, `fifth`, `fortyTwo`, `secondToLast`, `thirdToLast`
- **Creation:** `create`, `createBang`, `new`, `findOrCreateBy`, `findOrInitializeBy`, `createOrFindBy`, `createOrFindByBang`
- **Mutation:** `update`, `updateBang`, `destroy`, `destroyBy`, `destroyAll`

### DX impact
```ts
class User extends Base { declare name: string; }
const u = await User.findBy({ name: "dean" });   // User | null
const created = await User.create({ name: "a" }); // User
const gone = await User.destroyAll();             // User[]
```

Before this PR every one of those was `Base` / `Base | null` / `Base[]`, forcing casts.

### dx-tests
Extended `basic-crud.test-d.ts` with assertions covering the full finder / CRUD surface. **45/45 DX type tests pass.**

## Test plan
- [x] `pnpm build` / `pnpm typecheck` green
- [x] `pnpm test` green (17024 runtime tests)
- [x] `pnpm test:types` green (45/45)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green