### PR TITLE
feat(activemodel): type lifecycle callbacks with polymorphic this

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ scripts/api-compare/.rails-source
 .claude/worktrees/
 .claude/hooks/
 .claude/skills/
+
+# Local SQLite test databases
+*.db

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -184,9 +184,9 @@ export type AroundCallbackFn = (
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
 
-export interface CallbackConditions {
-  if?: (record: AnyRecord) => boolean;
-  unless?: (record: AnyRecord) => boolean;
+export interface CallbackConditions<TRecord = AnyRecord> {
+  if?: (record: TRecord) => boolean;
+  unless?: (record: TRecord) => boolean;
   prepend?: boolean;
   on?: string | string[];
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -571,7 +571,7 @@ export class Model {
   static beforeValidation<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this._ensureOwnCallbacks();
     this._callbackChain.register(
@@ -585,7 +585,7 @@ export class Model {
   static afterValidation<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this._ensureOwnCallbacks();
     this._callbackChain.register(
@@ -599,7 +599,7 @@ export class Model {
   static beforeSave<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -609,7 +609,7 @@ export class Model {
   static afterSave<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -619,7 +619,7 @@ export class Model {
   static beforeCreate<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -629,7 +629,7 @@ export class Model {
   static afterCreate<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -639,7 +639,7 @@ export class Model {
   static beforeUpdate<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -649,7 +649,7 @@ export class Model {
   static afterUpdate<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -659,7 +659,7 @@ export class Model {
   static beforeDestroy<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -674,7 +674,7 @@ export class Model {
   static afterDestroy<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -686,7 +686,7 @@ export class Model {
     fn:
       | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
       | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -703,7 +703,7 @@ export class Model {
     fn:
       | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
       | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -720,7 +720,7 @@ export class Model {
     fn:
       | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
       | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -737,7 +737,7 @@ export class Model {
     fn:
       | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
       | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
@@ -752,7 +752,7 @@ export class Model {
   static afterCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
@@ -764,7 +764,7 @@ export class Model {
   static afterSaveCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this.afterCommit(fn, { ...conditions, on: ["create", "update"] });
   }
@@ -772,7 +772,7 @@ export class Model {
   static afterCreateCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this.afterCommit(fn, { ...conditions, on: "create" });
   }
@@ -780,7 +780,7 @@ export class Model {
   static afterUpdateCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this.afterCommit(fn, { ...conditions, on: "update" });
   }
@@ -788,7 +788,7 @@ export class Model {
   static afterDestroyCommit<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this.afterCommit(fn, { ...conditions, on: "destroy" });
   }
@@ -796,7 +796,7 @@ export class Model {
   static afterRollback<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
@@ -813,7 +813,7 @@ export class Model {
   static afterInitialize<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this._ensureOwnCallbacks();
     this._callbackChain.register(
@@ -827,7 +827,7 @@ export class Model {
   static afterFind<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "find", fn as CallbackFn | CallbackObject, conditions);
@@ -836,7 +836,7 @@ export class Model {
   static afterTouch<T extends typeof Model>(
     this: T,
     fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
-    conditions?: CallbackConditions,
+    conditions?: CallbackConditions<InstanceType<T>>,
   ): void {
     this._ensureOwnCallbacks();
     this._callbackChain.register("after", "touch", fn as CallbackFn | CallbackObject, conditions);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -568,145 +568,278 @@ export class Model {
 
   // -- Callbacks (Phase 1200) --
 
-  static beforeValidation(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static beforeValidation<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "validation", fn, conditions);
+    this._callbackChain.register(
+      "before",
+      "validation",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
-  static afterValidation(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterValidation<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "validation", fn, conditions);
+    this._callbackChain.register(
+      "after",
+      "validation",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
-  static beforeSave(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "save", fn, conditions);
-  }
-
-  static afterSave(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "save", fn, conditions);
-  }
-
-  static beforeCreate(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "create", fn, conditions);
-  }
-
-  static afterCreate(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "create", fn, conditions);
-  }
-
-  static beforeUpdate(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "update", fn, conditions);
-  }
-
-  static afterUpdate(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "update", fn, conditions);
-  }
-
-  static beforeDestroy(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("before", "destroy", fn, conditions);
-  }
-
-  static afterDestroy(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "destroy", fn, conditions);
-  }
-
-  static aroundSave(fn: AroundCallbackFn | CallbackObject, conditions?: CallbackConditions): void {
-    _rejectOnOption(conditions);
-    this._ensureOwnCallbacks();
-    this._callbackChain.register("around", "save", fn, conditions);
-  }
-
-  static aroundCreate(
-    fn: AroundCallbackFn | CallbackObject,
+  static beforeSave<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
-    this._callbackChain.register("around", "create", fn, conditions);
+    this._callbackChain.register("before", "save", fn as CallbackFn | CallbackObject, conditions);
   }
 
-  static aroundUpdate(
-    fn: AroundCallbackFn | CallbackObject,
+  static afterSave<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
-    this._callbackChain.register("around", "update", fn, conditions);
+    this._callbackChain.register("after", "save", fn as CallbackFn | CallbackObject, conditions);
   }
 
-  static aroundDestroy(
-    fn: AroundCallbackFn | CallbackObject,
+  static beforeCreate<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
     _rejectOnOption(conditions);
     this._ensureOwnCallbacks();
-    this._callbackChain.register("around", "destroy", fn, conditions);
+    this._callbackChain.register("before", "create", fn as CallbackFn | CallbackObject, conditions);
   }
 
-  static afterCommit(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterCreate<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("after", "create", fn as CallbackFn | CallbackObject, conditions);
+  }
+
+  static beforeUpdate<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("before", "update", fn as CallbackFn | CallbackObject, conditions);
+  }
+
+  static afterUpdate<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("after", "update", fn as CallbackFn | CallbackObject, conditions);
+  }
+
+  static beforeDestroy<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "before",
+      "destroy",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
+  }
+
+  static afterDestroy<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register("after", "destroy", fn as CallbackFn | CallbackObject, conditions);
+  }
+
+  static aroundSave<T extends typeof Model>(
+    this: T,
+    fn:
+      | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
+      | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "around",
+      "save",
+      fn as AroundCallbackFn | CallbackObject,
+      conditions,
+    );
+  }
+
+  static aroundCreate<T extends typeof Model>(
+    this: T,
+    fn:
+      | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
+      | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "around",
+      "create",
+      fn as AroundCallbackFn | CallbackObject,
+      conditions,
+    );
+  }
+
+  static aroundUpdate<T extends typeof Model>(
+    this: T,
+    fn:
+      | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
+      | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "around",
+      "update",
+      fn as AroundCallbackFn | CallbackObject,
+      conditions,
+    );
+  }
+
+  static aroundDestroy<T extends typeof Model>(
+    this: T,
+    fn:
+      | ((record: InstanceType<T>, proceed: () => void | Promise<void>) => void | Promise<void>)
+      | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
+    _rejectOnOption(conditions);
+    this._ensureOwnCallbacks();
+    this._callbackChain.register(
+      "around",
+      "destroy",
+      fn as AroundCallbackFn | CallbackObject,
+      conditions,
+    );
+  }
+
+  static afterCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "commit", fn, conditions);
+    this._callbackChain.register("after", "commit", fn as CallbackFn | CallbackObject, conditions);
   }
 
-  static afterSaveCommit(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterSaveCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this.afterCommit(fn, { ...conditions, on: ["create", "update"] });
   }
 
-  static afterCreateCommit(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterCreateCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this.afterCommit(fn, { ...conditions, on: "create" });
   }
 
-  static afterUpdateCommit(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterUpdateCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this.afterCommit(fn, { ...conditions, on: "update" });
   }
 
-  static afterDestroyCommit(
-    fn: CallbackFn | CallbackObject,
+  static afterDestroyCommit<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
     conditions?: CallbackConditions,
   ): void {
     this.afterCommit(fn, { ...conditions, on: "destroy" });
   }
 
-  static afterRollback(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterRollback<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     if (conditions?.on !== undefined) {
       _validateOnCondition(conditions.on);
     }
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "rollback", fn, conditions);
+    this._callbackChain.register(
+      "after",
+      "rollback",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
-  static afterInitialize(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterInitialize<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "initialize", fn, conditions);
+    this._callbackChain.register(
+      "after",
+      "initialize",
+      fn as CallbackFn | CallbackObject,
+      conditions,
+    );
   }
 
-  static afterFind(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterFind<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "find", fn, conditions);
+    this._callbackChain.register("after", "find", fn as CallbackFn | CallbackObject, conditions);
   }
 
-  static afterTouch(fn: CallbackFn | CallbackObject, conditions?: CallbackConditions): void {
+  static afterTouch<T extends typeof Model>(
+    this: T,
+    fn: ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>) | CallbackObject,
+    conditions?: CallbackConditions,
+  ): void {
     this._ensureOwnCallbacks();
-    this._callbackChain.register("after", "touch", fn, conditions);
+    this._callbackChain.register("after", "touch", fn as CallbackFn | CallbackObject, conditions);
   }
 
   private static _ensureOwnCallbacks(): void {

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -165,6 +165,19 @@ describe("basic CRUD DX — defining and using a model", () => {
         this.afterCommit((record) => {
           expectTypeOf(record).toEqualTypeOf<WithHooks>();
         });
+        // Conditions' `if` / `unless` predicates are typed too.
+        this.beforeSave(
+          (record) => {
+            expectTypeOf(record).toEqualTypeOf<WithHooks>();
+          },
+          {
+            if: (record) => {
+              expectTypeOf(record).toEqualTypeOf<WithHooks>();
+              return record.name.length > 0;
+            },
+            unless: (record) => record.name === "skip",
+          },
+        );
       }
     }
     assertType(WithHooks);

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -142,6 +142,34 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(await User.asyncFindBySql("SELECT * FROM users")).toEqualTypeOf<User[]>();
   });
 
+  it("lifecycle callbacks: `record` is typed as the concrete subclass", () => {
+    class WithHooks extends Base {
+      declare name: string;
+      static {
+        this.attribute("name", "string");
+        this.beforeSave((record) => {
+          expectTypeOf(record).toEqualTypeOf<WithHooks>();
+          expectTypeOf(record.name).toBeString();
+        });
+        this.afterCreate((record) => {
+          expectTypeOf(record).toEqualTypeOf<WithHooks>();
+        });
+        this.beforeValidation((record) => {
+          expectTypeOf(record).toEqualTypeOf<WithHooks>();
+        });
+        this.aroundSave((record, proceed) => {
+          expectTypeOf(record).toEqualTypeOf<WithHooks>();
+          expectTypeOf(proceed).toBeFunction();
+          return proceed();
+        });
+        this.afterCommit((record) => {
+          expectTypeOf(record).toEqualTypeOf<WithHooks>();
+        });
+      }
+    }
+    assertType(WithHooks);
+  });
+
   it("serialization methods expose a JSON-ish shape", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
     expectTypeOf(u.toJson()).toBeString();

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -8,13 +8,17 @@
  * Mirrors: ActiveRecord::Callbacks
  */
 
-export type CallbackOptions = {
-  if?: (record: any) => boolean;
-  unless?: (record: any) => boolean;
+import type { Base } from "./base.js";
+
+type ModelCtor = typeof Base;
+
+export type CallbackOptions<TRecord = Base> = {
+  if?: (record: TRecord) => boolean;
+  unless?: (record: TRecord) => boolean;
   prepend?: boolean;
 };
 
-export type ValidationCallbackOptions = CallbackOptions & {
+export type ValidationCallbackOptions<TRecord = Base> = CallbackOptions<TRecord> & {
   on?: "create" | "update" | Array<"create" | "update">;
 };
 
@@ -23,10 +27,10 @@ export type ValidationCallbackOptions = CallbackOptions & {
  *
  * Mirrors: ActiveRecord::Callbacks.before_validation
  */
-export function beforeValidation(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: ValidationCallbackOptions,
+export function beforeValidation<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: ValidationCallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "validation", fn, options);
 }
@@ -36,10 +40,10 @@ export function beforeValidation(
  *
  * Mirrors: ActiveRecord::Callbacks.after_validation
  */
-export function afterValidation(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: ValidationCallbackOptions,
+export function afterValidation<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: ValidationCallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "validation", fn, options);
 }
@@ -49,10 +53,10 @@ export function afterValidation(
  *
  * Mirrors: ActiveRecord::Callbacks.before_save
  */
-export function beforeSave(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void> | false,
-  options?: CallbackOptions,
+export function beforeSave<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "save", fn, options);
 }
@@ -62,10 +66,10 @@ export function beforeSave(
  *
  * Mirrors: ActiveRecord::Callbacks.after_save
  */
-export function afterSave(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: CallbackOptions,
+export function afterSave<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "save", fn, options);
 }
@@ -75,10 +79,10 @@ export function afterSave(
  *
  * Mirrors: ActiveRecord::Callbacks.before_create
  */
-export function beforeCreate(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void> | false,
-  options?: CallbackOptions,
+export function beforeCreate<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "create", fn, options);
 }
@@ -88,10 +92,10 @@ export function beforeCreate(
  *
  * Mirrors: ActiveRecord::Callbacks.after_create
  */
-export function afterCreate(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: CallbackOptions,
+export function afterCreate<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "create", fn, options);
 }
@@ -101,10 +105,10 @@ export function afterCreate(
  *
  * Mirrors: ActiveRecord::Callbacks.before_update
  */
-export function beforeUpdate(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void> | false,
-  options?: CallbackOptions,
+export function beforeUpdate<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "update", fn, options);
 }
@@ -114,10 +118,10 @@ export function beforeUpdate(
  *
  * Mirrors: ActiveRecord::Callbacks.after_update
  */
-export function afterUpdate(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: CallbackOptions,
+export function afterUpdate<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "update", fn, options);
 }
@@ -127,10 +131,10 @@ export function afterUpdate(
  *
  * Mirrors: ActiveRecord::Callbacks.before_destroy
  */
-export function beforeDestroy(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void> | false,
-  options?: CallbackOptions,
+export function beforeDestroy<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "destroy", fn, options);
 }
@@ -140,33 +144,46 @@ export function beforeDestroy(
  *
  * Mirrors: ActiveRecord::Callbacks.after_destroy
  */
-export function afterDestroy(
-  modelClass: any,
-  fn: (record: any) => void | Promise<void>,
-  options?: CallbackOptions,
+export function afterDestroy<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
+  options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "destroy", fn, options);
 }
 
+type AnyCallbackOptions = CallbackOptions<never> | ValidationCallbackOptions<never>;
+
 function registerCallback(
-  modelClass: any,
+  modelClass: ModelCtor,
   timing: "before" | "after",
   event: string,
   fn: Function,
-  options?: CallbackOptions | ValidationCallbackOptions,
+  options?: AnyCallbackOptions,
 ): void {
-  if (!modelClass._callbackChain) return;
+  const klass = modelClass as unknown as {
+    _callbackChain?: {
+      clone(): unknown;
+      register(
+        timing: "before" | "after",
+        event: string,
+        fn: Function,
+        conditions: Record<string, unknown>,
+      ): void;
+    };
+  };
+  if (!klass._callbackChain) return;
   // Clone the chain if it's inherited from a parent, so we don't
   // register callbacks on sibling subclasses
   if (!Object.prototype.hasOwnProperty.call(modelClass, "_callbackChain")) {
-    modelClass._callbackChain = modelClass._callbackChain.clone();
+    klass._callbackChain = klass._callbackChain.clone() as typeof klass._callbackChain;
   }
   const conditions: Record<string, unknown> = {};
   if (options?.if) conditions.if = options.if;
   if (options?.unless) conditions.unless = options.unless;
   if (options?.prepend) conditions.prepend = options.prepend;
   if (event === "validation" && "on" in (options ?? {})) {
-    conditions.on = (options as ValidationCallbackOptions).on;
+    conditions.on = (options as ValidationCallbackOptions<never>).on;
   }
-  modelClass._callbackChain.register(timing, event, fn, conditions);
+  klass._callbackChain!.register(timing, event, fn, conditions);
 }


### PR DESCRIPTION
## Summary
Every `static beforeX / afterX / aroundX / afterXCommit / afterRollback / afterInitialize / afterFind / afterTouch` method on `Model` now uses polymorphic `this` so the `record` parameter is typed as the concrete subclass instead of `any`.

```ts
class Post extends Base {
  declare title: string;
  static {
    this.attribute("title", "string");
    this.beforeSave((record) => {
      // Before: record: any
      // After:  record: Post
      record.title = record.title.trim();
    });
    this.aroundSave((record, proceed) => {
      // record: Post, proceed: () => void | Promise<void>
      return proceed();
    });
  }
}
```

### Surface covered (15 callbacks)
`beforeValidation`, `afterValidation`, `beforeSave`, `afterSave`, `beforeCreate`, `afterCreate`, `beforeUpdate`, `afterUpdate`, `beforeDestroy`, `afterDestroy`, `aroundSave`, `aroundCreate`, `aroundUpdate`, `aroundDestroy`, `afterCommit`, `afterSaveCommit`, `afterCreateCommit`, `afterUpdateCommit`, `afterDestroyCommit`, `afterRollback`, `afterInitialize`, `afterFind`, `afterTouch`.

### No runtime change
`fn` is cast back to the erased `CallbackFn` / `AroundCallbackFn` shape before passing to `_callbackChain.register`, so existing callbacks passed as method-name strings or `CallbackObject`s keep working. 17052 runtime tests pass.

### Relation<T> audit
While in the area, audited `Relation.ts` for remaining `any` returns. The only hits were intentional/internal — variadic overload impls (`select(...args: any[])`, `mergeBang(other: any)`, `_buildProjections`). No changes there.

### dx-tests
Added a `WithHooks` scenario covering `beforeSave`, `afterCreate`, `beforeValidation`, `aroundSave`, `afterCommit` (62/62 DX types pass).

## Test plan
- [x] `pnpm build` / `pnpm typecheck` green
- [x] `pnpm test` green (17052 runtime tests)
- [x] `pnpm test:types` green (62/62)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green