### PR TITLE
feat(activerecord): Phase 4 — db prepare / test:prepare / seed:replant / truncate_all

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1497,6 +1497,18 @@ export class Migrator {
   }
 
   /**
+   * Read-only check for whether `schema_migrations` already exists.
+   * Used by `db prepare` to decide whether the DB is fresh (should run
+   * seeds) vs. already-initialized (just run pending migrations).
+   *
+   * Mirrors Rails' `initialize_database` which checks
+   * `schema_migration.table_exists?` for the same purpose.
+   */
+  async schemaMigrationTableExists(): Promise<boolean> {
+    return this._schemaMigration.tableExists();
+  }
+
+  /**
    * Read-only variant of {@link currentVersion}: returns 0 when the
    * schema_migrations table doesn't yet exist, without creating it.
    *

--- a/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { MySQLDatabaseTasks } from "./mysql-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
@@ -39,5 +39,62 @@ describe("MySQLDatabaseTasks", () => {
     MySQLDatabaseTasks.register();
     expect(DatabaseTasks.resolveTask("mysql2")).toBeDefined();
     expect(DatabaseTasks.resolveTask("trilogy")).toBeDefined();
+  });
+
+  it("test_truncate_all_queries_information_schema_and_truncates_each_user_table", async () => {
+    const executeCalls: Array<{ sql: string; binds?: unknown[] }> = [];
+    const mutationCalls: string[] = [];
+    const closeMock = vi.fn(async () => {});
+
+    class FakeMysql2Adapter {
+      constructor(_opts: unknown) {
+        void _opts;
+      }
+      async execute(sql: string, binds?: unknown[]) {
+        executeCalls.push({ sql, binds });
+        // information_schema.tables result — returns three user tables
+        // plus the two bookkeeping tables that truncateAll must skip.
+        return [{ table_name: "widgets" }, { table_name: "posts" }, { table_name: "comments" }];
+      }
+      async executeMutation(sql: string) {
+        mutationCalls.push(sql);
+      }
+      close = closeMock;
+    }
+
+    vi.resetModules();
+    vi.doMock("../adapters/mysql2-adapter.js", () => ({ Mysql2Adapter: FakeMysql2Adapter }));
+
+    try {
+      const mod =
+        (await import("./mysql-database-tasks.js")) as typeof import("./mysql-database-tasks.js");
+      await new mod.MySQLDatabaseTasks(
+        new HashConfig("development", "primary", {
+          adapter: "mysql2",
+          database: "trails_test",
+        }),
+      ).truncateAll();
+    } finally {
+      vi.doUnmock("../adapters/mysql2-adapter.js");
+      vi.resetModules();
+    }
+
+    // Exactly one information_schema query with the db name bound.
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0].sql).toMatch(/FROM information_schema\.tables/i);
+    expect(executeCalls[0].sql).toMatch(
+      /table_name NOT IN \('schema_migrations', 'ar_internal_metadata'\)/,
+    );
+    expect(executeCalls[0].binds).toEqual(["trails_test"]);
+
+    // FK checks toggled around per-table truncates.
+    expect(mutationCalls[0]).toBe("SET FOREIGN_KEY_CHECKS = 0");
+    expect(mutationCalls[mutationCalls.length - 1]).toBe("SET FOREIGN_KEY_CHECKS = 1");
+    expect(mutationCalls).toContain("TRUNCATE TABLE `widgets`");
+    expect(mutationCalls).toContain("TRUNCATE TABLE `posts`");
+    expect(mutationCalls).toContain("TRUNCATE TABLE `comments`");
+
+    // Adapter was closed.
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -130,6 +130,47 @@ export class MySQLDatabaseTasks {
     await this.runCmd("mysql", args, "loading", stdin);
   }
 
+  /**
+   * Truncate every user table in the current database, skipping
+   * schema_migrations and ar_internal_metadata. Disables FK checks for
+   * the duration so TRUNCATE order doesn't matter (matching Rails'
+   * Mysql2Adapter#truncate_tables behavior).
+   */
+  async truncateAll(): Promise<void> {
+    const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
+    const dbName = this.requireDatabaseName();
+    const adapter = new Mysql2Adapter({
+      host: this.resolvedField("host") ?? "localhost",
+      port: Number(this.resolvedField("port") ?? 3306),
+      database: dbName,
+      user: this.resolvedField("username"),
+      password: this.resolvedField("password"),
+    });
+    try {
+      const rows = (await adapter.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = ? " +
+          "AND table_type = 'BASE TABLE' " +
+          "AND table_name NOT IN ('schema_migrations', 'ar_internal_metadata')",
+        [dbName],
+      )) as Array<{ table_name?: string; TABLE_NAME?: string }>;
+      const names = rows
+        .map((r) => r.table_name ?? r.TABLE_NAME)
+        .filter((n): n is string => typeof n === "string");
+      if (names.length === 0) return;
+      await adapter.executeMutation("SET FOREIGN_KEY_CHECKS = 0");
+      try {
+        for (const name of names) {
+          await adapter.executeMutation(`TRUNCATE TABLE \`${name.replace(/`/g, "``")}\``);
+        }
+      } finally {
+        await adapter.executeMutation("SET FOREIGN_KEY_CHECKS = 1");
+      }
+    } finally {
+      const close = (adapter as unknown as { close?: () => Promise<void> }).close;
+      if (typeof close === "function") await close.call(adapter);
+    }
+  }
+
   static register(): void {
     const handler = {
       create: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).create(),
@@ -137,6 +178,7 @@ export class MySQLDatabaseTasks {
       purge: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).purge(),
       charset: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).charset(),
       collation: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).collation(),
