### PR TITLE
feat(activerecord): Phase R.1 — array-likeness on CollectionProxy

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1339,11 +1339,12 @@ function wrapCollectionProxy<T extends Base = Base>(
       if (prop in target) return value;
       if (typeof prop === "symbol") return value;
 
-      // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target.
-      // Matches array semantics; same constraint as the other array-likeness
-      // on CollectionProxy (no fresh load; await first if you need one).
+      // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target
+      // via the public `target` accessor. Matches array semantics; same
+      // constraint as the other array-likeness on CollectionProxy (no fresh
+      // load; await first if you need one).
       if (typeof prop === "string" && /^(0|[1-9]\d*)$/.test(prop)) {
-        return target._target[Number(prop)];
+        return target.target[Number(prop)];
       }
 
       if (target._record._strictLoading && !target._record._strictLoadingBypassCount) {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1329,6 +1329,8 @@ export function association<T extends Base = Base>(
  * 1. Own/prototype properties (CollectionProxy methods, extend methods)
  * 2. Relation query methods + named scopes (via scope()'s own proxy)
  */
+const NUMERIC_INDEX_PATTERN = /^(0|[1-9]\d*)$/;
+
 function wrapCollectionProxy<T extends Base = Base>(
   proxy: CollectionProxy<T>,
 ): AssociationProxy<T> {
@@ -1343,7 +1345,7 @@ function wrapCollectionProxy<T extends Base = Base>(
       // via the public `target` accessor. Matches array semantics; same
       // constraint as the other array-likeness on CollectionProxy (no fresh
       // load; await first if you need one).
-      if (typeof prop === "string" && /^(0|[1-9]\d*)$/.test(prop)) {
+      if (typeof prop === "string" && NUMERIC_INDEX_PATTERN.test(prop)) {
         return target.target[Number(prop)];
       }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1343,8 +1343,9 @@ function wrapCollectionProxy<T extends Base = Base>(
 
       // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target
       // via the public `target` accessor. Matches array semantics; same
-      // constraint as the other array-likeness on CollectionProxy (no fresh
-      // load; await first if you need one).
+      // constraint as the other array-likeness on CollectionProxy: reads
+      // whatever's loaded. `await proxy` (or `await proxy.load()`) hydrates
+      // `_target` first if you need a fresh load.
       if (typeof prop === "string" && NUMERIC_INDEX_PATTERN.test(prop)) {
         return target.target[Number(prop)];
       }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1339,6 +1339,13 @@ function wrapCollectionProxy<T extends Base = Base>(
       if (prop in target) return value;
       if (typeof prop === "symbol") return value;
 
+      // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target.
+      // Matches array semantics; same constraint as the other array-likeness
+      // on CollectionProxy (no fresh load; await first if you need one).
+      if (typeof prop === "string" && /^(0|[1-9]\d*)$/.test(prop)) {
+        return target._target[Number(prop)];
+      }
+
       if (target._record._strictLoading && !target._record._strictLoadingBypassCount) {
         throw StrictLoadingViolationError.forAssociation(target._record, target._assocName);
       }

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -81,11 +81,13 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(titles).toEqual(["a", "b", "c"]);
   });
 
-  it("supports numeric indexing (proxy[0])", async () => {
+  it("supports numeric indexing (proxy[0]) — typed via the index signature", async () => {
     const blog = await blogWithPosts();
-    const proxy = association<ApPost>(blog, "apPosts") as any;
-    expect(proxy[0].title).toBe("a");
-    expect(proxy[2].title).toBe("c");
+    const proxy = association<ApPost>(blog, "apPosts");
+    // No `as any` needed — CollectionProxy declares
+    // `[index: number]: T | undefined`. Out-of-range returns undefined.
+    expect(proxy[0]?.title).toBe("a");
+    expect(proxy[2]?.title).toBe("c");
     expect(proxy[99]).toBeUndefined();
   });
 

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -154,4 +154,32 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const arr = await proxy;
     expect(arr.map((p) => p.title)).toEqual(["a", "b", "c"]);
   });
+
+  it("keys / values / entries work", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect([...proxy.keys()]).toEqual([0, 1, 2]);
+    expect([...proxy.values()].map((p) => p.title)).toEqual(["a", "b", "c"]);
+    expect([...proxy.entries()].map(([i, p]) => `${i}:${p.title}`)).toEqual(["0:a", "1:b", "2:c"]);
+  });
+
+  it("Array.isArray returns false on the proxy (known limitation)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    // `Array.isArray` checks an internal slot that proxies cannot fake.
+    // Consumers of the post-R.2 reader who branch on Array.isArray must
+    // reach for the loaded target via `await` or `Array.from(...)`.
+    expect(Array.isArray(proxy)).toBe(false);
+    expect(Array.isArray(Array.from(proxy))).toBe(true);
+  });
+
+  it("does NOT shadow Relation#find (PK lookup) with Array#find", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    // `find` falls through to Relation, which interprets it as a PK lookup.
+    // We intentionally don't add Array#find on CollectionProxy — Rails
+    // gives Relation#find the same priority.
+    const found = await proxy.find(blog.apPosts[0]?.id);
+    expect(found?.title).toBe("a");
+  });
 });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -191,6 +191,23 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(arr.map((p) => p.title)).toEqual(["a", "b", "c"]);
   });
 
