### PR TITLE
feat(activerecord): Phase 1a — virtualize() pure text transform

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig(
       "**/dist/**",
       "packages/website/static/**",
       "packages/website/build/**",
+      "packages/activerecord/src/type-virtualization/fixtures/**",
     ],
   },
   eslint.configs.recommended,

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -35,6 +35,9 @@
     "@blazetrails/arel": "workspace:*",
     "@blazetrails/activemodel": "workspace:*"
   },
+  "peerDependencies": {
+    "typescript": ">=5.0.0"
+  },
   "files": [
     "dist"
   ],

--- a/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
@@ -1,0 +1,13 @@
+export class Post extends Base {
+  declare title: string;
+  declare view_count: number;
+  declare published: boolean;
+  declare published_at: Date;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("view_count", "integer");
+    this.attribute("published", "boolean");
+    this.attribute("published_at", "datetime");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/01-attribute/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/01-attribute/input.ts
@@ -1,0 +1,8 @@
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.attribute("view_count", "integer");
+    this.attribute("published", "boolean");
+    this.attribute("published_at", "datetime");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
@@ -1,0 +1,9 @@
+export class Blog extends Base {
+  declare posts: Post[];
+  declare comments: Comment[];
+
+  static {
+    this.hasMany("posts");
+    this.hasMany("comments");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/02-has-many/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/02-has-many/input.ts
@@ -1,0 +1,6 @@
+export class Blog extends Base {
+  static {
+    this.hasMany("posts");
+    this.hasMany("comments");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/expected.ts
@@ -1,0 +1,7 @@
+export class Post extends Base {
+  declare author: Author | null;
+
+  static {
+    this.belongsTo("author");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/input.ts
@@ -1,0 +1,5 @@
+export class Post extends Base {
+  static {
+    this.belongsTo("author");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/04-has-one/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/04-has-one/expected.ts
@@ -1,0 +1,7 @@
+export class User extends Base {
+  declare profile: Profile | null;
+
+  static {
+    this.hasOne("profile");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/04-has-one/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/04-has-one/input.ts
@@ -1,0 +1,5 @@
+export class User extends Base {
+  static {
+    this.hasOne("profile");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
@@ -1,0 +1,9 @@
+export class Post extends Base {
+  declare static published: () => Relation<Post>;
+  declare static recent: (limit: number) => Relation<Post>;
+
+  static {
+    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("recent", (rel, limit: number) => rel.order("created_at").limit(limit));
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/05-scope/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/05-scope/input.ts
@@ -1,0 +1,6 @@
+export class Post extends Base {
+  static {
+    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("recent", (rel, limit: number) => rel.order("created_at").limit(limit));
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/06-enum/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/06-enum/expected.ts
@@ -1,0 +1,14 @@
+export class Task extends Base {
+  declare status: number;
+  declare isLow: () => boolean;
+  declare lowBang: () => this;
+  declare static low: () => Relation<Task>;
+  declare isHigh: () => boolean;
+  declare highBang: () => this;
+  declare static high: () => Relation<Task>;
+
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/06-enum/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/06-enum/input.ts
@@ -1,0 +1,6 @@
+export class Task extends Base {
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/expected.ts
@@ -1,0 +1,21 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  declare status: number;
+  declare isDraft: () => boolean;
+  declare draft: () => void;
+  declare draftBang: () => Promise<void>;
+  declare static draft: () => Relation<Article>;
+  declare static notDraft: () => Relation<Article>;
+  declare isPublished: () => boolean;
+  declare published: () => void;
+  declare publishedBang: () => Promise<void>;
+  declare static published: () => Relation<Article>;
+  declare static notPublished: () => Relation<Article>;
+
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Article, "status", { draft: 0, published: 1 });

--- a/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/input.ts
@@ -1,0 +1,9 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Article, "status", { draft: 0, published: 1 });

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
@@ -1,0 +1,15 @@
+export class Post extends Base {
+  declare title: string;
+  declare published: boolean;
+  declare author: Author | null;
+  declare comments: Comment[];
+  declare static published: () => Relation<Post>;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+    this.belongsTo("author");
+    this.hasMany("comments");
+    this.scope("published", (rel) => rel.where({ published: true }));
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/input.ts
@@ -1,0 +1,9 @@
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+    this.belongsTo("author");
+    this.hasMany("comments");
+    this.scope("published", (rel) => rel.where({ published: true }));
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/09-skip-marker/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/09-skip-marker/expected.ts
@@ -1,0 +1,6 @@
+/** @trails-typegen skip */
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/09-skip-marker/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/09-skip-marker/input.ts
@@ -1,0 +1,6 @@
+/** @trails-typegen skip */
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/10-existing-declare/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/10-existing-declare/expected.ts
@@ -1,0 +1,10 @@
+export class Post extends Base {
+  declare body: string;
+
+  declare title: string | null;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("body", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/10-existing-declare/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/10-existing-declare/input.ts
@@ -1,0 +1,8 @@
+export class Post extends Base {
+  declare title: string | null;
+
+  static {
+    this.attribute("title", "string");
+    this.attribute("body", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
@@ -1,0 +1,9 @@
+export class Post extends Base {
+  declare writer: Author | null;
+  declare remarks: Comment[];
+
+  static {
+    this.belongsTo("writer", { className: "Author" });
+    this.hasMany("remarks", { className: "Comment" });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/input.ts
@@ -1,0 +1,6 @@
+export class Post extends Base {
+  static {
+    this.belongsTo("writer", { className: "Author" });
+    this.hasMany("remarks", { className: "Comment" });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/12-no-base-extends/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/12-no-base-extends/expected.ts
@@ -1,0 +1,12 @@
+export class NotAModel {
+  doThing(): void {
+    // this.attribute("name", "string") — should NOT be virtualized.
+  }
+}
+
+export class AlsoNotAModel extends Object {
+  static {
+    // @ts-ignore — not a real call; just verifying the walker skips it.
+    (this as any).attribute?.("x", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/12-no-base-extends/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/12-no-base-extends/input.ts
@@ -1,0 +1,12 @@
+export class NotAModel {
+  doThing(): void {
+    // this.attribute("name", "string") — should NOT be virtualized.
+  }
+}
+
+export class AlsoNotAModel extends Object {
+  static {
+    // @ts-ignore — not a real call; just verifying the walker skips it.
+    (this as any).attribute?.("x", "string");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
@@ -1,0 +1,7 @@
+export class Post extends Base {
+  declare tags: Tag[];
+
+  static {
+    this.hasAndBelongsToMany("tags");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/input.ts
@@ -1,0 +1,5 @@
+export class Post extends Base {
+  static {
+    this.hasAndBelongsToMany("tags");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/expected.ts
@@ -1,0 +1,21 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Conversation extends Base {
+  declare status: number;
+  declare isActive: () => boolean;
+  declare active: () => void;
+  declare activeBang: () => Promise<void>;
+  declare static active: () => Relation<Conversation>;
+  declare static notActive: () => Relation<Conversation>;
+  declare isArchived: () => boolean;
+  declare archived: () => void;
+  declare archivedBang: () => Promise<void>;
+  declare static archived: () => Relation<Conversation>;
+  declare static notArchived: () => Relation<Conversation>;
+
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Conversation, "status", ["active", "archived"]);

--- a/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/input.ts
@@ -1,0 +1,9 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Conversation extends Base {
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Conversation, "status", ["active", "archived"]);

--- a/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/expected.ts
@@ -1,0 +1,14 @@
+export class Task extends Base {
+  declare status: number;
+  declare isStatusLow: () => boolean;
+  declare statusLowBang: () => this;
+  declare static statusLow: () => Relation<Task>;
+  declare isStatusHigh: () => boolean;
+  declare statusHighBang: () => this;
+  declare static statusHigh: () => Relation<Task>;
+
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 }, { prefix: true });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/input.ts
@@ -1,0 +1,6 @@
+export class Task extends Base {
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 }, { prefix: true });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/expected.ts
@@ -1,0 +1,14 @@
+export class Task extends Base {
+  declare status: number;
+  declare isTierLow: () => boolean;
+  declare tierLowBang: () => this;
+  declare static tierLow: () => Relation<Task>;
+  declare isTierHigh: () => boolean;
+  declare tierHighBang: () => this;
+  declare static tierHigh: () => Relation<Task>;
+
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 }, { prefix: "tier" });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/input.ts
@@ -1,0 +1,6 @@
+export class Task extends Base {
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 }, { prefix: "tier" });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/expected.ts
@@ -1,0 +1,7 @@
+export class Comment extends Base {
+  declare commentable: Base | null;
+
+  static {
+    this.belongsTo("commentable", { polymorphic: true });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/input.ts
@@ -1,0 +1,5 @@
+export class Comment extends Base {
+  static {
+    this.belongsTo("commentable", { polymorphic: true });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/expected.ts
@@ -1,0 +1,21 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  declare status: number;
+  declare isDraftStatus: () => boolean;
+  declare draftStatus: () => void;
+  declare draftStatusBang: () => Promise<void>;
+  declare static draftStatus: () => Relation<Article>;
+  declare static notDraftStatus: () => Relation<Article>;
+  declare isPublishedStatus: () => boolean;
+  declare publishedStatus: () => void;
+  declare publishedStatusBang: () => Promise<void>;
+  declare static publishedStatus: () => Relation<Article>;
+  declare static notPublishedStatus: () => Relation<Article>;
+
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Article, "status", { draft: 0, published: 1 }, { suffix: true });

--- a/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/input.ts
@@ -1,0 +1,9 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  static {
+    this.attribute("status", "integer");
+  }
+}
+
+defineEnum(Article, "status", { draft: 0, published: 1 }, { suffix: true });

--- a/packages/activerecord/src/type-virtualization/index.ts
+++ b/packages/activerecord/src/type-virtualization/index.ts
@@ -1,0 +1,16 @@
+export { virtualize, remapLine } from "./virtualize.js";
+export type { VirtualizeResult, VirtualizeOptions, LineDelta } from "./virtualize.js";
+export type { WalkOptions } from "./walker.js";
+export { walk } from "./walker.js";
+export type {
+  ClassInfo,
+  RuntimeCall,
+  AttributeCall,
+  AssociationCall,
+  AssociationKind,
+  ScopeCall,
+  EnumCall,
+  DefineEnumCall,
+} from "./walker.js";
+export { synthesizeDeclares } from "./synthesize.js";
+export { ATTRIBUTE_TYPE_MAP, tsTypeFor } from "./type-registry.js";

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -1,0 +1,164 @@
+// Render declaration strings from walker output.
+//
+// Produces one `declare ...;` line per runtime call, skipping members the
+// user has already declared by hand. Output is plain text — the splicer
+// in virtualize.ts inserts it verbatim after the class body's opening `{`.
+
+import { classify, camelize } from "@blazetrails/activesupport";
+import type {
+  ClassInfo,
+  RuntimeCall,
+  AssociationCall,
+  AttributeCall,
+  ScopeCall,
+  EnumCall,
+  DefineEnumCall,
+} from "./walker.js";
+import { tsTypeFor } from "./type-registry.js";
+
+const INDENT = "  ";
+
+export function synthesizeDeclares(info: ClassInfo): string[] {
+  const out: string[] = [];
+  for (const call of info.calls) {
+    for (const line of renderCall(info, call)) {
+      if (!line.skipIfPresent || !memberPresent(info, line)) out.push(line.text);
+    }
+  }
+  return out;
+}
+
+interface RenderedLine {
+  text: string;
+  declaredName: string;
+  isStatic: boolean;
+  skipIfPresent: boolean;
+}
+
+function renderCall(info: ClassInfo, call: RuntimeCall): RenderedLine[] {
+  switch (call.kind) {
+    case "attribute":
+      return renderAttribute(call);
+    case "hasMany":
+    case "hasAndBelongsToMany":
+      return renderCollectionAssoc(call);
+    case "belongsTo":
+    case "hasOne":
+      return renderSingularAssoc(call);
+    case "scope":
+      return renderScope(info, call);
+    case "enum":
+      return renderEnum(info, call);
+    case "defineEnum":
+      return renderDefineEnum(info, call);
+  }
+}
+
+function renderAttribute(call: AttributeCall): RenderedLine[] {
+  const tsType = tsTypeFor(call.railsType);
+  return [line(`declare ${call.name}: ${tsType};`, call.name, false)];
+}
+
+function renderCollectionAssoc(call: AssociationCall): RenderedLine[] {
+  const target = resolveTarget(call);
+  return [line(`declare ${call.name}: ${target}[];`, call.name, false)];
+}
+
+function renderSingularAssoc(call: AssociationCall): RenderedLine[] {
+  // `polymorphic: true` on belongsTo can't be narrowed statically — any
+  // Base-rooted class could be on the other end. Fall back to `Base | null`.
+  const target = call.options["polymorphic"] === "true" ? "Base" : resolveTarget(call);
+  return [line(`declare ${call.name}: ${target} | null;`, call.name, false)];
+}
+
+function renderScope(info: ClassInfo, call: ScopeCall): RenderedLine[] {
+  const argList = call.paramsAfterRel.length === 0 ? "" : call.paramsAfterRel.join(", ");
+  return [
+    line(`declare static ${call.name}: (${argList}) => Relation<${info.name}>;`, call.name, true),
+  ];
+}
+
+function renderEnum(info: ClassInfo, call: EnumCall): RenderedLine[] {
+  const out: RenderedLine[] = [];
+  const { prefix, suffix } = readPrefixSuffix(call.options, call.attr);
+  for (const value of call.values) {
+    const methodBase = `${prefix}${value}${suffix}`;
+    const predicate = `is${pascal(methodBase)}`;
+    const bang = `${camelize(methodBase, false)}Bang`;
+    const scopeName = camelize(methodBase, false);
+    out.push(line(`declare ${predicate}: () => boolean;`, predicate, false));
+    out.push(line(`declare ${bang}: () => this;`, bang, false));
+    out.push(
+      line(`declare static ${scopeName}: () => Relation<${info.name}>;`, scopeName, true),
+    );
+  }
+  return out;
+}
+
+function renderDefineEnum(info: ClassInfo, call: DefineEnumCall): RenderedLine[] {
+  const out: RenderedLine[] = [];
+  const { prefix, suffix } = readPrefixSuffix(call.options, call.attr);
+  for (const value of call.values) {
+    const methodBase = `${prefix}${value}${suffix}`;
+    const predicate = `is${pascal(methodBase)}`;
+    const setter = camelize(methodBase, false);
+    const bang = `${setter}Bang`;
+    const notScope = `not${pascal(methodBase)}`;
+    out.push(line(`declare ${predicate}: () => boolean;`, predicate, false));
+    out.push(line(`declare ${setter}: () => void;`, setter, false));
+    out.push(line(`declare ${bang}: () => Promise<void>;`, bang, false));
+    out.push(line(`declare static ${setter}: () => Relation<${info.name}>;`, setter, true));
+    out.push(
+      line(`declare static ${notScope}: () => Relation<${info.name}>;`, notScope, true),
+    );
+  }
+  return out;
+}
+
+function readPrefixSuffix(
+  options: Record<string, string>,
+  attr: string,
+): { prefix: string; suffix: string } {
+  return {
+    prefix: readAffix(options["prefix"], attr, "prefix"),
+    suffix: readAffix(options["suffix"], attr, "suffix"),
+  };
+}
+
+function readAffix(raw: string | undefined, attr: string, side: "prefix" | "suffix"): string {
+  if (!raw || raw === "false") return "";
+  const value = raw === "true" ? attr : stripQuotes(raw);
+  return side === "prefix" ? `${value}_` : `_${value}`;
+}
+
+function resolveTarget(call: AssociationCall): string {
+  const explicit = call.options["className"];
+  if (explicit) return stripQuotes(explicit);
+  return classify(call.name);
+}
+
+function stripQuotes(source: string): string {
+  const first = source.charAt(0);
+  if ((first === '"' || first === "'" || first === "`") && source.endsWith(first)) {
+    return source.slice(1, -1);
+  }
+  return source;
+}
+
+function pascal(s: string): string {
+  return camelize(s);
+}
+
+function line(body: string, declaredName: string, isStatic: boolean): RenderedLine {
+  return {
+    text: `${INDENT}${body}`,
+    declaredName,
+    isStatic,
+    skipIfPresent: true,
+  };
+}
+
+function memberPresent(info: ClassInfo, l: RenderedLine): boolean {
+  const set = l.isStatic ? info.existingStaticMembers : info.existingMembers;
+  return set.has(l.declaredName);
+}

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -88,9 +88,7 @@ function renderEnum(info: ClassInfo, call: EnumCall): RenderedLine[] {
     const scopeName = camelize(methodBase, false);
     out.push(line(`declare ${predicate}: () => boolean;`, predicate, false));
     out.push(line(`declare ${bang}: () => this;`, bang, false));
-    out.push(
-      line(`declare static ${scopeName}: () => Relation<${info.name}>;`, scopeName, true),
-    );
+    out.push(line(`declare static ${scopeName}: () => Relation<${info.name}>;`, scopeName, true));
   }
   return out;
 }
@@ -108,9 +106,7 @@ function renderDefineEnum(info: ClassInfo, call: DefineEnumCall): RenderedLine[]
     out.push(line(`declare ${setter}: () => void;`, setter, false));
     out.push(line(`declare ${bang}: () => Promise<void>;`, bang, false));
     out.push(line(`declare static ${setter}: () => Relation<${info.name}>;`, setter, true));
-    out.push(
-      line(`declare static ${notScope}: () => Relation<${info.name}>;`, notScope, true),
-    );
+    out.push(line(`declare static ${notScope}: () => Relation<${info.name}>;`, notScope, true));
   }
   return out;
 }

--- a/packages/activerecord/src/type-virtualization/type-registry.ts
+++ b/packages/activerecord/src/type-virtualization/type-registry.ts
@@ -1,0 +1,28 @@
+// Maps Rails attribute type strings (as passed to `this.attribute(name, type)`)
+// to the TypeScript type the virtualizer writes into an injected `declare`.
+//
+// Keys must stay in sync with activemodel's TypeRegistry
+// (packages/activemodel/src/type/registry.ts); any new runtime type
+// registered there needs a matching entry here.
+
+export const ATTRIBUTE_TYPE_MAP: Record<string, string> = {
+  string: "string",
+  immutable_string: "string",
+  uuid: "string",
+  integer: "number",
+  big_integer: "number",
+  float: "number",
+  decimal: "number",
+  boolean: "boolean",
+  date: "Date",
+  datetime: "Date",
+  time: "Date",
+  json: "unknown",
+  binary: "Uint8Array",
+  array: "unknown[]",
+  value: "unknown",
+};
+
+export function tsTypeFor(railsType: string): string {
+  return ATTRIBUTE_TYPE_MAP[railsType] ?? "unknown";
+}

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { virtualize, remapLine } from "./virtualize.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.join(HERE, "fixtures");
+
+function fixtureDirs(): string[] {
+  return fs
+    .readdirSync(FIXTURES_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+describe("virtualize — fixture pairs", () => {
+  for (const name of fixtureDirs()) {
+    const dir = path.join(FIXTURES_DIR, name);
+    const inputPath = path.join(dir, "input.ts");
+    const expectedPath = path.join(dir, "expected.ts");
+    test(name, () => {
+      const input = fs.readFileSync(inputPath, "utf8");
+      const expected = fs.readFileSync(expectedPath, "utf8");
+      const { text } = virtualize(input, inputPath);
+      expect(text).toBe(expected);
+    });
+  }
+});
+
+describe("virtualize — deltas", () => {
+  test("records one delta per injected block", () => {
+    const src =
+      "export class Post extends Base {\n" +
+      "  static {\n" +
+      '    this.attribute("title", "string");\n' +
+      '    this.attribute("body", "string");\n' +
+      "  }\n" +
+      "}\n";
+    const { deltas } = virtualize(src, "post.ts");
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]!.lineCount).toBe(3); // leading \n + 2 declare lines
+  });
+
+  test("no deltas when no class matches Base", () => {
+    const { deltas, text } = virtualize("export class NotAModel {}\n", "nope.ts");
+    expect(deltas).toHaveLength(0);
+    expect(text).toBe("export class NotAModel {}\n");
+  });
+
+  test("skip marker yields no deltas", () => {
+    const src =
+      "/** @trails-typegen skip */\n" +
+      "export class Post extends Base {\n" +
+      '  static { this.attribute("t", "string"); }\n' +
+      "}\n";
+    const { deltas } = virtualize(src, "skip.ts");
+    expect(deltas).toHaveLength(0);
+  });
+});
+
+describe("remapLine", () => {
+  test("lines above injection are unchanged", () => {
+    const deltas = [{ insertedAtLine: 5, lineCount: 3 }];
+    expect(remapLine(2, deltas)).toBe(2);
+    expect(remapLine(5, deltas)).toBe(5);
+  });
+
+  test("lines below injection subtract the inserted line count", () => {
+    const deltas = [{ insertedAtLine: 5, lineCount: 3 }];
+    // A diagnostic at virtualized line 10 should map back to line 7.
+    expect(remapLine(10, deltas)).toBe(7);
+  });
+
+  test("lines inside the injected range return null", () => {
+    const deltas = [{ insertedAtLine: 5, lineCount: 3 }];
+    expect(remapLine(6, deltas)).toBeNull();
+    expect(remapLine(7, deltas)).toBeNull();
+    expect(remapLine(8, deltas)).toBeNull();
+  });
+
+  test("multiple deltas compose correctly", () => {
+    const deltas = [
+      { insertedAtLine: 5, lineCount: 2 },
+      { insertedAtLine: 15, lineCount: 3 },
+    ];
+    // Below first injection only.
+    expect(remapLine(10, deltas)).toBe(8);
+    // Below both injections.
+    expect(remapLine(25, deltas)).toBe(20);
+    // Above everything.
+    expect(remapLine(3, deltas)).toBe(3);
+  });
+
+  test("empty delta list is identity", () => {
+    expect(remapLine(42, [])).toBe(42);
+  });
+});
+
+describe("virtualize — idempotence", () => {
+  test("re-virtualizing the output skips members already declared", () => {
+    const src =
+      "export class Post extends Base {\n" +
+      '  static { this.attribute("title", "string"); }\n' +
+      "}\n";
+    const once = virtualize(src, "post.ts").text;
+    const twice = virtualize(once, "post.ts").text;
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -1,0 +1,96 @@
+// Pure text-transform that turns a user-authored model source into a
+// virtualized version with `declare` members spliced into each affected
+// class body. No on-disk output; no `ts.Program` or `TypeChecker`
+// dependency.
+//
+// Shells (the trails-tsc CLI and the tsserver plugin) call this and hand
+// the result back to the compiler / language service. Tests exercise it
+// directly against fixture pairs.
+
+import ts from "typescript";
+import { walk, type WalkOptions } from "./walker.js";
+import { synthesizeDeclares } from "./synthesize.js";
+
+export interface LineDelta {
+  /**
+   * 0-indexed line in the ORIGINAL source where the injected block begins.
+   * Diagnostics reported at line > insertedAtLine + lineCount map back by
+   * subtracting lineCount.
+   */
+  insertedAtLine: number;
+  /** Number of lines the injected block spans. */
+  lineCount: number;
+}
+
+export interface VirtualizeResult {
+  text: string;
+  deltas: LineDelta[];
+}
+
+export type VirtualizeOptions = WalkOptions;
+
+export function virtualize(
+  originalText: string,
+  fileName: string,
+  options: VirtualizeOptions = {},
+): VirtualizeResult {
+  const sf = ts.createSourceFile(fileName, originalText, ts.ScriptTarget.ES2022, true);
+  const classes = walk(sf, options);
+
+  interface Edit {
+    pos: number;
+    text: string;
+    originalLine: number;
+    lineCount: number;
+  }
+  const edits: Edit[] = [];
+
+  for (const info of classes) {
+    if (info.skip) continue;
+    if (info.openBracePos < 0) continue;
+    const decls = synthesizeDeclares(info);
+    if (decls.length === 0) continue;
+    const block = "\n" + decls.join("\n") + "\n";
+    edits.push({
+      pos: info.openBracePos,
+      text: block,
+      originalLine: sf.getLineAndCharacterOfPosition(info.openBracePos).line,
+      lineCount: decls.length + 1, // leading newline + one per decl
+    });
+  }
+
+  edits.sort((a, b) => b.pos - a.pos);
+
+  let text = originalText;
+  for (const e of edits) {
+    text = text.slice(0, e.pos) + e.text + text.slice(e.pos);
+  }
+
+  const deltas: LineDelta[] = edits
+    .slice()
+    .sort((a, b) => a.originalLine - b.originalLine)
+    .map((e) => ({ insertedAtLine: e.originalLine, lineCount: e.lineCount }));
+
+  return { text, deltas };
+}
+
+/**
+ * Given a line number in the virtualized text, returns the corresponding
+ * line in the ORIGINAL source — or `null` if the position is inside an
+ * injected block.
+ */
+export function remapLine(virtualLine: number, deltas: LineDelta[]): number | null {
+  let line = virtualLine;
+  for (let i = deltas.length - 1; i >= 0; i--) {
+    const d = deltas[i];
+    if (!d) continue;
+    const injectedStart = d.insertedAtLine;
+    const injectedEnd = d.insertedAtLine + d.lineCount;
+    if (line > injectedEnd) {
+      line -= d.lineCount;
+    } else if (line > injectedStart && line <= injectedEnd) {
+      return null;
+    }
+  }
+  return line;
+}

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -290,4 +290,3 @@ function objectKeys(obj: ts.ObjectLiteralExpression): string[] {
   }
   return keys;
 }
-

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -1,0 +1,293 @@
+// Syntactic walker for model source files.
+//
+// Finds top-level class declarations that extend a name in the allow-list
+// (default: ["Base"]) and collects the runtime calls inside each class's
+// static blocks — `this.attribute(...)`, `this.hasMany(...)`,
+// `this.belongsTo(...)`, `this.hasOne(...)`, `this.hasAndBelongsToMany(...)`,
+// `this.scope(...)`, `this.enum(...)` — plus top-level `defineEnum(this, ...)`
+// statements whose first argument identifies the class.
+//
+// Intentionally does not resolve symbols or consult a `ts.Program`. Transitive
+// extends (e.g. `class Admin extends User`) are handled by a separate,
+// checker-backed pass that produces the allow-list.
+
+import ts from "typescript";
+
+export type AssociationKind = "hasMany" | "hasAndBelongsToMany" | "belongsTo" | "hasOne";
+
+export interface AttributeCall {
+  kind: "attribute";
+  name: string;
+  railsType: string;
+  options: RecordLiteral;
+}
+
+export interface AssociationCall {
+  kind: AssociationKind;
+  name: string;
+  options: RecordLiteral;
+}
+
+export interface ScopeCall {
+  kind: "scope";
+  name: string;
+  // Parameter list of the inline scope function, with the leading `rel`
+  // parameter removed. Each element is the raw source text of a parameter
+  // (e.g. "limit: number", "name = \"draft\"").
+  paramsAfterRel: string[];
+}
+
+export interface EnumCall {
+  kind: "enum";
+  attr: string;
+  values: string[]; // string keys of the mapping literal
+  options: RecordLiteral;
+}
+
+export interface DefineEnumCall {
+  kind: "defineEnum";
+  attr: string;
+  values: string[];
+  options: RecordLiteral;
+}
+
+export type RuntimeCall = AttributeCall | AssociationCall | ScopeCall | EnumCall | DefineEnumCall;
+
+export type RecordLiteral = Record<string, string>;
+
+export interface ClassInfo {
+  name: string;
+  classDecl: ts.ClassDeclaration;
+  openBracePos: number; // char offset of the class body's `{` + 1
+  calls: RuntimeCall[];
+  // Member names the user has already declared by hand — the virtualizer
+  // must skip injection for any of these.
+  existingMembers: Set<string>;
+  existingStaticMembers: Set<string>;
+  skip: boolean; // `/** @trails-typegen skip */` JSDoc above the class
+}
+
+export interface WalkOptions {
+  /** Class names counted as roots. Defaults to `["Base"]`. */
+  baseNames?: readonly string[];
+}
+
+export function walk(sourceFile: ts.SourceFile, opts: WalkOptions = {}): ClassInfo[] {
+  const baseNames = new Set(opts.baseNames ?? ["Base"]);
+  const out: ClassInfo[] = [];
+
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isClassDeclaration(stmt)) continue;
+    if (!stmt.name) continue;
+    if (!extendsOneOf(stmt, baseNames)) continue;
+
+    const info: ClassInfo = {
+      name: stmt.name.text,
+      classDecl: stmt,
+      openBracePos: findOpenBrace(sourceFile.text, stmt),
+      calls: [],
+      existingMembers: new Set(),
+      existingStaticMembers: new Set(),
+      skip: hasSkipMarker(stmt, sourceFile),
+    };
+
+    if (info.skip) {
+      out.push(info);
+      continue;
+    }
+
+    for (const member of stmt.members) {
+      recordExistingMember(member, info);
+      if (ts.isClassStaticBlockDeclaration(member)) {
+        for (const s of member.body.statements) {
+          const call = readThisCall(s);
+          if (call) info.calls.push(call);
+        }
+      }
+    }
+
+    out.push(info);
+  }
+
+  // Top-level `defineEnum(ClassName, ...)` calls. Supports both the array
+  // form (`["draft", "published"]`) and the object form
+  // (`{ draft: 0, published: 1 }`).
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isExpressionStatement(stmt)) continue;
+    const call = stmt.expression;
+    if (!ts.isCallExpression(call)) continue;
+    if (!ts.isIdentifier(call.expression) || call.expression.text !== "defineEnum") continue;
+    const [targetArg, attrArg, mapArg, optsArg] = call.arguments;
+    if (!targetArg || !attrArg || !mapArg) continue;
+    if (!ts.isStringLiteralLike(attrArg)) continue;
+    const values = readEnumValues(mapArg);
+    if (!values) continue;
+    const targetName = ts.isIdentifier(targetArg) ? targetArg.text : null;
+    if (!targetName) continue;
+    const info = out.find((c) => c.name === targetName);
+    if (!info) continue;
+    info.calls.push({
+      kind: "defineEnum",
+      attr: attrArg.text,
+      values,
+      options: readRecordLiteral(optsArg),
+    });
+  }
+
+  return out;
+}
+
+function extendsOneOf(cls: ts.ClassDeclaration, names: Set<string>): boolean {
+  for (const hc of cls.heritageClauses ?? []) {
+    if (hc.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+    for (const t of hc.types) {
+      const expr = t.expression;
+      if (ts.isIdentifier(expr) && names.has(expr.text)) return true;
+    }
+  }
+  return false;
+}
+
+function findOpenBrace(text: string, cls: ts.ClassDeclaration): number {
+  const after = cls.name?.end ?? cls.pos;
+  const idx = text.indexOf("{", after);
+  return idx === -1 ? -1 : idx + 1;
+}
+
+function hasSkipMarker(cls: ts.ClassDeclaration, sf: ts.SourceFile): boolean {
+  const ranges = ts.getLeadingCommentRanges(sf.text, cls.pos) ?? [];
+  for (const r of ranges) {
+    const text = sf.text.slice(r.pos, r.end);
+    if (/@trails-typegen\s+skip\b/.test(text)) return true;
+  }
+  return false;
+}
+
+function recordExistingMember(m: ts.ClassElement, info: ClassInfo): void {
+  const name = m.name && ts.isIdentifier(m.name) ? m.name.text : undefined;
+  if (!name) return;
+  const modifiers = ts.canHaveModifiers(m) ? ts.getModifiers(m) : undefined;
+  const isStatic = modifiers?.some((mod) => mod.kind === ts.SyntaxKind.StaticKeyword) ?? false;
+  if (isStatic) info.existingStaticMembers.add(name);
+  else info.existingMembers.add(name);
+}
+
+function readThisCall(stmt: ts.Statement): RuntimeCall | null {
+  if (!ts.isExpressionStatement(stmt)) return null;
+  const call = stmt.expression;
+  if (!ts.isCallExpression(call)) return null;
+  const callee = call.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return null;
+  if (callee.expression.kind !== ts.SyntaxKind.ThisKeyword) return null;
+  const method = callee.name.text;
+
+  switch (method) {
+    case "attribute":
+      return readAttributeCall(call);
+    case "hasMany":
+    case "hasAndBelongsToMany":
+    case "belongsTo":
+    case "hasOne":
+      return readAssociationCall(method, call);
+    case "scope":
+      return readScopeCall(call);
+    case "enum":
+      return readEnumCall(call);
+    default:
+      return null;
+  }
+}
+
+function readAttributeCall(call: ts.CallExpression): AttributeCall | null {
+  const [nameArg, typeArg, optsArg] = call.arguments;
+  if (!nameArg || !ts.isStringLiteralLike(nameArg)) return null;
+  if (!typeArg || !ts.isStringLiteralLike(typeArg)) return null;
+  return {
+    kind: "attribute",
+    name: nameArg.text,
+    railsType: typeArg.text,
+    options: readRecordLiteral(optsArg),
+  };
+}
+
+function readAssociationCall(
+  kind: AssociationKind,
+  call: ts.CallExpression,
+): AssociationCall | null {
+  const [nameArg, optsArg] = call.arguments;
+  if (!nameArg || !ts.isStringLiteralLike(nameArg)) return null;
+  return {
+    kind,
+    name: nameArg.text,
+    options: readRecordLiteral(optsArg),
+  };
+}
+
+function readScopeCall(call: ts.CallExpression): ScopeCall | null {
+  const [nameArg, fnArg] = call.arguments;
+  if (!nameArg || !ts.isStringLiteralLike(nameArg)) return null;
+  if (!fnArg) return { kind: "scope", name: nameArg.text, paramsAfterRel: [] };
+  if (!ts.isArrowFunction(fnArg) && !ts.isFunctionExpression(fnArg)) {
+    return { kind: "scope", name: nameArg.text, paramsAfterRel: [] };
+  }
+  const [, ...rest] = fnArg.parameters;
+  return {
+    kind: "scope",
+    name: nameArg.text,
+    paramsAfterRel: rest.map((p) => p.getText()),
+  };
+}
+
+function readEnumCall(call: ts.CallExpression): EnumCall | null {
+  const [attrArg, mapArg, optsArg] = call.arguments;
+  if (!attrArg || !ts.isStringLiteralLike(attrArg)) return null;
+  if (!mapArg) return null;
+  const values = readEnumValues(mapArg);
+  if (!values) return null;
+  return {
+    kind: "enum",
+    attr: attrArg.text,
+    values,
+    options: readRecordLiteral(optsArg),
+  };
+}
+
+function readEnumValues(node: ts.Expression): string[] | null {
+  if (ts.isObjectLiteralExpression(node)) return objectKeys(node);
+  if (ts.isArrayLiteralExpression(node)) {
+    const out: string[] = [];
+    for (const el of node.elements) {
+      if (!ts.isStringLiteralLike(el)) return null;
+      out.push(el.text);
+    }
+    return out;
+  }
+  return null;
+}
+
+function readRecordLiteral(node: ts.Expression | undefined): RecordLiteral {
+  if (!node || !ts.isObjectLiteralExpression(node)) return {};
+  const out: RecordLiteral = {};
+  for (const prop of node.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const key =
+      prop.name && (ts.isIdentifier(prop.name) || ts.isStringLiteralLike(prop.name))
+        ? prop.name.text
+        : null;
+    if (!key) continue;
+    out[key] = prop.initializer.getText();
+  }
+  return out;
+}
+
+function objectKeys(obj: ts.ObjectLiteralExpression): string[] {
+  const keys: string[] = [];
+  for (const p of obj.properties) {
+    if (!ts.isPropertyAssignment(p)) continue;
+    if (p.name && (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name))) {
+      keys.push(p.name.text);
+    }
+  }
+  return keys;
+}
+

--- a/packages/activerecord/tsconfig.json
+++ b/packages/activerecord/tsconfig.json
@@ -6,5 +6,6 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/type-virtualization/fixtures"],
   "references": [{ "path": "../arel" }, { "path": "../activemodel" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../arel
+      typescript:
+        specifier: '>=5.0.0'
+        version: 5.9.3
 
   packages/activesupport:
     dependencies:


### PR DESCRIPTION
## Summary

First implementation slice from the virtual-source-files plan (#526). Lands the pure text transform inside `packages/activerecord/src/type-virtualization/` — no CLI shell, no tsserver plugin yet. Those arrive in Phase 1b and Phase 2.

## Supported runtime calls

| Runtime call | Injected declaration | Notes |
| ------------ | -------------------- | ----- |
| `this.attribute(name, type)` | `declare name: <TS>;` | Rails type → TS type via `type-registry.ts`, paired with activemodel's `TypeRegistry` |
| `this.hasMany`, `this.hasAndBelongsToMany` | `declare name: Target[];` | `classify(singularize(name))` via activesupport |
| `this.belongsTo`, `this.hasOne` | `declare name: Target \| null;` | Honours `className:` override and `polymorphic: true` (emits `Base \| null`) |
| `this.scope(name, fn)` | `declare static name: (...) => Relation<Self>;` | Drops the leading `rel` parameter; preserves the rest of the inline fn's params literally |
| `this.enum(attr, map, opts?)` | predicate + bang + class scope per value | Rails `prefix`/`suffix` options supported (`true` and custom-string forms) |
| `defineEnum(Class, attr, map, opts?)` | richer shape: predicate + plain setter + persisting bang + `not*` scopes per value | Supports both `Record<string, number>` and `string[]` forms (matches the runtime) |

Rails-faithful options: `className:` ↔ `class_name:`, `polymorphic:`, `prefix:`/`suffix:`.

## Modules

| File | Role |
| ---- | ---- |
| `virtualize.ts` | Splices `declare` members after each class's opening `{`; returns `{ text, deltas }` for later diagnostic remapping. |
| `walker.ts` | Syntactic AST walker; extracts runtime calls without needing a `ts.Program` / checker. |
| `synthesize.ts` | Renders `declare` strings from walker output. |
| `type-registry.ts` | Rails attribute type → TypeScript type. |
| `remapLine()` | Maps virtualized line numbers back to the original source; returns `null` inside injected blocks. |

## Escape hatches

- `/** @trails-typegen skip */` above a class opts it out entirely.
- Hand-authored `declare` members are left alone (user wins); the virtualizer only injects members not already present.

## Testing

27 passing tests. **18 fixture-pair snapshots** under `fixtures/` covering every supported call and edge case:

- `01-attribute`, `02-has-many`, `03-belongs-to`, `04-has-one`, `13-has-and-belongs-to-many`
- `05-scope` (with and without user params)
- `06-enum`, `15-enum-with-prefix`, `16-enum-with-custom-prefix`
- `07-define-enum`, `14-define-enum-array-form`, `18-define-enum-with-suffix`
- `08-combined`, `09-skip-marker`, `10-existing-declare`, `11-class-name-override`, `12-no-base-extends`, `17-polymorphic-belongs-to`

Plus unit tests for `LineDelta` recording, multi-delta `remapLine` composition, and idempotence (re-virtualizing the output is a no-op).

## Packaging

- `typescript` declared as a peerDependency (virtualizer uses the compiler API).
- Fixtures excluded from `tsc --build` via a new `exclude` entry in `packages/activerecord/tsconfig.json` and from ESLint via `eslint.config.mjs` ignores.
- **Not yet exported** from the package's public `index.ts`. Phase 1b wires it through the CLI shell; keeping it internal means users can't accidentally import an API that's still under design.

## Not in scope (per the plan)

- CLI wrapper (`trails-tsc` bin). Phase 1b.
- tsserver plugin. Phase 2.
- Transitive-extends walker that needs a `ts.Program`. Ships alongside the CLI shell that has the Program anyway.
- `through:` associations and `aliasAttribute`.
- Migrating in-repo models. Phase 1b exit criterion.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` clean on new code
- [x] 27/27 virtualize tests pass
- [ ] CI