### PR TITLE
ci: scope DB tests to activerecord, split out unit-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: >
-          pnpm vitest run --no-file-parallelism
+          pnpm vitest run
           packages/arel
           packages/activemodel
           packages/activesupport

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,18 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run --no-file-parallelism --exclude 'packages/activerecord/**'
+      - run: >
+          pnpm vitest run --no-file-parallelism
+          packages/arel
+          packages/activemodel
+          packages/activesupport
+          packages/rack
+          packages/actionpack
+          packages/actionview
+          packages/railties
+          packages/trailties
+          packages/cli
+          scripts/guides-typecheck
 
   sqlite-tests:
     name: SQLite Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: >
-          pnpm vitest run --no-file-parallelism
-          packages/arel
-          packages/activemodel
-          packages/activesupport
-          packages/rack
-          packages/actionpack
-          packages/actionview
-          packages/railties
-          packages/trailties
-          packages/cli
-          scripts/guides-typecheck
+      - run: pnpm vitest run --no-file-parallelism --exclude 'packages/activerecord/**'
 
   sqlite-tests:
     name: SQLite Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,7 @@ jobs:
           packages/rack
           packages/actionpack
           packages/actionview
-          packages/railties
           packages/trailties
-          packages/cli
           scripts/guides-typecheck
 
   sqlite-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,32 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:types
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: >
+          pnpm vitest run --no-file-parallelism
+          packages/arel
+          packages/activemodel
+          packages/activesupport
+          packages/rack
+          packages/actionpack
+          packages/actionview
+          packages/railties
+          packages/trailties
+          packages/cli
+          scripts/guides-typecheck
+
   sqlite-tests:
     name: SQLite Tests
     runs-on: ubuntu-latest
@@ -95,7 +121,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run --no-file-parallelism
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
 
   postgres-tests:
     name: PostgreSQL Tests
@@ -124,7 +150,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run --no-file-parallelism
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
 
@@ -157,7 +183,7 @@ jobs:
       - name: Set MariaDB to case-sensitive collation
         run: |
           mysql -h 127.0.0.1 -u root -e "ALTER DATABASE rails_js_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
-      - run: pnpm vitest run --no-file-parallelism
+      - run: pnpm vitest run --no-file-parallelism packages/activerecord
         env:
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
 


### PR DESCRIPTION
## Summary
- Add a `unit-tests` job that runs vitest against the non-DB packages (arel, activemodel, activesupport, rack, actionpack, actionview, railties, trailties, cli, guides-typecheck) with no database service.
- Scope `sqlite-tests`, `postgres-tests`, and `mariadb-tests` to `packages/activerecord` so the DB matrix only runs where it matters.

## Test plan
- [ ] `unit-tests` job is green without a DB service
- [ ] `sqlite-tests` / `postgres-tests` / `mariadb-tests` each run only activerecord tests
- [ ] No coverage regression across packages