### PR TITLE
docs(activerecord): canonical catalog of the declare patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,22 +224,24 @@ class Post extends Base {
 ```
 
 **Enums** (`this.enum(name, mapping)` generates a predicate + in-memory
-setter + persisting setter per value, plus class-level scopes):
+bang setter per value, plus a class-level scope per value):
 
 ```ts
 class Task extends Base {
   declare status: string;
   declare isLow: () => boolean;
-  declare low: () => void;
-  declare lowBang: () => Promise<void>;
+  declare lowBang: () => this; // in-memory; does not persist
   declare static low: () => Relation<Task>;
-  declare static notLow: () => Relation<Task>;
   static {
     this.attribute("status", "integer");
     this.enum("status", { low: 0, high: 1 });
   }
 }
 ```
+
+For a richer surface — async persisting bang setters, plain in-memory
+setters, and `not*` scopes — use `defineEnum(modelClass, ...)` from
+`@blazetrails/activerecord/enum.js` instead of `this.enum`.
 
 **Do not** redeclare `id` on subclasses — `Base#id` is an accessor
 (`PrimaryKeyValue`) and TS forbids overriding accessors with differently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,10 +227,19 @@ class Post extends Base {
 }
 ```
 
-**Enums** (`this.enum(name, mapping)` generates a predicate + in-memory
-bang setter per value, plus a class-level scope per value):
+**Enums** — two forms with different surfaces:
+
+- `this.enum(name, mapping)` (`Base.enum`) generates a predicate +
+  in-memory bang setter (returns `this`, no persistence) + class scope
+  per value.
+- `defineEnum(modelClass, name, mapping)` (`@blazetrails/activerecord`'s
+  `defineEnum`) generates the same + a plain in-memory setter + an async
+  persisting `*Bang` + `not*` class scopes per value. Use this when
+  you want bang methods to persist, matching Rails' `enum` semantics
+  (see section 7 of the ActiveRecord deviations guide).
 
 ```ts
+// Base.enum — simpler
 class Task extends Base {
   declare status: string;
   declare isLow: () => boolean;
@@ -241,11 +250,21 @@ class Task extends Base {
     this.enum("status", { low: 0, high: 1 });
   }
 }
-```
 
-For a richer surface — async persisting bang setters, plain in-memory
-setters, and `not*` scopes — use `defineEnum(modelClass, ...)` from
-`@blazetrails/activerecord/enum.js` instead of `this.enum`.
+// defineEnum — full surface
+class Article extends Base {
+  declare status: string;
+  declare isDraft: () => boolean;
+  declare draft: () => void; // plain in-memory setter
+  declare draftBang: () => Promise<void>; // async, persists via updateColumn
+  declare static draft: () => Relation<Article>;
+  declare static notDraft: () => Relation<Article>;
+  static {
+    this.attribute("status", "integer");
+    defineEnum(this, "status", { draft: 0, published: 1 });
+  }
+}
+```
 
 **Do not** redeclare `id` on subclasses — `Base#id` is an accessor
 (`PrimaryKeyValue`) and TS forbids overriding accessors with differently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,17 @@ A dedicated `DX Type Tests` CI job runs on every push.
 Several things in ActiveRecord are attached to a class/instance at
 runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`,
 ...) and aren't visible to the TypeScript type system by default.
-Because `Model` has an `[key: string]: unknown` index signature, access
-type-checks but falls through to `unknown`. Opt into static typing
-per-member with `declare`. Every snippet below assumes:
+
+- **Instance members** (`record.name`, `post.comments`): `Model`'s
+  `[key: string]: unknown` index signature means the access type-checks
+  but resolves to `unknown`. Opt in with `declare name: string` etc.
+- **Static members** (`Post.published`, enum class scopes): there's no
+  static index signature, so without `declare static`, the access is a
+  `Property 'published' does not exist on type 'typeof Post'` error.
+  Always pair `this.scope(...)`, `this.enum(...)`, and
+  `defineEnum(...)` with a matching `declare static`.
+
+Every snippet below assumes:
 
 ```ts
 import {
@@ -178,6 +186,7 @@ import {
   Relation,
   association,
   defineEnum,
+  readEnumValue,
 } from "@blazetrails/activerecord";
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,12 +162,29 @@ the assertion flips and signals the test should be tightened.
 
 A dedicated `DX Type Tests` CI job runs on every push.
 
-### Typed association accessors
+### The `declare` pattern for typed runtime-attached members
 
-`hasMany`/`hasAndBelongsToMany` runtime-attach a `CollectionProxy` onto the
-instance. Because `Model` has an `[key: string]: unknown` index signature,
-access like `blog.posts` type-checks but falls through to `unknown`. Opt
-into static typing per-association by declaring the field:
+Several things in ActiveRecord are attached to a class/instance at
+runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`,
+...) and aren't visible to the TypeScript type system by default.
+Because `Model` has an `[key: string]: unknown` index signature, access
+type-checks but falls through to `unknown`. Opt into static typing
+per-member with `declare`:
+
+**Attributes** (`this.attribute(name, type)`):
+
+```ts
+class User extends Base {
+  declare name: string;
+  declare admin: boolean;
+  static {
+    this.attribute("name", "string");
+    this.attribute("admin", "boolean", { default: false });
+  }
+}
+```
+
+**has_many / HABTM** (`this.hasMany(name)`):
 
 ```ts
 class Blog extends Base {
@@ -176,11 +193,62 @@ class Blog extends Base {
     this.hasMany("posts");
   }
 }
-
-const blog = new Blog({ name: "dean" });
-await blog.posts.first(); // Promise<Post | null>
 ```
 
+**belongs_to / has_one** (synchronous reader — returns the record, not a Promise):
+
+```ts
+class Post extends Base {
+  declare author: Author | null;
+  static {
+    this.belongsTo("author");
+  }
+}
+class Author extends Base {
+  declare profile: Profile | null;
+  static {
+    this.hasOne("profile");
+  }
+}
+```
+
+**Named scopes** (`this.scope(name, fn)` — class-level):
+
+```ts
+class Post extends Base {
+  declare static published: () => Relation<Post>;
+  static {
+    this.scope("published", (rel) => rel.where({ published: true }));
+  }
+}
+```
+
+**Enums** (`this.enum(name, mapping)` generates a predicate + in-memory
+setter + persisting setter per value, plus class-level scopes):
+
+```ts
+class Task extends Base {
+  declare status: string;
+  declare isLow: () => boolean;
+  declare low: () => void;
+  declare lowBang: () => Promise<void>;
+  declare static low: () => Relation<Task>;
+  declare static notLow: () => Relation<Task>;
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 });
+  }
+}
+```
+
+**Do not** redeclare `id` on subclasses — `Base#id` is an accessor
+(`PrimaryKeyValue`) and TS forbids overriding accessors with differently
+typed instance properties. Narrow at the use site instead:
+`record.id as number`.
+
+See `packages/activerecord/dx-tests/declare-patterns.test-d.ts` for the
+canonical, compiled reference for every pattern.
+
 `CollectionProxy<T>` and `AssociationProxy<T>` are both generic in the
