### PR TITLE
feat(activerecord,activesupport): implement logging subsystem

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -911,20 +911,34 @@ async function logSql<T>(
   binds: unknown[] | undefined,
   fn: () => Promise<T>,
 ): Promise<T> {
+  // Rails' log() separates binds (Attribute objects) from type_casted_binds
+  // (primitive values). type_casted_binds can be a lazy callable in Rails;
+  // here we pass the primitive values directly.
+  const bindArray = binds ?? [];
   const payload: Record<string, unknown> = {
     sql,
     name,
-    binds: binds ?? [],
-    type_casted_binds: binds ?? [],
+    binds: bindArray,
+    type_casted_binds: bindArray.map((b: any) =>
+      b && typeof b === "object" && "value" in b ? b.value : b,
+    ),
     connection: host,
     row_count: 0,
   };
   return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-    const result = await fn();
-    if (result instanceof Result) {
-      payload.row_count = result.length;
+    try {
+      const result = await fn();
+      if (result instanceof Result) {
+        payload.row_count = result.length;
+      }
+      return result;
+    } catch (e: any) {
+      // Rails' Instrumenter sets payload[:exception] and [:exception_object]
+      // so subscribers (e.g. ExplainSubscriber) can detect failed queries.
+      payload.exception = e;
+      payload.exception_object = e;
+      throw e;
     }
-    return result;
   }) as Promise<T>;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -919,9 +919,12 @@ async function logSql<T>(
     sql,
     name,
     binds: bindArray,
-    type_casted_binds: bindArray.map((b: any) =>
-      b && typeof b === "object" && "value" in b ? b.value : b,
-    ),
+    type_casted_binds: bindArray.map((b: any) => {
+      if (b && typeof b === "object" && typeof b.valueForDatabase === "function") {
+        return b.valueForDatabase();
+      }
+      return b && typeof b === "object" && "value" in b ? b.value : b;
+    }),
     connection: host,
     row_count: 0,
   };

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -5,6 +5,7 @@
  */
 
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
+import { Notifications } from "@blazetrails/activesupport";
 import { TransactionIsolationError } from "../../errors.js";
 import { quote, quoteTableName, quoteColumnName } from "./quoting.js";
 import { TransactionManager } from "./transaction.js";
@@ -900,6 +901,34 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
 }
 
 /**
+ * Wraps query execution in a `sql.active_record` instrumentation event,
+ * mirroring Rails' `AbstractAdapter#log`.
+ */
+async function logSql<T>(
+  host: DatabaseStatementsHost,
+  sql: string,
+  name: string,
+  binds: unknown[] | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const payload: Record<string, unknown> = {
+    sql,
+    name,
+    binds: binds ?? [],
+    type_casted_binds: binds ?? [],
+    connection: host,
+    row_count: 0,
+  };
+  return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    const result = await fn();
+    if (result instanceof Result) {
+      payload.row_count = result.length;
+    }
+    return result;
+  }) as Promise<T>;
+}
+
+/**
  * Executes a raw query and returns an ActiveRecord::Result.
  * Delegates to rawExecute + castResult.
  *
@@ -914,12 +943,15 @@ export async function rawExecQuery(
   if (!this.rawExecute) {
     throw new Error("rawExecQuery requires rawExecute on the adapter");
   }
-  // Materialize lazy transactions before executing SQL, matching Rails'
-  // with_raw_connection which calls materialize_transactions.
-  const tm = (this as any)._transactionManager as TransactionManager | undefined;
-  if (tm) await tm.materializeTransactions();
-  const rawResult = await this.rawExecute(sql, name ?? "SQL", binds);
-  return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
+  const sqlName = name ?? "SQL";
+  return logSql(this, sql, sqlName, binds, async () => {
+    // Materialize lazy transactions before executing SQL, matching Rails'
+    // with_raw_connection which calls materialize_transactions.
+    const tm = (this as any)._transactionManager as TransactionManager | undefined;
+    if (tm) await tm.materializeTransactions();
+    const rawResult = await this.rawExecute!(sql, sqlName, binds);
+    return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
+  });
 }
 
 /**
@@ -934,22 +966,25 @@ export async function internalExecQuery(
   name?: string | null,
   binds?: unknown[],
 ): Promise<Result> {
-  // Materialize lazy transactions before executing SQL
-  const tm = (this as any)._transactionManager as TransactionManager | undefined;
-  if (tm) await tm.materializeTransactions();
-  if (this?.internalExecute) {
-    const rawResult = await this.internalExecute(sql, name ?? "SQL", binds);
-    return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
-  }
-  if (binds && binds.length > 0) {
-    throw new Error(
-      "internalExecQuery requires internalExecute on the adapter when binds are provided",
-    );
-  }
-  // Fallback: delegate through this.execute only when there are no binds
-  const doExecute = this?.execute ?? execute;
-  const result = await doExecute(sql);
-  return normalizeResult(result);
+  const sqlName = name ?? "SQL";
+  return logSql(this, sql, sqlName, binds, async () => {
+    // Materialize lazy transactions before executing SQL
+    const tm = (this as any)._transactionManager as TransactionManager | undefined;
+    if (tm) await tm.materializeTransactions();
+    if (this?.internalExecute) {
+      const rawResult = await this.internalExecute(sql, sqlName, binds);
+      return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
+    }
+    if (binds && binds.length > 0) {
+      throw new Error(
+        "internalExecQuery requires internalExecute on the adapter when binds are provided",
+      );
+    }
+    // Fallback: delegate through this.execute only when there are no binds
+    const doExecute = this?.execute ?? execute;
+    const result = await doExecute(sql);
+    return normalizeResult(result);
+  });
 }
 
 // --- Private helpers ---

--- a/packages/activerecord/src/explain-registry.ts
+++ b/packages/activerecord/src/explain-registry.ts
@@ -1,0 +1,44 @@
+/**
+ * ActiveRecord::ExplainRegistry — thread-local registry for EXPLAIN queries.
+ *
+ * Collects SQL/binds pairs when `collect` is enabled, so they can be
+ * passed to the adapter's EXPLAIN.
+ */
+export class ExplainRegistry {
+  private static _instance: ExplainRegistry | null = null;
+
+  private static get instance(): ExplainRegistry {
+    if (!this._instance) this._instance = new ExplainRegistry();
+    return this._instance;
+  }
+
+  static get collect(): boolean {
+    return this.instance._collect;
+  }
+
+  static set collect(value: boolean) {
+    this.instance._collect = value;
+  }
+
+  static collectEnabled(): boolean {
+    return this.instance._collect;
+  }
+
+  static get queries(): [string, unknown[]][] {
+    return this.instance._queries;
+  }
+
+  static reset(): void {
+    if (this._instance) {
+      this._instance._collect = false;
+      this._instance._queries = [];
+    } else {
+      this._instance = new ExplainRegistry();
+    }
+  }
+
+  // -- Instance state ------------------------------------------------------
+
+  private _collect = false;
+  private _queries: [string, unknown[]][] = [];
+}

--- a/packages/activerecord/src/explain-subscriber.test.ts
+++ b/packages/activerecord/src/explain-subscriber.test.ts
@@ -1,12 +1,70 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { ExplainSubscriber } from "./explain-subscriber.js";
+import { ExplainRegistry } from "./explain-registry.js";
+
+const SUBSCRIBER = new ExplainSubscriber();
 
 describe("ExplainSubscriberTest", () => {
-  it.skip("collects nothing if the payload has an exception", () => {});
-  it.skip("collects nothing for ignored payloads", () => {});
-  it.skip("collects nothing if collect is false", () => {});
-  it.skip("collects pairs of queries and binds", () => {});
-  it.skip("collects nothing if the statement is not explainable", () => {});
-  it.skip("collects nothing if the statement is only partially matched", () => {});
-  it.skip("collects cte queries", () => {});
-  it.skip("collects queries starting with comment", () => {});
+  beforeEach(() => {
+    ExplainRegistry.reset();
+    ExplainRegistry.collect = true;
+  });
+
+  afterEach(() => {
+    ExplainRegistry.reset();
+  });
+
+  it("collects nothing if the payload has an exception", () => {
+    SUBSCRIBER.finish(null, null, { exception: new Error("boom") });
+    expect(ExplainRegistry.queries).toEqual([]);
+  });
+
+  it("collects nothing for ignored payloads", () => {
+    for (const ip of ExplainSubscriber.IGNORED_PAYLOADS) {
+      SUBSCRIBER.finish(null, null, { name: ip });
+    }
+    expect(ExplainRegistry.queries).toEqual([]);
+  });
+
+  it("collects nothing if collect is false", () => {
+    ExplainRegistry.collect = false;
+    SUBSCRIBER.finish(null, null, { name: "SQL", sql: "select 1 from users", binds: [1, 2] });
+    expect(ExplainRegistry.queries).toEqual([]);
+  });
+
+  it("collects pairs of queries and binds", () => {
+    const sql = "select 1 from users";
+    const binds = [1, 2];
+    SUBSCRIBER.finish(null, null, { name: "SQL", sql, binds });
+    expect(ExplainRegistry.queries.length).toBe(1);
+    expect(ExplainRegistry.queries[0][0]).toBe(sql);
+    expect(ExplainRegistry.queries[0][1]).toEqual(binds);
+  });
+
+  it("collects nothing if the statement is not explainable", () => {
+    SUBSCRIBER.finish(null, null, { name: "SQL", sql: "SHOW max_identifier_length" });
+    expect(ExplainRegistry.queries).toEqual([]);
+  });
+
+  it("collects nothing if the statement is only partially matched", () => {
+    SUBSCRIBER.finish(null, null, { name: "SQL", sql: "select_db yo_mama" });
+    expect(ExplainRegistry.queries).toEqual([]);
+  });
+
+  it("collects cte queries", () => {
+    SUBSCRIBER.finish(null, null, {
+      name: "SQL",
+      sql: "with s as (values(3)) select 1 from s",
+    });
+    expect(ExplainRegistry.queries.length).toBe(1);
+  });
+
+  it("collects queries starting with comment", () => {
+    SUBSCRIBER.finish(null, null, {
+      name: "SQL",
+      sql: "/* comment */ select 1 from users",
+    });
+    expect(ExplainRegistry.queries.length).toBe(1);
+  });
 });

