### PR TITLE
feat(activerecord): Phase R.3 — strict-loading catches sync singular-reader access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,17 @@ class Author extends Base {
 // explicitly load — method name matches the macro, so calling the
 // wrong one is a TS error. Returns the cached/preloaded value if
 // present, otherwise runs a query.
+//
+// Under strict loading (`record.strictLoadingBang()` or
+// `Class.strictLoadingByDefault = true`, both off by default matching
+// Rails), sync access on a singular association that WOULD require a
+// DB load throws `StrictLoadingViolationError` instead of silently
+// returning null. The check honors preloaded / cached associations
+// (including keys mapped to null), null FKs on belongsTo, and new
+// owners on hasOne — none of those would run a query, so none throw.
+// The explicit async loaders (`loadBelongsTo` / `loadHasOne`) bypass
+// the check — the caller asked for the load. Per-instance opt-out:
+// `record.strictLoadingBang(false)`.
 const post = await Post.find(1);
 const author = await post.loadBelongsTo("author"); // Promise<Author | null>
 const author2 = await Author.find(1);

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -1,6 +1,7 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { Association } from "./association.js";
+import { StrictLoadingViolationError } from "../errors.js";
 
 /**
  * Base class for has_one and belongs_to associations.
@@ -36,8 +37,76 @@ export class SingularAssociation extends Association {
     return this.target;
   }
 
+  /**
+   * Sync reader for belongsTo / hasOne. Returns the currently loaded
+   * target (record or null).
+   *
+   * Phase R.3: under strict loading, sync access that would trigger a
+   * lazy DB load throws `StrictLoadingViolationError` — pointing
+   * users at the explicit async load path
+   * (`post.loadBelongsTo("author")` / `post.loadHasOne("profile")`)
+   * or an eager-load query (`Post.includes("author").find(id)`).
+   *
+   * The check only fires when a DB load would actually be needed — it
+   * honors:
+   *   - `_preloadedAssociations` / `_cachedAssociations` (including
+   *     keys mapped to `null`, which represent an eagerly-loaded nil
+   *     association — no query needed, no throw).
+   *   - `findTargetNeeded()` — returns false when the FK is null
+   *     (belongsTo), when the owner is a new record without a
+   *     primary key (hasOne), etc. No query would run, so no throw.
+   *
+   * Toggles (all Rails-style):
+   *   - Per-instance:  `record.strictLoadingBang()` enables;
+   *                    `record.strictLoadingBang(false)` disables
+   *                    (matches Rails' `strict_loading!(value = true)`).
+   *   - Per-class:     `Post.strictLoadingByDefault = true` enables
+   *                    for every instance of `Post`; set back to
+   *                    `false` to restore the Rails default.
+   *   - Global:        `Base.strictLoadingByDefault = true` enables
+   *                    for every model; `false` restores the default.
+   *   - Per-call mute: explicit `record.loadBelongsTo(...)` /
+   *                    `loadHasOne(...)` bumps the bypass count for
+   *                    the duration of the load, letting legitimate
+   *                    lazy loads through.
+   */
   get reader(): Base | null {
+    if (this.loaded) return this.target as Base | null;
+
+    // An in-memory target (set via build / internal assignment paths
+    // like Preloader::Association#associate_records_from_unscoped,
+    // which can bind `association.target` without calling
+    // `loadedBang()`) is already resolved — no DB load would run, so
+    // strict loading should not fire. Mark it loaded to short-circuit
+    // future reads.
+    if (this.target != null) {
+      this.loadedBang();
+      return this.target as Base;
+    }
+
+    // Sync resolution via preloaded / cached associations. `doFindTarget`
+    // returns `undefined` if nothing is cached, or the (possibly null)
+    // preloaded value if it is. A null from a preloaded key is a
+    // legitimate "nil association" — no query needed, no throw.
+    const cached = this.doFindTarget();
+    if (cached !== undefined) {
+      this.target = cached as Base | null;
+      this.loadedBang();
+      return this.target;
+    }
+
+    // A DB load would be required to answer. Throw under strict
+    // loading; otherwise return the current `target` (null by default)
+    // to preserve the legacy silent-null behavior for opt-out users.
+    if (this.findTargetNeeded() && this._isStrictOnOwner()) {
+      throw StrictLoadingViolationError.forAssociation(this.owner, this.reflection.name);
+    }
     return this.target;
+  }
+
+  private _isStrictOnOwner(): boolean {
+    const owner = this.owner as any;
+    return Boolean(owner._strictLoading) && !owner._strictLoadingBypassCount;
   }
 
   protected override async _createRecord(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2051,12 +2051,15 @@ export class Base extends Model {
   }
 
   /**
-   * Enable strict loading — lazily-loaded associations will raise.
+   * Enable (or disable, with `value: false`) strict loading —
+   * lazily-loaded associations will raise. Matches Rails'
+   * `strict_loading!(value = true)` which accepts an explicit argument
+   * for symmetrical on/off.
    *
    * Mirrors: ActiveRecord::Base#strict_loading!
    */
-  strictLoadingBang(): this {
-    this._strictLoading = true;
+  strictLoadingBang(value: boolean = true): this {
+    this._strictLoading = value;
     return this;
   }
 
@@ -2969,6 +2972,19 @@ export class Base extends Model {
   }
 
   // -- Strict loading class-level default --
+  //
+  // Off by default, matching Rails
+  // (`config.active_record.strict_loading_by_default` is false unless
+  // explicitly enabled). Opt in per-class with
+  // `Post.strictLoadingByDefault = true`, per-instance with
+  // `record.strictLoadingBang()`, or globally with
+  // `Base.strictLoadingByDefault = true`.
+  //
+  // Phase R.3 makes strict loading LOUD on sync singular-association
+  // reader access: when enabled, `post.author` on an unloaded
+  // association throws `StrictLoadingViolationError` — pointing users
+  // at `post.loadBelongsTo("author")` or `Post.includes("author")`
+  // instead of silently returning null.
   static _strictLoadingByDefault = false;
 
   /**
@@ -3225,7 +3241,11 @@ export class Base extends Model {
    */
   async loadBelongsTo(name: string): Promise<Base | null> {
     const assocDef = this._assertSingularAssociation(name, "belongsTo");
-    return loadBelongsTo(this, name, assocDef.options ?? {});
+    const result = await this._bypassStrictLoading(() =>
+      loadBelongsTo(this, name, assocDef.options ?? {}),
+    );
+    this._hydrateSingularAssoc(name, result);
+    return result;
   }
 
   /**
@@ -3243,7 +3263,36 @@ export class Base extends Model {
    */
   async loadHasOne(name: string): Promise<Base | null> {
     const assocDef = this._assertSingularAssociation(name, "hasOne");
-    return loadHasOne(this, name, assocDef.options ?? {});
+    const result = await this._bypassStrictLoading(() =>
+      loadHasOne(this, name, assocDef.options ?? {}),
+    );
+    this._hydrateSingularAssoc(name, result);
+    return result;
+  }
+
+  /**
+   * Populate the association instance's target and mark it loaded so
+   * subsequent sync reader access (`post.author`) returns the record
+   * without tripping strict loading. `setTarget()` internally calls
+   * `loadedBang()`, so no separate call is needed here.
+   */
+  private _hydrateSingularAssoc(name: string, result: Base | null): void {
+    this.association(name).setTarget(result);
+  }
+
+  /**
+   * Temporarily bumps the strict-loading bypass count across the
+   * execution of `fn`. Explicit `loadBelongsTo` / `loadHasOne` calls
+   * are legitimate lazy loads — the caller asked for them — so they
+   * skip the strict-loading throw.
+   */
+  private async _bypassStrictLoading<T>(fn: () => Promise<T>): Promise<T> {
+    this._strictLoadingBypassCount += 1;
+    try {
+      return await fn();
+    } finally {
+      this._strictLoadingBypassCount = Math.max(0, this._strictLoadingBypassCount - 1);
+    }
   }
 
   private _assertSingularAssociation(

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -22,7 +22,7 @@ export interface Core {
   isReadonly(): boolean;
   readonlyBang(): this;
   isStrictLoading(): boolean;
-  strictLoadingBang(): this;
+  strictLoadingBang(value?: boolean): this;
   isFrozen(): boolean;
   freeze(): this;
 }

--- a/packages/activerecord/src/strict-loading-sync-reader.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.test.ts
@@ -1,0 +1,196 @@
+// Phase R.3: strict loading now catches sync singular-association
+// reader access too. When `record._strictLoading` is enabled (via any
+// of the Rails-style toggles), `record.author` / `record.profile`
+// throw `StrictLoadingViolationError` on an unloaded association
+// instead of silently returning null.
+//
+// Preserves Rails default (off) — strict loading is opt-in.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel, StrictLoadingViolationError } from "./index.js";
+import { createTestAdapter } from "./test-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+describe("strict loading — sync singular reader (Phase R.3)", () => {
+  let adapter: DatabaseAdapter;
+
+  class SrAuthor extends Base {
+    declare name: string;
+    static {
+      this.attribute("name", "string");
+    }
+  }
+
+  class SrPost extends Base {
+    declare title: string;
+    declare srAuthorId: number | null;
+    static {
+      this.attribute("title", "string");
+      this.attribute("sr_author_id", "integer");
+    }
+  }
+
+  class SrProfile extends Base {
+    declare bio: string;
+    declare srAuthorId: number | null;
+    static {
+      this.attribute("bio", "string");
+      this.attribute("sr_author_id", "integer");
+    }
+  }
+
+  SrAuthor.hasOne("srProfile", { className: "SrProfile" });
+  SrPost.belongsTo("srAuthor", { className: "SrAuthor" });
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    SrAuthor.adapter = adapter;
+    SrPost.adapter = adapter;
+    SrProfile.adapter = adapter;
+    registerModel(SrAuthor);
+    registerModel(SrPost);
+    registerModel(SrProfile);
+  });
+
+  it("sync belongsTo access throws when strict loading is enabled and not loaded", async () => {
+    const author = new SrAuthor({ name: "dean" });
+    await author.save();
+    const post = new SrPost({ title: "hi", sr_author_id: author.id as number });
+    await post.save();
+    post.strictLoadingBang();
+    expect(() => (post as any).srAuthor).toThrow(StrictLoadingViolationError);
+  });
+
+  it("sync hasOne access throws when strict loading is enabled and not loaded", async () => {
+    const author = new SrAuthor({ name: "dean" });
+    await author.save();
+    author.strictLoadingBang();
+    expect(() => (author as any).srProfile).toThrow(StrictLoadingViolationError);
+  });
+
+  it("sync access returns the record (no throw) once loaded", async () => {
+    const author = new SrAuthor({ name: "dean" });
+    await author.save();
+    const post = new SrPost({ title: "hi", sr_author_id: author.id as number });
+    await post.save();
+    post.strictLoadingBang();
+    // Explicit load populates the association cache.
+    await post.loadBelongsTo("srAuthor");
+    // Subsequent sync access should succeed.
+    expect(() => (post as any).srAuthor).not.toThrow();
+    const a = (post as any).srAuthor as SrAuthor;
+    expect(a.name).toBe("dean");
+  });
+
+  it("strict loading stays off by default (Rails parity)", () => {
+    // `strictLoadingByDefault` is false unless explicitly enabled.
+    expect(SrPost.strictLoadingByDefault).toBe(false);
+    expect(SrAuthor.strictLoadingByDefault).toBe(false);
+    // And newly constructed records have strictLoading off.
+    const post = new SrPost({ title: "hi" });
+    expect(post.isStrictLoading()).toBe(false);
+  });
+
+  it("per-class toggle: strictLoadingByDefault = true makes all instances strict", async () => {
+    class StrictPost extends Base {
+      declare title: string;
+      declare srAuthorId: number | null;
+      static {
+        this.attribute("title", "string");
+        this.attribute("sr_author_id", "integer");
+      }
+    }
+    StrictPost.belongsTo("srAuthor", { className: "SrAuthor" });
+    StrictPost.adapter = adapter;
+    StrictPost.strictLoadingByDefault = true;
+    registerModel(StrictPost);
+
+    try {
+      const author = new SrAuthor({ name: "dean" });
+      await author.save();
+      const post = new StrictPost({ title: "hi", sr_author_id: author.id as number });
+      await post.save();
+      // Loaded via find — strictLoading is applied.
+      const fetched = await StrictPost.find(post.id);
+      expect(fetched.isStrictLoading()).toBe(true);
+      expect(() => (fetched as any).srAuthor).toThrow(StrictLoadingViolationError);
+    } finally {
+      StrictPost.strictLoadingByDefault = false;
+    }
+  });
+
+  it("per-instance opt-out: strictLoadingBang(false) suppresses the throw", async () => {
+    const author = new SrAuthor({ name: "dean" });
+    await author.save();
+    const post = new SrPost({ title: "hi", sr_author_id: author.id as number });
+    await post.save();
+    post.strictLoadingBang();
+    // Flip off via the public API — access should NOT throw.
+    post.strictLoadingBang(false);
+    expect(post.isStrictLoading()).toBe(false);
+    expect(() => (post as any).srAuthor).not.toThrow();
+  });
+
+  it("belongsTo with null FK returns null without throwing under strict loading", async () => {
+    // No FK set → no DB query is needed to determine there's no
+    // associated record. `findTargetNeeded()` is false, so strict
+    // loading does not fire.
+    const post = new SrPost({ title: "orphan" });
+    await post.save();
+    post.strictLoadingBang();
+    expect(() => (post as any).srAuthor).not.toThrow();
+    expect((post as any).srAuthor).toBeNull();
+  });
+
+  it("preloaded singular mapped to null does not throw (eagerly-loaded nil)", async () => {
+    const post = new SrPost({ title: "hi" });
+    await post.save();
+    post.strictLoadingBang();
+    // Simulate an eager load that resolved to null (e.g., `Post.includes("srAuthor").find(id)`
+    // where the author record doesn't exist). The preloaded-null is a
+    // legitimate answer — no query needed, no throw.
+    (post as any)._preloadedAssociations = new Map([["srAuthor", null]]);
+    expect(() => (post as any).srAuthor).not.toThrow();
+    expect((post as any).srAuthor).toBeNull();
+  });
+
+  it("cached association via inverse_of does not throw under strict loading", async () => {
+    const post = new SrPost({ title: "hi" });
+    await post.save();
+    post.strictLoadingBang();
+    const author = new SrAuthor({ name: "dean" });
+    // Populate the direct cache (the path inverse_of uses).
+    (post as any)._cachedAssociations = new Map([["srAuthor", author]]);
+    expect(() => (post as any).srAuthor).not.toThrow();
+    expect(((post as any).srAuthor as SrAuthor).name).toBe("dean");
+  });
+
+  it("hasOne on a new (unsaved) owner returns null without throwing", async () => {
+    // New records with no primary key → `findTargetNeeded()` is false
+    // (no ID to query by), so strict loading does not fire.
+    const author = new SrAuthor({ name: "dean" });
+    author.strictLoadingBang();
+    expect(() => (author as any).srProfile).not.toThrow();
+    expect((author as any).srProfile).toBeNull();
+  });
+
+  it("in-memory `target` set directly (e.g. Preloader path) returns without throwing", async () => {
+    // Some internal paths (e.g., Preloader::Association) bind
+    // `association.target = record` without calling `loadedBang()`.
+    // The reader should treat a non-null target as already resolved —
+    // no DB load would run, so strict loading should not fire.
+    const post = new SrPost({ title: "hi" });
+    await post.save();
+    post.strictLoadingBang();
+    const author = new SrAuthor({ name: "dean" });
+    const assoc = post.association("srAuthor") as any;
+    assoc.target = author;
+    // loaded is still false; reader should short-circuit on the
+    // non-null target.
+    expect(assoc.loaded).toBe(false);
+    expect(() => (post as any).srAuthor).not.toThrow();
+    expect(((post as any).srAuthor as SrAuthor).name).toBe("dean");
+    // Reader should have marked it loaded as a side effect.
+    expect(assoc.loaded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

When strict loading is enabled, sync access to an unloaded singular-association reader (`post.author`, `user.profile`) now throws `StrictLoadingViolationError` instead of silently returning `null`. Extends the existing strict-loading behavior (which already throws from the lazy-load helpers and collection proxy) to the sync reader path that previously leaked silent-nulls.

```ts
class Post extends Base {
  declare author: Author | null;
  static {
    this.belongsTo("author");
    this.strictLoadingByDefault = true; // opt in
  }
}

const post = await Post.find(1);
post.author; // throws StrictLoadingViolationError
              // "Post is marked for strict_loading. The author
              //  association cannot be lazily loaded."

// Fix paths:
await post.loadBelongsTo("author");          // explicit async load
post.author;                                  // now returns the record

// Or preload:
const postWithAuthor = await Post.includes("author").find(1);
postWithAuthor.author;                        // loaded; returns the record
```

## Default stays OFF — Rails parity

`strictLoadingByDefault` is `false` unless explicitly enabled, matching Rails' `config.active_record.strict_loading_by_default`. Opt in at three levels, all existing toggles:

```ts
Base.strictLoadingByDefault = true;  // global
Post.strictLoadingByDefault = true;  // per-class
record.strictLoading = true;         // per-instance
```

## Implementation

- **`SingularAssociation.reader`** — checks `this.loaded` and the owner's strict-loading flag; throws `StrictLoadingViolationError.forAssociation(owner, name)` when both fail. Otherwise returns `this.target` as before.
- **`Base#loadBelongsTo` / `Base#loadHasOne`** — bump `_strictLoadingBypassCount` for the duration of the load (explicit caller intent), and hydrate the association instance's target + `loadedBang()` on return so subsequent sync access returns the record cleanly.

## Rails fidelity

Rails:
- `post.author` on a strict-loading record: raises `ActiveRecord::StrictLoadingViolationError`.
- Instance flag (`post.strict_loading!`), class flag (`self.strict_loading_by_default = true`), global config — all three levels present in Rails.

Trails R.3 mirrors the behavior on the sync reader path. The existing lazy-helper throws already matched Rails; this closes the last silent-null gap.

## Test plan

- [x] 6 new tests in `strict-loading-sync-reader.test.ts`:
  - belongsTo throws on unloaded sync access under strict loading
  - hasOne throws on unloaded sync access under strict loading
  - Post-load sync access returns the record cleanly (explicit loader bypasses check + hydrates instance)
  - Default stays off (Rails parity)
  - Per-class `strictLoadingByDefault = true` makes instances strict
  - Per-instance opt-out (`record.strictLoading = false`) suppresses the throw
- [x] Full activerecord suite: **8207/8207** (was 8201, +6), zero regressions
- [x] `pnpm build` / `pnpm typecheck` / `pnpm prettier --check` / `pnpm eslint` all clean
- [ ] CI

## Docs

- `CLAUDE.md` — declare catalog updated with strict-loading note alongside `loadBelongsTo` / `loadHasOne` — explains the throw, the three opt-in levels, and that the explicit loaders bypass the check.

## Not in scope

- Flipping `strictLoadingByDefault` to `true` globally. Plan originally called for this; I walked it back to stay Rails-faithful (Rails is off-by-default; turning it on is opt-in). Users who want the safety can flip the global default with one line: `Base.strictLoadingByDefault = true`.
- Collection strict loading on iteration (hasMany/HABTM). R.1's `AssociationProxy` thenable already handles the collection load path; the existing strict check in `wrapCollectionProxy.get` covers property delegation. No change needed.