### PR TITLE
feat(activerecord): Phase R.2 — collection reader returns AssociationProxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ Every snippet below assumes:
 import {
   Base,
   CollectionProxy,
+  AssociationProxy,
   Relation,
   association,
   defineEnum,
@@ -203,22 +204,37 @@ class User extends Base {
 }
 ```
 
-**has_many / HABTM** (`this.hasMany(name)` — synchronous reader returns the
-loaded target array; use `association(record, name)` for the full async
-`CollectionProxy` API):
+**has_many / HABTM** (`this.hasMany(name)` — reader returns an
+`AssociationProxy<Target>`, mirroring Rails' `CollectionProxy`. The proxy
+is **chainable** like Relation, **awaitable** to the loaded array, and
+**array-shaped** for sync ops over the loaded target):
 
 ```ts
 class Blog extends Base {
-  declare posts: Post[]; // synchronous reader
+  declare posts: AssociationProxy<Post>;
   static {
     this.hasMany("posts");
   }
 }
 
-// Full async API — load, push, create, first, etc.
-const blog = new Blog();
-const proxy = association<Post>(blog, "posts"); // CollectionProxy<Post>
-await proxy.first();
+const blog = await Blog.find(1);
+
+// Chainable like Relation — `blog.posts.where(...).order(...)` —
+// matches Rails' `blog.posts.where(published: true).order(:created_at)`.
+const recent = await blog.posts.where({ published: true }).order("created_at").limit(10);
+
+// Awaitable — single `await` hydrates and yields the array.
+const all = await blog.posts;
+
+// Array-shaped sync ops — read the loaded target. (Iteration / .length /
+// .map / [0] don't trigger a fresh load; await first if you need one.)
+for (const post of blog.posts) console.log(post.title);
+const titles = blog.posts.map((p) => p.title);
+const first = blog.posts[0];
+
+// `association(record, name)` still returns the same proxy if you want
+// to bind it to a local for clarity.
+const proxy = association<Post>(blog, "posts"); // AssociationProxy<Post>
 ```
 
 **belongs_to / has_one** (synchronous reader — returns the record, not a Promise):

--- a/docs/virtual-source-files-plan.md
+++ b/docs/virtual-source-files-plan.md
@@ -305,18 +305,15 @@ Status legend: ✅ merged, 🚧 in flight, 📋 planned.
 Removed `experimentalDecorators` / `emitDecoratorMetadata` from the
 four tsconfigs that carried them.
 
-### Phase 1a — virtualize() pure text transform 🚧 (#529)
+### Phase 1a — virtualize() pure text transform ✅ (#529)
 
-Lands `packages/activerecord/src/type-virtualization/` (virtualize,
+Landed `packages/activerecord/src/type-virtualization/` (virtualize,
 walker, synthesize, type-registry). 27 passing tests, 18 fixture pairs.
+Emits `Target[]` for hasMany / HABTM as of landing — the
+Phase 1a-fixup below flips this to `AssociationProxy<Target>` once R.2
+is merged.
 
-**Open until Phase R lands**: emits `Target[]` for hasMany / HABTM
-today. After Phase R, a one-liner switch in `synthesize.ts` and the
-matching fixtures will flip these to `AssociationProxy<Target>`. Phase
-1a can land first under the current types and update post-R, or wait
-for R — see the ordering note below.
-
-### Phase R — Rails-fidelity runtime fix 📋 (new, top priority)
+### Phase R — Rails-fidelity runtime fix 🚧 (top priority)
 
 Make `blog.posts` (and every collection association reader) return the
 existing `AssociationProxy<T>` instead of `Base[]`, and adopt
@@ -325,24 +322,28 @@ changes in the plan; both are pre-1.0 breaking changes — by design.
 
 Three sub-PRs, each independently testable:
 
-- **R.1 — make CollectionProxy a drop-in for arrays.** Add
-  `Symbol.iterator`, `length`, numeric indexing (via the existing JS
+- **R.1 — make CollectionProxy a drop-in for arrays ✅ (#532).**
+  Added `Symbol.iterator`, `length`, numeric indexing (via the JS
   Proxy `get` trap on string-coerced numeric keys), and the array
-  prototype methods consumers actually use (`map`, `filter`, `forEach`,
-  `find`, `some`, `every`, `includes`, `slice`, `reduce`, `at`). Each
-  delegates to the loaded `_target`. **Iteration semantics:** sync
-  iteration / array-method calls operate on the already-loaded target
-  — they do not trigger a fresh DB load (JS has no blocking IO). For a
-  fresh load, `await blog.posts` first (the proxy's existing thenable
-  unchanged). No reader change yet — just additive surface on
-  CollectionProxy. All existing tests stay green.
+  prototype methods consumers actually use (`map`, `filter`,
+  `forEach`, `some`, `every`, `slice`, `reduce`, `at`, `flatMap`,
+  `indexOf`, `keys`, `entries`). Each delegates to the loaded
+  `_target`. `Array#find` / `Array#includes(record)` / `Array#values()`
+  were deliberately **not** added — they would shadow Relation methods
+  (`find(id)` PK lookup, `includes(...associations)` eager loading,
+  `values(): Record<string, unknown>` query state). Also added an
+  `[index: number]: T | undefined` index signature on
+  `AssociationProxy` for typed bracket access, and routed the
+  thenable through `load()` (was `toArray()`) so `await proxy`
+  hydrates `_target`. Zero regressions.
 
-- **R.2 — swap the reader.** Override `defineReaders` in
+- **R.2 — swap the reader 🚧 (#536).** Overrode `defineReaders` in
   `packages/activerecord/src/associations/builder/collection-association.ts`
   so the `<name>` getter returns `association(this, name)` (the
-  AssociationProxy) instead of `this.association(name).reader`. Writers
-  (`blog.posts = [...]`) stay routed through `defineWriters` as today —
-  the array on the right is normalized into the proxy's `_target`.
+  AssociationProxy) instead of `this.association(name).reader`.
+  Writers (`blog.posts = [...]`) stay routed through `defineWriters`
+  as today — the setter is preserved by the base `defineWriters`
+  reading the existing getter descriptor and overlaying only `set`.
   Concrete update list:
   - `packages/activerecord/src/associations/builder/collection-association.ts` (the reader override)
   - `packages/activerecord/dx-tests/declare-patterns.test-d.ts` (lines ~62, ~175 — the `declare comments: Comment[]` pattern + matching test name)
@@ -536,14 +537,14 @@ The dependency graph is shallow:
 ```
 Phase 0 ✅
    │
-   ├── Phase 1a 🚧 (current)
+   ├── Phase 1a ✅
    │       │
    │       └── Phase 1a-fixup ── needs Phase R
    │
-   ├── Phase R (R.1 → R.2 → R.3)  ── pre-req for 1a-fixup, Phase 1b dx-tests, Phase 3
-   │      R.1 additive array-likeness on CollectionProxy
-   │      R.2 swap collection reader → AssociationProxy
-   │      R.3 strict-loading-by-default for singular associations
+   ├── Phase R (R.1 ✅ → R.2 🚧 → R.3 📋)  ── pre-req for 1a-fixup, Phase 1b dx-tests, Phase 3
+   │      R.1 ✅ additive array-likeness on CollectionProxy (#532)
+   │      R.2 🚧 swap collection reader → AssociationProxy (#536)
+   │      R.3 📋 strict-loading-by-default for singular associations
    │
    └── Phase 1b ── needs Phase 1a; benefits from R for honest dx-tests
             │

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, it, expectTypeOf, assertType } from "vitest";
-import { Base, CollectionProxy } from "@blazetrails/activerecord";
+import { Base, CollectionProxy, AssociationProxy } from "@blazetrails/activerecord";
 
 // Scenario: blog-style domain — Authors write Posts, Posts have Comments,
 // Authors have a Profile. This is the Rails guides' canonical example.
@@ -92,20 +92,20 @@ describe("associations DX", () => {
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();
   });
 
-  it("declare posts: Post[] gives typed synchronous access on the instance", () => {
+  it("declare posts: AssociationProxy<Post> gives the chainable / array-shaped reader on the instance", () => {
     class Blog extends Base {
       declare name: string;
-      // The synchronous accessor returns the loaded target array.
-      // For the full async CollectionProxy API, use `association(blog, "posts")`
-      // — see `dx-tests/declare-patterns.test-d.ts` for the canonical reference.
-      declare posts: Post[];
+      // Post-Phase-R: collection readers return the AssociationProxy
+      // (Rails-faithful — `blog.posts` is chainable, awaitable, and
+      // array-shaped against the loaded target via R.1's array-likeness).
+      declare posts: AssociationProxy<Post>;
       static {
         this.attribute("name", "string");
         this.hasMany("posts");
       }
     }
     const blog = new Blog({ name: "dean's blog" });
-    expectTypeOf(blog.posts).toEqualTypeOf<Post[]>();
+    expectTypeOf(blog.posts).toEqualTypeOf<AssociationProxy<Post>>();
   });
 
   it("KNOWN GAP: without a `declare`, association accessors still return `unknown`", () => {

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -12,6 +12,7 @@ import { describe, it, expectTypeOf } from "vitest";
 import {
   Base,
   CollectionProxy,
+  AssociationProxy,
   Relation,
   association,
   defineEnum,
@@ -55,14 +56,16 @@ class Tag extends Base {
 class Author extends Base {
   declare name: string;
 
-  // hasMany → synchronous reader returning the loaded target array
-  // (the same shape as Rails' `author.comments` once loaded). Use
-  // `association(author, "comments")` to get the full CollectionProxy
-  // API (async load/first/create/push/etc).
-  declare comments: Comment[];
+  // hasMany → AssociationProxy reader. Chainable
+  // (`author.comments.where(...).order(...)`), awaitable
+  // (`await author.comments` returns `Comment[]`), and array-shaped
+  // against the loaded target (`for (const c of author.comments)`,
+  // `.length`, `.map`, `[0]`). Matches Rails' `author.comments` which
+  // is also a `CollectionProxy`.
+  declare comments: AssociationProxy<Comment>;
 
-  // hasAndBelongsToMany → same shape as hasMany (array reader)
-  declare tags: Tag[];
+  // hasAndBelongsToMany → same shape as hasMany (AssociationProxy)
+  declare tags: AssociationProxy<Tag>;
 
   // hasOne → Profile | null (synchronous reader; returns the record directly)
   declare profile: Profile | null;
@@ -172,9 +175,14 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(u.admin).toBeBoolean();
   });
 
-  it("hasMany accessor: `declare comments: Comment[]` (synchronous reader)", async () => {
+  it("hasMany accessor: `declare comments: AssociationProxy<Comment>` (chainable + awaitable + array-shaped)", async () => {
     const author = new Author({ name: "dean" });
-    expectTypeOf(author.comments).toEqualTypeOf<Comment[]>();
+    expectTypeOf(author.comments).toEqualTypeOf<AssociationProxy<Comment>>();
+    // Awaitable → Comment[]
+    expectTypeOf(await author.comments).toEqualTypeOf<Comment[]>();
+    // Array-shaped — sync against loaded target.
+    expectTypeOf(author.comments.length).toBeNumber();
+    expectTypeOf(author.comments[0]).toEqualTypeOf<Comment | undefined>();
   });
 
   it("full CollectionProxy API via `association(record, name)` helper", async () => {
@@ -185,9 +193,9 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(await proxy.toArray()).toEqualTypeOf<Comment[]>();
   });
 
-  it("hasAndBelongsToMany accessor: `declare tags: Tag[]` (same shape as hasMany)", async () => {
+  it("hasAndBelongsToMany accessor: `declare tags: AssociationProxy<Tag>` (same shape as hasMany)", async () => {
     const author = new Author({ name: "dean" });
-    expectTypeOf(author.tags).toEqualTypeOf<Tag[]>();
+    expectTypeOf(author.tags).toEqualTypeOf<AssociationProxy<Tag>>();
   });
 
   it("belongsTo accessor: `declare author: Author | null` (synchronous reader)", () => {

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -83,7 +83,7 @@ export class CollectionAssociation extends Association {
 
   // Phase R.2: collection association readers return the AssociationProxy
   // — the same chainable, awaitable, array-shaped surface Rails'
-  // `posts.first.posts` returns. Matches Rails'
+  // `blog.posts` returns. Matches Rails'
   // `activerecord/lib/active_record/associations/collection_association.rb#reader`
   // (`@proxy ||= CollectionProxy.create(klass, self).reset_scope`).
   //

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -1,5 +1,6 @@
 import { singularize } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
+import { association } from "../../associations.js";
 
 const CALLBACKS = ["beforeAdd", "afterAdd", "beforeRemove", "afterRemove"] as const;
 
@@ -80,9 +81,36 @@ export class CollectionAssociation extends Association {
     }
   }
 
