### PR TITLE
feat(activerecord): loadBelongsTo / loadHasOne instance methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,9 @@ const blog = await Blog.find(1);
 // matches Rails' `blog.posts.where(published: true).order(:created_at)`.
 const recent = await blog.posts.where({ published: true }).order("created_at").limit(10);
 
-// Awaitable — single `await` hydrates and yields the array.
+// Awaitable — single `await` hydrates and yields the array. This IS
+// the explicit-load path for collections; no separate `loadPosts()`
+// method exists (the proxy's thenable is the loader).
 const all = await blog.posts;
 
 // Array-shaped sync ops — read the loaded target. (Iteration / .length /
@@ -237,7 +239,10 @@ const first = blog.posts[0];
 const proxy = association<Post>(blog, "posts"); // AssociationProxy<Post>
 ```
 
-**belongs_to / has_one** (synchronous reader — returns the record, not a Promise):
+**belongs_to / has_one** (sync reader returns the currently loaded
+record or `null`; `loadBelongsTo(name)` / `loadHasOne(name)` perform
+an explicit async load, returning the cached/preloaded value if
+present or running a query otherwise):
 
 ```ts
 class Post extends Base {
@@ -252,6 +257,28 @@ class Author extends Base {
     this.hasOne("profile");
   }
 }
