### PR TITLE
feat(trailties): Phase 6 — schemaFormat config key + --format CLI flag

### DIFF
--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createProgram } from "../cli.js";
-import { loadDatabaseConfig, connectAdapter, resolveEnv } from "../database.js";
+import {
+  loadDatabaseConfig,
+  connectAdapter,
+  resolveEnv,
+  resolveSchemaFormat,
+} from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
 import { Migrator } from "@blazetrails/activerecord";
 import * as fs from "node:fs";
@@ -215,6 +220,77 @@ describe("loadDatabaseConfig", () => {
     await expect(loadDatabaseConfig("production", tmpDir)).rejects.toThrow(
       /No database configuration for environment "production"/,
     );
+  });
+});
+
+describe("resolveSchemaFormat", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sf-"));
+    fs.mkdirSync(path.join(tmpDir, "config"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("prefers an explicit --format flag over everything else", async () => {
+    // Even with config.schemaFormat = "ts" and an existing structure.sql,
+    // --format=js must win (explicit intent beats inference).
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "ts",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    fs.writeFileSync(path.join(tmpDir, "db", "structure.sql"), "");
+    expect(await resolveSchemaFormat({ format: "js" }, tmpDir)).toBe("js");
+  });
+
+  it("rejects invalid --format values", async () => {
+    await expect(resolveSchemaFormat({ format: "yaml" }, tmpDir)).rejects.toThrow(
+      /Invalid --format value/,
+    );
+  });
+
+  it("reads top-level schemaFormat from config/database.ts", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "sql",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    expect(await resolveSchemaFormat({}, tmpDir)).toBe("sql");
+  });
+
+  it("infers sql when db/structure.sql exists and nothing else is set", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { development: { adapter: "sqlite3", database: ":memory:" } };`,
+    );
+    fs.writeFileSync(path.join(tmpDir, "db", "structure.sql"), "-- dump\n");
+    expect(await resolveSchemaFormat({}, tmpDir)).toBe("sql");
+  });
+
+  it("infers js when db/schema.js exists", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { development: { adapter: "sqlite3", database: ":memory:" } };`,
+    );
+    fs.writeFileSync(path.join(tmpDir, "db", "schema.js"), "");
+    expect(await resolveSchemaFormat({}, tmpDir)).toBe("js");
+  });
+
+  it("defaults to ts when nothing else applies", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { development: { adapter: "sqlite3", database: ":memory:" } };`,
+    );
+    expect(await resolveSchemaFormat({}, tmpDir)).toBe("ts");
   });
 });
 
@@ -1257,5 +1333,58 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     expect(parsed.indexes["users"]).toEqual([
       { name: "users_on_email", columns: ["email"], unique: true },
     ]);
+  });
+
+  it("db schema:dump --format=sql writes db/structure.sql", async () => {
+    const dbFile = path.join(tmpDir, "fmt.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)");
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["schema:dump", "--format=sql"]);
+
+    // The --format flag should route through the structure-dump path,
+    // producing db/structure.sql — not db/schema.ts.
+    expect(fs.existsSync(path.join(tmpDir, "db", "structure.sql"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "db", "schema.ts"))).toBe(false);
+    const dumped = fs.readFileSync(path.join(tmpDir, "db", "structure.sql"), "utf8");
+    expect(dumped).toContain("CREATE TABLE widgets");
+  });
+
+  it("db schema:dump reads schemaFormat from config/database.ts", async () => {
+    const dbFile = path.join(tmpDir, "cfg.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "sql",
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seed = new SQLite3Adapter(dbFile);
+    try {
+      await seed.executeMutation("CREATE TABLE items (id INTEGER PRIMARY KEY)");
+    } finally {
+      await seed.close();
+    }
+
+    await runDb(["schema:dump"]);
+
+    // No --format flag — config.schemaFormat drives it.
+    expect(fs.existsSync(path.join(tmpDir, "db", "structure.sql"))).toBe(true);
   });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -334,6 +334,22 @@ describe("resolveSchemaFormat", () => {
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
   });
 
+  it("formats non-string schemaFormat values without JSON.stringify crashing on bigint", async () => {
+    // A bigint in config would make JSON.stringify throw; normalize()
+    // uses util.inspect so the error message still reaches the user
+    // with a readable repr of the offending value.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: 42n,
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(
+      /schemaFormat in .*database\.ts.*42n/s,
+    );
+  });
+
   it("filters top-level keys out of the 'Available envs' error message", async () => {
     // schemaFormat is a config-level setting, not a database environment —
     // including it in the error list would make users think they can
@@ -385,6 +401,19 @@ describe("resolveSchemaFormat", () => {
       `export default { development: { adapter: "sqlite3", database: ":memory:" } };`,
     );
     expect(await resolveSchemaFormat({}, tmpDir)).toBe("ts");
+  });
+
+  it("reports 'No environments defined' when config has only top-level keys", async () => {
+    // Without this branch the error ends with a bare 'Available: ' —
+    // technically accurate, visually confusing. Explicit wording makes
+    // the misconfiguration obvious.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { schemaFormat: "ts" };`,
+    );
+    await expect(loadDatabaseConfig("development", tmpDir)).rejects.toThrow(
+      /No environments defined/,
+    );
   });
 });
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -284,6 +284,20 @@ describe("resolveSchemaFormat", () => {
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/SCHEMA_FORMAT env var/);
   });
 