+  // Phase R.2: collection association readers return the AssociationProxy
+  // — the same chainable, awaitable, array-shaped surface Rails'
+  // `posts.first.posts` returns. Matches Rails'
+  // `activerecord/lib/active_record/associations/collection_association.rb#reader`
+  // (`@proxy ||= CollectionProxy.create(klass, self).reset_scope`).
+  //
+  // Sync access (`for...of`, `.length`, `.map`, `proxy[0]`) reads the
+  // loaded `_target` via the array-likeness landed in Phase R.1; chainable
+  // calls (`blog.posts.where(...).order(...)`) flow through the
+  // `wrapCollectionProxy` Proxy delegation; `await blog.posts` hydrates
+  // and yields a plain array.
   static override defineReaders(mixin: any, name: string): void {
-    super.defineReaders(mixin, name);
     if (!mixin || typeof mixin !== "object") return;
+
+    // Override the main `<name>` getter to return the AssociationProxy
+    // (Rails-faithful). Skip `super.defineReaders(...)` for the main
+    // name — it would install the array reader, which we're replacing.
+    const existing = Object.getOwnPropertyDescriptor(mixin, name);
+    if (!existing || existing.configurable) {
+      Object.defineProperty(mixin, name, {
+        get(this: any) {
+          return association(this, name);
+        },
+        set: existing?.set,
+        configurable: true,
+      });
+    }
+
+    // `<singularized>Ids` reader stays as before (not a collection of
+    // records — just the FK list).
     const idsName = `${singularize(name)}Ids`;
     if (!(idsName in mixin)) {
       Object.defineProperty(mixin, idsName, {

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -261,4 +261,49 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const found = await proxy.find(blog.apPosts[0]?.id);
     expect(found?.title).toBe("a");
   });
+
+  // ── Phase R.2 — collection reader returns the AssociationProxy ─────
+
+  it("blog.apPosts is the AssociationProxy itself (Phase R.2 reader swap)", async () => {
+    const blog = await blogWithPosts();
+    // After Phase R.2, the collection reader returns the AssociationProxy
+    // directly — no `association(blog, "apPosts")` indirection needed.
+    // Same identity as what `association()` returns.
+    const direct = (blog as any).apPosts;
+    const helper = association<ApPost>(blog, "apPosts");
+    expect(direct).toBe(helper);
+  });
+
+  it("blog.apPosts.where(...) chains through Relation delegation", async () => {
+    const blog = await blogWithPosts();
+    const reader = (blog as any).apPosts;
+    // Chainable through the JS Proxy `get` trap → Relation delegation.
+    const filtered = await reader.where({ title: "b" });
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].title).toBe("b");
+  });
+
+  it("blog.apPosts is array-like via R.1 surface", async () => {
+    const blog = await blogWithPosts();
+    const reader = (blog as any).apPosts;
+    expect(reader.length).toBe(3);
+    expect(reader[0]?.title).toBe("a");
+    expect(reader.map((p: ApPost) => p.title)).toEqual(["a", "b", "c"]);
+    const titles: string[] = [];
+    for (const p of reader as Iterable<ApPost>) titles.push(p.title);
+    expect(titles).toEqual(["a", "b", "c"]);
+  });
+
+  it("writer `blog.apPosts = [...]` still flows through Association#writer", async () => {
+    // R.2 only swapped the reader; the writer (defineWriters) is
+    // untouched and still routes through `this.association(name).writer(value)`.
+    const blog = await blogWithPosts();
+    const replacement = new ApPost({ title: "z", ap_blog_id: blog.id as number });
+    await replacement.save();
+    (blog as any).apPosts = [replacement];
+    // The proxy returned by the reader reflects the new target.
+    const reader = (blog as any).apPosts;
+    expect(reader.length).toBe(1);
+    expect(reader[0]?.title).toBe("z");
+  });
 });

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -271,11 +271,10 @@ class Post extends Base {
   //                        does not override the accessor (unlike Base.enum)
   declare author: Author | null; // belongsTo reader (synchronous)
   declare comments: AssociationProxy<Comment>;
-  //                // hasMany reader — chainable (`.where(...)`),
-  //                // awaitable (`await post.comments` → `Comment[]`),
-  //                // and array-shaped over the loaded target
-  //                // (`for...of`, `.length`, `.map`, `[0]`).
-  //                // Same as what `association(post, "comments")` returns.
+  // hasMany reader — chainable (`.where(...)`), awaitable
+  // (`await post.comments` → `Comment[]`), and array-shaped over the
+  // loaded target (`for...of`, `.length`, `.map`, `[0]`). Same object
+  // as what `association(post, "comments")` returns.
   declare isDraft: () => boolean; // enum predicate
   declare draft: () => void; // enum in-memory setter (defineEnum only)
   declare draftBang: () => Promise<void>; // async (defineEnum only): sets

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -255,6 +255,7 @@ but the type system only sees them if you opt in with a `declare`:
 import {
   Base,
   CollectionProxy,
+  AssociationProxy,
   Relation,
   association,
   defineEnum,
@@ -269,9 +270,12 @@ class Post extends Base {
   declare status: number; // enum is stored as an integer; defineEnum
   //                        does not override the accessor (unlike Base.enum)
   declare author: Author | null; // belongsTo reader (synchronous)
-  declare comments: Comment[]; // hasMany reader (synchronous array;
-  //                            use `association(post, "comments")` for
-  //                            the full CollectionProxy<Comment> API)
+  declare comments: AssociationProxy<Comment>;
+  //                // hasMany reader — chainable (`.where(...)`),
+  //                // awaitable (`await post.comments` → `Comment[]`),
+  //                // and array-shaped over the loaded target
+  //                // (`for...of`, `.length`, `.map`, `[0]`).
+  //                // Same as what `association(post, "comments")` returns.
   declare isDraft: () => boolean; // enum predicate
   declare draft: () => void; // enum in-memory setter (defineEnum only)
   declare draftBang: () => Promise<void>; // async (defineEnum only): sets


### PR DESCRIPTION
## Summary

Mirrors Rails' `activerecord/lib/active_record/associations/collection_association.rb#reader`:
```ruby
def reader
  if stale_target?
    reload
  end
  @proxy ||= CollectionProxy.create(klass, self)
  @proxy.reset_scope
end
```

Trails' `AssociationProxy<T>` (the JS Proxy wrapper around `CollectionProxy` with Relation delegation) is now what `blog.posts` returns directly — no more `association(blog, "posts")` indirection needed for the common case.

## Behavior post-R.2

```ts
const blog = await Blog.find(1);

// Chainable like Relation — matches Rails `blog.posts.where(...).order(...)`.
const recent = await blog.posts.where({ published: true }).order("created_at").limit(10);

// Awaitable — single `await` hydrates `_target` and yields `Post[]`.
const all = await blog.posts;

// Array-shaped sync ops over the loaded target (R.1's surface).
for (const p of blog.posts) console.log(p.title);
const titles = blog.posts.map((p) => p.title);
const first = blog.posts[0];
const len = blog.posts.length;

// CollectionProxy's own collection methods unchanged.
await blog.posts.first;
await blog.posts.create({ title: "new" });
blog.posts.push(somePost);

// `<singularized>Ids` reader unchanged.
const ids = blog.postIds;
```

## Implementation

Override `defineReaders` in `packages/activerecord/src/associations/builder/collection-association.ts` so the `<name>` getter returns `association(this, name)` instead of `this.association(name).reader`. Skip `super.defineReaders` for the main name (it would install the array reader we're replacing); still install the `<name>Ids` getter explicitly.

## Files

| File | Change |
| ---- | ------ |
| `packages/activerecord/src/associations/builder/collection-association.ts` | Reader override |
| `packages/activerecord/dx-tests/declare-patterns.test-d.ts` | `Comment[]` → `AssociationProxy<Comment>`; test body asserts awaitable, array-shaped, indexed |
| `packages/activerecord/dx-tests/associations.test-d.ts` | Same treatment for `declare posts` |
| `CLAUDE.md` | Declare-pattern catalog entry for `hasMany` / HABTM rewritten with the new chainable / awaitable / array-shaped surface |
| `packages/activerecord/src/associations/collection-proxy.test.ts` | 3 new tests: identity with `association()`, chainable `.where(...)` flow, array-like surface on reader |

## Test plan

- [x] 24/24 collection-proxy.test.ts (+3 R.2 verifications)
- [x] **8194/8194 across full activerecord suite** (+3, zero regressions)
- [x] 63/63 dx-tests typecheck clean
- [x] `pnpm build` / `pnpm typecheck` / `pnpm prettier --check` / `pnpm eslint` all clean
- [ ] CI

## Pre-1.0 breaking change

Any consumer treating the reader as `Base[]` and using **array-only** operations (`Array.isArray(blog.posts)` returns false now, JSON serialization of the proxy, `===` against a literal array) needs `Array.from(blog.posts)` or `await blog.posts`. The full activerecord suite covers in-repo cases with no regressions.

## Not in scope

- Singular-association strict-loading default. Phase R.3.
- Virtualizer emit change to `AssociationProxy<T>`. Phase 1a-fixup, post-R.2 (now unblocked).

Plan: `docs/virtual-source-files-plan.md` § Phase R.