--- a/packages/activerecord/src/explain-subscriber.ts
+++ b/packages/activerecord/src/explain-subscriber.ts
@@ -1,0 +1,39 @@
+import { ExplainRegistry } from "./explain-registry.js";
+
+export interface ExplainPayload {
+  sql?: string;
+  binds?: unknown[];
+  name?: string;
+  exception?: unknown;
+  cached?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * ActiveRecord::ExplainSubscriber — collects queries for EXPLAIN analysis.
+ *
+ * Subscribes to `sql.active_record` and pushes [sql, binds] pairs into
+ * ExplainRegistry when collection is enabled.
+ */
+export class ExplainSubscriber {
+  static readonly IGNORED_PAYLOADS = ["SCHEMA", "EXPLAIN"];
+  static readonly EXPLAINED_SQLS = /^\s*(\/\*.*\*\/)?\s*(with|select|update|delete|insert)\b/i;
+
+  start(_name: unknown, _id: unknown, _payload: ExplainPayload): void {
+    // unused — matches Rails' no-op start
+  }
+
+  finish(_name: unknown, _id: unknown, payload: ExplainPayload): void {
+    if (ExplainRegistry.collectEnabled() && !this.ignorePayload(payload)) {
+      ExplainRegistry.queries.push([payload.sql!, payload.binds ?? []]);
+    }
+  }
+
+  ignorePayload(payload: ExplainPayload): boolean {
+    if (payload.exception) return true;
+    if (payload.cached) return true;
+    if (ExplainSubscriber.IGNORED_PAYLOADS.includes(payload.name ?? "")) return true;
+    if (!payload.sql || !ExplainSubscriber.EXPLAINED_SQLS.test(payload.sql)) return true;
+    return false;
+  }
+}

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -56,6 +56,9 @@ export type { AssociationProxy } from "./associations/collection-proxy.js";
 export type { AssociationOptions } from "./associations.js";
 export { Transaction } from "./connection-adapters/abstract/transaction.js";
 export { ActiveRecordTransaction } from "./transaction.js";
+export { LogSubscriber } from "./log-subscriber.js";
+export { ExplainSubscriber } from "./explain-subscriber.js";
+export { ExplainRegistry } from "./explain-registry.js";
 export {
   transaction,
   savepoint,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -56,9 +56,33 @@ export type { AssociationProxy } from "./associations/collection-proxy.js";
 export type { AssociationOptions } from "./associations.js";
 export { Transaction } from "./connection-adapters/abstract/transaction.js";
 export { ActiveRecordTransaction } from "./transaction.js";
-export { LogSubscriber } from "./log-subscriber.js";
+export {
+  LogSubscriber,
+  getVerboseQueryLogs,
+  setVerboseQueryLogs,
+  setBaseResolver as setLogSubscriberBaseResolver,
+} from "./log-subscriber.js";
 export { ExplainSubscriber } from "./explain-subscriber.js";
 export { ExplainRegistry } from "./explain-registry.js";
+
+// Wire LogSubscriber's Base resolver so it can delegate logger/filter
+// to ActiveRecord::Base without circular imports.
+import { setBaseResolver as _setBaseResolver } from "./log-subscriber.js";
+_setBaseResolver(() => _Base);
+
+// Auto-attach LogSubscriber to :active_record, matching Rails'
+// `ActiveRecord::LogSubscriber.attach_to :active_record`.
+import { LogSubscriber as _LogSubscriber } from "./log-subscriber.js";
+_LogSubscriber.attachTo("active_record");
+
+// Auto-subscribe ExplainSubscriber to sql.active_record, matching Rails'
+// `ActiveSupport::Notifications.subscribe("sql.active_record", new)`.
+import { Notifications as _Notifications } from "@blazetrails/activesupport";
+import { ExplainSubscriber as _ExplainSubscriber } from "./explain-subscriber.js";
+const _explainSub = new _ExplainSubscriber();
+_Notifications.subscribe("sql.active_record", (event) => {
+  _explainSub.finish(event.name, event.transactionId, event.payload);
+});
 export {
   transaction,
   savepoint,

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -1,25 +1,377 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { LogSubscriber } from "./log-subscriber.js";
+import {
+  LogSubscriber as BaseLogSubscriber,
+  NotificationEvent as Event,
+  Logger,
+} from "@blazetrails/activesupport";
+
+const REGEXP_CLEAR_STR = `\\x1b\\[${BaseLogSubscriber.MODES.clear}m`;
+const REGEXP_BOLD_STR = `\\x1b\\[${BaseLogSubscriber.MODES.bold}m`;
+const REGEXP_MAGENTA_STR = escapeRegex(BaseLogSubscriber.MAGENTA);
+const REGEXP_CYAN_STR = escapeRegex(BaseLogSubscriber.CYAN);
+
+const SQL_COLORINGS: Record<string, string> = {
+  SELECT: escapeRegex(BaseLogSubscriber.BLUE),
+  INSERT: escapeRegex(BaseLogSubscriber.GREEN),
+  UPDATE: escapeRegex(BaseLogSubscriber.YELLOW),
+  DELETE: escapeRegex(BaseLogSubscriber.RED),
+  LOCK: escapeRegex(BaseLogSubscriber.WHITE),
+  ROLLBACK: escapeRegex(BaseLogSubscriber.RED),
+  TRANSACTION: REGEXP_CYAN_STR,
+  OTHER: REGEXP_MAGENTA_STR,
+};
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+class MockLogger extends Logger {
+  private _logged: Record<string, string[]> = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  };
+
+  constructor() {
+    super(null);
+  }
+
+  logged(level: string): string[] {
+    return this._logged[level] ?? [];
+  }
+
+  override debug(message?: string | (() => string)): boolean {
+    if (this.level > Logger.DEBUG) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.debug.push(msg);
+    return true;
+  }
+
+  override info(message?: string | (() => string)): boolean {
+    if (this.level > Logger.INFO) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.info.push(msg);
+    return true;
+  }
+
+  override warn(message?: string | (() => string)): boolean {
+    if (this.level > Logger.WARN) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.warn.push(msg);
+    return true;
+  }
+
+  override error(message?: string | (() => string)): boolean {
+    if (this.level > Logger.ERROR) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.error.push(msg);
+    return true;
+  }
+}
+
+class TestDebugLogSubscriber extends LogSubscriber {
+  override get logger(): Logger | null {
+    return (this.constructor as typeof LogSubscriber).logger;
+  }
+}
 
 describe("LogSubscriberTest", () => {
-  it.skip("schema statements are ignored", () => {});
-  it.skip("sql statements are not squeezed", () => {});
+  let mockLogger: MockLogger;
+  let subscriber: TestDebugLogSubscriber;
+
+  beforeEach(() => {
+    mockLogger = new MockLogger();
+    LogSubscriber.logger = mockLogger;
+    TestDebugLogSubscriber.logger = mockLogger;
+    LogSubscriber.colorizeLogging = true;
+    subscriber = new TestDebugLogSubscriber();
+  });
+
+  afterEach(() => {
+    LogSubscriber.logger = null;
+    LogSubscriber.verboseQueryLogs = false;
+  });
+
+  it("schema statements are ignored", () => {
+    expect(subscriber.debugs.length).toBe(0);
+
+    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!" }));
+    expect(subscriber.debugs.length).toBe(1);
+
+    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!", name: "foo" }));
+    expect(subscriber.debugs.length).toBe(2);
+
+    subscriber.sql(new Event("sql.active_record", new Date(), { sql: "hi mom!", name: "SCHEMA" }));
+    expect(subscriber.debugs.length).toBe(2);
+  });
+
+  it("sql statements are not squeezed", () => {
+    subscriber.sql(makeEvent({ sql: "ruby   rails" }));
+    expect(subscriber.debugs[0]).toMatch(/ruby {3}rails/);
+  });
+
   it.skip("basic query logging", () => {});
-  it.skip("basic query logging coloration", () => {});
-  it.skip("logging sql coloration disabled", () => {});
-  it.skip("basic payload name logging coloration generic sql", () => {});
-  it.skip("basic payload name logging coloration named sql", () => {});
-  it.skip("async query", () => {});
-  it.skip("query logging coloration with nested select", () => {});
-  it.skip("query logging coloration with multi line nested select", () => {});
-  it.skip("query logging coloration with lock", () => {});
+
+  it("basic query logging coloration", () => {
+    subscriber.colorizeLogging = true;
+    for (const [verb, colorRegex] of Object.entries(SQL_COLORINGS)) {
+      subscriber.sql(makeEvent({ sql: verb }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(`${REGEXP_BOLD_STR}${colorRegex}${verb}${REGEXP_CLEAR_STR}`, "i"),
+      );
+    }
+  });
+
+  it("logging sql coloration disabled", () => {
+    subscriber.colorizeLogging = false;
+
+    for (const [verb, colorRegex] of Object.entries(SQL_COLORINGS)) {
+      subscriber.sql(makeEvent({ sql: verb }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).not.toMatch(
+        new RegExp(`${REGEXP_BOLD_STR}${colorRegex}${verb}${REGEXP_CLEAR_STR}`, "i"),
+      );
+    }
+  });
+
+  it("basic payload name logging coloration generic sql", () => {
+    subscriber.colorizeLogging = true;
+    for (const verb of Object.keys(SQL_COLORINGS)) {
+      subscriber.sql(makeEvent({ sql: verb }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(`${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR} \\(0\\.9ms\\)${REGEXP_CLEAR_STR}`, "i"),
+      );
+
+      subscriber.sql(makeEvent({ sql: verb, name: "SQL" }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR}SQL \\(0\\.9ms\\)${REGEXP_CLEAR_STR}`,
+          "i",
+        ),
+      );
+    }
+  });
+
+  it("basic payload name logging coloration named sql", () => {
+    subscriber.colorizeLogging = true;
+    for (const verb of Object.keys(SQL_COLORINGS)) {
+      subscriber.sql(makeEvent({ sql: verb, name: "Model Load" }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_CYAN_STR}Model Load \\(0\\.9ms\\)${REGEXP_CLEAR_STR}`,
+          "i",
+        ),
+      );
+
+      subscriber.sql(makeEvent({ sql: verb, name: "Model Exists" }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_CYAN_STR}Model Exists \\(0\\.9ms\\)${REGEXP_CLEAR_STR}`,
+          "i",
+        ),
+      );
+
+      subscriber.sql(makeEvent({ sql: verb, name: "ANY SPECIFIC NAME" }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_CYAN_STR}ANY SPECIFIC NAME \\(0\\.9ms\\)${REGEXP_CLEAR_STR}`,
+          "i",
+        ),
+      );
+    }
+  });
+
+  it("async query", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "SELECT * from models",
+        name: "Model Load",
+        async: true,
+        lock_wait: 0.01,
+      }),
+    );
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+      /ASYNC Model Load \(0\.0ms\) \(db time 0\.9ms\).*SELECT/i,
+    );
+  });
+
+  it("query logging coloration with nested select", () => {
+    subscriber.colorizeLogging = true;
+    for (const verb of ["SELECT", "INSERT", "UPDATE", "DELETE"]) {
+      const colorRegex = SQL_COLORINGS[verb];
+      subscriber.sql(makeEvent({ sql: `${verb} WHERE ID IN SELECT` }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR} \\(0\\.9ms\\)${REGEXP_CLEAR_STR}  ${REGEXP_BOLD_STR}${colorRegex}${verb} WHERE ID IN SELECT${REGEXP_CLEAR_STR}`,
+          "i",
+        ),
+      );
+    }
+  });
+
+  it("query logging coloration with multi line nested select", () => {
+    subscriber.colorizeLogging = true;
+    for (const verb of ["SELECT", "INSERT", "UPDATE", "DELETE"]) {
+      const colorRegex = SQL_COLORINGS[verb];
+      const sql = `
+        ${verb}
+        WHERE ID IN (
+          SELECT ID FROM THINGS
+        )
+      `;
+      subscriber.sql(makeEvent({ sql }));
+      expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+        new RegExp(
+          `${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR} \\(0\\.9ms\\)${REGEXP_CLEAR_STR}  ${REGEXP_BOLD_STR}${colorRegex}.*${verb}.*${REGEXP_CLEAR_STR}`,
+          "mis",
+        ),
+      );
+    }
+  });
+
+  it("query logging coloration with lock", () => {
+    subscriber.colorizeLogging = true;
+
+    let sql = `
+      SELECT * FROM
+        (SELECT * FROM mytable FOR UPDATE) ss
+      WHERE col1 = 5;
+    `;
+    subscriber.sql(makeEvent({ sql }));
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+      new RegExp(
+        `${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR} \\(0\\.9ms\\)${REGEXP_CLEAR_STR}  ${REGEXP_BOLD_STR}${SQL_COLORINGS.LOCK}.*FOR UPDATE.*${REGEXP_CLEAR_STR}`,
+        "mis",
+      ),
+    );
+
+    sql = `
+      LOCK TABLE films IN SHARE MODE;
+    `;
+    subscriber.sql(makeEvent({ sql }));
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+      new RegExp(
+        `${REGEXP_BOLD_STR}${REGEXP_MAGENTA_STR} \\(0\\.9ms\\)${REGEXP_CLEAR_STR}  ${REGEXP_BOLD_STR}${SQL_COLORINGS.LOCK}.*LOCK TABLE.*${REGEXP_CLEAR_STR}`,
+        "mis",
+      ),
+    );
+  });
+
   it.skip("exists query logging", () => {});
-  it.skip("verbose query logs", () => {});
-  it.skip("verbose query with ignored callstack", () => {});
-  it.skip("verbose query logs disabled by default", () => {});
-  it.skip("cached queries", () => {});
-  it.skip("basic query doesnt log when level is not debug", () => {});
-  it.skip("cached queries doesnt log when level is not debug", () => {});
-  it.skip("where in binds logging include attribute names", () => {});
-  it.skip("binary data is not logged", () => {});
-  it.skip("binary data hash", () => {});
+
+  it("verbose query logs", () => {
+    LogSubscriber.verboseQueryLogs = true;
+    subscriber.sql(makeEvent({ sql: "hi mom!" }));
+    expect(mockLogger.logged("debug").length).toBe(2);
+    expect(mockLogger.logged("debug")[mockLogger.logged("debug").length - 1]).toMatch(/↳/);
+  });
+
+  it("verbose query with ignored callstack", () => {
+    LogSubscriber.verboseQueryLogs = true;
+    const original = (subscriber as any)._querySourceLocation;
+    (subscriber as any)._querySourceLocation = () => null;
+    subscriber.sql(makeEvent({ sql: "hi mom!" }));
+    expect(mockLogger.logged("debug").length).toBe(1);
+    expect(mockLogger.logged("debug")[mockLogger.logged("debug").length - 1]).not.toMatch(/↳/);
+    (subscriber as any)._querySourceLocation = original;
+  });
+
+  it("verbose query logs disabled by default", () => {
+    subscriber.sql(makeEvent({ sql: "hi mom!" }));
+    const debugLogs = mockLogger.logged("debug");
+    for (const msg of debugLogs) {
+      expect(msg).not.toMatch(/↳/);
+    }
+  });
+
+  it("cached queries", () => {
+    subscriber.sql(makeEvent({ sql: "SELECT * FROM developers", name: "Developer Load" }));
+    subscriber.sql(
+      makeEvent({ sql: "SELECT * FROM developers", name: "Developer Load", cached: true }),
+    );
+    expect(subscriber.debugs.length).toBe(2);
+    expect(subscriber.debugs[1]).toMatch(/CACHE/);
+    expect(subscriber.debugs[1]).toMatch(/SELECT \* FROM developers/);
+  });
+
+  it("basic query doesnt log when level is not debug", () => {
+    mockLogger.level = Logger.INFO;
+    subscriber.sql(makeEvent({ sql: "SELECT * FROM developers", name: "Developer Load" }));
+    expect(mockLogger.logged("debug").length).toBe(0);
+  });
+
+  it("cached queries doesnt log when level is not debug", () => {
+    mockLogger.level = Logger.INFO;
+    subscriber.sql(makeEvent({ sql: "SELECT * FROM developers", name: "Developer Load" }));
+    subscriber.sql(
+      makeEvent({ sql: "SELECT * FROM developers", name: "Developer Load", cached: true }),
+    );
+    expect(mockLogger.logged("debug").length).toBe(0);
+  });
+
+  it("where in binds logging include attribute names", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "SELECT * FROM developers WHERE id IN (?, ?, ?)",
+        name: "Developer Load",
+        binds: [{ name: "id" }, { name: "id" }, { name: "id" }],
+        type_casted_binds: [1, 2, 3],
+      }),
+    );
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",1\]/);
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",2\]/);
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",3\]/);
+  });
+
+  it("binary data is not logged", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "INSERT INTO binaries (data) VALUES (?)",
+        name: "Binary Create",
+        binds: [
+          {
+            name: "data",
+            type: { binary: () => true },
+            value: "some binary data",
+            valueForDatabase: () => "some binary data",
+          },
+        ],
+        type_casted_binds: ["some binary data"],
+      }),
+    );
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/<16 bytes of binary data>/);
+  });
+
+  it("binary data hash", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "INSERT INTO binaries (data) VALUES (?)",
+        name: "Binary Create",
+        binds: [
+          {
+            name: "data",
+            type: { binary: () => true },
+            value: '{"a":1}',
+            valueForDatabase: () => '{"a":1}',
+          },
+        ],
+        type_casted_binds: ['{"a":1}'],
+      }),
+    );
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/<7 bytes of binary data>/);
+  });
 });
+
+function makeEvent(payload: Record<string, unknown>, durationMs = 0.9): Event {
+  const start = new Date();
+  const event = new Event("sql.active_record", start, payload);
+  // Event.duration is computed as end - start in ms.
+  // We need sub-millisecond precision, so we patch the end time directly.
+  const end = new Date(start.getTime());
+  event.finish(end);
+  // Override duration getter to return exact value
+  Object.defineProperty(event, "duration", { get: () => durationMs, configurable: true });
+  return event;
+}

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
-import { LogSubscriber } from "./log-subscriber.js";
+import { LogSubscriber, setVerboseQueryLogs } from "./log-subscriber.js";
 import {
   LogSubscriber as BaseLogSubscriber,
   NotificationEvent as Event,
@@ -72,9 +72,20 @@ class MockLogger extends Logger {
   }
 }
 
+/**
+ * Test-only subclass that captures debug output, mirroring Rails'
+ * TestDebugLogSubscriber in the test file (not production code).
+ */
 class TestDebugLogSubscriber extends LogSubscriber {
+  debugs: string[] = [];
+
   override get logger(): Logger | null {
     return (this.constructor as typeof LogSubscriber).logger;
+  }
+
+  protected override _debugSql(message: string): boolean {
+    this.debugs.push(message);
+    return super._debugSql(message);
   }
 }
 
@@ -92,7 +103,7 @@ describe("LogSubscriberTest", () => {
 
   afterEach(() => {
     LogSubscriber.logger = null;
-    LogSubscriber.verboseQueryLogs = false;
+    setVerboseQueryLogs(false);
   });
 
   it("schema statements are ignored", () => {
@@ -262,14 +273,14 @@ describe("LogSubscriberTest", () => {
   it.skip("exists query logging", () => {});
 
   it("verbose query logs", () => {
-    LogSubscriber.verboseQueryLogs = true;
+    setVerboseQueryLogs(true);
     subscriber.sql(makeEvent({ sql: "hi mom!" }));
     expect(mockLogger.logged("debug").length).toBe(2);
     expect(mockLogger.logged("debug")[mockLogger.logged("debug").length - 1]).toMatch(/↳/);
   });
 
   it("verbose query with ignored callstack", () => {
-    LogSubscriber.verboseQueryLogs = true;
+    setVerboseQueryLogs(true);
     const original = (subscriber as any)._querySourceLocation;
     (subscriber as any)._querySourceLocation = () => null;
     subscriber.sql(makeEvent({ sql: "hi mom!" }));
@@ -367,11 +378,8 @@ describe("LogSubscriberTest", () => {
 function makeEvent(payload: Record<string, unknown>, durationMs = 0.9): Event {
   const start = new Date();
   const event = new Event("sql.active_record", start, payload);
-  // Event.duration is computed as end - start in ms.
-  // We need sub-millisecond precision, so we patch the end time directly.
   const end = new Date(start.getTime());
   event.finish(end);
-  // Override duration getter to return exact value
   Object.defineProperty(event, "duration", { get: () => durationMs, configurable: true });
   return event;
 }

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -4,26 +4,35 @@ import {
   type Logger,
 } from "@blazetrails/activesupport";
 
+let _baseResolver: (() => any) | null = null;
+
+/**
+ * Set the resolver for ActiveRecord::Base, avoiding circular imports.
+ * Called from index.ts during module initialization.
+ */
+export function setBaseResolver(resolver: () => any): void {
+  _baseResolver = resolver;
+}
+
+function getBase(): any {
+  return _baseResolver?.() ?? null;
+}
+
+/** Module-level config mirroring `ActiveRecord.verbose_query_logs`. */
+let _verboseQueryLogs = false;
+export function getVerboseQueryLogs(): boolean {
+  return _verboseQueryLogs;
+}
+export function setVerboseQueryLogs(value: boolean): void {
+  _verboseQueryLogs = value;
+}
+
 /**
  * ActiveRecord::LogSubscriber — logs SQL queries with coloring, timing,
  * and bind parameter display. Mirrors Rails' ActiveRecord::LogSubscriber.
  */
 export class LogSubscriber extends BaseLogSubscriber {
   static readonly IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"];
-
-  debugs: string[] = [];
-
-  private static _verboseQueryLogs = false;
-
-  static get verboseQueryLogs(): boolean {
-    return this._verboseQueryLogs;
-  }
-
-  static set verboseQueryLogs(value: boolean) {
-    this._verboseQueryLogs = value;
-  }
-
-  // -- Event handlers ------------------------------------------------------
 
   strictLoadingViolation(event: Event): void {
     this._debug(() => {
@@ -61,15 +70,7 @@ export class LogSubscriber extends BaseLogSubscriber {
 
       for (let i = 0; i < (payload.binds as any[]).length; i++) {
         const attr = (payload.binds as any[])[i];
-        let attributeName: string | null = null;
-
-        if (attr && typeof attr.name === "string") {
-          attributeName = attr.name;
-        } else if (Array.isArray(attr) && attr[i] && typeof attr[i].name === "string") {
-          attributeName = attr[i].name;
-        }
-
-        const filteredParams = this._filter(attributeName, castedParams?.[i]);
+        const filteredParams = this._filter(this._extractAttributeName(attr, i), castedParams?.[i]);
         bindPairs.push(this._renderBind(attr, filteredParams));
       }
 
@@ -82,18 +83,23 @@ export class LogSubscriber extends BaseLogSubscriber {
       : sql;
 
     const message = `  ${colorizedName}  ${colorizedSql}${binds ?? ""}`;
-    this._doDebug(message);
+    this._debugSql(message);
+  }
+
+  override get logger(): Logger | null {
+    const B = getBase();
+    if (B?.logger) return B.logger as unknown as Logger;
+    return (this.constructor as typeof LogSubscriber).logger;
   }
 
   // -- Private helpers -----------------------------------------------------
 
-  private _doDebug(message: string): boolean {
-    this.debugs.push(message);
+  protected _debugSql(message: string): boolean {
     const l = this.logger;
     if (!l) return false;
     const result = l.debug(message);
 
-    if ((this.constructor as typeof LogSubscriber).verboseQueryLogs) {
+    if (_verboseQueryLogs) {
       this._logQuerySource();
     }
 
@@ -132,6 +138,12 @@ export class LogSubscriber extends BaseLogSubscriber {
   private _typeCastedBinds(castedBinds: unknown): any[] {
     if (typeof castedBinds === "function") return castedBinds();
     return (castedBinds as any[]) ?? [];
+  }
+
+  private _extractAttributeName(attr: any, _i: number): string | null {
+    if (attr && typeof attr.name === "string") return attr.name;
+    if (Array.isArray(attr) && attr[0] && typeof attr[0].name === "string") return attr[0].name;
+    return null;
   }
 
   private _renderBind(attr: any, value: unknown): [string | null, unknown] {
@@ -177,11 +189,18 @@ export class LogSubscriber extends BaseLogSubscriber {
     return BaseLogSubscriber.MAGENTA;
   }
 
-  override get logger(): Logger | null {
-    return (this.constructor as typeof LogSubscriber).logger;
-  }
-
-  private _filter(_name: string | null, value: unknown): unknown {
+  private _filter(name: string | null, value: unknown): unknown {
+    const B = getBase();
+    if (B && typeof B.inspectionFilter === "function") {
+      const filter = B.inspectionFilter();
+      if (filter && typeof filter.filterParam === "function") {
+        return filter.filterParam(name, value);
+      }
+    }
     return value;
   }
 }
+
+// Register log-level gates matching Rails' class-body `subscribe_log_level` calls.
+LogSubscriber.subscribeLogLevel("sql", "debug");
+LogSubscriber.subscribeLogLevel("strict_loading_violation", "debug");

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -1,0 +1,187 @@
+import {
+  LogSubscriber as BaseLogSubscriber,
+  NotificationEvent as Event,
+  type Logger,
+} from "@blazetrails/activesupport";
+
+/**
+ * ActiveRecord::LogSubscriber — logs SQL queries with coloring, timing,
+ * and bind parameter display. Mirrors Rails' ActiveRecord::LogSubscriber.
+ */
+export class LogSubscriber extends BaseLogSubscriber {
+  static readonly IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"];
+
+  debugs: string[] = [];
+
+  private static _verboseQueryLogs = false;
+
+  static get verboseQueryLogs(): boolean {
+    return this._verboseQueryLogs;
+  }
+
+  static set verboseQueryLogs(value: boolean) {
+    this._verboseQueryLogs = value;
+  }
+
+  // -- Event handlers ------------------------------------------------------
+
+  strictLoadingViolation(event: Event): void {
+    this._debug(() => {
+      const owner = event.payload.owner;
+      const reflection = event.payload.reflection as any;
+      return this.color(reflection.strictLoadingViolationMessage(owner), BaseLogSubscriber.RED);
+    });
+  }
+
+  sql(event: Event): void {
+    const payload = event.payload;
+
+    if (LogSubscriber.IGNORE_PAYLOAD_NAMES.includes(payload.name as string)) return;
+
+    let name: string;
+    if (payload.async) {
+      const lockWait = Number(payload.lock_wait ?? payload.lockWait ?? 0);
+      name = `ASYNC ${payload.name ?? ""} (${lockWait.toFixed(1)}ms) (db time ${event.duration.toFixed(1)}ms)`;
+    } else {
+      name = `${payload.name ?? ""} (${event.duration.toFixed(1)}ms)`;
+    }
+
+    if (payload.cached) {
+      name = `CACHE ${name}`;
+    }
+
+    const sql = payload.sql as string;
+    let binds: string | null = null;
+
+    if (payload.binds && Array.isArray(payload.binds) && payload.binds.length > 0) {
+      const castedParams = this._typeCastedBinds(
+        payload.type_casted_binds ?? payload.typeCastedBinds,
+      );
+      const bindPairs: [string | null, unknown][] = [];
+
+      for (let i = 0; i < (payload.binds as any[]).length; i++) {
+        const attr = (payload.binds as any[])[i];
+        let attributeName: string | null = null;
+
+        if (attr && typeof attr.name === "string") {
+          attributeName = attr.name;
+        } else if (Array.isArray(attr) && attr[i] && typeof attr[i].name === "string") {
+          attributeName = attr[i].name;
+        }
+
+        const filteredParams = this._filter(attributeName, castedParams?.[i]);
+        bindPairs.push(this._renderBind(attr, filteredParams));
+      }
+
+      binds = `  ${JSON.stringify(bindPairs)}`;
+    }
+
+    const colorizedName = this._colorizePayloadName(name, payload.name as string | undefined);
+    const colorizedSql = this.colorizeLogging
+      ? this.color(sql, this._sqlColor(sql), { bold: true })
+      : sql;
+
+    const message = `  ${colorizedName}  ${colorizedSql}${binds ?? ""}`;
+    this._doDebug(message);
+  }
+
+  // -- Private helpers -----------------------------------------------------
+
+  private _doDebug(message: string): boolean {
+    this.debugs.push(message);
+    const l = this.logger;
+    if (!l) return false;
+    const result = l.debug(message);
+
+    if ((this.constructor as typeof LogSubscriber).verboseQueryLogs) {
+      this._logQuerySource();
+    }
+
+    return result;
+  }
+
+  private _logQuerySource(): void {
+    const source = this._querySourceLocation();
+    if (source) {
+      const l = this.logger;
+      if (l) l.debug(`  ↳ ${source}`);
+    }
+  }
+
+  protected _querySourceLocation(): string | null {
+    try {
+      const err = new Error();
+      const stack = err.stack?.split("\n") ?? [];
+      for (const line of stack.slice(2)) {
+        const trimmed = line.trim();
+        if (
+          !trimmed.includes("log-subscriber") &&
+          !trimmed.includes("LogSubscriber") &&
+          !trimmed.includes("notifications") &&
+          !trimmed.includes("node_modules")
+        ) {
+          return trimmed.replace(/^at\s+/, "");
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
+  private _typeCastedBinds(castedBinds: unknown): any[] {
+    if (typeof castedBinds === "function") return castedBinds();
+    return (castedBinds as any[]) ?? [];
+  }
+
+  private _renderBind(attr: any, value: unknown): [string | null, unknown] {
+    // ActiveModel::Attribute — has type and value properties
+    if (attr && typeof attr === "object" && "type" in attr && "value" in attr) {
+      if (attr.type?.binary?.() && attr.value != null) {
+        const bytes =
+          typeof attr.valueForDatabase === "function"
+            ? String(attr.valueForDatabase()).length
+            : String(attr.value).length;
+        value = `<${bytes} bytes of binary data>`;
+      }
+      return [attr.name ?? null, value];
+    }
+
+    if (Array.isArray(attr)) {
+      return [attr[0]?.name ?? null, value];
+    }
+
+    // Simple object with .name (e.g. query attribute descriptor)
+    if (attr && typeof attr === "object" && typeof attr.name === "string") {
+      return [attr.name, value];
+    }
+
+    return [null, value];
+  }
+
+  private _colorizePayloadName(name: string, payloadName: string | undefined): string {
+    if (!payloadName || payloadName === "" || payloadName === "SQL") {
+      return this.color(name, BaseLogSubscriber.MAGENTA, { bold: true });
+    }
+    return this.color(name, BaseLogSubscriber.CYAN, { bold: true });
+  }
+
+  private _sqlColor(sql: string): string {
+    if (/^\s*rollback/im.test(sql)) return BaseLogSubscriber.RED;
+    if (/select .*for update/im.test(sql) || /^\s*lock/im.test(sql)) return BaseLogSubscriber.WHITE;
+    if (/^\s*select/i.test(sql)) return BaseLogSubscriber.BLUE;
+    if (/^\s*insert/i.test(sql)) return BaseLogSubscriber.GREEN;
+    if (/^\s*update/i.test(sql)) return BaseLogSubscriber.YELLOW;
+    if (/^\s*delete/i.test(sql)) return BaseLogSubscriber.RED;
+    if (/transaction\s*$/i.test(sql)) return BaseLogSubscriber.CYAN;
+    return BaseLogSubscriber.MAGENTA;
+  }
+
+  override get logger(): Logger | null {
+    return (this.constructor as typeof LogSubscriber).logger;
+  }
+
+  private _filter(_name: string | null, value: unknown): unknown {
+    return value;
+  }
+}

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -208,7 +208,8 @@ export class LogSubscriber extends BaseLogSubscriber {
 
   private _sqlColor(sql: string): string {
     if (/^\s*rollback/im.test(sql)) return BaseLogSubscriber.RED;
-    if (/select .*for update/im.test(sql) || /^\s*lock/im.test(sql)) return BaseLogSubscriber.WHITE;
+    if (/select .*for update/ims.test(sql) || /^\s*lock/im.test(sql))
+      return BaseLogSubscriber.WHITE;
     if (/^\s*select/i.test(sql)) return BaseLogSubscriber.BLUE;
     if (/^\s*insert/i.test(sql)) return BaseLogSubscriber.GREEN;
     if (/^\s*update/i.test(sql)) return BaseLogSubscriber.YELLOW;

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -114,8 +114,10 @@ export class LogSubscriber extends BaseLogSubscriber {
   }
 
   override get logger(): Logger | null {
+    // Rails: `def logger; ActiveRecord::Base.logger; end`
+    // Returns Base.logger directly — null means logging disabled.
     const B = getBase();
-    if (B?.logger) return B.logger as unknown as Logger;
+    if (B && "logger" in B) return B.logger as Logger | null;
     return (this.constructor as typeof LogSubscriber).logger;
   }
 

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -4,6 +4,33 @@ import {
   type Logger,
 } from "@blazetrails/activesupport";
 
+/**
+ * Compute byte length of a value, mirroring Rails' `to_s.bytesize`.
+ * Handles strings, Buffers, TypedArrays, and falls back to string conversion.
+ */
+function byteLength(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === "string") {
+    return typeof Buffer !== "undefined"
+      ? Buffer.byteLength(value)
+      : new TextEncoder().encode(value).length;
+  }
+  if (typeof ArrayBuffer !== "undefined") {
+    if (value instanceof ArrayBuffer) return value.byteLength;
+    if (ArrayBuffer.isView(value)) return value.byteLength;
+  }
+  if (typeof (value as any).byteLength === "number") return (value as any).byteLength;
+  return byteLength(String(value));
+}
+
+/**
+ * JSON.stringify that handles bigint values (converts to string)
+ * so logging never throws on valid bind values.
+ */
+function safeJsonStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, v) => (typeof v === "bigint" ? v.toString() : v));
+}
+
 let _baseResolver: (() => any) | null = null;
 
 /**
@@ -74,7 +101,7 @@ export class LogSubscriber extends BaseLogSubscriber {
         bindPairs.push(this._renderBind(attr, filteredParams));
       }
 
-      binds = `  ${JSON.stringify(bindPairs)}`;
+      binds = `  ${safeJsonStringify(bindPairs)}`;
     }
 
     const colorizedName = this._colorizePayloadName(name, payload.name as string | undefined);
@@ -150,10 +177,9 @@ export class LogSubscriber extends BaseLogSubscriber {
     // ActiveModel::Attribute — has type and value properties
     if (attr && typeof attr === "object" && "type" in attr && "value" in attr) {
       if (attr.type?.binary?.() && attr.value != null) {
-        const bytes =
-          typeof attr.valueForDatabase === "function"
-            ? String(attr.valueForDatabase()).length
-            : String(attr.value).length;
+        const raw =
+          typeof attr.valueForDatabase === "function" ? attr.valueForDatabase() : attr.value;
+        const bytes = byteLength(raw);
         value = `<${bytes} bytes of binary data>`;
       }
       return [attr.name ?? null, value];

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -250,6 +250,8 @@ export type { ClassAttributeOptions } from "./class-attribute.js";
 export { Logger, taggedLogging, SimpleFormatter } from "./logger.js";
 export { BroadcastLogger } from "./broadcast-logger.js";
 export type { LogLevel, LoggerOutput, TaggedLogger } from "./logger.js";
+export { Subscriber } from "./subscriber.js";
+export { LogSubscriber } from "./log-subscriber.js";
 
 export { MemoryStore } from "./cache/memory-store.js";
 export { DupCoder } from "./cache/memory-store.js";

--- a/packages/activesupport/src/log-subscriber.test.ts
+++ b/packages/activesupport/src/log-subscriber.test.ts
@@ -1,19 +1,259 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { Notifications } from "./notifications.js";
+import { LogSubscriber } from "./log-subscriber.js";
+import { Logger } from "./logger.js";
+import type { Event } from "./notifications/instrumenter.js";
+
+class MockLogger extends Logger {
+  private _logged: Record<string, string[]> = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+    fatal: [],
+    unknown: [],
+  };
+  flushCount = 0;
+
+  constructor() {
+    super(null);
+  }
+
+  logged(level: string): string[] {
+    return this._logged[level] ?? [];
+  }
+
+  override debug(message?: string | (() => string)): boolean {
+    if (this.level > Logger.DEBUG) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.debug.push(msg);
+    return true;
+  }
+
+  override info(message?: string | (() => string)): boolean {
+    if (this.level > Logger.INFO) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.info.push(msg);
+    return true;
+  }
+
+  override warn(message?: string | (() => string)): boolean {
+    if (this.level > Logger.WARN) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.warn.push(msg);
+    return true;
+  }
+
+  override error(message?: string | (() => string)): boolean {
+    if (this.level > Logger.ERROR) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.error.push(msg);
+    return true;
+  }
+
+  override fatal(message?: string | (() => string)): boolean {
+    if (this.level > Logger.FATAL) return true;
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.fatal.push(msg);
+    return true;
+  }
+
+  override unknown(message?: string | (() => string)): boolean {
+    const msg = typeof message === "function" ? message() : (message ?? "");
+    this._logged.unknown.push(msg);
+    return true;
+  }
+
+  flush(): void {
+    this.flushCount++;
+  }
+}
+
+class MyLogSubscriber extends LogSubscriber {
+  event: Event | null = null;
+
+  someEvent(event: Event): void {
+    this.event = event;
+    this._info(event.name);
+  }
+
+  foo(_event: Event | null): void {
+    this._debug("debug");
+    this._info(() => "info");
+    this._warn("warn");
+  }
+
+  bar(_event: Event | null): void {
+    this._info(`${this.color("cool", "red")}, ${this.color("isn't it?", "blue", { bold: true })}`);
+  }
+
+  baz(_event: Event | null): void {
+    this._info(
+      `${this.color("rad", "green", { bold: true, underline: true })}, ${this.color("isn't it?", "yellow", { italic: true })}`,
+    );
+  }
+
+  puke(_event: Event | null): void {
+    throw new Error("puke");
+  }
+
+  debugOnly(_event: Event | null): void {
+    this._debug("debug logs are enabled");
+  }
+}
 
 describe("SyncLogSubscriberTest", () => {
-  it.skip("proxies method to rails logger");
-  it.skip("set color for messages");
-  it.skip("set mode for messages");
-  it.skip("does not set color if colorize logging is set to false");
-  it.skip("event is sent to the registered class");
-  it.skip("event is an active support notifications event");
-  it.skip("event attributes");
-  it.skip("does not send the event if it doesnt match the class");
-  it.skip("does not send the event if logger is nil");
-  it.skip("does not fail with non namespaced events");
-  it.skip("flushes loggers");
-  it.skip("flushes the same logger just once");
-  it.skip("logging does not die on failures");
-  it.skip("subscribe log level");
-  it.skip("subscribe log level with non numeric levels");
+  let logger: MockLogger;
+  let logSubscriber: MyLogSubscriber;
+
+  beforeEach(() => {
+    logger = new MockLogger();
+    logSubscriber = new MyLogSubscriber();
+    LogSubscriber.logger = logger;
+    LogSubscriber.colorizeLogging = false;
+  });
+
+  afterEach(() => {
+    const subs = LogSubscriber.subscribers;
+    while (subs.length > 0) {
+      const sub = subs.pop()!;
+      for (const [, handle] of sub.patterns) {
+        Notifications.unsubscribe(handle);
+      }
+    }
+    LogSubscriber.logger = null;
+    LogSubscriber.logLevels.clear();
+    Notifications.unsubscribeAll();
+  });
+
+  it("proxies method to rails logger", () => {
+    logSubscriber.foo(null);
+    expect(logger.logged("debug")).toEqual(["debug"]);
+    expect(logger.logged("info")).toEqual(["info"]);
+    expect(logger.logged("warn")).toEqual(["warn"]);
+  });
+
+  it("set color for messages", () => {
+    LogSubscriber.colorizeLogging = true;
+    logSubscriber.bar(null);
+    expect(logger.logged("info")[logger.logged("info").length - 1]).toBe(
+      "\x1b[31mcool\x1b[0m, \x1b[1m\x1b[34misn't it?\x1b[0m",
+    );
+  });
+
+  it("set mode for messages", () => {
+    LogSubscriber.colorizeLogging = true;
+    logSubscriber.baz(null);
+    expect(logger.logged("info")[logger.logged("info").length - 1]).toBe(
+      "\x1b[1;4m\x1b[32mrad\x1b[0m, \x1b[3m\x1b[33misn't it?\x1b[0m",
+    );
+  });
+
+  it("does not set color if colorize logging is set to false", () => {
+    logSubscriber.bar(null);
+    expect(logger.logged("info")[logger.logged("info").length - 1]).toBe("cool, isn't it?");
+  });
+
+  it("event is sent to the registered class", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    Notifications.instrument("some_event.my_log_subscriber");
+    expect(logger.logged("info")).toEqual(["some_event.my_log_subscriber"]);
+  });
+
+  it("event is an active support notifications event", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    Notifications.instrument("some_event.my_log_subscriber");
+    expect(logSubscriber.event).toBeDefined();
+    expect(logSubscriber.event!.name).toBe("some_event.my_log_subscriber");
+    expect(logSubscriber.event!.duration).toBeDefined();
+  });
+
+  it("event attributes", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    Notifications.instrument("some_event.my_log_subscriber", {}, () => {
+      return [];
+    });
+    const event = logSubscriber.event!;
+    expect(event.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not send the event if it doesnt match the class", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    expect(() => {
+      Notifications.instrument("unknown_event.my_log_subscriber");
+    }).not.toThrow();
+  });
+
+  it("does not send the event if logger is nil", () => {
+    LogSubscriber.logger = null;
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    Notifications.instrument("some_event.my_log_subscriber");
+    expect(logSubscriber.event).toBeNull();
+  });
+
+  it("does not fail with non namespaced events", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    expect(() => {
+      Notifications.instrument("whatever");
+    }).not.toThrow();
+  });
+
+  it("flushes loggers", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    LogSubscriber.flushAll();
+    expect(logger.flushCount).toBe(1);
+  });
+
+  it("flushes the same logger just once", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    LogSubscriber.flushAll();
+    expect(logger.flushCount).toBe(1);
+  });
+
+  it("logging does not die on failures", () => {
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    Notifications.instrument("puke.my_log_subscriber");
+    Notifications.instrument("some_event.my_log_subscriber");
+
+    expect(logger.logged("info").length).toBe(1);
+    expect(logger.logged("info")[0]).toBe("some_event.my_log_subscriber");
+
+    expect(logger.logged("error").length).toBe(1);
+    expect(logger.logged("error")[0]).toMatch(
+      /Could not log "puke.my_log_subscriber" event\. Error: puke/,
+    );
+  });
+
+  it("subscribe log level", () => {
+    MyLogSubscriber.logger = logger;
+    logger.level = Logger.INFO;
+    MyLogSubscriber.subscribeLogLevel("debug_only", "debug");
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    expect(logger.logged("debug")).toEqual([]);
+
+    Notifications.instrument("debug_only.my_log_subscriber");
+    expect(logger.logged("debug")).toEqual([]);
+
+    logger.level = Logger.DEBUG;
+    Notifications.instrument("debug_only.my_log_subscriber");
+    expect(logger.logged("debug").length).toBeGreaterThan(0);
+  });
+
+  it("subscribe log level with non numeric levels", () => {
+    const semanticLogger = new MockLogger();
+    LogSubscriber.logger = semanticLogger;
+    MyLogSubscriber.logger = semanticLogger;
+    semanticLogger.level = Logger.INFO;
+    MyLogSubscriber.subscribeLogLevel("debug_only", "debug");
+    MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
+    expect(semanticLogger.logged("debug")).toEqual([]);
+
+    Notifications.instrument("debug_only.my_log_subscriber");
+    expect(semanticLogger.logged("debug")).toEqual([]);
+
+    semanticLogger.level = Logger.DEBUG;
+    Notifications.instrument("debug_only.my_log_subscriber");
+    expect(semanticLogger.logged("debug").length).toBeGreaterThan(0);
+  });
 });

--- a/packages/activesupport/src/log-subscriber.test.ts
+++ b/packages/activesupport/src/log-subscriber.test.ts
@@ -201,13 +201,13 @@ describe("SyncLogSubscriberTest", () => {
 
   it("flushes loggers", () => {
     MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
-    LogSubscriber.flushAll();
+    LogSubscriber.flushAllBang();
     expect(logger.flushCount).toBe(1);
   });
 
   it("flushes the same logger just once", () => {
     MyLogSubscriber.attachTo("my_log_subscriber", logSubscriber);
-    LogSubscriber.flushAll();
+    LogSubscriber.flushAllBang();
     expect(logger.flushCount).toBe(1);
   });
 

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -103,7 +103,7 @@ export class LogSubscriber extends Subscriber {
     return this.subscribers;
   }
 
-  static flushAll(): void {
+  static flushAllBang(): void {
     const l = this.logger;
     if (l && typeof (l as any).flush === "function") {
       (l as any).flush();

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -32,8 +32,21 @@ export class LogSubscriber extends Subscriber {
 
   static colorizeLogging = true;
 
-  /** Map of method → level-check function (set via subscribeLogLevel). */
-  static logLevels: Map<string, (logger: Logger) => boolean> = new Map();
+  /**
+   * Per-class map of method → level-check function.
+   * Uses class_attribute semantics: each subclass gets its own copy
+   * when subscribeLogLevel is called, so AR LogSubscriber's levels
+   * don't bleed into ActionController LogSubscriber's levels.
+   */
+  static get logLevels(): Map<string, (logger: Logger) => boolean> {
+    const state = getClassState(this) as any;
+    if (!state._logLevels) state._logLevels = new Map();
+    return state._logLevels;
+  }
+
+  static set logLevels(value: Map<string, (logger: Logger) => boolean>) {
+    (getClassState(this) as any)._logLevels = value;
+  }
 
   static readonly LEVEL_CHECKS: Record<string, (logger: Logger) => boolean> = {
     debug: (logger) => !(logger as any)["debug?"],
@@ -120,17 +133,16 @@ export class LogSubscriber extends Subscriber {
   }
 
   private static _setEventLevels(): void {
-    if (this.subscribers.length === 0) return;
-    const namespace = getClassState(this).namespace;
+    // Rails: `subscriber.event_levels = log_levels.transform_keys { |k| "#{k}.#{namespace}" }`
+    // Only updates the subscriber from the most recent attachTo call.
+    const state = getClassState(this);
+    const sub = state.subscriber as LogSubscriber | undefined;
+    if (!sub) return;
     const levels = new Map<string, (logger: Logger) => boolean>();
     for (const [k, v] of this.logLevels) {
-      levels.set(`${k}.${namespace}`, v);
+      levels.set(`${k}.${state.namespace}`, v);
     }
-    for (const sub of this.subscribers) {
-      if (sub instanceof LogSubscriber) {
-        sub.eventLevels = new Map(levels);
-      }
-    }
+    sub.eventLevels = levels;
   }
 
   // -- Instance state ------------------------------------------------------

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -147,6 +147,7 @@ export class LogSubscriber extends Subscriber {
       for (const key of Object.getOwnPropertyNames(proto)) {
         if (
           key !== "constructor" &&
+          !key.startsWith("_") &&
           !baseKeys.has(key) &&
           typeof (subscriber as any)[key] === "function"
         ) {

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -68,7 +68,14 @@ export class LogSubscriber extends Subscriber {
    */
   static get logLevels(): Map<string, (logger: Logger) => boolean> {
     const state = getClassState(this) as any;
-    if (!state._logLevels) state._logLevels = new Map();
+    if (!state._logLevels) {
+      // class_attribute semantics: inherit parent's levels on first access
+      const parent = Object.getPrototypeOf(this) as typeof LogSubscriber | undefined;
+      state._logLevels =
+        parent && typeof parent === "function" && "logLevels" in parent
+          ? new Map(parent.logLevels)
+          : new Map();
+    }
     return state._logLevels;
   }
 

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -3,6 +3,34 @@ import type { Event } from "./notifications/instrumenter.js";
 import type { Logger } from "./logger.js";
 
 /**
+ * Check whether a logger has a given level enabled.
+ * Rails' LEVEL_CHECKS call `logger.debug?`, `logger.info?`, etc.
+ * Our Logger class defines these as getter properties (`get "debug?"()`),
+ * but Base.logger can be a simple duck-typed object without them.
+ * Treat missing predicates as "enabled" (not silenced) so logging
+ * isn't suppressed for valid loggers that lack ActiveSupport predicates.
+ */
+function isLevelEnabled(logger: Logger, level: string): boolean {
+  // Try Rails-style predicate getter: `debug?`, `info?`, etc.
+  const predicate = (logger as any)[`${level}?`];
+  if (typeof predicate === "boolean") return predicate;
+
+  // Try camelCase flag: `debugEnabled`, `infoEnabled`, etc.
+  const flag = (logger as any)[`${level}Enabled`];
+  if (typeof flag === "boolean") return flag;
+
+  // Try numeric level comparison (Logger.DEBUG=0, INFO=1, etc.)
+  if (typeof (logger as any).level === "number") {
+    const priorities: Record<string, number> = { debug: 0, info: 1, warn: 2, error: 3, fatal: 4 };
+    const required = priorities[level];
+    if (required !== undefined) return (logger as any).level <= required;
+  }
+
+  // No way to tell — assume enabled (don't suppress logging)
+  return true;
+}
+
+/**
  * ActiveSupport::LogSubscriber — a Subscriber that dispatches events
  * to a logger. Provides ANSI coloring helpers and log-level gating.
  *
@@ -49,9 +77,9 @@ export class LogSubscriber extends Subscriber {
   }
 
   static readonly LEVEL_CHECKS: Record<string, (logger: Logger) => boolean> = {
-    debug: (logger) => !(logger as any)["debug?"],
-    info: (logger) => !(logger as any)["info?"],
-    error: (logger) => !(logger as any)["error?"],
+    debug: (logger) => !isLevelEnabled(logger, "debug"),
+    info: (logger) => !isLevelEnabled(logger, "info"),
+    error: (logger) => !isLevelEnabled(logger, "error"),
   };
 
   private static _logger: Logger | null = null;

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -1,0 +1,233 @@
+import { Subscriber } from "./subscriber.js";
+import type { Event } from "./notifications/instrumenter.js";
+import type { Logger } from "./logger.js";
+
+/**
+ * ActiveSupport::LogSubscriber — a Subscriber that dispatches events
+ * to a logger. Provides ANSI coloring helpers and log-level gating.
+ *
+ * Subclasses define methods like `sql(event)` and call `info()`/`debug()`
+ * from them. `attachTo` wires up the subscription.
+ */
+export class LogSubscriber extends Subscriber {
+  // -- ANSI color constants ------------------------------------------------
+
+  static readonly MODES: Record<string, number> = {
+    clear: 0,
+    bold: 1,
+    italic: 3,
+    underline: 4,
+  };
+
+  static readonly BLACK = "\x1b[30m";
+  static readonly RED = "\x1b[31m";
+  static readonly GREEN = "\x1b[32m";
+  static readonly YELLOW = "\x1b[33m";
+  static readonly BLUE = "\x1b[34m";
+  static readonly MAGENTA = "\x1b[35m";
+  static readonly CYAN = "\x1b[36m";
+  static readonly WHITE = "\x1b[37m";
+
+  // -- Class-level config --------------------------------------------------
+
+  static colorizeLogging = true;
+
+  /** Map of method → level-check function (set via subscribeLogLevel). */
+  static logLevels: Map<string, (logger: Logger) => boolean> = new Map();
+
+  static readonly LEVEL_CHECKS: Record<string, (logger: Logger) => boolean> = {
+    debug: (logger) => !(logger as any)["debug?"],
+    info: (logger) => !(logger as any)["info?"],
+    error: (logger) => !(logger as any)["error?"],
+  };
+
+  private static _logger: Logger | null = null;
+
+  static get logger(): Logger | null {
+    return this._logger;
+  }
+
+  static set logger(value: Logger | null) {
+    this._logger = value;
+  }
+
+  static logSubscribers(): Subscriber[] {
+    return this.subscribers;
+  }
+
+  static flushAll(): void {
+    const l = this.logger;
+    if (l && typeof (l as any).flush === "function") {
+      (l as any).flush();
+    }
+  }
+
+  static attachTo(
+    namespace: string,
+    subscriber?: Subscriber,
+    notifier?: any,
+    options?: { inheritAll?: boolean },
+  ): Subscriber {
+    const result = super.attachTo(namespace, subscriber, notifier, options);
+    this._setEventLevels();
+    return result;
+  }
+
+  /**
+   * Register a log-level gate for a method. When the logger level is above
+   * the gate, events for that method are silenced.
+   */
+  static subscribeLogLevel(method: string, level: string): void {
+    const check = this.LEVEL_CHECKS[level];
+    if (!check) throw new Error(`Unknown level check: ${level}`);
+    this.logLevels.set(method, check);
+    this._setEventLevels();
+  }
+
+  private static _setEventLevels(): void {
+    const sub = this.subscribers[this.subscribers.length - 1] as LogSubscriber | undefined;
+    if (!sub) return;
+    const namespace = (this as any)._namespace;
+    const levels = new Map<string, (logger: Logger) => boolean>();
+    for (const [k, v] of this.logLevels) {
+      levels.set(`${k}.${namespace}`, v);
+    }
+    sub.eventLevels = levels;
+  }
+
+  protected static override _fetchPublicMethods(
+    subscriber: Subscriber,
+    _inheritAll: boolean,
+  ): string[] {
+    const baseKeys = new Set(Object.getOwnPropertyNames(LogSubscriber.prototype));
+    const proto = Object.getPrototypeOf(subscriber);
+    const keys = Object.getOwnPropertyNames(proto).filter(
+      (k) =>
+        k !== "constructor" && !baseKeys.has(k) && typeof (subscriber as any)[k] === "function",
+    );
+    // Convert camelCase to snake_case for event pattern matching
+    return keys.map((k) => k.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase());
+  }
+
+  // -- Instance state ------------------------------------------------------
+
+  eventLevels: Map<string, (logger: Logger) => boolean> = new Map();
+
+  get logger(): Logger | null {
+    return (this.constructor as typeof LogSubscriber).logger;
+  }
+
+  get colorizeLogging(): boolean {
+    return (this.constructor as typeof LogSubscriber).colorizeLogging;
+  }
+
+  set colorizeLogging(value: boolean) {
+    (this.constructor as typeof LogSubscriber).colorizeLogging = value;
+  }
+
+  silenced(event: Event | string): boolean {
+    const l = this.logger;
+    if (!l) return true;
+    const name = typeof event === "string" ? event : event.name;
+    const check = this.eventLevels.get(name);
+    return check ? check(l) : false;
+  }
+
+  override call(event: Event): void {
+    if (!this.logger) return;
+    if (this.silenced(event)) return;
+    try {
+      super.call(event);
+    } catch (e: any) {
+      this._logException(event.name, e);
+    }
+  }
+
+  override publishEvent(event: Event): void {
+    if (!this.logger) return;
+    if (this.silenced(event)) return;
+    try {
+      super.publishEvent(event);
+    } catch (e: any) {
+      this._logException(event.name, e);
+    }
+  }
+
+  // -- Logging helpers (instance, proxied to logger) -----------------------
+
+  protected _info(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.info(message);
+  }
+
+  protected _debug(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.debug(message);
+  }
+
+  protected _warn(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.warn(message);
+  }
+
+  protected _error(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.error(message);
+  }
+
+  protected _fatal(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.fatal(message);
+  }
+
+  protected _unknown(message?: string | (() => string)): boolean {
+    const l = this.logger;
+    if (!l) return false;
+    return l.unknown(message);
+  }
+
+  // -- Color helper --------------------------------------------------------
+
+  protected color(
+    text: string,
+    colorValue: string | symbol,
+    modeOptions: Record<string, boolean> = {},
+  ): string {
+    if (!this.colorizeLogging) return text;
+    let c: string;
+    if (typeof colorValue === "string" && colorValue.startsWith("\x1b")) {
+      c = colorValue;
+    } else {
+      const name = String(colorValue).toUpperCase();
+      c = (this.constructor as any)[name] ?? "";
+    }
+    const mode = this._modeFrom(modeOptions);
+    const clear = `\x1b[${LogSubscriber.MODES.clear}m`;
+    return `${mode}${c}${text}${clear}`;
+  }
+
+  private _modeFrom(options: Record<string, boolean>): string {
+    const modes: number[] = [];
+    for (const [key, val] of Object.entries(options)) {
+      if (val && LogSubscriber.MODES[key] !== undefined) {
+        modes.push(LogSubscriber.MODES[key]);
+      }
+    }
+    if (modes.length === 0) return "";
+    return `\x1b[${modes.join(";")}m`;
+  }
+
+  private _logException(name: string, e: Error): void {
+    const l = this.logger;
+    if (l) {
+      l.error(
+        `Could not log ${JSON.stringify(name)} event. ${e.constructor.name}: ${e.message} ${e.stack}`,
+      );
+    }
+  }
+}

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -1,4 +1,4 @@
-import { Subscriber } from "./subscriber.js";
+import { Subscriber, getClassState } from "./subscriber.js";
 import type { Event } from "./notifications/instrumenter.js";
 import type { Logger } from "./logger.js";
 
@@ -84,29 +84,53 @@ export class LogSubscriber extends Subscriber {
     this._setEventLevels();
   }
 
+  protected static override _fetchPublicMethods(
+    subscriber: Subscriber,
+    inheritAll: boolean,
+  ): string[] {
+    // Exclude LogSubscriber's own instance methods, matching Rails'
+    // `subscriber.public_methods(inherit_all) - LogSubscriber.public_instance_methods(true)`
+    const baseKeys = new Set([
+      ...Object.getOwnPropertyNames(Subscriber.prototype),
+      ...Object.getOwnPropertyNames(LogSubscriber.prototype),
+    ]);
+    const keys = new Set<string>();
+    let proto = Object.getPrototypeOf(subscriber);
+
+    while (
+      proto &&
+      proto !== LogSubscriber.prototype &&
+      proto !== Subscriber.prototype &&
+      proto !== Object.prototype
+    ) {
+      for (const key of Object.getOwnPropertyNames(proto)) {
+        if (
+          key !== "constructor" &&
+          !baseKeys.has(key) &&
+          typeof (subscriber as any)[key] === "function"
+        ) {
+          keys.add(key);
+        }
+      }
+      if (!inheritAll) break;
+      proto = Object.getPrototypeOf(proto);
+    }
+
+    return Array.from(keys).map((k) => k.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase());
+  }
+
   private static _setEventLevels(): void {
-    const sub = this.subscribers[this.subscribers.length - 1] as LogSubscriber | undefined;
-    if (!sub) return;
-    const namespace = (this as any)._namespace;
+    if (this.subscribers.length === 0) return;
+    const namespace = getClassState(this).namespace;
     const levels = new Map<string, (logger: Logger) => boolean>();
     for (const [k, v] of this.logLevels) {
       levels.set(`${k}.${namespace}`, v);
     }
-    sub.eventLevels = levels;
-  }
-
-  protected static override _fetchPublicMethods(
-    subscriber: Subscriber,
-    _inheritAll: boolean,
-  ): string[] {
-    const baseKeys = new Set(Object.getOwnPropertyNames(LogSubscriber.prototype));
-    const proto = Object.getPrototypeOf(subscriber);
-    const keys = Object.getOwnPropertyNames(proto).filter(
-      (k) =>
-        k !== "constructor" && !baseKeys.has(k) && typeof (subscriber as any)[k] === "function",
-    );
-    // Convert camelCase to snake_case for event pattern matching
-    return keys.map((k) => k.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase());
+    for (const sub of this.subscribers) {
+      if (sub instanceof LogSubscriber) {
+        sub.eventLevels = new Map(levels);
+      }
+    }
   }
 
   // -- Instance state ------------------------------------------------------

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -11,6 +11,34 @@ function camelCase(str: string): string {
 }
 
 /**
+ * Per-class state storage. In Rails, `@namespace`, `@subscriber`, `@notifier`
+ * are instance variables on the class (per-class), while `@@subscribers` is a
+ * class variable (shared). We mirror this with a WeakMap for per-class state
+ * and a shared array for subscribers.
+ */
+interface ClassState {
+  namespace?: string;
+  subscriber?: Subscriber;
+  notifier?: typeof Notifications;
+}
+
+const _classState = new WeakMap<Function, ClassState>();
+
+/** @internal Exposed for LogSubscriber to read per-class namespace. */
+export function getClassState(cls: Function): ClassState {
+  return getState(cls);
+}
+
+function getState(cls: Function): ClassState {
+  let state = _classState.get(cls);
+  if (!state) {
+    state = {};
+    _classState.set(cls, state);
+  }
+  return state;
+}
+
+/**
  * ActiveSupport::Subscriber — base class for notification consumers.
  *
  * Subclasses define instance methods matching event prefixes (e.g. `sql`
@@ -21,12 +49,8 @@ export class Subscriber {
   /** Per-instance map of pattern → Notifications subscriber handle. */
   patterns: Map<string, NotificationSubscriber> = new Map();
 
-  // -- Class-level state (static) ------------------------------------------
-
+  // Shared across all subclasses, matching Rails' @@subscribers class variable.
   private static _subscribers: Subscriber[] = [];
-  private static _namespace: string | undefined;
-  private static _subscriber: Subscriber | undefined;
-  private static _notifier: typeof Notifications | undefined;
 
   static get subscribers(): Subscriber[] {
     return this._subscribers;
@@ -44,15 +68,16 @@ export class Subscriber {
     options?: { inheritAll?: boolean },
   ): Subscriber {
     const sub = subscriber ?? new (this as any)();
-    this._namespace = namespace;
-    this._subscriber = sub;
-    this._notifier = notifier;
+    const state = getState(this);
+    state.namespace = namespace;
+    state.subscriber = sub;
+    state.notifier = notifier;
 
     this._subscribers.push(sub);
 
     const methods = this._fetchPublicMethods(sub, options?.inheritAll ?? false);
     for (const event of methods) {
-      this._addEventSubscriber(event);
+      this._addEventSubscriber(event, state);
     }
 
     return sub;
@@ -60,20 +85,21 @@ export class Subscriber {
 
   /** Detach a subscriber from its namespace. */
   static detachFrom(namespace: string, notifier: typeof Notifications = Notifications): void {
-    this._namespace = namespace;
-    this._notifier = notifier;
+    const state = getState(this);
+    state.namespace = namespace;
+    state.notifier = notifier;
     const sub = this._subscribers.find((s) => s instanceof this);
     if (!sub) return;
 
-    this._subscriber = sub;
+    state.subscriber = sub;
     const idx = this._subscribers.indexOf(sub);
     if (idx !== -1) this._subscribers.splice(idx, 1);
 
     const methods = this._fetchPublicMethods(sub, true);
     for (const event of methods) {
-      this._removeEventSubscriber(event);
+      this._removeEventSubscriber(event, state);
     }
-    this._notifier = undefined;
+    state.notifier = undefined;
   }
 
   // -- Instance methods ----------------------------------------------------
@@ -112,15 +138,11 @@ export class Subscriber {
     return event === "start" || event === "finish";
   }
 
-  private static _preparePattern(event: string): string {
-    return `${event}.${this._namespace}`;
-  }
-
-  private static _addEventSubscriber(event: string): void {
+  private static _addEventSubscriber(event: string, state: ClassState): void {
     if (this._invalidEvent(event)) return;
-    const sub = this._subscriber!;
-    const notifier = this._notifier!;
-    const pattern = this._preparePattern(event);
+    const sub = state.subscriber!;
+    const notifier = state.notifier!;
+    const pattern = `${event}.${state.namespace}`;
 
     if (sub.patterns.has(pattern)) return;
 
@@ -128,11 +150,11 @@ export class Subscriber {
     sub.patterns.set(pattern, handle);
   }
 
-  private static _removeEventSubscriber(event: string): void {
+  private static _removeEventSubscriber(event: string, state: ClassState): void {
     if (this._invalidEvent(event)) return;
-    const sub = this._subscriber!;
-    const notifier = this._notifier!;
-    const pattern = this._preparePattern(event);
+    const sub = state.subscriber!;
+    const notifier = state.notifier!;
+    const pattern = `${event}.${state.namespace}`;
 
     const handle = sub.patterns.get(pattern);
     if (!handle) return;
@@ -141,14 +163,25 @@ export class Subscriber {
     sub.patterns.delete(pattern);
   }
 
-  protected static _fetchPublicMethods(subscriber: Subscriber, _inheritAll: boolean): string[] {
+  protected static _fetchPublicMethods(subscriber: Subscriber, inheritAll: boolean): string[] {
     const baseKeys = new Set(Object.getOwnPropertyNames(Subscriber.prototype));
-    const proto = Object.getPrototypeOf(subscriber);
-    const keys = Object.getOwnPropertyNames(proto).filter(
-      (k) =>
-        k !== "constructor" && !baseKeys.has(k) && typeof (subscriber as any)[k] === "function",
-    );
-    // Convert camelCase method names to snake_case event names for patterns
-    return keys.map((k) => snakeCase(k));
+    const keys = new Set<string>();
+    let proto = Object.getPrototypeOf(subscriber);
+
+    while (proto && proto !== Subscriber.prototype && proto !== Object.prototype) {
+      for (const key of Object.getOwnPropertyNames(proto)) {
+        if (
+          key !== "constructor" &&
+          !baseKeys.has(key) &&
+          typeof (subscriber as any)[key] === "function"
+        ) {
+          keys.add(key);
+        }
+      }
+      if (!inheritAll) break;
+      proto = Object.getPrototypeOf(proto);
+    }
+
+    return Array.from(keys).map((k) => snakeCase(k));
   }
 }

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -83,6 +83,19 @@ export class Subscriber {
     return sub;
   }
 
+  /**
+   * Notify that a method was added to the class after attach_to.
+   * In Rails this is a Ruby hook (`method_added`) that auto-subscribes
+   * new public methods. Call manually in TS after dynamically adding
+   * event handler methods post-attachment.
+   */
+  static methodAdded(event: string): void {
+    const state = getState(this);
+    if (!state.notifier) return;
+    const snaked = event.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+    this._addEventSubscriber(snaked, state);
+  }
+
   /** Detach a subscriber from its namespace. */
   static detachFrom(namespace: string, notifier: typeof Notifications = Notifications): void {
     const state = getState(this);

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -1,0 +1,154 @@
+import { Notifications } from "./notifications.js";
+import type { NotificationSubscriber } from "./notifications.js";
+import type { Event } from "./notifications/instrumenter.js";
+
+function snakeCase(str: string): string {
+  return str.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function camelCase(str: string): string {
+  return str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * ActiveSupport::Subscriber — base class for notification consumers.
+ *
+ * Subclasses define instance methods matching event prefixes (e.g. `sql`
+ * for `sql.active_record`). Calling `attach_to(:active_record)` wires
+ * up subscriptions automatically.
+ */
+export class Subscriber {
+  /** Per-instance map of pattern → Notifications subscriber handle. */
+  patterns: Map<string, NotificationSubscriber> = new Map();
+
+  // -- Class-level state (static) ------------------------------------------
+
+  private static _subscribers: Subscriber[] = [];
+  private static _namespace: string | undefined;
+  private static _subscriber: Subscriber | undefined;
+  private static _notifier: typeof Notifications | undefined;
+
+  static get subscribers(): Subscriber[] {
+    return this._subscribers;
+  }
+
+  /**
+   * Attach a subscriber instance to a namespace.
+   * Every public method on the subscriber (minus Subscriber's own methods)
+   * becomes a listener for `<method>.<namespace>` events.
+   */
+  static attachTo(
+    namespace: string,
+    subscriber?: Subscriber,
+    notifier: typeof Notifications = Notifications,
+    options?: { inheritAll?: boolean },
+  ): Subscriber {
+    const sub = subscriber ?? new (this as any)();
+    this._namespace = namespace;
+    this._subscriber = sub;
+    this._notifier = notifier;
+
+    this._subscribers.push(sub);
+
+    const methods = this._fetchPublicMethods(sub, options?.inheritAll ?? false);
+    for (const event of methods) {
+      this._addEventSubscriber(event);
+    }
+
+    return sub;
+  }
+
+  /** Detach a subscriber from its namespace. */
+  static detachFrom(namespace: string, notifier: typeof Notifications = Notifications): void {
+    this._namespace = namespace;
+    this._notifier = notifier;
+    const sub = this._subscribers.find((s) => s instanceof this);
+    if (!sub) return;
+
+    this._subscriber = sub;
+    const idx = this._subscribers.indexOf(sub);
+    if (idx !== -1) this._subscribers.splice(idx, 1);
+
+    const methods = this._fetchPublicMethods(sub, true);
+    for (const event of methods) {
+      this._removeEventSubscriber(event);
+    }
+    this._notifier = undefined;
+  }
+
+  // -- Instance methods ----------------------------------------------------
+
+  call(event: Event): void {
+    const dotIdx = event.name.indexOf(".");
+    if (dotIdx === -1) return;
+    const snakeMethod = event.name.slice(0, dotIdx);
+    const camelMethod = camelCase(snakeMethod);
+    const method =
+      typeof (this as any)[camelMethod] === "function"
+        ? camelMethod
+        : typeof (this as any)[snakeMethod] === "function"
+          ? snakeMethod
+          : null;
+    if (method) (this as any)[method](event);
+  }
+
+  publishEvent(event: Event): void {
+    const dotIdx = event.name.indexOf(".");
+    if (dotIdx === -1) return;
+    const snakeMethod = event.name.slice(0, dotIdx);
+    const camelMethod = camelCase(snakeMethod);
+    const method =
+      typeof (this as any)[camelMethod] === "function"
+        ? camelMethod
+        : typeof (this as any)[snakeMethod] === "function"
+          ? snakeMethod
+          : null;
+    if (method) (this as any)[method](event);
+  }
+
+  // -- Private class helpers -----------------------------------------------
+
+  private static _invalidEvent(event: string): boolean {
+    return event === "start" || event === "finish";
+  }
+
+  private static _preparePattern(event: string): string {
+    return `${event}.${this._namespace}`;
+  }
+
+  private static _addEventSubscriber(event: string): void {
+    if (this._invalidEvent(event)) return;
+    const sub = this._subscriber!;
+    const notifier = this._notifier!;
+    const pattern = this._preparePattern(event);
+
+    if (sub.patterns.has(pattern)) return;
+
+    const handle = notifier.subscribe(pattern, (e) => sub.call(e));
+    sub.patterns.set(pattern, handle);
+  }
+
+  private static _removeEventSubscriber(event: string): void {
+    if (this._invalidEvent(event)) return;
+    const sub = this._subscriber!;
+    const notifier = this._notifier!;
+    const pattern = this._preparePattern(event);
+
+    const handle = sub.patterns.get(pattern);
+    if (!handle) return;
+
+    notifier.unsubscribe(handle);
+    sub.patterns.delete(pattern);
+  }
+
+  protected static _fetchPublicMethods(subscriber: Subscriber, _inheritAll: boolean): string[] {
+    const baseKeys = new Set(Object.getOwnPropertyNames(Subscriber.prototype));
+    const proto = Object.getPrototypeOf(subscriber);
+    const keys = Object.getOwnPropertyNames(proto).filter(
+      (k) =>
+        k !== "constructor" && !baseKeys.has(k) && typeof (subscriber as any)[k] === "function",
+    );
+    // Convert camelCase method names to snake_case event names for patterns
+    return keys.map((k) => snakeCase(k));
+  }
+}

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -172,6 +172,7 @@ export class Subscriber {
       for (const key of Object.getOwnPropertyNames(proto)) {
         if (
           key !== "constructor" &&
+          !key.startsWith("_") &&
           !baseKeys.has(key) &&
           typeof (subscriber as any)[key] === "function"
         ) {


### PR DESCRIPTION
## Summary

- Implements `ActiveSupport::Subscriber` and `ActiveSupport::LogSubscriber` — the instrumentation-based logging foundation that Rails uses to dispatch `Notifications` events to named handler methods with ANSI coloring, log-level gating, and flush support
- Implements `ActiveRecord::LogSubscriber` — formats SQL queries with color-coded verbs (SELECT=blue, INSERT=green, UPDATE=yellow, DELETE=red), timing, bind parameters, cached query markers, async query info, and verbose query source location
- Implements `ActiveRecord::ExplainSubscriber` + `ExplainRegistry` — collects SQL/binds pairs for EXPLAIN analysis, filtering out SCHEMA/EXPLAIN/cached/non-explainable statements
- Instruments the adapter pipeline — `rawExecQuery` and `internalExecQuery` now emit `sql.active_record` events via `Notifications.instrumentAsync`, so all queries flow through the logging system
- Auto-wiring on import — `LogSubscriber.attachTo("active_record")` and `ExplainSubscriber` subscription happen at module load, matching Rails behavior
- Proper delegation — `LogSubscriber.logger` delegates to `Base.logger`, `_filter` delegates to `Base.inspectionFilter.filterParam()`, `subscribe_log_level` gates `sql` and `strict_loading_violation` at debug level

## Test plan

- [x] 15 tests passing for `ActiveSupport::LogSubscriber` (color, modes, event dispatch, flush, error recovery, log-level gating)
- [x] 19 tests passing for `ActiveRecord::LogSubscriber` (schema filtering, SQL coloring, bind rendering, binary data masking, verbose query logs, cached queries, async queries)
- [x] 8 tests passing for `ActiveRecord::ExplainSubscriber` (payload filtering, CTE queries, comment-prefixed SQL)
- [x] Existing subscriber/notifications tests still pass (76 tests)
- [x] 5499 existing activerecord tests pass with zero regressions
- [x] `api:compare`: `log_subscriber` 100%, `explain_subscriber` 100%