### PR TITLE
feat(activerecord): Phase 13 — composite primary keys in SchemaCache

### DIFF
--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -314,13 +314,12 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   }
 
   /**
-   * Return the single-column primary key name, or null for composite /
-   * no-PK tables. Uses the same `information_schema.statistics` +
-   * `seq_in_index` shape Rails emits in
-   * `abstract_mysql_adapter#primary_keys` — works across all MySQL
-   * versions + MariaDB.
+   * Return the primary key: scalar string for single-column PKs,
+   * array for composite PKs, null for no-PK tables. Uses the same
+   * `information_schema.statistics` + `seq_in_index` shape Rails
+   * emits in `abstract_mysql_adapter#primary_keys`.
    */
-  async primaryKey(tableName: string): Promise<string | null> {
+  async primaryKey(tableName: string): Promise<string | string[] | null> {
     const { schema, table } = this.parseMysqlName(tableName);
     const rows = (await this.execute(
       `SELECT column_name AS name FROM information_schema.statistics
@@ -331,8 +330,9 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
       [schema ?? null, table],
     )) as Array<{ name?: string; NAME?: string; COLUMN_NAME?: string }>;
     const names = rows.map((r) => (r.name ?? r.NAME ?? r.COLUMN_NAME) as string);
+    if (names.length === 0) return null;
     if (names.length === 1) return names[0];
-    return null;
+    return names;
   }
 
   /**

--- a/packages/activerecord/src/adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/adapters/postgresql-adapter.ts
@@ -504,6 +504,11 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       tableCondition = `t.oid = to_regclass($1)`;
     }
 
+    // Order by the column's position within the index key array so
+    // composite PKs come back in declaration order, not the
+    // non-deterministic order pg_attribute happens to yield rows.
+    // `array_position(i.indkey, a.attnum)` gives each column's
+    // 0-based index inside the index definition.
     const rows = await this.execute(
       `SELECT a.attname
        FROM pg_index i
@@ -511,7 +516,8 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
        JOIN pg_class t ON t.oid = i.indrelid
        JOIN pg_namespace n ON n.oid = t.relnamespace
        WHERE ${tableCondition}
-         AND i.indisprimary = true`,
+         AND i.indisprimary = true
+       ORDER BY array_position(i.indkey, a.attnum)`,
       binds,
     );
 

--- a/packages/activerecord/src/adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/adapters/postgresql-adapter.ts
@@ -508,7 +508,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     // composite PKs come back in declaration order, not the
     // non-deterministic order pg_attribute happens to yield rows.
     // `array_position(i.indkey, a.attnum)` gives each column's
-    // 0-based index inside the index definition.
+    // 1-based position inside the index definition.
     const rows = await this.execute(
       `SELECT a.attname
        FROM pg_index i

--- a/packages/activerecord/src/adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/adapters/postgresql-adapter.ts
@@ -490,7 +490,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     return idxs.some((idx) => idx.name === indexName);
   }
 
-  async primaryKey(tableName: string): Promise<string | null> {
+  async primaryKey(tableName: string): Promise<string | string[] | null> {
     const { schema, table } = this.parseSchemaQualifiedName(tableName);
 
     let tableCondition: string;
@@ -516,7 +516,8 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     );
 
     if (rows.length === 0) return null;
-    return rows[0].attname as string;
+    if (rows.length === 1) return rows[0].attname as string;
+    return rows.map((r) => r.attname as string);
   }
 
   async pkAndSequenceFor(

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -252,6 +252,47 @@ describe("SchemaCacheTest", () => {
     const pkKeys = Object.keys(coder["primary_keys"] as Record<string, unknown>);
     expect(pkKeys).toEqual(["alpacas", "zebras"]);
   });
+
+  it("stores and round-trips composite primary keys as arrays", () => {
+    // Rails' SchemaCache stores composite PKs as an array of column
+    // names. Phase 13 widened the type from string|null to
+    // string|string[]|null. Verify encode → initWith round-trips.
+    const cache = new SchemaCache();
+    cache.setPrimaryKeys("memberships", ["user_id", "group_id"]);
+
+    const coder: Record<string, unknown> = {};
+    cache.encodeWith(coder);
+    const serialized = coder["primary_keys"] as Record<string, unknown>;
+    expect(serialized["memberships"]).toEqual(["user_id", "group_id"]);
+
+    const restored = new SchemaCache();
+    restored.initWith(coder);
+    // Reading back via the internal map — the value survives the
+    // Object.entries → Map → Object.fromEntries round-trip.
+    const pool = null;
+    return restored.primaryKeys(pool, "memberships").then((pk) => {
+      expect(pk).toEqual(["user_id", "group_id"]);
+    });
+  });
+
+  it("marshalDump / marshalLoad round-trips composite primary keys", () => {
+    const cache = new SchemaCache();
+    cache.setPrimaryKeys("memberships", ["user_id", "group_id"]);
+    cache.setPrimaryKeys("users", "id");
+
+    const data = cache.marshalDump();
+    const restored = new SchemaCache();
+    restored.marshalLoad(data);
+
+    return Promise.all([
+      restored.primaryKeys(null, "memberships").then((pk) => {
+        expect(pk).toEqual(["user_id", "group_id"]);
+      }),
+      restored.primaryKeys(null, "users").then((pk) => {
+        expect(pk).toBe("id");
+      }),
+    ]);
+  });
 });
 
 describe("SchemaReflectionTest", () => {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -65,7 +65,7 @@ function rehydrateColumn(data: unknown): Column {
 export class SchemaCache {
   private _columns = new Map<string, Column[]>();
   private _columnsHash = new Map<string, Record<string, Column>>();
-  private _primaryKeys = new Map<string, string | null>();
+  private _primaryKeys = new Map<string, string | string[] | null>();
   private _dataSourceExists = new Map<string, boolean>();
   private _indexes = new Map<string, unknown[]>();
   private _version: string | number | null = null;
@@ -126,10 +126,10 @@ export class SchemaCache {
     }
 
     if (coder["primary_keys"] instanceof Map) {
-      this._primaryKeys = coder["primary_keys"] as Map<string, string | null>;
+      this._primaryKeys = coder["primary_keys"] as Map<string, string | string[] | null>;
     } else if (coder["primary_keys"] && typeof coder["primary_keys"] === "object") {
       this._primaryKeys = new Map(
-        Object.entries(coder["primary_keys"] as Record<string, string | null>),
+        Object.entries(coder["primary_keys"] as Record<string, string | string[] | null>),
       );
     }
 
@@ -164,7 +164,10 @@ export class SchemaCache {
     return this._columns.has(tableName);
   }
 
-  async primaryKeys(pool: unknown, tableName: string): Promise<string | null | undefined> {
+  async primaryKeys(
+    pool: unknown,
+    tableName: string,
+  ): Promise<string | string[] | null | undefined> {
     if (this._primaryKeys.has(tableName)) {
       return this._primaryKeys.get(tableName);
     }
@@ -318,7 +321,7 @@ export class SchemaCache {
     this._dataSourceExists.set(tableName, true);
   }
 
-  setPrimaryKeys(tableName: string, pk: string | null): void {
+  setPrimaryKeys(tableName: string, pk: string | string[] | null): void {
     this._primaryKeys.set(tableName, pk);
   }
 
@@ -368,7 +371,7 @@ export class SchemaCache {
       Object.entries(rawCols).map(([table, cols]) => [table, cols.map((c) => rehydrateColumn(c))]),
     );
     this._primaryKeys = new Map(
-      Object.entries((primaryKeys as Record<string, string | null>) ?? {}),
+      Object.entries((primaryKeys as Record<string, string | string[] | null>) ?? {}),
     );
     this._dataSourceExists = new Map(
       Object.entries((dataSources as Record<string, boolean>) ?? {}),
@@ -460,7 +463,10 @@ export class SchemaReflection {
     return this._cache;
   }
 
-  async primaryKeys(pool: unknown, tableName: string): Promise<string | null | undefined> {
+  async primaryKeys(
+    pool: unknown,
+    tableName: string,
+  ): Promise<string | string[] | null | undefined> {
     return (await this.cache(pool)).primaryKeys(pool, tableName);
   }
 
@@ -638,7 +644,7 @@ export class BoundSchemaReflection {
     return this._schemaReflection.isCached(tableName);
   }
 
-  async primaryKeys(tableName: string): Promise<string | null | undefined> {
+  async primaryKeys(tableName: string): Promise<string | string[] | null | undefined> {
     return this._schemaReflection.primaryKeys(this._pool, tableName);
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -916,24 +916,26 @@ export class SQLite3Adapter
   }
 
   /**
-   * Return the single-column primary key name, or null for composite /
-   * rowid-only tables. Rails' SchemaCache stores the composite case as
-   * an array, but the common path for cache-dump is a scalar name.
+   * Return the primary key for the named table: a single string for
+   * scalar PKs, an array for composite PKs, or null for rowid-only
+   * tables (no explicit PK column). Matches Rails' SchemaCache which
+   * stores `string | string[] | null` for primary_keys entries.
    *
    * Uses the `PRAGMA schema.table_info(table)` form for schema-qualified
    * names (e.g. `temp.widgets`). The `PRAGMA table_info("schema"."table")`
    * form does NOT work — SQLite treats the whole quoted string as a
    * single table name and returns no rows.
    */
-  async primaryKey(tableName: string): Promise<string | null> {
+  async primaryKey(tableName: string): Promise<string | string[] | null> {
     const { schema, bare } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
     const rows = (await this.execute(
       `PRAGMA ${pragmaPrefix}table_info(${quoteColumnName(bare)})`,
     )) as Array<{ name: string; pk: number }>;
     const pks = rows.filter((r) => r.pk > 0).sort((a, b) => a.pk - b.pk);
+    if (pks.length === 0) return null;
     if (pks.length === 1) return pks[0].name;
-    return null;
+    return pks.map((r) => r.name);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -28,7 +28,7 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(await adapter.primaryKey("widgets")).toBe("id");
   });
 
-  it("primaryKey returns an array for composite primary keys", async () => {
+  it("primaryKey returns null for composite primary keys", async () => {
     await adapter.executeMutation(
       "CREATE TABLE memberships (user_id INTEGER, group_id INTEGER, PRIMARY KEY (user_id, group_id))",
     );

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -28,11 +28,11 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(await adapter.primaryKey("widgets")).toBe("id");
   });
 
-  it("primaryKey returns null for composite primary keys", async () => {
+  it("primaryKey returns an array for composite primary keys", async () => {
     await adapter.executeMutation(
       "CREATE TABLE memberships (user_id INTEGER, group_id INTEGER, PRIMARY KEY (user_id, group_id))",
     );
-    expect(await adapter.primaryKey("memberships")).toBeNull();
+    expect(await adapter.primaryKey("memberships")).toEqual(["user_id", "group_id"]);
   });
 
   it("columns returns Column metadata keyed by name", async () => {


### PR DESCRIPTION
## Summary

Rails' `SchemaCache` stores composite primary keys as arrays of column names (`["user_id", "group_id"]`). Previously trails typed the slot as `string | null` and every adapter returned `null` for composite tables — making them invisible in the schema cache.

- `SchemaCache._primaryKeys` widened from `Map<string, string | null>` to `Map<string, string | string[] | null>`. All serialization paths updated: `encodeWith`, `initWith`, `marshalDump`, `marshalLoad`, `setPrimaryKeys`, `primaryKeys` return type.
- `BoundSchemaReflection` + `SchemaReflection` `primaryKeys` return type widened to match.
- `SQLite3Adapter.primaryKey`: returns `string[]` for multi-column PKs (PRAGMA `table_info` with `pk > 0`, sorted by pk index).
- `PostgreSQLAdapter.primaryKey`: returns `string[]` for multi-column PKs (`pg_index` + `pg_attribute`, multiple rows).
- `Mysql2Adapter.primaryKey`: returns `string[]` for multi-column PKs (`information_schema.statistics`, multiple rows).

## Test plan

- [x] `pnpm test` — 17200 passing
- [x] `sqlite3-introspection`: composite PK returns `["user_id", "group_id"]` (previously `null`)
- [x] `schema-cache`: `encodeWith` → `initWith` round-trip preserves composite PK array
- [x] `schema-cache`: `marshalDump` → `marshalLoad` round-trip preserves both scalar and composite PKs