+  it("await proxy hydrates `_target` so subsequent sync ops work", async () => {
+    // Build a blog/post pair WITHOUT pre-loading via blogWithPosts (which
+    // calls .load()). `await proxy` alone should be enough to make
+    // `proxy.length`, `proxy[0]`, iteration all work afterwards.
+    const blog = new ApBlog({ name: "Fresh" });
+    await blog.save();
+    for (const title of ["x", "y"]) {
+      const p = new ApPost({ title, ap_blog_id: blog.id as number });
+      await p.save();
+    }
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    await proxy;
+    expect(proxy.length).toBe(2);
+    expect(proxy[0]?.title).toBe("x");
+    expect([...proxy].map((p: ApPost) => p.title)).toEqual(["x", "y"]);
+  });
+
   it("keys / entries work (values intentionally not added)", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -96,13 +96,38 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(seen).toEqual(["a", "b", "c"]);
   });
 
-  it("some / every / includes work", async () => {
+  it("some / every work", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");
     expect(proxy.some((p) => p.title === "b")).toBe(true);
     expect(proxy.every((p) => p.title.length === 1)).toBe(true);
+  });
+
+  it("preserves Relation#includes (eager loading) — proxy.includes routes to Relation", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
     const first = proxy.at(0)!;
-    expect(proxy.includes(first)).toBe(true);
+    // CollectionProxy intentionally does NOT define an Array-style
+    // includes — that would shadow Relation#includes(...associations).
+    // proxy.includes(...) falls through to Relation and builds an
+    // eager-loading Relation. Membership is via Array.from(proxy).
+    const rel = proxy.includes("apPosts");
+    expect(typeof rel?.where).toBe("function"); // it's a Relation, not a boolean
+    expect(Array.from(proxy as Iterable<ApPost>).includes(first)).toBe(true);
+    expect(proxy.target.includes(first)).toBe(true);
+  });
+
+  it("preserves Relation#values (query state) — proxy.values routes to Relation", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    // CollectionProxy intentionally does NOT define an Array-style
+    // values() — that would shadow Relation#values which returns the
+    // query-state Record<string, unknown>. Iteration is via
+    // [Symbol.iterator] / spread / Array.from.
+    const v = proxy.values();
+    expect(typeof v).toBe("object");
+    expect(Array.isArray(v)).toBe(false); // confirms it's not the array iterator
+    expect([...(proxy as Iterable<ApPost>)].map((p) => p.title)).toEqual(["a", "b", "c"]);
   });
 
   it("slice returns a plain array shallow copy", async () => {
@@ -155,12 +180,33 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(arr.map((p) => p.title)).toEqual(["a", "b", "c"]);
   });
 