-element type. Without the `declare`, the accessor still resolves to
-`unknown` (same as before).
+element type. Without the `declare`, any of these runtime-attached
+members still resolves to `unknown`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,13 @@ type-checks but falls through to `unknown`. Opt into static typing
 per-member with `declare`. Every snippet below assumes:
 
 ```ts
-import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+import {
+  Base,
+  CollectionProxy,
+  Relation,
+  association,
+  defineEnum,
+} from "@blazetrails/activerecord";
 ```
 
 **Attributes** (`this.attribute(name, type)`):
@@ -188,15 +194,22 @@ class User extends Base {
 }
 ```
 
-**has_many / HABTM** (`this.hasMany(name)`):
+**has_many / HABTM** (`this.hasMany(name)` — synchronous reader returns the
+loaded target array; use `association(record, name)` for the full async
+`CollectionProxy` API):
 
 ```ts
 class Blog extends Base {
-  declare posts: CollectionProxy<Post>;
+  declare posts: Post[]; // synchronous reader
   static {
     this.hasMany("posts");
   }
 }
+
+// Full async API — load, push, create, first, etc.
+const blog = new Blog();
+const proxy = association<Post>(blog, "posts"); // CollectionProxy<Post>
+await proxy.first();
 ```
 
 **belongs_to / has_one** (synchronous reader — returns the record, not a Promise):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,9 @@ class Article extends Base {
   declare status: number;
   declare isDraft: () => boolean;
   declare draft: () => void; // plain in-memory setter
-  declare draftBang: () => Promise<void>; // async, persists via updateColumn
+  declare draftBang: () => Promise<void>; // async; in-memory on new records,
+  //                                         otherwise persists via updateColumn
+  //                                         (bypasses validations/callbacks)
   declare static draft: () => Relation<Article>;
   declare static notDraft: () => Relation<Article>;
   static {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,11 @@ runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`,
 ...) and aren't visible to the TypeScript type system by default.
 Because `Model` has an `[key: string]: unknown` index signature, access
 type-checks but falls through to `unknown`. Opt into static typing
