### PR TITLE
chore(phase-0): remove unused experimentalDecorators / emitDecoratorMetadata

### DIFF
--- a/packages/activemodel/tsconfig.json
+++ b/packages/activemodel/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [{ "path": "../arel" }, { "path": "../activesupport" }]

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "composite": false,
     "noEmit": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],

--- a/packages/activerecord/tsconfig.json
+++ b/packages/activerecord/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [{ "path": "../arel" }, { "path": "../activemodel" }]

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -90,8 +90,6 @@ export class AppGenerator extends GeneratorBase {
             skipLibCheck: true,
             outDir: "dist",
             rootDir: "src",
-            experimentalDecorators: true,
-            emitDecoratorMetadata: true,
           },
           include: ["src"],
         },


### PR DESCRIPTION
## Summary

Prep PR for the virtual-source-files plan (#526). Removes the `experimentalDecorators` and `emitDecoratorMetadata` flags everywhere they're set — four surfaces total.

## What's removed

| File | Why it had the flags |
| ---- | -------------------- |
| `packages/activerecord/tsconfig.json` | Abandoned typing experiment |
| `packages/activemodel/tsconfig.json` | Same |
| `packages/activerecord/dx-tests/tsconfig.json` | Inherited from activerecord |
| `packages/trailties/src/generators/app-generator.ts` | Emitted in the tsconfig template for new `trails new` apps — so future generated apps start clean too |

## Why

- Zero legacy decorators (`@Something`) anywhere in the codebase.
- Zero references to `reflect-metadata`.
- Legacy decorators and stage-3 decorators (ECMA standard) are mutually exclusive under TS — leaving these on blocks future decorator work.
- Slightly shrinks emit by dropping decorator helper code.
- Rails parity note: Rails doesn't use TS decorators at all, so this change is purely TS-config hygiene; no Rails API surface is affected.

## Verification
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `packages/trailties/.../app-generator.test.ts` — 7/7 pass (generator output now writes the cleaner tsconfig)
- [x] `packages/activerecord/dx-tests/*.test-d.ts` typecheck mode — 63/63 pass, zero type errors
- [ ] CI

## Test plan
- [ ] CI green