### PR TITLE
feat(activerecord): Phase 5 — db schema:cache:dump / schema:cache:clear

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -885,16 +885,32 @@ export class SQLite3Adapter
     return [...new Set([...(await this.tables()), ...(await this.views())])];
   }
 
+  /**
+   * Resolve the sqlite_master reference for a possibly-schema-qualified
+   * name. SQLite stores each attached DB's schema in its own
+   * `<schema>.sqlite_master`; `aux.widgets` is row `name='widgets'` in
+   * `aux.sqlite_master`, never `name='aux.widgets'` in the main catalog.
+   */
+  private _sqliteMasterFor(name: string): { sqliteMaster: string; bare: string } {
+    const { schema, bare } = this._splitTableName(name);
+    return {
+      sqliteMaster: schema ? `${quoteColumnName(schema)}.sqlite_master` : "sqlite_master",
+      bare,
+    };
+  }
+
   async tableExists(name: string): Promise<boolean> {
+    const { sqliteMaster, bare } = this._sqliteMasterFor(name);
     const rows = (await this.execute(
-      `SELECT 1 AS one FROM sqlite_master WHERE type='table' AND name=${quoteString(name)}`,
+      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name=${quoteString(bare)}`,
     )) as Array<{ one: number }>;
     return rows.length > 0;
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
+    const { sqliteMaster, bare } = this._sqliteMasterFor(name);
     const rows = (await this.execute(
-      `SELECT 1 AS one FROM sqlite_master WHERE type IN ('table','view') AND name=${quoteString(name)}`,
+      `SELECT 1 AS one FROM ${sqliteMaster} WHERE type IN ('table','view') AND name=${quoteString(bare)}`,
     )) as Array<{ one: number }>;
     return rows.length > 0;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -36,6 +36,8 @@ import {
   CheckConstraintDefinition,
   type AddForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
+import { Column } from "./column.js";
+import { SqlTypeMetadata } from "./sql-type-metadata.js";
 
 /**
  * SQLite adapter — connects ActiveRecord to a real SQLite database.
@@ -854,6 +856,115 @@ export class SQLite3Adapter
     // SqlLiteral or objects with toSql
     if (typeof (value as any)?.toSql === "function") return String((value as any).toSql());
     return quoteString(String(value));
+  }
+
+  // --- Schema introspection (drives SchemaCache.addAll) ---
+
+  /**
+   * List user tables. Excludes SQLite's internal `sqlite_*` tables and
+   * matches Rails' SQLite3::SchemaStatements#tables filter.
+   */
+  async tables(): Promise<string[]> {
+    const rows = (await this.execute(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )) as Array<{ name: string }>;
+    return rows.map((r) => r.name);
+  }
+
+  async views(): Promise<string[]> {
+    const rows = (await this.execute(
+      "SELECT name FROM sqlite_master WHERE type='view' ORDER BY name",
+    )) as Array<{ name: string }>;
+    return rows.map((r) => r.name);
+  }
+
+  /**
+   * Tables + views, deduped. Mirrors AbstractAdapter#data_sources.
+   */
+  async dataSources(): Promise<string[]> {
+    return [...new Set([...(await this.tables()), ...(await this.views())])];
+  }
+
+  async tableExists(name: string): Promise<boolean> {
+    const rows = (await this.execute(
+      `SELECT 1 AS one FROM sqlite_master WHERE type='table' AND name=${quoteString(name)}`,
+    )) as Array<{ one: number }>;
+    return rows.length > 0;
+  }
+
+  async dataSourceExists(name: string): Promise<boolean> {
+    const rows = (await this.execute(
+      `SELECT 1 AS one FROM sqlite_master WHERE type IN ('table','view') AND name=${quoteString(name)}`,
+    )) as Array<{ one: number }>;
+    return rows.length > 0;
+  }
+
+  /**
+   * Return the single-column primary key name, or null for composite /
+   * rowid-only tables. Rails' SchemaCache stores the composite case as
+   * an array, but the common path for cache-dump is a scalar name.
+   */
+  async primaryKey(tableName: string): Promise<string | null> {
+    const rows = (await this.execute(`PRAGMA table_info(${quoteTableName(tableName)})`)) as Array<{
+      name: string;
+      pk: number;
+    }>;
+    const pks = rows.filter((r) => r.pk > 0).sort((a, b) => a.pk - b.pk);
+    if (pks.length === 1) return pks[0].name;
+    return null;
+  }
+
+  /**
+   * Return Column objects for the named table. Only the fields the
+   * schema cache actually serializes are populated — name, default,
+   * null, sqlTypeMetadata, primaryKey.
+   */
+  async columns(tableName: string): Promise<Column[]> {
+    const rows = (await this.execute(`PRAGMA table_info(${quoteTableName(tableName)})`)) as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+      pk: number;
+    }>;
+    return rows.map((r) => {
+      const sqlType = r.type || "";
+      const meta = new SqlTypeMetadata({
+        sqlType,
+        type: sqlType.toLowerCase(),
+        limit: null,
+        precision: null,
+        scale: null,
+      });
+      return new Column(r.name, r.dflt_value, meta, r.notnull === 0, {
+        primaryKey: r.pk > 0,
+      });
+    });
+  }
+
+  async indexes(tableName: string): Promise<unknown[]> {
+    const rows = (await this.execute(`PRAGMA index_list(${quoteTableName(tableName)})`)) as Array<{
+      name: string;
+      unique: number;
+      origin: string;
+    }>;
+    // Skip auto-indexes that SQLite generates for PRIMARY KEY / UNIQUE
+    // constraints — Rails' schema cache records user-defined indexes
+    // only, and the auto ones are redundant with the CREATE TABLE sql.
+    const userIndexes = rows.filter((r) => r.origin === "c");
+    const result: Array<{ name: string; columns: string[]; unique: boolean }> = [];
+    for (const idx of userIndexes) {
+      const cols = (await this.execute(`PRAGMA index_info(${quoteTableName(idx.name)})`)) as Array<{
+        name: string;
+        seqno: number;
+      }>;
+      result.push({
+        name: idx.name,
+        columns: cols.sort((a, b) => a.seqno - b.seqno).map((c) => c.name),
+        unique: idx.unique === 1,
+      });
+    }
+    return result;
   }
 
   // --- FK / Check constraint operations (SQLite requires table rebuild) ---

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -903,12 +903,18 @@ export class SQLite3Adapter
    * Return the single-column primary key name, or null for composite /
    * rowid-only tables. Rails' SchemaCache stores the composite case as
    * an array, but the common path for cache-dump is a scalar name.
+   *
+   * Uses the `PRAGMA schema.table_info(table)` form for schema-qualified
+   * names (e.g. `temp.widgets`). The `PRAGMA table_info("schema"."table")`
+   * form does NOT work — SQLite treats the whole quoted string as a
+   * single table name and returns no rows.
    */
   async primaryKey(tableName: string): Promise<string | null> {
-    const rows = (await this.execute(`PRAGMA table_info(${quoteTableName(tableName)})`)) as Array<{
-      name: string;
-      pk: number;
-    }>;
+    const { schema, bare } = this._splitTableName(tableName);
+    const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
+    const rows = (await this.execute(
+      `PRAGMA ${pragmaPrefix}table_info(${quoteColumnName(bare)})`,
+    )) as Array<{ name: string; pk: number }>;
     const pks = rows.filter((r) => r.pk > 0).sort((a, b) => a.pk - b.pk);
     if (pks.length === 1) return pks[0].name;
     return null;
@@ -920,7 +926,11 @@ export class SQLite3Adapter
    * null, sqlTypeMetadata, primaryKey.
    */
   async columns(tableName: string): Promise<Column[]> {
-    const rows = (await this.execute(`PRAGMA table_info(${quoteTableName(tableName)})`)) as Array<{
+    const { schema, bare } = this._splitTableName(tableName);
+    const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
+    const rows = (await this.execute(
+      `PRAGMA ${pragmaPrefix}table_info(${quoteColumnName(bare)})`,
+    )) as Array<{
       name: string;
       type: string;
       notnull: number;
@@ -943,21 +953,22 @@ export class SQLite3Adapter
   }
 
   async indexes(tableName: string): Promise<unknown[]> {
-    const rows = (await this.execute(`PRAGMA index_list(${quoteTableName(tableName)})`)) as Array<{
-      name: string;
-      unique: number;
-      origin: string;
-    }>;
+    const { schema, bare } = this._splitTableName(tableName);
+    const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
+    const rows = (await this.execute(
+      `PRAGMA ${pragmaPrefix}index_list(${quoteColumnName(bare)})`,
+    )) as Array<{ name: string; unique: number; origin: string }>;
     // Skip auto-indexes that SQLite generates for PRIMARY KEY / UNIQUE
     // constraints — Rails' schema cache records user-defined indexes
     // only, and the auto ones are redundant with the CREATE TABLE sql.
     const userIndexes = rows.filter((r) => r.origin === "c");
     const result: Array<{ name: string; columns: string[]; unique: boolean }> = [];
     for (const idx of userIndexes) {
-      const cols = (await this.execute(`PRAGMA index_info(${quoteTableName(idx.name)})`)) as Array<{
-        name: string;
-        seqno: number;
-      }>;
+      // index_info takes the bare index name; the schema qualifier, if
+      // any, comes before the PRAGMA keyword — same shape as above.
+      const cols = (await this.execute(
+        `PRAGMA ${pragmaPrefix}index_info(${quoteColumnName(idx.name)})`,
+      )) as Array<{ name: string; seqno: number }>;
       result.push({
         name: idx.name,
         columns: cols.sort((a, b) => a.seqno - b.seqno).map((c) => c.name),

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+describe("SQLite3Adapter schema introspection", () => {
+  let adapter: SQLite3Adapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sqlite-introspect-"));
+    adapter = new SQLite3Adapter(path.join(tmpDir, "db.sqlite3"));
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("tables returns user-created tables, hiding sqlite_* internals", async () => {
+    await adapter.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
+    expect(await adapter.tables()).toEqual(["widgets"]);
+  });
+
+  it("primaryKey returns the single-column pk name", async () => {
+    await adapter.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)");
+    expect(await adapter.primaryKey("widgets")).toBe("id");
+  });
+
+  it("primaryKey returns null for composite primary keys", async () => {
+    await adapter.executeMutation(
+      "CREATE TABLE memberships (user_id INTEGER, group_id INTEGER, PRIMARY KEY (user_id, group_id))",
+    );
+    expect(await adapter.primaryKey("memberships")).toBeNull();
+  });
+
+  it("columns returns Column metadata keyed by name", async () => {
+    await adapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, weight REAL)",
+    );
+    const cols = await adapter.columns("widgets");
+    const names = cols.map((c) => c.name);
+    expect(names).toEqual(["id", "name", "weight"]);
+    const name = cols.find((c) => c.name === "name");
+    expect(name?.null).toBe(false);
+    expect(name?.sqlType).toBe("TEXT");
+    const id = cols.find((c) => c.name === "id");
+    expect(id?.primaryKey).toBe(true);
+  });
+
+  it("indexes returns user-created indexes and skips auto-indexes", async () => {
+    await adapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, email TEXT UNIQUE, owner TEXT)",
+    );
+    await adapter.executeMutation("CREATE INDEX widgets_on_owner ON widgets (owner)");
+    const indexes = (await adapter.indexes("widgets")) as Array<{
+      name: string;
+      columns: string[];
+      unique: boolean;
+    }>;
+    // Only the explicitly-created index should surface; the auto-index for
+    // UNIQUE(email) and the primary-key rowid mapping are filtered out.
+    expect(indexes).toEqual([{ name: "widgets_on_owner", columns: ["owner"], unique: false }]);
+  });
+
+  it("introspection PRAGMAs work against schema-qualified names", async () => {
+    // Attach a separate sqlite file under the `aux` alias. PRAGMAs that
+    // accept a schema prefix must use the `PRAGMA aux.table_info(widgets)`
+    // form; `PRAGMA table_info("aux"."widgets")` returns zero rows
+    // because SQLite treats the whole quoted argument as a bare table
+    // name. This test guards against that regression — which is what
+    // Copilot flagged on #527.
+    const auxPath = path.join(tmpDir, "aux.sqlite3");
+    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
+    await adapter.executeMutation(
+      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    );
+    await adapter.executeMutation("CREATE INDEX aux.widgets_on_name ON widgets (name)");
+
+    expect(await adapter.primaryKey("aux.widgets")).toBe("id");
+    const cols = await adapter.columns("aux.widgets");
+    expect(cols.map((c) => c.name)).toEqual(["id", "name"]);
+    const indexes = (await adapter.indexes("aux.widgets")) as Array<{
+      name: string;
+      columns: string[];
+    }>;
+    expect(indexes).toEqual([{ name: "widgets_on_name", columns: ["name"], unique: false }]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -87,4 +87,20 @@ describe("SQLite3Adapter schema introspection", () => {
     }>;
     expect(indexes).toEqual([{ name: "widgets_on_name", columns: ["name"], unique: false }]);
   });
+
+  it("tableExists/dataSourceExists resolve schema-qualified names correctly", async () => {
+    // Companion to the PRAGMA test: sqlite_master lookups must route to
+    // `<schema>.sqlite_master` for ATTACHed DBs. Matching on
+    // `name='aux.widgets'` in the main catalog would return false even
+    // though the table does exist in aux.
+    const auxPath = path.join(tmpDir, "aux2.sqlite3");
+    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
+    await adapter.executeMutation("CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY)");
+    await adapter.executeMutation("CREATE VIEW aux.widget_view AS SELECT id FROM aux.widgets");
+
+    expect(await adapter.tableExists("aux.widgets")).toBe(true);
+    expect(await adapter.dataSourceExists("aux.widgets")).toBe(true);
+    expect(await adapter.dataSourceExists("aux.widget_view")).toBe(true);
+    expect(await adapter.tableExists("aux.missing")).toBe(false);
+  });
 });

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -68,7 +68,10 @@ export class HashConfig extends DatabaseConfig {
    * Mirrors: HashConfig#default_schema_cache_path
    */
   defaultSchemaCachePath(dbDir: string = "db"): string {
-    const file = this.isPrimary() ? "schema_cache.yml" : `${this.name}_schema_cache.yml`;
+    // Rails writes YAML; trails writes JSON (no Ruby Marshal/YAML in TS), so
+    // the on-disk extension is .json to match what DatabaseTasks.dumpSchemaCache
+    // actually produces.
+    const file = this.isPrimary() ? "schema_cache.json" : `${this.name}_schema_cache.json`;
     return `${dbDir}/${file}`;
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -956,6 +956,60 @@ describe("DatabaseTasks schema cache", () => {
     }
   });
 
+  it("dumpSchemaCache validates through withConnection when given a pool", async () => {
+    // Pool-shaped: methods live on the connection yielded by
+    // `withConnection`, not on the pool itself. Validation must go
+    // through the same pool.withConnection that SchemaCache.addAll uses,
+    // otherwise pools would incorrectly report missing methods.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    const connection = {
+      dataSources: async () => ["widgets"],
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => [{ name: "id", default: null, null: false, primaryKey: true }],
+      indexes: async () => [],
+      schemaVersion: async () => null,
+    };
+    const pool = {
+      async withConnection<T>(cb: (c: unknown) => T | Promise<T>): Promise<T> {
+        return await cb(connection);
+      },
+    };
+    try {
+      await DatabaseTasks.dumpSchemaCache(pool, filename);
+      const parsed = JSON.parse(fs.readFileSync(filename, "utf8"));
+      expect(Object.keys(parsed.columns)).toEqual(["widgets"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("dumpSchemaCache delegates to a reflection-shaped schemaCache.dumpTo", async () => {
+    // Rails path: `conn_or_pool.schema_cache.dump_to(filename)` on a pool
+    // whose schema_cache is a BoundSchemaReflection. We detect the
+    // reflection by its `dumpTo` + absence of `addAll` (SchemaCache has
+    // both; reflections only have dumpTo).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    let called = false;
+    const poolWithReflection = {
+      schemaCache: {
+        dumpTo: async (f: string) => {
+          called = true;
+          fs.writeFileSync(f, '{"delegated":true}');
+        },
+      },
+    };
+    try {
+      await DatabaseTasks.dumpSchemaCache(poolWithReflection, filename);
+      expect(called).toBe(true);
+      expect(JSON.parse(fs.readFileSync(filename, "utf8"))).toEqual({ delegated: true });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("clearSchemaCache removes the file when present", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
     const filename = path.join(tmp, "schema_cache.json");

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -914,3 +914,67 @@ describe("DatabaseTasksLoadSchemaTsFormatTest", () => {
     }
   });
 });
+
+describe("DatabaseTasks schema cache", () => {
+  it("dumpSchemaCache writes tables from a freshly introspected adapter", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    const stubAdapter = {
+      dataSources: async () => ["widgets"],
+      tables: async () => ["widgets"],
+      views: async () => [],
+      dataSourceExists: async (name: string) => name === "widgets",
+      primaryKey: async () => "id",
+      columns: async () => [
+        { name: "id", default: null, null: false, primaryKey: true },
+        { name: "name", default: null, null: true, primaryKey: false },
+      ],
+      indexes: async () => [],
+      schemaVersion: async () => "20260101000000",
+    };
+    try {
+      await DatabaseTasks.dumpSchemaCache(stubAdapter, filename);
+      const parsed = JSON.parse(fs.readFileSync(filename, "utf8"));
+      expect(Object.keys(parsed.columns)).toEqual(["widgets"]);
+      expect(parsed.data_sources["widgets"]).toBe(true);
+      expect(parsed.primary_keys["widgets"]).toBe("id");
+      expect(parsed.version).toBe("20260101000000");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("dumpSchemaCache throws when the adapter lacks introspection methods", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    try {
+      await expect(DatabaseTasks.dumpSchemaCache({}, filename)).rejects.toThrow(
+        /dataSources.*columns.*primaryKey.*indexes/,
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("clearSchemaCache removes the file when present", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    fs.writeFileSync(filename, "{}");
+    try {
+      DatabaseTasks.clearSchemaCache(filename);
+      expect(fs.existsSync(filename)).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("clearSchemaCache is a no-op when the file is absent", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));
+    const filename = path.join(tmp, "schema_cache.json");
+    try {
+      expect(() => DatabaseTasks.clearSchemaCache(filename)).not.toThrow();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -491,6 +491,25 @@ export class DatabaseTasks {
    * whatever incidental entries the in-memory cache accumulated.
    */
   static async dumpSchemaCache(connOrPool: unknown, filename: string): Promise<void> {
+    // SchemaCache.addAll calls connection.dataSources() and then, for each
+    // table, connection.columns / primaryKey / indexes. Silently skipping
+    // an adapter that doesn't implement those would produce an empty
+    // schema_cache.json, which is worse than failing loudly — surface the
+    // gap so users pick it up in CI instead of noticing a stale cache in
+    // production. Only SQLite has the full introspection surface today;
+    // PG/MySQL will pick this path up once their adapters expose the
+    // same method set.
+    const required = ["dataSources", "columns", "primaryKey", "indexes"] as const;
+    const missing = required.filter(
+      (m) => typeof (connOrPool as Record<string, unknown>)[m] !== "function",
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `dumpSchemaCache requires the adapter to implement [${missing.join(", ")}]. ` +
+          `The current adapter exposes neither a pool-level schemaCache nor the ` +
+          `direct introspection API needed to populate one.`,
+      );
+    }
     const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
     const fresh = new SchemaCache();
     await fresh.addAll(connOrPool);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -494,10 +494,13 @@ export class DatabaseTasks {
     // Rails: `conn_or_pool.schema_cache.dump_to(filename)`. On a real pool
     // `schema_cache` is a BoundSchemaReflection whose `dump_to` runs
     // `add_all(pool)` + write. Honor that when the caller wires up such a
-    // reflection — delegate straight to it. Adapter.schemaCache (plain
-    // SchemaCache with no bound pool) lacks `addAll`, so skip that path
-    // and let the fresh-cache fallback below do the populate+dump, which
-    // matches what Rails' BoundSchemaReflection.dump_to does internally.
+    // reflection — delegate straight to it. Adapter.schemaCache exposes a
+    // plain SchemaCache with no bound pool (SchemaCache DOES define
+    // `addAll`, but it takes a pool arg that the adapter-level getter
+    // can't supply), so don't treat that as the self-populating
+    // reflection path; let the fresh-cache fallback below drive the
+    // populate+dump, which is what BoundSchemaReflection.dump_to does
+    // internally.
     const reflection = (connOrPool as { schemaCache?: { dumpTo?: unknown; addAll?: unknown } })
       ?.schemaCache;
     if (

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -479,11 +479,22 @@ export class DatabaseTasks {
     return `${this.dbDir}/schema_cache.json`;
   }
 
+  /**
+   * Dump the schema cache to `filename`. Mirrors Rails'
+   * `DatabaseTasks.dump_schema_cache`, which delegates to
+   * `conn_or_pool.schema_cache.dump_to(filename)`. In Rails the pool-side
+   * `schema_cache` is a `BoundSchemaReflection` whose `dump_to` allocates a
+   * fresh `SchemaCache`, `add_all`s every data source through the pool, then
+   * writes it. Our adapter's `schemaCache` getter returns a plain
+   * `SchemaCache`, so replicate the BoundSchemaReflection semantics here:
+   * always dump from a freshly-populated cache instead of serializing
+   * whatever incidental entries the in-memory cache accumulated.
+   */
   static async dumpSchemaCache(connOrPool: unknown, filename: string): Promise<void> {
-    const schemaCache = (connOrPool as any).schemaCache;
-    if (schemaCache && typeof schemaCache.dumpTo === "function") {
-      await schemaCache.dumpTo(filename);
-    }
+    const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
+    const fresh = new SchemaCache();
+    await fresh.addAll(connOrPool);
+    fresh.dumpTo(filename);
   }
 
   static clearSchemaCache(filename: string): void {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -491,25 +491,55 @@ export class DatabaseTasks {
    * whatever incidental entries the in-memory cache accumulated.
    */
   static async dumpSchemaCache(connOrPool: unknown, filename: string): Promise<void> {
-    // SchemaCache.addAll calls connection.dataSources() and then, for each
-    // table, connection.columns / primaryKey / indexes. Silently skipping
-    // an adapter that doesn't implement those would produce an empty
-    // schema_cache.json, which is worse than failing loudly — surface the
-    // gap so users pick it up in CI instead of noticing a stale cache in
-    // production. Only SQLite has the full introspection surface today;
-    // PG/MySQL will pick this path up once their adapters expose the
-    // same method set.
-    const required = ["dataSources", "columns", "primaryKey", "indexes"] as const;
-    const missing = required.filter(
-      (m) => typeof (connOrPool as Record<string, unknown>)[m] !== "function",
-    );
-    if (missing.length > 0) {
-      throw new Error(
-        `dumpSchemaCache requires the adapter to implement [${missing.join(", ")}]. ` +
-          `The current adapter exposes neither a pool-level schemaCache nor the ` +
-          `direct introspection API needed to populate one.`,
-      );
+    // Rails: `conn_or_pool.schema_cache.dump_to(filename)`. On a real pool
+    // `schema_cache` is a BoundSchemaReflection whose `dump_to` runs
+    // `add_all(pool)` + write. Honor that when the caller wires up such a
+    // reflection — delegate straight to it. Adapter.schemaCache (plain
+    // SchemaCache with no bound pool) lacks `addAll`, so skip that path
+    // and let the fresh-cache fallback below do the populate+dump, which
+    // matches what Rails' BoundSchemaReflection.dump_to does internally.
+    const reflection = (connOrPool as { schemaCache?: { dumpTo?: unknown; addAll?: unknown } })
+      ?.schemaCache;
+    if (
+      reflection &&
+      typeof (reflection as { dumpTo?: unknown }).dumpTo === "function" &&
+      typeof (reflection as { addAll?: unknown }).addAll !== "function"
+    ) {
+      // Reflection-shaped (dump_to pulls its own pool): let it self-dump.
+      // We distinguish by the absence of `addAll`, which is the
+      // SchemaCache-specific populate entry point.
+      await (reflection as { dumpTo: (f: string) => Promise<void> | void }).dumpTo(filename);
+      return;
     }
+
+    // Adapter/connection path: SchemaCache.addAll routes through
+    // `pool.withConnection(...)` when present, so the introspection check
+    // has to go through the same lens — otherwise false negatives for
+    // real pools whose methods live on the yielded connection.
+    const required = ["dataSources", "columns", "primaryKey", "indexes"] as const;
+    const assertSupported = (connection: unknown): void => {
+      const missing = required.filter(
+        (m) => typeof (connection as Record<string, unknown>)[m] !== "function",
+      );
+      if (missing.length > 0) {
+        throw new Error(
+          `dumpSchemaCache requires the connection to implement [${missing.join(", ")}]. ` +
+            `The adapter isn't exposing the schema introspection API that ` +
+            `SchemaCache.addAll needs to populate a cache dump.`,
+        );
+      }
+    };
+    const maybePool = connOrPool as {
+      withConnection?: <T>(cb: (connection: unknown) => T | Promise<T>) => Promise<T> | T;
+    };
+    if (typeof maybePool.withConnection === "function") {
+      await maybePool.withConnection((connection: unknown) => {
+        assertSupported(connection);
+      });
+    } else {
+      assertSupported(connOrPool);
+    }
+
     const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
     const fresh = new SchemaCache();
     await fresh.addAll(connOrPool);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -103,6 +103,18 @@ describe("DbCommand", () => {
     const db = program.commands.find((c) => c.name() === "db");
     expect(db?.commands.some((c) => c.name() === "migrate:down")).toBe(true);
   });