+  it("rejects an invalid schemaFormat in the config file", async () => {
+    // Previously we silently fell through to inference when config had
+    // a garbage value. Now the config path validates the same way as
+    // --format and SCHEMA_FORMAT — misconfig should be a loud error.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "yaml",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
+  });
+
   it("reads top-level schemaFormat from config/database.ts", async () => {
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -298,6 +298,44 @@ describe("resolveSchemaFormat", () => {
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
   });
 
+  it("treats empty-string overrides as present-and-invalid, not unset", async () => {
+    // --format="", SCHEMA_FORMAT="", schemaFormat: "" in config all
+    // represent an explicitly-set knob; they shouldn't silently fall
+    // through to inference. Detection is presence-based (`!== undefined`
+    // / `"KEY" in process.env` / `"schemaFormat" in module`) so a
+    // deliberately-empty value reaches the validator.
+    await expect(resolveSchemaFormat({ format: "" }, tmpDir)).rejects.toThrow(/Invalid --format/);
+
+    process.env.SCHEMA_FORMAT = "";
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/SCHEMA_FORMAT env var/);
+    delete process.env.SCHEMA_FORMAT;
+
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
+  });
+
+  it("filters top-level keys out of the 'Available envs' error message", async () => {
+    // schemaFormat is a config-level setting, not a database environment —
+    // including it in the error list would make users think they can
+    // TRAILS_ENV=schemaFormat their way to a connection.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "ts",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(loadDatabaseConfig("production", tmpDir)).rejects.toThrow(
+      /Available: development$/,
+    );
+  });
+
   it("reads top-level schemaFormat from config/database.ts", async () => {
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -320,6 +320,20 @@ describe("resolveSchemaFormat", () => {
     await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
   });
 
+  it("rejects non-string schemaFormat values in config without crashing", async () => {
+    // schemaFormat is user-authored JS; TS can't prevent a number/bool
+    // from slipping in. normalize() now refuses with a source-labeled
+    // error instead of throwing a TypeError on .toLowerCase().
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: 42,
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/schemaFormat in .*database\.ts/);
+  });
+
   it("filters top-level keys out of the 'Available envs' error message", async () => {
     // schemaFormat is a config-level setting, not a database environment —
     // including it in the error list would make users think they can

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -416,6 +416,32 @@ describe("resolveSchemaFormat", () => {
       /No environments defined/,
     );
   });
+
+  it("rejects env names that collide with top-level config keys", async () => {
+    // TRAILS_ENV=schemaFormat must not resolve to the string "ts" as a
+    // DatabaseConfig — adapter resolution would crash later with a
+    // confusing error. Reject up front instead.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "ts",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    await expect(loadDatabaseConfig("schemaFormat", tmpDir)).rejects.toThrow(
+      /No database configuration for environment "schemaFormat"/,
+    );
+  });
+
+  it("rejects a non-object default export with a source-named error", async () => {
+    // `export default "oops"` imports fine, but treating the string as
+    // a config would crash downstream `in`/Object.keys lookups. Surface
+    // it early with a clear message.
+    fs.writeFileSync(path.join(tmpDir, "config", "database.ts"), `export default "oops";`);
+    await expect(loadDatabaseConfig("development", tmpDir)).rejects.toThrow(
+      /Invalid database config in .*database\.ts.*"oops"/,
+    );
+  });
 });
 
 describe("discoverMigrations", () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -336,8 +336,9 @@ describe("resolveSchemaFormat", () => {
 
   it("formats non-string schemaFormat values without JSON.stringify crashing on bigint", async () => {
     // A bigint in config would make JSON.stringify throw; normalize()
-    // uses util.inspect so the error message still reaches the user
-    // with a readable repr of the offending value.
+    // routes through the local formatUnknown() helper so the error
+    // message still reaches the user with a readable repr of the
+    // offending value ("42n" for bigint, per the helper's toString).
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),
       `export default {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -225,15 +225,22 @@ describe("loadDatabaseConfig", () => {
 
 describe("resolveSchemaFormat", () => {
   let tmpDir: string;
+  const origSchemaFormatEnv = process.env.SCHEMA_FORMAT;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sf-"));
     fs.mkdirSync(path.join(tmpDir, "config"), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, "db"), { recursive: true });
+    // Phase 6 reads SCHEMA_FORMAT as a Rails-parity override; make sure
+    // tests start from a clean slot so a stray env var from the outer
+    // process doesn't flip results.
+    delete process.env.SCHEMA_FORMAT;
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (origSchemaFormatEnv === undefined) delete process.env.SCHEMA_FORMAT;
+    else process.env.SCHEMA_FORMAT = origSchemaFormatEnv;
   });
 
   it("prefers an explicit --format flag over everything else", async () => {
@@ -254,6 +261,27 @@ describe("resolveSchemaFormat", () => {
     await expect(resolveSchemaFormat({ format: "yaml" }, tmpDir)).rejects.toThrow(
       /Invalid --format value/,
     );
+  });
+
+  it("honors SCHEMA_FORMAT env var below --format but above config", async () => {
+    // Matches Rails' rake: ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  schemaFormat: "ts",
+  development: { adapter: "sqlite3", database: ":memory:" },
+};`,
+    );
+    process.env.SCHEMA_FORMAT = "sql";
+    // Env wins over config.
+    expect(await resolveSchemaFormat({}, tmpDir)).toBe("sql");
+    // --format still beats env.
+    expect(await resolveSchemaFormat({ format: "js" }, tmpDir)).toBe("js");
+  });
+
+  it("rejects invalid SCHEMA_FORMAT env values", async () => {
+    process.env.SCHEMA_FORMAT = "yaml";
+    await expect(resolveSchemaFormat({}, tmpDir)).rejects.toThrow(/SCHEMA_FORMAT env var/);
   });
 
   it("reads top-level schemaFormat from config/database.ts", async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -785,17 +785,16 @@ export function dbCommand(): Command {
         // any throw from resolve, schemaDumpPath, or setAdapter.
         const previousFormat = DatabaseTasks.schemaFormat;
         const previous = DatabaseTasks.migrationConnection();
-        let filename: string;
         try {
           DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
-          filename = DatabaseTasks.schemaDumpPath(config);
+          const filename = DatabaseTasks.schemaDumpPath(config);
           DatabaseTasks.setAdapter(adapter);
           await DatabaseTasks.dumpSchema(config);
+          console.log(`Schema dumped to ${filename}`);
         } finally {
           DatabaseTasks.setAdapter(previous);
           DatabaseTasks.schemaFormat = previousFormat;
         }
-        console.log(`Schema dumped to ${filename}`);
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -772,7 +772,7 @@ export function dbCommand(): Command {
   cmd
     .command("schema:dump")
     .description(
-      "Dump the current database schema (format precedence: --format > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
+      "Dump the current database schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
     )
     .option("--format <format>", "Override schema format: ts, js, or sql")
     .action(async (opts) => {
@@ -796,7 +796,7 @@ export function dbCommand(): Command {
   cmd
     .command("schema:load")
     .description(
-      "Load the schema (format precedence: --format > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
+      "Load the schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
     )
     .option("--format <format>", "Override schema format: ts, js, or sql")
     .action(async (opts) => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -830,7 +830,8 @@ export function dbCommand(): Command {
               const enhanced = new Error(
                 `Failed to load schema file "${filename}". ` +
                   `Ensure a TypeScript loader (tsx, ts-node) is configured, ` +
-                  `or set DatabaseTasks.schemaFormat = "js" / "sql".`,
+                  `or choose a different schema format with --format js/sql, ` +
+                  `SCHEMA_FORMAT=js/sql, or config.schemaFormat.`,
               );
               (enhanced as { cause?: unknown }).cause = error;
               throw enhanced;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -772,7 +772,7 @@ export function dbCommand(): Command {
   cmd
     .command("schema:dump")
     .description(
-      "Dump the current database schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
+      "Dump the current database schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing structure.sql/schema.js/schema.ts > ts)",
     )
     .option("--format <format>", "Override schema format: ts, js, or sql")
     .action(async (opts) => {
@@ -796,7 +796,7 @@ export function dbCommand(): Command {
   cmd
     .command("schema:load")
     .description(
-      "Load the schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
+      "Load the schema (format precedence: --format > SCHEMA_FORMAT env > config.schemaFormat > existing structure.sql/schema.js/schema.ts > ts)",
     )
     .option("--format <format>", "Override schema format: ts, js, or sql")
     .action(async (opts) => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -778,12 +778,18 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
+        // Capture the prior format BEFORE calling resolveSchemaFormat —
+        // the resolver can throw (bad --format / SCHEMA_FORMAT / config
+        // value) and we want the restore-in-finally path to run even
+        // then. Assigning inside the try keeps global state clean on
+        // any throw from resolve, schemaDumpPath, or setAdapter.
         const previousFormat = DatabaseTasks.schemaFormat;
-        DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
-        const filename = DatabaseTasks.schemaDumpPath(config);
         const previous = DatabaseTasks.migrationConnection();
-        DatabaseTasks.setAdapter(adapter);
+        let filename: string;
         try {
+          DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
+          filename = DatabaseTasks.schemaDumpPath(config);
+          DatabaseTasks.setAdapter(adapter);
           await DatabaseTasks.dumpSchema(config);
         } finally {
           DatabaseTasks.setAdapter(previous);
@@ -806,31 +812,32 @@ export function dbCommand(): Command {
         // it on check_protected_environments.
         await runProtectedEnvCheck(config, config.envName);
         const previousFormat = DatabaseTasks.schemaFormat;
-        DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
-        const filename = DatabaseTasks.schemaDumpPath(config);
-        if (!fs.existsSync(filename)) {
-          console.error(`No schema file found at ${filename}`);
-          process.exitCode = 1;
-          DatabaseTasks.schemaFormat = previousFormat;
-          return;
-        }
         const previous = DatabaseTasks.migrationConnection();
-        DatabaseTasks.setAdapter(adapter);
         try {
-          console.log(`Loading schema from ${filename}...`);
-          await DatabaseTasks.loadSchema(config);
-          console.log("Schema loaded.");
-        } catch (error: unknown) {
-          if (filename.endsWith(".ts")) {
-            const enhanced = new Error(
-              `Failed to load schema file "${filename}". ` +
-                `Ensure a TypeScript loader (tsx, ts-node) is configured, ` +
-                `or set DatabaseTasks.schemaFormat = "js" / "sql".`,
-            );
-            (enhanced as { cause?: unknown }).cause = error;
-            throw enhanced;
+          DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
+          const filename = DatabaseTasks.schemaDumpPath(config);
+          if (!fs.existsSync(filename)) {
+            console.error(`No schema file found at ${filename}`);
+            process.exitCode = 1;
+            return;
           }
-          throw error;
+          DatabaseTasks.setAdapter(adapter);
+          try {
+            console.log(`Loading schema from ${filename}...`);
+            await DatabaseTasks.loadSchema(config);
+            console.log("Schema loaded.");
+          } catch (error: unknown) {
+            if (filename.endsWith(".ts")) {
+              const enhanced = new Error(
+                `Failed to load schema file "${filename}". ` +
+                  `Ensure a TypeScript loader (tsx, ts-node) is configured, ` +
+                  `or set DatabaseTasks.schemaFormat = "js" / "sql".`,
+              );
+              (enhanced as { cause?: unknown }).cause = error;
+              throw enhanced;
+            }
+            throw error;
+          }
         } finally {
           DatabaseTasks.setAdapter(previous);
           DatabaseTasks.schemaFormat = previousFormat;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -6,6 +6,7 @@ import {
   loadDatabaseConfig,
   connectAdapter,
   resolveEnv,
+  resolveSchemaFormat,
   type DatabaseConfig as RawConfig,
 } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
@@ -771,11 +772,14 @@ export function dbCommand(): Command {
   cmd
     .command("schema:dump")
     .description(
-      "Dump the current database schema (format: DatabaseTasks.schemaFormat — ts/js/sql)",
+      "Dump the current database schema (format precedence: --format > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
     )
-    .action(async () => {
+    .option("--format <format>", "Override schema format: ts, js, or sql")
+    .action(async (opts) => {
       await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
+        const previousFormat = DatabaseTasks.schemaFormat;
+        DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
         const filename = DatabaseTasks.schemaDumpPath(config);
         const previous = DatabaseTasks.migrationConnection();
         DatabaseTasks.setAdapter(adapter);
@@ -783,6 +787,7 @@ export function dbCommand(): Command {
           await DatabaseTasks.dumpSchema(config);
         } finally {
           DatabaseTasks.setAdapter(previous);
+          DatabaseTasks.schemaFormat = previousFormat;
         }
         console.log(`Schema dumped to ${filename}`);
       });
@@ -791,18 +796,22 @@ export function dbCommand(): Command {
   cmd
     .command("schema:load")
     .description(
-      "Load the schema (format: DatabaseTasks.schemaFormat — ts/js/sql) into the database",
+      "Load the schema (format precedence: --format > config.schemaFormat > existing schema.ts/js/structure.sql > ts)",
     )
-    .action(async () => {
+    .option("--format <format>", "Override schema format: ts, js, or sql")
+    .action(async (opts) => {
       await withAdapter(async (adapter, raw) => {
         const config = toDbConfig(raw);
         // schema:load is destructive (replaces the schema) — Rails gates
         // it on check_protected_environments.
         await runProtectedEnvCheck(config, config.envName);
+        const previousFormat = DatabaseTasks.schemaFormat;
+        DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
         const filename = DatabaseTasks.schemaDumpPath(config);
         if (!fs.existsSync(filename)) {
           console.error(`No schema file found at ${filename}`);
           process.exitCode = 1;
+          DatabaseTasks.schemaFormat = previousFormat;
           return;
         }
         const previous = DatabaseTasks.migrationConnection();
@@ -824,6 +833,7 @@ export function dbCommand(): Command {
           throw error;
         } finally {
           DatabaseTasks.setAdapter(previous);
+          DatabaseTasks.schemaFormat = previousFormat;
         }
       });
     });

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -85,12 +85,19 @@ export type SchemaFormat = "ts" | "js" | "sql";
  * Resolve the effective `schemaFormat` for CLI dump/load commands.
  *
  * Precedence (highest wins):
- *   1. Explicit CLI flag (`opts.format`)
- *   2. Top-level `schemaFormat` key in config/database.ts
- *   3. Existence inference — pick ts/js/sql based on which schema file
- *      is already present in `db/`. Lets users migrate to a different
- *      format by simply deleting the old file + dumping.
- *   4. Default "ts"
+ *   1. Explicit CLI flag (`opts.format`) — Rails' rake task arg equivalent
+ *   2. `SCHEMA_FORMAT` env var — matches Rails
+ *      `ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym`
+ *      pattern used throughout `activerecord/lib/active_record/railties/
+ *      databases.rake`
+ *   3. Top-level `schemaFormat` key in config/database.ts — equivalent
+ *      of `ActiveRecord.schema_format` (set via
+ *      `config.active_record.schema_format` in Rails' application.rb)
+ *   4. Existence inference — pick ts/js/sql based on which schema file
+ *      is already present in `db/`. Trails-specific convenience so
+ *      deleting the old file + dumping migrates format without touching
+ *      config.
+ *   5. Default "ts"
  *
  * Returns the resolved format. Callers should assign it to
  * `DatabaseTasks.schemaFormat` before invoking dump/load.
@@ -99,13 +106,18 @@ export async function resolveSchemaFormat(
   opts: { format?: string } = {},
   cwd: string = process.cwd(),
 ): Promise<SchemaFormat> {
-  if (opts.format) {
-    const normalized = opts.format.toLowerCase();
+  const normalize = (raw: string, source: string): SchemaFormat => {
+    const normalized = raw.toLowerCase();
     if (normalized !== "ts" && normalized !== "js" && normalized !== "sql") {
-      throw new Error(`Invalid --format value "${opts.format}". Expected one of: ts, js, sql.`);
+      throw new Error(`Invalid ${source} value "${raw}". Expected one of: ts, js, sql.`);
     }
-    return normalized as SchemaFormat;
-  }
+    return normalized;
+  };
+
+  if (opts.format) return normalize(opts.format, "--format");
+
+  const envFormat = process.env.SCHEMA_FORMAT?.trim();
+  if (envFormat) return normalize(envFormat, "SCHEMA_FORMAT env var");
 
   // Inspect the config file for a top-level `schemaFormat` key (sibling
   // of the per-env configs). Rails sets this via

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -34,6 +34,14 @@ export interface DatabaseConfigModule {
 }
 
 /**
+ * Top-level keys that configure the CLI itself rather than naming a
+ * database environment. The env-name lookup / "Available" error
+ * message excludes these so users don't see `schemaFormat` listed
+ * alongside `development`/`test`/`production`.
+ */
+const TOP_LEVEL_CONFIG_KEYS = new Set<string>(["schemaFormat"]);
+
+/**
  * Locate + import the app's `config/database.*`. Centralized so we only
  * pay the dynamic-import cost once per CLI invocation — both
  * loadDatabaseConfig and resolveSchemaFormat route through here. Node's
@@ -67,10 +75,14 @@ export async function loadDatabaseConfigModule(
   let mod: { default?: DatabaseConfigModule } & DatabaseConfigModule;
   try {
     mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
-  } catch (error) {
+  } catch (error: unknown) {
     const rel = path.relative(cwd, configPath);
+    // Extract a useful message even when user code throws a non-Error
+    // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
+    // would produce `undefined` or crash.
+    const message = error instanceof Error ? error.message : String(error);
     const enhanced = new Error(
-      `Failed to load database config from "${rel}": ${(error as Error).message}. ` +
+      `Failed to load database config from "${rel}": ${message}. ` +
         `Run with tsx (e.g., "npx tsx node_modules/.bin/trails").`,
     );
     (enhanced as { cause?: unknown }).cause = error;
@@ -100,9 +112,9 @@ export async function loadDatabaseConfig(
     | DatabaseConfig
     | undefined;
   if (!envConfig) {
+    const envs = Object.keys(loaded.module).filter((k) => !TOP_LEVEL_CONFIG_KEYS.has(k));
     throw new Error(
-      `No database configuration for environment "${resolvedEnv}". ` +
-        `Available: ${Object.keys(loaded.module).join(", ")}`,
+      `No database configuration for environment "${resolvedEnv}". Available: ${envs.join(", ")}`,
     );
   }
 
@@ -144,10 +156,14 @@ export async function resolveSchemaFormat(
     return normalized;
   };
 
-  if (opts.format) return normalize(opts.format, "--format");
+  // Presence-based, not truthy — `--format ""` and `SCHEMA_FORMAT=""`
+  // should error (caller clearly set the knob to something) rather than
+  // silently falling through to the next rung.
+  if (opts.format !== undefined) return normalize(opts.format, "--format");
 
-  const envFormat = process.env.SCHEMA_FORMAT?.trim();
-  if (envFormat) return normalize(envFormat, "SCHEMA_FORMAT env var");
+  if ("SCHEMA_FORMAT" in process.env) {
+    return normalize(process.env.SCHEMA_FORMAT ?? "", "SCHEMA_FORMAT env var");
+  }
 
   // Inspect the config file for a top-level `schemaFormat` key (sibling
   // of the per-env configs). Rails sets this via
@@ -161,10 +177,11 @@ export async function resolveSchemaFormat(
   // "failed to load config" rethrow) in one place and surfaces real
   // import failures instead of silently falling through to inference.
   const loaded = await loadDatabaseConfigModule(cwd);
-  if (loaded?.module.schemaFormat) {
-    // Validate strictly — an unknown value in config is a misconfig, not
-    // something we want to paper over with silent inference.
-    return normalize(loaded.module.schemaFormat, `schemaFormat in ${loaded.path}`);
+  if (loaded && "schemaFormat" in loaded.module) {
+    // Presence-based: an explicitly-set-but-garbage value (including an
+    // empty string) is a misconfig that should throw, not silently fall
+    // through to inference.
+    return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loaded.path}`);
   }
 
   const dbDir = path.join(cwd, "db");

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -24,9 +24,10 @@ export function resolveEnv(): string {
 
 /**
  * Shape of the exported object in config/database.ts: each env key maps
- * to a DatabaseConfig, plus a few optional top-level keys (e.g.
- * schemaFormat). Kept loose (`unknown`) so callers inspect the keys
- * they need without the type fighting them.
+ * to a DatabaseConfig, plus the optional `schemaFormat` top-level key
+ * (the only non-env key we currently recognize — keep in sync with
+ * TOP_LEVEL_CONFIG_KEYS below). Kept loose (`unknown`) so callers
+ * inspect the keys they need without the type fighting them.
  */
 export interface DatabaseConfigModule {
   [key: string]: unknown;
@@ -34,10 +35,12 @@ export interface DatabaseConfigModule {
 }
 
 /**
- * Top-level keys that configure the CLI itself rather than naming a
- * database environment. The env-name lookup / "Available" error
+ * Non-environment top-level keys recognized in config/database.ts.
+ * Currently: `schemaFormat`. The env-name lookup / "Available" error
  * message excludes these so users don't see `schemaFormat` listed
- * alongside `development`/`test`/`production`.
+ * alongside `development`/`test`/`production`. When adding a new
+ * top-level key, update both this set and the DatabaseConfigModule
+ * shape above.
  */
 const TOP_LEVEL_CONFIG_KEYS = new Set<string>(["schemaFormat"]);
 
@@ -76,11 +79,14 @@ export async function loadDatabaseConfigModule(
   try {
     mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
   } catch (error: unknown) {
-    const rel = path.relative(cwd, configPath);
+    const rel = path.relative(cwd, configPath) || configPath;
     // Extract a useful message even when user code throws a non-Error
     // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
     // would produce `undefined` or crash.
-    const message = error instanceof Error ? error.message : String(error);
+    // Strip trailing punctuation from the inner message so the final
+    // string doesn't end up with a double period like "...message..".
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const message = rawMessage.replace(/[.!?]+$/, "");
     const enhanced = new Error(
       `Failed to load database config from "${rel}": ${message}. ` +
         `Run with tsx (e.g., "npx tsx node_modules/.bin/trails").`,
@@ -180,8 +186,10 @@ export async function resolveSchemaFormat(
   if (loaded && "schemaFormat" in loaded.module) {
     // Presence-based: an explicitly-set-but-garbage value (including an
     // empty string) is a misconfig that should throw, not silently fall
-    // through to inference.
-    return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loaded.path}`);
+    // through to inference. Use a relative path in the error source so
+    // it stays short and consistent with other config-loading errors.
+    const loadedRel = path.relative(cwd, loaded.path) || loaded.path;
+    return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loadedRel}`);
   }
 
   const dbDir = path.join(cwd, "db");

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -154,7 +154,16 @@ export async function resolveSchemaFormat(
   opts: { format?: string } = {},
   cwd: string = process.cwd(),
 ): Promise<SchemaFormat> {
-  const normalize = (raw: string, source: string): SchemaFormat => {
+  const normalize = (raw: unknown, source: string): SchemaFormat => {
+    // `schemaFormat` in config/database.ts is user-authored with only
+    // structural typing, so we can be handed a number, boolean, etc.
+    // Refuse with the same source-labeled error instead of blowing up
+    // when the unchecked input lacks `.toLowerCase`.
+    if (typeof raw !== "string") {
+      throw new Error(
+        `Invalid ${source} value ${JSON.stringify(raw)}. Expected one of: ts, js, sql.`,
+      );
+    }
     const normalized = raw.toLowerCase();
     if (normalized !== "ts" && normalized !== "js" && normalized !== "sql") {
       throw new Error(`Invalid ${source} value "${raw}". Expected one of: ts, js, sql.`);

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -79,6 +79,74 @@ export async function loadDatabaseConfig(
   return envConfig as DatabaseConfig;
 }
 
+export type SchemaFormat = "ts" | "js" | "sql";
+
+/**
+ * Resolve the effective `schemaFormat` for CLI dump/load commands.
+ *
+ * Precedence (highest wins):
+ *   1. Explicit CLI flag (`opts.format`)
+ *   2. Top-level `schemaFormat` key in config/database.ts
+ *   3. Existence inference — pick ts/js/sql based on which schema file
+ *      is already present in `db/`. Lets users migrate to a different
+ *      format by simply deleting the old file + dumping.
+ *   4. Default "ts"
+ *
+ * Returns the resolved format. Callers should assign it to
+ * `DatabaseTasks.schemaFormat` before invoking dump/load.
+ */
+export async function resolveSchemaFormat(
+  opts: { format?: string } = {},
+  cwd: string = process.cwd(),
+): Promise<SchemaFormat> {
+  if (opts.format) {
+    const normalized = opts.format.toLowerCase();
+    if (normalized !== "ts" && normalized !== "js" && normalized !== "sql") {
+      throw new Error(`Invalid --format value "${opts.format}". Expected one of: ts, js, sql.`);
+    }
+    return normalized as SchemaFormat;
+  }
+
+  // Inspect the config file for a top-level `schemaFormat` key (sibling
+  // of the per-env configs). Rails sets this via
+  // `config.active_record.schema_format` in config/application.rb; trails
+  // folds it into config/database.ts so the one file holds everything a
+  // db command needs to know.
+  const candidates = [
+    path.join(cwd, "config", "database.ts"),
+    path.join(cwd, "config", "database.js"),
+    path.join(cwd, "src", "config", "database.ts"),
+    path.join(cwd, "src", "config", "database.js"),
+  ];
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    try {
+      const mod = (await import(pathToFileURL(candidate).href)) as {
+        default?: { schemaFormat?: string };
+        schemaFormat?: string;
+      };
+      const configs = mod.default ?? mod;
+      const fromConfig = (configs as { schemaFormat?: string }).schemaFormat;
+      if (fromConfig) {
+        const normalized = fromConfig.toLowerCase();
+        if (normalized === "ts" || normalized === "js" || normalized === "sql") {
+          return normalized;
+        }
+      }
+    } catch {
+      // Fall through to inference — broken config files are surfaced by
+      // the main loadDatabaseConfig call, not this lookup.
+    }
+    break;
+  }
+
+  const dbDir = path.join(cwd, "db");
+  if (fs.existsSync(path.join(dbDir, "structure.sql"))) return "sql";
+  if (fs.existsSync(path.join(dbDir, "schema.js"))) return "js";
+  if (fs.existsSync(path.join(dbDir, "schema.ts"))) return "ts";
+  return "ts";
+}
+
 /**
  * Create the appropriate database adapter from a config object.
  */

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -108,10 +108,12 @@ export async function loadDatabaseConfigModule(
     const rel = path.relative(cwd, configPath) || configPath;
     // Extract a useful message even when user code throws a non-Error
     // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
-    // would produce `undefined` or crash.
+    // would produce `undefined` or crash. Route non-Errors through
+    // formatUnknown so a thrown object with a poisoned toString()
+    // can't bring down the fallback path too.
     // Strip trailing punctuation from the inner message so the final
     // string doesn't end up with a double period like "...message..".
-    const rawMessage = error instanceof Error ? error.message : String(error);
+    const rawMessage = error instanceof Error ? error.message : formatUnknown(error);
     const message = rawMessage.replace(/[.!?]+$/, "");
     const enhanced = new Error(
       `Failed to load database config from "${rel}": ${message}. ` +

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { pathToFileURL } from "node:url";
+import { inspect } from "node:util";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
@@ -119,9 +120,12 @@ export async function loadDatabaseConfig(
     | undefined;
   if (!envConfig) {
     const envs = Object.keys(loaded.module).filter((k) => !TOP_LEVEL_CONFIG_KEYS.has(k));
-    throw new Error(
-      `No database configuration for environment "${resolvedEnv}". Available: ${envs.join(", ")}`,
-    );
+    // Distinguish "asked for 'production' but only have 'development'"
+    // from "config file defines no environments at all" — the latter
+    // would otherwise produce the confusing "Available: " with nothing
+    // after the colon.
+    const available = envs.length > 0 ? `Available: ${envs.join(", ")}` : "No environments defined";
+    throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
   return envConfig;
@@ -160,9 +164,22 @@ export async function resolveSchemaFormat(
     // Refuse with the same source-labeled error instead of blowing up
     // when the unchecked input lacks `.toLowerCase`.
     if (typeof raw !== "string") {
-      throw new Error(
-        `Invalid ${source} value ${JSON.stringify(raw)}. Expected one of: ts, js, sql.`,
-      );
+      // JSON.stringify can itself throw on bigint / circular values.
+      // util.inspect handles those (and returns a readable repr for
+      // non-string types like `42` → "42", `true` → "true"), so the
+      // fallback to String() stays as a last resort if inspect ever
+      // throws.
+      let formatted: string;
+      try {
+        formatted = inspect(raw, { breakLength: Infinity });
+      } catch {
+        try {
+          formatted = String(raw);
+        } catch {
+          formatted = "<unformattable>";
+        }
+      }
+      throw new Error(`Invalid ${source} value ${formatted}. Expected one of: ts, js, sql.`);
     }
     const normalized = raw.toLowerCase();
     if (normalized !== "ts" && normalized !== "js" && normalized !== "sql") {

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,7 +1,6 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { pathToFileURL } from "node:url";
-import { inspect } from "node:util";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
@@ -44,6 +43,32 @@ export interface DatabaseConfigModule {
  * shape above.
  */
 const TOP_LEVEL_CONFIG_KEYS = new Set<string>(["schemaFormat"]);
+
+/**
+ * Safely render an unknown value for inclusion in an error message.
+ * Total over every JS value: bigint -> `42n`, symbol -> `Symbol(foo)`,
+ * undefined/null -> `undefined`/`null`, objects fall back to a type tag
+ * when they can't be JSON-serialized (circular refs, thrown toJSON).
+ * No Node deps — this file sits at the boundary between trailties CLI
+ * code and the rest of the system, which should stay browser-safe.
+ */
+function formatUnknown(value: unknown): string {
+  if (value === null) return "null";
+  const type = typeof value;
+  if (type === "string") return JSON.stringify(value);
+  if (type === "bigint") return `${value as bigint}n`;
+  if (type === "symbol" || type === "function" || type === "undefined") return String(value);
+  if (type === "number" || type === "boolean") return String(value);
+  // Objects: prefer a JSON repr, fall back to a type tag if that
+  // blows up (circular ref, toJSON that throws, etc).
+  try {
+    return JSON.stringify(value);
+  } catch {
+    const proto = Object.getPrototypeOf(value as object);
+    const ctor = proto?.constructor?.name ?? "Object";
+    return `[object ${ctor}]`;
+  }
+}
 
 /**
  * Locate + import the app's `config/database.*`. Centralized so we only
@@ -164,22 +189,15 @@ export async function resolveSchemaFormat(
     // Refuse with the same source-labeled error instead of blowing up
     // when the unchecked input lacks `.toLowerCase`.
     if (typeof raw !== "string") {
-      // JSON.stringify can itself throw on bigint / circular values.
-      // util.inspect handles those (and returns a readable repr for
-      // non-string types like `42` → "42", `true` → "true"), so the
-      // fallback to String() stays as a last resort if inspect ever
-      // throws.
-      let formatted: string;
-      try {
-        formatted = inspect(raw, { breakLength: Infinity });
-      } catch {
-        try {
-          formatted = String(raw);
-        } catch {
-          formatted = "<unformattable>";
-        }
-      }
-      throw new Error(`Invalid ${source} value ${formatted}. Expected one of: ts, js, sql.`);
+      // Format the offending value for the error message. JSON.stringify
+      // throws on bigint / circular objects, and util.inspect would pull
+      // in a Node-only dep — neither is acceptable for code that sits
+      // in a package whose runtime surface should route through
+      // activesupport adapters. Roll our own minimal, total formatter:
+      // typeof-dispatched and always returns a string.
+      throw new Error(
+        `Invalid ${source} value ${formatUnknown(raw)}. Expected one of: ts, js, sql.`,
+      );
     }
     const normalized = raw.toLowerCase();
     if (normalized !== "ts" && normalized !== "js" && normalized !== "sql") {

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -71,15 +71,20 @@ function formatUnknown(value: unknown): string {
 }
 
 /**
- * Locate + import the app's `config/database.*`. Centralized so we only
- * pay the dynamic-import cost once per CLI invocation — both
- * loadDatabaseConfig and resolveSchemaFormat route through here. Node's
- * ESM loader caches by URL, so repeat calls for the same path return
- * the same module without re-running side effects.
+ * Locate + import the app's `config/database.*`. Centralizing this keeps
+ * the lookup/import logic in one place — both loadDatabaseConfig and
+ * resolveSchemaFormat route through here. Node's ESM loader caches by
+ * URL, so repeat calls for the same path return the same module without
+ * re-running module side effects (the import() call itself still runs,
+ * it just resolves against the cache).
  *
  * Returns `null` when no config file is present — callers decide whether
  * that's an error (loadDatabaseConfig) or just absence (resolver
  * falling through to existence inference).
+ *
+ * Throws a source-labeled error when the config file loads but its
+ * default export isn't an object (e.g. `export default "oops"`), so
+ * downstream code doesn't need to defensively guard every key lookup.
  */
 export async function loadDatabaseConfigModule(
   cwd: string = process.cwd(),
@@ -101,7 +106,7 @@ export async function loadDatabaseConfigModule(
   }
   if (!configPath) return null;
 
-  let mod: { default?: DatabaseConfigModule } & DatabaseConfigModule;
+  let mod: { default?: unknown } & Record<string, unknown>;
   try {
     mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
   } catch (error: unknown) {
@@ -122,8 +127,18 @@ export async function loadDatabaseConfigModule(
     (enhanced as { cause?: unknown }).cause = error;
     throw enhanced;
   }
-  const module = (mod.default ?? mod) as DatabaseConfigModule;
-  return { path: configPath, module };
+  // `export default "oops"` loads fine but leaves us with a non-object
+  // default that will crash downstream `in` / Object.keys lookups with
+  // a confusing TypeError. Check up front and throw a clear message
+  // with the offending value's repr.
+  const candidate = mod.default ?? mod;
+  if (candidate === null || (typeof candidate !== "object" && typeof candidate !== "function")) {
+    const rel = path.relative(cwd, configPath) || configPath;
+    throw new Error(
+      `Invalid database config in "${rel}": expected an object, got ${formatUnknown(candidate)}.`,
+    );
+  }
+  return { path: configPath, module: candidate as DatabaseConfigModule };
 }
 
 /**
@@ -142,16 +157,25 @@ export async function loadDatabaseConfig(
     );
   }
 
+  const envs = Object.keys(loaded.module).filter((k) => !TOP_LEVEL_CONFIG_KEYS.has(k));
+  // Distinguish "asked for 'production' but only have 'development'"
+  // from "config file defines no environments at all" — the latter
+  // would otherwise produce the confusing "Available: " with nothing
+  // after the colon.
+  const available = envs.length > 0 ? `Available: ${envs.join(", ")}` : "No environments defined";
+
+  // Explicitly reject env names that collide with top-level keys (e.g.
+  // `TRAILS_ENV=schemaFormat`). Without this, the lookup below would
+  // happily return the string "ts" as a DatabaseConfig and adapter
+  // resolution would crash with a confusing error downstream.
+  if (TOP_LEVEL_CONFIG_KEYS.has(resolvedEnv)) {
+    throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
+  }
+
   const envConfig = (loaded.module as Record<string, unknown>)[resolvedEnv] as
     | DatabaseConfig
     | undefined;
   if (!envConfig) {
-    const envs = Object.keys(loaded.module).filter((k) => !TOP_LEVEL_CONFIG_KEYS.has(k));
-    // Distinguish "asked for 'production' but only have 'development'"
-    // from "config file defines no environments at all" — the latter
-    // would otherwise produce the confusing "Available: " with nothing
-    // after the colon.
-    const available = envs.length > 0 ? `Available: ${envs.join(", ")}` : "No environments defined";
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -23,15 +23,30 @@ export function resolveEnv(): string {
 }
 
 /**
- * Load the database configuration for the given environment.
- * Looks for config/database.ts or src/config/database.ts in the cwd.
+ * Shape of the exported object in config/database.ts: each env key maps
+ * to a DatabaseConfig, plus a few optional top-level keys (e.g.
+ * schemaFormat). Kept loose (`unknown`) so callers inspect the keys
+ * they need without the type fighting them.
  */
-export async function loadDatabaseConfig(
-  env?: string,
-  cwd: string = process.cwd(),
-): Promise<DatabaseConfig> {
-  const resolvedEnv = env ?? resolveEnv();
+export interface DatabaseConfigModule {
+  [key: string]: unknown;
+  schemaFormat?: string;
+}
 
+/**
+ * Locate + import the app's `config/database.*`. Centralized so we only
+ * pay the dynamic-import cost once per CLI invocation — both
+ * loadDatabaseConfig and resolveSchemaFormat route through here. Node's
+ * ESM loader caches by URL, so repeat calls for the same path return
+ * the same module without re-running side effects.
+ *
+ * Returns `null` when no config file is present — callers decide whether
+ * that's an error (loadDatabaseConfig) or just absence (resolver
+ * falling through to existence inference).
+ */
+export async function loadDatabaseConfigModule(
+  cwd: string = process.cwd(),
+): Promise<{ path: string; module: DatabaseConfigModule } | null> {
   // Prefer .ts (source of truth) over .js (compiled)
   const candidates = [
     path.join(cwd, "config", "database.ts"),
@@ -47,36 +62,51 @@ export async function loadDatabaseConfig(
       break;
     }
   }
+  if (!configPath) return null;
 
-  if (!configPath) {
+  let mod: { default?: DatabaseConfigModule } & DatabaseConfigModule;
+  try {
+    mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
+  } catch (error) {
+    const rel = path.relative(cwd, configPath);
+    const enhanced = new Error(
+      `Failed to load database config from "${rel}": ${(error as Error).message}. ` +
+        `Run with tsx (e.g., "npx tsx node_modules/.bin/trails").`,
+    );
+    (enhanced as { cause?: unknown }).cause = error;
+    throw enhanced;
+  }
+  const module = (mod.default ?? mod) as DatabaseConfigModule;
+  return { path: configPath, module };
+}
+
+/**
+ * Load the database configuration for the given environment.
+ * Looks for config/database.ts or src/config/database.ts in the cwd.
+ */
+export async function loadDatabaseConfig(
+  env?: string,
+  cwd: string = process.cwd(),
+): Promise<DatabaseConfig> {
+  const resolvedEnv = env ?? resolveEnv();
+  const loaded = await loadDatabaseConfigModule(cwd);
+  if (!loaded) {
     throw new Error(
       "No database config found. Expected config/database.ts (.js) or src/config/database.ts (.js)",
     );
   }
 
-  let mod: any;
-  try {
-    mod = await import(pathToFileURL(configPath).href);
-  } catch (error: any) {
-    const rel = path.relative(cwd, configPath);
-    const enhanced = new Error(
-      `Failed to load database config from "${rel}": ${error.message}. ` +
-        `Run with tsx (e.g., "npx tsx node_modules/.bin/trails").`,
-    );
-    (enhanced as any).cause = error;
-    throw enhanced;
-  }
-  const configs = mod.default ?? mod;
-
-  const envConfig = configs[resolvedEnv];
+  const envConfig = (loaded.module as Record<string, unknown>)[resolvedEnv] as
+    | DatabaseConfig
+    | undefined;
   if (!envConfig) {
     throw new Error(
       `No database configuration for environment "${resolvedEnv}". ` +
-        `Available: ${Object.keys(configs).join(", ")}`,
+        `Available: ${Object.keys(loaded.module).join(", ")}`,
     );
   }
 
-  return envConfig as DatabaseConfig;
+  return envConfig;
 }
 
 export type SchemaFormat = "ts" | "js" | "sql";
@@ -124,32 +154,17 @@ export async function resolveSchemaFormat(
   // `config.active_record.schema_format` in config/application.rb; trails
   // folds it into config/database.ts so the one file holds everything a
   // db command needs to know.
-  const candidates = [
-    path.join(cwd, "config", "database.ts"),
-    path.join(cwd, "config", "database.js"),
-    path.join(cwd, "src", "config", "database.ts"),
-    path.join(cwd, "src", "config", "database.js"),
-  ];
-  for (const candidate of candidates) {
-    if (!fs.existsSync(candidate)) continue;
-    try {
-      const mod = (await import(pathToFileURL(candidate).href)) as {
-        default?: { schemaFormat?: string };
-        schemaFormat?: string;
-      };
-      const configs = mod.default ?? mod;
-      const fromConfig = (configs as { schemaFormat?: string }).schemaFormat;
-      if (fromConfig) {
-        const normalized = fromConfig.toLowerCase();
-        if (normalized === "ts" || normalized === "js" || normalized === "sql") {
-          return normalized;
-        }
-      }
-    } catch {
-      // Fall through to inference — broken config files are surfaced by
-      // the main loadDatabaseConfig call, not this lookup.
-    }
-    break;
+  //
+  // Routes through the shared loader so we don't double-import the
+  // config file — Node's ESM cache already dedups by URL, but funneling
+  // both call sites through one function keeps error handling (the
+  // "failed to load config" rethrow) in one place and surfaces real
+  // import failures instead of silently falling through to inference.
+  const loaded = await loadDatabaseConfigModule(cwd);
+  if (loaded?.module.schemaFormat) {
+    // Validate strictly — an unknown value in config is a misconfig, not
+    // something we want to paper over with silent inference.
+    return normalize(loaded.module.schemaFormat, `schemaFormat in ${loaded.path}`);
   }
 
   const dbDir = path.join(cwd, "db");


### PR DESCRIPTION
## Summary

Adds schema-format selection for the trailties CLI, mirroring Rails' `config.active_record.schema_format` from `config/application.rb` and the `ENV["SCHEMA_FORMAT"]` override that `activerecord/lib/active_record/railties/databases.rake` consults.

Precedence (highest wins):
1. `--format=ts|js|sql` CLI flag on `db schema:dump` / `db schema:load` (Rails rake-arg equivalent)
2. `SCHEMA_FORMAT` env var — matches Rails `ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym`
3. Top-level `schemaFormat` key in `config/database.ts` (trails equivalent of `ActiveRecord.schema_format`)
4. Existence inference: `db/structure.sql` → sql, `db/schema.js` → js, `db/schema.ts` → ts
5. Default `ts`

Invalid values at any of the first three rungs throw a clear error naming the source.

## Test plan

- [x] `pnpm test` — full suite, 17088 passing / 4442 skipped
- [x] Unit: `resolveSchemaFormat` honors each precedence rung
- [x] Unit: invalid values at `--format`, `SCHEMA_FORMAT`, and `config.schemaFormat` are rejected with source-named errors
- [x] Integration: `db schema:dump --format=sql` writes `db/structure.sql`, not `db/schema.ts`
- [x] Integration: `db schema:dump` with `schemaFormat: "sql"` in config also writes `db/structure.sql`