### PR TITLE
feat(activerecord): Phase 12 — schema cache boot load + version check

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -756,23 +756,23 @@ export class ConnectionPool implements ReapablePool {
     // Trails' equivalent is `SchemaReflection.lazilyLoadSchemaCache`
     // (static flag, off by default — apps opt in). The load is
     // fire-and-forget because newConnection is sync and the load
-    // path involves `connection.schemaVersion()` introspection for
-    // version-check; errors are surfaced via console.warn by
-    // SchemaReflection.loadCache itself, so a failed cache load
-    // won't block the pool. First adoption is detected by
-    // `_lazyLoadTriggered` — only fires once per pool.
+    // involves async work (schemaVersion introspection for version-
+    // check). SchemaReflection.loadCache already swallows errors
+    // internally (console.warn on version mismatch, returns null on
+    // file-not-found / parse failure), so the .catch here is purely
+    // defensive — it should never fire in practice. Callers can
+    // observe the pending/resolved load via _lazyLoadPromise (used
+    // by tests to await the actual completion instead of timing hacks).
     if (
       SchemaReflection.lazilyLoadSchemaCache &&
       !this._lazyLoadTriggered &&
       !this.poolConfig.schemaCache
     ) {
       this._lazyLoadTriggered = true;
-      this.schemaCache.loadBang().catch((err) => {
-        // Rails lets SchemaReflection log-and-continue on load
-        // errors; mirror that behavior so a bad cache file doesn't
-        // crash the pool at first-checkout time.
-
-        console.warn(`Failed to lazily load schema cache: ${(err as Error).message}`);
+      this._lazyLoadPromise = this.schemaCache.loadBang().catch(() => {
+        // loadCache swallows read/parse/version errors internally;
+        // this is a belt-and-suspenders guard against an unexpected
+        // throw from BoundSchemaReflection/SchemaReflection glue.
       });
     }
     return conn;
@@ -784,6 +784,13 @@ export class ConnectionPool implements ReapablePool {
    * `@schema_cache.nil?` guard on `adopt_connection`.
    */
   private _lazyLoadTriggered = false;
+
+  /**
+   * Exposed so tests (and eager-boot callers) can await the lazy
+   * load's completion instead of relying on timing. Null when no
+   * lazy load was triggered.
+   */
+  _lazyLoadPromise: Promise<unknown> | null = null;
 
   remove(conn: DatabaseAdapter): void {
     this._connectionLease().clear(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -790,9 +790,29 @@ export class ConnectionPool implements ReapablePool {
         queueMicrotask(() => {
           this.schemaCache
             .loadBang()
-            .catch(() => {
+            .then(() => {
+              // Propagate the loaded SchemaCache into
+              // poolConfig.schemaCache so adapter-side consumers
+              // (AbstractAdapter.schemaCache, TypeCaster::Connection)
+              // see the preloaded data without hitting the DB. The
+              // reflection is the primary store; poolConfig.schemaCache
+              // is the adapter-facing mirror.
+              const loaded = this.schemaReflection.loadedCache;
+              if (loaded && !this.poolConfig.schemaCache) {
+                this.poolConfig.schemaCache = loaded;
+              }
+            })
+            .catch((err) => {
               // loadCache swallows read/parse/version errors
               // internally; this is a belt-and-suspenders guard.
+              // Log enough context to diagnose if a future change
+              // introduces an unexpected rejection path.
+
+              console.warn(
+                `[trails] Failed to lazily load schema cache for pool ` +
+                  `${this.poolConfig.connectionSpecName}: ` +
+                  `${err instanceof Error ? err.message : String(err)}`,
+              );
             })
             .finally(resolve);
         });

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -745,8 +745,45 @@ export class ConnectionPool implements ReapablePool {
     if (conn instanceof AbstractAdapter) {
       (conn as unknown as { pool: unknown }).pool = this;
     }
+    // Lazily load the on-disk schema cache when the first connection
+    // for this pool is adopted. Mirrors Rails'
+    // `ConnectionPool#adopt_connection`:
+    //
+    //     if @schema_cache.nil? && ActiveRecord.lazily_load_schema_cache
+    //       schema_cache.load!
+    //     end
+    //
+    // Trails' equivalent is `SchemaReflection.lazilyLoadSchemaCache`
+    // (static flag, off by default — apps opt in). The load is
+    // fire-and-forget because newConnection is sync and the load
+    // path involves `connection.schemaVersion()` introspection for
+    // version-check; errors are surfaced via console.warn by
+    // SchemaReflection.loadCache itself, so a failed cache load
+    // won't block the pool. First adoption is detected by
+    // `_lazyLoadTriggered` — only fires once per pool.
+    if (
+      SchemaReflection.lazilyLoadSchemaCache &&
+      !this._lazyLoadTriggered &&
+      !this.poolConfig.schemaCache
+    ) {
+      this._lazyLoadTriggered = true;
+      this.schemaCache.loadBang().catch((err) => {
+        // Rails lets SchemaReflection log-and-continue on load
+        // errors; mirror that behavior so a bad cache file doesn't
+        // crash the pool at first-checkout time.
+
+        console.warn(`Failed to lazily load schema cache: ${(err as Error).message}`);
+      });
+    }
     return conn;
   }
+
+  /**
+   * Set once per pool when the lazy-load trigger fires, so subsequent
+   * connections don't re-run the load. Mirrors Rails'
+   * `@schema_cache.nil?` guard on `adopt_connection`.
+   */
+  private _lazyLoadTriggered = false;
 
   remove(conn: DatabaseAdapter): void {
     this._connectionLease().clear(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -776,47 +776,38 @@ export class ConnectionPool implements ReapablePool {
       !this.poolConfig.schemaCache
     ) {
       this._lazyLoadTriggered = true;
-      // Defer the load to the next microtask so we don't re-enter
-      // the pool mid-checkout. SchemaReflection.loadCache calls
-      // pool.withConnection to query connection.schemaVersion() for
-      // the version check — if we called loadBang synchronously
-      // from inside newConnection (which is called from checkout),
-      // the outer lease hasn't been set yet and withConnection would
-      // trigger another checkout, potentially creating an extra
-      // connection or recursing. queueMicrotask defers until the
-      // current checkout finishes and the connection is available
-      // for reuse.
-      this._lazyLoadPromise = new Promise<void>((resolve) => {
-        queueMicrotask(() => {
-          this.schemaCache
-            .loadBang()
-            .then(() => {
-              // Propagate the loaded SchemaCache into
-              // poolConfig.schemaCache so adapter-side consumers
-              // (AbstractAdapter.schemaCache, TypeCaster::Connection)
-              // see the preloaded data without hitting the DB. The
-              // reflection is the primary store; poolConfig.schemaCache
-              // is the adapter-facing mirror.
-              const loaded = this.schemaReflection.loadedCache;
-              if (loaded && !this.poolConfig.schemaCache) {
-                this.poolConfig.schemaCache = loaded;
-              }
-            })
-            .catch((err) => {
-              // loadCache swallows read/parse/version errors
-              // internally; this is a belt-and-suspenders guard.
-              // Log enough context to diagnose if a future change
-              // introduces an unexpected rejection path.
+      // Use BoundSchemaReflection.forLoneConnection so the version-
+      // check in loadCache routes through a FakePool that yields the
+      // just-created connection — never re-enters the real pool's
+      // checkout. Without this, pool size=1 would deadlock: loadCache
+      // calls pool.withConnection to query schemaVersion(), which tries
+      // to checkout a second connection that doesn't exist.
+      //
+      // The loneRef shares the same SchemaReflection as `this.schemaCache`,
+      // so a successful load populates both.
+      const loneRef = BoundSchemaReflection.forLoneConnection(this.schemaReflection, conn);
+      this._lazyLoadPromise = loneRef
+        .loadBang()
+        .then(() => {
+          // Propagate the loaded SchemaCache into poolConfig.schemaCache
+          // so adapter-side consumers (AbstractAdapter.schemaCache,
+          // TypeCaster::Connection) see the preloaded data.
+          const loaded = this.schemaReflection.loadedCache;
+          if (loaded && !this.poolConfig.schemaCache) {
+            this.poolConfig.schemaCache = loaded;
+          }
+        })
+        .catch((err) => {
+          // loadCache swallows read/parse/version errors internally;
+          // this is a belt-and-suspenders guard. Log enough context to
+          // diagnose if a future change adds an unexpected rejection.
 
-              console.warn(
-                `[trails] Failed to lazily load schema cache for pool ` +
-                  `${this.poolConfig.connectionSpecName}: ` +
-                  `${err instanceof Error ? err.message : String(err)}`,
-              );
-            })
-            .finally(resolve);
+          console.warn(
+            `[trails] Failed to lazily load schema cache for pool ` +
+              `${this.poolConfig.connectionSpecName}: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+          );
         });
-      });
     }
     return conn;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -282,13 +282,17 @@ export class ConnectionPool implements ReapablePool {
     // next schemaCache access wraps the new reflection, not the
     // stale one.
     this._boundSchemaCache = undefined;
-    // Also reset the lazy-load guard so the new reflection's
-    // on-disk cache path gets loaded on the next first-connection
-    // event — without this, a swap followed by a fresh checkout
-    // would skip the load because _lazyLoadTriggered is still true
-    // from the old reflection.
+    // Also reset the lazy-load guard AND the raw cache so the new
+    // reflection's on-disk cache path gets loaded on the next first-
+    // connection event. Without resetting _lazyLoadTriggered the
+    // guard would still be true from the old reflection; without
+    // resetting poolConfig.schemaCache the `!this.poolConfig.schemaCache`
+    // guard in newConnection would prevent the new lazy-load from
+    // triggering, and adapter-side consumers would keep seeing stale
+    // cache data from the old reflection.
     this._lazyLoadTriggered = false;
     this._lazyLoadPromise = null;
+    this.poolConfig.schemaCache = null;
   }
 
   /**
@@ -827,9 +831,8 @@ export class ConnectionPool implements ReapablePool {
   private _lazyLoadTriggered = false;
 
   /**
-   * Exposed so tests (and eager-boot callers) can await the lazy
-   * load's completion instead of relying on timing. Null when no
-   * lazy load was triggered.
+   * @internal Exposed so tests (and eager-boot callers) can await the
+   * lazy load's completion. Null when no lazy load was triggered.
    */
   _lazyLoadPromise: Promise<void> | null = null;
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -813,7 +813,7 @@ export class ConnectionPool implements ReapablePool {
    * load's completion instead of relying on timing. Null when no
    * lazy load was triggered.
    */
-  _lazyLoadPromise: Promise<unknown> | null = null;
+  _lazyLoadPromise: Promise<void> | null = null;
 
   remove(conn: DatabaseAdapter): void {
     this._connectionLease().clear(conn);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -793,7 +793,14 @@ export class ConnectionPool implements ReapablePool {
           // so adapter-side consumers (AbstractAdapter.schemaCache,
           // TypeCaster::Connection) see the preloaded data.
           const loaded = this.schemaReflection.loadedCache;
-          if (loaded && !this.poolConfig.schemaCache) {
+          if (loaded) {
+            // Always assign: poolConfig.schemaCache may have been
+            // populated with an empty SchemaCache during the in-flight
+            // load (e.g., AbstractAdapter.schemaCache accessed
+            // synchronously by TypeCaster::Connection before the
+            // promise resolved). Overwriting that empty cache with the
+            // fully-populated one is the correct outcome — the preloaded
+            // data should win.
             this.poolConfig.schemaCache = loaded;
           }
         })

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -282,6 +282,13 @@ export class ConnectionPool implements ReapablePool {
     // next schemaCache access wraps the new reflection, not the
     // stale one.
     this._boundSchemaCache = undefined;
+    // Also reset the lazy-load guard so the new reflection's
+    // on-disk cache path gets loaded on the next first-connection
+    // event — without this, a swap followed by a fresh checkout
+    // would skip the load because _lazyLoadTriggered is still true
+    // from the old reflection.
+    this._lazyLoadTriggered = false;
+    this._lazyLoadPromise = null;
   }
 
   /**
@@ -769,10 +776,26 @@ export class ConnectionPool implements ReapablePool {
       !this.poolConfig.schemaCache
     ) {
       this._lazyLoadTriggered = true;
-      this._lazyLoadPromise = this.schemaCache.loadBang().catch(() => {
-        // loadCache swallows read/parse/version errors internally;
-        // this is a belt-and-suspenders guard against an unexpected
-        // throw from BoundSchemaReflection/SchemaReflection glue.
+      // Defer the load to the next microtask so we don't re-enter
+      // the pool mid-checkout. SchemaReflection.loadCache calls
+      // pool.withConnection to query connection.schemaVersion() for
+      // the version check — if we called loadBang synchronously
+      // from inside newConnection (which is called from checkout),
+      // the outer lease hasn't been set yet and withConnection would
+      // trigger another checkout, potentially creating an extra
+      // connection or recursing. queueMicrotask defers until the
+      // current checkout finishes and the connection is available
+      // for reuse.
+      this._lazyLoadPromise = new Promise<void>((resolve) => {
+        queueMicrotask(() => {
+          this.schemaCache
+            .loadBang()
+            .catch(() => {
+              // loadCache swallows read/parse/version errors
+              // internally; this is a belt-and-suspenders guard.
+            })
+            .finally(resolve);
+        });
       });
     }
     return conn;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -448,6 +448,17 @@ export class SchemaReflection {
     return this;
   }
 
+  /**
+   * Return the internal SchemaCache if already loaded, or null if no
+   * cache has been populated yet. Used by ConnectionPool to propagate
+   * the reflection's loaded cache into poolConfig.schemaCache so
+   * adapter-side consumers (AbstractAdapter.schemaCache) see the
+   * preloaded data from a schema_cache.json without hitting the DB.
+   */
+  get loadedCache(): SchemaCache | null {
+    return this._cache;
+  }
+
   async primaryKeys(pool: unknown, tableName: string): Promise<string | null | undefined> {
     return (await this.cache(pool)).primaryKeys(pool, tableName);
   }

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -416,6 +416,18 @@ export class SchemaCache {
 export class SchemaReflection {
   static useSchemaCacheDump = true;
   static checkSchemaCacheDumpVersion = true;
+  /**
+   * Mirrors Rails' `ActiveRecord.lazily_load_schema_cache` (default
+   * false). When true, ConnectionPool.newConnection will kick off a
+   * fire-and-forget `schemaCache.loadBang()` on first connection —
+   * apps that commit `db/schema_cache.json` get it populated at boot
+   * without paying the introspection cost on every model load.
+   *
+   * Off by default because the load involves file I/O + optional
+   * schema-version validation; apps opt in by setting this to true
+   * (typically in production boot) the same way Rails exposes it.
+   */
+  static lazilyLoadSchemaCache = false;
 
   private _cache: SchemaCache | null;
   private _cachePath: string | null;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -449,11 +449,12 @@ export class SchemaReflection {
   }
 
   /**
-   * Return the internal SchemaCache if already loaded, or null if no
-   * cache has been populated yet. Used by ConnectionPool to propagate
-   * the reflection's loaded cache into poolConfig.schemaCache so
-   * adapter-side consumers (AbstractAdapter.schemaCache) see the
+   * @internal Return the internal SchemaCache if already loaded, or
+   * null if no cache has been populated yet. Used by ConnectionPool to
+   * propagate the reflection's loaded cache into poolConfig.schemaCache
+   * so adapter-side consumers (AbstractAdapter.schemaCache) see the
    * preloaded data from a schema_cache.json without hitting the DB.
+   * External callers should not mutate the returned cache.
    */
   get loadedCache(): SchemaCache | null {
     return this._cache;

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -845,6 +845,9 @@ describe("ConnectionPool schema cache", () => {
     try {
       pool.leaseConnection();
       pool.releaseConnection();
+      // Verify lazy-load actually triggered so we're testing the
+      // version-mismatch rejection — not just the absence of a load.
+      expect(pool._lazyLoadPromise).not.toBeNull();
       await pool._lazyLoadPromise;
       expect(pool.schemaCache.isCached("stale_thing")).toBe(false);
     } finally {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -733,14 +733,48 @@ describe("ConnectionPool schema cache", () => {
     expect(after).not.toBe(before);
   });
 
+  // Realistic Column.toJSON shape for cache fixture files.
+  const realisticColumnJson = {
+    name: "id",
+    default: null,
+    sqlTypeMetadata: {
+      sqlType: "INTEGER",
+      type: "integer",
+      limit: null,
+      precision: null,
+      scale: null,
+    },
+    null: false,
+    defaultFunction: null,
+    collation: null,
+    comment: null,
+    primaryKey: true,
+  };
+
+  async function writeCacheFixture(
+    cacheFile: string,
+    tableName: string,
+    version: string | number | null,
+  ): Promise<void> {
+    const fsSync = await import("node:fs");
+    fsSync.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        columns: { [tableName]: [realisticColumnJson] },
+        primary_keys: { [tableName]: "id" },
+        data_sources: { [tableName]: true },
+        indexes: {},
+        version,
+      }),
+    );
+  }
+
   it("lazily loads the schema cache on first connection when enabled", async () => {
-    // Rails: ConnectionPool#adopt_connection calls
-    // schema_cache.load! on first adoption when
-    // ActiveRecord.lazily_load_schema_cache is true. Trails'
-    // equivalent flag is SchemaReflection.lazilyLoadSchemaCache.
-    // Load is fire-and-forget; this test triggers the first
-    // connection and awaits a microtask turn to observe the
-    // populated cache.
+    // Rails: ConnectionPool#adopt_connection calls schema_cache.load!
+    // on first adoption when ActiveRecord.lazily_load_schema_cache is
+    // true. Use version=0 so the version-check (enabled by default)
+    // passes against AbstractAdapter's schemaVersion() which returns 0.
+    // Await pool._lazyLoadPromise so we're not timing-dependent.
     const fs = await import("node:fs");
     const path = await import("node:path");
     const os = await import("node:os");
@@ -749,19 +783,9 @@ describe("ConnectionPool schema cache", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-lazy-load-"));
     const dbFile = path.join(tmp, "lazy.sqlite3");
     const cacheFile = path.join(tmp, "schema_cache.json");
-    fs.writeFileSync(
-      cacheFile,
-      JSON.stringify({
-        columns: { gadgets: [{ name: "id", null: false, primaryKey: true }] },
-        primary_keys: { gadgets: "id" },
-        data_sources: { gadgets: true },
-        indexes: {},
-        version: null,
-      }),
-    );
-    const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
+    await writeCacheFixture(cacheFile, "gadgets", 0);
+
     const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
-    SchemaReflection.checkSchemaCacheDumpVersion = false;
     SchemaReflection.lazilyLoadSchemaCache = true;
 
     const dbConfig = new HashConfig("test", "primary", {
@@ -775,11 +799,11 @@ describe("ConnectionPool schema cache", () => {
     });
     const pool = new ConnectionPool(pc);
     try {
-      pool.newConnection();
-      await new Promise<void>((r) => setImmediate(r));
+      pool.leaseConnection();
+      pool.releaseConnection();
+      await pool._lazyLoadPromise;
       expect(pool.schemaCache.isCached("gadgets")).toBe(true);
     } finally {
-      SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
       SchemaReflection.lazilyLoadSchemaCache = prevLazy;
       await closePoolConnections(pool);
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -787,11 +811,7 @@ describe("ConnectionPool schema cache", () => {
   });
 
   it("rejects a stale schema cache when checkSchemaCacheDumpVersion is enabled", async () => {
-    // Rails: SchemaReflection.loadCache compares the cache file's
-    // version against connection.schemaVersion() and returns null
-    // (with a console.warn) when they disagree. The pool therefore
-    // won't pick up the stale cache. Tests the version-check half of
-    // Phase 12 end-to-end via the lazy-load path.
+    // Cache claims version 42; schemaVersion() returns 0 → mismatch.
     const fs = await import("node:fs");
     const path = await import("node:path");
     const os = await import("node:os");
@@ -800,24 +820,11 @@ describe("ConnectionPool schema cache", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-stale-cache-"));
     const dbFile = path.join(tmp, "stale.sqlite3");
     const cacheFile = path.join(tmp, "schema_cache.json");
-    // Cache claims version 42, but connection.schemaVersion() defaults
-    // to 0 on AbstractAdapter. Mismatch → loadCache returns null.
-    fs.writeFileSync(
-      cacheFile,
-      JSON.stringify({
-        columns: { stale_thing: [{ name: "id" }] },
-        primary_keys: { stale_thing: "id" },
-        data_sources: { stale_thing: true },
-        indexes: {},
-        version: 42,
-      }),
-    );
-    const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
+    await writeCacheFixture(cacheFile, "stale_thing", 42);
+
     const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
-    const prevWarn = console.warn;
-    SchemaReflection.checkSchemaCacheDumpVersion = true;
     SchemaReflection.lazilyLoadSchemaCache = true;
-    console.warn = () => {}; // quiet the expected mismatch warning
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const dbConfig = new HashConfig("test", "primary", {
       adapter: "sqlite3",
@@ -830,22 +837,20 @@ describe("ConnectionPool schema cache", () => {
     });
     const pool = new ConnectionPool(pc);
     try {
-      pool.newConnection();
-      await new Promise<void>((r) => setImmediate(r));
-      // Mismatch → cache was rejected → table not reported as cached.
+      pool.leaseConnection();
+      pool.releaseConnection();
+      await pool._lazyLoadPromise;
       expect(pool.schemaCache.isCached("stale_thing")).toBe(false);
     } finally {
-      SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
       SchemaReflection.lazilyLoadSchemaCache = prevLazy;
-      console.warn = prevWarn;
+      vi.restoreAllMocks();
       await closePoolConnections(pool);
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 
   it("does not lazy-load when the flag is off (default)", async () => {
-    // Default: no file I/O at first-connection time. Apps that
-    // don't opt in must not pay for the cache load path.
+    // Default: no file I/O at first-connection time.
     const fs = await import("node:fs");
     const path = await import("node:path");
     const os = await import("node:os");
@@ -854,16 +859,7 @@ describe("ConnectionPool schema cache", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-no-lazy-"));
     const dbFile = path.join(tmp, "no_lazy.sqlite3");
     const cacheFile = path.join(tmp, "schema_cache.json");
-    fs.writeFileSync(
-      cacheFile,
-      JSON.stringify({
-        columns: { widgets: [{ name: "id" }] },
-        primary_keys: { widgets: "id" },
-        data_sources: { widgets: true },
-        indexes: {},
-        version: null,
-      }),
-    );
+    await writeCacheFixture(cacheFile, "widgets", 0);
     expect(SchemaReflection.lazilyLoadSchemaCache).toBe(false);
 
     const dbConfig = new HashConfig("test", "primary", {
@@ -877,8 +873,10 @@ describe("ConnectionPool schema cache", () => {
     });
     const pool = new ConnectionPool(pc);
     try {
-      pool.newConnection();
-      await new Promise<void>((r) => setImmediate(r));
+      pool.leaseConnection();
+      pool.releaseConnection();
+      // _lazyLoadPromise is null when the flag is off.
+      expect(pool._lazyLoadPromise).toBeNull();
       expect(pool.schemaCache.isCached("widgets")).toBe(false);
     } finally {
       await closePoolConnections(pool);

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -733,6 +733,102 @@ describe("ConnectionPool schema cache", () => {
     expect(after).not.toBe(before);
   });
 
+  it("lazily loads the schema cache on first connection when enabled", async () => {
+    // Rails: ConnectionPool#adopt_connection calls
+    // schema_cache.load! on first adoption when
+    // ActiveRecord.lazily_load_schema_cache is true. Trails'
+    // equivalent flag is SchemaReflection.lazilyLoadSchemaCache.
+    // Load is fire-and-forget; this test triggers the first
+    // connection and awaits a microtask turn to observe the
+    // populated cache.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-lazy-load-"));
+    const dbFile = path.join(tmp, "lazy.sqlite3");
+    const cacheFile = path.join(tmp, "schema_cache.json");
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        columns: { gadgets: [{ name: "id", null: false, primaryKey: true }] },
+        primary_keys: { gadgets: "id" },
+        data_sources: { gadgets: true },
+        indexes: {},
+        version: null,
+      }),
+    );
+    const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
+    const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
+    SchemaReflection.checkSchemaCacheDumpVersion = false;
+    SchemaReflection.lazilyLoadSchemaCache = true;
+
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+      reapingFrequency: null,
+      schemaCachePath: cacheFile,
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: () => new SQLite3Adapter(dbFile),
+    });
+    const pool = new ConnectionPool(pc);
+    try {
+      pool.newConnection();
+      await new Promise<void>((r) => setImmediate(r));
+      expect(pool.schemaCache.isCached("gadgets")).toBe(true);
+    } finally {
+      SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
+      SchemaReflection.lazilyLoadSchemaCache = prevLazy;
+      await closePoolConnections(pool);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not lazy-load when the flag is off (default)", async () => {
+    // Default: no file I/O at first-connection time. Apps that
+    // don't opt in must not pay for the cache load path.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-no-lazy-"));
+    const dbFile = path.join(tmp, "no_lazy.sqlite3");
+    const cacheFile = path.join(tmp, "schema_cache.json");
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        columns: { widgets: [{ name: "id" }] },
+        primary_keys: { widgets: "id" },
+        data_sources: { widgets: true },
+        indexes: {},
+        version: null,
+      }),
+    );
+    expect(SchemaReflection.lazilyLoadSchemaCache).toBe(false);
+
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+      reapingFrequency: null,
+      schemaCachePath: cacheFile,
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: () => new SQLite3Adapter(dbFile),
+    });
+    const pool = new ConnectionPool(pc);
+    try {
+      pool.newConnection();
+      await new Promise<void>((r) => setImmediate(r));
+      expect(pool.schemaCache.isCached("widgets")).toBe(false);
+    } finally {
+      await closePoolConnections(pool);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("BoundSchemaReflection.dumpTo(filename) round-trips through the pool", async () => {
     // End-to-end Rails path: pool.schema_cache.dump_to(filename)
     // allocates a fresh SchemaCache, addAll(pool) populates it via

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -786,6 +786,63 @@ describe("ConnectionPool schema cache", () => {
     }
   });
 
+  it("rejects a stale schema cache when checkSchemaCacheDumpVersion is enabled", async () => {
+    // Rails: SchemaReflection.loadCache compares the cache file's
+    // version against connection.schemaVersion() and returns null
+    // (with a console.warn) when they disagree. The pool therefore
+    // won't pick up the stale cache. Tests the version-check half of
+    // Phase 12 end-to-end via the lazy-load path.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-stale-cache-"));
+    const dbFile = path.join(tmp, "stale.sqlite3");
+    const cacheFile = path.join(tmp, "schema_cache.json");
+    // Cache claims version 42, but connection.schemaVersion() defaults
+    // to 0 on AbstractAdapter. Mismatch → loadCache returns null.
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        columns: { stale_thing: [{ name: "id" }] },
+        primary_keys: { stale_thing: "id" },
+        data_sources: { stale_thing: true },
+        indexes: {},
+        version: 42,
+      }),
+    );
+    const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;
+    const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
+    const prevWarn = console.warn;
+    SchemaReflection.checkSchemaCacheDumpVersion = true;
+    SchemaReflection.lazilyLoadSchemaCache = true;
+    console.warn = () => {}; // quiet the expected mismatch warning
+
+    const dbConfig = new HashConfig("test", "primary", {
+      adapter: "sqlite3",
+      database: dbFile,
+      reapingFrequency: null,
+      schemaCachePath: cacheFile,
+    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
+      adapterFactory: () => new SQLite3Adapter(dbFile),
+    });
+    const pool = new ConnectionPool(pc);
+    try {
+      pool.newConnection();
+      await new Promise<void>((r) => setImmediate(r));
+      // Mismatch → cache was rejected → table not reported as cached.
+      expect(pool.schemaCache.isCached("stale_thing")).toBe(false);
+    } finally {
+      SchemaReflection.checkSchemaCacheDumpVersion = prevCheck;
+      SchemaReflection.lazilyLoadSchemaCache = prevLazy;
+      console.warn = prevWarn;
+      await closePoolConnections(pool);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("does not lazy-load when the flag is off (default)", async () => {
     // Default: no file I/O at first-connection time. Apps that
     // don't opt in must not pay for the cache load path.

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -802,7 +802,13 @@ describe("ConnectionPool schema cache", () => {
       pool.leaseConnection();
       pool.releaseConnection();
       await pool._lazyLoadPromise;
+      // BoundSchemaReflection side:
       expect(pool.schemaCache.isCached("gadgets")).toBe(true);
+      // Adapter-visible raw cache (poolConfig.schemaCache) — after
+      // lazy load the reflection's internal cache is propagated so
+      // adapter.schemaCache consumers see preloaded data without DB.
+      expect(pool.poolConfig.schemaCache).not.toBeNull();
+      expect(pool.poolConfig.schemaCache!.isCached("gadgets")).toBe(true);
     } finally {
       SchemaReflection.lazilyLoadSchemaCache = prevLazy;
       await closePoolConnections(pool);


### PR DESCRIPTION
## Summary

Rails' `ConnectionPool#adopt_connection` triggers `schema_cache.load!` on the first-connection adoption when `ActiveRecord.lazily_load_schema_cache` is true. Apps that commit `db/schema_cache.json` get the cache populated at boot without paying the introspection cost on every model load. `SchemaReflection.useSchemaCacheDump` / `checkSchemaCacheDumpVersion` + the loadCache version-validation path already existed from Phase 5; Phase 12 wires them into the pool lifecycle.

- `SchemaReflection.lazilyLoadSchemaCache` static (default `false`, matching Rails). Apps opt in; off by default so pools that never need the cache don't pay for the file read.
- `ConnectionPool.newConnection` kicks off `pool.schemaCache.loadBang()` fire-and-forget when: the flag is on, the pool hasn't loaded yet, and no raw cache already exists. A `_lazyLoadTriggered` guard means only the first connection fires the load.
- Load errors are caught + surfaced via `console.warn` — mirrors Rails' `SchemaReflection.loadCache` `rescue` branch so a bad `schema_cache.json` doesn't crash the pool at checkout time.
- Version check was already wired via `SchemaReflection.checkSchemaCacheDumpVersion` + `loadCache`'s schema-version comparison; the lazy-load path inherits it automatically.

## Test plan

- [x] `pnpm test` — 17192 passing, +2 over baseline
- [x] Lazy-load populates `pool.schemaCache.isCached` after a pre-written `schema_cache.json` + `lazilyLoadSchemaCache = true`
- [x] Default-off path leaves the cache empty at first connection (no accidental file read)