### PR TITLE
feat(trailties): Phase 8 — multi-DB config loader

### DIFF
--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -242,6 +242,18 @@ describe("loadDatabaseConfig", () => {
     expect(config.database).toBe("db/primary.sqlite3");
   });
 
+  it("rejects an array env value instead of silently falling through", async () => {
+    // Arrays are objects in JS; without an explicit guard the check
+    // would slip into multi-DB handling and confuse users with a
+    // 'no primary' error. Reject up front.
+    const configDir = path.join(tmpDir, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, "database.ts"), `export default { development: [] };`);
+    await expect(loadDatabaseConfig("development", tmpDir)).rejects.toThrow(
+      /Invalid database configuration for environment "development".*expected an object/,
+    );
+  });
+
   it("errors when a multi-DB env has no primary sub-config", async () => {
     const configDir = path.join(tmpDir, "config");
     fs.mkdirSync(configDir, { recursive: true });
@@ -331,7 +343,10 @@ describe("loadAllDatabaseConfigs", () => {
     );
   });
 
-  it("treats a url-only env value as single-DB (has adapter config fields)", async () => {
+  it("treats a url-only env value as single-DB (the string value fails Rails' all-hashes check)", async () => {
+    // Detection rule is `config.values.all?(Hash)`. Here the only
+    // value is a string, so the predicate is false and the whole env
+    // object becomes the single primary config.
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),
       `export default {
@@ -342,6 +357,20 @@ describe("loadAllDatabaseConfigs", () => {
     expect(all).toHaveLength(1);
     expect(all[0].name).toBe("primary");
     expect(all[0].config.url).toBe("sqlite3:///tmp/dev.sqlite3");
+  });
+
+  it("rejects an array env value with a clear error", async () => {
+    // Arrays pass `typeof === 'object'` but a `development: []` config
+    // is never valid — catch it up front instead of letting it slip
+    // into the multi-DB path and producing a misleading
+    // 'no database configurations defined' error.
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { development: [] };`,
+    );
+    await expect(loadAllDatabaseConfigs("development", tmpDir)).rejects.toThrow(
+      /Invalid database configuration for environment "development".*expected an object/,
+    );
   });
 });
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -300,18 +300,25 @@ describe("loadAllDatabaseConfigs", () => {
     expect(all[1].config.database).toBe("db/animals.sqlite3");
   });
 