-per-member with `declare`:
+per-member with `declare`. Every snippet below assumes:
+
+```ts
+import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+```
 
 **Attributes** (`this.attribute(name, type)`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,10 @@ class Task extends Base {
 
 // defineEnum — full surface
 class Article extends Base {
-  declare status: string;
+  // defineEnum does NOT override the attribute accessor: `status` stays
+  // the integer column. Use `readEnumValue(record, "status")` when you
+  // want the string label.
+  declare status: number;
   declare isDraft: () => boolean;
   declare draft: () => void; // plain in-memory setter
   declare draftBang: () => Promise<void>; // async, persists via updateColumn

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -92,27 +92,25 @@ describe("associations DX", () => {
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();
   });
 
-  it("declare posts: CollectionProxy<Post> gives typed access on the instance", async () => {
+  it("declare posts: Post[] gives typed synchronous access on the instance", () => {
     class Blog extends Base {
       declare name: string;
-      declare posts: CollectionProxy<Post>;
+      // The synchronous accessor returns the loaded target array.
+      // For the full async CollectionProxy API, use `association(blog, "posts")`
+      // — see `dx-tests/declare-patterns.test-d.ts` for the canonical reference.
+      declare posts: Post[];
       static {
         this.attribute("name", "string");
         this.hasMany("posts");
       }
     }
     const blog = new Blog({ name: "dean's blog" });
-    // Even though runtime attaches `posts` dynamically, the explicit
-    // `declare` wins for static typing — no more `unknown` fallthrough
-    // via Model's `[key: string]: unknown` index signature.
-    expectTypeOf(blog.posts).toMatchTypeOf<CollectionProxy<Post>>();
-    const titles = (await blog.posts.toArray()).map((p) => p.title);
-    expectTypeOf(titles).toEqualTypeOf<string[]>();
+    expectTypeOf(blog.posts).toEqualTypeOf<Post[]>();
   });
 
   it("KNOWN GAP: without a `declare`, association accessors still return `unknown`", () => {
-    // `Model` has `[key: string]: unknown`, so without `declare posts:
-    // CollectionProxy<Post>` on the class body, the accessor still falls
+    // `Model` has `[key: string]: unknown`, so without a `declare posts:
+    // Post[]` (or similar) on the class body, the accessor still falls
     // through to `unknown`. Users opt in per-association.
     const post = new Post({ title: "hi", author_id: 1, published: true });
     expectTypeOf(post.author).toBeUnknown();

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -1,0 +1,181 @@
+/**
+ * DX: the `declare` patterns for typing runtime-attached members.
+ *
+ * Several things in ActiveRecord are attached to a class/instance at runtime
+ * (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`, ...)
+ * and so aren't visible to the TypeScript type system by default. Use a
+ * `declare` field on the class body to pin the static type. This file is
+ * the canonical reference for every supported pattern.
+ */
+
+import { describe, it, expectTypeOf } from "vitest";
+import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+
+// --- Attribute typing: `this.attribute("name", "string")` + `declare name: string` ---
+// (Don't redeclare `id` — Base defines it as an accessor; narrow at the use
+// site with `user.id as number` instead.)
+class User extends Base {
+  declare name: string;
+  declare email: string;
+  declare admin: boolean;
+
+  static {
+    this.attribute("name", "string");
+    this.attribute("email", "string");
+    this.attribute("admin", "boolean", { default: false });
+  }
+}
+
+// --- Association typing ---
+
+class Comment extends Base {
+  declare body: string;
+  declare post_id: number;
+
+  static {
+    this.attribute("body", "string");
+    this.attribute("post_id", "integer");
+    this.belongsTo("post");
+  }
+}
+
+class Author extends Base {
+  declare name: string;
+
+  // hasMany → CollectionProxy<Comment>
+  declare comments: CollectionProxy<Comment>;
+
+  // hasOne → Profile | null (synchronous reader; returns the record directly)
+  declare profile: Profile | null;
+
+  static {
+    this.attribute("name", "string");
+    this.hasMany("comments");
+    this.hasOne("profile");
+  }
+}
+
+class Profile extends Base {
+  declare bio: string;
+  declare author_id: number;
+
+  // belongsTo → Author | null (synchronous reader)
+  declare author: Author | null;
+
+  static {
+    this.attribute("bio", "string");
+    this.attribute("author_id", "integer");
+    this.belongsTo("author");
+  }
+}
+
+// --- Named scope typing: `this.scope("published", fn)` + `declare static published: ...` ---
+class Post extends Base {
+  declare title: string;
+  declare published: boolean;
+
+  // Class-level scope returns the scoped Relation.
+  declare static published: () => Relation<Post>;
+  declare static recent: (sinceDays: number) => Relation<Post>;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
+    this.scope("recent", (rel: Relation<Post>, sinceDays: number) => {
+      void sinceDays;
+      return rel.where({});
+    });
+  }
+}
+
+// --- Enum typing: `this.enum("status", {...})` generates predicate/setter/scope trio ---
+class Task extends Base {
+  declare status: string;
+
+  // record.isLow() / record.isHigh() — boolean predicates
+  declare isLow: () => boolean;
+  declare isHigh: () => boolean;
+  // record.low() / record.high() — in-memory setters
+  declare low: () => void;
+  declare high: () => void;
+  // record.lowBang() / record.highBang() — persisting setters
+  declare lowBang: () => Promise<void>;
+  declare highBang: () => Promise<void>;
+  // Class-level enum scopes: Task.low() / Task.high() / Task.notLow() / Task.notHigh()
+  declare static low: () => Relation<Task>;
+  declare static high: () => Relation<Task>;
+  declare static notLow: () => Relation<Task>;
+  declare static notHigh: () => Relation<Task>;
+
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 });
+  }
+}
+
+describe("declare patterns — typing runtime-attached members", () => {
+  it("attributes: `declare name: string` exposes the typed field", () => {
+    const u = new User({ name: "dean", email: "d@example.com", admin: false });
+    expectTypeOf(u.name).toBeString();
+    expectTypeOf(u.email).toBeString();
+    expectTypeOf(u.admin).toBeBoolean();
+  });
+
+  it("hasMany accessor: `declare comments: CollectionProxy<Comment>`", async () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.comments).toMatchTypeOf<CollectionProxy<Comment>>();
+    expectTypeOf(await author.comments.first()).toEqualTypeOf<Comment | null>();
+  });
+
+  it("belongsTo accessor: `declare author: Author | null` (synchronous reader)", () => {
+    const profile = new Profile({ bio: "hi", author_id: 1 });
+    expectTypeOf(profile.author).toEqualTypeOf<Author | null>();
+  });
+
+  it("hasOne accessor: `declare profile: Profile | null`", () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.profile).toEqualTypeOf<Profile | null>();
+  });
+
+  it("named scope (static): `declare static published: () => Relation<Post>`", () => {
+    expectTypeOf(Post.published).toEqualTypeOf<() => Relation<Post>>();
+    expectTypeOf(Post.published()).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.recent).toEqualTypeOf<(sinceDays: number) => Relation<Post>>();
+  });
+
+  it("enum predicate: `declare isLow: () => boolean`", () => {
+    const t = new Task({ status: 0 });
+    expectTypeOf(t.isLow).toEqualTypeOf<() => boolean>();
+    expectTypeOf(t.isLow()).toBeBoolean();
+  });
+
+  it("enum setter (in-memory): `declare low: () => void`", () => {
+    const t = new Task({ status: 0 });
+    expectTypeOf(t.low).toEqualTypeOf<() => void>();
+  });
+
+  it("enum setter (persisting): `declare lowBang: () => Promise<void>`", () => {
+    const t = new Task({ status: 0 });
+    expectTypeOf(t.lowBang).toEqualTypeOf<() => Promise<void>>();
+  });
+
+  it("enum class scopes: `declare static low: () => Relation<Task>`", () => {
+    expectTypeOf(Task.low).toEqualTypeOf<() => Relation<Task>>();
+    expectTypeOf(Task.notHigh()).toMatchTypeOf<Relation<Task>>();
+  });
+
+  it("without a declare, runtime members fall through to `unknown`", () => {
+    class Plain extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("posts");
+        this.scope("active", (rel: Relation<Plain>) => rel);
+      }
+    }
+    const p = new Plain({ name: "x" });
+    expectTypeOf(p.name).toBeUnknown();
+    expectTypeOf(p.posts).toBeUnknown();
+    expectTypeOf((Plain as typeof Plain & { active: unknown }).active).toBeUnknown();
+  });
+});

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -39,11 +39,21 @@ class Comment extends Base {
   }
 }
 
