### PR TITLE
feat(activerecord): Phase 1a-fixup — virtualizer emits AssociationProxy<T> for collections

### DIFF
--- a/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
@@ -1,6 +1,6 @@
 export class Blog extends Base {
-  declare posts: Post[];
-  declare comments: Comment[];
+  declare posts: AssociationProxy<Post>;
+  declare comments: AssociationProxy<Comment>;
 
   static {
     this.hasMany("posts");

--- a/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/02-has-many/expected.ts
@@ -1,6 +1,6 @@
 export class Blog extends Base {
-  declare posts: AssociationProxy<Post>;
-  declare comments: AssociationProxy<Comment>;
+  declare posts: import("@blazetrails/activerecord").AssociationProxy<Post>;
+  declare comments: import("@blazetrails/activerecord").AssociationProxy<Comment>;
 
   static {
     this.hasMany("posts");

--- a/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
@@ -1,6 +1,6 @@
 export class Post extends Base {
-  declare static published: () => Relation<Post>;
-  declare static recent: (limit: number) => Relation<Post>;
+  declare static published: () => import("@blazetrails/activerecord").Relation<Post>;
+  declare static recent: (limit: number) => import("@blazetrails/activerecord").Relation<Post>;
 
   static {
     this.scope("published", (rel) => rel.where({ published: true }));

--- a/packages/activerecord/src/type-virtualization/fixtures/06-enum/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/06-enum/expected.ts
@@ -2,10 +2,10 @@ export class Task extends Base {
   declare status: number;
   declare isLow: () => boolean;
   declare lowBang: () => this;
-  declare static low: () => Relation<Task>;
+  declare static low: () => import("@blazetrails/activerecord").Relation<Task>;
   declare isHigh: () => boolean;
   declare highBang: () => this;
-  declare static high: () => Relation<Task>;
+  declare static high: () => import("@blazetrails/activerecord").Relation<Task>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/07-define-enum/expected.ts
@@ -5,13 +5,13 @@ export class Article extends Base {
   declare isDraft: () => boolean;
   declare draft: () => void;
   declare draftBang: () => Promise<void>;
-  declare static draft: () => Relation<Article>;
-  declare static notDraft: () => Relation<Article>;
+  declare static draft: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notDraft: () => import("@blazetrails/activerecord").Relation<Article>;
   declare isPublished: () => boolean;
   declare published: () => void;
   declare publishedBang: () => Promise<void>;
-  declare static published: () => Relation<Article>;
-  declare static notPublished: () => Relation<Article>;
+  declare static published: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notPublished: () => import("@blazetrails/activerecord").Relation<Article>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
@@ -2,7 +2,7 @@ export class Post extends Base {
   declare title: string;
   declare published: boolean;
   declare author: Author | null;
-  declare comments: Comment[];
+  declare comments: AssociationProxy<Comment>;
   declare static published: () => Relation<Post>;
 
   static {

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
@@ -2,8 +2,8 @@ export class Post extends Base {
   declare title: string;
   declare published: boolean;
   declare author: Author | null;
-  declare comments: AssociationProxy<Comment>;
-  declare static published: () => Relation<Post>;
+  declare comments: import("@blazetrails/activerecord").AssociationProxy<Comment>;
+  declare static published: () => import("@blazetrails/activerecord").Relation<Post>;
 
   static {
     this.attribute("title", "string");

--- a/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
@@ -1,6 +1,6 @@
 export class Post extends Base {
   declare writer: Author | null;
-  declare remarks: AssociationProxy<Comment>;
+  declare remarks: import("@blazetrails/activerecord").AssociationProxy<Comment>;
 
   static {
     this.belongsTo("writer", { className: "Author" });

--- a/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
@@ -1,6 +1,6 @@
 export class Post extends Base {
   declare writer: Author | null;
-  declare remarks: Comment[];
+  declare remarks: AssociationProxy<Comment>;
 
   static {
     this.belongsTo("writer", { className: "Author" });

--- a/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
@@ -1,5 +1,5 @@
 export class Post extends Base {
-  declare tags: AssociationProxy<Tag>;
+  declare tags: import("@blazetrails/activerecord").AssociationProxy<Tag>;
 
   static {
     this.hasAndBelongsToMany("tags");

--- a/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/13-has-and-belongs-to-many/expected.ts
@@ -1,5 +1,5 @@
 export class Post extends Base {
-  declare tags: Tag[];
+  declare tags: AssociationProxy<Tag>;
 
   static {
     this.hasAndBelongsToMany("tags");

--- a/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/14-define-enum-array-form/expected.ts
@@ -5,13 +5,13 @@ export class Conversation extends Base {
   declare isActive: () => boolean;
   declare active: () => void;
   declare activeBang: () => Promise<void>;
-  declare static active: () => Relation<Conversation>;
-  declare static notActive: () => Relation<Conversation>;
+  declare static active: () => import("@blazetrails/activerecord").Relation<Conversation>;
+  declare static notActive: () => import("@blazetrails/activerecord").Relation<Conversation>;
   declare isArchived: () => boolean;
   declare archived: () => void;
   declare archivedBang: () => Promise<void>;
-  declare static archived: () => Relation<Conversation>;
-  declare static notArchived: () => Relation<Conversation>;
+  declare static archived: () => import("@blazetrails/activerecord").Relation<Conversation>;
+  declare static notArchived: () => import("@blazetrails/activerecord").Relation<Conversation>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/15-enum-with-prefix/expected.ts
@@ -2,10 +2,10 @@ export class Task extends Base {
   declare status: number;
   declare isStatusLow: () => boolean;
   declare statusLowBang: () => this;
-  declare static statusLow: () => Relation<Task>;
+  declare static statusLow: () => import("@blazetrails/activerecord").Relation<Task>;
   declare isStatusHigh: () => boolean;
   declare statusHighBang: () => this;
-  declare static statusHigh: () => Relation<Task>;
+  declare static statusHigh: () => import("@blazetrails/activerecord").Relation<Task>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/16-enum-with-custom-prefix/expected.ts
@@ -2,10 +2,10 @@ export class Task extends Base {
   declare status: number;
   declare isTierLow: () => boolean;
   declare tierLowBang: () => this;
-  declare static tierLow: () => Relation<Task>;
+  declare static tierLow: () => import("@blazetrails/activerecord").Relation<Task>;
   declare isTierHigh: () => boolean;
   declare tierHighBang: () => this;
-  declare static tierHigh: () => Relation<Task>;
+  declare static tierHigh: () => import("@blazetrails/activerecord").Relation<Task>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/18-define-enum-with-suffix/expected.ts
@@ -5,13 +5,13 @@ export class Article extends Base {
   declare isDraftStatus: () => boolean;
   declare draftStatus: () => void;
   declare draftStatusBang: () => Promise<void>;
-  declare static draftStatus: () => Relation<Article>;
-  declare static notDraftStatus: () => Relation<Article>;
+  declare static draftStatus: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notDraftStatus: () => import("@blazetrails/activerecord").Relation<Article>;
   declare isPublishedStatus: () => boolean;
   declare publishedStatus: () => void;
   declare publishedStatusBang: () => Promise<void>;
-  declare static publishedStatus: () => Relation<Article>;
-  declare static notPublishedStatus: () => Relation<Article>;
+  declare static publishedStatus: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notPublishedStatus: () => import("@blazetrails/activerecord").Relation<Article>;
 
   static {
     this.attribute("status", "integer");

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -18,6 +18,14 @@ import { tsTypeFor } from "./type-registry.js";
 
 const INDENT = "  ";
 
+// Built-in generic types emitted by the virtualizer — qualified with
+// inline `import("...")` so users don't need to add imports to their
+// model files. Erased at runtime. User-defined target classes
+// (Author, Comment, etc.) are still emitted bare and resolve against
+// the user's existing imports or the CLI/plugin's auto-import pass
+// (see the plan § "Auto-import resolution under Phase 1b").
+const AR_IMPORT = `import("@blazetrails/activerecord")`;
+
 export function synthesizeDeclares(info: ClassInfo): string[] {
   const out: string[] = [];
   for (const call of info.calls) {
@@ -64,7 +72,9 @@ function renderCollectionAssoc(call: AssociationCall): RenderedLine[] {
   // not a plain `Target[]`. Matches what `blog.posts` returns at
   // runtime and what `dx-tests/declare-patterns.test-d.ts` asserts.
   const target = resolveTarget(call);
-  return [line(`declare ${call.name}: AssociationProxy<${target}>;`, call.name, false)];
+  return [
+    line(`declare ${call.name}: ${AR_IMPORT}.AssociationProxy<${target}>;`, call.name, false),
+  ];
 }
 
 function renderSingularAssoc(call: AssociationCall): RenderedLine[] {
@@ -77,7 +87,11 @@ function renderSingularAssoc(call: AssociationCall): RenderedLine[] {
 function renderScope(info: ClassInfo, call: ScopeCall): RenderedLine[] {
   const argList = call.paramsAfterRel.length === 0 ? "" : call.paramsAfterRel.join(", ");
   return [
-    line(`declare static ${call.name}: (${argList}) => Relation<${info.name}>;`, call.name, true),
+    line(
+      `declare static ${call.name}: (${argList}) => ${AR_IMPORT}.Relation<${info.name}>;`,
+      call.name,
+      true,
+    ),
   ];
 }
 
@@ -91,7 +105,13 @@ function renderEnum(info: ClassInfo, call: EnumCall): RenderedLine[] {
     const scopeName = camelize(methodBase, false);
     out.push(line(`declare ${predicate}: () => boolean;`, predicate, false));
     out.push(line(`declare ${bang}: () => this;`, bang, false));
-    out.push(line(`declare static ${scopeName}: () => Relation<${info.name}>;`, scopeName, true));
+    out.push(
+      line(
+        `declare static ${scopeName}: () => ${AR_IMPORT}.Relation<${info.name}>;`,
+        scopeName,
+        true,
+      ),
+    );
   }
   return out;
 }
@@ -108,8 +128,16 @@ function renderDefineEnum(info: ClassInfo, call: DefineEnumCall): RenderedLine[]
     out.push(line(`declare ${predicate}: () => boolean;`, predicate, false));
     out.push(line(`declare ${setter}: () => void;`, setter, false));
     out.push(line(`declare ${bang}: () => Promise<void>;`, bang, false));
-    out.push(line(`declare static ${setter}: () => Relation<${info.name}>;`, setter, true));
-    out.push(line(`declare static ${notScope}: () => Relation<${info.name}>;`, notScope, true));
+    out.push(
+      line(`declare static ${setter}: () => ${AR_IMPORT}.Relation<${info.name}>;`, setter, true),
+    );
+    out.push(
+      line(
+        `declare static ${notScope}: () => ${AR_IMPORT}.Relation<${info.name}>;`,
+        notScope,
+        true,
+      ),
+    );
   }
   return out;
 }

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -60,8 +60,11 @@ function renderAttribute(call: AttributeCall): RenderedLine[] {
 }
 
 function renderCollectionAssoc(call: AssociationCall): RenderedLine[] {
+  // Post-Phase-R.2: collection readers return an AssociationProxy,
+  // not a plain `Target[]`. Matches what `blog.posts` returns at
+  // runtime and what `dx-tests/declare-patterns.test-d.ts` asserts.
   const target = resolveTarget(call);
-  return [line(`declare ${call.name}: ${target}[];`, call.name, false)];
+  return [line(`declare ${call.name}: AssociationProxy<${target}>;`, call.name, false)];
 }
 
 function renderSingularAssoc(call: AssociationCall): RenderedLine[] {


### PR DESCRIPTION
## Summary

Phase 1a-fixup from the plan, plus extended for zero-import ergonomics:

1. The virtualizer landed in #529 emitting `Target[]` for hasMany / HABTM because that matched the runtime reader at the time. Phase R.2 (#536) swapped the runtime reader to return the `AssociationProxy` directly — this PR flips the emit to match, closing the gap.

2. While there, the built-in generic types (`AssociationProxy`, `Relation`) are now emitted with inline `import("@blazetrails/activerecord").<Type><...>` so a zero-declare model file doesn't need users to add imports for the types the virtualizer injects. This was flagged by Copilot mid-review; extended to `Relation` for consistency (scopes and enums also emit `Relation<Self>`).

## Output shape

| Runtime call | Emitted declaration |
| ------------ | ------------------- |
| `this.hasMany("posts")` / `this.hasAndBelongsToMany("tags")` | `declare posts: import("@blazetrails/activerecord").AssociationProxy<Post>;` |
| `this.scope("published", ...)` | `declare static published: () => import("@blazetrails/activerecord").Relation<Post>;` |
| `this.enum("status", ...)` | per-value: `declare static <value>: () => import("@blazetrails/activerecord").Relation<Self>;` |
| `defineEnum(Class, ...)` | per-value setter/scope: `import("@blazetrails/activerecord").Relation<Self>` |
| `this.belongsTo(...)` / `this.hasOne(...)` / `this.attribute(...)` | unchanged (target / built-in types, no qualification needed) |

User-defined target classes (Author, Comment, Tag) are still emitted bare — those come from the user's existing imports or the Phase 1b auto-import resolution pass the plan specifies.

## Changes

- `packages/activerecord/src/type-virtualization/synthesize.ts` — switch `renderCollectionAssoc` from `Target[]` to `AssociationProxy<Target>`; qualify built-in generics (`AssociationProxy`, `Relation`) with inline `import(...)`.
- **11 fixture `expected.ts`** files updated:
  - hasMany / HABTM: `02-has-many`, `08-combined`, `11-class-name-override`, `13-has-and-belongs-to-many`
  - scope: `05-scope`, `08-combined`
  - enum: `06-enum`, `15-enum-with-prefix`, `16-enum-with-custom-prefix`
  - defineEnum: `07-define-enum`, `14-define-enum-array-form`, `18-define-enum-with-suffix`

## Rationale for inline `import(...)`

Inline `import("pkg").Type` is erased at runtime by TypeScript — no runtime module load, no user-facing ceremony. The zero-declare-zero-import model file becomes reachable:

```ts
// User writes:
import { Base } from "@blazetrails/activerecord";
class Post extends Base {
  static {
    this.hasMany("comments");                             // -> declare comments: import("…").AssociationProxy<Comment>;
    this.scope("published", rel => rel.where({...}));     // -> declare static published: () => import("…").Relation<Post>;
  }
}
```

They still need to import `Comment` (or let Phase 1b's auto-import resolution handle it) — that's a user-defined target.

## Test plan
- [x] 27/27 virtualizer fixture-pair tests pass
- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [ ] CI

## Rails fidelity

Matches Rails' `CollectionAssociation#reader` on both runtime AND type-virtualization sides. The `import(...)` qualification is a TS ergonomic fix with no Rails analog (Ruby has constant autoloading; TS needs explicit module resolution).

Plan: `docs/virtual-source-files-plan.md` § Phase 1a-fixup.