+      truncateAll: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).truncateAll(),
       structureDump: async (
         config: DatabaseConfig,
         filename: string,

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -139,13 +139,29 @@ export class MySQLDatabaseTasks {
   async truncateAll(): Promise<void> {
     const { Mysql2Adapter } = await import("../adapters/mysql2-adapter.js");
     const dbName = this.requireDatabaseName();
-    const adapter = new Mysql2Adapter({
-      host: this.resolvedField("host") ?? "localhost",
-      port: Number(this.resolvedField("port") ?? 3306),
+    // Build the adapter config the same way withAdmin does: prefer a
+    // unix socket when the config provides one, coerce port safely so
+    // invalid/NaN values don't leak into mysql2.
+    const socket = this.resolvedField("socket");
+    const adapterConfig: {
+      host?: string;
+      port?: number;
+      database: string;
+      user?: string;
+      password?: string;
+      socketPath?: string;
+    } = {
       database: dbName,
       user: this.resolvedField("username"),
       password: this.resolvedField("password"),
-    });
+    };
+    if (socket) {
+      adapterConfig.socketPath = socket;
+    } else {
+      adapterConfig.host = this.resolvedField("host") ?? "localhost";
+      adapterConfig.port = coercePort(this.resolvedField("port"), 3306);
+    }
+    const adapter = new Mysql2Adapter(adapterConfig);
     try {
       const rows = (await adapter.execute(
         "SELECT table_name FROM information_schema.tables WHERE table_schema = ? " +

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { PostgreSQLDatabaseTasks } from "./postgresql-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
@@ -36,5 +36,65 @@ describe("PostgreSQLDatabaseTasks", () => {
     DatabaseTasks.clearRegisteredTasks();
     PostgreSQLDatabaseTasks.register();
     expect(DatabaseTasks.resolveTask("postgresql")).toBeDefined();
+  });
+
+  it("test_truncate_all_queries_pg_tables_and_issues_cascade_truncate", async () => {
+    const executeCalls: Array<{ sql: string; binds?: unknown[] }> = [];
+    const mutationCalls: string[] = [];
+    const closeMock = vi.fn(async () => {});
+
+    class FakePostgreSQLAdapter {
+      constructor(_opts: unknown) {
+        void _opts;
+      }
+      async execute(sql: string, binds?: unknown[]) {
+        executeCalls.push({ sql, binds });
+        // pg_tables result — three user tables in `public`. truncateAll
+        // filters out schema_migrations and ar_internal_metadata at the
+        // query level, so the mock doesn't need to return them.
+        return [{ tablename: "widgets" }, { tablename: "posts" }, { tablename: "comments" }];
+      }
+      async executeMutation(sql: string) {
+        mutationCalls.push(sql);
+      }
+      close = closeMock;
+    }
+
+    vi.resetModules();
+    vi.doMock("../adapters/postgresql-adapter.js", () => ({
+      PostgreSQLAdapter: FakePostgreSQLAdapter,
+    }));
+
+    try {
+      const mod =
+        (await import("./postgresql-database-tasks.js")) as typeof import("./postgresql-database-tasks.js");
+      await new mod.PostgreSQLDatabaseTasks(
+        new HashConfig("development", "primary", {
+          adapter: "postgresql",
+          database: "trails_test",
+        }),
+      ).truncateAll();
+    } finally {
+      vi.doUnmock("../adapters/postgresql-adapter.js");
+      vi.resetModules();
+    }
+
+    // Queries pg_tables scoped to the public schema, skipping the
+    // bookkeeping tables.
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0].sql).toMatch(/FROM pg_tables/i);
+    expect(executeCalls[0].sql).toMatch(/schemaname = 'public'/);
+    expect(executeCalls[0].sql).toMatch(
+      /tablename NOT IN \('schema_migrations', 'ar_internal_metadata'\)/,
+    );
+
+    // One TRUNCATE statement with all three tables, RESTART IDENTITY
+    // CASCADE, double-quoted.
+    expect(mutationCalls).toHaveLength(1);
+    expect(mutationCalls[0]).toBe(
+      `TRUNCATE TABLE "widgets", "posts", "comments" RESTART IDENTITY CASCADE`,
+    );
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -168,6 +168,37 @@ export class PostgreSQLDatabaseTasks {
     await this.runCmd("psql", args, "loading");
   }
 
+  /**
+   * Truncate every user table in `public`, skipping schema_migrations
+   * and ar_internal_metadata. TRUNCATE ... RESTART IDENTITY CASCADE
+   * matches Rails' default for PG (identity sequences reset; FK
+   * dependencies cascaded).
+   */
+  async truncateAll(): Promise<void> {
+    const { PostgreSQLAdapter } = await import("../adapters/postgresql-adapter.js");
+    const c = this.configurationHash;
+    const adapter: DatabaseAdapter = c.url
+      ? new PostgreSQLAdapter(String(c.url))
+      : new PostgreSQLAdapter({
+          host: (c.host as string) ?? "localhost",
+          port: coercePort(c.port, 5432),
+          database: this.requireDatabaseName(),
+          user: c.username as string | undefined,
+          password: c.password as string | undefined,
+        });
+    try {
+      const rows = (await adapter.execute(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' " +
+          "AND tablename NOT IN ('schema_migrations', 'ar_internal_metadata')",
+      )) as Array<{ tablename: string }>;
+      if (rows.length === 0) return;
+      const quoted = rows.map((r) => `"${r.tablename.replace(/"/g, '""')}"`).join(", ");
+      await adapter.executeMutation(`TRUNCATE TABLE ${quoted} RESTART IDENTITY CASCADE`);
+    } finally {
+      await this.closeAdapter(adapter);
+    }
+  }
+
   static register(): void {
     DatabaseTasks.registerTask(/postgres/, {
       create: async (config) => new PostgreSQLDatabaseTasks(config).create(),
@@ -175,6 +206,7 @@ export class PostgreSQLDatabaseTasks {
       purge: async (config) => new PostgreSQLDatabaseTasks(config).purge(),
       charset: async (config) => new PostgreSQLDatabaseTasks(config).charset(),
       collation: async (config) => new PostgreSQLDatabaseTasks(config).collation(),
+      truncateAll: async (config) => new PostgreSQLDatabaseTasks(config).truncateAll(),
       structureDump: async (config, filename, flags) =>
         new PostgreSQLDatabaseTasks(config).structureDump(filename, flags),
       structureLoad: async (config, filename, flags) =>

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -171,6 +171,31 @@ export class SQLiteDatabaseTasks {
     }
   }
 
+  /**
+   * Truncate every user table in the database — used by
+   * `DatabaseTasks.truncate_all` / `trails db seed:replant`. SQLite
+   * doesn't support TRUNCATE TABLE, so we DELETE FROM each user table
+   * then VACUUM (the Rails parallel is Arel::Truncate which falls back
+   * to DELETE for sqlite adapters).
+   *
+   * Skips schema_migrations and ar_internal_metadata so migration state
+   * and environment stamping survive.
+   */
+  async truncateAll(): Promise<void> {
+    const adapter = await this.connectAdapter();
+    try {
+      const rows = (await adapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' " +
+          "AND name <> 'schema_migrations' AND name <> 'ar_internal_metadata'",
+      )) as Array<{ name: string }>;
+      for (const row of rows) {
+        await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
+      }
+    } finally {
+      await this.closeAdapter(adapter);
+    }
+  }
+
   private resolveDbPath(): string {
     const path = getPath();
     // Align with DatabaseTasks._connectFor which defaults missing sqlite
@@ -201,6 +226,7 @@ export class SQLiteDatabaseTasks {
       drop: async (config) => new SQLiteDatabaseTasks(config).drop(),
       purge: async (config) => new SQLiteDatabaseTasks(config).purge(),
       charset: async (config) => new SQLiteDatabaseTasks(config).charset(),
+      truncateAll: async (config) => new SQLiteDatabaseTasks(config).truncateAll(),
       structureDump: async (config, filename, flags) =>
         new SQLiteDatabaseTasks(config).structureDump(filename, flags),
       structureLoad: async (config, filename, flags) =>

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -200,6 +200,18 @@ export class SQLiteDatabaseTasks {
         for (const row of rows) {
           await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
         }
+        // Match TRUNCATE/RESTART IDENTITY semantics by clearing the
+        // AUTOINCREMENT counters for the truncated tables. Rails'
+        // SQLite3Adapter#truncate_tables does the same thing.
+        // sqlite_sequence only exists once any AUTOINCREMENT column has
+        // been created — silently skip when it's absent.
+        const hasSequence = (await adapter.execute(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
+        )) as Array<{ name: string }>;
+        if (hasSequence.length > 0 && rows.length > 0) {
+          const list = rows.map((r) => `'${r.name.replace(/'/g, "''")}'`).join(", ");
+          await adapter.executeMutation(`DELETE FROM sqlite_sequence WHERE name IN (${list})`);
+        }
       };
       if (typeof withFks.disableReferentialIntegrity === "function") {
         await withFks.disableReferentialIntegrity(run);

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -175,11 +175,16 @@ export class SQLiteDatabaseTasks {
    * Truncate every user table in the database — used by
    * `DatabaseTasks.truncate_all` / `trails db seed:replant`. SQLite
    * doesn't support TRUNCATE TABLE, so we DELETE FROM each user table
-   * then VACUUM (the Rails parallel is Arel::Truncate which falls back
-   * to DELETE for sqlite adapters).
+   * instead (the Rails parallel is Arel::Truncate which falls back to
+   * DELETE for sqlite adapters).
    *
-   * Skips schema_migrations and ar_internal_metadata so migration state
-   * and environment stamping survive.
+   * Skips schema_migrations and ar_internal_metadata so migration
+   * state and environment stamping survive.
+   *
+   * Wraps the per-table deletes in disableReferentialIntegrity so
+   * foreign-key constraints don't block deletion of a parent table
+   * while its children are still populated — matches the FK-safety
+   * the PG/MySQL truncateAll implementations provide.
    */
   async truncateAll(): Promise<void> {
     const adapter = await this.connectAdapter();
@@ -188,8 +193,18 @@ export class SQLiteDatabaseTasks {
         "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' " +
           "AND name <> 'schema_migrations' AND name <> 'ar_internal_metadata'",
       )) as Array<{ name: string }>;
-      for (const row of rows) {
-        await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
+      const withFks = adapter as DatabaseAdapter & {
+        disableReferentialIntegrity?: (fn: () => Promise<void>) => Promise<void>;
+      };
+      const run = async () => {
+        for (const row of rows) {
+          await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
+        }
+      };
+      if (typeof withFks.disableReferentialIntegrity === "function") {
+        await withFks.disableReferentialIntegrity(run);
+      } else {
+        await run();
       }
     } finally {
       await this.closeAdapter(adapter);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -990,4 +990,176 @@ export class CreatePosts extends Migration {
       await adapter.close();
     }
   });
+
+  it("SQLiteDatabaseTasks.truncateAll deletes user tables but keeps schema_migrations + ar_internal_metadata", async () => {
+    const {
+      SQLiteDatabaseTasks,
+      Migrator,
+      HashConfig: HC,
+    } = await import("@blazetrails/activerecord");
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+
+    const dbFile = path.join(tmpDir, "truncate.sqlite3");
+    const seedAdapter = new SQLite3Adapter(dbFile);
+    try {
+      await seedAdapter.executeMutation("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)");
+      await seedAdapter.executeMutation("INSERT INTO posts (title) VALUES ('a'), ('b')");
+      const migrator = new Migrator(seedAdapter, []);
+      await migrator.internalMetadata.createTableAndSetFlags("development");
+      await seedAdapter.executeMutation(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR NOT NULL PRIMARY KEY)",
+      );
+      await seedAdapter.executeMutation(
+        "INSERT INTO schema_migrations (version) VALUES ('20260101000000')",
+      );
+    } finally {
+      await seedAdapter.close();
+    }
+
+    const config = new HC("development", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+    });
+    await new SQLiteDatabaseTasks(config).truncateAll();
+
+    const verify = new SQLite3Adapter(dbFile);
+    try {
+      const postsCount = (await verify.execute(`SELECT COUNT(*) AS c FROM posts`)) as Array<{
+        c: number;
+      }>;
+      expect(Number(postsCount[0].c)).toBe(0);
+
+      const schemaCount = (await verify.execute(
+        `SELECT COUNT(*) AS c FROM schema_migrations`,
+      )) as Array<{ c: number }>;
+      expect(Number(schemaCount[0].c)).toBe(1);
+
+      const metaCount = (await verify.execute(
+        `SELECT COUNT(*) AS c FROM ar_internal_metadata WHERE key = 'environment'`,
+      )) as Array<{ c: number }>;
+      expect(Number(metaCount[0].c)).toBe(1);
+    } finally {
+      await verify.close();
+    }
+  });
+
+  it("db truncate_all empties user tables", async () => {
+    const dbFile = path.join(tmpDir, "cli-truncate.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)");
+      await seed.executeMutation("INSERT INTO widgets (name) VALUES ('x'), ('y')");
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["truncate_all"]);
+    expect(process.exitCode).toBeUndefined();
+
+    const verify = new SQLite3Adapter(dbFile);
+    try {
+      const rows = (await verify.execute(`SELECT COUNT(*) AS c FROM widgets`)) as Array<{
+        c: number;
+      }>;
+      expect(Number(rows[0].c)).toBe(0);
+    } finally {
+      await verify.close();
+    }
+  });
+
+  it("db prepare creates, migrates, and seeds a fresh database", async () => {
+    const dbFile = path.join(tmpDir, "prepare.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-widgets.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateWidgets extends Migration {
+  async up() { await this.createTable("widgets", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("widgets"); }
+}`,
+    );
+    const seedMarker = path.join(tmpDir, "db", "seeds-ran");
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "seeds.ts"),
+      `import * as fs from "node:fs";
+fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
+    );
+
+    expect(fs.existsSync(dbFile)).toBe(false);
+    await runDb(["prepare"]);
+    expect(fs.existsSync(dbFile)).toBe(true);
+    expect(fs.existsSync(seedMarker)).toBe(true);
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const a = new SQLite3Adapter(dbFile);
+    try {
+      const tables = await a.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='widgets'`,
+      );
+      expect(tables).toHaveLength(1);
+    } finally {
+      await a.close();
+    }
+  });
+
+  it("db seed:replant truncates tables then runs seeds", async () => {
+    const dbFile = path.join(tmpDir, "replant.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    const seedMarker = path.join(tmpDir, "db", "seed-count");
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "seeds.ts"),
+      `import * as fs from "node:fs";
+const prev = fs.existsSync(${JSON.stringify(seedMarker)})
+  ? Number(fs.readFileSync(${JSON.stringify(seedMarker)}, "utf8"))
+  : 0;
+fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
+    );
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)");
+      await seed.executeMutation("INSERT INTO widgets (name) VALUES ('keep-me')");
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["seed:replant"]);
+    expect(fs.readFileSync(seedMarker, "utf8")).toBe("1");
+
+    const verify = new SQLite3Adapter(dbFile);
+    try {
+      const rows = (await verify.execute(`SELECT COUNT(*) AS c FROM widgets`)) as Array<{
+        c: number;
+      }>;
+      expect(Number(rows[0].c)).toBe(0);
+    } finally {
+      await verify.close();
+    }
+  });
 });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -141,13 +141,12 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 }
 
 /**
- * Run `fn` with `DatabaseTasks.databaseConfiguration` and the module-level
- * `DatabaseConfigurations.current` singleton temporarily pointed at a
- * DatabaseConfigurations built from `config`. Mirrors the capture/restore
- * pattern in `runProtectedEnvCheck` — lets us call into methods like
- * `DatabaseTasks.truncateAll` / `DatabaseTasks.prepareAll` that depend on
- * `configsFor` returning a non-empty list even when the CLI didn't
- * globally register configurations.
+ * Run `fn` with `DatabaseTasks.databaseConfiguration`, the module-level
+ * `DatabaseConfigurations.current` singleton, AND `DatabaseTasks.env`
+ * temporarily aligned with `config`. Captures/restores all three so
+ * callers can safely invoke methods like `DatabaseTasks.truncateAll(env)`
+ * that resolve the env via `_normalizeEnv()` (reads DatabaseTasks.env by
+ * default) and then call `configsFor` against it.
  */
 async function withRegisteredConfiguration<T>(
   config: HashConfig,
@@ -156,12 +155,15 @@ async function withRegisteredConfiguration<T>(
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   const previousTasksConfig = DatabaseTasks.databaseConfiguration;
   const previousCurrent = DatabaseConfigurations.current;
+  const previousEnv = DatabaseTasks.env;
   DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
+  DatabaseTasks.env = config.envName;
   try {
     return await fn();
   } finally {
     DatabaseTasks.databaseConfiguration = previousTasksConfig;
     DatabaseConfigurations.current = previousCurrent;
+    DatabaseTasks.env = previousEnv;
   }
 }
 
@@ -537,29 +539,39 @@ export function dbCommand(): Command {
     .command("seed:replant")
     .description("Truncate all tables in the current environment and re-run seeds")
     .action(async () => {
-      await withAdapter(async (adapter, raw) => {
-        const config = toDbConfig(raw);
-        // Delegate through DatabaseTasks.truncateAll so the centralized
-        // protected-env check + multi-config iteration apply. Register
-        // the config first so configsFor returns a non-empty list.
-        await withRegisteredConfiguration(config, async () => {
-          await DatabaseTasks.truncateAll(config.envName);
-        });
+      // Run the truncate path first (no connection in the CLI — the
+      // DatabaseTasks.truncateAll handler opens/closes its own per-
+      // config connection). Open the seed adapter only after the
+      // protected-env guard has passed and the truncate has completed,
+      // so we don't double-connect.
+      const raw = normalizeRawConfig(await loadDatabaseConfig());
+      const config = toDbConfig(raw);
+      await withRegisteredConfiguration(config, async () => {
+        await DatabaseTasks.truncateAll(config.envName);
+      });
+
+      const adapter = await connectAdapter(raw);
+      try {
         const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
-      });
+      } finally {
+        await closeAdapter(adapter);
+      }
     });
 
   cmd
     .command("truncate_all")
     .description("Truncate all tables in the current environment")
     .action(async () => {
-      await withAdapter(async (_adapter, raw) => {
-        const config = toDbConfig(raw);
-        await withRegisteredConfiguration(config, async () => {
-          await DatabaseTasks.truncateAll(config.envName);
-        });
+      // No need for withAdapter — DatabaseTasks.truncateAll opens its
+      // own per-config connection. Connecting here first would create
+      // sqlite files as a side effect before the protected-env guard
+      // can abort.
+      const raw = normalizeRawConfig(await loadDatabaseConfig());
+      const config = toDbConfig(raw);
+      await withRegisteredConfiguration(config, async () => {
+        await DatabaseTasks.truncateAll(config.envName);
       });
     });
 
@@ -617,6 +629,15 @@ export function dbCommand(): Command {
       const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
       const config = toDbConfig(raw, "test");
       await runProtectedEnvCheck(config, "test");
+      const filename = DatabaseTasks.schemaDumpPath(config);
+      if (!fs.existsSync(filename)) {
+        // Match the test:prepare / schema:load friendly-error path
+        // instead of letting loadSchema fail with a low-level dynamic-
+        // import error when there's nothing to load.
+        console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
+        process.exitCode = 1;
+        return;
+      }
       await DatabaseTasks.purge(config);
       const adapter = await connectAdapter(raw);
       try {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -266,6 +266,67 @@ async function runRollback(
   if (!options.skipDump) await dumpSchemaAfterMigrate(adapter, raw);
 }
 
+/**
+ * Run a seed-running callback with `Base.adapter` temporarily set so
+ * seed files that touch ActiveRecord models work. Restores the previous
+ * `Base.adapter` on exit (including when the outer caller is about to
+ * close the provided adapter) so we don't leave `Base` pointing at a
+ * closed connection.
+ */
+async function withSeedAdapter(adapter: DatabaseAdapter, fn: () => Promise<void>): Promise<void> {
+  const { Base } = await import("@blazetrails/activerecord");
+  // Read/restore via the _adapter backing field so a previous null value
+  // can be re-assigned (the public setter is DatabaseAdapter, not
+  // DatabaseAdapter | null).
+  const previous = Base._adapter;
+  Base.adapter = adapter;
+  try {
+    await fn();
+  } finally {
+    Base._adapter = previous;
+  }
+}
+
+/**
+ * Purge the test DB and load the schema file. Shared implementation
+ * behind `trails db test:load_schema` and `trails db test:prepare` —
+ * Rails' `db:test:prepare` task just invokes `db:test:load_schema`, so
+ * keeping the flow in one helper prevents the two commands from
+ * drifting.
+ *
+ * Rails' chain: `test:load_schema → test:purge → DatabaseTasks.purge`
+ * (disconnect → drop → create → reconnect). We delegate to
+ * DatabaseTasks.purge to preserve the disconnect/reconnect semantics
+ * instead of hand-rolling drop+create.
+ */
+async function runTestLoadSchema(options: {
+  successMessage: (displayName: string, filename: string) => string;
+}): Promise<void> {
+  const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
+  const config = toDbConfig(raw, "test");
+  await runProtectedEnvCheck(config, "test");
+  const filename = DatabaseTasks.schemaDumpPath(config);
+  if (!fs.existsSync(filename)) {
+    console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
+    process.exitCode = 1;
+    return;
+  }
+  await DatabaseTasks.purge(config);
+  const adapter = await connectAdapter(raw);
+  try {
+    const previous = DatabaseTasks.migrationConnection();
+    DatabaseTasks.setAdapter(adapter);
+    try {
+      await DatabaseTasks.loadSchema(config);
+    } finally {
+      DatabaseTasks.setAdapter(previous);
+    }
+  } finally {
+    await closeAdapter(adapter);
+  }
+  console.log(options.successMessage(displayNameFor(config, raw), filename));
+}
+
 async function runSeed(): Promise<void> {
   const seedCandidates = [
     path.join(process.cwd(), "db", "seeds.ts"),
@@ -529,9 +590,7 @@ export function dbCommand(): Command {
     .description("Run database seeds")
     .action(async () => {
       await withAdapter(async (adapter) => {
-        const { Base } = await import("@blazetrails/activerecord");
-        Base.adapter = adapter;
-        await runSeed();
+        await withSeedAdapter(adapter, runSeed);
       });
     });
 
@@ -552,9 +611,7 @@ export function dbCommand(): Command {
 
       const adapter = await connectAdapter(raw);
       try {
-        const { Base } = await import("@blazetrails/activerecord");
-        Base.adapter = adapter;
-        await runSeed();
+        await withSeedAdapter(adapter, runSeed);
       } finally {
         await closeAdapter(adapter);
       }
@@ -608,9 +665,7 @@ export function dbCommand(): Command {
 
         await runMigrate(adapter, raw);
         if (wasFresh) {
-          const { Base } = await import("@blazetrails/activerecord");
-          Base.adapter = adapter;
-          await runSeed();
+          await withSeedAdapter(adapter, runSeed);
         }
       } finally {
         const close = (adapter as { close?: () => Promise<void> }).close;
@@ -622,71 +677,18 @@ export function dbCommand(): Command {
     .command("test:load_schema")
     .description("Purge the test DB and load the schema")
     .action(async () => {
-      // Rails: test:load_schema → test:purge → DatabaseTasks.purge →
-      // disconnect → drop → create → reconnect. Delegate to
-      // DatabaseTasks.purge so the disconnect/reconnect semantics are
-      // preserved instead of our own drop+create pair.
-      const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
-      const config = toDbConfig(raw, "test");
-      await runProtectedEnvCheck(config, "test");
-      const filename = DatabaseTasks.schemaDumpPath(config);
-      if (!fs.existsSync(filename)) {
-        // Match the test:prepare / schema:load friendly-error path
-        // instead of letting loadSchema fail with a low-level dynamic-
-        // import error when there's nothing to load.
-        console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
-        process.exitCode = 1;
-        return;
-      }
-      await DatabaseTasks.purge(config);
-      const adapter = await connectAdapter(raw);
-      try {
-        const previous = DatabaseTasks.migrationConnection();
-        DatabaseTasks.setAdapter(adapter);
-        try {
-          await DatabaseTasks.loadSchema(config);
-        } finally {
-          DatabaseTasks.setAdapter(previous);
-        }
-      } finally {
-        const close = (adapter as { close?: () => Promise<void> }).close;
-        if (typeof close === "function") await close.call(adapter);
-      }
-      console.log(`Loaded test schema into '${displayNameFor(config, raw)}'`);
+      await runTestLoadSchema({ successMessage: (d) => `Loaded test schema into '${d}'` });
     });
 
   cmd
     .command("test:prepare")
     .description("Prepare the test database (Rails parallel to db:test:prepare)")
     .action(async () => {
-      // Rails: test:prepare → test:load_schema. They're effectively the
-      // same command; test:prepare exists as a semantically-named entry
-      // point for dev/CI scripts. Delegate so behavior stays in one
-      // place.
-      const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
-      const config = toDbConfig(raw, "test");
-      await runProtectedEnvCheck(config, "test");
-      const filename = DatabaseTasks.schemaDumpPath(config);
-      if (!fs.existsSync(filename)) {
-        console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
-        process.exitCode = 1;
-        return;
-      }
-      await DatabaseTasks.purge(config);
-      const adapter = await connectAdapter(raw);
-      try {
-        const previous = DatabaseTasks.migrationConnection();
-        DatabaseTasks.setAdapter(adapter);
-        try {
-          await DatabaseTasks.loadSchema(config);
-        } finally {
-          DatabaseTasks.setAdapter(previous);
-        }
-      } finally {
-        const close = (adapter as { close?: () => Promise<void> }).close;
-        if (typeof close === "function") await close.call(adapter);
-      }
-      console.log(`Test database prepared (${filename})`);
+      // Rails db:test:prepare → db:test:load_schema. The two commands
+      // run the same flow — test:prepare exists as a semantically-named
+      // entry point for dev/CI scripts; the implementation delegates to
+      // the shared runTestLoadSchema helper.
+      await runTestLoadSchema({ successMessage: (_d, f) => `Test database prepared (${f})` });
     });
 
   cmd.command("create").description("Create the database").action(runCreate);
@@ -745,9 +747,7 @@ export function dbCommand(): Command {
       await runCreate();
       await withAdapter(async (adapter, raw) => {
         await runMigrate(adapter, raw);
-        const { Base } = await import("@blazetrails/activerecord");
-        Base.adapter = adapter;
-        await runSeed();
+        await withSeedAdapter(adapter, runSeed);
       });
     });
 
@@ -758,9 +758,7 @@ export function dbCommand(): Command {
       await runCreate();
       await withAdapter(async (adapter, raw) => {
         await runMigrate(adapter, raw);
-        const { Base } = await import("@blazetrails/activerecord");
-        Base.adapter = adapter;
-        await runSeed();
+        await withSeedAdapter(adapter, runSeed);
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -148,6 +148,14 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
  * `EnvironmentMismatchError` and the protected-stamp case this PR cares
  * about.
  */
+async function resolveHandler(
+  config: HashConfig,
+): Promise<import("@blazetrails/activerecord").DatabaseTaskHandler | undefined> {
+  const adapter = config.adapter;
+  if (!adapter) return undefined;
+  return DatabaseTasks.resolveTask(adapter);
+}
+
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   // DatabaseConfigurations' constructor registers itself as the
@@ -507,6 +515,134 @@ export function dbCommand(): Command {
         Base.adapter = adapter;
         await runSeed();
       });
+    });
+
+  cmd
+    .command("seed:replant")
+    .description("Truncate all tables in the current environment and re-run seeds")
+    .action(async () => {
+      await withAdapter(async (adapter, raw) => {
+        const config = toDbConfig(raw);
+        await runProtectedEnvCheck(config, config.envName);
+        const handler = await resolveHandler(config);
+        if (handler?.truncateAll) {
+          await handler.truncateAll(config);
+        }
+        const { Base } = await import("@blazetrails/activerecord");
+        Base.adapter = adapter;
+        await runSeed();
+      });
+    });
+
+  cmd
+    .command("truncate_all")
+    .description("Truncate all tables in the current environment")
+    .action(async () => {
+      await withAdapter(async (_adapter, raw) => {
+        const config = toDbConfig(raw);
+        await runProtectedEnvCheck(config, config.envName);
+        const handler = await resolveHandler(config);
+        if (handler?.truncateAll) {
+          await handler.truncateAll(config);
+        }
+      });
+    });
+
+  cmd
+    .command("prepare")
+    .description(
+      "Create the database if it doesn't exist, run pending migrations, and seed when fresh",
+    )
+    .action(async () => {
+      await withAdapter(async (adapter, raw) => {
+        const config = toDbConfig(raw);
+        const { DatabaseAlreadyExists, Migrator } = await import("@blazetrails/activerecord");
+
+        // Rails measures "fresh" via
+        // `!schema_migration.table_exists?` — not via whether the DB
+        // file/db exists. A sqlite DB "exists" as soon as anyone opens a
+        // connection (better-sqlite3 creates the file on open), so
+        // checking DatabaseTasks.create's success would almost always
+        // report not-fresh. Use the schema_migrations presence probe.
+        const preMigrator = new Migrator(adapter, []);
+        const wasFresh = !(await preMigrator.schemaMigrationTableExists());
+
+        try {
+          await DatabaseTasks.create(config);
+          if (wasFresh) console.log(`Created database '${displayNameFor(config, raw)}'`);
+        } catch (error) {
+          if (!(error instanceof DatabaseAlreadyExists)) throw error;
+        }
+        await runMigrate(adapter, raw);
+        if (wasFresh) {
+          const { Base } = await import("@blazetrails/activerecord");
+          Base.adapter = adapter;
+          await runSeed();
+        }
+      });
+    });
+
+  cmd
+    .command("test:load_schema")
+    .description("Purge the test DB and load the schema")
+    .action(async () => {
+      const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
+      const config = toDbConfig(raw, "test");
+      await runProtectedEnvCheck(config, "test");
+      try {
+        await DatabaseTasks.drop(config);
+      } catch {
+        // ignore — test DB may not exist
+      }
+      await DatabaseTasks.create(config);
+      const adapter = await connectAdapter(raw);
+      try {
+        const previous = DatabaseTasks.migrationConnection();
+        DatabaseTasks.setAdapter(adapter);
+        try {
+          await DatabaseTasks.loadSchema(config);
+        } finally {
+          DatabaseTasks.setAdapter(previous);
+        }
+      } finally {
+        const close = (adapter as { close?: () => Promise<void> }).close;
+        if (typeof close === "function") await close.call(adapter);
+      }
+      console.log(`Loaded test schema into '${displayNameFor(config, raw)}'`);
+    });
+
+  cmd
+    .command("test:prepare")
+    .description("Prepare the test database (load schema from db/schema.ts / .js / structure.sql)")
+    .action(async () => {
+      const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
+      const config = toDbConfig(raw, "test");
+      await runProtectedEnvCheck(config, "test");
+      const filename = DatabaseTasks.schemaDumpPath(config);
+      if (!fs.existsSync(filename)) {
+        console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
+        process.exitCode = 1;
+        return;
+      }
+      try {
+        await DatabaseTasks.create(config);
+      } catch {
+        // ignore — test DB may exist already
+      }
+      const adapter = await connectAdapter(raw);
+      try {
+        const previous = DatabaseTasks.migrationConnection();
+        DatabaseTasks.setAdapter(adapter);
+        try {
+          await DatabaseTasks.loadSchema(config);
+        } finally {
+          DatabaseTasks.setAdapter(previous);
+        }
+      } finally {
+        const close = (adapter as { close?: () => Promise<void> }).close;
+        if (typeof close === "function") await close.call(adapter);
+      }
+      console.log(`Test database prepared (${filename})`);
     });
 
   cmd.command("create").description("Create the database").action(runCreate);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -141,14 +141,6 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 }
 
 /**
- * Run Rails' `check_protected_environments!` guard with a temporarily-
- * registered `DatabaseTasks.databaseConfiguration` so it actually consults
- * the stored env in `ar_internal_metadata`. Without the registration the
- * guard falls back to checking only the current env name, which misses
- * `EnvironmentMismatchError` and the protected-stamp case this PR cares
- * about.
- */
-/**
  * Run `fn` with `DatabaseTasks.databaseConfiguration` and the module-level
  * `DatabaseConfigurations.current` singleton temporarily pointed at a
  * DatabaseConfigurations built from `config`. Mirrors the capture/restore
@@ -173,6 +165,13 @@ async function withRegisteredConfiguration<T>(
   }
 }
 
+/**
+ * Run Rails' `check_protected_environments!` guard with a temporarily-
+ * registered `DatabaseTasks.databaseConfiguration` so it actually consults
+ * the stored env in `ar_internal_metadata`. Without the registration the
+ * guard falls back to checking only the current env name, which misses
+ * `EnvironmentMismatchError` and the protected-stamp case.
+ */
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   // DatabaseConfigurations' constructor registers itself as the
@@ -570,33 +569,41 @@ export function dbCommand(): Command {
       "Create the database if it doesn't exist, run pending migrations, and seed when fresh",
     )
     .action(async () => {
-      await withAdapter(async (adapter, raw) => {
-        const config = toDbConfig(raw);
-        const { DatabaseAlreadyExists, Migrator } = await import("@blazetrails/activerecord");
+      // Do NOT go through withAdapter — connectAdapter would try to
+      // connect to the target DB before we've had a chance to create
+      // it, which fails for pg/mysql when the DB doesn't exist yet.
+      // Create first, then connect.
+      const raw = normalizeRawConfig(await loadDatabaseConfig());
+      const config = toDbConfig(raw);
+      const { DatabaseAlreadyExists, Migrator } = await import("@blazetrails/activerecord");
 
-        // Rails measures "fresh" via
-        // `!schema_migration.table_exists?` — not via whether the DB
-        // file/db exists. A sqlite DB "exists" as soon as anyone opens a
-        // connection (better-sqlite3 creates the file on open), so
-        // checking DatabaseTasks.create's success would almost always
-        // report not-fresh. Use the schema_migrations presence probe,
-        // matching Rails' initialize_database contract.
-        const preMigrator = new Migrator(adapter, []);
-        const wasFresh = !(await preMigrator.schemaMigrationTableExists());
+      try {
+        await DatabaseTasks.create(config);
+        console.log(`Created database '${displayNameFor(config, raw)}'`);
+      } catch (error) {
+        if (!(error instanceof DatabaseAlreadyExists)) throw error;
+      }
 
-        try {
-          await DatabaseTasks.create(config);
-          if (wasFresh) console.log(`Created database '${displayNameFor(config, raw)}'`);
-        } catch (error) {
-          if (!(error instanceof DatabaseAlreadyExists)) throw error;
-        }
+      const adapter = await connectAdapter(raw);
+      try {
+        // Rails measures "fresh" via `!schema_migration.table_exists?`,
+        // matching its `initialize_database` contract. A sqlite DB file
+        // may have been created by either our DatabaseTasks.create call
+        // above or by better-sqlite3 on connect; the meaningful signal
+        // is whether migrations have been applied.
+        const migrator = new Migrator(adapter, []);
+        const wasFresh = !(await migrator.schemaMigrationTableExists());
+
         await runMigrate(adapter, raw);
         if (wasFresh) {
           const { Base } = await import("@blazetrails/activerecord");
           Base.adapter = adapter;
           await runSeed();
         }
-      });
+      } finally {
+        const close = (adapter as { close?: () => Promise<void> }).close;
+        if (typeof close === "function") await close.call(adapter);
+      }
     });
 
   cmd

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -148,12 +148,29 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
  * `EnvironmentMismatchError` and the protected-stamp case this PR cares
  * about.
  */
-async function resolveHandler(
+/**
+ * Run `fn` with `DatabaseTasks.databaseConfiguration` and the module-level
+ * `DatabaseConfigurations.current` singleton temporarily pointed at a
+ * DatabaseConfigurations built from `config`. Mirrors the capture/restore
+ * pattern in `runProtectedEnvCheck` — lets us call into methods like
+ * `DatabaseTasks.truncateAll` / `DatabaseTasks.prepareAll` that depend on
+ * `configsFor` returning a non-empty list even when the CLI didn't
+ * globally register configurations.
+ */
+async function withRegisteredConfiguration<T>(
   config: HashConfig,
-): Promise<import("@blazetrails/activerecord").DatabaseTaskHandler | undefined> {
-  const adapter = config.adapter;
-  if (!adapter) return undefined;
-  return DatabaseTasks.resolveTask(adapter);
+  fn: () => Promise<T>,
+): Promise<T> {
+  const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
+  const previousTasksConfig = DatabaseTasks.databaseConfiguration;
+  const previousCurrent = DatabaseConfigurations.current;
+  DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
+  try {
+    return await fn();
+  } finally {
+    DatabaseTasks.databaseConfiguration = previousTasksConfig;
+    DatabaseConfigurations.current = previousCurrent;
+  }
 }
 
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
@@ -523,11 +540,12 @@ export function dbCommand(): Command {
     .action(async () => {
       await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
-        await runProtectedEnvCheck(config, config.envName);
-        const handler = await resolveHandler(config);
-        if (handler?.truncateAll) {
-          await handler.truncateAll(config);
-        }
+        // Delegate through DatabaseTasks.truncateAll so the centralized
+        // protected-env check + multi-config iteration apply. Register
+        // the config first so configsFor returns a non-empty list.
+        await withRegisteredConfiguration(config, async () => {
+          await DatabaseTasks.truncateAll(config.envName);
+        });
         const { Base } = await import("@blazetrails/activerecord");
         Base.adapter = adapter;
         await runSeed();
@@ -540,11 +558,9 @@ export function dbCommand(): Command {
     .action(async () => {
       await withAdapter(async (_adapter, raw) => {
         const config = toDbConfig(raw);
-        await runProtectedEnvCheck(config, config.envName);
-        const handler = await resolveHandler(config);
-        if (handler?.truncateAll) {
-          await handler.truncateAll(config);
-        }
+        await withRegisteredConfiguration(config, async () => {
+          await DatabaseTasks.truncateAll(config.envName);
+        });
       });
     });
 
@@ -563,7 +579,8 @@ export function dbCommand(): Command {
         // file/db exists. A sqlite DB "exists" as soon as anyone opens a
         // connection (better-sqlite3 creates the file on open), so
         // checking DatabaseTasks.create's success would almost always
-        // report not-fresh. Use the schema_migrations presence probe.
+        // report not-fresh. Use the schema_migrations presence probe,
+        // matching Rails' initialize_database contract.
         const preMigrator = new Migrator(adapter, []);
         const wasFresh = !(await preMigrator.schemaMigrationTableExists());
 
@@ -586,15 +603,14 @@ export function dbCommand(): Command {
     .command("test:load_schema")
     .description("Purge the test DB and load the schema")
     .action(async () => {
+      // Rails: test:load_schema → test:purge → DatabaseTasks.purge →
+      // disconnect → drop → create → reconnect. Delegate to
+      // DatabaseTasks.purge so the disconnect/reconnect semantics are
+      // preserved instead of our own drop+create pair.
       const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
       const config = toDbConfig(raw, "test");
       await runProtectedEnvCheck(config, "test");
-      try {
-        await DatabaseTasks.drop(config);
-      } catch {
-        // ignore — test DB may not exist
-      }
-      await DatabaseTasks.create(config);
+      await DatabaseTasks.purge(config);
       const adapter = await connectAdapter(raw);
       try {
         const previous = DatabaseTasks.migrationConnection();
@@ -613,8 +629,12 @@ export function dbCommand(): Command {
 
   cmd
     .command("test:prepare")
-    .description("Prepare the test database (load schema from db/schema.ts / .js / structure.sql)")
+    .description("Prepare the test database (Rails parallel to db:test:prepare)")
     .action(async () => {
+      // Rails: test:prepare → test:load_schema. They're effectively the
+      // same command; test:prepare exists as a semantically-named entry
+      // point for dev/CI scripts. Delegate so behavior stays in one
+      // place.
       const raw = normalizeRawConfig(await loadDatabaseConfig("test"));
       const config = toDbConfig(raw, "test");
       await runProtectedEnvCheck(config, "test");
@@ -624,11 +644,7 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      try {
-        await DatabaseTasks.create(config);
-      } catch {
-        // ignore — test DB may exist already
-      }
+      await DatabaseTasks.purge(config);
       const adapter = await connectAdapter(raw);
       try {
         const previous = DatabaseTasks.migrationConnection();

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -275,15 +275,21 @@ async function runRollback(
  */
 async function withSeedAdapter(adapter: DatabaseAdapter, fn: () => Promise<void>): Promise<void> {
   const { Base } = await import("@blazetrails/activerecord");
-  // Read/restore via the _adapter backing field so a previous null value
-  // can be re-assigned (the public setter is DatabaseAdapter, not
-  // DatabaseAdapter | null).
   const previous = Base._adapter;
   Base.adapter = adapter;
   try {
     await fn();
   } finally {
-    Base._adapter = previous;
+    // Preserve setter side effects (Base.adapter's setter fires the
+    // internal _onAdapterSet hook) when restoring a non-null adapter.
+    // Fall back to the backing field for a previous null because the
+    // public setter is typed as DatabaseAdapter, not DatabaseAdapter |
+    // null.
+    if (previous === null) {
+      Base._adapter = previous;
+    } else {
+      Base.adapter = previous;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 4 of the full-migration-parity plan. Ships the task-level CLI commands that make trails mirror Rails' full `bin/rails db:*` surface for fresh-DB setup, test-DB management, seed replanting, and cross-env truncation.

### New \`trails db\` subcommands

| Command | Behavior |
|---|---|
| \`truncate_all\` | TRUNCATE every user table (skips \`schema_migrations\` + \`ar_internal_metadata\`), gated on \`check_protected_environments\`. |
| \`prepare\` | Create the DB if missing, run pending migrations, and seed when fresh. |
| \`seed:replant\` | \`truncate_all\` + re-run \`db/seeds.ts\`. |
| \`test:prepare\` | Create the test DB if missing, load the schema file. |
| \`test:load_schema\` | Drop + create the test DB, then load the schema file. |

### Freshness contract

\`prepare\` matches Rails' \`initialize_database\` contract: "fresh" is decided by \`schema_migration.table_exists?\`, not by whether the DB file exists. Without this, a sqlite DB that better-sqlite3 creates on connection open would defeat the seed step.

Added \`Migrator.schemaMigrationTableExists()\` for the read-only probe.

### Per-adapter \`truncateAll\`

Filled in the \`truncateAll\` handler on all three \`DatabaseTasks\` adapter classes (previously stubbed through the handler interface but not implemented):

- **SQLite** — \`DELETE FROM\` each user table (SQLite lacks TRUNCATE).
- **PostgreSQL** — \`TRUNCATE TABLE ... RESTART IDENTITY CASCADE\` across \`pg_tables\` where \`schemaname = 'public'\`.
- **MySQL** — \`SET FOREIGN_KEY_CHECKS = 0\` wrapped around per-table \`TRUNCATE\` (matches Rails' \`Mysql2Adapter#truncate_tables\`).

All three skip \`schema_migrations\` + \`ar_internal_metadata\` so migration state and environment stamping survive.

### Rails references

- \`activerecord/lib/active_record/railties/databases.rake\` — tasks \`truncate_all\`, \`prepare\`, \`seed:replant\`, \`test:prepare\`, \`test:load_schema\`
- \`activerecord/lib/active_record/tasks/database_tasks.rb\` — \`prepare_all\`, \`initialize_database\`, \`truncate_all\`

### Tests

4 new integration tests:
- \`SQLiteDatabaseTasks.truncateAll\` deletes user tables, keeps \`schema_migrations\` + \`ar_internal_metadata\`.
- \`db truncate_all\` empties user tables via CLI.
- \`db prepare\` creates, migrates, and seeds a fresh database.
- \`db seed:replant\` truncates tables then runs seeds.

### Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 17,056 pass / 0 fail
- [x] \`pnpm api:compare --package activerecord\` — 81.5%

## Next in the plan

- Phase 5: schema cache persistence (db:schema:cache:dump / cache:clear)
- Phase 6: structure dump/load file format
- #36 follow-up: schemaFormat config wiring