-  it("keys / values / entries work", async () => {
+  it("keys / entries work (values intentionally not added)", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");
     expect([...proxy.keys()]).toEqual([0, 1, 2]);
-    expect([...proxy.values()].map((p) => p.title)).toEqual(["a", "b", "c"]);
     expect([...proxy.entries()].map(([i, p]) => `${i}:${p.title}`)).toEqual(["0:a", "1:b", "2:c"]);
+  });
+
+  it("array methods accept a thisArg (matches Array.prototype signatures)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const ctx = { suffix: "!" };
+    const titles = proxy.map(function (this: { suffix: string }, p) {
+      return p.title + this.suffix;
+    }, ctx);
+    expect(titles).toEqual(["a!", "b!", "c!"]);
+  });
+
+  it("reduce supports the no-initial overload (Array.prototype parity)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    // Without an initial value, accumulator type is the element type (T).
+    // Use `_loaded` as a sentinel to grab the first record then concatenate.
+    const concat = proxy.reduce((acc, p) => {
+      // ts-ignore the lie: we're concatenating titles for a string demo
+      return { ...acc, title: (acc as ApPost).title + p.title } as ApPost;
+    });
+    expect(concat.title).toBe("abc");
   });
 
   it("Array.isArray returns false on the proxy (known limitation)", async () => {

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -84,8 +84,9 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("supports numeric indexing (proxy[0]) — typed via the index signature", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");
-    // No `as any` needed — CollectionProxy declares
-    // `[index: number]: T | undefined`. Out-of-range returns undefined.
+    // No `as any` needed — AssociationProxy declares
+    // `[index: number]: T | undefined` (the runtime support comes from
+    // `wrapCollectionProxy`'s `get` trap). Out-of-range returns undefined.
     expect(proxy[0]?.title).toBe("a");
     expect(proxy[2]?.title).toBe("c");
     expect(proxy[99]).toBeUndefined();
@@ -249,12 +250,14 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(Array.isArray(Array.from(proxy))).toBe(true);
   });
 
-  it("does NOT shadow Relation#find (PK lookup) with Array#find", async () => {
+  it("preserves PK-lookup `find(id)` — Array-style find(predicate) intentionally not added", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts") as any;
-    // `find` falls through to Relation, which interprets it as a PK lookup.
-    // We intentionally don't add Array#find on CollectionProxy — Rails
-    // gives Relation#find the same priority.
+    // CollectionProxy already defines `async find(id): Promise<T | T[]>`
+    // (the Rails-style PK lookup form), and that's what `proxy.find(...)`
+    // resolves to. We intentionally do NOT add an Array-style
+    // `find(predicate)` overload — it would shadow the PK lookup.
+    // For Array semantics use `Array.from(proxy).find(p => ...)`.
     const found = await proxy.find(blog.apPosts[0]?.id);
     expect(found?.title).toBe("a");
   });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -1,0 +1,157 @@
+// Phase R.1: array-likeness on CollectionProxy / AssociationProxy.
+//
+// These tests exercise the additive surface that makes an
+// AssociationProxy a drop-in for the Base[] reader collection
+// associations return today. No reader change yet — these methods
+// just exist on the proxy returned by `association(record, name)`.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, association, registerModel } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("CollectionProxy — array-likeness (Phase R.1)", () => {
+  let adapter: DatabaseAdapter;
+
+  class ApBlog extends Base {
+    declare name: string;
+    declare apPosts: ApPost[];
+
+    static {
+      this.attribute("name", "string");
+    }
+  }
+
+  class ApPost extends Base {
+    declare apBlogId: number | null;
+    declare title: string;
+
+    static {
+      this.attribute("title", "string");
+      this.attribute("ap_blog_id", "integer");
+    }
+  }
+
+  // hasMany must be set up after both classes exist so the inflection
+  // can find ApPost in the model registry.
+  ApBlog.hasMany("apPosts", { className: "ApPost" });
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    ApBlog.adapter = adapter;
+    ApPost.adapter = adapter;
+    registerModel(ApBlog);
+    registerModel(ApPost);
+  });
+
+  async function blogWithPosts(): Promise<ApBlog> {
+    const blog = new ApBlog({ name: "Dev" });
+    await blog.save();
+    for (const title of ["a", "b", "c"]) {
+      const p = new ApPost({ title, ap_blog_id: blog.id as number });
+      await p.save();
+    }
+    const proxy = association<ApPost>(blog, "apPosts");
+    await proxy.load();
+    return blog;
+  }
+
+  it("exposes `length` against the loaded target", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect(proxy.length).toBe(3);
+  });
+
+  it("is iterable via `for ... of`", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const titles: string[] = [];
+    for (const p of proxy) titles.push(p.title);
+    expect(titles).toEqual(["a", "b", "c"]);
+  });
+
+  it("supports numeric indexing (proxy[0])", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    expect(proxy[0].title).toBe("a");
+    expect(proxy[2].title).toBe("c");
+    expect(proxy[99]).toBeUndefined();
+  });
+
+  it("at(index) returns the record or undefined", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect(proxy.at(0)?.title).toBe("a");
+    expect(proxy.at(-1)?.title).toBe("c");
+    expect(proxy.at(99)).toBeUndefined();
+  });
+
+  it("map / filter / forEach delegate to the target", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect(proxy.map((p) => p.title)).toEqual(["a", "b", "c"]);
+    expect(proxy.filter((p) => p.title !== "b").map((p) => p.title)).toEqual(["a", "c"]);
+    const seen: string[] = [];
+    proxy.forEach((p) => seen.push(p.title));
+    expect(seen).toEqual(["a", "b", "c"]);
+  });
+
+  it("some / every / includes work", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect(proxy.some((p) => p.title === "b")).toBe(true);
+    expect(proxy.every((p) => p.title.length === 1)).toBe(true);
+    const first = proxy.at(0)!;
+    expect(proxy.includes(first)).toBe(true);
+  });
+
+  it("slice returns a plain array shallow copy", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const head = proxy.slice(0, 2);
+    expect(head.map((p) => p.title)).toEqual(["a", "b"]);
+    expect(Array.isArray(head)).toBe(true);
+  });
+
+  it("reduce composes over the target", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const concatenated = proxy.reduce((acc, p) => acc + p.title, "");
+    expect(concatenated).toBe("abc");
+  });
+
+  it("indexOf / flatMap work", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const second = proxy.at(1)!;
+    expect(proxy.indexOf(second)).toBe(1);
+    expect(proxy.flatMap((p) => [p.title, p.title.toUpperCase()])).toEqual([
+      "a",
+      "A",
+      "b",
+      "B",
+      "c",
+      "C",
+    ]);
+  });
+
+  it("array spread reads the loaded target", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const titles = [...proxy].map((p) => p.title);
+    expect(titles).toEqual(["a", "b", "c"]);
+  });
+
+  it("Array.from reads the loaded target", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    expect(Array.from(proxy).length).toBe(3);
+  });
+
+  it("await still resolves to the loaded array (thenable preserved)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const arr = await proxy;
+    expect(arr.map((p) => p.title)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -62,6 +62,17 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(proxy.length).toBe(3);
   });
 
