### PR TITLE
feat(activerecord): Phase 1b.1 — trails-tsc CLI skeleton + single-file virtualization

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig(
       "packages/website/static/**",
       "packages/website/build/**",
       "packages/activerecord/src/type-virtualization/fixtures/**",
+      "packages/activerecord/src/tsc-wrapper/__fixtures__/**",
     ],
   },
   eslint.configs.recommended,
@@ -72,6 +73,7 @@ export default defineConfig(
       "packages/activesupport/src/child-process-adapter.ts",
       "packages/activesupport/src/os-adapter.ts",
       // Node-only modules exposed via subpath imports (no browser equivalent)
+      "packages/activerecord/src/tsc-wrapper/**",
       "packages/activesupport/src/gzip.ts",
       "packages/rack/src/deflater.ts",
       "packages/activerecord/src/encryption/config.ts",

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -22,10 +22,17 @@
       "types": "./dist/adapters/mysql2-adapter.d.ts",
       "default": "./dist/adapters/mysql2-adapter.js"
     },
+    "./tsc": {
+      "types": "./dist/tsc-wrapper/index.d.ts",
+      "default": "./dist/tsc-wrapper/index.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"
     }
+  },
+  "bin": {
+    "trails-tsc": "./dist/tsc-wrapper/cli.js"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/consumer.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/consumer.ts
@@ -1,0 +1,5 @@
+import { Post } from "./post.js";
+
+const post = new Post();
+export const title: string = post.title;
+export const published: boolean = post.published;

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/model.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/model.ts
@@ -1,0 +1,9 @@
+export class Model {
+  [key: string]: unknown;
+  constructor(_attrs?: Record<string, unknown>) {}
+  static attribute(_name: string, _type: string): void {}
+  static hasMany(_name: string, _opts?: Record<string, unknown>): void {}
+  static belongsTo(_name: string, _opts?: Record<string, unknown>): void {}
+  static scope(_name: string, _fn: (...args: unknown[]) => unknown): void {}
+}
+export class Base extends Model {}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/post.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/post.ts
@@ -1,0 +1,8 @@
+import { Base } from "./model.js";
+
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["model.ts", "post.ts", "consumer.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import ts from "typescript";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTrailsProgram } from "./program.js";
+
+const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.resolve(CURRENT_DIR, "__fixtures__");
+
+describe("trails-tsc CLI — Phase 1b.1", () => {
+  it("virtualizes a single-file model: post.title types as string with no declares", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+
+    const diagnostics = [...program.getSemanticDiagnostics(), ...program.getSyntacticDiagnostics()];
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("consumer.ts types `post.title` as string, `post.published` as boolean", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const checker = program.getTypeChecker();
+
+    const consumerFile = program.getSourceFile(path.join(FIXTURES_DIR, "consumer.ts"));
+    expect(consumerFile).toBeDefined();
+
+    const probed: Record<string, string> = {};
+    function visit(node: ts.Node): void {
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        const type = checker.getTypeAtLocation(node.initializer);
+        probed[node.name.text] = checker.typeToString(type);
+      }
+      node.forEachChild(visit);
+    }
+    consumerFile!.forEachChild(visit);
+
+    expect(probed["title"]).toBe("string");
+    expect(probed["published"]).toBe("boolean");
+  });
+
+  it("non-Base files pass through unchanged (no virtualization)", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+
+    const modelFile = program.getSourceFile(path.join(FIXTURES_DIR, "model.ts"));
+    expect(modelFile).toBeDefined();
+    // model.ts has no static block with `this.attribute(...)` calls
+    // on a class that extends Base — it IS the Base. No declares injected.
+    expect(modelFile!.text).not.toContain("declare title");
+  });
+
+  it("zero diagnostics across all diagnostic categories", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const allDiags = [...ts.getPreEmitDiagnostics(program)];
+    expect(allDiags).toHaveLength(0);
+  });
+
+  it("CLI binary exits 0 on clean fixture", async () => {
+    const fs = await import("node:fs");
+    const binPath = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
+    // Skip if dist hasn't been built (CI test jobs that skip `pnpm build`).
+    // The programmatic API tests above cover the same behavior; this test
+    // exercises the real binary entry path as an extra integration check.
+    if (!fs.existsSync(binPath)) return;
+    const { execFileSync } = await import("node:child_process");
+    const result = execFileSync(
+      "node",
+      [binPath, "-p", path.join(FIXTURES_DIR, "tsconfig.json"), "--noEmit"],
+      {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    // Clean exit — no output expected on success.
+    expect(result).toBe("");
+  });
+});

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import ts from "typescript";
+import * as path from "node:path";
+import { createTrailsProgram } from "./program.js";
+
+function main(): void {
+  const args = process.argv.slice(2);
+
+  // Find -p / --project flag; default to ./tsconfig.json.
+  // Error if the flag is present but no value follows (matches tsc).
+  let configPath: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p" || args[i] === "--project") {
+      if (!args[i + 1] || args[i + 1]!.startsWith("-")) {
+        process.stderr.write("trails-tsc: Compiler option '--project' expects an argument.\n");
+        process.exit(1);
+      }
+      configPath = args[i + 1];
+    }
+  }
+  // When no -p is given, search upward from cwd for the nearest
+  // tsconfig.json — matches tsc's default behavior.
+  if (!configPath) {
+    configPath =
+      ts.findConfigFile(process.cwd(), ts.sys.fileExists) ?? path.resolve("tsconfig.json");
+  } else {
+    configPath = path.resolve(configPath);
+  }
+
+  const { program, configDiagnostics } = createTrailsProgram(configPath);
+
+  const formatHost: ts.FormatDiagnosticsHost = {
+    getCurrentDirectory: () => process.cwd(),
+    getCanonicalFileName: (f) => (ts.sys.useCaseSensitiveFileNames ? f : f.toLowerCase()),
+    getNewLine: () => ts.sys.newLine,
+  };
+
+  // Config-level errors (bad tsconfig read / parse) — format and
+  // exit before attempting to use the program.
+  if (configDiagnostics.length > 0) {
+    process.stderr.write(ts.formatDiagnostics(configDiagnostics, formatHost));
+    process.exit(1);
+  }
+
+  // getPreEmitDiagnostics includes semantic + syntactic + global +
+  // options diagnostics — matches what tsc reports before emit.
+  const diagnostics = [...ts.getPreEmitDiagnostics(program)];
+
+  // Check for --noEmit
+  const noEmit = args.includes("--noEmit") || program.getCompilerOptions().noEmit;
+
+  if (!noEmit) {
+    const emitResult = program.emit();
+    diagnostics.push(...emitResult.diagnostics);
+  }
+
+  // Sort + deduplicate to match tsc output ordering and avoid dupes.
+  const sorted = ts.sortAndDeduplicateDiagnostics(diagnostics);
+
+  if (sorted.length > 0) {
+    // Mirror tsc's --pretty default: on when stdout is a TTY,
+    // off otherwise. Explicit --pretty true/false overrides.
+    const prettyIndex = args.indexOf("--pretty");
+    const prettyFromArgs =
+      prettyIndex === -1 ? undefined : args[prettyIndex + 1] === "false" ? false : true;
+    const pretty =
+      prettyFromArgs ?? program.getCompilerOptions().pretty ?? ts.sys.writeOutputIsTTY?.() ?? false;
+    const output = pretty
+      ? ts.formatDiagnosticsWithColorAndContext(sorted, formatHost)
+      : ts.formatDiagnostics(sorted, formatHost);
+
+    process.stderr.write(output);
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+try {
+  main();
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`trails-tsc: ${msg}\n`);
+  process.exit(1);
+}

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -1,0 +1,79 @@
+import ts from "typescript";
+import * as path from "node:path";
+import { virtualize, type VirtualizeResult } from "../type-virtualization/virtualize.js";
+
+const BASE_PATTERN = /\bextends\s+Base\b/;
+const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
+
+export interface TrailsCompilerHost extends ts.CompilerHost {
+  getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;
+}
+
+export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHost {
+  const baseHost = ts.createCompilerHost(options, true);
+  const deltaMap = new Map<string, VirtualizeResult["deltas"]>();
+  const virtualizedTextCache = new Map<string, string>();
+
+  function shouldVirtualize(text: string): boolean {
+    return BASE_PATTERN.test(text) && STATIC_BLOCK_PATTERN.test(text);
+  }
+
+  function getVirtualizedText(resolved: string): string | undefined {
+    if (virtualizedTextCache.has(resolved)) return virtualizedTextCache.get(resolved)!;
+    const originalText = baseHost.readFile(resolved);
+    if (originalText == null) return undefined;
+    if (!shouldVirtualize(originalText)) {
+      virtualizedTextCache.set(resolved, originalText);
+      return originalText;
+    }
+    const result = virtualize(originalText, resolved);
+    virtualizedTextCache.set(resolved, result.text);
+    deltaMap.set(resolved, result.deltas);
+    return result.text;
+  }
+
+  const sourceFileCache = new Map<string, ts.SourceFile>();
+
+  const host: TrailsCompilerHost = {
+    ...baseHost,
+
+    getSourceFile(fileName, languageVersionOrOptions, onError, shouldCreateNewSourceFile) {
+      const resolved = path.resolve(fileName);
+
+      // In watch/incremental mode, shouldCreateNewSourceFile signals
+      // that the file changed on disk. Flush all caches for this path
+      // so we re-read, re-virtualize, and re-parse.
+      if (shouldCreateNewSourceFile) {
+        virtualizedTextCache.delete(resolved);
+        deltaMap.delete(resolved);
+        sourceFileCache.delete(resolved);
+      }
+
+      const text = getVirtualizedText(resolved);
+      if (text == null) {
+        return baseHost.getSourceFile(
+          fileName,
+          languageVersionOrOptions,
+          onError,
+          shouldCreateNewSourceFile,
+        );
+      }
+      if (sourceFileCache.has(resolved)) {
+        return sourceFileCache.get(resolved)!;
+      }
+      const sf = ts.createSourceFile(resolved, text, languageVersionOrOptions, true);
+      sourceFileCache.set(resolved, sf);
+      return sf;
+    },
+
+    readFile(fileName) {
+      return getVirtualizedText(path.resolve(fileName)) ?? baseHost.readFile(fileName);
+    },
+
+    getDeltasForFile(fileName) {
+      return deltaMap.get(path.resolve(fileName));
+    },
+  };
+
+  return host;
+}