-  it("rejects non-object sub-configs in a multi-DB env", async () => {
+  it("treats an env with any non-object sub-value as single-DB (Rails all-values-are-hashes rule)", async () => {
+    // Matches Rails' `DatabaseConfigurations#build_configs`: unless every
+    // sub-value is a Hash, the whole env-level object is the primary
+    // config. Here `url` is a string, so the env-object is NOT walked
+    // as sub-configs — the whole thing becomes the single primary
+    // config. Trails mirrors this behavior exactly.
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),
       `export default {
   development: {
-    primary: "postgres://host/db",
+    url: "postgres://host/db",
+    primary: { adapter: "sqlite3", database: "ignored.sqlite3" },
   },
 };`,
     );
-    await expect(loadAllDatabaseConfigs("development", tmpDir)).rejects.toThrow(
-      /Invalid database configuration "development.primary"/,
-    );
+    const all = await loadAllDatabaseConfigs("development", tmpDir);
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("primary");
+    expect((all[0].config as { url?: string }).url).toBe("postgres://host/db");
   });
 
   it("rejects an empty multi-DB env", async () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createProgram } from "../cli.js";
 import {
   loadDatabaseConfig,
+  loadAllDatabaseConfigs,
   connectAdapter,
   resolveEnv,
   resolveSchemaFormat,
@@ -220,6 +221,120 @@ describe("loadDatabaseConfig", () => {
     await expect(loadDatabaseConfig("production", tmpDir)).rejects.toThrow(
       /No database configuration for environment "production"/,
     );
+  });
+
+  it("returns the primary sub-config for a multi-DB environment", async () => {
+    // Rails-style multi-DB shape: env key -> named sub-configs.
+    // loadDatabaseConfig picks 'primary' so single-adapter CLI commands
+    // still have something to connect to.
+    const configDir = path.join(tmpDir, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: "db/primary.sqlite3" },
+    animals: { adapter: "sqlite3", database: "db/animals.sqlite3" },
+  },
+};`,
+    );
+    const config = await loadDatabaseConfig("development", tmpDir);
+    expect(config.database).toBe("db/primary.sqlite3");
+  });
+
+  it("errors when a multi-DB env has no primary sub-config", async () => {
+    const configDir = path.join(tmpDir, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "database.ts"),
+      `export default {
+  development: {
+    animals: { adapter: "sqlite3", database: "db/animals.sqlite3" },
+  },
+};`,
+    );
+    await expect(loadDatabaseConfig("development", tmpDir)).rejects.toThrow(
+      /no "primary" sub-config.*Found: animals/,
+    );
+  });
+});
+
+describe("loadAllDatabaseConfigs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-multi-"));
+    fs.mkdirSync(path.join(tmpDir, "config"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns [{name:'primary', config}] for a flat single-DB config", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: "db/dev.sqlite3" },
+};`,
+    );
+    const all = await loadAllDatabaseConfigs("development", tmpDir);
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("primary");
+    expect(all[0].config.database).toBe("db/dev.sqlite3");
+  });
+
+  it("returns one entry per named sub-config for multi-DB", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: "db/primary.sqlite3" },
+    animals: { adapter: "sqlite3", database: "db/animals.sqlite3" },
+  },
+};`,
+    );
+    const all = await loadAllDatabaseConfigs("development", tmpDir);
+    expect(all.map((c) => c.name)).toEqual(["primary", "animals"]);
+    expect(all[0].config.database).toBe("db/primary.sqlite3");
+    expect(all[1].config.database).toBe("db/animals.sqlite3");
+  });
+
+  it("rejects non-object sub-configs in a multi-DB env", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: "postgres://host/db",
+  },
+};`,
+    );
+    await expect(loadAllDatabaseConfigs("development", tmpDir)).rejects.toThrow(
+      /Invalid database configuration "development.primary"/,
+    );
+  });
+
+  it("rejects an empty multi-DB env", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default { development: {} };`,
+    );
+    await expect(loadAllDatabaseConfigs("development", tmpDir)).rejects.toThrow(
+      /has no database configurations defined/,
+    );
+  });
+
+  it("treats a url-only env value as single-DB (has adapter config fields)", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { url: "sqlite3:///tmp/dev.sqlite3" },
+};`,
+    );
+    const all = await loadAllDatabaseConfigs("development", tmpDir);
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("primary");
+    expect(all[0].config.url).toBe("sqlite3:///tmp/dev.sqlite3");
   });
 });
 
@@ -1483,6 +1598,53 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     expect(parsed.indexes["users"]).toEqual([
       { name: "users_on_email", columns: ["email"], unique: true },
     ]);
