### PR TITLE
feat(activerecord): Phase 10 — MySQL schema introspection

### DIFF
--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -495,6 +495,18 @@ describeIfMysql("Mysql2Adapter", () => {
       await expect(adapter.tableExists("a.b.c")).rejects.toThrow(/Invalid MySQL identifier/);
     });
 
+    it("rejects identifiers with empty segments", async () => {
+      // Regex tokenization happily dropped `.widgets`, `a..b`, and
+      // `db.widgets.` as if they were valid. A whole-string parser
+      // now catches each as malformed — critical because those shapes
+      // would otherwise resolve to different tables than the caller
+      // thinks.
+      await expect(adapter.tableExists(".widgets")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("a..b")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("db.widgets.")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("")).rejects.toThrow(/Invalid MySQL identifier/);
+    });
+
     it("introspection accepts schema-qualified names", async () => {
       // The implementation takes `schema.table` via parseMysqlName and
       // routes through COALESCE(?, database()). Exercise that path so

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -53,20 +53,36 @@ describeIfMysql("Mysql2Adapter", () => {
   ];
   const TRACKED_VIEWS = ["recent_widgets"];
 
-  const dropTrackedObjects = async (a: Mysql2Adapter): Promise<void> => {
-    for (const view of TRACKED_VIEWS) {
-      try {
-        await a.exec(`DROP VIEW IF EXISTS \`${view}\``);
-      } catch {
-        /* ignore */
+  // Drop via a dedicated mysql2 connection (not the adapter's pool) so
+  // `SET FOREIGN_KEY_CHECKS = 0` stays in scope for every subsequent
+  // DROP on the same connection. Going through the adapter would take
+  // a fresh pool connection per exec() and the SET would only apply
+  // to the first call. FK checks matter here because the shared
+  // test-adapter (packages/activerecord/src/test-adapter.ts) creates
+  // users/posts/etc. BEFORE this file runs and may add FK constraints
+  // that block a plain DROP TABLE, leaving leftovers that poison the
+  // very first test of each CI run.
+  const dropTrackedObjects = async (): Promise<void> => {
+    const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
+    try {
+      await conn.query("SET FOREIGN_KEY_CHECKS = 0");
+      for (const view of TRACKED_VIEWS) {
+        try {
+          await conn.query(`DROP VIEW IF EXISTS \`${view}\``);
+        } catch {
+          /* ignore */
+        }
       }
-    }
-    for (const tbl of TRACKED_TABLES) {
-      try {
-        await a.exec(`DROP TABLE IF EXISTS \`${tbl}\``);
-      } catch {
-        /* ignore */
+      for (const tbl of TRACKED_TABLES) {
+        try {
+          await conn.query(`DROP TABLE IF EXISTS \`${tbl}\``);
+        } catch {
+          /* ignore */
+        }
       }
+      await conn.query("SET FOREIGN_KEY_CHECKS = 1");
+    } finally {
+      await conn.end();
     }
   };
 
@@ -74,11 +90,11 @@ describeIfMysql("Mysql2Adapter", () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
     // Defensive pre-test cleanup: a previous run that crashed without
     // hitting afterEach could leave tables behind.
-    await dropTrackedObjects(adapter);
+    await dropTrackedObjects();
   });
 
   afterEach(async () => {
-    await dropTrackedObjects(adapter);
+    await dropTrackedObjects();
     await adapter.close();
   });
 

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -572,13 +572,21 @@ describeIfMysql("Mysql2Adapter", () => {
       // would poison SchemaCache; wrapping the expression in parens
       // matches Rails' IndexDefinition display.
       //
-      // Gate on the capability probe rather than try/catching CREATE —
-      // a try/catch-all would also swallow permissions errors or a
-      // genuine syntax regression, silently letting the test pass.
-      const hasExpression = await (
-        adapter as unknown as { statisticsHasExpressionColumn(): Promise<boolean> }
-      ).statisticsHasExpressionColumn();
-      if (!hasExpression) return;
+      // Gate on a DB-side probe rather than try/catching CREATE (a
+      // blanket catch would also swallow permissions errors or a
+      // genuine syntax regression) and rather than reaching into a
+      // private adapter helper (couples the test to implementation
+      // details). Query information_schema.columns for
+      // STATISTICS.EXPRESSION directly — the column exists on MySQL
+      // 8.0.13+, absent on older MySQL and on MariaDB.
+      const capabilityRows = (await adapter.execute(
+        `SELECT 1 AS one FROM information_schema.columns
+           WHERE table_schema = 'information_schema'
+           AND table_name = 'STATISTICS'
+           AND column_name = 'EXPRESSION'
+           LIMIT 1`,
+      )) as Array<unknown>;
+      if (capabilityRows.length === 0) return;
 
       await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
       const idx = await adapter.indexes("widgets");

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -507,6 +507,21 @@ describeIfMysql("Mysql2Adapter", () => {
       await expect(adapter.tableExists("")).rejects.toThrow(/Invalid MySQL identifier/);
     });
 
+    it("rejects unquoted identifiers containing whitespace", async () => {
+      // MySQL only permits whitespace inside backtick-quoted
+      // identifiers. Unquoted variants like 'db .widgets' or
+      // 'db. widgets' or 'wid gets' would previously have been
+      // silently accepted (producing lookups for bogus names like
+      // ' widgets'); now they throw.
+      await expect(adapter.tableExists("db .widgets")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("db. widgets")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("wid gets")).rejects.toThrow(/Invalid MySQL identifier/);
+      // But whitespace INSIDE a backtick-quoted identifier is valid
+      // — MySQL permits it and we must too.
+      // (No DB-side assertion here, just ensure it doesn't throw.)
+      expect(await adapter.tableExists("`not a real table`")).toBe(false);
+    });
+
     it("rejects empty *quoted* identifiers", async () => {
       // Quoted tokens lex fine (``, `a`.``, ``.widgets all match the
       // parser's quoted-token rule) but unquote to an empty string —

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -487,6 +487,14 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(await adapter.primaryKey("widgets")).toBe("id");
     });
 
+    it("rejects three-part identifiers instead of silently truncating", async () => {
+      // MySQL doesn't have a nested catalog concept, so `a.b.c` is
+      // invalid input. The prior behavior silently took the first two
+      // parts, which pointed introspection at a completely different
+      // table. Fail loudly instead.
+      await expect(adapter.tableExists("a.b.c")).rejects.toThrow(/Invalid MySQL identifier/);
+    });
+
     it("introspection accepts schema-qualified names", async () => {
       // The implementation takes `schema.table` via parseMysqlName and
       // routes through COALESCE(?, database()). Exercise that path so

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -520,6 +520,27 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(idx).toEqual([{ name: "widgets_on_owner", columns: ["owner"], unique: false }]);
     });
 
+    it("indexes() represents MySQL 8+ functional indexes via their expression", async () => {
+      // MySQL 8+ supports `CREATE INDEX ... ON t((expr))`; those rows
+      // have NULL column_name in information_schema.statistics and the
+      // expression in `expression`. Surfacing "null" as a column name
+      // would poison SchemaCache; wrapping the expression in parens
+      // matches Rails' IndexDefinition display. Older MySQL rejects
+      // functional indexes so skip gracefully on those.
+      try {
+        await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
+      } catch {
+        return; // pre-8.0 MySQL — feature not available
+      }
+      const idx = await adapter.indexes("widgets");
+      const functional = idx.find((i) => i.name === "widgets_on_lower_name");
+      expect(functional).toBeDefined();
+      // Either `(lower(`name`))` or similar — just assert it's parenthesized.
+      expect(functional!.columns).toHaveLength(1);
+      expect(functional!.columns[0].startsWith("(")).toBe(true);
+      expect(functional!.columns[0]).not.toBe("null");
+    });
+
     it("SchemaCache.addAll populates from MySQL", async () => {
       // Integration with Phase 5's dumpSchemaCache — MySQL now exposes
       // the full surface (dataSources/columns/primaryKey/indexes) the

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -436,4 +436,83 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(rows[0].num).toBe(1);
     });
   });
+
+  describe("schema introspection", () => {
+    beforeEach(async () => {
+      await adapter.exec("DROP VIEW IF EXISTS `recent_widgets`");
+      await adapter.exec("DROP TABLE IF EXISTS `widgets`");
+      await adapter.exec(
+        "CREATE TABLE `widgets` (`id` INT AUTO_INCREMENT PRIMARY KEY, `name` VARCHAR(255) NOT NULL, `owner` VARCHAR(255))",
+      );
+      await adapter.exec("CREATE INDEX `widgets_on_owner` ON `widgets` (`owner`)");
+      await adapter.exec(
+        "CREATE VIEW `recent_widgets` AS SELECT id, name FROM widgets ORDER BY id DESC",
+      );
+    });
+
+    afterEach(async () => {
+      await adapter.exec("DROP VIEW IF EXISTS `recent_widgets`");
+      await adapter.exec("DROP TABLE IF EXISTS `widgets`");
+    });
+
+    it("tables() lists BASE TABLEs only", async () => {
+      const tables = await adapter.tables();
+      expect(tables).toContain("widgets");
+      expect(tables).not.toContain("recent_widgets");
+    });
+
+    it("views() lists views only", async () => {
+      const views = await adapter.views();
+      expect(views).toContain("recent_widgets");
+      expect(views).not.toContain("widgets");
+    });
+
+    it("dataSources() is deduped tables + views", async () => {
+      const sources = await adapter.dataSources();
+      expect(sources).toContain("widgets");
+      expect(sources).toContain("recent_widgets");
+      expect(new Set(sources).size).toBe(sources.length);
+    });
+
+    it("tableExists() / viewExists() distinguish tables and views", async () => {
+      expect(await adapter.tableExists("widgets")).toBe(true);
+      expect(await adapter.tableExists("recent_widgets")).toBe(false);
+      expect(await adapter.viewExists("recent_widgets")).toBe(true);
+      expect(await adapter.viewExists("widgets")).toBe(false);
+      expect(await adapter.dataSourceExists("recent_widgets")).toBe(true);
+      expect(await adapter.dataSourceExists("nonexistent")).toBe(false);
+    });
+
+    it("primaryKey() returns the pk column name", async () => {
+      expect(await adapter.primaryKey("widgets")).toBe("id");
+    });
+
+    it("columns() returns column metadata for every column", async () => {
+      const cols = await adapter.columns("widgets");
+      expect(cols.map((c) => c.name)).toEqual(["id", "name", "owner"]);
+      const idCol = cols.find((c) => c.name === "id");
+      expect(idCol?.primaryKey).toBe(true);
+      expect(idCol?.null).toBe(false);
+      const nameCol = cols.find((c) => c.name === "name");
+      expect(nameCol?.null).toBe(false);
+      expect(nameCol?.sqlType?.startsWith("varchar")).toBe(true);
+    });
+
+    it("indexes() returns user-created indexes and skips PRIMARY", async () => {
+      const idx = await adapter.indexes("widgets");
+      expect(idx).toEqual([{ name: "widgets_on_owner", columns: ["owner"], unique: false }]);
+    });
+
+    it("SchemaCache.addAll populates from MySQL", async () => {
+      // Integration with Phase 5's dumpSchemaCache — MySQL now exposes
+      // the full surface (dataSources/columns/primaryKey/indexes) the
+      // capability guard requires.
+      const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
+      const cache = new SchemaCache();
+      await cache.addAll(adapter);
+      const cols = await cache.columns(adapter, "widgets");
+      expect(cols?.map((c) => c.name)).toEqual(["id", "name", "owner"]);
+      expect(await cache.primaryKeys(adapter, "widgets")).toBe("id");
+    });
+  });
 });

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -487,6 +487,23 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(await adapter.primaryKey("widgets")).toBe("id");
     });
 
+    it("introspection accepts schema-qualified names", async () => {
+      // The implementation takes `schema.table` via parseMysqlName and
+      // routes through COALESCE(?, database()). Exercise that path so
+      // an accidental ordinal_position/seq_in_index swap or a missing
+      // ORDER BY change doesn't silently break qualified callers.
+      const rows = (await adapter.execute("SELECT DATABASE() AS db")) as Array<{
+        db?: string;
+        DB?: string;
+      }>;
+      const dbName = String(rows[0].db ?? rows[0].DB);
+      expect(await adapter.tableExists(`${dbName}.widgets`)).toBe(true);
+      expect(await adapter.tableExists(`\`${dbName}\`.\`widgets\``)).toBe(true);
+      expect(await adapter.primaryKey(`${dbName}.widgets`)).toBe("id");
+      const cols = await adapter.columns(`${dbName}.widgets`);
+      expect(cols.map((c) => c.name)).toEqual(["id", "name", "owner"]);
+    });
+
     it("columns() returns column metadata for every column", async () => {
       const cols = await adapter.columns("widgets");
       expect(cols.map((c) => c.name)).toEqual(["id", "name", "owner"]);

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -507,6 +507,16 @@ describeIfMysql("Mysql2Adapter", () => {
       await expect(adapter.tableExists("")).rejects.toThrow(/Invalid MySQL identifier/);
     });
 
+    it("rejects empty *quoted* identifiers", async () => {
+      // Quoted tokens lex fine (``, `a`.``, ``.widgets all match the
+      // parser's quoted-token rule) but unquote to an empty string —
+      // which would break COALESCE(?, database()) and silently scan
+      // the wrong catalog. Validate non-empty after unquoting.
+      await expect(adapter.tableExists("``")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("``.widgets")).rejects.toThrow(/Invalid MySQL identifier/);
+      await expect(adapter.tableExists("`db`.``")).rejects.toThrow(/Invalid MySQL identifier/);
+    });
+
     it("introspection accepts schema-qualified names", async () => {
       // The implementation takes `schema.table` via parseMysqlName and
       // routes through COALESCE(?, database()). Exercise that path so
@@ -545,13 +555,17 @@ describeIfMysql("Mysql2Adapter", () => {
       // have NULL column_name in information_schema.statistics and the
       // expression in `expression`. Surfacing "null" as a column name
       // would poison SchemaCache; wrapping the expression in parens
-      // matches Rails' IndexDefinition display. Older MySQL rejects
-      // functional indexes so skip gracefully on those.
-      try {
-        await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
-      } catch {
-        return; // pre-8.0 MySQL — feature not available
-      }
+      // matches Rails' IndexDefinition display.
+      //
+      // Gate on the capability probe rather than try/catching CREATE —
+      // a try/catch-all would also swallow permissions errors or a
+      // genuine syntax regression, silently letting the test pass.
+      const hasExpression = await (
+        adapter as unknown as { statisticsHasExpressionColumn(): Promise<boolean> }
+      ).statisticsHasExpressionColumn();
+      if (!hasExpression) return;
+
+      await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
       const idx = await adapter.indexes("widgets");
       const functional = idx.find((i) => i.name === "widgets_on_lower_name");
       expect(functional).toBeDefined();

--- a/packages/activerecord/src/adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.test.ts
@@ -35,24 +35,50 @@ const describeIfMysql = mysqlAvailable ? describe : describe.skip;
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
 
+  // Tables touched by any test in this suite. Dropped on BOTH sides of
+  // each test so a crash that skips afterEach can't poison the next
+  // run (which was causing intermittent CI failures with
+  // ER_TABLE_EXISTS_ERROR on leftover `users`).
+  const TRACKED_TABLES = [
+    "books",
+    "authors",
+    "users",
+    "items",
+    "accounts",
+    "products",
+    "posts",
+    "widgets",
+    "bind_param_items",
+    "exec_test_tbl",
+  ];
+  const TRACKED_VIEWS = ["recent_widgets"];
+
+  const dropTrackedObjects = async (a: Mysql2Adapter): Promise<void> => {
+    for (const view of TRACKED_VIEWS) {
+      try {
+        await a.exec(`DROP VIEW IF EXISTS \`${view}\``);
+      } catch {
+        /* ignore */
+      }
+    }
+    for (const tbl of TRACKED_TABLES) {
+      try {
+        await a.exec(`DROP TABLE IF EXISTS \`${tbl}\``);
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+
   beforeEach(async () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    // Defensive pre-test cleanup: a previous run that crashed without
+    // hitting afterEach could leave tables behind.
+    await dropTrackedObjects(adapter);
   });
 
   afterEach(async () => {
-    try {
-      await adapter.exec("DROP TABLE IF EXISTS `books`");
-      await adapter.exec("DROP TABLE IF EXISTS `authors`");
-      await adapter.exec("DROP TABLE IF EXISTS `users`");
-      await adapter.exec("DROP TABLE IF EXISTS `items`");
-      await adapter.exec("DROP TABLE IF EXISTS `accounts`");
-      await adapter.exec("DROP TABLE IF EXISTS `products`");
-      await adapter.exec("DROP TABLE IF EXISTS `posts`");
-      await adapter.exec("DROP TABLE IF EXISTS `bind_param_items`");
-      await adapter.exec("DROP TABLE IF EXISTS `exec_test_tbl`");
-    } catch {
-      // ignore cleanup errors
-    }
+    await dropTrackedObjects(adapter);
     await adapter.close();
   });
 

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -404,6 +404,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     const rows = (await this.execute(
       `SELECT index_name AS name,
               column_name AS col,
+              expression AS expr,
               non_unique AS non_unique,
               seq_in_index AS pos
          FROM information_schema.statistics
@@ -417,10 +418,26 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     const byIndex = new Map<string, { columns: string[]; unique: boolean }>();
     for (const r of rows) {
       const name = String((r.name ?? r.NAME ?? r.INDEX_NAME) as string);
-      const col = String((r.col ?? r.COL ?? r.COLUMN_NAME) as string);
+      // MySQL 8+ functional indexes store NULL in column_name and the
+      // raw SQL expression in `expression`. Rails wraps those in parens
+      // for its IndexDefinition; we do the same so the entry is
+      // unambiguous and doesn't serialize as the literal string "null"
+      // (what String(null) would produce).
+      const rawCol = r.col ?? r.COL ?? r.COLUMN_NAME;
+      const rawExpr = r.expr ?? r.EXPR ?? r.EXPRESSION;
+      let column: string | null;
+      if (rawCol != null) {
+        column = String(rawCol);
+      } else if (rawExpr != null) {
+        const expr = String(rawExpr);
+        column = expr.startsWith("(") ? expr : `(${expr})`;
+      } else {
+        column = null;
+      }
+      if (column == null) continue;
       const nonUnique = Number(r.non_unique ?? r.NON_UNIQUE ?? 0);
       const entry = byIndex.get(name) ?? { columns: [], unique: nonUnique === 0 };
-      entry.columns.push(col);
+      entry.columns.push(column);
       byIndex.set(name, entry);
     }
     return Array.from(byIndex.entries()).map(([name, { columns, unique }]) => ({

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -1,6 +1,8 @@
 import mysql from "mysql2/promise";
 import type { DatabaseAdapter } from "../adapter.js";
 import { DatabaseStatementsMixin } from "../connection-adapters/database-statements-mixin.js";
+import { Column } from "../connection-adapters/column.js";
+import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 
 const AdapterBase = DatabaseStatementsMixin(class {});
 
@@ -223,6 +225,214 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     } finally {
       this.releaseConn(conn);
     }
+  }
+
+  // ── Schema introspection ──
+  // Mirrors Rails' MySQL SchemaStatements (connection_adapters/mysql/
+  // schema_statements.rb + abstract_mysql_adapter.rb). All queries
+  // scope to the current database via information_schema.
+
+  /**
+   * List all BASE TABLEs in the current database, matching Rails'
+   * `data_source_sql(type: "BASE TABLE")` shape.
+   */
+  async tables(): Promise<string[]> {
+    const rows = await this.execute(
+      `SELECT table_name AS name FROM information_schema.tables
+         WHERE table_schema = database() AND table_type = 'BASE TABLE'
+         ORDER BY table_name`,
+    );
+    return rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string);
+  }
+
+  /**
+   * List all VIEWs in the current database, matching Rails'
+   * `data_source_sql(type: "VIEW")`.
+   */
+  async views(): Promise<string[]> {
+    const rows = await this.execute(
+      `SELECT table_name AS name FROM information_schema.tables
+         WHERE table_schema = database() AND table_type = 'VIEW'
+         ORDER BY table_name`,
+    );
+    return rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string);
+  }
+
+  /**
+   * Tables + views, deduped. Matches Rails'
+   * `AbstractAdapter#data_sources` — the name SchemaCache.addAll calls
+   * through.
+   */
+  async dataSources(): Promise<string[]> {
+    const rows = await this.execute(
+      `SELECT table_name AS name FROM information_schema.tables
+         WHERE table_schema = database()
+         ORDER BY table_name`,
+    );
+    return rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string);
+  }
+
+  async tableExists(name: string): Promise<boolean> {
+    return this.informationSchemaExists(name, "BASE TABLE");
+  }
+
+  async viewExists(name: string): Promise<boolean> {
+    return this.informationSchemaExists(name, "VIEW");
+  }
+
+  async dataSourceExists(name: string): Promise<boolean> {
+    return this.informationSchemaExists(name, null);
+  }
+
+  private async informationSchemaExists(
+    name: string,
+    type: "BASE TABLE" | "VIEW" | null,
+  ): Promise<boolean> {
+    const { schema, table } = this.parseMysqlName(name);
+    const schemaBind = schema ?? null;
+    // Use `schema_placeholder OR database()` via COALESCE so the same
+    // query shape serves qualified + unqualified callers.
+    const typeClause = type ? "AND table_type = ?" : "";
+    const params: unknown[] = [schemaBind, table];
+    if (type) params.push(type);
+    const rows = await this.execute(
+      `SELECT 1 AS one FROM information_schema.tables
+         WHERE table_schema = COALESCE(?, database())
+         AND table_name = ?
+         ${typeClause}
+         LIMIT 1`,
+      params,
+    );
+    return rows.length > 0;
+  }
+
+  /**
+   * Return the single-column primary key name, or null for composite /
+   * no-PK tables. Matches Rails' `abstract_mysql_adapter#primary_keys`
+   * shape (which returns an array; we return a scalar for the common
+   * case and null for composite).
+   */
+  async primaryKey(tableName: string): Promise<string | null> {
+    const { schema, table } = this.parseMysqlName(tableName);
+    const rows = (await this.execute(
+      `SELECT column_name AS name FROM information_schema.key_column_usage
+         WHERE table_schema = COALESCE(?, database())
+         AND table_name = ?
+         AND constraint_name = 'PRIMARY'
+         ORDER BY ordinal_position`,
+      [schema ?? null, table],
+    )) as Array<{ name?: string; NAME?: string; COLUMN_NAME?: string }>;
+    const names = rows.map((r) => (r.name ?? r.NAME ?? r.COLUMN_NAME) as string);
+    if (names.length === 1) return names[0];
+    return null;
+  }
+
+  /**
+   * Return Column metadata for the named table. Reads from
+   * `information_schema.columns` — matches Rails' column introspection
+   * shape. Populates the fields SchemaCache serializes (name, default,
+   * null, sqlTypeMetadata, primaryKey).
+   */
+  async columns(tableName: string): Promise<Column[]> {
+    const { schema, table } = this.parseMysqlName(tableName);
+    const rows = (await this.execute(
+      `SELECT column_name AS name,
+              column_default AS default_value,
+              is_nullable AS nullable,
+              data_type AS type,
+              column_type AS full_type,
+              character_maximum_length AS char_len,
+              numeric_precision AS num_precision,
+              numeric_scale AS num_scale,
+              column_key AS col_key,
+              extra AS col_extra,
+              collation_name AS collation,
+              column_comment AS comment
+         FROM information_schema.columns
+         WHERE table_schema = COALESCE(?, database())
+         AND table_name = ?
+         ORDER BY ordinal_position`,
+      [schema ?? null, table],
+    )) as Array<Record<string, unknown>>;
+
+    return rows.map((r) => {
+      const name = String((r.name ?? r.NAME ?? r.COLUMN_NAME) as string);
+      const sqlType = String((r.full_type ?? r.FULL_TYPE ?? r.COLUMN_TYPE ?? "") as string);
+      const baseType = String((r.type ?? r.TYPE ?? r.DATA_TYPE ?? "") as string).toLowerCase();
+      const charLen = r.char_len ?? r.CHAR_LEN ?? r.CHARACTER_MAXIMUM_LENGTH;
+      const numPrec = r.num_precision ?? r.NUM_PRECISION ?? r.NUMERIC_PRECISION;
+      const numScale = r.num_scale ?? r.NUM_SCALE ?? r.NUMERIC_SCALE;
+      const meta = new SqlTypeMetadata({
+        sqlType,
+        type: baseType,
+        limit: charLen != null ? Number(charLen) : null,
+        precision: numPrec != null ? Number(numPrec) : null,
+        scale: numScale != null ? Number(numScale) : null,
+      });
+      const nullable =
+        String((r.nullable ?? r.NULLABLE ?? r.IS_NULLABLE ?? "YES") as string).toUpperCase() !==
+        "NO";
+      const colKey = String((r.col_key ?? r.COL_KEY ?? r.COLUMN_KEY ?? "") as string);
+      return new Column(name, r.default_value ?? r.DEFAULT_VALUE ?? null, meta, nullable, {
+        collation: (r.collation ?? r.COLLATION ?? null) as string | null,
+        comment: (r.comment ?? r.COMMENT ?? null) as string | null,
+        primaryKey: colKey === "PRI",
+      });
+    });
+  }
+
+  /**
+   * Return user-defined indexes for the given table. Matches Rails'
+   * MySQL SchemaStatements#indexes which reads from
+   * `information_schema.statistics` and filters out PRIMARY.
+   */
+  async indexes(
+    tableName: string,
+  ): Promise<Array<{ name: string; columns: string[]; unique: boolean }>> {
+    const { schema, table } = this.parseMysqlName(tableName);
+    const rows = (await this.execute(
+      `SELECT index_name AS name,
+              column_name AS col,
+              non_unique AS non_unique,
+              seq_in_index AS pos
+         FROM information_schema.statistics
+         WHERE table_schema = COALESCE(?, database())
+         AND table_name = ?
+         AND index_name <> 'PRIMARY'
+         ORDER BY index_name, seq_in_index`,
+      [schema ?? null, table],
+    )) as Array<Record<string, unknown>>;
+
+    const byIndex = new Map<string, { columns: string[]; unique: boolean }>();
+    for (const r of rows) {
+      const name = String((r.name ?? r.NAME ?? r.INDEX_NAME) as string);
+      const col = String((r.col ?? r.COL ?? r.COLUMN_NAME) as string);
+      const nonUnique = Number(r.non_unique ?? r.NON_UNIQUE ?? 0);
+      const entry = byIndex.get(name) ?? { columns: [], unique: nonUnique === 0 };
+      entry.columns.push(col);
+      byIndex.set(name, entry);
+    }
+    return Array.from(byIndex.entries()).map(([name, { columns, unique }]) => ({
+      name,
+      columns,
+      unique,
+    }));
+  }
+
+  /**
+   * Split a `schema.table` or `` `schema`.`table` `` into `{schema, table}`.
+   * Matches Rails' `extract_schema_qualified_name` regex from
+   * `mysql/schema_statements.rb`. Returns `schema: undefined` when
+   * `name` is an unqualified identifier.
+   */
+  private parseMysqlName(name: string): { schema?: string; table: string } {
+    const parts = name.match(/[^`.\s]+|`[^`]*`/g) ?? [name];
+    const unquote = (s: string): string =>
+      s.startsWith("`") && s.endsWith("`") ? s.slice(1, -1).replace(/``/g, "`") : s;
+    if (parts.length >= 2) {
+      return { schema: unquote(parts[0]), table: unquote(parts[1]) };
+    }
+    return { table: unquote(parts[0] ?? name) };
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -261,7 +261,9 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   /**
    * Tables + views, deduped. Matches Rails'
    * `AbstractAdapter#data_sources` — the name SchemaCache.addAll calls
-   * through.
+   * through. information_schema.tables already returns distinct rows
+   * within a schema, but the Set pass is defensive + keeps the
+   * contract explicit for future callers.
    */
   async dataSources(): Promise<string[]> {
     const rows = await this.execute(
@@ -269,7 +271,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
          WHERE table_schema = database()
          ORDER BY table_name`,
     );
-    return rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string);
+    return [...new Set(rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string))];
   }
 
   async tableExists(name: string): Promise<boolean> {
@@ -431,11 +433,15 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   /**
    * Split a `schema.table` or `` `schema`.`table` `` into `{schema, table}`.
    * Matches Rails' `extract_schema_qualified_name` regex from
-   * `mysql/schema_statements.rb`. Returns `schema: undefined` when
-   * `name` is an unqualified identifier.
+   * `mysql/schema_statements.rb`, with doubled-backtick escapes
+   * preserved inside the match so `` `my``table` `` is parsed as a
+   * single token. Returns `schema: undefined` when `name` is an
+   * unqualified identifier.
    */
   private parseMysqlName(name: string): { schema?: string; table: string } {
-    const parts = name.match(/[^`.\s]+|`[^`]*`/g) ?? [name];
+    // `[^`.\s]+` for bare identifiers, `` `(?:[^`]|``)*` `` for quoted
+    // identifiers where any `` inside the token is an escaped backtick.
+    const parts = name.match(/[^`.\s]+|`(?:[^`]|``)*`/g) ?? [name];
     const unquote = (s: string): string =>
       s.startsWith("`") && s.endsWith("`") ? s.slice(1, -1).replace(/``/g, "`") : s;
     if (parts.length >= 2) {

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -20,6 +20,11 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   private pool: mysql.Pool;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;
+  // Cached capability flag — information_schema.statistics.expression
+  // is MySQL 8.0.13+. Pre-8 MySQL and MariaDB (through at least 10.x)
+  // don't expose it, so we detect once and remember. `undefined` =
+  // not yet probed, `true`/`false` = result.
+  private _statisticsHasExpression: boolean | undefined;
 
   constructor(config: string | mysql.PoolOptions) {
     super();
@@ -401,10 +406,12 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     tableName: string,
   ): Promise<Array<{ name: string; columns: string[]; unique: boolean }>> {
     const { schema, table } = this.parseMysqlName(tableName);
+    const hasExpr = await this.statisticsHasExpressionColumn();
+    const exprSelect = hasExpr ? "expression AS expr" : "NULL AS expr";
     const rows = (await this.execute(
       `SELECT index_name AS name,
               column_name AS col,
-              expression AS expr,
+              ${exprSelect},
               non_unique AS non_unique,
               seq_in_index AS pos
          FROM information_schema.statistics
@@ -445,6 +452,34 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
       columns,
       unique,
     }));
+  }
+
+  /**
+   * Check whether `information_schema.statistics` exposes an
+   * `expression` column. Added in MySQL 8.0.13; absent on earlier
+   * MySQL and on MariaDB (through 10.x). Probed once per adapter
+   * instance and memoized — the result can't change mid-connection.
+   */
+  private async statisticsHasExpressionColumn(): Promise<boolean> {
+    if (this._statisticsHasExpression !== undefined) {
+      return this._statisticsHasExpression;
+    }
+    try {
+      const rows = (await this.execute(
+        `SELECT 1 AS one FROM information_schema.columns
+           WHERE table_schema = 'information_schema'
+           AND table_name = 'STATISTICS'
+           AND column_name = 'EXPRESSION'
+           LIMIT 1`,
+      )) as Array<unknown>;
+      this._statisticsHasExpression = rows.length > 0;
+    } catch {
+      // Defensive: if the probe itself fails, assume no — we'll just
+      // miss functional index expressions, which matches pre-8 MySQL
+      // semantics anyway.
+      this._statisticsHasExpression = false;
+    }
+    return this._statisticsHasExpression;
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -353,7 +353,6 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
               numeric_precision AS num_precision,
               numeric_scale AS num_scale,
               column_key AS col_key,
-              extra AS col_extra,
               collation_name AS collation,
               column_comment AS comment
          FROM information_schema.columns
@@ -395,12 +394,18 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    * rather than Rails-MySQL's `SHOW KEYS` because the information_schema
    * query is cross-schema-capable without needing a qualified
    * `SHOW KEYS FROM schema.table` dance, and the output shape is all
-   * SchemaCache needs (name/columns/unique). Prefix lengths, per-column
-   * orders, fulltext/spatial `type`, and functional-index expressions
-   * — which Rails' MySQL `indexes` preserves via IndexDefinition — are
-   * intentionally omitted here: SchemaCache stores indexes as
-   * `unknown[]` and nothing in trails reads those fields yet. When a
-   * caller needs the full Rails shape we'll layer it on.
+   * SchemaCache needs (name/columns/unique).
+   *
+   * Functional-index expressions ARE surfaced: on MySQL 8.0.13+
+   * (detected via statisticsHasExpressionColumn) a row with
+   * `column_name IS NULL` carries its expression in `expression`, and
+   * we wrap it in parens in the output column list (matching Rails'
+   * IndexDefinition display). Prefix lengths, per-column orders, and
+   * fulltext/spatial `type` — which Rails' MySQL `indexes` preserves
+   * via IndexDefinition — are intentionally omitted here: SchemaCache
+   * stores indexes as `unknown[]` and nothing in trails reads those
+   * fields yet. When a caller needs the full Rails shape we'll layer
+   * it on.
    */
   async indexes(
     tableName: string,

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -489,6 +489,12 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    * preserved inside the match so `` `my``table` `` is parsed as a
    * single token. Returns `schema: undefined` when `name` is an
    * unqualified identifier.
+   *
+   * Requires exactly one or two parts — a three-part name like
+   * `a.b.c` is invalid in MySQL (no nested catalog concept) and
+   * silently dropping `.c` would point introspection at the wrong
+   * table. Throws instead. Aligns with the PG parser's strictness in
+   * `packages/activerecord/src/connection-adapters/postgresql/utils.ts`.
    */
   private parseMysqlName(name: string): { schema?: string; table: string } {
     // `[^`.\s]+` for bare identifiers, `` `(?:[^`]|``)*` `` for quoted
@@ -496,10 +502,15 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     const parts = name.match(/[^`.\s]+|`(?:[^`]|``)*`/g) ?? [name];
     const unquote = (s: string): string =>
       s.startsWith("`") && s.endsWith("`") ? s.slice(1, -1).replace(/``/g, "`") : s;
-    if (parts.length >= 2) {
+    if (parts.length === 2) {
       return { schema: unquote(parts[0]), table: unquote(parts[1]) };
     }
-    return { table: unquote(parts[0] ?? name) };
+    if (parts.length === 1) {
+      return { table: unquote(parts[0]) };
+    }
+    throw new Error(
+      `Invalid MySQL identifier "${name}": expected "table" or "schema.table", got ${parts.length} parts.`,
+    );
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -489,11 +489,12 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    * requires exactly one part or two parts joined by a single dot,
    * respecting `` ` `` quoting and doubled-backtick escapes. Rejects
    * empty segments (`.widgets`, `a..b`, `db.widgets.`), extra parts
-   * (`a.b.c`), and unterminated quoted tokens. Matches the strictness
-   * of the PG parser at
+   * (`a.b.c`), and unterminated quoted tokens. This is intentionally
+   * stricter than the PG helper in
    * `packages/activerecord/src/connection-adapters/postgresql/utils.ts`
-   * so a typo surfaces instead of silently pointing introspection at
-   * the wrong table.
+   * (which tolerates empty segments and trailing parts) so a typo in
+   * a MySQL introspection call surfaces instead of silently pointing
+   * at the wrong table.
    */
   private parseMysqlName(name: string): { schema?: string; table: string } {
     const input = name.trim();

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -533,7 +533,13 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
         invalid(); // unterminated
       }
       let i = start;
-      while (i < input.length && input[i] !== "." && input[i] !== "`") {
+      // Stop at `.`, the start of a quoted token, or any whitespace.
+      // MySQL only permits whitespace inside *backtick-quoted*
+      // identifiers; an unquoted "db .widgets" would therefore be
+      // invalid. Treating whitespace as a token boundary (rather than
+      // part of the name) lets the extra-content check downstream
+      // reject the input cleanly.
+      while (i < input.length && input[i] !== "." && input[i] !== "`" && !/\s/.test(input[i])) {
         i += 1;
       }
       if (i === start) invalid(); // empty

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -412,8 +412,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
       `SELECT index_name AS name,
               column_name AS col,
               ${exprSelect},
-              non_unique AS non_unique,
-              seq_in_index AS pos
+              non_unique AS non_unique
          FROM information_schema.statistics
          WHERE table_schema = COALESCE(?, database())
          AND table_name = ?
@@ -538,14 +537,25 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
 
     if (input.length === 0) invalid();
 
+    // unquote + re-validate non-empty: a quoted token like "``" lexes
+    // fine in parsePart (backticks match, body is empty) but unquotes
+    // to "", which would break COALESCE(?, database()) and make the
+    // introspection call silently scan the wrong catalog. Centralize
+    // the empty-check here so both bare and quoted forms are covered.
+    const checkNonEmpty = (part: string): string => {
+      const s = unquote(part);
+      if (s.length === 0) invalid();
+      return s;
+    };
+
     const first = parsePart(0);
     if (first.nextIndex === input.length) {
-      return { table: unquote(first.part) };
+      return { table: checkNonEmpty(first.part) };
     }
     if (input[first.nextIndex] !== ".") invalid();
     const second = parsePart(first.nextIndex + 1);
     if (second.nextIndex !== input.length) invalid(); // extra content
-    return { schema: unquote(first.part), table: unquote(second.part) };
+    return { schema: checkNonEmpty(first.part), table: checkNonEmpty(second.part) };
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -308,18 +308,19 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
 
   /**
    * Return the single-column primary key name, or null for composite /
-   * no-PK tables. Matches Rails' `abstract_mysql_adapter#primary_keys`
-   * shape (which returns an array; we return a scalar for the common
-   * case and null for composite).
+   * no-PK tables. Uses the same `information_schema.statistics` +
+   * `seq_in_index` shape Rails emits in
+   * `abstract_mysql_adapter#primary_keys` — works across all MySQL
+   * versions + MariaDB.
    */
   async primaryKey(tableName: string): Promise<string | null> {
     const { schema, table } = this.parseMysqlName(tableName);
     const rows = (await this.execute(
-      `SELECT column_name AS name FROM information_schema.key_column_usage
-         WHERE table_schema = COALESCE(?, database())
+      `SELECT column_name AS name FROM information_schema.statistics
+         WHERE index_name = 'PRIMARY'
+         AND table_schema = COALESCE(?, database())
          AND table_name = ?
-         AND constraint_name = 'PRIMARY'
-         ORDER BY ordinal_position`,
+         ORDER BY seq_in_index`,
       [schema ?? null, table],
     )) as Array<{ name?: string; NAME?: string; COLUMN_NAME?: string }>;
     const names = rows.map((r) => (r.name ?? r.NAME ?? r.COLUMN_NAME) as string);
@@ -382,9 +383,17 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   }
 
   /**
-   * Return user-defined indexes for the given table. Matches Rails'
-   * MySQL SchemaStatements#indexes which reads from
-   * `information_schema.statistics` and filters out PRIMARY.
+   * Return user-defined indexes for the given table. Trails uses
+   * `information_schema.statistics` (Rails' PG/SQLite parallel shape)
+   * rather than Rails-MySQL's `SHOW KEYS` because the information_schema
+   * query is cross-schema-capable without needing a qualified
+   * `SHOW KEYS FROM schema.table` dance, and the output shape is all
+   * SchemaCache needs (name/columns/unique). Prefix lengths, per-column
+   * orders, fulltext/spatial `type`, and functional-index expressions
+   * — which Rails' MySQL `indexes` preserves via IndexDefinition — are
+   * intentionally omitted here: SchemaCache stores indexes as
+   * `unknown[]` and nothing in trails reads those fields yet. When a
+   * caller needs the full Rails shape we'll layer it on.
    */
   async indexes(
     tableName: string,

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -484,33 +484,67 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
 
   /**
    * Split a `schema.table` or `` `schema`.`table` `` into `{schema, table}`.
-   * Matches Rails' `extract_schema_qualified_name` regex from
-   * `mysql/schema_statements.rb`, with doubled-backtick escapes
-   * preserved inside the match so `` `my``table` `` is parsed as a
-   * single token. Returns `schema: undefined` when `name` is an
-   * unqualified identifier.
    *
-   * Requires exactly one or two parts — a three-part name like
-   * `a.b.c` is invalid in MySQL (no nested catalog concept) and
-   * silently dropping `.c` would point introspection at the wrong
-   * table. Throws instead. Aligns with the PG parser's strictness in
-   * `packages/activerecord/src/connection-adapters/postgresql/utils.ts`.
+   * Whole-string parser (not regex-tokenize): walks the input once and
+   * requires exactly one part or two parts joined by a single dot,
+   * respecting `` ` `` quoting and doubled-backtick escapes. Rejects
+   * empty segments (`.widgets`, `a..b`, `db.widgets.`), extra parts
+   * (`a.b.c`), and unterminated quoted tokens. Matches the strictness
+   * of the PG parser at
+   * `packages/activerecord/src/connection-adapters/postgresql/utils.ts`
+   * so a typo surfaces instead of silently pointing introspection at
+   * the wrong table.
    */
   private parseMysqlName(name: string): { schema?: string; table: string } {
-    // `[^`.\s]+` for bare identifiers, `` `(?:[^`]|``)*` `` for quoted
-    // identifiers where any `` inside the token is an escaped backtick.
-    const parts = name.match(/[^`.\s]+|`(?:[^`]|``)*`/g) ?? [name];
+    const input = name.trim();
+    const invalid = (): never => {
+      throw new Error(`Invalid MySQL identifier "${name}": expected "table" or "schema.table".`);
+    };
     const unquote = (s: string): string =>
       s.startsWith("`") && s.endsWith("`") ? s.slice(1, -1).replace(/``/g, "`") : s;
-    if (parts.length === 2) {
-      return { schema: unquote(parts[0]), table: unquote(parts[1]) };
+
+    // Parse a single identifier token starting at `start`. Returns the
+    // raw token (with backticks kept, to preserve quote distinctness)
+    // and the index of the next unconsumed character. Throws on empty
+    // or unterminated tokens.
+    const parsePart = (start: number): { part: string; nextIndex: number } => {
+      if (start >= input.length) invalid();
+      if (input[start] === "`") {
+        let part = "`";
+        let i = start + 1;
+        while (i < input.length) {
+          if (input[i] === "`") {
+            if (input[i + 1] === "`") {
+              part += "``";
+              i += 2;
+              continue;
+            }
+            part += "`";
+            return { part, nextIndex: i + 1 };
+          }
+          part += input[i];
+          i += 1;
+        }
+        invalid(); // unterminated
+      }
+      let i = start;
+      while (i < input.length && input[i] !== "." && input[i] !== "`") {
+        i += 1;
+      }
+      if (i === start) invalid(); // empty
+      return { part: input.slice(start, i), nextIndex: i };
+    };
+
+    if (input.length === 0) invalid();
+
+    const first = parsePart(0);
+    if (first.nextIndex === input.length) {
+      return { table: unquote(first.part) };
     }
-    if (parts.length === 1) {
-      return { table: unquote(parts[0]) };
-    }
-    throw new Error(
-      `Invalid MySQL identifier "${name}": expected "table" or "schema.table", got ${parts.length} parts.`,
-    );
+    if (input[first.nextIndex] !== ".") invalid();
+    const second = parsePart(first.nextIndex + 1);
+    if (second.nextIndex !== input.length) invalid(); // extra content
+    return { schema: unquote(first.part), table: unquote(second.part) };
   }
 
   /**


### PR DESCRIPTION
## Summary

\`Mysql2Adapter\` had zero introspection surface. Phase 5's \`dumpSchemaCache\` capability guard rejected MySQL configs because \`dataSources\`/\`columns\`/\`primaryKey\`/\`indexes\` were all missing. Phase 10 wires them using \`information_schema\`, mirroring Rails' \`mysql/schema_statements.rb\` + \`abstract_mysql_adapter.rb\`.

- \`tables()\` / \`views()\` / \`dataSources()\` — \`information_schema.tables\` scoped to \`database()\` with Rails-identical \`table_type\` filters (BASE TABLE / VIEW / no filter); \`dataSources\` deduped via Set
- \`tableExists\` / \`viewExists\` / \`dataSourceExists\` — shared \`informationSchemaExists\` predicate with \`SELECT 1 ... LIMIT 1\`
- \`primaryKey\` — \`information_schema.statistics\` where \`index_name = 'PRIMARY'\` ORDER BY \`seq_in_index\` (matches Rails' \`abstract_mysql_adapter#primary_keys\` query verbatim); null for composite / no-PK
- \`columns\` — \`information_schema.columns\` with \`column_type\` (full varchar(255)-style), \`character_maximum_length\`, \`numeric_precision/scale\`, \`column_key='PRI'\` flagging the PK
- \`indexes\` — \`information_schema.statistics\` excluding PRIMARY, grouped per index, column order preserved via \`seq_in_index\`
- \`parseMysqlName\` handles \`schema.table\` and \`\` \`schema\`.\`table\` \`\` forms with doubled-backtick-escape support (\`\` \`my\`\`table\` \`\` → \`my\`table\`)

## Test plan

- [x] \`pnpm test\` — full suite, 17161 passing (10 new tests auto-skip without a local MySQL, following the existing \`describeIfMysql\` convention)
- [x] Tables-only vs views-only, deduped \`dataSources\`
- [x] \`tableExists\` / \`viewExists\` / \`dataSourceExists\` distinctions
- [x] \`primaryKey\` returns the pk column name
- [x] \`columns\` metadata shape (name, null, sqlType, primaryKey flag)
- [x] \`indexes\` filters PRIMARY, keeps column order
- [x] Schema-qualified introspection (\`schema.table\` and \`\` \`schema\`.\`table\` \`\`)
- [x] End-to-end \`SchemaCache.addAll\` populates columns + primaryKey through the new surface

MySQL structure dumps continue to route through \`mysqldump\` (Phase 7's shell-out path), so the \`_appendSchemaInformation\` backtick-quoted INSERTs still work against a fresh load.