--- a/packages/activerecord/src/tsc-wrapper/index.ts
+++ b/packages/activerecord/src/tsc-wrapper/index.ts
@@ -1,0 +1,2 @@
+export { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
+export { createTrailsProgram, type TrailsProgram } from "./program.js";

--- a/packages/activerecord/src/tsc-wrapper/program.ts
+++ b/packages/activerecord/src/tsc-wrapper/program.ts
@@ -1,0 +1,56 @@
+import ts from "typescript";
+import * as path from "node:path";
+import { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
+
+export interface TrailsProgram {
+  program: ts.Program;
+  host: TrailsCompilerHost;
+  configDiagnostics: readonly ts.Diagnostic[];
+}
+
+export function createTrailsProgram(configPath: string): TrailsProgram {
+  // Resolve config path the same way tsc does: accept either a file or
+  // a directory (appends /tsconfig.json). Unlike ts.findConfigFile, we
+  // don't search upward — tsc -p <dir> expects <dir>/tsconfig.json and
+  // errors if it doesn't exist.
+  const resolvedConfig = ts.sys.directoryExists(configPath)
+    ? path.join(configPath, "tsconfig.json")
+    : configPath;
+
+  const configFile = ts.readConfigFile(resolvedConfig, ts.sys.readFile);
+  if (configFile.error) {
+    // Return early with the diagnostic — let the CLI format it
+    // consistently with the same FormatDiagnosticsHost used for
+    // program diagnostics. No program to construct.
+    return {
+      program: undefined!,
+      host: undefined!,
+      configDiagnostics: [configFile.error],
+    };
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(resolvedConfig),
+    undefined,
+    resolvedConfig,
+  );
+
+  if (parsed.errors.length > 0) {
+    return {
+      program: undefined!,
+      host: undefined!,
+      configDiagnostics: parsed.errors,
+    };
+  }
+
+  const host = buildCompilerHost(parsed.options);
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+    host,
+  });
+
+  return { program, host, configDiagnostics: [] };
+}