+
+// Sync reads return whatever's currently cached (may be null if
+// nothing loaded). Use `loadBelongsTo(name)` / `loadHasOne(name)` to
+// explicitly load — method name matches the macro, so calling the
+// wrong one is a TS error. Returns the cached/preloaded value if
+// present, otherwise runs a query.
+const post = await Post.find(1);
+const author = await post.loadBelongsTo("author"); // Promise<Author | null>
+const author2 = await Author.find(1);
+const profile = await author2.loadHasOne("profile"); // Promise<Profile | null>
+
+// Virtualizer emits typed overloads so the return type narrows
+// automatically. Without the virtualizer, declare by hand:
+//   declare loadBelongsTo: (name: "author") => Promise<Author | null>;
+//   declare loadHasOne: (name: "profile") => Promise<Profile | null>;
+//
+// Collections (hasMany / hasAndBelongsToMany) have no explicit
+// loader — the AssociationProxy is awaitable (`await blog.posts`).
+// Calling `loadBelongsTo("posts")` throws with a pointer to the
+// proxy-await form. Calling the wrong macro for a singular
+// (`loadHasOne("author")` on a belongsTo) also throws with a
+// pointer to the right method.
 ```
 
 **Named scopes** (`this.scope(name, fn)` — class-level):

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -64,11 +64,21 @@ class Author extends Base {
   // is also a `CollectionProxy`.
   declare comments: AssociationProxy<Comment>;
 
-  // hasAndBelongsToMany → same shape as hasMany (AssociationProxy)
+  // hasAndBelongsToMany → same shape as hasMany (AssociationProxy).
+  // Collections don't need a loader method — `await author.tags`
+  // triggers the load directly via the proxy's thenable.
   declare tags: AssociationProxy<Tag>;
 
-  // hasOne → Profile | null (synchronous reader; returns the record directly)
+  // hasOne → Profile | null (sync reader; returns the currently loaded
+  // record or null). Use `author.loadHasOne("profile")` for an
+  // explicit async load — the typed overload below narrows the return.
   declare profile: Profile | null;
+
+  // Per-macro singular-association loaders. Virtualizer aggregates
+  // all belongsTo calls into `declare loadBelongsTo: ...` and all
+  // hasOne calls into `declare loadHasOne: ...`. Hand-written version
+  // shown here for the dx-test reference.
+  declare loadHasOne: (name: "profile") => Promise<Profile | null>;
 
   static {
     this.attribute("name", "string");

--- a/packages/activerecord/src/associations/loader-methods.test.ts
+++ b/packages/activerecord/src/associations/loader-methods.test.ts
@@ -1,0 +1,102 @@
+// Per-macro instance loaders — `record.loadBelongsTo(name)` and
+// `record.loadHasOne(name)`.
+//
+// Two methods on Base.prototype that delegate to the standalone
+// `loadBelongsTo` / `loadHasOne` helpers. Method name matches the
+// association macro the user wrote, giving compile-time enforcement
+// via virtualizer-emitted overloads.
+//
+// For collections (`hasMany` / `hasAndBelongsToMany`), the
+// AssociationProxy's thenable handles the load — `await record.<name>`.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel, AssociationNotFoundError } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("Base#loadBelongsTo / Base#loadHasOne", () => {
+  let adapter: DatabaseAdapter;
+
+  class LoAuthor extends Base {
+    declare name: string;
+    static {
+      this.attribute("name", "string");
+    }
+  }
+
+  class LoPost extends Base {
+    declare title: string;
+    declare loAuthorId: number | null;
+    static {
+      this.attribute("title", "string");
+      this.attribute("lo_author_id", "integer");
+    }
+  }
+
+  class LoProfile extends Base {
+    declare bio: string;
+    declare loAuthorId: number | null;
+    static {
+      this.attribute("bio", "string");
+      this.attribute("lo_author_id", "integer");
+    }
+  }
+
+  LoAuthor.hasMany("loPosts", { className: "LoPost" });
+  LoAuthor.hasOne("loProfile", { className: "LoProfile" });
+  LoPost.belongsTo("loAuthor", { className: "LoAuthor" });
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    LoAuthor.adapter = adapter;
+    LoPost.adapter = adapter;
+    LoProfile.adapter = adapter;
+    registerModel(LoAuthor);
+    registerModel(LoPost);
+    registerModel(LoProfile);
+  });
+
+  it("loadBelongsTo returns the associated record", async () => {
+    const author = new LoAuthor({ name: "dean" });
+    await author.save();
+    const post = new LoPost({ title: "hi", lo_author_id: author.id as number });
+    await post.save();
+    const loaded = await post.loadBelongsTo("loAuthor");
+    expect((loaded as LoAuthor | null)?.name).toBe("dean");
+  });
+
+  it("loadHasOne returns the associated record", async () => {
+    const author = new LoAuthor({ name: "dean" });
+    await author.save();
+    const profile = new LoProfile({ bio: "hey", lo_author_id: author.id as number });
+    await profile.save();
+    const loaded = await author.loadHasOne("loProfile");
+    expect((loaded as LoProfile | null)?.bio).toBe("hey");
+  });
+
+  it("loadBelongsTo on a hasOne throws with a pointer to loadHasOne", async () => {
+    const author = new LoAuthor({ name: "dean" });
+    await expect(author.loadBelongsTo("loProfile")).rejects.toThrow(
+      /is a hasOne, not belongsTo.*loadHasOne/,
+    );
+  });
+
+  it("loadHasOne on a belongsTo throws with a pointer to loadBelongsTo", async () => {
+    const post = new LoPost({ title: "hi" });
+    await expect(post.loadHasOne("loAuthor")).rejects.toThrow(
+      /is a belongsTo, not hasOne.*loadBelongsTo/,
+    );
+  });
+
+  it("loadBelongsTo on a hasMany throws with a pointer to await", async () => {
+    const author = new LoAuthor({ name: "dean" });
+    await author.save();
+    await expect(author.loadBelongsTo("loPosts")).rejects.toThrow(/await record\.loPosts/);
+  });
+
+  it("unknown association name throws AssociationNotFoundError", async () => {
+    const author = new LoAuthor({ name: "dean" });
+    await expect(author.loadBelongsTo("nope")).rejects.toBeInstanceOf(AssociationNotFoundError);
+    await expect(author.loadHasOne("nope")).rejects.toBeInstanceOf(AssociationNotFoundError);
+  });
+});

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -106,7 +106,7 @@ import { ScopeRegistry } from "./scoping.js";
 import { Default as DefaultScoping } from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
 import { AssociationNotFoundError } from "./associations/errors.js";
-import { Associations as _Associations } from "./associations.js";
+import { Associations as _Associations, loadBelongsTo, loadHasOne } from "./associations.js";
 import { BelongsToAssociation } from "./associations/belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./associations/belongs-to-polymorphic-association.js";
 import { HasOneAssociation } from "./associations/has-one-association.js";
@@ -3206,6 +3206,69 @@ export class Base extends Model {
     this._syncAssociationInstance(name, instance);
     this._associationInstances.set(name, instance);
     return instance;
+  }
+
+  /**
+   * Explicit async load for a belongsTo association. Same shape as
+   * the standalone `loadBelongsTo(record, name, opts)` helper, but
+   * takes just the association name.
+   *
+   * Returns the cached/preloaded value if present; otherwise runs a
+   * query. Not a forced reload — use `record.reload()` for that.
+   *
+   * The virtualizer emits typed overloads so `post.loadBelongsTo("author")`
+   * narrows to `Promise<Author | null>` without a hand-written declare.
+   *
+   * Mirrors Rails' `ActiveRecord::Associations::Preloader::Branch` /
+   * `BelongsToAssociation` which are the belongs_to-specific preload
+   * paths.
+   */
+  async loadBelongsTo(name: string): Promise<Base | null> {
+    const assocDef = this._assertSingularAssociation(name, "belongsTo");
+    return loadBelongsTo(this, name, assocDef.options ?? {});
+  }
+
+  /**
+   * Explicit async load for a hasOne association. Same shape as the
+   * standalone `loadHasOne(record, name, opts)` helper, but takes just
+   * the association name.
+   *
+   * Returns the cached/preloaded value if present; otherwise runs a
+   * query. Not a forced reload — use `record.reload()` for that.
+   *
+   * The virtualizer emits typed overloads so `user.loadHasOne("profile")`
+   * narrows to `Promise<Profile | null>` without a hand-written declare.
+   *
+   * Mirrors Rails' `HasOneAssociation` preload path.
+   */
+  async loadHasOne(name: string): Promise<Base | null> {
+    const assocDef = this._assertSingularAssociation(name, "hasOne");
+    return loadHasOne(this, name, assocDef.options ?? {});
+  }
+
+  private _assertSingularAssociation(
+    name: string,
+    expected: "belongsTo" | "hasOne",
+  ): { type: string; options: any } {
+    const ctor = this.constructor as any;
+    const associations: any[] = ctor._associations ?? [];
+    const assocDef = associations.find((a: any) => a.name === name);
+    if (!assocDef) {
+      throw new AssociationNotFoundError(this, name);
+    }
+    if (assocDef.type !== expected) {
+      if (assocDef.type === "hasMany" || assocDef.type === "hasAndBelongsToMany") {
+        throw new Error(
+          `load${expected === "belongsTo" ? "BelongsTo" : "HasOne"} is for singular associations. ` +
+            `\`${ctor.name}.${name}\` is a ${assocDef.type} — await the reader: \`await record.${name}\`.`,
+        );
+      }
+      const right = assocDef.type === "belongsTo" ? "loadBelongsTo" : "loadHasOne";
+      throw new Error(
+        `\`${ctor.name}.${name}\` is a ${assocDef.type}, not ${expected}. Use \`record.${right}("${name}")\` instead.`,
+      );
+    }
+    return assocDef;
   }
 
   private _buildAssociationInstance(assocDef: any): AssociationInstance {

--- a/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/03-belongs-to/expected.ts
@@ -1,5 +1,6 @@
 export class Post extends Base {
   declare author: Author | null;
+  declare loadBelongsTo: (name: "author") => Promise<Author | null>;
 
   static {
     this.belongsTo("author");

--- a/packages/activerecord/src/type-virtualization/fixtures/04-has-one/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/04-has-one/expected.ts
@@ -1,5 +1,6 @@
 export class User extends Base {
   declare profile: Profile | null;
+  declare loadHasOne: (name: "profile") => Promise<Profile | null>;
 
   static {
     this.hasOne("profile");

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
@@ -4,6 +4,7 @@ export class Post extends Base {
   declare author: Author | null;
   declare comments: import("@blazetrails/activerecord").AssociationProxy<Comment>;
   declare static published: () => import("@blazetrails/activerecord").Relation<Post>;
+  declare loadBelongsTo: (name: "author") => Promise<Author | null>;
 
   static {
     this.attribute("title", "string");

--- a/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/11-class-name-override/expected.ts
@@ -1,6 +1,7 @@
 export class Post extends Base {
   declare writer: Author | null;
   declare remarks: import("@blazetrails/activerecord").AssociationProxy<Comment>;
+  declare loadBelongsTo: (name: "writer") => Promise<Author | null>;
 
   static {
     this.belongsTo("writer", { className: "Author" });

--- a/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/17-polymorphic-belongs-to/expected.ts
@@ -1,5 +1,6 @@
 export class Comment extends Base {
   declare commentable: Base | null;
+  declare loadBelongsTo: (name: "commentable") => Promise<Base | null>;
 
   static {
     this.belongsTo("commentable", { polymorphic: true });

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -33,7 +33,54 @@ export function synthesizeDeclares(info: ClassInfo): string[] {
       if (!line.skipIfPresent || !memberPresent(info, line)) out.push(line.text);
     }
   }
+  for (const l of renderLoaderOverloads(info)) {
+    if (!info.existingMembers.has(l.declaredName)) out.push(l.text);
+  }
   return out;
+}
+
+/**
+ * Aggregates singular associations into `declare loadBelongsTo` and
+ * `declare loadHasOne` lines, each with intersection-typed overloads
+ * for every belongsTo / hasOne on the class. Users get typed narrowing
+ * on the association name (`post.loadBelongsTo("author")` →
+ * `Promise<Author | null>`), and calling the wrong macro (e.g.
+ * `post.loadHasOne("author")` on a belongsTo) is a TS error because
+ * the `loadHasOne` overloads don't include that name.
+ *
+ * Collections (hasMany / HABTM) use `await record.<name>` for explicit
+ * loads — no method emitted.
+ */
+function renderLoaderOverloads(info: ClassInfo): RenderedLine[] {
+  const belongsToOverloads: string[] = [];
+  const hasOneOverloads: string[] = [];
+  for (const call of info.calls) {
+    if (call.kind !== "belongsTo" && call.kind !== "hasOne") continue;
+    const target =
+      (call as AssociationCall).options["polymorphic"] === "true"
+        ? "Base"
+        : resolveTarget(call as AssociationCall);
+    const overload = `((name: "${call.name}") => Promise<${target} | null>)`;
+    if (call.kind === "belongsTo") belongsToOverloads.push(overload);
+    else hasOneOverloads.push(overload);
+  }
+  const out: RenderedLine[] = [];
+  if (belongsToOverloads.length > 0) {
+    out.push(
+      line(`declare loadBelongsTo: ${joinOverloads(belongsToOverloads)};`, "loadBelongsTo", false),
+    );
+  }
+  if (hasOneOverloads.length > 0) {
+    out.push(line(`declare loadHasOne: ${joinOverloads(hasOneOverloads)};`, "loadHasOne", false));
+  }
+  return out;
+}
+
+function joinOverloads(overloads: string[]): string {
+  // Single-overload case: drop the outer parens for readability.
+  // Multiple: TS treats A & B where A and B are callable as an
+  // overloaded function type.
+  return overloads.length === 1 ? overloads[0]!.slice(1, -1) : overloads.join(" & ");
 }
 
 interface RenderedLine {
@@ -69,8 +116,11 @@ function renderAttribute(call: AttributeCall): RenderedLine[] {
 
 function renderCollectionAssoc(call: AssociationCall): RenderedLine[] {
   // Post-Phase-R.2: collection readers return an AssociationProxy,
-  // not a plain `Target[]`. Matches what `blog.posts` returns at
-  // runtime and what `dx-tests/declare-patterns.test-d.ts` asserts.
+  // not a plain `Target[]`. The proxy is awaitable — `await blog.posts`
+  // hydrates and returns `Post[]` — so we don't emit a loader for
+  // collections. Singular associations (belongsTo / hasOne) are
+  // covered by `loadBelongsTo` / `loadHasOne` overloads rendered by
+  // `renderLoaderOverloads` at the end of `synthesizeDeclares`.
   const target = resolveTarget(call);
   return [
     line(`declare ${call.name}: ${AR_IMPORT}.AssociationProxy<${target}>;`, call.name, false),
@@ -80,6 +130,9 @@ function renderCollectionAssoc(call: AssociationCall): RenderedLine[] {
 function renderSingularAssoc(call: AssociationCall): RenderedLine[] {
   // `polymorphic: true` on belongsTo can't be narrowed statically — any
   // Base-rooted class could be on the other end. Fall back to `Base | null`.
+  // Per-association loader declarations are aggregated into
+  // `declare loadBelongsTo: ...` / `declare loadHasOne: ...` lines
+  // by `renderLoaderOverloads` below.
   const target = call.options["polymorphic"] === "true" ? "Base" : resolveTarget(call);
   return [line(`declare ${call.name}: ${target} | null;`, call.name, false)];
 }

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -269,12 +269,25 @@ class Post extends Base {
   declare featured: boolean; // attribute (backs the named scope below)
   declare status: number; // enum is stored as an integer; defineEnum
   //                        does not override the accessor (unlike Base.enum)
-  declare author: Author | null; // belongsTo reader (synchronous)
+  declare author: Author | null; // belongsTo reader (synchronous —
+  //                                returns the currently loaded record
+  //                                or null; use `post.loadBelongsTo("author")`
+  //                                for an explicit async load — returns
+  //                                the cached/preloaded value if present,
+  //                                otherwise runs a query)
   declare comments: AssociationProxy<Comment>;
   // hasMany reader — chainable (`.where(...)`), awaitable
   // (`await post.comments` → `Comment[]`), and array-shaped over the
   // loaded target (`for...of`, `.length`, `.map`, `[0]`). Same object
-  // as what `association(post, "comments")` returns.
+  // as what `association(post, "comments")` returns. Collections have
+  // no explicit loader — `await post.comments` IS the load.
+  declare loadBelongsTo: (name: "author") => Promise<Author | null>;
+  // Per-macro singular-association loaders. The virtualizer aggregates
+  // all belongsTo calls into a single `declare loadBelongsTo: ...`
+  // intersection and all hasOne calls into `declare loadHasOne: ...`.
+  // Method-name-matches-macro means calling the wrong one for a given
+  // association is a TS error (the other method doesn't include that
+  // name in its overload set).
   declare isDraft: () => boolean; // enum predicate
   declare draft: () => void; // enum in-memory setter (defineEnum only)
   declare draftBang: () => Promise<void>; // async (defineEnum only): sets


### PR DESCRIPTION
## Summary

Add `record.loadBelongsTo(name)` and `record.loadHasOne(name)` — two methods on `Base.prototype` whose name matches the association macro. Virtualizer emits typed overloads per method, so calling the wrong macro for a given association is a TS error.

```ts
const post = await Post.find(1);
const author = await post.loadBelongsTo("author");    // Promise<Author | null>

const user = await User.find(1);
const profile = await user.loadHasOne("profile");     // Promise<Profile | null>

// Compile error (author is a belongsTo, not hasOne):
await post.loadHasOne("author");
// Type error: "author" is not assignable to the hasOne overload set

// Runtime error at the wrong macro site (catches the case where
// virtualizer isn't in play):
// "`Post.author` is a belongsTo, not hasOne. Use `record.loadBelongsTo(\"author\")` instead."

// For collections, no explicit loader — await the proxy:
const posts = await blog.posts;                       // Promise<Post[]>
```

## Why two methods instead of generic `loadOne(name)`

1. **Method name == macro name.** You wrote `belongsTo("author")`, you call `loadBelongsTo("author")`. 1:1 correspondence.
2. **Existing standalone helpers are already named `loadBelongsTo` / `loadHasOne`** — instance methods match.
3. **Compile-time typo check.** Virtualizer emits different overload sets per method; calling the wrong macro is a type error, not a runtime throw.
4. **Rails parity.** Rails' preloader has distinct `BelongsToAssociation` / `HasOneAssociation` classes; these are separate concepts, not a unified "singular" dispatcher.

## Runtime

- `Base#loadBelongsTo(name)` / `Base#loadHasOne(name)` delegate to existing standalone `loadBelongsTo` / `loadHasOne` helpers.
- Shared `_assertSingularAssociation(name, expected)` validates macro; mismatches throw with pointer to the right method or `await record.<name>` for collections.
- Returns cached/preloaded value if present; otherwise runs a query. Not a forced reload — use `record.reload()` for that.

## Virtualizer

- Aggregates belongsTo calls per class into a single `declare loadBelongsTo: A & B;` intersection-overload line (TS treats intersected callables as overloads).
- Same for hasOne.
- No emit for collections.

## Test plan

- [x] 6 runtime tests in `loader-methods.test.ts`:
  - loadBelongsTo happy path
  - loadHasOne happy path
  - loadBelongsTo on hasOne throws with pointer
  - loadHasOne on belongsTo throws with pointer
  - loadBelongsTo on hasMany throws with pointer to `await record.<name>`
  - Unknown name throws `AssociationNotFoundError` (asserted via `toBeInstanceOf`)
- [x] Full activerecord suite: **8201/8201**, zero regressions
- [x] 27/27 virtualizer fixture-pair tests (5 fixtures updated)
- [x] 63/63 dx-tests typecheck clean
- [x] `pnpm build` / `pnpm typecheck` / `pnpm prettier --check` all clean
- [ ] CI

## Docs

- `CLAUDE.md` — declare catalog shows `loadBelongsTo(name)` / `loadHasOne(name)` for singulars + `await record.<name>` for collections.
- `packages/website/docs/guides/activerecord-rails-deviations.md` § 13 — same treatment.
- `dx-tests/declare-patterns.test-d.ts` — canonical reference with typed overloads.

## Not in scope

- R.3 strict-loading-by-default (next) — will throw `StrictLoadingViolationError` on sync `post.author` access when unloaded, pointing users at `post.loadBelongsTo("author")` as the fix.