+
+  it("has schema:cache:dump subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "schema:cache:dump")).toBe(true);
+  });
+
+  it("has schema:cache:clear subcommand", () => {
+    const program = createProgram();
+    const db = program.commands.find((c) => c.name() === "db");
+    expect(db?.commands.some((c) => c.name() === "schema:cache:clear")).toBe(true);
+  });
 });
 
 describe("resolveEnv", () => {
@@ -1161,5 +1173,54 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     } finally {
       await verify.close();
     }
+  });
+
+  it("db schema:cache:dump writes a populated schema_cache.json", async () => {
+    const dbFile = path.join(tmpDir, "cache.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation(
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+      );
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["schema:cache:dump"]);
+
+    const cachePath = path.join(tmpDir, "db", "schema_cache.json");
+    expect(fs.existsSync(cachePath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as {
+      columns: Record<string, unknown[]>;
+      data_sources: Record<string, boolean>;
+    };
+    expect(Object.keys(parsed.columns)).toContain("widgets");
+    expect(parsed.data_sources["widgets"]).toBe(true);
+  });
+
+  it("db schema:cache:clear deletes the schema_cache.json file", async () => {
+    const cachePath = path.join(tmpDir, "db", "schema_cache.json");
+    fs.writeFileSync(cachePath, "{}");
+    expect(fs.existsSync(cachePath)).toBe(true);
+
+    await runDb(["schema:cache:clear"]);
+
+    expect(fs.existsSync(cachePath)).toBe(false);
+  });
+
+  it("db schema:cache:clear is a no-op when no cache file exists", async () => {
+    const cachePath = path.join(tmpDir, "db", "schema_cache.json");
+    expect(fs.existsSync(cachePath)).toBe(false);
+    await runDb(["schema:cache:clear"]);
+    expect(errs).toHaveLength(0);
   });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1222,6 +1222,9 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     expect(fs.existsSync(cachePath)).toBe(false);
     await runDb(["schema:cache:clear"]);
     expect(errs).toHaveLength(0);
+    // No "Cleared ..." log when nothing was deleted — the command
+    // previously logged unconditionally which falsely implied a deletion.
+    expect(logs.find((l) => l.includes("Cleared schema cache"))).toBeUndefined();
   });
 
   it("db schema:cache:dump captures user-created indexes", async () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1223,4 +1223,36 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     await runDb(["schema:cache:clear"]);
     expect(errs).toHaveLength(0);
   });