--- a/packages/activerecord/tsconfig.json
+++ b/packages/activerecord/tsconfig.json
@@ -6,6 +6,6 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["src/type-virtualization/fixtures"],
+  "exclude": ["src/type-virtualization/fixtures", "src/tsc-wrapper/__fixtures__"],
   "references": [{ "path": "../arel" }, { "path": "../activemodel" }]
 }


### PR DESCRIPTION
## Summary

First sub-PR of the `trails-tsc` CLI (Phase 1b). Adds the packaging, bin entry, custom `ts.CompilerHost`, and a single-file end-to-end test demonstrating zero-declare model typing.

```ts
// post.ts — no declares
import { Base } from "./model.js";
class Post extends Base {
  static {
    this.attribute("title", "string");
    this.attribute("published", "boolean");
  }
}

// consumer.ts
const post = new Post();
export const title: string = post.title;       // ✅ types as string
export const published: boolean = post.published; // ✅ types as boolean
```

`trails-tsc --noEmit -p fixture/tsconfig.json` → exit 0, zero diagnostics.

## What's in it

| File | Role |
| ---- | ---- |
| `packages/activerecord/src/tsc-wrapper/cli.ts` | Bin entry; parses `-p` / `--noEmit` / `--pretty`; runs `createTrailsProgram`, collects diagnostics, exits 0/1 |
| `packages/activerecord/src/tsc-wrapper/program.ts` | `createTrailsProgram(configPath)` — wraps `ts.createProgram` with the custom host |
| `packages/activerecord/src/tsc-wrapper/host.ts` | `buildCompilerHost(options)` — overrides `getSourceFile`/`readFile` to call `virtualize()` on files matching `extends Base` + `static {`. Stores per-file `LineDelta[]` for future diagnostic remap (1b.2) |
| `packages/activerecord/src/tsc-wrapper/index.ts` | Barrel export |
| `packages/activerecord/package.json` | `bin: trails-tsc` + `"./tsc"` subpath export |

## Not in scope (per the plan)

- Transitive extends (1b.3)
- Auto-import resolution (1b.4)
- `--build` / composite projects (1b.5)
- Diagnostic range remap (1b.2)

## Test plan

- [x] 4 integration tests (`cli.test.ts`):
  - Zero diagnostics on the fixture
  - Type-checker probes: `post.title` → `string`, `post.published` → `boolean`
  - Non-Base files pass through unchanged
  - Zero diagnostics = exit code 0
- [x] Full activerecord suite: **8224/8224**, zero regressions
- [x] `pnpm build` / `pnpm typecheck` clean
- [x] Prettier + ESLint clean
- [ ] CI

Plan: `docs/virtual-source-files-plan.md` § Phase 1b.1.