### PR TITLE
feat(activerecord): Phase 3 — protected environments + InternalMetadata stamping

### DIFF
--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -64,6 +64,23 @@ export class DatabaseConfigurations {
     this._defaultEnv = value;
   }
 
+  /**
+   * The DatabaseConfigurations instance most recently registered (via
+   * constructor or explicit set). `HashConfig.isPrimary` consults it,
+   * matching Rails' `Base.configurations.primary?(name)`.
+   *
+   * Exposed so callers that temporarily swap configurations (e.g. the
+   * trailties CLI's `runProtectedEnvCheck`) can capture and restore the
+   * singleton without having to re-instantiate it.
+   */
+  static get current(): DatabaseConfigurations | null {
+    return _currentConfigurations;
+  }
+
+  static set current(value: DatabaseConfigurations | null) {
+    _currentConfigurations = value;
+  }
+
   private _configurations: DatabaseConfig[];
 
   constructor(configurations: RawConfigurations | DatabaseConfig[] = {}) {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -233,7 +233,14 @@ import { MySQLDatabaseTasks as _MySQLTasks } from "./tasks/mysql-database-tasks.
 _SQLiteTasks.register();
 _PGTasks.register();
 _MySQLTasks.register();
-export { Migrator, UnknownMigrationVersionError } from "./migration.js";
+export {
+  Migrator,
+  UnknownMigrationVersionError,
+  ProtectedEnvironmentError,
+  EnvironmentMismatchError,
+  EnvironmentStorageError,
+  NoEnvironmentInSchemaError,
+} from "./migration.js";
 export type { MigrationProxy, MigrationLike } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -241,6 +241,7 @@ export {
   EnvironmentStorageError,
   NoEnvironmentInSchemaError,
 } from "./migration.js";
+export { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
 export type { MigrationProxy, MigrationLike } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -104,6 +104,11 @@ export class InternalMetadata {
   }
 
   async dropTable(): Promise<void> {
+    // Symmetric with createTable / createTableAndSetFlags: silently no-op
+    // when metadata is disabled. Prevents a disabled instance from
+    // reaching over and dropping ar_internal_metadata that another
+    // config or adapter is actively using.
+    if (!this._enabled) return;
     await this._adapter.executeMutation(
       `DROP TABLE IF EXISTS ${quoteTableName(this.tableName, this._adapterName)}`,
     );

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -115,6 +115,10 @@ export class InternalMetadata {
   }
 
   async get(key: string): Promise<string | null> {
+    // When metadata is disabled, treat every key as unset without
+    // probing ar_internal_metadata — callers shouldn't observe stale
+    // rows from a previous run that had the flag enabled.
+    if (!this._enabled) return null;
     const entry = await this.selectEntry(key);
     if (!entry) return null;
     const value = entry[this.valueKey];
@@ -155,6 +159,10 @@ export class InternalMetadata {
   }
 
   async tableExists(): Promise<boolean> {
+    // When disabled, report the table as absent so callers don't
+    // accidentally trust it. The physical table may still exist on disk
+    // from a previous run; the flag is what drives semantic visibility.
+    if (!this._enabled) return false;
     try {
       const sm = new SelectManager(this.arelTable);
       sm.project(new Nodes.Quoted(1));

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -146,6 +146,11 @@ export class InternalMetadata {
   }
 
   async deleteAllEntries(): Promise<void> {
+    // Symmetric with get() / tableExists() / count() / createTable() /
+    // dropTable(): a disabled instance treats the store as empty — don't
+    // run a DELETE that would either mutate a supposedly-invisible store
+    // or throw against a missing table.
+    if (!this._enabled) return;
     const dm = new DeleteManager();
     dm.from(this.arelTable);
     await this._adapter.executeMutation(dm.toSql());

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -7,6 +7,7 @@
 import type { DatabaseAdapter } from "./adapter.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
+import { EnvironmentStorageError } from "./migration-errors.js";
 import {
   Table,
   SelectManager,
@@ -131,8 +132,8 @@ export class InternalMetadata {
       // Rails' `environment:set` raises EnvironmentStorageError when
       // internal_metadata is disabled; surface the same error here so
       // callers that attempt to write through a disabled instance fail
-      // loudly rather than silently no-op.
-      const { EnvironmentStorageError } = await import("./migration.js");
+      // loudly rather than silently no-op. Imported statically from
+      // migration-errors.ts to avoid a circular dep with migration.ts.
       throw new EnvironmentStorageError();
     }
     const existing = await this.selectEntry(key);

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -28,6 +28,10 @@ export class NullInternalMetadata {
   async tableExists(): Promise<boolean> {
     return false;
   }
+
+  get enabled(): boolean {
+    return false;
+  }
 }
 
 export class InternalMetadata {
@@ -55,9 +59,22 @@ export class InternalMetadata {
     return InternalMetadata.TABLE_NAME;
   }
 
-  constructor(adapter: DatabaseAdapter) {
+  private _enabled: boolean;
+
+  constructor(adapter: DatabaseAdapter, options: { enabled?: boolean } = {}) {
     this._adapter = adapter;
     this.arelTable = new Table(this.tableName);
+    this._enabled = options.enabled ?? true;
+  }
+
+  /**
+   * Whether metadata storage is enabled for this configuration.
+   *
+   * Mirrors ActiveRecord::InternalMetadata#enabled? — false only when the
+   * db_config opts out via `use_metadata_table: false`. Defaults to true.
+   */
+  get enabled(): boolean {
+    return this._enabled;
   }
 
   async createTable(): Promise<void> {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -152,6 +152,10 @@ export class InternalMetadata {
   }
 
   async count(): Promise<number> {
+    // Symmetric with get() / tableExists(): a disabled instance reports
+    // an empty store, without probing ar_internal_metadata (which may
+    // not exist, or may carry stale rows from a prior enabled run).
+    if (!this._enabled) return 0;
     const sm = new SelectManager(this.arelTable);
     sm.project(new Nodes.NamedFunction("COUNT", [star]).as("cnt"));
     const rows = await this._adapter.execute(sm.toSql());

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -78,6 +78,7 @@ export class InternalMetadata {
   }
 
   async createTable(): Promise<void> {
+    if (!this._enabled) return;
     const tsType = this._adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
     const q = (n: string) => this._q(n);
     await this._adapter.executeMutation(
@@ -87,6 +88,19 @@ export class InternalMetadata {
         `${q("created_at")} ${tsType} NOT NULL, ` +
         `${q("updated_at")} ${tsType} NOT NULL)`,
     );
+  }
+
+  /**
+   * Create the metadata table if needed and write the given environment
+   * (and optional schema SHA1) in one call. Matches Rails'
+   * `ActiveRecord::InternalMetadata#create_table_and_set_flags` — silently
+   * returns when `enabled?` is false.
+   */
+  async createTableAndSetFlags(environment: string, schemaSha1?: string): Promise<void> {
+    if (!this._enabled) return;
+    await this.createTable();
+    await this.set("environment", environment);
+    if (schemaSha1 !== undefined) await this.set("schema_sha1", schemaSha1);
   }
 
   async dropTable(): Promise<void> {
@@ -104,6 +118,14 @@ export class InternalMetadata {
   }
 
   async set(key: string, value: string): Promise<void> {
+    if (!this._enabled) {
+      // Rails' `environment:set` raises EnvironmentStorageError when
+      // internal_metadata is disabled; surface the same error here so
+      // callers that attempt to write through a disabled instance fail
+      // loudly rather than silently no-op.
+      const { EnvironmentStorageError } = await import("./migration.js");
+      throw new EnvironmentStorageError();
+    }
     const existing = await this.selectEntry(key);
     if (existing) {
       if (existing[this.valueKey] !== value) {

--- a/packages/activerecord/src/migration-errors.ts
+++ b/packages/activerecord/src/migration-errors.ts
@@ -1,0 +1,111 @@
+/**
+ * Migration error classes — factored into a standalone module so
+ * `internal-metadata.ts` can import them without creating a circular
+ * dependency with `migration.ts` (which itself imports InternalMetadata).
+ *
+ * `migration.ts` re-exports these, so existing consumers of
+ * `@blazetrails/activerecord/migration` keep working.
+ */
+
+export class MigrationError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "MigrationError";
+  }
+}
+
+export class IrreversibleMigration extends MigrationError {
+  constructor(message = "This migration uses a feature that is not reversible.") {
+    super(message);
+    this.name = "IrreversibleMigration";
+  }
+}
+
+export class DuplicateMigrationVersionError extends MigrationError {
+  constructor(version: string | number) {
+    super(`Duplicate migration version: ${version}`);
+    this.name = "DuplicateMigrationVersionError";
+  }
+}
+
+export class DuplicateMigrationNameError extends MigrationError {
+  constructor(name: string) {
+    super(`Duplicate migration name: ${name}`);
+    this.name = "DuplicateMigrationNameError";
+  }
+}
+
+export class UnknownMigrationVersionError extends MigrationError {
+  constructor(version: string | number) {
+    super(`No migration with version number ${version}.`);
+    this.name = "UnknownMigrationVersionError";
+  }
+}
+
+export class IllegalMigrationNameError extends MigrationError {
+  constructor(name: string) {
+    super(`Illegal name for migration file: ${name}.`);
+    this.name = "IllegalMigrationNameError";
+  }
+}
+
+export class InvalidMigrationTimestampError extends MigrationError {
+  constructor(version: string | number) {
+    super(`Invalid timestamp ${version} in migration file name.`);
+    this.name = "InvalidMigrationTimestampError";
+  }
+}
+
+export class PendingMigrationError extends MigrationError {
+  constructor(message = "Migrations are pending. Run `migrate` to resolve.") {
+    super(message);
+    this.name = "PendingMigrationError";
+  }
+}
+
+export class ConcurrentMigrationError extends MigrationError {
+  constructor(message = "Cannot run migrations because another migration is currently running.") {
+    super(message);
+    this.name = "ConcurrentMigrationError";
+  }
+}
+
+export class NoEnvironmentInSchemaError extends MigrationError {
+  constructor(message = "Environment data not found in the schema.") {
+    super(message);
+    this.name = "NoEnvironmentInSchemaError";
+  }
+}
+
+export class ProtectedEnvironmentError extends MigrationError {
+  constructor(env: string) {
+    super(`You are attempting to run a destructive action against your '${env}' database.`);
+    this.name = "ProtectedEnvironmentError";
+  }
+}
+
+export class EnvironmentMismatchError extends MigrationError {
+  /**
+   * Accept either a prebuilt message (one-arg) or `(current, stored)`
+   * separately (two-arg) matching Rails'
+   * `EnvironmentMismatchError.new(current:, stored:)`.
+   */
+  constructor(currentOrMessage?: string, stored?: string) {
+    const message =
+      stored !== undefined && currentOrMessage !== undefined
+        ? `You are attempting to modify a database that was last run in \`${stored}\` environment.\n` +
+          `You are running in \`${currentOrMessage}\` environment. ` +
+          `If you are sure you want to continue, first set the environment using:\n\n` +
+          `        trails db environment:set\n`
+        : (currentOrMessage ?? "The environment does not match the stored environment.");
+    super(message);
+    this.name = "EnvironmentMismatchError";
+  }
+}
+
+export class EnvironmentStorageError extends MigrationError {
+  constructor(message = "Cannot store environment data.") {
+    super(message);
+    this.name = "EnvironmentStorageError";
+  }
+}

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1777,7 +1777,15 @@ export class Migrator {
     await this._strategy.exec(direction, migration, this._adapter);
     if (direction === "up") {
       await this._schemaMigration.recordVersion(proxy.version);
-      await this._internalMetadata.set("environment", this._environment);
+      // Skip stamping when internal metadata is disabled
+      // (`use_metadata_table: false`). Writing through a disabled
+      // InternalMetadata raises EnvironmentStorageError, which would
+      // otherwise break the migrate path for consumers that intentionally
+      // opt out. Rails' equivalent call site is similarly guarded via
+      // `internal_metadata.enabled?`.
+      if (this._internalMetadata.enabled) {
+        await this._internalMetadata.set("environment", this._environment);
+      }
     } else {
       await this._schemaMigration.deleteVersion(proxy.version);
     }
@@ -1795,7 +1803,11 @@ export class Migrator {
    * Mirrors: ActiveRecord::Tasks::DatabaseTasks.check_current_environment
    */
   async checkEnvironment(): Promise<void> {
-    if (process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK === "1") return;
+    // Match Rails' `return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]` —
+    // any non-empty value bypasses (consistent with DatabaseTasks'
+    // checkProtectedEnvironmentsBang so operators don't get mixed
+    // semantics across the two guards).
+    if (process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK) return;
     await this._ensureSchemaTable();
     const stored = await this._internalMetadata.get("environment");
     if (stored === null) {
@@ -1896,11 +1908,15 @@ export class Migrator {
   }
 
   async lastStoredEnvironment(): Promise<string | null> {
+    // When metadata storage is explicitly opted out (`use_metadata_table:
+    // false`), treat the DB as unstamped even if a stale
+    // ar_internal_metadata table exists from a previous run — Rails'
+    // MigrationContext#last_stored_environment short-circuits on
+    // `internal_metadata.enabled?` before the table_exists? read.
+    if (!this._internalMetadata.enabled) return null;
     // Read-only: if ar_internal_metadata doesn't exist yet, the database
     // has never been stamped with an environment — return null without
-    // creating the table. Matches Rails'
-    // `MigrationContext#last_stored_environment` which short-circuits on
-    // `internal_metadata.table_exists?`.
+    // creating the table.
     if (!(await this._internalMetadata.tableExists())) return null;
     return this._internalMetadata.get("environment");
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1809,9 +1809,12 @@ export class Migrator {
    * Mirrors: ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
    */
   async checkProtectedEnvironments(protectedEnvironments?: string[]): Promise<void> {
-    await this._ensureSchemaTable();
-    const stored = await this._internalMetadata.get("environment");
-    const env = stored ?? this._environment;
+    // Matches Rails: protected_environment? returns nil when nothing has
+    // been stamped yet, so a fresh DB under NODE_ENV=production doesn't
+    // trip the guard until it's actually been migrated and stamped.
+    // Read-only — no _ensureSchemaTable side effect.
+    const stored = await this.lastStoredEnvironment();
+    if (!stored) return;
 
     let envList = protectedEnvironments;
     if (!envList) {
@@ -1819,9 +1822,22 @@ export class Migrator {
       envList = Base.protectedEnvironments ?? ["production"];
     }
 
-    if (envList.includes(env)) {
-      throw new ProtectedEnvironmentError(env);
+    if (envList.includes(stored)) {
+      throw new ProtectedEnvironmentError(stored);
     }
+  }
+
+  /**
+   * Boolean mirror of {@link checkProtectedEnvironments}.
+   *
+   * Mirrors: ActiveRecord::MigrationContext#protected_environment?
+   */
+  async protectedEnvironment(): Promise<boolean> {
+    const stored = await this.lastStoredEnvironment();
+    if (!stored) return false;
+    const { Base } = await import("./base.js");
+    const list = Base.protectedEnvironments ?? ["production"];
+    return list.includes(stored);
   }
 
   get internalMetadata(): InternalMetadata {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1818,8 +1818,9 @@ export class Migrator {
     if (stored !== this._environment) {
       // Use the Rails-style (current, stored) constructor so the error
       // message stays consistent with DatabaseTasks'
-      // checkProtectedEnvironmentsBang and the NO_DATABASE_ENVIRONMENT_CHECK
-      // bypass line is baked into the shared template.
+      // checkProtectedEnvironmentsBang and the
+      // DISABLE_DATABASE_ENVIRONMENT_CHECK bypass line is baked into the
+      // shared template.
       throw new EnvironmentMismatchError(this._environment, stored);
     }
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -112,7 +112,19 @@ export class ProtectedEnvironmentError extends MigrationError {
 }
 
 export class EnvironmentMismatchError extends MigrationError {
-  constructor(message = "The environment does not match the stored environment.") {
+  /**
+   * Accept either a prebuilt message (one-arg) or `(current, stored)`
+   * separately (two-arg) matching Rails'
+   * `EnvironmentMismatchError.new(current:, stored:)`.
+   */
+  constructor(currentOrMessage?: string, stored?: string) {
+    const message =
+      stored !== undefined && currentOrMessage !== undefined
+        ? `You are attempting to modify a database that was last run in \`${stored}\` environment.\n` +
+          `You are running in \`${currentOrMessage}\` environment. ` +
+          `If you are sure you want to continue, first set the environment using:\n\n` +
+          `        trails db environment:set\n`
+        : (currentOrMessage ?? "The environment does not match the stored environment.");
     super(message);
     this.name = "EnvironmentMismatchError";
   }
@@ -1857,7 +1869,12 @@ export class Migrator {
   }
 
   async lastStoredEnvironment(): Promise<string | null> {
-    await this._ensureSchemaTable();
+    // Read-only: if ar_internal_metadata doesn't exist yet, the database
+    // has never been stamped with an environment — return null without
+    // creating the table. Matches Rails'
+    // `MigrationContext#last_stored_environment` which short-circuits on
+    // `internal_metadata.table_exists?`.
+    if (!(await this._internalMetadata.tableExists())) return null;
     return this._internalMetadata.get("environment");
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1416,11 +1416,22 @@ export class Migrator {
   constructor(
     adapter: DatabaseAdapter,
     migrations: MigrationProxy[],
-    options: { environment?: string; strategy?: ExecutionStrategy } = {},
+    options: {
+      environment?: string;
+      strategy?: ExecutionStrategy;
+      /**
+       * Set to false when the db_config opts out of metadata storage
+       * (Rails' `use_metadata_table: false`). environment stamping is a
+       * no-op / raises in `environment:set` when this is false.
+       */
+      internalMetadataEnabled?: boolean;
+    } = {},
   ) {
     this._adapter = adapter;
     this._schemaMigration = new SchemaMigration(adapter);
-    this._internalMetadata = new InternalMetadata(adapter);
+    this._internalMetadata = new InternalMetadata(adapter, {
+      enabled: options.internalMetadataEnabled ?? true,
+    });
     this._environment =
       options.environment ?? (process.env.NODE_ENV || DatabaseConfigurations.defaultEnv);
     this._strategy = options.strategy ?? new DefaultStrategy();

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1818,9 +1818,7 @@ export class Migrator {
     if (stored !== this._environment) {
       // Use the Rails-style (current, stored) constructor so the error
       // message stays consistent with DatabaseTasks'
-      // checkProtectedEnvironmentsBang and the
-      // DISABLE_DATABASE_ENVIRONMENT_CHECK bypass line is baked into the
-      // shared template.
+      // checkProtectedEnvironmentsBang path.
       throw new EnvironmentMismatchError(this._environment, stored);
     }
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1803,11 +1803,11 @@ export class Migrator {
    * Mirrors: ActiveRecord::Tasks::DatabaseTasks.check_current_environment
    */
   async checkEnvironment(): Promise<void> {
-    // Match Rails' `return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]` —
-    // any non-empty value bypasses (consistent with DatabaseTasks'
-    // checkProtectedEnvironmentsBang so operators don't get mixed
-    // semantics across the two guards).
-    if (process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK) return;
+    // Match Rails' `return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]`.
+    // In Ruby, "" is truthy, so any *present* value (including empty
+    // string) bypasses the check. JS treats "" as falsy, so we use a
+    // presence check instead to preserve Rails semantics.
+    if (process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK !== undefined) return;
     await this._ensureSchemaTable();
     const stored = await this._internalMetadata.get("environment");
     if (stored === null) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1816,11 +1816,11 @@ export class Migrator {
       );
     }
     if (stored !== this._environment) {
-      throw new EnvironmentMismatchError(
-        `You are attempting to modify a database that was last used in the '${stored}' environment. ` +
-          `You are running in the '${this._environment}' environment. ` +
-          `If you are sure you want to continue, run with DISABLE_DATABASE_ENVIRONMENT_CHECK=1.`,
-      );
+      // Use the Rails-style (current, stored) constructor so the error
+      // message stays consistent with DatabaseTasks'
+      // checkProtectedEnvironmentsBang and the NO_DATABASE_ENVIRONMENT_CHECK
+      // bypass line is baked into the shared template.
+      throw new EnvironmentMismatchError(this._environment, stored);
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -34,108 +34,40 @@ export {
   type Compatibility,
 } from "./migration/compatibility.js";
 
-export class MigrationError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "MigrationError";
-  }
-}
-
-export class IrreversibleMigration extends MigrationError {
-  constructor(message = "This migration uses a feature that is not reversible.") {
-    super(message);
-    this.name = "IrreversibleMigration";
-  }
-}
-
-export class DuplicateMigrationVersionError extends MigrationError {
-  constructor(version: string | number) {
-    super(`Duplicate migration version: ${version}`);
-    this.name = "DuplicateMigrationVersionError";
-  }
-}
-
-export class DuplicateMigrationNameError extends MigrationError {
-  constructor(name: string) {
-    super(`Duplicate migration name: ${name}`);
-    this.name = "DuplicateMigrationNameError";
-  }
-}
-
-export class UnknownMigrationVersionError extends MigrationError {
-  constructor(version: string | number) {
-    super(`No migration with version number ${version}.`);
-    this.name = "UnknownMigrationVersionError";
-  }
-}
-
-export class IllegalMigrationNameError extends MigrationError {
-  constructor(name: string) {
-    super(`Illegal name for migration file: ${name}.`);
-    this.name = "IllegalMigrationNameError";
-  }
-}
-
-export class InvalidMigrationTimestampError extends MigrationError {
-  constructor(version: string | number) {
-    super(`Invalid timestamp ${version} in migration file name.`);
-    this.name = "InvalidMigrationTimestampError";
-  }
-}
-
-export class PendingMigrationError extends MigrationError {
-  constructor(message = "Migrations are pending. Run `migrate` to resolve.") {
-    super(message);
-    this.name = "PendingMigrationError";
-  }
-}
-
-export class ConcurrentMigrationError extends MigrationError {
-  constructor(message = "Cannot run migrations because another migration is currently running.") {
-    super(message);
-    this.name = "ConcurrentMigrationError";
-  }
-}
-
-export class NoEnvironmentInSchemaError extends MigrationError {
-  constructor(message = "Environment data not found in the schema.") {
-    super(message);
-    this.name = "NoEnvironmentInSchemaError";
-  }
-}
-
-export class ProtectedEnvironmentError extends MigrationError {
-  constructor(env: string) {
-    super(`You are attempting to run a destructive action against your '${env}' database.`);
-    this.name = "ProtectedEnvironmentError";
-  }
-}
-
-export class EnvironmentMismatchError extends MigrationError {
-  /**
-   * Accept either a prebuilt message (one-arg) or `(current, stored)`
-   * separately (two-arg) matching Rails'
-   * `EnvironmentMismatchError.new(current:, stored:)`.
-   */
-  constructor(currentOrMessage?: string, stored?: string) {
-    const message =
-      stored !== undefined && currentOrMessage !== undefined
-        ? `You are attempting to modify a database that was last run in \`${stored}\` environment.\n` +
-          `You are running in \`${currentOrMessage}\` environment. ` +
-          `If you are sure you want to continue, first set the environment using:\n\n` +
-          `        trails db environment:set\n`
-        : (currentOrMessage ?? "The environment does not match the stored environment.");
-    super(message);
-    this.name = "EnvironmentMismatchError";
-  }
-}
-
-export class EnvironmentStorageError extends MigrationError {
-  constructor(message = "Cannot store environment data.") {
-    super(message);
-    this.name = "EnvironmentStorageError";
-  }
-}
+// Migration error classes live in a standalone module so leaf modules
+// like InternalMetadata can import EnvironmentStorageError without
+// creating a cycle through migration.ts. Imported here for local use
+// AND re-exported for existing consumers.
+import {
+  MigrationError,
+  IrreversibleMigration,
+  DuplicateMigrationVersionError,
+  DuplicateMigrationNameError,
+  UnknownMigrationVersionError,
+  IllegalMigrationNameError,
+  InvalidMigrationTimestampError,
+  PendingMigrationError,
+  ConcurrentMigrationError,
+  NoEnvironmentInSchemaError,
+  ProtectedEnvironmentError,
+  EnvironmentMismatchError,
+  EnvironmentStorageError,
+} from "./migration-errors.js";
+export {
+  MigrationError,
+  IrreversibleMigration,
+  DuplicateMigrationVersionError,
+  DuplicateMigrationNameError,
+  UnknownMigrationVersionError,
+  IllegalMigrationNameError,
+  InvalidMigrationTimestampError,
+  PendingMigrationError,
+  ConcurrentMigrationError,
+  NoEnvironmentInSchemaError,
+  ProtectedEnvironmentError,
+  EnvironmentMismatchError,
+  EnvironmentStorageError,
+};
 
 /**
  * Migration — base class for database migrations.

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -379,7 +379,14 @@ export class DatabaseTasks {
     const { Base } = await import("../base.js");
     const protectedEnvs = Base.protectedEnvironments ?? ["production"];
 
-    const configs = this.configsFor(envName);
+    // Include hidden / `databaseTasks: false` / replica configs so the
+    // guard is a superset of everything destructive callers like dropAll
+    // might touch — a hidden config stamped as production should still
+    // block the operation even though the regular configsFor filter
+    // would have hidden it.
+    const configs = this.databaseConfiguration
+      ? this.databaseConfiguration.configsFor({ envName, includeHidden: true })
+      : [];
     if (configs.length === 0) {
       // Two reasons configsFor can come back empty:
       //   (a) DatabaseTasks.databaseConfiguration was never set (e.g.
@@ -407,11 +414,11 @@ export class DatabaseTasks {
           // false, Rails treats the DB as unstamped and
           // last_stored_environment returns nil — don't probe the
           // ar_internal_metadata table even if it's there from a prior
-          // run with the flag enabled.
-          const useMetadataTable = (config.configuration as { useMetadataTable?: boolean })
-            .useMetadataTable;
+          // run with the flag enabled. Read via the DatabaseConfig
+          // getter so defaulting/coercion stays consistent across
+          // HashConfig / UrlConfig.
           const migrator = new Migrator(adapter, [], {
-            internalMetadataEnabled: useMetadataTable !== false,
+            internalMetadataEnabled: config.useMetadataTable,
           });
           const stored = await migrator.lastStoredEnvironment();
           if (stored && protectedEnvs.includes(stored)) {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -380,11 +380,17 @@ export class DatabaseTasks {
     const protectedEnvs = Base.protectedEnvironments ?? ["production"];
 
     const configs = this.configsFor(envName);
-    // Fall back to checking the current env name directly when no
-    // DatabaseConfigurations is registered (e.g. in-memory tests /
-    // stand-alone CLI invocations with just DatabaseTasks.env set).
     if (configs.length === 0) {
-      if (protectedEnvs.includes(envName)) {
+      // Two reasons configsFor can come back empty:
+      //   (a) DatabaseTasks.databaseConfiguration was never set (e.g.
+      //       in-memory tests or a stand-alone CLI invocation with
+      //       just DatabaseTasks.env). Fall back to an env-name-only
+      //       check so a flat "production" still raises.
+      //   (b) DatabaseConfigurations is registered but has no entries
+      //       for this env. Rails' check_protected_environments! loops
+      //       over 0 configs and performs no checks — don't raise just
+      //       because the requested env is in the protected list.
+      if (!this.databaseConfiguration && protectedEnvs.includes(envName)) {
         throw new ProtectedEnvironmentError(envName);
       }
       return;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -352,12 +352,64 @@ export class DatabaseTasks {
     }
   }
 
+  /**
+   * Guard destructive tasks against being run against a database that was
+   * last stamped with a protected environment (e.g. production).
+   *
+   * Mirrors ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+   * exactly:
+   *   - If DISABLE_DATABASE_ENVIRONMENT_CHECK is set in the environment,
+   *     this is a no-op (escape hatch for intentional production ops).
+   *   - For each config in the target environment, read the stored
+   *     `environment` key from InternalMetadata.
+   *   - Raise ProtectedEnvironmentError if that stored env is in
+   *     Base.protectedEnvironments.
+   *   - Raise EnvironmentMismatchError if a stored env exists but differs
+   *     from the current env.
+   *   - Swallow NoDatabaseError (can't check a database that isn't there).
+   */
   static async checkProtectedEnvironmentsBang(environment?: string): Promise<void> {
-    const env = this._normalizeEnv(environment);
+    const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+    if (proc?.env?.DISABLE_DATABASE_ENVIRONMENT_CHECK) return;
+
+    const envName = this._normalizeEnv(environment);
     const { Base } = await import("../base.js");
-    const protectedEnvs = Base.protectedEnvironments;
-    if (protectedEnvs.includes(env)) {
-      throw new ProtectedEnvironmentError(env);
+    const protectedEnvs = Base.protectedEnvironments ?? ["production"];
+
+    const configs = this.configsFor(envName);
+    // Fall back to checking the current env name directly when no
+    // DatabaseConfigurations is registered (e.g. in-memory tests /
+    // stand-alone CLI invocations with just DatabaseTasks.env set).
+    if (configs.length === 0) {
+      if (protectedEnvs.includes(envName)) {
+        throw new ProtectedEnvironmentError(envName);
+      }
+      return;
+    }
+
+    const { NoDatabaseError } = await import("../errors.js");
+    const { Migrator, EnvironmentMismatchError } = await import("../migration.js");
+
+    for (const config of configs) {
+      try {
+        const adapter = await this._connectFor(config);
+        try {
+          const migrator = new Migrator(adapter, []);
+          const stored = await migrator.lastStoredEnvironment();
+          if (stored && protectedEnvs.includes(stored)) {
+            throw new ProtectedEnvironmentError(stored);
+          }
+          if (stored && stored !== envName) {
+            throw new EnvironmentMismatchError(envName, stored);
+          }
+        } finally {
+          const close = (adapter as { close?: () => Promise<void> }).close;
+          if (typeof close === "function") await close.call(adapter);
+        }
+      } catch (error) {
+        if (error instanceof NoDatabaseError) continue;
+        throw error;
+      }
     }
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -369,8 +369,11 @@ export class DatabaseTasks {
    *   - Swallow NoDatabaseError (can't check a database that isn't there).
    */
   static async checkProtectedEnvironmentsBang(environment?: string): Promise<void> {
+    // Rails: `return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]`.
+    // In Ruby "" is truthy, so any *present* value bypasses. JS "" is
+    // falsy, so we use a presence check to preserve Rails semantics.
     const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
-    if (proc?.env?.DISABLE_DATABASE_ENVIRONMENT_CHECK) return;
+    if (proc?.env?.DISABLE_DATABASE_ENVIRONMENT_CHECK !== undefined) return;
 
     const envName = this._normalizeEnv(environment);
     const { Base } = await import("../base.js");
@@ -394,7 +397,16 @@ export class DatabaseTasks {
       try {
         const adapter = await this._connectFor(config);
         try {
-          const migrator = new Migrator(adapter, []);
+          // Honor the config's use_metadata_table opt-out. When set to
+          // false, Rails treats the DB as unstamped and
+          // last_stored_environment returns nil — don't probe the
+          // ar_internal_metadata table even if it's there from a prior
+          // run with the flag enabled.
+          const useMetadataTable = (config.configuration as { useMetadataTable?: boolean })
+            .useMetadataTable;
+          const migrator = new Migrator(adapter, [], {
+            internalMetadataEnabled: useMetadataTable !== false,
+          });
           const stored = await migrator.lastStoredEnvironment();
           if (stored && protectedEnvs.includes(stored)) {
             throw new ProtectedEnvironmentError(stored);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -760,7 +760,15 @@ export class CreatePosts extends Migration {
         DatabaseTasks.checkProtectedEnvironmentsBang("production"),
       ).rejects.toBeInstanceOf(ProtectedEnvironmentError);
     } finally {
-      DatabaseTasks.databaseConfiguration = previous;
+      // DatabaseConfigurations constructor registers itself as the
+      // module-level current-configurations singleton — restore that too,
+      // not just DatabaseTasks.databaseConfiguration.
+      if (previous) {
+        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
+      } else {
+        DatabaseTasks.databaseConfiguration = null;
+        new DatabaseConfigurations([]);
+      }
     }
   });
 
@@ -795,7 +803,12 @@ export class CreatePosts extends Migration {
         DatabaseTasks.checkProtectedEnvironmentsBang("development"),
       ).rejects.toBeInstanceOf(EnvironmentMismatchError);
     } finally {
-      DatabaseTasks.databaseConfiguration = previous;
+      if (previous) {
+        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
+      } else {
+        DatabaseTasks.databaseConfiguration = null;
+        new DatabaseConfigurations([]);
+      }
     }
   });
 
@@ -827,7 +840,12 @@ export class CreatePosts extends Migration {
         DatabaseTasks.checkProtectedEnvironmentsBang("production"),
       ).resolves.toBeUndefined();
     } finally {
-      DatabaseTasks.databaseConfiguration = previous;
+      if (previous) {
+        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
+      } else {
+        DatabaseTasks.databaseConfiguration = null;
+        new DatabaseConfigurations([]);
+      }
       if (origEnv === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
       else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = origEnv;
     }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -754,6 +754,7 @@ export class CreatePosts extends Migration {
       new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
+    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = configurations;
     try {
       await expect(
@@ -763,12 +764,8 @@ export class CreatePosts extends Migration {
       // DatabaseConfigurations constructor registers itself as the
       // module-level current-configurations singleton — restore that too,
       // not just DatabaseTasks.databaseConfiguration.
-      if (previous) {
-        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
-      } else {
-        DatabaseTasks.databaseConfiguration = null;
-        new DatabaseConfigurations([]);
-      }
+      DatabaseTasks.databaseConfiguration = previous;
+      DatabaseConfigurations.current = previousCurrent;
     }
   });
 
@@ -797,18 +794,15 @@ export class CreatePosts extends Migration {
       new HashConfig("development", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
+    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = configurations;
     try {
       await expect(
         DatabaseTasks.checkProtectedEnvironmentsBang("development"),
       ).rejects.toBeInstanceOf(EnvironmentMismatchError);
     } finally {
-      if (previous) {
-        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
-      } else {
-        DatabaseTasks.databaseConfiguration = null;
-        new DatabaseConfigurations([]);
-      }
+      DatabaseTasks.databaseConfiguration = previous;
+      DatabaseConfigurations.current = previousCurrent;
     }
   });
 
@@ -832,6 +826,7 @@ export class CreatePosts extends Migration {
       new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
+    const previousCurrent = DatabaseConfigurations.current;
     const origEnv = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
     DatabaseTasks.databaseConfiguration = configurations;
     process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
@@ -840,12 +835,8 @@ export class CreatePosts extends Migration {
         DatabaseTasks.checkProtectedEnvironmentsBang("production"),
       ).resolves.toBeUndefined();
     } finally {
-      if (previous) {
-        DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
-      } else {
-        DatabaseTasks.databaseConfiguration = null;
-        new DatabaseConfigurations([]);
-      }
+      DatabaseTasks.databaseConfiguration = previous;
+      DatabaseConfigurations.current = previousCurrent;
       if (origEnv === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
       else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = origEnv;
     }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -866,26 +866,46 @@ export class CreatePosts extends Migration {
     }
   });
 
-  it("environment:set raises EnvironmentStorageError when internal metadata is disabled", async () => {
-    const { Migrator, EnvironmentStorageError } = await import("@blazetrails/activerecord");
+  it("InternalMetadata with enabled=false refuses set writes with EnvironmentStorageError", async () => {
+    const { EnvironmentStorageError, InternalMetadata } = await import("@blazetrails/activerecord");
     const { SQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
 
     const dbFile = path.join(tmpDir, "disabled.sqlite3");
     const adapter = new SQLite3Adapter(dbFile);
     try {
-      const { InternalMetadata } = await import("@blazetrails/activerecord");
       const disabledMeta = new InternalMetadata(adapter, { enabled: false });
       expect(disabledMeta.enabled).toBe(false);
-      // The CLI command creates a Migrator that reads Base defaults; the
-      // public assertion we care about here is that the error class is
-      // exported and constructible, since the CLI wraps it.
-      expect(new EnvironmentStorageError()).toBeInstanceOf(Error);
-      // Guard on enabled is exercised via InternalMetadata.enabled, not
-      // Migrator.internalMetadata.enabled (Migrator currently constructs
-      // with default enabled=true — config-driven opt-out is follow-up
-      // surface). The test confirms the flag plumbing.
-      void Migrator;
+
+      // createTable + createTableAndSetFlags silently no-op (Rails'
+      // create_table_and_set_flags returns early when enabled? is false).
+      await expect(disabledMeta.createTable()).resolves.toBeUndefined();
+      await expect(disabledMeta.createTableAndSetFlags("production")).resolves.toBeUndefined();
+      expect(await disabledMeta.tableExists()).toBe(false);
+
+      // Direct `set` raises so callers that attempt a write through a
+      // disabled instance fail loudly.
+      await expect(disabledMeta.set("environment", "test")).rejects.toBeInstanceOf(
+        EnvironmentStorageError,
+      );
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("Migrator plumbs internalMetadataEnabled=false through to InternalMetadata", async () => {
+    const { Migrator, EnvironmentStorageError } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "disabled-migrator.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      const migrator = new Migrator(adapter, [], { internalMetadataEnabled: false });
+      expect(migrator.internalMetadata.enabled).toBe(false);
+      await expect(
+        migrator.internalMetadata.set("environment", "production"),
+      ).rejects.toBeInstanceOf(EnvironmentStorageError);
     } finally {
       await adapter.close();
     }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -910,4 +910,75 @@ export class CreatePosts extends Migration {
       await adapter.close();
     }
   });
+
+  it("Migrator with internalMetadataEnabled=false migrates without stamping", async () => {
+    const { Migrator } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "no-metadata-migrate.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      // Low-level MigrationLike shape (same pattern migrator.test.ts uses)
+      // — bypasses the Migration base class so the test doesn't depend on
+      // its schema-helper wiring.
+      const migrations = [
+        {
+          version: "20260101000000",
+          name: "CreateWidgets",
+          migration: () => ({
+            up: async (a: typeof adapter) => {
+              await a.executeMutation(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
+            },
+            down: async (a: typeof adapter) => {
+              await a.executeMutation(`DROP TABLE widgets`);
+            },
+          }),
+        },
+      ];
+      const migrator = new Migrator(adapter, migrations, {
+        internalMetadataEnabled: false,
+      });
+
+      // Migrate should succeed and NOT throw EnvironmentStorageError
+      // despite the stamping call site being hit.
+      await expect(migrator.migrate()).resolves.toBeUndefined();
+
+      // Table exists; metadata table does not.
+      const tables = (await adapter.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`,
+      )) as Array<{ name: string }>;
+      const names = tables.map((t) => t.name);
+      expect(names).toContain("widgets");
+      expect(names).not.toContain("ar_internal_metadata");
+
+      // lastStoredEnvironment short-circuits to null when disabled.
+      expect(await migrator.lastStoredEnvironment()).toBeNull();
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("lastStoredEnvironment returns null when metadata is disabled even if table exists", async () => {
+    const { Migrator, InternalMetadata } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "stale-metadata.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      // Seed a real metadata table + environment value with a separate
+      // enabled=true instance.
+      const enabledMeta = new InternalMetadata(adapter, { enabled: true });
+      await enabledMeta.createTable();
+      await enabledMeta.set("environment", "production");
+
+      // Disabled Migrator should still report null (no stale read).
+      const migrator = new Migrator(adapter, [], { internalMetadataEnabled: false });
+      expect(await migrator.lastStoredEnvironment()).toBeNull();
+      expect(await migrator.protectedEnvironment()).toBe(false);
+    } finally {
+      await adapter.close();
+    }
+  });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -695,4 +695,141 @@ export class CreatePosts extends Migration {
     // 'no silent success' since we'd otherwise have printed something).
     expect(logs.filter((l) => l.startsWith("=="))).toHaveLength(0);
   });
+
+  it("db environment:set stamps the schema with the current env", async () => {
+    const dbFile = path.join(tmpDir, "test.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+
+    await runDb(["environment:set"]);
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const a = new SQLite3Adapter(dbFile);
+    try {
+      const rows = await a.execute(
+        `SELECT value FROM ar_internal_metadata WHERE key = 'environment'`,
+      );
+      // Matches whatever NODE_ENV / TRAILS_ENV resolves to at test time
+      // (vitest sets NODE_ENV=test).
+      expect((rows[0] as { value: string }).value).toBe(resolveEnv());
+    } finally {
+      await a.close();
+    }
+    expect(logs.some((l) => l.includes("Stamped schema with environment"))).toBe(true);
+  });
+
+  it("db environment:check is a no-op for non-protected environments", async () => {
+    await runDb(["environment:check"]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("checkProtectedEnvironmentsBang raises when stored env is protected", async () => {
+    const {
+      DatabaseTasks,
+      Migrator,
+      ProtectedEnvironmentError,
+      DatabaseConfigurations,
+      HashConfig,
+    } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "prod.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      const migrator = new Migrator(adapter, []);
+      await migrator.internalMetadata.createTable();
+      await migrator.internalMetadata.set("environment", "production");
+    } finally {
+      await adapter.close();
+    }
+
+    const configurations = new DatabaseConfigurations([
+      new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
+    ]);
+    const previous = DatabaseTasks.databaseConfiguration;
+    DatabaseTasks.databaseConfiguration = configurations;
+    try {
+      await expect(
+        DatabaseTasks.checkProtectedEnvironmentsBang("production"),
+      ).rejects.toBeInstanceOf(ProtectedEnvironmentError);
+    } finally {
+      DatabaseTasks.databaseConfiguration = previous;
+    }
+  });
+
+  it("checkProtectedEnvironmentsBang raises EnvironmentMismatchError when stored != current", async () => {
+    const {
+      DatabaseTasks,
+      Migrator,
+      EnvironmentMismatchError,
+      DatabaseConfigurations,
+      HashConfig,
+    } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "staging.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      const migrator = new Migrator(adapter, []);
+      await migrator.internalMetadata.createTable();
+      await migrator.internalMetadata.set("environment", "staging");
+    } finally {
+      await adapter.close();
+    }
+
+    const configurations = new DatabaseConfigurations([
+      new HashConfig("development", "primary", { adapter: "sqlite3", database: dbFile }),
+    ]);
+    const previous = DatabaseTasks.databaseConfiguration;
+    DatabaseTasks.databaseConfiguration = configurations;
+    try {
+      await expect(
+        DatabaseTasks.checkProtectedEnvironmentsBang("development"),
+      ).rejects.toBeInstanceOf(EnvironmentMismatchError);
+    } finally {
+      DatabaseTasks.databaseConfiguration = previous;
+    }
+  });
+
+  it("DISABLE_DATABASE_ENVIRONMENT_CHECK bypasses the check", async () => {
+    const { DatabaseTasks, Migrator, DatabaseConfigurations, HashConfig } =
+      await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "prod2.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      const migrator = new Migrator(adapter, []);
+      await migrator.internalMetadata.createTable();
+      await migrator.internalMetadata.set("environment", "production");
+    } finally {
+      await adapter.close();
+    }
+
+    const configurations = new DatabaseConfigurations([
+      new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
+    ]);
+    const previous = DatabaseTasks.databaseConfiguration;
+    const origEnv = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+    DatabaseTasks.databaseConfiguration = configurations;
+    process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
+    try {
+      await expect(
+        DatabaseTasks.checkProtectedEnvironmentsBang("production"),
+      ).resolves.toBeUndefined();
+    } finally {
+      DatabaseTasks.databaseConfiguration = previous;
+      if (origEnv === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+      else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = origEnv;
+    }
+  });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -832,4 +832,62 @@ export class CreatePosts extends Migration {
       else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = origEnv;
     }
   });
+
+  it("Migrator.checkProtectedEnvironments is read-only and a no-op on fresh DB", async () => {
+    const { Migrator, ProtectedEnvironmentError, Base } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "fresh.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    const previousProtected = Base.protectedEnvironments;
+    Base.protectedEnvironments = ["production"];
+    try {
+      const migrator = new Migrator(adapter, [], { environment: "production" });
+      // No environment stamped yet → no raise even though current env is
+      // in the protected list. Matches Rails' protected_environment? ==
+      // nil semantics.
+      await expect(migrator.checkProtectedEnvironments()).resolves.toBeUndefined();
+      expect(await migrator.protectedEnvironment()).toBe(false);
+
+      // Verify no ar_internal_metadata was created by the check.
+      expect(await migrator.internalMetadata.tableExists()).toBe(false);
+
+      // After stamping as production, both calls reflect the protected state.
+      await migrator.internalMetadata.createTable();
+      await migrator.internalMetadata.set("environment", "production");
+      expect(await migrator.protectedEnvironment()).toBe(true);
+      await expect(migrator.checkProtectedEnvironments()).rejects.toBeInstanceOf(
+        ProtectedEnvironmentError,
+      );
+    } finally {
+      Base.protectedEnvironments = previousProtected;
+      await adapter.close();
+    }
+  });
+
+  it("environment:set raises EnvironmentStorageError when internal metadata is disabled", async () => {
+    const { Migrator, EnvironmentStorageError } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "disabled.sqlite3");
+    const adapter = new SQLite3Adapter(dbFile);
+    try {
+      const { InternalMetadata } = await import("@blazetrails/activerecord");
+      const disabledMeta = new InternalMetadata(adapter, { enabled: false });
+      expect(disabledMeta.enabled).toBe(false);
+      // The CLI command creates a Migrator that reads Base defaults; the
+      // public assertion we care about here is that the error class is
+      // exported and constructible, since the CLI wraps it.
+      expect(new EnvironmentStorageError()).toBeInstanceOf(Error);
+      // Guard on enabled is exercised via InternalMetadata.enabled, not
+      // Migrator.internalMetadata.enabled (Migrator currently constructs
+      // with default enabled=true — config-driven opt-out is follow-up
+      // surface). The test confirms the flag plumbing.
+      void Migrator;
+    } finally {
+      await adapter.close();
+    }
+  });
 });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -147,6 +147,25 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
  * route through the same code path the standalone `trails db schema:dump`
  * subcommand uses.
  */
+/**
+ * Run Rails' `check_protected_environments!` guard with a temporarily-
+ * registered `DatabaseTasks.databaseConfiguration` so it actually consults
+ * the stored env in `ar_internal_metadata`. Without the registration the
+ * guard falls back to checking only the current env name, which misses
+ * `EnvironmentMismatchError` and the protected-stamp case this PR cares
+ * about.
+ */
+async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
+  const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
+  const previous = DatabaseTasks.databaseConfiguration;
+  DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
+  try {
+    await DatabaseTasks.checkProtectedEnvironmentsBang(envName);
+  } finally {
+    DatabaseTasks.databaseConfiguration = previous;
+  }
+}
+
 async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;
   const config = toDbConfig(raw);
@@ -272,7 +291,7 @@ async function runDrop(): Promise<void> {
   const displayName = displayNameFor(config, raw);
   // Rails db:drop is gated on check_protected_environments; we match.
   // DISABLE_DATABASE_ENVIRONMENT_CHECK=1 is the Rails escape hatch.
-  await DatabaseTasks.checkProtectedEnvironmentsBang(config.envName);
+  await runProtectedEnvCheck(config, config.envName);
   try {
     await DatabaseTasks.drop(config);
     console.log(`Dropped database '${displayName}'`);
@@ -384,18 +403,21 @@ export function dbCommand(): Command {
     .command("environment:check")
     .description("Abort if the stored schema environment is protected")
     .action(async () => {
-      await withAdapter(async () => {
-        // Pass resolveEnv() explicitly so the check runs against the
-        // environment the CLI is currently operating as. RawConfig
-        // doesn't carry envName — the previous `raw.envName` cast was a
-        // silent undefined that defaulted to DatabaseTasks.env.
-        try {
-          await DatabaseTasks.checkProtectedEnvironmentsBang(resolveEnv());
-        } catch (error) {
-          console.error(error instanceof Error ? error.message : String(error));
-          process.exitCode = 1;
-        }
-      });
+      // Don't go through withAdapter — we don't want to open a connection
+      // here. The guard itself connects per-config (and swallows
+      // NoDatabaseError) so a missing DB shouldn't crash this command.
+      // Pass resolveEnv() explicitly so the check runs against the
+      // environment the CLI is currently operating as (RawConfig doesn't
+      // carry envName).
+      const envName = resolveEnv();
+      const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
+      const config = toDbConfig(raw, envName);
+      try {
+        await runProtectedEnvCheck(config, envName);
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+      }
     });
 
   cmd
@@ -580,7 +602,7 @@ export function dbCommand(): Command {
         const config = toDbConfig(raw);
         // schema:load is destructive (replaces the schema) — Rails gates
         // it on check_protected_environments.
-        await DatabaseTasks.checkProtectedEnvironmentsBang(config.envName);
+        await runProtectedEnvCheck(config, config.envName);
         const filename = DatabaseTasks.schemaDumpPath(config);
         if (!fs.existsSync(filename)) {
           console.error(`No schema file found at ${filename}`);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -141,13 +141,6 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 }
 
 /**
- * Dump the schema to disk after a migration-writing task. Mirrors Rails'
- * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration`, and
- * delegates to `DatabaseTasks.dumpSchema(config)` so ts / js / sql formats
- * route through the same code path the standalone `trails db schema:dump`
- * subcommand uses.
- */
-/**
  * Run Rails' `check_protected_environments!` guard with a temporarily-
  * registered `DatabaseTasks.databaseConfiguration` so it actually consults
  * the stored env in `ar_internal_metadata`. Without the registration the
@@ -166,6 +159,13 @@ async function runProtectedEnvCheck(config: HashConfig, envName: string): Promis
   }
 }
 
+/**
+ * Dump the schema to disk after a migration-writing task. Mirrors Rails'
+ * `db:_dump`: gated on `DatabaseTasks.dumpSchemaAfterMigration`, and
+ * delegates to `DatabaseTasks.dumpSchema(config)` so ts / js / sql formats
+ * route through the same code path the standalone `trails db schema:dump`
+ * subcommand uses.
+ */
 async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;
   const config = toDbConfig(raw);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -416,7 +416,9 @@ export function dbCommand(): Command {
 
   cmd
     .command("environment:check")
-    .description("Abort if the stored schema environment is protected")
+    .description(
+      "Abort if the stored schema environment is protected or does not match the current environment",
+    )
     .action(async () => {
       // Don't go through withAdapter — we don't want to open a connection
       // here. The guard itself connects per-config (and swallows

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -356,17 +356,27 @@ export function dbCommand(): Command {
     .command("environment:set")
     .description("Stamp the schema with the current environment name")
     .action(async () => {
-      await withAdapter(async (adapter) => {
-        const migrator = new Migrator(adapter, []);
+      await withAdapter(async (adapter, raw) => {
+        // Use resolveEnv() so the stamped env matches what the trails
+        // CLI considers 'current' (TRAILS_ENV takes precedence over
+        // NODE_ENV). Without this, `TRAILS_ENV=production trails db
+        // environment:set` with NODE_ENV=development would stamp the DB
+        // as development and defeat the protected-env guard.
+        const envName = resolveEnv();
+        const internalMetadataEnabled =
+          (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
+        const migrator = new Migrator(adapter, [], {
+          environment: envName,
+          internalMetadataEnabled,
+        });
         // Rails: raise EnvironmentStorageError when
         // internal_metadata.enabled? is false (use_metadata_table opt-out).
         if (!migrator.internalMetadata.enabled) {
           const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
           throw new EnvironmentStorageError();
         }
-        await migrator.internalMetadata.createTable();
-        await migrator.internalMetadata.set("environment", migrator.currentEnvironment);
-        console.log(`Stamped schema with environment: ${migrator.currentEnvironment}`);
+        await migrator.internalMetadata.createTableAndSetFlags(envName);
+        console.log(`Stamped schema with environment: ${envName}`);
       });
     });
 
@@ -374,9 +384,13 @@ export function dbCommand(): Command {
     .command("environment:check")
     .description("Abort if the stored schema environment is protected")
     .action(async () => {
-      await withAdapter(async (_adapter, raw) => {
+      await withAdapter(async () => {
+        // Pass resolveEnv() explicitly so the check runs against the
+        // environment the CLI is currently operating as. RawConfig
+        // doesn't carry envName — the previous `raw.envName` cast was a
+        // silent undefined that defaulted to DatabaseTasks.env.
         try {
-          await DatabaseTasks.checkProtectedEnvironmentsBang((raw as { envName?: string }).envName);
+          await DatabaseTasks.checkProtectedEnvironmentsBang(resolveEnv());
         } catch (error) {
           console.error(error instanceof Error ? error.message : String(error));
           process.exitCode = 1;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -267,9 +267,12 @@ async function runCreate(): Promise<void> {
 }
 
 async function runDrop(): Promise<void> {
-  const raw = await loadDatabaseConfig();
+  const raw = normalizeRawConfig(await loadDatabaseConfig());
   const config = toDbConfig(raw);
   const displayName = displayNameFor(config, raw);
+  // Rails db:drop is gated on check_protected_environments; we match.
+  // DISABLE_DATABASE_ENVIRONMENT_CHECK=1 is the Rails escape hatch.
+  await DatabaseTasks.checkProtectedEnvironmentsBang(config.envName);
   try {
     await DatabaseTasks.drop(config);
     console.log(`Dropped database '${displayName}'`);
@@ -346,6 +349,32 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, []);
         const version = await migrator.currentVersionReadOnly();
         console.log(`Current version: ${version}`);
+      });
+    });
+
+  cmd
+    .command("environment:set")
+    .description("Stamp the schema with the current environment name")
+    .action(async () => {
+      await withAdapter(async (adapter) => {
+        const migrator = new Migrator(adapter, []);
+        await migrator.internalMetadata.createTable();
+        await migrator.internalMetadata.set("environment", migrator.currentEnvironment);
+        console.log(`Stamped schema with environment: ${migrator.currentEnvironment}`);
+      });
+    });
+
+  cmd
+    .command("environment:check")
+    .description("Abort if the stored schema environment is protected")
+    .action(async () => {
+      await withAdapter(async (_adapter, raw) => {
+        try {
+          await DatabaseTasks.checkProtectedEnvironmentsBang((raw as { envName?: string }).envName);
+        } catch (error) {
+          console.error(error instanceof Error ? error.message : String(error));
+          process.exitCode = 1;
+        }
       });
     });
 
@@ -529,6 +558,9 @@ export function dbCommand(): Command {
     .action(async () => {
       await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
+        // schema:load is destructive (replaces the schema) — Rails gates
+        // it on check_protected_environments.
+        await DatabaseTasks.checkProtectedEnvironmentsBang(config.envName);
         const filename = DatabaseTasks.schemaDumpPath(config);
         if (!fs.existsSync(filename)) {
           console.error(`No schema file found at ${filename}`);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -358,6 +358,12 @@ export function dbCommand(): Command {
     .action(async () => {
       await withAdapter(async (adapter) => {
         const migrator = new Migrator(adapter, []);
+        // Rails: raise EnvironmentStorageError when
+        // internal_metadata.enabled? is false (use_metadata_table opt-out).
+        if (!migrator.internalMetadata.enabled) {
+          const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
+          throw new EnvironmentStorageError();
+        }
         await migrator.internalMetadata.createTable();
         await migrator.internalMetadata.set("environment", migrator.currentEnvironment);
         console.log(`Stamped schema with environment: ${migrator.currentEnvironment}`);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -151,11 +151,26 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   const previous = DatabaseTasks.databaseConfiguration;
+  // DatabaseConfigurations' constructor registers itself as the
+  // module-level "current configurations" singleton (HashConfig.isPrimary
+  // consults it), so swapping back DatabaseTasks.databaseConfiguration
+  // isn't enough on its own — the finally has to re-register whatever
+  // was current before this call, or construct an empty DatabaseConfigurations
+  // when nothing was set to avoid leaking our ephemeral one.
   DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
   try {
     await DatabaseTasks.checkProtectedEnvironmentsBang(envName);
   } finally {
-    DatabaseTasks.databaseConfiguration = previous;
+    if (previous) {
+      // Re-constructing restores the singleton to `previous` because its
+      // constructor assigns _currentConfigurations = this.
+      DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
+    } else {
+      DatabaseTasks.databaseConfiguration = null;
+      // Neutralize the ephemeral singleton so a later HashConfig.isPrimary
+      // lookup doesn't see our temporary DatabaseConfigurations.
+      new DatabaseConfigurations([]);
+    }
   }
 }
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -150,27 +150,22 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
  */
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
-  const previous = DatabaseTasks.databaseConfiguration;
   // DatabaseConfigurations' constructor registers itself as the
-  // module-level "current configurations" singleton (HashConfig.isPrimary
-  // consults it), so swapping back DatabaseTasks.databaseConfiguration
-  // isn't enough on its own — the finally has to re-register whatever
-  // was current before this call, or construct an empty DatabaseConfigurations
-  // when nothing was set to avoid leaking our ephemeral one.
+  // module-level "current" singleton (HashConfig.isPrimary consults it),
+  // so swapping DatabaseTasks.databaseConfiguration isn't enough on its
+  // own. Capture BOTH slots — they may differ when other code (e.g.
+  // connection-handling) created a DatabaseConfigurations without
+  // assigning it to DatabaseTasks.databaseConfiguration — and restore
+  // both in finally instead of clobbering the singleton with an empty
+  // fallback.
+  const previousTasksConfig = DatabaseTasks.databaseConfiguration;
+  const previousCurrent = DatabaseConfigurations.current;
   DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
   try {
     await DatabaseTasks.checkProtectedEnvironmentsBang(envName);
   } finally {
-    if (previous) {
-      // Re-constructing restores the singleton to `previous` because its
-      // constructor assigns _currentConfigurations = this.
-      DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(previous.configurations);
-    } else {
-      DatabaseTasks.databaseConfiguration = null;
-      // Neutralize the ephemeral singleton so a later HashConfig.isPrimary
-      // lookup doesn't see our temporary DatabaseConfigurations.
-      new DatabaseConfigurations([]);
-    }
+    DatabaseTasks.databaseConfiguration = previousTasksConfig;
+    DatabaseConfigurations.current = previousCurrent;
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the full-migration-parity plan. Ships Rails' protected-environments guard against destructive tasks, environment stamping via \`ar_internal_metadata\`, and the \`environment:set\` / \`environment:check\` CLI commands.

Builds on Phase 1 (which already wired \`InternalMetadata\` and the migrator's \`environment\` write on migrate) and Phase 2's \`abort_if_pending_migrations\` — this PR closes the loop so destructive CLI commands (\`db drop\`, \`db schema:load\`) actually consult the stored environment.

### Rails references

- \`activerecord/lib/active_record/migration.rb\` — errors, \`MigrationContext#{protected_environment?,last_stored_environment,current_environment}\`
- \`activerecord/lib/active_record/tasks/database_tasks.rb\` — \`check_protected_environments!\` + \`check_current_protected_environment!\`
- \`activerecord/lib/active_record/railties/databases.rake\` — \`environment:set\`, \`check_protected_environments\`, destructive tasks gated on \`:check_protected_environments\`

### Changes

1. **\`DatabaseTasks.checkProtectedEnvironmentsBang\`** rewritten to match Rails exactly:
   - Honors \`DISABLE_DATABASE_ENVIRONMENT_CHECK=1\` escape hatch.
   - Opens a temp connection per config, reads stored \`environment\` from \`ar_internal_metadata\`, raises \`ProtectedEnvironmentError\` when stored env is in \`Base.protectedEnvironments\`.
   - Raises \`EnvironmentMismatchError\` when stored ≠ current.
   - Swallows \`NoDatabaseError\` (can't check a DB that isn't there).
   - Falls back to a current-env-only check when no \`DatabaseConfigurations\` registered.

2. **\`EnvironmentMismatchError\`** constructor now accepts \`(current, stored)\` positional args and renders the Rails message verbatim.

3. **\`Migrator.lastStoredEnvironment\`** is read-only — checks \`internalMetadata.tableExists()\` before querying; returns \`null\` on miss without creating tables.

4. **New \`trails db\` subcommands**:
   - \`environment:set\` — creates \`ar_internal_metadata\` if needed, stamps with the current env.
   - \`environment:check\` — runs the guard; exit 1 + error message on failure.

5. **Destructive CLI commands** now gate on the check:
   - \`db drop\`
   - \`db schema:load\`

6. **Re-exports** \`ProtectedEnvironmentError\`, \`EnvironmentMismatchError\`, \`EnvironmentStorageError\`, \`NoEnvironmentInSchemaError\` from the activerecord package entry.

### Tests

5 new integration tests in \`packages/trailties/src/commands/db.test.ts\`:
- \`environment:set\` stamps \`ar_internal_metadata\` with the current env.
- \`environment:check\` is a no-op for non-protected envs.
- \`checkProtectedEnvironmentsBang\` raises \`ProtectedEnvironmentError\` when stored env is protected.
- \`checkProtectedEnvironmentsBang\` raises \`EnvironmentMismatchError\` when stored ≠ current.
- \`DISABLE_DATABASE_ENVIRONMENT_CHECK=1\` bypasses the check.

### api:compare

activerecord stays at **81.5%** — Phase 3 adds behavior, not new method names beyond what was already stubbed.

### Test plan

- [x] \`pnpm build\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 17,047 pass / 0 fail
- [x] \`pnpm api:compare --package activerecord\` — 81.5%

## Next in the plan

- Phase 4: \`db:prepare\` + \`db:test:prepare\` + \`db:seed:replant\`
- #36 follow-up: schemaFormat config wiring