+class Tag extends Base {
+  declare name: string;
+  static {
+    this.attribute("name", "string");
+  }
+}
+
 class Author extends Base {
   declare name: string;
 
   // hasMany → CollectionProxy<Comment>
   declare comments: CollectionProxy<Comment>;
+
+  // hasAndBelongsToMany → CollectionProxy<Tag> (same shape as hasMany)
+  declare tags: CollectionProxy<Tag>;
 
   // hasOne → Profile | null (synchronous reader; returns the record directly)
   declare profile: Profile | null;
@@ -51,6 +61,7 @@ class Author extends Base {
   static {
     this.attribute("name", "string");
     this.hasMany("comments");
+    this.hasAndBelongsToMany("tags");
     this.hasOne("profile");
   }
 }
@@ -126,6 +137,12 @@ describe("declare patterns — typing runtime-attached members", () => {
     const author = new Author({ name: "dean" });
     expectTypeOf(author.comments).toMatchTypeOf<CollectionProxy<Comment>>();
     expectTypeOf(await author.comments.first()).toEqualTypeOf<Comment | null>();
+  });
+
+  it("hasAndBelongsToMany accessor: `declare tags: CollectionProxy<Tag>` (same shape)", async () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.tags).toMatchTypeOf<CollectionProxy<Tag>>();
+    expectTypeOf(await author.tags.first()).toEqualTypeOf<Tag | null>();
   });
 
   it("belongsTo accessor: `declare author: Author | null` (synchronous reader)", () => {

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -147,7 +147,9 @@ class Article extends Base {
   // Plain in-memory setters (defineEnum only) — return void
   declare draft: () => void;
   declare published: () => void;
-  // Async persisting bang setters (defineEnum only) — return Promise<void>
+  // Async bang setters (defineEnum only). Sets the attribute in memory; if
+  // the record is already persisted, also calls `updateColumn(...)` — which
+  // bypasses validations and callbacks. For a new record, it's in-memory only.
   declare draftBang: () => Promise<void>;
   declare publishedBang: () => Promise<void>;
   // Class scopes (positive + negative, defineEnum only for `not*`)

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -100,24 +100,25 @@ class Post extends Base {
   }
 }
 
-// --- Enum typing: `this.enum("status", {...})` generates predicate/setter/scope trio ---
+// --- Enum typing: `this.enum("status", {...})` generates a predicate and an
+// in-memory bang setter per value, plus a class-level scope per value.
+// (The `defineEnum(...)` helper in `enum.ts` generates a richer surface
+//  including async persisting bang setters, plain in-memory setters, and
+//  `not*` scopes; see its docs if you opt into that form.)
 class Task extends Base {
   declare status: string;
 
   // record.isLow() / record.isHigh() — boolean predicates
   declare isLow: () => boolean;
   declare isHigh: () => boolean;
-  // record.low() / record.high() — in-memory setters
-  declare low: () => void;
-  declare high: () => void;
-  // record.lowBang() / record.highBang() — persisting setters
-  declare lowBang: () => Promise<void>;
-  declare highBang: () => Promise<void>;
-  // Class-level enum scopes: Task.low() / Task.high() / Task.notLow() / Task.notHigh()
+  // record.lowBang() / record.highBang() — in-memory setters, return this.
+  // Not async, does not persist. Use `record.updateColumn("status", "low")`
+  // if you want a persisting one-liner.
+  declare lowBang: () => this;
+  declare highBang: () => this;
+  // Class-level enum scopes: Task.low() / Task.high()
   declare static low: () => Relation<Task>;
   declare static high: () => Relation<Task>;
-  declare static notLow: () => Relation<Task>;
-  declare static notHigh: () => Relation<Task>;
 
   static {
     this.attribute("status", "integer");
@@ -167,19 +168,14 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(t.isLow()).toBeBoolean();
   });
 
-  it("enum setter (in-memory): `declare low: () => void`", () => {
+  it("enum bang setter: `declare lowBang: () => this` (in-memory, returns self)", () => {
     const t = new Task({ status: 0 });
-    expectTypeOf(t.low).toEqualTypeOf<() => void>();
-  });
-
-  it("enum setter (persisting): `declare lowBang: () => Promise<void>`", () => {
-    const t = new Task({ status: 0 });
-    expectTypeOf(t.lowBang).toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf(t.lowBang()).toMatchTypeOf<Task>();
   });
 
   it("enum class scopes: `declare static low: () => Relation<Task>`", () => {
     expectTypeOf(Task.low).toEqualTypeOf<() => Relation<Task>>();
-    expectTypeOf(Task.notHigh()).toMatchTypeOf<Relation<Task>>();
+    expectTypeOf(Task.low()).toMatchTypeOf<Relation<Task>>();
   });
 
   it("without a declare, runtime members fall through to `unknown`", () => {

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expectTypeOf } from "vitest";
-import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+import { Base, CollectionProxy, Relation, defineEnum } from "@blazetrails/activerecord";
 
 // --- Attribute typing: `this.attribute("name", "string")` + `declare name: string` ---
 // (Don't redeclare `id` — Base defines it as an accessor; narrow at the use
@@ -100,11 +100,9 @@ class Post extends Base {
   }
 }
 
-// --- Enum typing: `this.enum("status", {...})` generates a predicate and an
-// in-memory bang setter per value, plus a class-level scope per value.
-// (The `defineEnum(...)` helper in `enum.ts` generates a richer surface
-//  including async persisting bang setters, plain in-memory setters, and
-//  `not*` scopes; see its docs if you opt into that form.)
+// --- Enum typing (Base.enum form): `this.enum("status", {...})` generates
+// a predicate and an in-memory bang setter per value, plus a class-level
+// scope per value.
 class Task extends Base {
   declare status: string;
 
@@ -123,6 +121,32 @@ class Task extends Base {
   static {
     this.attribute("status", "integer");
     this.enum("status", { low: 0, high: 1 });
+  }
+}
+
+// --- Enum typing (defineEnum form): richer surface with async persisting
+// bang setters, plain in-memory setters, and `not*` scopes.
+class Article extends Base {
+  declare status: string;
+
+  // Predicates (same as Base.enum)
+  declare isDraft: () => boolean;
+  declare isPublished: () => boolean;
+  // Plain in-memory setters (defineEnum only) — return void
+  declare draft: () => void;
+  declare published: () => void;
+  // Async persisting bang setters (defineEnum only) — return Promise<void>
+  declare draftBang: () => Promise<void>;
+  declare publishedBang: () => Promise<void>;
+  // Class scopes (positive + negative, defineEnum only for `not*`)
+  declare static draft: () => Relation<Article>;
+  declare static published: () => Relation<Article>;
+  declare static notDraft: () => Relation<Article>;
+  declare static notPublished: () => Relation<Article>;
+
+  static {
+    this.attribute("status", "integer");
+    defineEnum(this, "status", { draft: 0, published: 1 });
   }
 }
 
@@ -168,14 +192,22 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(t.isLow()).toBeBoolean();
   });
 
-  it("enum bang setter: `declare lowBang: () => this` (in-memory, returns self)", () => {
+  it("Base.enum bang setter: `declare lowBang: () => this` (in-memory, returns self)", () => {
     const t = new Task({ status: 0 });
     expectTypeOf(t.lowBang()).toMatchTypeOf<Task>();
   });
 
-  it("enum class scopes: `declare static low: () => Relation<Task>`", () => {
+  it("Base.enum class scopes: `declare static low: () => Relation<Task>`", () => {
     expectTypeOf(Task.low).toEqualTypeOf<() => Relation<Task>>();
     expectTypeOf(Task.low()).toMatchTypeOf<Relation<Task>>();
+  });
+
+  it("defineEnum adds plain setters + async bangs + not* scopes", async () => {
+    const a = new Article({ status: 0 });
+    expectTypeOf(a.draft).toEqualTypeOf<() => void>();
+    expectTypeOf(a.draftBang).toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf(await a.draftBang()).toBeVoid();
+    expectTypeOf(Article.notDraft()).toMatchTypeOf<Relation<Article>>();
   });
 
   it("without a declare, runtime members fall through to `unknown`", () => {

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -135,8 +135,11 @@ class Task extends Base {
 
 // --- Enum typing (defineEnum form): richer surface with async persisting
 // bang setters, plain in-memory setters, and `not*` scopes.
+// Unlike Base.enum, defineEnum does NOT override the attribute accessor —
+// `record.status` still returns the underlying integer. Use `readEnumValue`
+// (exported from `@blazetrails/activerecord`) when you want the string label.
 class Article extends Base {
-  declare status: string;
+  declare status: number; // integer column — defineEnum leaves the accessor alone
 
   // Predicates (same as Base.enum)
   declare isDraft: () => boolean;

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -9,7 +9,13 @@
  */
 
 import { describe, it, expectTypeOf } from "vitest";
-import { Base, CollectionProxy, Relation, defineEnum } from "@blazetrails/activerecord";
+import {
+  Base,
+  CollectionProxy,
+  Relation,
+  association,
+  defineEnum,
+} from "@blazetrails/activerecord";
 
 // --- Attribute typing: `this.attribute("name", "string")` + `declare name: string` ---
 // (Don't redeclare `id` — Base defines it as an accessor; narrow at the use
@@ -49,11 +55,14 @@ class Tag extends Base {
 class Author extends Base {
   declare name: string;
 
-  // hasMany → CollectionProxy<Comment>
-  declare comments: CollectionProxy<Comment>;
+  // hasMany → synchronous reader returning the loaded target array
+  // (the same shape as Rails' `author.comments` once loaded). Use
+  // `association(author, "comments")` to get the full CollectionProxy
+  // API (async load/first/create/push/etc).
+  declare comments: Comment[];
 
-  // hasAndBelongsToMany → CollectionProxy<Tag> (same shape as hasMany)
-  declare tags: CollectionProxy<Tag>;
+  // hasAndBelongsToMany → same shape as hasMany (array reader)
+  declare tags: Tag[];
 
   // hasOne → Profile | null (synchronous reader; returns the record directly)
   declare profile: Profile | null;
@@ -158,16 +167,22 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(u.admin).toBeBoolean();
   });
 
-  it("hasMany accessor: `declare comments: CollectionProxy<Comment>`", async () => {
+  it("hasMany accessor: `declare comments: Comment[]` (synchronous reader)", async () => {
     const author = new Author({ name: "dean" });
-    expectTypeOf(author.comments).toMatchTypeOf<CollectionProxy<Comment>>();
-    expectTypeOf(await author.comments.first()).toEqualTypeOf<Comment | null>();
+    expectTypeOf(author.comments).toEqualTypeOf<Comment[]>();
   });
 
-  it("hasAndBelongsToMany accessor: `declare tags: CollectionProxy<Tag>` (same shape)", async () => {
+  it("full CollectionProxy API via `association(record, name)` helper", async () => {
     const author = new Author({ name: "dean" });
-    expectTypeOf(author.tags).toMatchTypeOf<CollectionProxy<Tag>>();
-    expectTypeOf(await author.tags.first()).toEqualTypeOf<Tag | null>();
+    const proxy = association<Comment>(author, "comments");
+    expectTypeOf(proxy).toMatchTypeOf<CollectionProxy<Comment>>();
+    expectTypeOf(await proxy.first()).toEqualTypeOf<Comment | null>();
+    expectTypeOf(await proxy.toArray()).toEqualTypeOf<Comment[]>();
+  });
+
+  it("hasAndBelongsToMany accessor: `declare tags: Tag[]` (same shape as hasMany)", async () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.tags).toEqualTypeOf<Tag[]>();
   });
 
   it("belongsTo accessor: `declare author: Author | null` (synchronous reader)", () => {

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -228,7 +228,7 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(Article.notDraft()).toMatchTypeOf<Relation<Article>>();
   });
 
-  it("without a declare, runtime members fall through to `unknown`", () => {
+  it("without a declare, instance members fall through to `unknown`; static members don't exist at all", () => {
     class Plain extends Base {
       static {
         this.attribute("name", "string");
@@ -237,8 +237,13 @@ describe("declare patterns — typing runtime-attached members", () => {
       }
     }
     const p = new Plain({ name: "x" });
+    // Instance members type-check via Model's `[key: string]: unknown`
+    // index signature, but resolve to `unknown`.
     expectTypeOf(p.name).toBeUnknown();
     expectTypeOf(p.posts).toBeUnknown();
-    expectTypeOf((Plain as typeof Plain & { active: unknown }).active).toBeUnknown();
+    // Static members have no index signature — without `declare static`,
+    // they don't exist on the class type. Assert that:
+    type HasActive = "active" extends keyof typeof Plain ? true : false;
+    expectTypeOf<HasActive>().toEqualTypeOf<false>();
   });
 });

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -252,7 +252,13 @@ runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`)
 but the type system only sees them if you opt in with a `declare`:
 
 ```ts
-import { Base, Relation, defineEnum } from "@blazetrails/activerecord";
+import {
+  Base,
+  CollectionProxy,
+  Relation,
+  association,
+  defineEnum,
+} from "@blazetrails/activerecord";
 
 class Author extends Base {}
 class Comment extends Base {}

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -265,6 +265,7 @@ class Comment extends Base {}
 
 class Post extends Base {
   declare title: string; // attribute
+  declare featured: boolean; // attribute (backs the named scope below)
   declare status: number; // enum is stored as an integer; defineEnum
   //                        does not override the accessor (unlike Base.enum)
   declare author: Author | null; // belongsTo reader (synchronous)
@@ -275,11 +276,13 @@ class Post extends Base {
   declare draft: () => void; // enum in-memory setter (defineEnum only)
   declare draftBang: () => Promise<void>; // enum async persisting setter (defineEnum only)
   declare static draft: () => Relation<Post>; // enum class scope
+  declare static published: () => Relation<Post>; // enum class scope
   declare static notDraft: () => Relation<Post>; // enum `not*` scope (defineEnum only)
-  declare static published: () => Relation<Post>; // named scope
+  declare static featured: () => Relation<Post>; // named scope (distinct from the enum above)
 
   static {
     this.attribute("title", "string");
+    this.attribute("featured", "boolean", { default: false });
     this.attribute("status", "integer"); // defineEnum only attaches methods;
     //                                       the underlying column still needs an attribute
     this.belongsTo("author");
@@ -289,7 +292,8 @@ class Post extends Base {
     // simpler Base.enum surface (no plain setter, sync bang returning
     // `this`, no not* scopes).
     defineEnum(this, "status", { draft: 0, published: 1 });
-    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
+    // Named scope — use a name that doesn't collide with an enum value above.
+    this.scope("featured", (rel: Relation<Post>) => rel.where({ featured: true }));
   }
 }
 ```

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -252,7 +252,7 @@ runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`)
 but the type system only sees them if you opt in with a `declare`:
 
 ```ts
-import { Base, CollectionProxy, Relation, defineEnum } from "@blazetrails/activerecord";
+import { Base, Relation, defineEnum } from "@blazetrails/activerecord";
 
 class Author extends Base {}
 class Comment extends Base {}
@@ -260,7 +260,9 @@ class Comment extends Base {}
 class Post extends Base {
   declare title: string; // attribute
   declare author: Author | null; // belongsTo reader (synchronous)
-  declare comments: CollectionProxy<Comment>; // hasMany reader
+  declare comments: Comment[]; // hasMany reader (synchronous array;
+  //                            use `association(post, "comments")` for
+  //                            the full CollectionProxy<Comment> API)
   declare isDraft: () => boolean; // enum predicate
   declare draft: () => void; // enum in-memory setter (defineEnum only)
   declare draftBang: () => Promise<void>; // enum async persisting setter (defineEnum only)

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -252,6 +252,11 @@ runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`)
 but the type system only sees them if you opt in with a `declare`:
 
 ```ts
+import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+
+class Author extends Base {}
+class Comment extends Base {}
+
 class Post extends Base {
   declare title: string; // attribute
   declare author: Author | null; // belongsTo reader (synchronous)
@@ -267,7 +272,7 @@ class Post extends Base {
     this.belongsTo("author");
     this.hasMany("comments");
     this.enum("status", { draft: 0, published: 1 });
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
   }
 }
 ```

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -287,9 +287,18 @@ class Post extends Base {
 }
 ```
 
-Without `declare`, access type-checks (Model has `[key: string]: unknown`)
-but resolves to `unknown`. The compiled reference for every supported
-pattern lives in
+Without a matching `declare`:
+
+- **Instance access** (`record.title`, `post.comments`) type-checks via
+  `Model`'s `[key: string]: unknown` index signature and resolves to
+  `unknown`.
+- **Static access** (`Post.published`, enum class scopes like
+  `Post.draft`) is a `Property 'published' does not exist on type
+'typeof Post'` error — the class has no index signature. Always
+  pair `this.scope(...)`, `this.enum(...)`, or `defineEnum(...)` with
+  a matching `declare static`.
+
+The compiled reference for every supported pattern lives in
 `packages/activerecord/dx-tests/declare-patterns.test-d.ts`.
 
 Don't redeclare `id` — `Base#id` is an accessor typed as

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -243,6 +243,44 @@ All cross-package — see the index for
 and [symbols/kwargs](./index.md#symbols-kwargs). Every ActiveRecord API
 follows them.
 
+## 13. Typing runtime-attached members with `declare`
+
+Rails defines attributes/associations/scopes/enums dynamically, so a
+Ruby author just writes `post.title`, `post.author`, `Post.published`
+and everything works. In TypeScript, the same calls are attached at
+runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`)
+but the type system only sees them if you opt in with a `declare`:
+
+```ts
+class Post extends Base {
+  declare title: string; // attribute
+  declare author: Author | null; // belongsTo reader (synchronous)
+  declare comments: CollectionProxy<Comment>; // hasMany reader
+  declare isDraft: () => boolean; // enum predicate
+  declare draft: () => void; // enum in-memory setter
+  declare draftBang: () => Promise<void>; // enum persisting setter
+  declare static published: () => Relation<Post>; // named scope
+  declare static draft: () => Relation<Post>; // enum class scope
+
+  static {
+    this.attribute("title", "string");
+    this.belongsTo("author");
+    this.hasMany("comments");
+    this.enum("status", { draft: 0, published: 1 });
+    this.scope("published", (rel) => rel.where({ published: true }));
+  }
+}
+```
+
+Without `declare`, access type-checks (Model has `[key: string]: unknown`)
+but resolves to `unknown`. The compiled reference for every supported
+pattern lives in
+`packages/activerecord/dx-tests/declare-patterns.test-d.ts`.
+
+Don't redeclare `id` — `Base#id` is an accessor typed as
+`PrimaryKeyValue`, and TS forbids overriding an accessor with a
+differently-typed property. Narrow at the use site: `record.id as number`.
+
 ## Summary
 
 | Area                     | Rails                                   | Trails                                            |

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -259,6 +259,8 @@ class Comment extends Base {}
 
 class Post extends Base {
   declare title: string; // attribute
+  declare status: number; // enum is stored as an integer; defineEnum
+  //                        does not override the accessor (unlike Base.enum)
   declare author: Author | null; // belongsTo reader (synchronous)
   declare comments: Comment[]; // hasMany reader (synchronous array;
   //                            use `association(post, "comments")` for
@@ -272,6 +274,7 @@ class Post extends Base {
 
   static {
     this.attribute("title", "string");
+    this.attribute("status", "integer"); // must be declared before defineEnum
     this.belongsTo("author");
     this.hasMany("comments");
     // defineEnum (above, section 7) gives the full surface: plain setter,

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -252,7 +252,7 @@ runtime (via `this.attribute`, `this.hasMany`, `this.scope`, `this.enum`)
 but the type system only sees them if you opt in with a `declare`:
 
 ```ts
-import { Base, CollectionProxy, Relation } from "@blazetrails/activerecord";
+import { Base, CollectionProxy, Relation, defineEnum } from "@blazetrails/activerecord";
 
 class Author extends Base {}
 class Comment extends Base {}
@@ -262,15 +262,21 @@ class Post extends Base {
   declare author: Author | null; // belongsTo reader (synchronous)
   declare comments: CollectionProxy<Comment>; // hasMany reader
   declare isDraft: () => boolean; // enum predicate
-  declare draftBang: () => this; // enum in-memory bang setter (returns self)
+  declare draft: () => void; // enum in-memory setter (defineEnum only)
+  declare draftBang: () => Promise<void>; // enum async persisting setter (defineEnum only)
   declare static draft: () => Relation<Post>; // enum class scope
+  declare static notDraft: () => Relation<Post>; // enum `not*` scope (defineEnum only)
   declare static published: () => Relation<Post>; // named scope
 
   static {
     this.attribute("title", "string");
     this.belongsTo("author");
     this.hasMany("comments");
-    this.enum("status", { draft: 0, published: 1 });
+    // defineEnum (above, section 7) gives the full surface: plain setter,
+    // async bang, and not* scope. Use `this.enum(...)` instead for the
+    // simpler Base.enum surface (no plain setter, sync bang returning
+    // `this`, no not* scopes).
+    defineEnum(Post, "status", { draft: 0, published: 1 });
     this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
   }
 }

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -274,7 +274,8 @@ class Post extends Base {
 
   static {
     this.attribute("title", "string");
-    this.attribute("status", "integer"); // must be declared before defineEnum
+    this.attribute("status", "integer"); // defineEnum only attaches methods;
+    //                                       the underlying column still needs an attribute
     this.belongsTo("author");
     this.hasMany("comments");
     // defineEnum (above, section 7) gives the full surface: plain setter,
@@ -293,10 +294,9 @@ Without a matching `declare`:
   `Model`'s `[key: string]: unknown` index signature and resolves to
   `unknown`.
 - **Static access** (`Post.published`, enum class scopes like
-  `Post.draft`) is a `Property 'published' does not exist on type
-'typeof Post'` error — the class has no index signature. Always
-  pair `this.scope(...)`, `this.enum(...)`, or `defineEnum(...)` with
-  a matching `declare static`.
+  `Post.draft`) is a `Property 'published' does not exist on type 'typeof Post'`
+  error — the class has no index signature. Always pair `this.scope(...)`,
+  `this.enum(...)`, or `defineEnum(...)` with a matching `declare static`.
 
 The compiled reference for every supported pattern lives in
 `packages/activerecord/dx-tests/declare-patterns.test-d.ts`.

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -274,7 +274,10 @@ class Post extends Base {
   //                            the full CollectionProxy<Comment> API)
   declare isDraft: () => boolean; // enum predicate
   declare draft: () => void; // enum in-memory setter (defineEnum only)
-  declare draftBang: () => Promise<void>; // enum async persisting setter (defineEnum only)
+  declare draftBang: () => Promise<void>; // async (defineEnum only): sets
+  //                                         in-memory; if persisted, calls
+  //                                         updateColumn — bypasses
+  //                                         validations/callbacks
   declare static draft: () => Relation<Post>; // enum class scope
   declare static published: () => Relation<Post>; // enum class scope
   declare static notDraft: () => Relation<Post>; // enum `not*` scope (defineEnum only)

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -281,7 +281,7 @@ class Post extends Base {
     // async bang, and not* scope. Use `this.enum(...)` instead for the
     // simpler Base.enum surface (no plain setter, sync bang returning
     // `this`, no not* scopes).
-    defineEnum(Post, "status", { draft: 0, published: 1 });
+    defineEnum(this, "status", { draft: 0, published: 1 });
     this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
   }
 }

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -262,10 +262,9 @@ class Post extends Base {
   declare author: Author | null; // belongsTo reader (synchronous)
   declare comments: CollectionProxy<Comment>; // hasMany reader
   declare isDraft: () => boolean; // enum predicate
-  declare draft: () => void; // enum in-memory setter
-  declare draftBang: () => Promise<void>; // enum persisting setter
-  declare static published: () => Relation<Post>; // named scope
+  declare draftBang: () => this; // enum in-memory bang setter (returns self)
   declare static draft: () => Relation<Post>; // enum class scope
+  declare static published: () => Relation<Post>; // named scope
 
   static {
     this.attribute("title", "string");

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -36,11 +36,12 @@ published = Post.published.order(:title).to_a
 
 ```ts
 // TypeScript / Trails
-import { Base } from "@blazetrails/activerecord";
+import { Base, Relation } from "@blazetrails/activerecord";
 
 class Post extends Base {
-  title!: string;
-  published!: boolean;
+  declare title: string;
+  declare published: boolean;
+  declare static published: () => Relation<Post>;
 
   static {
     Post.attribute("title", "string");
@@ -48,15 +49,15 @@ class Post extends Base {
 
     Post.validates("title", { presence: true, length: { minimum: 3 } });
 
-    Post.beforeSave((record) => {
-      (record as Post).title = (record as Post).title.trim();
+    Post.beforeSave((record: Post) => {
+      record.title = record.title.trim();
     });
 
-    Post.scope("published", (rel: any) => rel.where({ published: true }));
+    Post.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
   }
 }
 
-const post = (await Post.createBang({ title: "Hello" })) as Post;
+const post = await Post.createBang({ title: "Hello" });
 await post.updateBang({ published: true });
 const published = await Post.where({ published: true }).order("title").toArray();
 ```
@@ -213,13 +214,13 @@ Trails puts the equivalent in a `static {}` initializer block.
 import { Model } from "@blazetrails/activemodel";
 
 class Post extends Model {
-  title!: string;
+  declare title: string;
 
   static {
     Post.attribute("title", "string");
     Post.validates("title", { presence: true });
-    Post.beforeSave((record) => {
-      (record as Post).title = (record as Post).title.trim();
+    Post.beforeSave((record: Post) => {
+      record.title = record.title.trim();
     });
   }
 }

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -59,7 +59,7 @@ class Post extends Base {
 
 const post = await Post.createBang({ title: "Hello" });
 await post.updateBang({ published: true });
-const published = await Post.where({ published: true }).order("title").toArray();
+const published = await Post.published().order("title").toArray();
 ```
 
 Everything below this point is that example broken into its


### PR DESCRIPTION
## Summary
The `declare` pattern is the TS-native opt-in for typing runtime-attached model members (attributes, associations, scopes, enums). This PR adds a **compiled, canonical reference** for every supported pattern + an updated CLAUDE.md section + a new website-guide section so users (and future agents) can find the full list in one place.

### dx-tests
New file `packages/activerecord/dx-tests/declare-patterns.test-d.ts` covers:
- **Attributes** — `declare name: string` alongside `this.attribute("name", "string")`
- **has_many / HABTM (synchronous reader)** — `declare posts: Post[]` (the accessor returns the loaded target array). For the full async `CollectionProxy` API, use the exported `association<Post>(record, "posts")` helper — also covered with its own assertions.
- **belongs_to / has_one** — `declare author: Author | null` (synchronous reader, not a Promise)
- **Named scopes** — `declare static published: () => Relation<Post>`
- **Enums — two surfaces with different semantics:**
  - `Base.enum` via `this.enum(...)` — `isLow()` predicate, `lowBang(): this` in-memory setter, `static low()` scope.
  - `defineEnum(this, ...)` — adds plain in-memory setters, async persisting `*Bang(): Promise<void>`, and `not*` class scopes. **Does not override the attribute accessor**, so the underlying column type stays as declared (`declare status: number` for an integer-backed enum).
- **Baseline gap** — without `declare`, runtime members fall through to `unknown`

Plus a note on *not* redeclaring `id` (Base defines it as an accessor; narrow at use sites with `record.id as number`).

### CLAUDE.md
Expanded into a full "declare pattern for typed runtime-attached members" catalog. Single `import { Base, CollectionProxy, Relation, association, defineEnum } from "@blazetrails/activerecord"` at the top so every snippet below is copy-pasteable.

### Website guide
New section 13 ("Typing runtime-attached members with `declare`") in `activerecord-rails-deviations.md` that aligns with the existing section 7 (Enums) and pairs `this.attribute("status", "integer")` with `defineEnum(this, "status", { draft: 0, published: 1 })` so the full example is runnable.

### idioms.md modernization
Dropped the no-longer-needed casts + `: any` annotations now that PRs #513/#517/#518/#519/#521 tightened the type surface:
- `title!: string` → `declare title: string`
- `(record as Post).title` → `(record: Post)` + direct access
- `(rel: any)` → `(rel: Relation<Post>)`
- `(await Post.createBang(...)) as Post` → dropped cast
- Final query uses `Post.published()` to exercise the declared scope

### associations.test-d.ts reconciliation
The prior scenario that declared `posts: CollectionProxy<Post>` was unsound — `record.posts` returns `Post[]` at runtime. Updated to `declare posts: Post[]` and pointed at the canonical catalog for the `association(...)` helper route.

### No library code changes
Pure documentation + DX-tests. The typing story was already supported (it's just `declare`); this PR makes it discoverable and consistent.

## Test plan
- [x] `pnpm build` / `pnpm typecheck` green
- [x] `pnpm test` green (17042 runtime tests)
- [x] `pnpm test:types` green (61/61)
- [x] `pnpm guides:typecheck` green (15/15 blocks)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green