+
+  it("db schema:cache:dump captures user-created indexes", async () => {
+    const dbFile = path.join(tmpDir, "idx.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)",
+      );
+      await seed.executeMutation("CREATE UNIQUE INDEX users_on_email ON users (email)");
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["schema:cache:dump"]);
+
+    const cachePath = path.join(tmpDir, "db", "schema_cache.json");
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as {
+      indexes: Record<string, Array<{ name: string; columns: string[]; unique: boolean }>>;
+    };
+    expect(parsed.indexes["users"]).toEqual([
+      { name: "users_on_email", columns: ["email"], unique: true },
+    ]);
+  });
 });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -830,13 +830,14 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:cache:dump")
-    .description("Dump a db/schema_cache.json for every configuration in the current environment")
+    .description("Dump db/schema_cache.json for the primary database configuration")
     .action(async () => {
-      // Rails: `with_temporary_pool_for_each { |pool| dump_schema_cache(pool, filename) }`.
-      // Iterate every config in the env so multi-DB apps get one
-      // schema_cache.json per config. withTemporaryPoolForEach sets the
-      // migration connection for each pass, which is what dumpSchemaCache
-      // reads through.
+      // Rails iterates `with_temporary_pool_for_each { |pool| ... }` across
+      // every config in the env. trailties' loadDatabaseConfig only returns
+      // the primary config today, so `configsFor(envName)` — and therefore
+      // `withTemporaryPoolForEach` — sees exactly that one. The iterator
+      // shape is still Rails-faithful; it'll fan out automatically once the
+      // multi-DB config loader lands.
       const envName = resolveEnv();
       const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
       const primary = toDbConfig(raw, envName);
@@ -853,17 +854,20 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:cache:clear")
-    .description(
-      "Delete the db/schema_cache.json file for every configuration in the current environment",
-    )
+    .description("Delete db/schema_cache.json for the primary database configuration")
     .action(async () => {
       // Rails: `configurations.configs_for(env_name: env).each { |c| clear_schema_cache(cache_dump_filename(c)) }`.
+      // trailties currently loads only the primary config; the loop is
+      // Rails-shaped and ready for multi-DB expansion.
       const envName = resolveEnv();
       const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
       const primary = toDbConfig(raw, envName);
       await withRegisteredConfiguration(primary, async () => {
         for (const config of DatabaseTasks.configsFor(envName)) {
           const filename = DatabaseTasks.cacheDumpFilename(config);
+          // clearSchemaCache is a no-op on ENOENT; don't log "Cleared"
+          // unless we actually removed something.
+          if (!fs.existsSync(filename)) continue;
           DatabaseTasks.clearSchemaCache(filename);
           console.log(`Cleared schema cache at ${filename}`);
         }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -832,35 +832,42 @@ export function dbCommand(): Command {
     .command("schema:cache:dump")
     .description("Dump a db/schema_cache.json for every configuration in the current environment")
     .action(async () => {
-      // Rails iterates configs_for(env_name: env) via with_temporary_pool_for_each
-      // so multi-DB apps get one schema_cache.json per config. Mirror that
-      // shape here — open a fresh adapter per config, derive the dump path
-      // from the config, delegate to DatabaseTasks.dumpSchemaCache.
+      // Rails: `with_temporary_pool_for_each { |pool| dump_schema_cache(pool, filename) }`.
+      // Iterate every config in the env so multi-DB apps get one
+      // schema_cache.json per config. withTemporaryPoolForEach sets the
+      // migration connection for each pass, which is what dumpSchemaCache
+      // reads through.
       const envName = resolveEnv();
       const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
-      const config = toDbConfig(raw, envName);
-      await withRegisteredConfiguration(config, async () => {
-        const adapter = await connectAdapter(raw);
-        try {
+      const primary = toDbConfig(raw, envName);
+      await withRegisteredConfiguration(primary, async () => {
+        await DatabaseTasks.withTemporaryPoolForEach(envName, async (config) => {
+          const adapter = DatabaseTasks.migrationConnection();
+          if (!adapter) return;
           const filename = DatabaseTasks.cacheDumpFilename(config);
           await DatabaseTasks.dumpSchemaCache(adapter, filename);
           console.log(`Schema cache dumped to ${filename}`);
-        } finally {
-          await closeAdapter(adapter);
-        }
+        });
       });
     });
 
   cmd
     .command("schema:cache:clear")
-    .description("Delete the db/schema_cache.json file for the current environment")
+    .description(
+      "Delete the db/schema_cache.json file for every configuration in the current environment",
+    )
     .action(async () => {
+      // Rails: `configurations.configs_for(env_name: env).each { |c| clear_schema_cache(cache_dump_filename(c)) }`.
       const envName = resolveEnv();
       const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
-      const config = toDbConfig(raw, envName);
-      const filename = DatabaseTasks.cacheDumpFilename(config);
-      DatabaseTasks.clearSchemaCache(filename);
-      console.log(`Cleared schema cache at ${filename}`);
+      const primary = toDbConfig(raw, envName);
+      await withRegisteredConfiguration(primary, async () => {
+        for (const config of DatabaseTasks.configsFor(envName)) {
+          const filename = DatabaseTasks.cacheDumpFilename(config);
+          DatabaseTasks.clearSchemaCache(filename);
+          console.log(`Cleared schema cache at ${filename}`);
+        }
+      });
     });
 
   return cmd;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -828,5 +828,40 @@ export function dbCommand(): Command {
       });
     });
 
+  cmd
+    .command("schema:cache:dump")
+    .description("Dump a db/schema_cache.json for every configuration in the current environment")
+    .action(async () => {
+      // Rails iterates configs_for(env_name: env) via with_temporary_pool_for_each
+      // so multi-DB apps get one schema_cache.json per config. Mirror that
+      // shape here — open a fresh adapter per config, derive the dump path
+      // from the config, delegate to DatabaseTasks.dumpSchemaCache.
+      const envName = resolveEnv();
+      const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
+      const config = toDbConfig(raw, envName);
+      await withRegisteredConfiguration(config, async () => {
+        const adapter = await connectAdapter(raw);
+        try {
+          const filename = DatabaseTasks.cacheDumpFilename(config);
+          await DatabaseTasks.dumpSchemaCache(adapter, filename);
+          console.log(`Schema cache dumped to ${filename}`);
+        } finally {
+          await closeAdapter(adapter);
+        }
+      });
+    });
+
+  cmd
+    .command("schema:cache:clear")
+    .description("Delete the db/schema_cache.json file for the current environment")
+    .action(async () => {
+      const envName = resolveEnv();
+      const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
+      const config = toDbConfig(raw, envName);
+      const filename = DatabaseTasks.cacheDumpFilename(config);
+      DatabaseTasks.clearSchemaCache(filename);
+      console.log(`Cleared schema cache at ${filename}`);
+    });
+
   return cmd;
 }


### PR DESCRIPTION
## Summary

Wires Rails' `db:schema:cache:dump` and `db:schema:cache:clear` into the trailties CLI, matching the Rails rake tasks in `activerecord/lib/active_record/railties/databases.rake` (`schema:cache:dump` / `schema:cache:clear`).

- `DatabaseTasks.dumpSchemaCache` now delegates to a freshly-populated `SchemaCache.addAll(pool)` + `dumpTo(filename)`, mirroring Rails `SchemaReflection#dump_to` — the previous impl serialized whatever incidental entries were in the in-memory cache, which in a CLI context is nothing.
- `HashConfig.defaultSchemaCachePath` returns `schema_cache.json` (our on-disk format) rather than Rails' `.yml`. We don't serialize YAML from TS, and `SchemaCache.dumpTo` already writes JSON.
- Adds minimum schema introspection on `SQLite3Adapter` that `SchemaCache.addAll` needs: `tables`, `views`, `dataSources`, `tableExists`, `dataSourceExists`, `primaryKey`, `columns`, `indexes`. Uses `sqlite_master` + `PRAGMA` queries. Previously these lived only on the unwired abstract `SchemaStatements` helper.

## Test plan

- [x] `pnpm test` — full suite, 17063 passing / 4442 skipped
- [x] Command-presence tests for `schema:cache:dump` / `schema:cache:clear`
- [x] Integration: create a sqlite file, run `trails db schema:cache:dump`, assert `db/schema_cache.json` contains the table's columns + data_sources
- [x] Integration: `trails db schema:cache:clear` removes the file; is a no-op when absent