+  });
+
+  it("db schema:cache:dump fans out across every multi-DB config", async () => {
+    // Rails multi-DB: each named sub-config gets its own
+    // `db/<name>_schema_cache.json`. HashConfig.defaultSchemaCachePath
+    // emits `schema_cache.json` for primary and `<name>_schema_cache.json`
+    // for others, so we assert both files show up.
+    const primaryDb = path.join(tmpDir, "primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const seedPrimary = new SQLite3Adapter(primaryDb);
+    try {
+      await seedPrimary.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
+    } finally {
+      await seedPrimary.close();
+    }
+    const seedAnimals = new SQLite3Adapter(animalsDb);
+    try {
+      await seedAnimals.executeMutation("CREATE TABLE dogs (id INTEGER PRIMARY KEY)");
+    } finally {
+      await seedAnimals.close();
+    }
+
+    await runDb(["schema:cache:dump"]);
+
+    const primaryCache = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "db", "schema_cache.json"), "utf8"),
+    ) as { columns: Record<string, unknown[]> };
+    const animalsCache = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "db", "animals_schema_cache.json"), "utf8"),
+    ) as { columns: Record<string, unknown[]> };
+    expect(Object.keys(primaryCache.columns)).toContain("widgets");
+    expect(Object.keys(animalsCache.columns)).toContain("dogs");
   });
 
   it("db schema:dump --format=sql writes db/structure.sql", async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   loadDatabaseConfig,
+  loadAllDatabaseConfigs,
   connectAdapter,
   resolveEnv,
   resolveSchemaFormat,
@@ -153,12 +154,28 @@ async function withRegisteredConfiguration<T>(
   config: HashConfig,
   fn: () => Promise<T>,
 ): Promise<T> {
+  return withRegisteredConfigurations([config], config.envName, fn);
+}
+
+/**
+ * Multi-config variant: register every HashConfig for the env so
+ * `DatabaseTasks.configsFor(envName)` fans out across them. Used by
+ * commands that mirror Rails' `with_temporary_pool_for_each` /
+ * `configs_for(env_name:).each` — schema:cache:dump, schema:cache:clear
+ * — which need to hit every named DB (primary + animals + ...) in a
+ * multi-DB app.
+ */
+async function withRegisteredConfigurations<T>(
+  configs: HashConfig[],
+  envName: string,
+  fn: () => Promise<T>,
+): Promise<T> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   const previousTasksConfig = DatabaseTasks.databaseConfiguration;
   const previousCurrent = DatabaseConfigurations.current;
   const previousEnv = DatabaseTasks.env;
-  DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
-  DatabaseTasks.env = config.envName;
+  DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(configs);
+  DatabaseTasks.env = envName;
   try {
     return await fn();
   } finally {
@@ -855,18 +872,21 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:cache:dump")
-    .description("Dump db/schema_cache.json for the primary database configuration")
+    .description(
+      "Dump db/schema_cache.json for every database configuration in the current environment",
+    )
     .action(async () => {
-      // Rails iterates `with_temporary_pool_for_each { |pool| ... }` across
-      // every config in the env. trailties' loadDatabaseConfig only returns
-      // the primary config today, so `configsFor(envName)` — and therefore
-      // `withTemporaryPoolForEach` — sees exactly that one. The iterator
-      // shape is still Rails-faithful; it'll fan out automatically once the
-      // multi-DB config loader lands.
+      // Rails: `with_temporary_pool_for_each { |pool| dump_schema_cache(pool, filename) }`.
+      // Fans out across every named DB in the env for multi-DB apps
+      // (primary + animals + ...) — each gets its own
+      // `db/<name>_schema_cache.json` per HashConfig.defaultSchemaCachePath.
       const envName = resolveEnv();
-      const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
-      const primary = toDbConfig(raw, envName);
-      await withRegisteredConfiguration(primary, async () => {
+      const named = await loadAllDatabaseConfigs(envName);
+      const configs = named.map(
+        ({ name, config }) =>
+          new HashConfig(envName, name, normalizeRawConfig(config) as Record<string, unknown>),
+      );
+      await withRegisteredConfigurations(configs, envName, async () => {
         await DatabaseTasks.withTemporaryPoolForEach(envName, async (config) => {
           const adapter = DatabaseTasks.migrationConnection();
           if (!adapter) return;
@@ -879,15 +899,18 @@ export function dbCommand(): Command {
 
   cmd
     .command("schema:cache:clear")
-    .description("Delete db/schema_cache.json for the primary database configuration")
+    .description(
+      "Delete db/schema_cache.json for every database configuration in the current environment",
+    )
     .action(async () => {
       // Rails: `configurations.configs_for(env_name: env).each { |c| clear_schema_cache(cache_dump_filename(c)) }`.
-      // trailties currently loads only the primary config; the loop is
-      // Rails-shaped and ready for multi-DB expansion.
       const envName = resolveEnv();
-      const raw = normalizeRawConfig(await loadDatabaseConfig(envName));
-      const primary = toDbConfig(raw, envName);
-      await withRegisteredConfiguration(primary, async () => {
+      const named = await loadAllDatabaseConfigs(envName);
+      const configs = named.map(
+        ({ name, config }) =>
+          new HashConfig(envName, name, normalizeRawConfig(config) as Record<string, unknown>),
+      );
+      await withRegisteredConfigurations(configs, envName, async () => {
         for (const config of DatabaseTasks.configsFor(envName)) {
           const filename = DatabaseTasks.cacheDumpFilename(config);
           // clearSchemaCache is a no-op on ENOENT; don't log "Cleared"

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -177,80 +177,67 @@ export async function loadDatabaseConfig(
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  // Legacy single-DB layout: env value IS the config.
-  if (isFlatDatabaseConfig(envConfig)) return envConfig as DatabaseConfig;
+  if (envConfig === null || typeof envConfig !== "object") {
+    throw new Error(
+      `Invalid database configuration for environment "${resolvedEnv}": ` +
+        `expected an object, got ${formatUnknown(envConfig)}.`,
+    );
+  }
+
+  // Legacy single-DB layout: the env value IS the config (Rails rule:
+  // not every sub-value is a Hash).
+  if (!isMultiDatabaseEnv(envConfig)) return envConfig as DatabaseConfig;
 
   // Multi-DB layout: pull the `primary` sub-config so single-adapter
   // CLI commands (migrate, schema:dump, etc.) operate against it.
   // Anything that needs to fan out across every named DB should call
   // loadAllDatabaseConfigs directly.
-  if (envConfig !== null && typeof envConfig === "object") {
-    const primary = (envConfig as Record<string, unknown>).primary;
-    if (isFlatDatabaseConfig(primary)) return primary as DatabaseConfig;
-    const names = Object.keys(envConfig).join(", ");
-    throw new Error(
-      `Multi-database environment "${resolvedEnv}" has no "primary" sub-config. ` +
-        `Found: ${names || "(empty)"}. Either add a primary entry or use loadAllDatabaseConfigs.`,
-    );
+  const primary = (envConfig as Record<string, unknown>).primary;
+  if (primary !== null && typeof primary === "object" && !Array.isArray(primary)) {
+    return primary as DatabaseConfig;
   }
-
+  const names = Object.keys(envConfig).join(", ");
   throw new Error(
-    `Invalid database configuration for environment "${resolvedEnv}": ` +
-      `expected an object, got ${formatUnknown(envConfig)}.`,
+    `Multi-database environment "${resolvedEnv}" has no "primary" sub-config. ` +
+      `Found: ${names || "(empty)"}. Either add a primary entry or use loadAllDatabaseConfigs.`,
   );
 }
 
 /**
- * Adapter-config field names that identify a node as a concrete
- * DatabaseConfig rather than a nested name-keyed wrapper. Matches the
- * keys Rails' `HashConfig` knows about (adapter, url, database, host,
- * port, username, password) plus a few we recognize (pool, timeout).
- * Used to distinguish Rails' multi-DB shape
+ * Distinguish Rails' multi-DB shape from the legacy single-DB shape:
  *
+ *   // multi-DB:
  *   development:
  *     primary: { adapter, database, ... }
  *     animals: { adapter, database, ... }
  *
- * from the legacy single-DB shape
- *
+ *   // single-DB:
  *   development: { adapter, database, ... }
  *
- * without requiring the user to opt in — whichever layout they wrote
- * Just Works.
+ * Mirrors Rails' rule from
+ * `DatabaseConfigurations#build_configs` (activerecord/lib/active_record/
+ * database_configurations.rb:205):
+ *
+ *     if config.is_a?(Hash) && config.values.all?(Hash)
+ *       walk_configs(env_name, config)     # multi-DB
+ *     else
+ *       build_db_config_from_raw_config(env_name, "primary", config)
+ *     end
+ *
+ * So an env value is treated as multi-DB iff it's a non-null object
+ * AND every value inside it is also a non-null object. A single
+ * string/number/boolean field inside the env collapses it back to
+ * single-DB — exactly matching Rails.
  */
-const ADAPTER_CONFIG_FIELDS = new Set<string>([
-  "adapter",
-  "url",
-  "database",
-  "host",
-  "port",
-  "username",
-  "password",
-  "socket",
-  "pool",
-  "timeout",
-  "sslmode",
-  "ssl",
-  "encoding",
-  "reconnect",
-  "replica",
-  "migrations_paths",
-  "migrationsPaths",
-  "schema_search_path",
-  "schemaSearchPath",
-]);
-
-/**
- * Return true when `value` looks like a concrete DatabaseConfig rather
- * than a nested `{ name: config, ... }` wrapper. Conservative: any of
- * the adapter-config fields present → treat as a flat config.
- */
-function isFlatDatabaseConfig(value: unknown): boolean {
+function isMultiDatabaseEnv(value: unknown): value is Record<string, object> {
   if (value === null || typeof value !== "object") return false;
-  for (const key of Object.keys(value as object)) {
-    if (ADAPTER_CONFIG_FIELDS.has(key)) return true;
-  }
-  return false;
+  // Matches Ruby's `.all? { Hash === _1 }` on hash values: vacuously
+  // true for an empty hash. An empty env still counts as multi-DB (with
+  // zero named sub-configs) — the caller catches that case and throws
+  // a clearer error than "single-DB with no fields".
+  return Object.values(value as object).every(
+    (v) => v !== null && typeof v === "object" && !Array.isArray(v),
+  );
 }
 
 /**
@@ -275,10 +262,11 @@ export interface NamedDatabaseConfig {
  *     primary: { adapter: "postgresql", database: "app_dev" }
  *     animals: { adapter: "postgresql", database: "app_animals_dev" }
  *
- * The shape is auto-detected by inspecting the env object: if any of
- * its keys is a known adapter-config field (adapter, url, database,
- * etc.) the env itself IS the config and gets returned as `"primary"`;
- * otherwise each key/value pair is treated as a named sub-config.
+ * Detection mirrors Rails' `DatabaseConfigurations#build_configs`:
+ * the env value is treated as multi-DB iff it's a non-null object AND
+ * every value inside it is also a non-null object. A single scalar
+ * field inside the env (e.g. `adapter: "sqlite3"`) collapses it back
+ * to single-DB — same rule as Rails' `config.values.all?(Hash)`.
  *
  * Mirrors: `ActiveRecord::DatabaseConfigurations#configs_for(env_name:)`
  * which returns one HashConfig per named DB in an environment.
@@ -307,35 +295,28 @@ export async function loadAllDatabaseConfigs(
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  if (isFlatDatabaseConfig(raw)) {
-    return [{ name: "primary", config: raw as DatabaseConfig }];
-  }
-
-  // Multi-DB: each key is a named sub-config. Validate every value is
-  // an object — a typo like `development: { primary: "postgres" }`
-  // would otherwise silently register a string as a HashConfig and
-  // crash on first use.
   if (raw === null || typeof raw !== "object") {
     throw new Error(
       `Invalid database configuration for environment "${resolvedEnv}": ` +
-        `expected an object or named sub-configs, got ${formatUnknown(raw)}.`,
+        `expected an object, got ${formatUnknown(raw)}.`,
     );
   }
+
+  if (!isMultiDatabaseEnv(raw)) {
+    // Single-DB: the env value IS the config — matches Rails'
+    // `build_db_config_from_raw_config(env, "primary", config)`
+    // fallback when `config.values.all?(Hash)` is false.
+    return [{ name: "primary", config: raw as DatabaseConfig }];
+  }
+
+  // Multi-DB: each key is a named sub-config. isMultiDatabaseEnv
+  // already enforces entries.length > 0, but double-check explicitly
+  // so the message makes sense if someone refactors the predicate.
   const entries = Object.entries(raw as Record<string, unknown>);
   if (entries.length === 0) {
     throw new Error(`Environment "${resolvedEnv}" has no database configurations defined.`);
   }
-  const results: NamedDatabaseConfig[] = [];
-  for (const [name, sub] of entries) {
-    if (!isFlatDatabaseConfig(sub)) {
-      throw new Error(
-        `Invalid database configuration "${resolvedEnv}.${name}": ` +
-          `expected an adapter config (with adapter/url/database/...), got ${formatUnknown(sub)}.`,
-      );
-    }
-    results.push({ name, config: sub as DatabaseConfig });
-  }
-  return results;
+  return entries.map(([name, sub]) => ({ name, config: sub as DatabaseConfig }));
 }
 
 export type SchemaFormat = "ts" | "js" | "sql";

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -177,7 +177,10 @@ export async function loadDatabaseConfig(
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  if (envConfig === null || typeof envConfig !== "object") {
+  // Reject arrays explicitly: they pass `typeof === "object"` but a
+  // `development: []` config is never valid and the downstream
+  // multi-DB error message would just confuse the user.
+  if (envConfig === null || typeof envConfig !== "object" || Array.isArray(envConfig)) {
     throw new Error(
       `Invalid database configuration for environment "${resolvedEnv}": ` +
         `expected an object, got ${formatUnknown(envConfig)}.`,
@@ -295,7 +298,10 @@ export async function loadAllDatabaseConfigs(
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  if (raw === null || typeof raw !== "object") {
+  // Reject arrays explicitly: they pass `typeof === "object"` but
+  // would slip into the multi-DB path and produce a misleading error
+  // about no configurations defined.
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(
       `Invalid database configuration for environment "${resolvedEnv}": ` +
         `expected an object, got ${formatUnknown(raw)}.`,
@@ -309,9 +315,11 @@ export async function loadAllDatabaseConfigs(
     return [{ name: "primary", config: raw as DatabaseConfig }];
   }
 
-  // Multi-DB: each key is a named sub-config. isMultiDatabaseEnv
-  // already enforces entries.length > 0, but double-check explicitly
-  // so the message makes sense if someone refactors the predicate.
+  // Multi-DB: each key is a named sub-config. isMultiDatabaseEnv is
+  // explicitly vacuously true for an empty object (matches Ruby's
+  // `[].all?` returning true), so this is the explicit empty-env
+  // check that produces a clear error instead of silently returning
+  // an empty array.
   const entries = Object.entries(raw as Record<string, unknown>);
   if (entries.length === 0) {
     throw new Error(`Environment "${resolvedEnv}" has no database configurations defined.`);

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -172,14 +172,170 @@ export async function loadDatabaseConfig(
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  const envConfig = (loaded.module as Record<string, unknown>)[resolvedEnv] as
-    | DatabaseConfig
-    | undefined;
-  if (!envConfig) {
+  const envConfig = (loaded.module as Record<string, unknown>)[resolvedEnv];
+  if (envConfig === undefined) {
     throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
   }
 
-  return envConfig;
+  // Legacy single-DB layout: env value IS the config.
+  if (isFlatDatabaseConfig(envConfig)) return envConfig as DatabaseConfig;
+
+  // Multi-DB layout: pull the `primary` sub-config so single-adapter
+  // CLI commands (migrate, schema:dump, etc.) operate against it.
+  // Anything that needs to fan out across every named DB should call
+  // loadAllDatabaseConfigs directly.
+  if (envConfig !== null && typeof envConfig === "object") {
+    const primary = (envConfig as Record<string, unknown>).primary;
+    if (isFlatDatabaseConfig(primary)) return primary as DatabaseConfig;
+    const names = Object.keys(envConfig).join(", ");
+    throw new Error(
+      `Multi-database environment "${resolvedEnv}" has no "primary" sub-config. ` +
+        `Found: ${names || "(empty)"}. Either add a primary entry or use loadAllDatabaseConfigs.`,
+    );
+  }
+
+  throw new Error(
+    `Invalid database configuration for environment "${resolvedEnv}": ` +
+      `expected an object, got ${formatUnknown(envConfig)}.`,
+  );
+}
+
+/**
+ * Adapter-config field names that identify a node as a concrete
+ * DatabaseConfig rather than a nested name-keyed wrapper. Matches the
+ * keys Rails' `HashConfig` knows about (adapter, url, database, host,
+ * port, username, password) plus a few we recognize (pool, timeout).
+ * Used to distinguish Rails' multi-DB shape
+ *
+ *   development:
+ *     primary: { adapter, database, ... }
+ *     animals: { adapter, database, ... }
+ *
+ * from the legacy single-DB shape
+ *
+ *   development: { adapter, database, ... }
+ *
+ * without requiring the user to opt in — whichever layout they wrote
+ * Just Works.
+ */
+const ADAPTER_CONFIG_FIELDS = new Set<string>([
+  "adapter",
+  "url",
+  "database",
+  "host",
+  "port",
+  "username",
+  "password",
+  "socket",
+  "pool",
+  "timeout",
+  "sslmode",
+  "ssl",
+  "encoding",
+  "reconnect",
+  "replica",
+  "migrations_paths",
+  "migrationsPaths",
+  "schema_search_path",
+  "schemaSearchPath",
+]);
+
+/**
+ * Return true when `value` looks like a concrete DatabaseConfig rather
+ * than a nested `{ name: config, ... }` wrapper. Conservative: any of
+ * the adapter-config fields present → treat as a flat config.
+ */
+function isFlatDatabaseConfig(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  for (const key of Object.keys(value as object)) {
+    if (ADAPTER_CONFIG_FIELDS.has(key)) return true;
+  }
+  return false;
+}
+
+/**
+ * Named database configuration for the given environment. `name` is
+ * `"primary"` for legacy single-DB configs; for multi-DB layouts it
+ * matches the key under the env object (`primary`, `animals`, etc.).
+ */
+export interface NamedDatabaseConfig {
+  name: string;
+  config: DatabaseConfig;
+}
+
+/**
+ * Load every database configuration defined for the given environment.
+ * Supports two config shapes:
+ *
+ *   // Single-DB (legacy):
+ *   development: { adapter: "sqlite3", database: "db/dev.sqlite3" }
+ *
+ *   // Multi-DB (Rails-style):
+ *   development:
+ *     primary: { adapter: "postgresql", database: "app_dev" }
+ *     animals: { adapter: "postgresql", database: "app_animals_dev" }
+ *
+ * The shape is auto-detected by inspecting the env object: if any of
+ * its keys is a known adapter-config field (adapter, url, database,
+ * etc.) the env itself IS the config and gets returned as `"primary"`;
+ * otherwise each key/value pair is treated as a named sub-config.
+ *
+ * Mirrors: `ActiveRecord::DatabaseConfigurations#configs_for(env_name:)`
+ * which returns one HashConfig per named DB in an environment.
+ */
+export async function loadAllDatabaseConfigs(
+  env?: string,
+  cwd: string = process.cwd(),
+): Promise<NamedDatabaseConfig[]> {
+  const resolvedEnv = env ?? resolveEnv();
+  const loaded = await loadDatabaseConfigModule(cwd);
+  if (!loaded) {
+    throw new Error(
+      "No database config found. Expected config/database.ts (.js) or src/config/database.ts (.js)",
+    );
+  }
+
+  const envs = Object.keys(loaded.module).filter((k) => !TOP_LEVEL_CONFIG_KEYS.has(k));
+  const available = envs.length > 0 ? `Available: ${envs.join(", ")}` : "No environments defined";
+
+  if (TOP_LEVEL_CONFIG_KEYS.has(resolvedEnv)) {
+    throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
+  }
+
+  const raw = (loaded.module as Record<string, unknown>)[resolvedEnv];
+  if (raw === undefined) {
+    throw new Error(`No database configuration for environment "${resolvedEnv}". ${available}`);
+  }
+
+  if (isFlatDatabaseConfig(raw)) {
+    return [{ name: "primary", config: raw as DatabaseConfig }];
+  }
+
+  // Multi-DB: each key is a named sub-config. Validate every value is
+  // an object — a typo like `development: { primary: "postgres" }`
+  // would otherwise silently register a string as a HashConfig and
+  // crash on first use.
+  if (raw === null || typeof raw !== "object") {
+    throw new Error(
+      `Invalid database configuration for environment "${resolvedEnv}": ` +
+        `expected an object or named sub-configs, got ${formatUnknown(raw)}.`,
+    );
+  }
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length === 0) {
+    throw new Error(`Environment "${resolvedEnv}" has no database configurations defined.`);
+  }
+  const results: NamedDatabaseConfig[] = [];
+  for (const [name, sub] of entries) {
+    if (!isFlatDatabaseConfig(sub)) {
+      throw new Error(
+        `Invalid database configuration "${resolvedEnv}.${name}": ` +
+          `expected an adapter config (with adapter/url/database/...), got ${formatUnknown(sub)}.`,
+      );
+    }
+    results.push({ name, config: sub as DatabaseConfig });
+  }
+  return results;
 }
 
 export type SchemaFormat = "ts" | "js" | "sql";


### PR DESCRIPTION
## Summary

Trailties now recognizes Rails-style multi-DB layouts in `config/database.ts`:

```ts
export default {
  development: {
    primary: { adapter: "postgresql", database: "app_dev" },
    animals: { adapter: "postgresql", database: "app_animals_dev" },
  },
};
```

Previously only the flat single-DB shape was supported, so CLI commands that iterate via `DatabaseTasks.withTemporaryPoolForEach` / `configsFor` silently fanned out across a single config even when the user had configured multiple.

- `loadAllDatabaseConfigs(env, cwd)` returns one `{name, config}` entry per named sub-config. Detection mirrors Rails' `DatabaseConfigurations#build_configs` rule verbatim (`config.values.all?(Hash)`): the env value is treated as multi-DB iff every sub-value is a non-null object; a single scalar field collapses it back to single-DB. Matches Rails' `DatabaseConfigurations#configs_for(env_name:)`.
- `loadDatabaseConfig` still returns a single DatabaseConfig for single-adapter CLI commands (migrate, schema:dump, etc.). For multi-DB envs it picks `primary` and errors clearly when no primary exists. Arrays are rejected up front with a clear error instead of slipping into the multi-DB path.
- `withRegisteredConfigurations` (plural) registers every HashConfig for the env so `configsFor` / `withTemporaryPoolForEach` fan out. Singular `withRegisteredConfiguration` delegates.
- `schema:cache:dump` and `schema:cache:clear` now produce per-sub-config output: `db/schema_cache.json` for primary, `db/<name>_schema_cache.json` for others (via `HashConfig.defaultSchemaCachePath`), matching Rails.

## Test plan

- [x] `pnpm test` — full suite, 17140 passing / 4442 skipped
- [x] Unit: `loadAllDatabaseConfigs` handles flat, multi-DB, url-only single-DB, empty multi-DB rejection, array rejection, scalar-value → single-DB (Rails all-hashes rule)
- [x] Unit: `loadDatabaseConfig` returns primary from multi-DB; errors clearly without a primary; rejects array env values
- [x] CLI integration: `schema:cache:dump` writes both `schema_cache.json` + `animals_schema_cache.json` for a multi-DB config

Single-adapter CLI commands (migrate, schema:dump/load, etc.) continue operating on `primary` only; fanning those out across named DBs needs per-DB `migrationsPaths` plumbing and is tracked as follow-up Phase 14.