+  it("shadows Relation#length() — use proxy.count() for async count", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    // `proxy.length` is now a sync number (mirrors Array / Rails).
+    expect(typeof proxy.length).toBe("number");
+    // For Relation's async count semantics, reach for .count() which still
+    // routes through to Relation via AssociationProxy delegation.
+    expect(typeof proxy.count).toBe("function");
+    expect(await proxy.count()).toBe(3);
+  });
+
   it("is iterable via `for ... of`", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -97,23 +97,23 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.at(index);
   }
 
-  map<U>(fn: (record: T, index: number, all: readonly T[]) => U, thisArg?: unknown): U[] {
+  map<U>(fn: (record: T, index: number, all: T[]) => U, thisArg?: unknown): U[] {
     return this._target.map(fn, thisArg);
   }
 
-  filter(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): T[] {
+  filter(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[] {
     return this._target.filter(fn, thisArg);
   }
 
-  forEach(fn: (record: T, index: number, all: readonly T[]) => void, thisArg?: unknown): void {
+  forEach(fn: (record: T, index: number, all: T[]) => void, thisArg?: unknown): void {
     this._target.forEach(fn, thisArg);
   }
 
-  some(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): boolean {
+  some(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
     return this._target.some(fn, thisArg);
   }
 
-  every(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): boolean {
+  every(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
     return this._target.every(fn, thisArg);
   }
 
@@ -129,8 +129,8 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.slice(start, end);
   }
 
-  reduce(fn: (acc: T, record: T, index: number, all: readonly T[]) => T): T;
-  reduce<U>(fn: (acc: U, record: T, index: number, all: readonly T[]) => U, initial: U): U;
+  reduce(fn: (acc: T, record: T, index: number, all: T[]) => T): T;
+  reduce<U>(fn: (acc: U, record: T, index: number, all: T[]) => U, initial: U): U;
   reduce(...args: [unknown, ...unknown[]]): unknown {
     // Forward verbatim so Array.prototype.reduce sees the right arity
     // (with vs. without an initial value picks different semantics).
@@ -141,10 +141,7 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.indexOf(record, fromIndex);
   }
 
-  flatMap<U>(
-    fn: (record: T, index: number, all: readonly T[]) => U | readonly U[],
-    thisArg?: unknown,
-  ): U[] {
+  flatMap<U>(fn: (record: T, index: number, all: T[]) => U | readonly U[], thisArg?: unknown): U[] {
     return this._target.flatMap(fn, thisArg);
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -73,6 +73,70 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target;
   }
 
+  // ──────────────────────────────────────────────────────────────────
+  // Array-likeness — sync ops over the loaded target.
+  //
+  // Rails' CollectionProxy IS a Relation that's iterable / countable
+  // / array-shaped against the loaded records. JS has no blocking IO,
+  // so these methods do NOT trigger a fresh DB load — they read
+  // whatever's in `_target` (populated by `await proxy`,
+  // `await proxy.load()`, `Post.includes(...)`, or push / build /
+  // create through the proxy). For a fresh load, await the proxy
+  // first.
+  // ──────────────────────────────────────────────────────────────────
+
+  get length(): number {
+    return this._target.length;
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this._target[Symbol.iterator]();
+  }
+
+  at(index: number): T | undefined {
+    return this._target.at(index);
+  }
+
+  map<U>(fn: (record: T, index: number, all: readonly T[]) => U): U[] {
+    return this._target.map(fn);
+  }
+
+  filter(fn: (record: T, index: number, all: readonly T[]) => unknown): T[] {
+    return this._target.filter(fn);
+  }
+
+  forEach(fn: (record: T, index: number, all: readonly T[]) => void): void {
+    this._target.forEach(fn);
+  }
+
+  some(fn: (record: T, index: number, all: readonly T[]) => unknown): boolean {
+    return this._target.some(fn);
+  }
+
+  every(fn: (record: T, index: number, all: readonly T[]) => unknown): boolean {
+    return this._target.every(fn);
+  }
+
+  includes(record: T, fromIndex?: number): boolean {
+    return this._target.includes(record, fromIndex);
+  }
+
+  slice(start?: number, end?: number): T[] {
+    return this._target.slice(start, end);
+  }
+
+  reduce<U>(fn: (acc: U, record: T, index: number, all: readonly T[]) => U, initial: U): U {
+    return this._target.reduce(fn, initial);
+  }
+
+  indexOf(record: T, fromIndex?: number): number {
+    return this._target.indexOf(record, fromIndex);
+  }
+
+  flatMap<U>(fn: (record: T, index: number, all: readonly T[]) => U | readonly U[]): U[] {
+    return this._target.flatMap(fn);
+  }
+
   /** @internal Initialize from preloaded association data. */
   _hydrateFromPreload(records: T[]): void {
     // Preserve any unsaved in-memory records (from build/push before preload ran)

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -111,8 +111,14 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.map(fn, thisArg);
   }
 
-  filter(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[] {
-    return this._target.filter(fn, thisArg);
+  // filter has the standard type-predicate overload from Array<T>.
+  filter<S extends T>(
+    predicate: (record: T, index: number, all: T[]) => record is S,
+    thisArg?: unknown,
+  ): S[];
+  filter(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[];
+  filter(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[] {
+    return this._target.filter(predicate, thisArg);
   }
 
   forEach(fn: (record: T, index: number, all: T[]) => void, thisArg?: unknown): void {
@@ -123,8 +129,14 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.some(fn, thisArg);
   }
 
-  every(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
-    return this._target.every(fn, thisArg);
+  // every has the standard type-predicate overload from Array<T>.
+  every<S extends T>(
+    predicate: (record: T, index: number, all: T[]) => record is S,
+    thisArg?: unknown,
+  ): boolean;
+  every(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean;
+  every(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
+    return this._target.every(predicate, thisArg);
   }
 
   // `includes` and `find` are intentionally NOT added — they would
@@ -142,9 +154,10 @@ export class CollectionProxy<T extends Base = Base> {
   reduce(fn: (acc: T, record: T, index: number, all: T[]) => T): T;
   reduce<U>(fn: (acc: U, record: T, index: number, all: T[]) => U, initial: U): U;
   reduce(...args: [unknown, ...unknown[]]): unknown {
-    // Forward verbatim so Array.prototype.reduce sees the right arity
-    // (with vs. without an initial value picks different semantics).
-    return (this._target.reduce as (...a: unknown[]) => unknown)(...args);
+    // Forward verbatim with the array as receiver — reduce needs `this`
+    // to be the array. (with-vs-without initial value picks different
+    // semantics, hence the variadic forwarding.)
+    return (this._target.reduce as (...a: unknown[]) => unknown).apply(this._target, args);
   }
 
   indexOf(record: T, fromIndex?: number): number {
@@ -1391,4 +1404,9 @@ export class CollectionProxy<T extends Base = Base> {
   }
 }
 
-applyThenable(CollectionProxy.prototype);
+// Route `await proxy` through `load()` (not `toArray`) so the thenable
+// also hydrates `_target` — matches the documented contract that
+// `await proxy; proxy[0]` / `proxy.length` work after a single await.
+// `toArray()` stays available for "give me a fresh array now without
+// touching the cache" callers.
+applyThenable(CollectionProxy.prototype, "load");

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -97,53 +97,65 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.at(index);
   }
 
-  map<U>(fn: (record: T, index: number, all: readonly T[]) => U): U[] {
-    return this._target.map(fn);
+  map<U>(fn: (record: T, index: number, all: readonly T[]) => U, thisArg?: unknown): U[] {
+    return this._target.map(fn, thisArg);
   }
 
-  filter(fn: (record: T, index: number, all: readonly T[]) => unknown): T[] {
-    return this._target.filter(fn);
+  filter(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): T[] {
+    return this._target.filter(fn, thisArg);
   }
 
-  forEach(fn: (record: T, index: number, all: readonly T[]) => void): void {
-    this._target.forEach(fn);
+  forEach(fn: (record: T, index: number, all: readonly T[]) => void, thisArg?: unknown): void {
+    this._target.forEach(fn, thisArg);
   }
 
-  some(fn: (record: T, index: number, all: readonly T[]) => unknown): boolean {
-    return this._target.some(fn);
+  some(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): boolean {
+    return this._target.some(fn, thisArg);
   }
 
-  every(fn: (record: T, index: number, all: readonly T[]) => unknown): boolean {
-    return this._target.every(fn);
+  every(fn: (record: T, index: number, all: readonly T[]) => unknown, thisArg?: unknown): boolean {
+    return this._target.every(fn, thisArg);
   }
 
-  includes(record: T, fromIndex?: number): boolean {
-    return this._target.includes(record, fromIndex);
-  }
+  // `includes` and `find` are intentionally NOT added — they would
+  // shadow `Relation#includes(...associations)` (eager-loading) and
+  // `Relation#find(id)` (PK lookup) on the AssociationProxy. Reach for
+  // membership / array-find via `Array.from(proxy).includes(...)` /
+  // `Array.from(proxy).find(...)` (or `proxy.target.includes(...)`).
+  // Matches Rails' priority — CollectionProxy preserves the Relation
+  // surface and lets array semantics route through `to_a`.
 
   slice(start?: number, end?: number): T[] {
     return this._target.slice(start, end);
   }
 
-  reduce<U>(fn: (acc: U, record: T, index: number, all: readonly T[]) => U, initial: U): U {
-    return this._target.reduce(fn, initial);
+  reduce(fn: (acc: T, record: T, index: number, all: readonly T[]) => T): T;
+  reduce<U>(fn: (acc: U, record: T, index: number, all: readonly T[]) => U, initial: U): U;
+  reduce(...args: [unknown, ...unknown[]]): unknown {
+    // Forward verbatim so Array.prototype.reduce sees the right arity
+    // (with vs. without an initial value picks different semantics).
+    return (this._target.reduce as (...a: unknown[]) => unknown)(...args);
   }
 
   indexOf(record: T, fromIndex?: number): number {
     return this._target.indexOf(record, fromIndex);
   }
 
-  flatMap<U>(fn: (record: T, index: number, all: readonly T[]) => U | readonly U[]): U[] {
-    return this._target.flatMap(fn);
+  flatMap<U>(
+    fn: (record: T, index: number, all: readonly T[]) => U | readonly U[],
+    thisArg?: unknown,
+  ): U[] {
+    return this._target.flatMap(fn, thisArg);
   }
 
   keys(): IterableIterator<number> {
     return this._target.keys();
   }
 
-  values(): IterableIterator<T> {
-    return this._target.values();
-  }
+  // `values()` is intentionally NOT added — it would shadow
+  // `Relation#values(): Record<string, unknown>` (query-state
+  // introspection used by the Relation merger). Use the proxy's
+  // built-in iteration (`for...of`, `[...proxy]`, `Array.from(proxy)`).
 
   entries(): IterableIterator<[number, T]> {
     return this._target.entries();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -22,7 +22,11 @@ import {
 } from "../associations.js";
 
 export interface CollectionProxy<T extends Base = Base> {
-  // Thenable — makes CollectionProxy awaitable (delegates to toArray)
+  // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
+  // which both returns the loaded records AND hydrates `_target`, so
+  // subsequent sync ops (`proxy.length`, `proxy[0]`, iteration) work
+  // after a single `await proxy`. Wired at the bottom of the file via
+  // `applyThenable(CollectionProxy.prototype, "load")`.
   then<TResult1 = T[], TResult2 = never>(
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -137,6 +137,18 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.flatMap(fn);
   }
 
+  keys(): IterableIterator<number> {
+    return this._target.keys();
+  }
+
+  values(): IterableIterator<T> {
+    return this._target.values();
+  }
+
+  entries(): IterableIterator<[number, T]> {
+    return this._target.entries();
+  }
+
   /** @internal Initialize from preloaded association data. */
   _hydrateFromPreload(records: T[]): void {
     // Preserve any unsaved in-memory records (from build/push before preload ran)

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -22,6 +22,12 @@ import {
 } from "../associations.js";
 
 export interface CollectionProxy<T extends Base = Base> {
+  // Numeric indexing — `proxy[0]` reads the loaded target via the
+  // wrapCollectionProxy `get` trap. Declared here so consumers don't
+  // need `as any`. Out-of-range / unloaded indices return `undefined`,
+  // matching `Array<T>[i]` semantics under TS's standard lib.
+  [index: number]: T | undefined;
+
   // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
   // which both returns the loaded records AND hydrates `_target`, so
   // subsequent sync ops (`proxy.length`, `proxy[0]`, iteration) work

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -154,13 +154,18 @@ export class CollectionProxy<T extends Base = Base> {
     return this._target.every(predicate, thisArg);
   }
 
-  // `includes` and `find` are intentionally NOT added — they would
-  // shadow `Relation#includes(...associations)` (eager-loading) and
-  // `Relation#find(id)` (PK lookup) on the AssociationProxy. Reach for
-  // membership / array-find via `Array.from(proxy).includes(...)` /
-  // `Array.from(proxy).find(...)` (or `proxy.target.includes(...)`).
-  // Matches Rails' priority — CollectionProxy preserves the Relation
-  // surface and lets array semantics route through `to_a`.
+  // The Array-style `includes(record)` and `find(predicate)` overloads
+  // are intentionally NOT added:
+  //   - Array-style `includes(record)` would shadow
+  //     `Relation#includes(...associations)` (eager loading).
+  //   - Array-style `find(predicate)` would shadow this class's own
+  //     `async find(id)` and `Relation#find(id)` — the Rails-style
+  //     PK-lookup forms.
+  // Reach for Array semantics via `Array.from(proxy).includes(...)` /
+  // `Array.from(proxy).find(...)` (or `proxy.target.includes(...)` /
+  // `proxy.target.find(...)`). Matches Rails' priority — CollectionProxy
+  // preserves the Relation + PK-find surface and lets Array semantics
+  // route through `to_a`.
 
   slice(start?: number, end?: number): T[] {
     return this._target.slice(start, end);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -85,6 +85,16 @@ export class CollectionProxy<T extends Base = Base> {
   // first.
   // ──────────────────────────────────────────────────────────────────
 
+  /**
+   * Sync count of the loaded target. Mirrors `Array.prototype.length`
+   * and Rails' `posts.length` (which blocks to load in Ruby). In trails,
+   * this reads `_target` — zero if nobody loaded. Await the proxy first
+   * (or `Post.includes(...)`) if you need a fresh load.
+   *
+   * Shadows `Relation#length()` (async, `Promise<number>`). For a Relation-
+   * style async count through the proxy, use `.count()` — which still
+   * routes through to Relation via the `AssociationProxy` delegation.
+   */
   get length(): number {
     return this._target.length;
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -22,12 +22,6 @@ import {
 } from "../associations.js";
 
 export interface CollectionProxy<T extends Base = Base> {
-  // Numeric indexing — `proxy[0]` reads the loaded target via the
-  // wrapCollectionProxy `get` trap. Declared here so consumers don't
-  // need `as any`. Out-of-range / unloaded indices return `undefined`,
-  // matching `Array<T>[i]` semantics under TS's standard lib.
-  [index: number]: T | undefined;
-
   // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
   // which both returns the loaded records AND hydrates `_target`, so
   // subsequent sync ops (`proxy.length`, `proxy[0]`, iteration) work
@@ -65,7 +59,18 @@ type DelegatedRelationMethods<T extends Base> = {
 export type AssociationProxy<
   T extends Base = Base,
   TExtensions extends Record<string, any> = Record<string, any>,
-> = CollectionProxy<T> & DelegatedRelationMethods<T> & TExtensions;
+> = CollectionProxy<T> &
+  DelegatedRelationMethods<T> &
+  TExtensions & {
+    // Numeric indexing — `proxy[0]` reads the loaded target via the
+    // `wrapCollectionProxy` `get` trap. Lives on AssociationProxy (not
+    // raw CollectionProxy) because the runtime support comes from the
+    // JS Proxy wrapper. A bare `new CollectionProxy(...)` does NOT
+    // support indexing — you'd get `undefined` at runtime.
+    // Out-of-range / unloaded indices return `undefined`, matching
+    // `Array<T>[i]` semantics under TS's standard lib.
+    readonly [index: number]: T | undefined;
+  };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> {
@@ -1417,6 +1422,8 @@ export class CollectionProxy<T extends Base = Base> {
 // Route `await proxy` through `load()` (not `toArray`) so the thenable
 // also hydrates `_target` — matches the documented contract that
 // `await proxy; proxy[0]` / `proxy.length` work after a single await.
-// `toArray()` stays available for "give me a fresh array now without
-// touching the cache" callers.
+// `toArray()` stays available for callers who want a fresh array
+// without hydrating this proxy's `_target` / `_loaded` (it still goes
+// through `loadHasMany`, which syncs into the record's association
+// instance cache — only this proxy's local cache is left untouched).
 applyThenable(CollectionProxy.prototype, "load");


### PR DESCRIPTION
## Summary

Pre-req for Phase R.2 (collection reader returning `AssociationProxy` instead of `Base[]`). Pure additive surface — no behavior change to today's reader. Once R.2 swaps the reader, existing array-style consumers of `blog.posts` (`for...of`, `.length`, `.map`, indexed access) keep working transparently against the loaded `_target`.

Mirrors Rails' `CollectionProxy`, which inherits from `Relation` and is both iterable and array-shaped over the loaded records.

## What's added

**On `CollectionProxy`:**
- `get length` — loaded target length
- `[Symbol.iterator]` — iteration over loaded target
- `at`, `map`, `filter`, `forEach`, `some`, `every`, `slice`, `reduce` (with both with- and without-initial overloads), `indexOf`, `flatMap`, `keys`, `entries`

**On the `wrapCollectionProxy` JS Proxy:**
- Numeric string indexing (`proxy[0]`, `proxy[2]`) — gated by `/^(0|[1-9]\d*)$/` before falling through to strict-loading / Relation delegation; reads via the public `target` accessor

## Intentionally NOT added (to preserve Relation surface)

Three `Array.prototype` methods were deliberately omitted because adding them to CollectionProxy would shadow `Relation` methods that must keep working through `AssociationProxy` delegation:

- **`find`** — shadows `Relation#find(id)` (PK lookup). `relation.ts:3116`
- **`includes`** — shadows `Relation#includes(...associations)` (eager loading). `relation.ts:1088`
- **`values`** — shadows `Relation#values()` (query-state introspection). `relation.ts:2864`

Use `Array.from(proxy).<method>(...)` or `proxy.target.<method>(...)` for the array-semantics variants. Matches Rails' priority — `CollectionProxy` preserves the Relation surface and lets array semantics route through `to_a`.

## Signature / type parity

Array methods match `Array.prototype` signatures:
- Callback receives `(record: T, index: number, all: T[])` (non-readonly third arg, matching native)
- All higher-order methods accept the `thisArg` parameter
- `reduce` has both overloads (with and without initial value)

## Semantics

Sync ops do **not** trigger a fresh DB load — they read whatever's in `_target` (populated by `await proxy`, `Post.includes(...)`, or push/build/create through the proxy). For a fresh load, `await proxy` first.

## Rails fidelity

- `posts.length` ↔ Rails `posts.length` (same)
- `for (const p of posts)` ↔ Rails `posts.each { |p| ... }` (sync over loaded)
- `posts[0]` ↔ Rails `posts[0]` (Array indexing on the proxy)
- `posts.map(...)`, `.filter(...)`, etc. ↔ Rails `posts.map { ... }`, `.select { ... }`, … (delegated to enumerable)
- `await proxy` ↔ Rails `posts.to_a` (force materialization)
- `posts.includes("comments")`, `posts.find(1)`, `posts.values` ↔ Rails' Relation delegation (eager-load / PK find / query state)

## Test plan
- [x] 19 tests in `collection-proxy.test.ts` covering every added method, iteration, spread, `Array.from`, the thenable path, the `thisArg`/`reduce-no-initial` parity, and explicit Relation-preservation tests for `includes` / `values` / `find`
- [x] Full activerecord suite: 8186/8186 passing, zero regressions
- [x] `pnpm build`, `pnpm typecheck`, `pnpm eslint`, `pnpm prettier --check` all clean
- [ ] CI

## Not in scope (per the plan)

- Reader swap (`blog.posts` returning the proxy). Phase R.2.
- Singular-association strict-loading default. Phase R.3.
- Virtualizer emit change to `AssociationProxy<T>`. Phase 1a-fixup, post-R.2.

Plan: `docs/virtual-source-files-plan.md` § Phase R.