### PR TITLE
feat(activerecord): type scope / defaultScope fn param as Relation<Self>

### DIFF
--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -67,6 +67,33 @@ describe("query chaining DX", () => {
     expectTypeOf(rows).toEqualTypeOf<Post[]>();
   });
 
+  it("this.scope(fn) infers `rel` as Relation<Self>; defaultScope same", () => {
+    class Article extends Base {
+      declare published: boolean;
+      declare static published: () => Relation<Article>;
+      declare static recent: (days: number) => Relation<Article>;
+
+      static {
+        this.attribute("published", "boolean");
+        // No manual `rel: Relation<Article>` annotation needed.
+        this.scope("published", (rel) => {
+          expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();
+          return rel.where({ published: true });
+        });
+        this.scope("recent", (rel, days: number) => {
+          expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();
+          expectTypeOf(days).toBeNumber();
+          return rel;
+        });
+        this.defaultScope((rel) => {
+          expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();
+          return rel.where({ published: true });
+        });
+      }
+    }
+    assertType(Article);
+  });
+
   it("Post.all() / Post.from(...) / Post.whereNot(...) preserve the generic", () => {
     expectTypeOf(Post.all()).toMatchTypeOf<Relation<Post>>();
     expectTypeOf(Post.from("posts")).toMatchTypeOf<Relation<Post>>();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -948,8 +948,11 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.default_scope
    */
-  static defaultScope(fn: (rel: any) => any): void {
-    this._defaultScope = fn;
+  static defaultScope<T extends typeof Base>(
+    this: T,
+    fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  ): void {
+    this._defaultScope = fn as (rel: any) => any;
   }
 
   /**

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -1,4 +1,5 @@
 import type { Base } from "../base.js";
+import type { Relation } from "../relation.js";
 
 /**
  * Named scope handling — defines named scopes on model classes
@@ -12,10 +13,10 @@ import type { Base } from "../base.js";
  *
  * Mirrors: ActiveRecord::Scoping::Named::ClassMethods#scope
  */
-export function scope(
-  this: typeof Base,
+export function scope<T extends typeof Base>(
+  this: T,
   name: string,
-  fn: (rel: any, ...args: any[]) => any,
+  fn: (rel: Relation<InstanceType<T>>, ...args: any[]) => Relation<any>,
   extension?: Record<string, Function>,
 ): void {
   const modelClass = this as any;

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -296,7 +296,7 @@ class Post extends Base {
     // `this`, no not* scopes).
     defineEnum(this, "status", { draft: 0, published: 1 });
     // Named scope — use a name that doesn't collide with an enum value above.
-    this.scope("featured", (rel: Relation<Post>) => rel.where({ featured: true }));
+    this.scope("featured", (rel) => rel.where({ featured: true }));
   }
 }
 ```

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -49,11 +49,11 @@ class Post extends Base {
 
     Post.validates("title", { presence: true, length: { minimum: 3 } });
 
-    Post.beforeSave((record: Post) => {
+    Post.beforeSave((record) => {
       record.title = record.title.trim();
     });
 
-    Post.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
+    Post.scope("published", (rel) => rel.where({ published: true }));
   }
 }
 


### PR DESCRIPTION
## Summary
`this.scope("published", (rel) => rel.where({ published: true }))` previously had `rel: any`, forcing users to hand-annotate `(rel: Relation<Post>) => ...` or write `(rel as any)` to get autocomplete.

Both scope entry points now use polymorphic `this`:

- `scope<T extends typeof Base>(this: T, name, fn: (rel: Relation<InstanceType<T>>, ...args) => Relation<any>)` — scope body's `rel` is inferred from the calling class.
- `static defaultScope<T extends typeof Base>(this: T, fn: (rel: Relation<InstanceType<T>>) => Relation<any>)` — same for `default_scope`.

### Before
```ts
class Post extends Base {
  static {
    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
    //                       ^^^^^^^^^^^^^^^^^^^^ required
  }
}
```

### After
```ts
class Post extends Base {
  static {
    this.scope("published", (rel) => rel.where({ published: true }));
    //                       ^^^ inferred as Relation<Post>
  }
}
```

### No runtime change
`fn` is still stored as `(rel: any) => any` internally — the Relation-proxy dispatch reaches it via the `_scopes` Map, so narrowing there would need a broader refactor. The typing is at the call site, where it matters.

### dx-tests
Added a scenario in `query-chaining.test-d.ts` covering `this.scope(fn)` with 1-arg and 2-arg forms + `this.defaultScope(fn)`. 63/63 DX types pass (was 62).

## Test plan
- [x] `pnpm build` / `pnpm typecheck` green
- [x] `pnpm test` green (17058 runtime tests)
- [x] `pnpm test:types` green (63/63)
- [x] `pnpm lint` / `pnpm format:check` green
- [ ] CI green