### PR TITLE
feat(activerecord): polymorphic this on findBySql, dup/clone/becomes

### DIFF
--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -122,13 +122,14 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(u.isPersisted()).toBeBoolean();
   });
 
-  it("dup / clone return `this` and becomes<K> returns InstanceType<K>", async () => {
+  it("dup / clone return `this` and becomes<K> / becomesBang<K> return InstanceType<K>", async () => {
     const u = new User({ name: "dean" });
     expectTypeOf(u.dup()).toEqualTypeOf<User>();
     expectTypeOf(u.clone()).toEqualTypeOf<User>();
-    // becomes lets you switch model classes (e.g., STI).
+    // becomes / becomesBang let you switch model classes (e.g., STI).
     class Admin extends User {}
     expectTypeOf(u.becomes(Admin)).toEqualTypeOf<Admin>();
+    expectTypeOf(u.becomesBang(Admin)).toEqualTypeOf<Admin>();
   });
 
   it("reload() resolves to the same model type", async () => {

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -122,6 +122,25 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(u.isPersisted()).toBeBoolean();
   });
 
+  it("dup / clone return `this` and becomes<K> returns InstanceType<K>", async () => {
+    const u = new User({ name: "dean" });
+    expectTypeOf(u.dup()).toEqualTypeOf<User>();
+    expectTypeOf(u.clone()).toEqualTypeOf<User>();
+    // becomes lets you switch model classes (e.g., STI).
+    class Admin extends User {}
+    expectTypeOf(u.becomes(Admin)).toEqualTypeOf<Admin>();
+  });
+
+  it("reload() resolves to the same model type", async () => {
+    const u = new User({ name: "dean" });
+    expectTypeOf(await u.reload()).toEqualTypeOf<User>();
+  });
+
+  it("findBySql / asyncFindBySql return User[]", async () => {
+    expectTypeOf(await User.findBySql("SELECT * FROM users")).toEqualTypeOf<User[]>();
+    expectTypeOf(await User.asyncFindBySql("SELECT * FROM users")).toEqualTypeOf<User[]>();
+  });
+
   it("serialization methods expose a JSON-ish shape", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
     expectTypeOf(u.toJson()).toBeString();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2891,7 +2891,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#dup
    */
-  dup(): Base {
+  dup(): this {
     const ctor = this.constructor as typeof Base;
     const attrs = { ...this.attributes };
     const pkCols = Array.isArray(ctor.primaryKey) ? ctor.primaryKey : [ctor.primaryKey];
@@ -2899,7 +2899,7 @@ export class Base extends Model {
       delete attrs[col]; // Remove PK so it's a new record
     }
     const copy = new ctor(attrs);
-    return copy;
+    return copy as this;
   }
 
   /**
@@ -2907,8 +2907,8 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Core#clone
    */
-  clone(): Base {
-    const copy = Object.create(Object.getPrototypeOf(this)) as Base;
+  clone(): this {
+    const copy = Object.create(Object.getPrototypeOf(this)) as this;
     Object.assign(copy, this);
     copy._attributes = this._attributes;
     copy._previouslyNewRecord = false;
@@ -2921,8 +2921,8 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#becomes
    */
-  becomes(klass: typeof Base): Base {
-    const instance = new klass({});
+  becomes<K extends typeof Base>(klass: K): InstanceType<K> {
+    const instance = new klass({}) as InstanceType<K>;
     // Share the same attributes map (Rails behavior)
     instance._attributes = this._attributes;
     instance._newRecord = this._newRecord;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3072,7 +3072,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base#becomes!
    */
-  becomesBang(klass: typeof Base): Base {
+  becomesBang<K extends typeof Base>(klass: K): InstanceType<K> {
     const instance = this.becomes(klass);
     // Set the STI type column — find it from the base class
     const base = getStiBase(klass);

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -38,13 +38,13 @@ export async function findBySql<T extends typeof Base>(
  * Rails: async_find_by_sql — same as find_by_sql but returns a Promise.
  * In our async-first codebase, this is identical to findBySql.
  */
-export function asyncFindBySql<T extends typeof Base>(
+export async function asyncFindBySql<T extends typeof Base>(
   this: T,
   sql: string | [string, ...unknown[]],
   binds: unknown[] = [],
   block?: (record: InstanceType<T>) => void,
 ): Promise<InstanceType<T>[]> {
-  return (findBySql as (...args: unknown[]) => Promise<InstanceType<T>[]>).call(
+  return findBySql.call<T, [typeof sql, typeof binds, typeof block], Promise<InstanceType<T>[]>>(
     this,
     sql,
     binds,

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -5,26 +5,19 @@
  * Mirrors: ActiveRecord::Querying
  */
 
+import type { Base } from "./base.js";
 import { sanitizeSql } from "./sanitization.js";
-
-interface QueryingHost {
-  name: string;
-  adapter: {
-    execute(sql: string): Promise<Record<string, unknown>[]>;
-  };
-  _instantiate(row: Record<string, unknown>, columnTypes?: Record<string, any>): any;
-}
 
 /**
  * Rails: find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
  * Executes raw SQL and instantiates model objects from the result rows.
  */
-export async function findBySql(
-  this: QueryingHost,
+export async function findBySql<T extends typeof Base>(
+  this: T,
   sql: string | [string, ...unknown[]],
   binds: unknown[] = [],
-  block?: (record: any) => void,
-): Promise<any[]> {
+  block?: (record: InstanceType<T>) => void,
+): Promise<InstanceType<T>[]> {
   // Rails passes binds to the connection for prepared statements.
   // Our adapter uses string substitution, so merge binds into the SQL.
   let sanitized: string;
@@ -45,13 +38,18 @@ export async function findBySql(
  * Rails: async_find_by_sql — same as find_by_sql but returns a Promise.
  * In our async-first codebase, this is identical to findBySql.
  */
-export function asyncFindBySql(
-  this: QueryingHost,
+export function asyncFindBySql<T extends typeof Base>(
+  this: T,
   sql: string | [string, ...unknown[]],
   binds: unknown[] = [],
-  block?: (record: any) => void,
-): Promise<any[]> {
-  return findBySql.call(this, sql, binds, block);
+  block?: (record: InstanceType<T>) => void,
+): Promise<InstanceType<T>[]> {
+  return (findBySql as (...args: unknown[]) => Promise<InstanceType<T>[]>).call(
+    this,
+    sql,
+    binds,
+    block,
+  );
 }
 
 /**
@@ -59,7 +57,7 @@ export function asyncFindBySql(
  * Uses select_value to get a single scalar, not full row instantiation.
  */
 export async function countBySql(
-  this: QueryingHost,
+  this: typeof Base,
   sql: string | [string, ...unknown[]],
 ): Promise<number> {
   const sanitized = typeof sql === "string" ? sql : sanitizeSql(sql);
@@ -75,7 +73,7 @@ export async function countBySql(
  * Rails: async_count_by_sql — same as count_by_sql but returns a Promise.
  */
 export function asyncCountBySql(
-  this: QueryingHost,
+  this: typeof Base,
   sql: string | [string, ...unknown[]],
 ): Promise<number> {
   return countBySql.call(this, sql);


### PR DESCRIPTION
## Summary
Complete the polymorphic-`this` pass started in #513/#519 by covering the remaining static and instance methods that were still returning plain `Base` or `any`.

### Changes
- **`findBySql` / `asyncFindBySql`** — `<T extends typeof Base>(this: T, ...)` → `Promise<InstanceType<T>[]>`. `User.findBySql(sql)` → `User[]`; the optional block callback is typed as `User`. Drops the internal `QueryingHost` interface in favour of `typeof Base` (same shape).
- **`countBySql` / `asyncCountBySql`** — tightened `this` to `typeof Base` (no element type involved, they return `Promise<number>`).
- **`dup()` / `clone()`** — return `this` instead of `Base`. `user.dup()` → `User`.
- **`becomes<K>(klass: K)`** — returns `InstanceType<K>`. `user.becomes(Admin)` → `Admin`, matching how Rails' STI-switching API works.

### Rails fidelity
Every public static finder/CRUD method and the main instance-mutation methods now return the calling class's type, matching Rails where `User.find_by_sql`, `user.dup`, `user.becomes(Admin)` all return their respective concrete types.

### dx-tests
Extended `basic-crud.test-d.ts` to 49 assertions (was 46):
- `u.dup()` / `u.clone()` → `User`
- `u.becomes(Admin)` → `Admin`
- `await u.reload()` → `User`
- `User.findBySql(...)` / `User.asyncFindBySql(...)` → `User[]`

## Test plan
- [x] `pnpm build` / `pnpm typecheck` green
- [x] `pnpm test` green (17042 runtime tests)
- [x] `pnpm test:types` green (49/49)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green