### PR TITLE
feat(activerecord): Phase 11 — BoundSchemaReflection on ConnectionPool

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -229,12 +229,21 @@ export class AbstractAdapter {
   }
 
   get schemaCache(): SchemaCache {
-    const pool = this.pool as any;
-    if (pool?.schemaCache) return pool.schemaCache;
+    // Phase 11 made `pool.schemaCache` return a BoundSchemaReflection
+    // (the Rails-shaped handle DatabaseTasks.dumpSchemaCache expects).
+    // The raw SchemaCache that AbstractAdapter caches incidental
+    // introspection into now lives on `pool.poolConfig.schemaCache`,
+    // matching Rails' PoolConfig @schema_cache slot. Share it so
+    // every connection in the pool hits the same cache, and fall
+    // back to a per-adapter slot when no pool is attached (tests,
+    // bare adapters).
+    const pool = this.pool as { poolConfig?: { schemaCache: SchemaCache | null } } | null;
+    const poolConfig = pool?.poolConfig;
+    if (poolConfig?.schemaCache) return poolConfig.schemaCache;
 
     if (!this._schemaCache) {
       this._schemaCache = new SchemaCache();
-      if (pool) pool.schemaCache = this._schemaCache;
+      if (poolConfig) poolConfig.schemaCache = this._schemaCache;
     }
     return this._schemaCache;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -10,6 +10,7 @@ import type { PoolConfig } from "../pool-config.js";
 import type { ConnectionDescriptor } from "./connection-descriptor.js";
 import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.js";
 import { SchemaReflection, BoundSchemaReflection } from "../schema-cache.js";
+import { AbstractAdapter } from "../abstract-adapter.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
 import { ConnectionLeasingQueue } from "./connection-pool/queue.js";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
@@ -730,13 +731,19 @@ export class ConnectionPool implements ReapablePool {
     // every connection in this pool. Rails' AbstractAdapter has the
     // same owner/pool reference threaded in via its connection
     // constructor; trails' factory signature doesn't expose it, so
-    // we assign it post-hoc here. Only assign when the adapter
-    // actually supports the slot (AbstractAdapter declares
-    // `pool: unknown = null`) — adapters that don't can safely ignore
-    // the write since we guard with the `in` check.
-    const withPool = conn as unknown as { pool?: unknown };
-    if ("pool" in (conn as object)) {
-      withPool.pool = this;
+    // we assign it post-hoc here.
+    //
+    // CRITICAL: gate on `instanceof AbstractAdapter`, not a
+    // generic `"pool" in conn` duck-type. Several driver-backed
+    // adapters (PostgreSQLAdapter, Mysql2Adapter) declare their own
+    // `pool` field holding the underlying pg.Pool / mysql.Pool —
+    // writing `this` over that would clobber the driver pool and
+    // break every subsequent query. Only AbstractAdapter's
+    // `pool: unknown = null` slot is safe to commandeer for this
+    // back-reference, and it's the only class that actually reads
+    // it (via `this.pool.poolConfig.schemaCache` etc.).
+    if (conn instanceof AbstractAdapter) {
+      (conn as unknown as { pool: unknown }).pool = this;
     }
     return conn;
   }
@@ -748,9 +755,10 @@ export class ConnectionPool implements ReapablePool {
     this._available?.delete(conn);
     // Clear the back-reference we set in newConnection so a removed
     // adapter can't observe stale pool/poolConfig state post-eviction.
-    const withPool = conn as unknown as { pool?: unknown };
-    if ("pool" in (conn as object) && withPool.pool === this) {
-      withPool.pool = null;
+    // Mirror the same narrow gate — only touch AbstractAdapter's slot,
+    // never a driver-adapter's own `pool` field.
+    if (conn instanceof AbstractAdapter && (conn as unknown as { pool: unknown }).pool === this) {
+      (conn as unknown as { pool: unknown }).pool = null;
     }
 
     for (const [ctxId, pin] of this._pinnedConnections) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -721,10 +721,24 @@ export class ConnectionPool implements ReapablePool {
   // --- Connection creation ---
 
   newConnection(): DatabaseAdapter {
-    if (this.poolConfig.adapterFactory) {
-      return this.poolConfig.adapterFactory();
+    if (!this.poolConfig.adapterFactory) {
+      throw new ConnectionNotEstablished("No adapter factory configured for connection pool");
     }
-    throw new ConnectionNotEstablished("No adapter factory configured for connection pool");
+    const conn = this.poolConfig.adapterFactory();
+    // Set the back-reference so AbstractAdapter#schemaCache can reach
+    // pool.poolConfig.schemaCache to share the raw SchemaCache across
+    // every connection in this pool. Rails' AbstractAdapter has the
+    // same owner/pool reference threaded in via its connection
+    // constructor; trails' factory signature doesn't expose it, so
+    // we assign it post-hoc here. Only assign when the adapter
+    // actually supports the slot (AbstractAdapter declares
+    // `pool: unknown = null`) — adapters that don't can safely ignore
+    // the write since we guard with the `in` check.
+    const withPool = conn as unknown as { pool?: unknown };
+    if ("pool" in (conn as object)) {
+      withPool.pool = this;
+    }
+    return conn;
   }
 
   remove(conn: DatabaseAdapter): void {
@@ -732,6 +746,12 @@ export class ConnectionPool implements ReapablePool {
     this._checkedOut.delete(conn);
     this._lastCheckinAt.delete(conn);
     this._available?.delete(conn);
+    // Clear the back-reference we set in newConnection so a removed
+    // adapter can't observe stale pool/poolConfig state post-eviction.
+    const withPool = conn as unknown as { pool?: unknown };
+    if ("pool" in (conn as object) && withPool.pool === this) {
+      withPool.pool = null;
+    }
 
     for (const [ctxId, pin] of this._pinnedConnections) {
       if (pin.connection === conn) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -9,7 +9,7 @@ import type { DatabaseConfig } from "../../database-configurations/database-conf
 import type { PoolConfig } from "../pool-config.js";
 import type { ConnectionDescriptor } from "./connection-descriptor.js";
 import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.js";
-import { SchemaReflection } from "../schema-cache.js";
+import { SchemaReflection, BoundSchemaReflection } from "../schema-cache.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
 import { ConnectionLeasingQueue } from "./connection-pool/queue.js";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
@@ -276,6 +276,26 @@ export class ConnectionPool implements ReapablePool {
 
   set schemaReflection(value: SchemaReflection) {
     this.poolConfig.schemaReflection = value;
+  }
+
+  /**
+   * Bound schema-cache handle for this pool. Mirrors Rails'
+   * `ConnectionPool#schema_cache`, which returns a
+   * `BoundSchemaReflection` wrapping the pool's SchemaReflection plus
+   * the pool itself. DatabaseTasks.dumpSchemaCache detects the
+   * reflection shape (dumpTo without addAll) and delegates straight
+   * to it — same code path Rails' `conn_or_pool.schema_cache.dump_to`
+   * drives.
+   *
+   * Memoized per-pool so callers consistently see the same reflection
+   * across invocations, matching Rails.
+   */
+  private _boundSchemaCache?: BoundSchemaReflection;
+  get schemaCache(): BoundSchemaReflection {
+    if (!this._boundSchemaCache) {
+      this._boundSchemaCache = new BoundSchemaReflection(this.schemaReflection, this);
+    }
+    return this._boundSchemaCache;
   }
 
   serverVersion(connection: DatabaseAdapter): unknown {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -276,6 +276,11 @@ export class ConnectionPool implements ReapablePool {
 
   set schemaReflection(value: SchemaReflection) {
     this.poolConfig.schemaReflection = value;
+    // Matches Rails' `schema_reflection=`: swap the underlying
+    // reflection AND bust the cached BoundSchemaReflection so the
+    // next schemaCache access wraps the new reflection, not the
+    // stale one.
+    this._boundSchemaCache = undefined;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -54,9 +54,28 @@ export class PoolConfig {
 
   get schemaReflection(): SchemaReflection {
     if (!this._schemaReflection) {
-      this._schemaReflection = new SchemaReflection(null);
+      // Rails: `SchemaReflection.new(db_config.lazy_schema_cache_path)` —
+      // the reflection remembers where to load its cache from on first
+      // access. HashConfig exposes lazySchemaCachePath when
+      // schemaCachePath is set, or falls back to
+      // `db/schema_cache.json`. A NullConfig or missing config leaves
+      // the cache path null, which is what SchemaReflection treats as
+      // "no persistent cache on disk" (possibleCacheAvailable → false).
+      const cachePath = this._lazySchemaCachePath();
+      this._schemaReflection = new SchemaReflection(cachePath);
     }
     return this._schemaReflection;
+  }
+
+  private _lazySchemaCachePath(): string | null {
+    const cfg = this.dbConfig as unknown as {
+      lazySchemaCachePath?: () => string | null | undefined;
+      schemaCachePath?: string | null;
+    };
+    if (typeof cfg?.lazySchemaCachePath === "function") {
+      return cfg.lazySchemaCachePath() ?? null;
+    }
+    return cfg?.schemaCachePath ?? null;
   }
 
   set schemaReflection(value: SchemaReflection) {

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -10,6 +10,7 @@ import type { SchemaCache } from "./schema-cache.js";
 import { ConnectionPool } from "./abstract/connection-pool.js";
 import { ConnectionDescriptor, type ConnectionOwner } from "./abstract/connection-descriptor.js";
 import { SchemaReflection } from "./schema-cache.js";
+import { DatabaseTasks } from "../tasks/database-tasks.js";
 
 const INSTANCES = new Set<WeakRef<PoolConfig>>();
 const registry =
@@ -58,24 +59,67 @@ export class PoolConfig {
       // the reflection remembers where to load its cache from on first
       // access. HashConfig exposes lazySchemaCachePath when
       // schemaCachePath is set, or falls back to
-      // `db/schema_cache.json`. A NullConfig or missing config leaves
-      // the cache path null, which is what SchemaReflection treats as
-      // "no persistent cache on disk" (possibleCacheAvailable → false).
+      // `<DatabaseTasks.dbDir>/schema_cache.json`. A NullConfig or
+      // missing config leaves the cache path null, which is what
+      // SchemaReflection treats as "no persistent cache on disk"
+      // (possibleCacheAvailable → false).
       const cachePath = this._lazySchemaCachePath();
       this._schemaReflection = new SchemaReflection(cachePath);
     }
     return this._schemaReflection;
   }
 
+  /**
+   * Resolve the on-disk cache path for this pool's SchemaReflection.
+   *
+   * Pulls `DatabaseTasks.dbDir` as the `db_dir` argument to
+   * `HashConfig.defaultSchemaCachePath` so callers that customize
+   * `DatabaseTasks.dbDir` get a reflection that reads from the same
+   * directory `DatabaseTasks.cacheDumpFilename` writes to. Without
+   * this alignment, `trails db schema:cache:dump` would write to
+   * `<dbDir>/schema_cache.json` while the reflection looked for
+   * `db/schema_cache.json` on boot.
+   *
+   * Normalizes blank/empty results to `null` so downstream fs.existsSync
+   * doesn't chase a pathological "".
+   */
   private _lazySchemaCachePath(): string | null {
     const cfg = this.dbConfig as unknown as {
-      lazySchemaCachePath?: () => string | null | undefined;
+      lazySchemaCachePath?: (dbDir?: string) => string | null | undefined;
+      defaultSchemaCachePath?: (dbDir?: string) => string | null | undefined;
       schemaCachePath?: string | null;
     };
+    const dbDir = this._resolveDbDir();
+    let raw: string | null | undefined;
     if (typeof cfg?.lazySchemaCachePath === "function") {
-      return cfg.lazySchemaCachePath() ?? null;
+      raw = cfg.lazySchemaCachePath(dbDir);
+    } else if (cfg?.schemaCachePath) {
+      raw = cfg.schemaCachePath;
+    } else if (typeof cfg?.defaultSchemaCachePath === "function") {
+      raw = cfg.defaultSchemaCachePath(dbDir);
     }
-    return cfg?.schemaCachePath ?? null;
+    const trimmed = typeof raw === "string" ? raw.trim() : "";
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  /**
+   * Read DatabaseTasks.dbDir so HashConfig.defaultSchemaCachePath uses
+   * the same directory DatabaseTasks.cacheDumpFilename writes to.
+   * Without this, customizing DatabaseTasks.dbDir would make
+   * `trails db schema:cache:dump` write to one place while the
+   * SchemaReflection loaded from another.
+   *
+   * DatabaseTasks doesn't import from pool-config, so the static
+   * import here introduces no cycle. Wrapped in try/catch as a
+   * belt-and-suspenders fallback for hypothetical bundler ordering
+   * weirdness.
+   */
+  private _resolveDbDir(): string {
+    try {
+      return DatabaseTasks.dbDir ?? "db";
+    } catch {
+      return "db";
+    }
   }
 
   set schemaReflection(value: SchemaReflection) {

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -85,15 +85,17 @@ export class PoolConfig {
    */
   private _lazySchemaCachePath(): string | null {
     const cfg = this.dbConfig as unknown as {
-      lazySchemaCachePath?: (dbDir?: string) => string | null | undefined;
       defaultSchemaCachePath?: (dbDir?: string) => string | null | undefined;
       schemaCachePath?: string | null;
     };
     const dbDir = this._resolveDbDir();
+    // Prefer an explicit schemaCachePath (user-authored); otherwise
+    // invoke defaultSchemaCachePath(dbDir) directly so it picks up
+    // the current DatabaseTasks.dbDir. We don't call
+    // HashConfig.lazySchemaCachePath() because it takes no dbDir arg
+    // and would hardcode the "db" default — defeating the alignment.
     let raw: string | null | undefined;
-    if (typeof cfg?.lazySchemaCachePath === "function") {
-      raw = cfg.lazySchemaCachePath(dbDir);
-    } else if (cfg?.schemaCachePath) {
+    if (cfg?.schemaCachePath) {
       raw = cfg.schemaCachePath;
     } else if (typeof cfg?.defaultSchemaCachePath === "function") {
       raw = cfg.defaultSchemaCachePath(dbDir);

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -89,13 +89,19 @@ export class PoolConfig {
       schemaCachePath?: string | null;
     };
     const dbDir = this._resolveDbDir();
-    // Prefer an explicit schemaCachePath (user-authored); otherwise
-    // invoke defaultSchemaCachePath(dbDir) directly so it picks up
-    // the current DatabaseTasks.dbDir. We don't call
-    // HashConfig.lazySchemaCachePath() because it takes no dbDir arg
-    // and would hardcode the "db" default — defeating the alignment.
+    // Presence-based (not truthy): if the user explicitly set
+    // schemaCachePath — even to "" — that's a deliberate "no cache"
+    // signal. Fall through to defaultSchemaCachePath(dbDir) only when
+    // the user didn't supply a value at all. Matches Phase 6's
+    // resolveSchemaFormat treating empty strings as "explicitly
+    // unset" rather than "use a default".
+    //
+    // Calling defaultSchemaCachePath(dbDir) directly (not
+    // lazySchemaCachePath()) because that HashConfig method takes no
+    // dbDir arg and would hardcode "db", defeating the alignment
+    // with DatabaseTasks.dbDir.
     let raw: string | null | undefined;
-    if (cfg?.schemaCachePath) {
+    if (cfg && "schemaCachePath" in cfg && cfg.schemaCachePath != null) {
       raw = cfg.schemaCachePath;
     } else if (typeof cfg?.defaultSchemaCachePath === "function") {
       raw = cfg.defaultSchemaCachePath(dbDir);

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -12,6 +12,20 @@ import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Result } from "./result.js";
 
+/**
+ * Close any SQLite/underlying connections still pinned to the pool
+ * before unlinking the DB file. ConnectionPool.disconnect clears pool
+ * bookkeeping but doesn't close the adapter's file handle; on Windows
+ * that keeps the sqlite file open and rmSync fails.
+ */
+async function closePoolConnections(pool: ConnectionPool): Promise<void> {
+  for (const conn of pool.connections) {
+    const close = (conn as { close?: () => void | Promise<void> }).close;
+    if (typeof close === "function") await close.call(conn);
+  }
+  await pool.disconnect();
+}
+
 function makePool(size: number = 5): ConnectionPool {
   const dbConfig = new HashConfig("test", "primary", {
     adapter: "sqlite3",
@@ -664,17 +678,36 @@ describe("ConnectionPool schema cache", () => {
     // defined and (b) throw on assignment (read-only getter). The
     // fix routes the raw cache through pool.poolConfig.schemaCache,
     // and this test locks that in.
+    //
+    // Uses SQLite3Adapter (not createTestAdapter) because the latter
+    // is a DatabaseStatementsMixin stub without the AbstractAdapter
+    // schemaCache getter.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
     const { SchemaCache } = await import("./connection-adapters/schema-cache.js");
-    const pool = makePool();
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-raw-cache-"));
+    const dbFile = path.join(tmp, "raw.sqlite3");
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+      reapingFrequency: null,
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: () => new SQLite3Adapter(dbFile),
+    });
+    const pool = new ConnectionPool(pc);
     try {
-      const cache = pool.withConnection((conn) => {
-        return (conn as unknown as { schemaCache: unknown }).schemaCache;
-      });
+      const cache = pool.withConnection(
+        (conn) => (conn as unknown as { schemaCache: unknown }).schemaCache,
+      );
       expect(cache).toBeInstanceOf(SchemaCache);
       expect(cache).not.toBe(pool.schemaCache); // bound reflection !== raw cache
       expect(pool.poolConfig.schemaCache).toBe(cache); // shared via poolConfig
     } finally {
-      await pool.disconnect();
+      await closePoolConnections(pool);
+      fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 
@@ -728,7 +761,7 @@ describe("ConnectionPool schema cache", () => {
       };
       expect(Object.keys(parsed.columns)).toContain("gizmos");
     } finally {
-      await pool.disconnect();
+      await closePoolConnections(pool);
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -775,21 +775,31 @@ describe("ConnectionPool schema cache", () => {
     }
   });
 
-  it("PoolConfig normalizes blank schemaCachePath to null", () => {
-    // A schemaCachePath: "" in user config would otherwise reach
-    // SchemaReflection as "" and be passed to fs.existsSync, which
-    // behaves unexpectedly. Trim + empty-check → null so the
-    // reflection treats it as 'no persistent cache'.
-    const dbConfig = new HashConfig("test", "primary", {
-      adapter: "sqlite3",
-      database: "test.db",
-      reapingFrequency: null,
-      schemaCachePath: "   ",
-    });
-    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-      adapterFactory: createTestAdapter,
-    });
-    expect((pc.schemaReflection as unknown as { _cachePath: string | null })._cachePath).toBeNull();
+  it("PoolConfig treats blank/empty schemaCachePath as presence-based 'no cache'", () => {
+    // User explicitly setting schemaCachePath — even to '' or '   ' —
+    // is a deliberate 'no cache' signal. Presence check ('in' +
+    // != null) catches it before the defaultSchemaCachePath
+    // fallback, trim + empty-check normalizes to null. Otherwise
+    // '' would silently fall through to db/schema_cache.json,
+    // defeating the user's intent.
+    for (const blank of ["", "   "]) {
+      const dbConfig = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: "test.db",
+        reapingFrequency: null,
+        schemaCachePath: blank,
+      });
+      const pc = new PoolConfig(
+        new ConnectionDescriptor("primary"),
+        dbConfig,
+        "writing",
+        "default",
+        { adapterFactory: createTestAdapter },
+      );
+      expect(
+        (pc.schemaReflection as unknown as { _cachePath: string | null })._cachePath,
+      ).toBeNull();
+    }
   });
 
   it("PoolConfig aligns SchemaReflection path with DatabaseTasks.dbDir", async () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -775,6 +775,52 @@ describe("ConnectionPool schema cache", () => {
     }
   });
 
+  it("PoolConfig normalizes blank schemaCachePath to null", () => {
+    // A schemaCachePath: "" in user config would otherwise reach
+    // SchemaReflection as "" and be passed to fs.existsSync, which
+    // behaves unexpectedly. Trim + empty-check → null so the
+    // reflection treats it as 'no persistent cache'.
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: "test.db",
+      reapingFrequency: null,
+      schemaCachePath: "   ",
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: createTestAdapter,
+    });
+    expect((pc.schemaReflection as unknown as { _cachePath: string | null })._cachePath).toBeNull();
+  });
+
+  it("PoolConfig aligns SchemaReflection path with DatabaseTasks.dbDir", async () => {
+    // When DatabaseTasks.dbDir is customized, the default cache path
+    // should follow — otherwise 'trails db schema:cache:dump' writes
+    // to <dbDir>/schema_cache.json while the reflection loads from
+    // db/schema_cache.json.
+    const { DatabaseTasks } = await import("./tasks/database-tasks.js");
+    const originalDbDir = DatabaseTasks.dbDir;
+    DatabaseTasks.dbDir = "custom_db_dir";
+    try {
+      const dbConfig = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        database: "test.db",
+        reapingFrequency: null,
+      });
+      const pc = new PoolConfig(
+        new ConnectionDescriptor("primary"),
+        dbConfig,
+        "writing",
+        "default",
+        { adapterFactory: createTestAdapter },
+      );
+      const cachePath = (pc.schemaReflection as unknown as { _cachePath: string | null })
+        ._cachePath;
+      expect(cachePath).toBe("custom_db_dir/schema_cache.json");
+    } finally {
+      DatabaseTasks.dbDir = originalDbDir;
+    }
+  });
+
   it("PoolConfig primes SchemaReflection with the config's schemaCachePath", () => {
     // Rails: `SchemaReflection.new(db_config.lazy_schema_cache_path)`.
     // HashConfig's lazySchemaCachePath returns the configured path

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -655,6 +655,19 @@ describe("ConnectionPool schema cache", () => {
     expect(pool.schemaCache).toBe(pool.schemaCache);
   });
 
+  it("swapping schemaReflection invalidates the cached BoundSchemaReflection", () => {
+    // Matches Rails' `ConnectionPool#schema_reflection=` which sets
+    // @schema_cache = nil after swapping so subsequent pool.schema_cache
+    // calls rebuild against the new reflection. Without this the
+    // bound wrapper would still point at the old reflection after a
+    // swap — subtle, rare in practice, but a real parity gap.
+    const pool = makePool();
+    const before = pool.schemaCache;
+    pool.schemaReflection = new SchemaReflection("db/other_cache.json");
+    const after = pool.schemaCache;
+    expect(after).not.toBe(before);
+  });
+
   it("BoundSchemaReflection.dumpTo(filename) round-trips through the pool", async () => {
     // End-to-end Rails path: pool.schema_cache.dump_to(filename)
     // allocates a fresh SchemaCache, addAll(pool) populates it via

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -655,6 +655,29 @@ describe("ConnectionPool schema cache", () => {
     expect(pool.schemaCache).toBe(pool.schemaCache);
   });
 
+  it("adapter.schemaCache reads the raw SchemaCache from poolConfig, not the bound reflection", async () => {
+    // Regression: Phase 11 made pool.schemaCache return a
+    // BoundSchemaReflection. AbstractAdapter#schemaCache previously
+    // reached into pool.schemaCache to store/share a raw SchemaCache
+    // instance — with the new getter that would (a) return a
+    // BoundSchemaReflection where .clear()/.setColumns() aren't
+    // defined and (b) throw on assignment (read-only getter). The
+    // fix routes the raw cache through pool.poolConfig.schemaCache,
+    // and this test locks that in.
+    const { SchemaCache } = await import("./connection-adapters/schema-cache.js");
+    const pool = makePool();
+    try {
+      const cache = pool.withConnection((conn) => {
+        return (conn as unknown as { schemaCache: unknown }).schemaCache;
+      });
+      expect(cache).toBeInstanceOf(SchemaCache);
+      expect(cache).not.toBe(pool.schemaCache); // bound reflection !== raw cache
+      expect(pool.poolConfig.schemaCache).toBe(cache); // shared via poolConfig
+    } finally {
+      await pool.disconnect();
+    }
+  });
+
   it("swapping schemaReflection invalidates the cached BoundSchemaReflection", () => {
     // Matches Rails' `ConnectionPool#schema_reflection=` which sets
     // @schema_cache = nil after swapping so subsequent pool.schema_cache

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./connection-adapters/abstract/connection-pool.js";
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
-import { SchemaReflection } from "./connection-adapters/schema-cache.js";
+import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { createTestAdapter } from "./test-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -637,4 +637,88 @@ it("inspect does not show secrets", () => {
   const pool2 = new ConnectionPool(pc);
   expect(pool2.inspect()).toMatch(/shard="shard_one"/);
   expect(pool2.inspect()).toMatch(/role="reading"/);
+});
+
+describe("ConnectionPool schema cache", () => {
+  it("exposes a BoundSchemaReflection via pool.schemaCache", () => {
+    // Mirrors Rails ConnectionPool#schema_cache: returns a
+    // BoundSchemaReflection wrapping the pool's SchemaReflection +
+    // the pool itself. Previously pool.schemaCache was undefined on
+    // the real ConnectionPool class, so DatabaseTasks.dumpSchemaCache
+    // never hit the Rails reflection-delegation path.
+    const pool = makePool();
+    expect(pool.schemaCache).toBeInstanceOf(BoundSchemaReflection);
+  });
+
+  it("memoizes the bound reflection across calls", () => {
+    const pool = makePool();
+    expect(pool.schemaCache).toBe(pool.schemaCache);
+  });
+
+  it("BoundSchemaReflection.dumpTo(filename) round-trips through the pool", async () => {
+    // End-to-end Rails path: pool.schema_cache.dump_to(filename)
+    // allocates a fresh SchemaCache, addAll(pool) populates it via
+    // the pool's withConnection, dumpTo writes the JSON. Covers the
+    // full chain Rails uses for db:schema:cache:dump.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-pool-schema-"));
+    const dbFile = path.join(tmp, "pool.sqlite3");
+    const seeded = new SQLite3Adapter(dbFile);
+    try {
+      await seeded.executeMutation(
+        "CREATE TABLE gizmos (id INTEGER PRIMARY KEY, label TEXT NOT NULL)",
+      );
+    } finally {
+      await seeded.close();
+    }
+
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+      reapingFrequency: null,
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: () => new SQLite3Adapter(dbFile),
+    });
+    const pool = new ConnectionPool(pc);
+    try {
+      const filename = path.join(tmp, "schema_cache.json");
+      await pool.schemaCache.dumpTo(filename);
+      const parsed = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+        columns: Record<string, unknown[]>;
+      };
+      expect(Object.keys(parsed.columns)).toContain("gizmos");
+    } finally {
+      await pool.disconnect();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("PoolConfig primes SchemaReflection with the config's schemaCachePath", () => {
+    // Rails: `SchemaReflection.new(db_config.lazy_schema_cache_path)`.
+    // HashConfig's lazySchemaCachePath returns the configured path
+    // (or defaultSchemaCachePath fallback), which the reflection
+    // remembers for its first on-disk load.
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: "test.db",
+      reapingFrequency: null,
+      schemaCachePath: "db/custom_cache.json",
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: createTestAdapter,
+    });
+    const reflection = pc.schemaReflection;
+    expect(reflection).toBeInstanceOf(SchemaReflection);
+    // Internal state check: the cache path reached the reflection.
+    // Reach in via a minimal cast — the field is private but the
+    // Rails-parity contract is 'reflection remembers its cache path',
+    // and this is the only way to assert it without exposing internals.
+    expect((reflection as unknown as { _cachePath: string | null })._cachePath).toBe(
+      "db/custom_cache.json",
+    );
+  });
 });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -702,9 +702,12 @@ describe("ConnectionPool schema cache", () => {
       const cache = pool.withConnection(
         (conn) => (conn as unknown as { schemaCache: unknown }).schemaCache,
       );
+      // The key regression: adapter.schemaCache must be a plain
+      // SchemaCache, NOT the BoundSchemaReflection pool.schemaCache
+      // returns. Before the fix it would have picked up the bound
+      // reflection and failed on .clear()/.setColumns() etc.
       expect(cache).toBeInstanceOf(SchemaCache);
-      expect(cache).not.toBe(pool.schemaCache); // bound reflection !== raw cache
-      expect(pool.poolConfig.schemaCache).toBe(cache); // shared via poolConfig
+      expect(cache).not.toBe(pool.schemaCache);
     } finally {
       await closePoolConnections(pool);
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -708,6 +708,12 @@ describe("ConnectionPool schema cache", () => {
       // reflection and failed on .clear()/.setColumns() etc.
       expect(cache).toBeInstanceOf(SchemaCache);
       expect(cache).not.toBe(pool.schemaCache);
+      // Verify the raw cache is actually shared through PoolConfig —
+      // ConnectionPool.newConnection now sets conn.pool = this so
+      // AbstractAdapter.schemaCache can write into
+      // pool.poolConfig.schemaCache and every connection sees the
+      // same instance.
+      expect(pool.poolConfig.schemaCache).toBe(cache);
     } finally {
       await closePoolConnections(pool);
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Rails' `DatabaseTasks.dump_schema_cache` delegates through `conn_or_pool.schema_cache.dump_to(filename)`. On a real pool, `schema_cache` returns a `BoundSchemaReflection` whose `dump_to` allocates a fresh `SchemaCache`, runs `add_all(pool)`, and writes. Phase 5 already wired the detection — if `conn_or_pool` exposes a `schemaCache` with `dumpTo` but no `addAll`, `dumpSchemaCache` delegates — but the real `ConnectionPool` class didn't implement that getter. It was a defensive branch with no production caller; now there's a caller.

- `ConnectionPool#schemaCache` returns a memoized `BoundSchemaReflection` wrapping the pool's `SchemaReflection` + the pool itself. Matches Rails' `ConnectionPool#schema_cache` verbatim.
- `PoolConfig` primes its `SchemaReflection` with `dbConfig.lazySchemaCachePath()` when available, falling back to `schemaCachePath` or `null`. Mirrors Rails' `SchemaReflection.new(db_config.lazy_schema_cache_path)` — reflections remember their on-disk cache path so first-access loads read the right file.
- `NullPool.schemaCache` still returns `null` (unchanged; callers handle both shapes).

## Test plan

- [x] `pnpm test` — full suite, 17169 passing
- [x] `pool.schemaCache` is a `BoundSchemaReflection`; memoized across calls
- [x] `PoolConfig` propagates `schemaCachePath` into the primed `SchemaReflection`
- [x] Full end-to-end: create pool against a real sqlite file → `pool.schemaCache.dumpTo(filename)` → verify the dumped JSON contains the seeded table's columns