### PR TITLE
feat(trailties): Phase 14 — per-DB migrate/schema fan-out for multi-DB apps

### DIFF
--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1782,6 +1782,60 @@ export class CreateDogs extends Migration {
     }
   });
 
+  it("db migrate respects migrationsPaths config override", async () => {
+    // A named DB can set migrationsPaths to override the default
+    // db/migrations_<name> convention. Verify the CLI discovers
+    // migrations from the configured path instead.
+    const primaryDb = path.join(tmpDir, "mp-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "mp-animals.sqlite3");
+    const customDir = "custom/animal_migrations";
+    fs.mkdirSync(path.join(tmpDir, customDir), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: ${JSON.stringify(customDir)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: ${JSON.stringify(customDir)} },
+  },
+};`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, customDir, "20260101000001-create-cats.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateCats extends Migration {
+  async up() { await this.createTable("cats", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("cats"); }
+}`,
+    );
+
+    await runDb(["create"]);
+    await runDb(["migrate", "--database=animals"]);
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const a = new SQLite3Adapter(animalsDb);
+    try {
+      const cats = await a.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='cats'",
+      );
+      expect(cats).toHaveLength(1);
+    } finally {
+      await a.close();
+    }
+  });
+
   it("db schema:cache:dump fans out across every multi-DB config", async () => {
     // Rails multi-DB: each named sub-config gets its own
     // `db/<name>_schema_cache.json`. HashConfig.defaultSchemaCachePath

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1709,6 +1709,17 @@ export class CreateDogs extends Migration {
     } finally {
       await aAdapter.close();
     }
+
+    // Schema dump fan-out: each named DB should get its own schema
+    // file — primary → db/schema.ts, animals → db/animals_schema.ts.
+    // Without the per-config HashConfig threading in
+    // dumpSchemaAfterMigrate, both would dump to db/schema.ts.
+    const primarySchema = path.join(tmpDir, "db", "schema.ts");
+    const animalsSchema = path.join(tmpDir, "db", "animals_schema.ts");
+    expect(fs.existsSync(primarySchema)).toBe(true);
+    expect(fs.existsSync(animalsSchema)).toBe(true);
+    expect(fs.readFileSync(primarySchema, "utf8")).toContain("users");
+    expect(fs.readFileSync(animalsSchema, "utf8")).toContain("dogs");
   });
 
   it("db migrate --database=animals targets only the named DB", async () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1636,6 +1636,141 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     ]);
   });
 
+  it("db create + migrate fans out across every multi-DB config", async () => {
+    // Multi-DB: `trails db create` and `trails db migrate` iterate
+    // every named config. Each gets its own DB file + migration dir.
+    const primaryDb = path.join(tmpDir, "primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    // Primary migrations in db/migrations; animals in db/migrations_animals.
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+
+    await runDb(["create"]);
+    expect(fs.existsSync(primaryDb)).toBe(true);
+    expect(fs.existsSync(animalsDb)).toBe(true);
+
+    await runDb(["migrate"]);
+
+    // Verify each DB got its own migration applied.
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const pAdapter = new SQLite3Adapter(primaryDb);
+    try {
+      const users = await pAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
+      );
+      expect(users).toHaveLength(1);
+      // users migration should NOT have landed in animals DB.
+      const noDogs = await pAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'",
+      );
+      expect(noDogs).toHaveLength(0);
+    } finally {
+      await pAdapter.close();
+    }
+    const aAdapter = new SQLite3Adapter(animalsDb);
+    try {
+      const dogs = await aAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'",
+      );
+      expect(dogs).toHaveLength(1);
+      const noUsers = await aAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
+      );
+      expect(noUsers).toHaveLength(0);
+    } finally {
+      await aAdapter.close();
+    }
+  });
+
+  it("db migrate --database=animals targets only the named DB", async () => {
+    const primaryDb = path.join(tmpDir, "primary2.sqlite3");
+    const animalsDb = path.join(tmpDir, "animals2.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+
+    await runDb(["create"]);
+    // Only migrate animals — primary should stay unmigrated.
+    await runDb(["migrate", "--database=animals"]);
+
+    const { SQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js");
+    const pAdapter = new SQLite3Adapter(primaryDb);
+    try {
+      const users = await pAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
+      );
+      expect(users).toHaveLength(0); // primary NOT migrated
+    } finally {
+      await pAdapter.close();
+    }
+    const aAdapter = new SQLite3Adapter(animalsDb);
+    try {
+      const dogs = await aAdapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'",
+      );
+      expect(dogs).toHaveLength(1); // animals IS migrated
+    } finally {
+      await aAdapter.close();
+    }
+  });
+
   it("db schema:cache:dump fans out across every multi-DB config", async () => {
     // Rails multi-DB: each named sub-config gets its own
     // `db/<name>_schema_cache.json`. HashConfig.defaultSchemaCachePath

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -567,7 +567,13 @@ async function withMigratorForDb(
     config: HashConfig;
   },
   operation: (migrator: Migrator) => Promise<void>,
-  opts?: { skipDump?: boolean },
+  opts?: {
+    skipDump?: boolean;
+    /** Called after migrator.output has been logged — use for
+     *  messages that should appear after the migration output
+     *  (e.g. "All migrations are up to date."). */
+    afterOutput?: (migrator: Migrator) => void | Promise<void>;
+  },
 ): Promise<void> {
   const mDirs = migrationsDirsForConfig(ctx.name, ctx.raw);
   const migrations = await discoverMigrationsFromDirs(mDirs);
@@ -578,6 +584,7 @@ async function withMigratorForDb(
   const migrator = new Migrator(ctx.adapter, migrations);
   await operation(migrator);
   for (const line of migrator.output) console.log(`${ctx.prefix}${line}`);
+  if (opts?.afterOutput) await opts.afterOutput(migrator);
   if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.adapter, ctx.raw, ctx.config);
 }
 
@@ -592,11 +599,20 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
-        await withMigratorForDb(ctx, async (migrator) => {
-          await migrator.migrate(opts.version ?? null);
-          const pending = await migrator.pendingMigrations();
-          if (pending.length === 0) console.log(`${ctx.prefix}All migrations are up to date.`);
-        });
+        await withMigratorForDb(
+          ctx,
+          async (migrator) => {
+            await migrator.migrate(opts.version ?? null);
+          },
+          {
+            afterOutput: async (migrator) => {
+              const pending = await migrator.pendingMigrations();
+              if (pending.length === 0) {
+                console.log(`${ctx.prefix}All migrations are up to date.`);
+              }
+            },
+          },
+        );
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -388,6 +388,27 @@ interface RunOptions {
   skipDump?: boolean;
 }
 
+/**
+ * Centralized Migrator construction so every CLI command stamps
+ * ar_internal_metadata.environment with the resolved TRAILS_ENV and
+ * respects useMetadataTable. Without this, `db migrate:up`,
+ * `db migrate:status`, etc. would default to NODE_ENV and potentially
+ * stamp a different env than `db migrate`.
+ */
+function createMigrator(
+  adapter: DatabaseAdapter,
+  migrations: Awaited<ReturnType<typeof discoverMigrations>>,
+  raw?: RawConfig,
+): Migrator {
+  const envName = resolveEnv();
+  const internalMetadataEnabled =
+    raw == null || (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
+  return new Migrator(adapter, migrations, {
+    environment: envName,
+    internalMetadataEnabled,
+  });
+}
+
 async function runMigrate(
   adapter: DatabaseAdapter,
   raw: RawConfig,
@@ -400,13 +421,7 @@ async function runMigrate(
     return;
   }
 
-  const envName = resolveEnv();
-  const internalMetadataEnabled =
-    (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
-  const migrator = new Migrator(adapter, migrations, {
-    environment: envName,
-    internalMetadataEnabled,
-  });
+  const migrator = createMigrator(adapter, migrations, raw);
   await migrator.migrate(targetVersion ?? null);
 
   for (const line of migrator.output) console.log(line);
@@ -429,7 +444,7 @@ async function runRollback(
     return;
   }
 
-  const migrator = new Migrator(adapter, migrations);
+  const migrator = createMigrator(adapter, migrations, raw);
   await migrator.rollback(steps);
 
   for (const line of migrator.output) console.log(line);
@@ -686,8 +701,8 @@ export function dbCommand(): Command {
     .description("Print the current schema version")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
-      await forEachDatabase(opts, async ({ adapter, prefix }) => {
-        const migrator = new Migrator(adapter, []);
+      await forEachDatabase(opts, async ({ adapter, prefix, raw: dbRaw }) => {
+        const migrator = createMigrator(adapter, [], dbRaw);
         const version = await migrator.currentVersionReadOnly();
         console.log(`${prefix}Current version: ${version}`);
       });
@@ -704,12 +719,7 @@ export function dbCommand(): Command {
         // environment:set` with NODE_ENV=development would stamp the DB
         // as development and defeat the protected-env guard.
         const envName = resolveEnv();
-        const internalMetadataEnabled =
-          (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
-        const migrator = new Migrator(adapter, [], {
-          environment: envName,
-          internalMetadataEnabled,
-        });
+        const migrator = createMigrator(adapter, [], raw);
         // Rails: raise EnvironmentStorageError when
         // internal_metadata.enabled? is false (use_metadata_table opt-out).
         if (!migrator.internalMetadata.enabled) {
@@ -748,10 +758,10 @@ export function dbCommand(): Command {
     .command("abort_if_pending_migrations")
     .description("Exit with non-zero status if any migrations are pending")
     .action(async () => {
-      await withAdapter(async (adapter) => {
+      await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
         if (migrations.length === 0) return;
-        const migrator = new Migrator(adapter, migrations);
+        const migrator = createMigrator(adapter, migrations, raw);
         // Use the read-only pending check so running this in a
         // production-health-check context (e.g. before deploying) doesn't
         // silently create schema_migrations / ar_internal_metadata.
@@ -789,7 +799,7 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
-        const migrator = new Migrator(adapter, migrations);
+        const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("up", opts.version);
         for (const line of migrator.output) console.log(line);
         await dumpSchemaAfterMigrate(adapter, raw);
@@ -803,7 +813,7 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
-        const migrator = new Migrator(adapter, migrations);
+        const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("down", opts.version);
         for (const line of migrator.output) console.log(line);
         await dumpSchemaAfterMigrate(adapter, raw);
@@ -885,7 +895,7 @@ export function dbCommand(): Command {
         // may have been created by either our DatabaseTasks.create call
         // above or by better-sqlite3 on connect; the meaningful signal
         // is whether migrations have been applied.
-        const migrator = new Migrator(adapter, []);
+        const migrator = createMigrator(adapter, [], raw);
         const wasFresh = !(await migrator.schemaMigrationTableExists());
 
         await runMigrate(adapter, raw);
@@ -932,14 +942,14 @@ export function dbCommand(): Command {
     .command("migrate:status")
     .description("Show migration status")
     .action(async () => {
-      await withAdapter(async (adapter) => {
+      await withAdapter(async (adapter, raw) => {
         const migrations = await discoverMigrations(migrationsDir());
         if (migrations.length === 0) {
           console.log("No migrations found.");
           return;
         }
 
-        const migrator = new Migrator(adapter, migrations);
+        const migrator = createMigrator(adapter, migrations, raw);
         const statuses = await migrator.migrationsStatus();
 
         console.log("");

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -93,8 +93,12 @@ function migrationsDir(): string {
  * `db/migrations_<name>`.
  */
 function migrationsDirForConfig(name: string, config: RawConfig): string {
-  const paths = (config as { migrationsPaths?: string[] }).migrationsPaths;
-  if (paths && paths.length > 0) return path.resolve(process.cwd(), paths[0]);
+  const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
+  if (typeof raw === "string" && raw.length > 0) return path.resolve(process.cwd(), raw);
+  if (Array.isArray(raw)) {
+    const first = raw.find((p) => p.length > 0);
+    if (first) return path.resolve(process.cwd(), first);
+  }
   if (name === "primary") return path.join(process.cwd(), "db", "migrations");
   return path.join(process.cwd(), "db", `migrations_${name}`);
 }
@@ -156,7 +160,7 @@ async function forEachDatabase(
  */
 async function forEachDatabaseConfig(
   opts: DatabaseOpts,
-  fn: (ctx: { raw: RawConfig; config: HashConfig; name: string }) => Promise<void>,
+  fn: (ctx: { raw: RawConfig; config: HashConfig; name: string; prefix: string }) => Promise<void>,
 ): Promise<void> {
   const envName = resolveEnv();
   const allConfigs = await loadAllDatabaseConfigs(envName);
@@ -168,10 +172,12 @@ async function forEachDatabaseConfig(
         `Available: ${available || "(none)"}`,
     );
   }
+  const multiDb = targets.length > 1;
   for (const { name, config: rawConfig } of targets) {
     const raw = normalizeRawConfig(rawConfig);
     const hashConfig = new HashConfig(envName, name, raw as Record<string, unknown>);
-    await fn({ raw, config: hashConfig, name });
+    const prefix = multiDb ? `[${name}] ` : "";
+    await fn({ raw, config: hashConfig, name, prefix });
   }
 }
 
@@ -315,9 +321,13 @@ async function runProtectedEnvCheck(config: HashConfig, envName: string): Promis
  * app that commits a structure.sql stays on sql through the whole
  * migrate → dump cycle.
  */
-async function dumpSchemaAfterMigrate(adapter: DatabaseAdapter, raw: RawConfig): Promise<void> {
+async function dumpSchemaAfterMigrate(
+  adapter: DatabaseAdapter,
+  raw: RawConfig,
+  hashConfig?: HashConfig,
+): Promise<void> {
   if (!DatabaseTasks.dumpSchemaAfterMigration) return;
-  const config = toDbConfig(raw);
+  const config = hashConfig ?? toDbConfig(raw);
   const previous = DatabaseTasks.migrationConnection();
   const previousFormat = DatabaseTasks.schemaFormat;
   try {
@@ -489,14 +499,14 @@ function displayNameFor(config: HashConfig, raw: RawConfig): string {
 }
 
 async function runCreate(opts: DatabaseOpts = {}): Promise<void> {
-  await forEachDatabaseConfig(opts, async ({ raw, config }) => {
+  await forEachDatabaseConfig(opts, async ({ raw, config, prefix }) => {
     const displayName = displayNameFor(config, raw);
     try {
       await DatabaseTasks.create(config);
-      console.log(`Created database '${displayName}'`);
+      console.log(`${prefix}Created database '${displayName}'`);
     } catch (error) {
       if (error instanceof DatabaseAlreadyExists) {
-        console.error(`Database '${displayName}' already exists`);
+        console.error(`${prefix}Database '${displayName}' already exists`);
         return;
       }
       throw error;
@@ -505,15 +515,15 @@ async function runCreate(opts: DatabaseOpts = {}): Promise<void> {
 }
 
 async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
-  await forEachDatabaseConfig(opts, async ({ raw, config }) => {
+  await forEachDatabaseConfig(opts, async ({ raw, config, prefix }) => {
     const displayName = displayNameFor(config, raw);
     await runProtectedEnvCheck(config, config.envName);
     try {
       await DatabaseTasks.drop(config);
-      console.log(`Dropped database '${displayName}'`);
+      console.log(`${prefix}Dropped database '${displayName}'`);
     } catch (error) {
       if (error instanceof NoDatabaseError) {
-        console.error(`Database '${displayName}' does not exist`);
+        console.error(`${prefix}Database '${displayName}' does not exist`);
         return;
       }
       throw error;
@@ -531,7 +541,7 @@ export function dbCommand(): Command {
     .option("--version <version>", "Migrate to a specific version")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
         const mDir = migrationsDirForConfig(name, raw);
         const migrations = await discoverMigrations(mDir);
         if (migrations.length === 0) {
@@ -543,7 +553,7 @@ export function dbCommand(): Command {
         for (const line of migrator.output) console.log(`${prefix}${line}`);
         const pending = await migrator.pendingMigrations();
         if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
-        await dumpSchemaAfterMigrate(adapter, raw);
+        await dumpSchemaAfterMigrate(adapter, raw, config);
       });
     });
 
@@ -559,7 +569,7 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
         const mDir = migrationsDirForConfig(name, raw);
         const migrations = await discoverMigrations(mDir);
         if (migrations.length === 0) {
@@ -569,7 +579,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.rollback(step);
         for (const line of migrator.output) console.log(`${prefix}${line}`);
-        await dumpSchemaAfterMigrate(adapter, raw);
+        await dumpSchemaAfterMigrate(adapter, raw, config);
       });
     });
 
@@ -585,7 +595,7 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
         const mDir = migrationsDirForConfig(name, raw);
         const migrations = await discoverMigrations(mDir);
         if (migrations.length === 0) {
@@ -595,7 +605,7 @@ export function dbCommand(): Command {
         const migrator = new Migrator(adapter, migrations);
         await migrator.forward(step);
         for (const line of migrator.output) console.log(`${prefix}${line}`);
-        await dumpSchemaAfterMigrate(adapter, raw);
+        await dumpSchemaAfterMigrate(adapter, raw, config);
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -122,6 +122,20 @@ interface DatabaseOpts {
 }
 
 /**
+ * Presence-based validation for --database. Rejects empty strings so
+ * `--database=""` doesn't silently fan out across all DBs (which
+ * would be destructive for `drop`).
+ */
+function validateDatabaseFlag(opts: DatabaseOpts): string | undefined {
+  if (opts.database === undefined) return undefined;
+  const trimmed = opts.database.trim();
+  if (trimmed.length === 0) {
+    throw new Error("--database requires a non-empty name (e.g. --database=primary).");
+  }
+  return trimmed;
+}
+
+/**
  * Iterate every named database config in the current env, optionally
  * filtered to a single name via `--database`. Mirrors Rails'
  * `DatabaseTasks.for_each(databases) { |name| ... }` which generates
@@ -145,12 +159,13 @@ async function forEachDatabase(
   }) => Promise<void>,
 ): Promise<void> {
   const envName = resolveEnv();
+  const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  const targets = opts.database ? allConfigs.filter((c) => c.name === opts.database) : allConfigs;
-  if (targets.length === 0 && opts.database) {
+  const targets = dbName ? allConfigs.filter((c) => c.name === dbName) : allConfigs;
+  if (targets.length === 0 && dbName) {
     const available = allConfigs.map((c) => c.name).join(", ");
     throw new Error(
-      `No database configuration named "${opts.database}" in environment "${envName}". ` +
+      `No database configuration named "${dbName}" in environment "${envName}". ` +
         `Available: ${available || "(none)"}`,
     );
   }
@@ -177,12 +192,13 @@ async function forEachDatabaseConfig(
   fn: (ctx: { raw: RawConfig; config: HashConfig; name: string; prefix: string }) => Promise<void>,
 ): Promise<void> {
   const envName = resolveEnv();
+  const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  const targets = opts.database ? allConfigs.filter((c) => c.name === opts.database) : allConfigs;
-  if (targets.length === 0 && opts.database) {
+  const targets = dbName ? allConfigs.filter((c) => c.name === dbName) : allConfigs;
+  if (targets.length === 0 && dbName) {
     const available = allConfigs.map((c) => c.name).join(", ");
     throw new Error(
-      `No database configuration named "${opts.database}" in environment "${envName}". ` +
+      `No database configuration named "${dbName}" in environment "${envName}". ` +
         `Available: ${available || "(none)"}`,
     );
   }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -161,18 +161,24 @@ async function forEachDatabase(
   const envName = resolveEnv();
   const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  const targets = dbName ? allConfigs.filter((c) => c.name === dbName) : allConfigs;
-  if (targets.length === 0 && dbName) {
-    const available = allConfigs.map((c) => c.name).join(", ");
+  // Build HashConfigs first so we can filter by databaseTasks() —
+  // replicas and configs with databaseTasks: false should be skipped,
+  // matching Rails' configsFor(includeHidden: false) filter.
+  const all = allConfigs.map(({ name, config: rawConfig }) => {
+    const raw = normalizeRawConfig(rawConfig);
+    return { name, raw, hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>) };
+  });
+  const taskable = all.filter((c) => c.hashConfig.databaseTasks());
+  const filtered = dbName ? taskable.filter((c) => c.name === dbName) : taskable;
+  if (filtered.length === 0 && dbName) {
+    const available = taskable.map((c) => c.name).join(", ");
     throw new Error(
       `No database configuration named "${dbName}" in environment "${envName}". ` +
         `Available: ${available || "(none)"}`,
     );
   }
-  const multiDb = targets.length > 1;
-  for (const { name, config: rawConfig } of targets) {
-    const raw = normalizeRawConfig(rawConfig);
-    const hashConfig = new HashConfig(envName, name, raw as Record<string, unknown>);
+  const multiDb = filtered.length > 1;
+  for (const { name, raw, hashConfig } of filtered) {
     const adapter = await connectAdapter(raw);
     const prefix = multiDb ? `[${name}] ` : "";
     try {
@@ -194,18 +200,21 @@ async function forEachDatabaseConfig(
   const envName = resolveEnv();
   const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  const targets = dbName ? allConfigs.filter((c) => c.name === dbName) : allConfigs;
-  if (targets.length === 0 && dbName) {
-    const available = allConfigs.map((c) => c.name).join(", ");
+  const all = allConfigs.map(({ name, config: rawConfig }) => {
+    const raw = normalizeRawConfig(rawConfig);
+    return { name, raw, hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>) };
+  });
+  const taskable = all.filter((c) => c.hashConfig.databaseTasks());
+  const filtered = dbName ? taskable.filter((c) => c.name === dbName) : taskable;
+  if (filtered.length === 0 && dbName) {
+    const available = taskable.map((c) => c.name).join(", ");
     throw new Error(
       `No database configuration named "${dbName}" in environment "${envName}". ` +
         `Available: ${available || "(none)"}`,
     );
   }
-  const multiDb = targets.length > 1;
-  for (const { name, config: rawConfig } of targets) {
-    const raw = normalizeRawConfig(rawConfig);
-    const hashConfig = new HashConfig(envName, name, raw as Record<string, unknown>);
+  const multiDb = filtered.length > 1;
+  for (const { name, raw, hashConfig } of filtered) {
     const prefix = multiDb ? `[${name}] ` : "";
     await fn({ raw, config: hashConfig, name, prefix });
   }
@@ -590,7 +599,10 @@ async function withMigratorForDb(
     console.log(`${ctx.prefix}No migrations found.`);
     return;
   }
-  const migrator = new Migrator(ctx.adapter, migrations);
+  const migrator = new Migrator(ctx.adapter, migrations, {
+    environment: ctx.config.envName,
+    internalMetadataEnabled: (ctx.raw as { useMetadataTable?: boolean }).useMetadataTable !== false,
+  });
   await operation(migrator);
   for (const line of migrator.output) console.log(`${ctx.prefix}${line}`);
   if (opts?.afterOutput) await opts.afterOutput(migrator);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -86,21 +86,42 @@ function migrationsDir(): string {
 }
 
 /**
- * Resolve the migrations directory for a named database config.
+ * Resolve the migrations directories for a named database config.
  * Mirrors Rails' per-DB migrations_paths: the user can set
- * `migrationsPaths` in config/database.ts; otherwise primary
- * defaults to `db/migrations` and named DBs default to
- * `db/migrations_<name>`.
+ * `migrationsPaths` (string or string[]) in config/database.ts;
+ * otherwise primary defaults to `db/migrations` and named DBs
+ * default to `db/migrations_<name>`. Returns an array because
+ * Rails supports multiple directories per config.
  */
-function migrationsDirForConfig(name: string, config: RawConfig): string {
+function migrationsDirsForConfig(name: string, config: RawConfig): string[] {
   const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
-  if (typeof raw === "string" && raw.length > 0) return path.resolve(process.cwd(), raw);
+  if (typeof raw === "string" && raw.length > 0) return [path.resolve(process.cwd(), raw)];
   if (Array.isArray(raw)) {
-    const first = raw.find((p) => p.length > 0);
-    if (first) return path.resolve(process.cwd(), first);
+    const dirs = [
+      ...new Set(raw.filter((p) => p.length > 0).map((p) => path.resolve(process.cwd(), p))),
+    ];
+    if (dirs.length > 0) return dirs;
   }
-  if (name === "primary") return path.join(process.cwd(), "db", "migrations");
-  return path.join(process.cwd(), "db", `migrations_${name}`);
+  if (name === "primary") return [path.join(process.cwd(), "db", "migrations")];
+  return [path.join(process.cwd(), "db", `migrations_${name}`)];
+}
+
+/**
+ * Discover migrations across multiple directories and merge/dedup
+ * by version. Matches Rails' behavior when migrations_paths contains
+ * multiple entries.
+ */
+async function discoverMigrationsFromDirs(dirs: string[]): ReturnType<typeof discoverMigrations> {
+  const all = await Promise.all(dirs.map((d) => discoverMigrations(d)));
+  const merged = all.flat();
+  // Dedup by version — first occurrence wins (matches Rails' behavior
+  // where a migration version can only appear once across all paths).
+  const seen = new Set<string>();
+  return merged.filter((m) => {
+    if (seen.has(m.version)) return false;
+    seen.add(m.version);
+    return true;
+  });
 }
 
 interface DatabaseOpts {
@@ -531,6 +552,35 @@ async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
   });
 }
 
+/**
+ * Shared helper for migrate/rollback/forward — discover migrations for
+ * the named DB, construct a Migrator, run the caller-provided operation,
+ * log output, and dump the schema. Extracts the pattern so the three
+ * commands can't drift.
+ */
+async function withMigratorForDb(
+  ctx: {
+    adapter: DatabaseAdapter;
+    raw: RawConfig;
+    name: string;
+    prefix: string;
+    config: HashConfig;
+  },
+  operation: (migrator: Migrator) => Promise<void>,
+  opts?: { skipDump?: boolean },
+): Promise<void> {
+  const mDirs = migrationsDirsForConfig(ctx.name, ctx.raw);
+  const migrations = await discoverMigrationsFromDirs(mDirs);
+  if (migrations.length === 0) {
+    console.log(`${ctx.prefix}No migrations found.`);
+    return;
+  }
+  const migrator = new Migrator(ctx.adapter, migrations);
+  await operation(migrator);
+  for (const line of migrator.output) console.log(`${ctx.prefix}${line}`);
+  if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.adapter, ctx.raw, ctx.config);
+}
+
 export function dbCommand(): Command {
   const cmd = new Command("db");
   cmd.description("Database management commands");
@@ -541,19 +591,12 @@ export function dbCommand(): Command {
     .option("--version <version>", "Migrate to a specific version")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDir = migrationsDirForConfig(name, raw);
-        const migrations = await discoverMigrations(mDir);
-        if (migrations.length === 0) {
-          console.log(`${prefix}No migrations found.`);
-          return;
-        }
-        const migrator = new Migrator(adapter, migrations);
-        await migrator.migrate(opts.version ?? null);
-        for (const line of migrator.output) console.log(`${prefix}${line}`);
-        const pending = await migrator.pendingMigrations();
-        if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
-        await dumpSchemaAfterMigrate(adapter, raw, config);
+      await forEachDatabase(opts, async (ctx) => {
+        await withMigratorForDb(ctx, async (migrator) => {
+          await migrator.migrate(opts.version ?? null);
+          const pending = await migrator.pendingMigrations();
+          if (pending.length === 0) console.log(`${ctx.prefix}All migrations are up to date.`);
+        });
       });
     });
 
@@ -569,17 +612,10 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDir = migrationsDirForConfig(name, raw);
-        const migrations = await discoverMigrations(mDir);
-        if (migrations.length === 0) {
-          console.log(`${prefix}No migrations found.`);
-          return;
-        }
-        const migrator = new Migrator(adapter, migrations);
-        await migrator.rollback(step);
-        for (const line of migrator.output) console.log(`${prefix}${line}`);
-        await dumpSchemaAfterMigrate(adapter, raw, config);
+      await forEachDatabase(opts, async (ctx) => {
+        await withMigratorForDb(ctx, async (migrator) => {
+          await migrator.rollback(step);
+        });
       });
     });
 
@@ -595,17 +631,10 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDir = migrationsDirForConfig(name, raw);
-        const migrations = await discoverMigrations(mDir);
-        if (migrations.length === 0) {
-          console.log(`${prefix}No migrations found.`);
-          return;
-        }
-        const migrator = new Migrator(adapter, migrations);
-        await migrator.forward(step);
-        for (const line of migrator.output) console.log(`${prefix}${line}`);
-        await dumpSchemaAfterMigrate(adapter, raw, config);
+      await forEachDatabase(opts, async (ctx) => {
+        await withMigratorForDb(ctx, async (migrator) => {
+          await migrator.forward(step);
+        });
       });
     });
 
@@ -902,10 +931,15 @@ export function dbCommand(): Command {
 
   cmd
     .command("reset")
-    .description("Drop, create, migrate, and seed the database")
+    .description("Drop, create, migrate, and seed the primary database")
     .action(async () => {
-      await runDrop();
-      await runCreate();
+      // reset/setup operate on the primary DB only — they call
+      // runMigrate/runSeed via withAdapter (primary-only), so
+      // create/drop must also target primary for consistency.
+      // Multi-DB apps use `trails db create --database=<name>`
+      // + `trails db migrate --database=<name>` individually.
+      await runDrop({ database: "primary" });
+      await runCreate({ database: "primary" });
       await withAdapter(async (adapter, raw) => {
         await runMigrate(adapter, raw);
         await withSeedAdapter(adapter, runSeed);
@@ -914,9 +948,9 @@ export function dbCommand(): Command {
 
   cmd
     .command("setup")
-    .description("Create, migrate, and seed the database")
+    .description("Create, migrate, and seed the primary database")
     .action(async () => {
-      await runCreate();
+      await runCreate({ database: "primary" });
       await withAdapter(async (adapter, raw) => {
         await runMigrate(adapter, raw);
         await withSeedAdapter(adapter, runSeed);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -107,21 +107,14 @@ function migrationsDirsForConfig(name: string, config: RawConfig): string[] {
 }
 
 /**
- * Discover migrations across multiple directories and merge/dedup
- * by version. Matches Rails' behavior when migrations_paths contains
- * multiple entries.
+ * Discover migrations across multiple directories and concatenate them.
+ * Duplicate-version validation is handled by Migrator (which throws
+ * DuplicateMigrationVersionError) so conflicting migrations are
+ * surfaced as errors instead of being silently skipped.
  */
 async function discoverMigrationsFromDirs(dirs: string[]): ReturnType<typeof discoverMigrations> {
   const all = await Promise.all(dirs.map((d) => discoverMigrations(d)));
-  const merged = all.flat();
-  // Dedup by version — first occurrence wins (matches Rails' behavior
-  // where a migration version can only appear once across all paths).
-  const seen = new Set<string>();
-  return merged.filter((m) => {
-    if (seen.has(m.version)) return false;
-    seen.add(m.version);
-    return true;
-  });
+  return all.flat();
 }
 
 interface DatabaseOpts {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -85,6 +85,96 @@ function migrationsDir(): string {
   return path.join(process.cwd(), "db", "migrations");
 }
 
+/**
+ * Resolve the migrations directory for a named database config.
+ * Mirrors Rails' per-DB migrations_paths: the user can set
+ * `migrationsPaths` in config/database.ts; otherwise primary
+ * defaults to `db/migrations` and named DBs default to
+ * `db/migrations_<name>`.
+ */
+function migrationsDirForConfig(name: string, config: RawConfig): string {
+  const paths = (config as { migrationsPaths?: string[] }).migrationsPaths;
+  if (paths && paths.length > 0) return path.resolve(process.cwd(), paths[0]);
+  if (name === "primary") return path.join(process.cwd(), "db", "migrations");
+  return path.join(process.cwd(), "db", `migrations_${name}`);
+}
+
+interface DatabaseOpts {
+  database?: string;
+}
+
+/**
+ * Iterate every named database config in the current env, optionally
+ * filtered to a single name via `--database`. Mirrors Rails'
+ * `DatabaseTasks.for_each(databases) { |name| ... }` which generates
+ * per-name rake tasks. Commander can't generate dynamic subcommands,
+ * so we use a `--database` flag instead.
+ *
+ * For each config: normalizes, builds a HashConfig, connects an adapter,
+ * runs `fn`, closes the adapter. `fn` receives the adapter, the raw
+ * config, the HashConfig, and the config name.
+ */
+async function forEachDatabase(
+  opts: DatabaseOpts,
+  fn: (ctx: {
+    adapter: DatabaseAdapter;
+    raw: RawConfig;
+    config: HashConfig;
+    name: string;
+    /** Prefix for log output — empty string for single-DB apps so
+     *  the output stays clean; "[name] " for multi-DB. */
+    prefix: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const envName = resolveEnv();
+  const allConfigs = await loadAllDatabaseConfigs(envName);
+  const targets = opts.database ? allConfigs.filter((c) => c.name === opts.database) : allConfigs;
+  if (targets.length === 0 && opts.database) {
+    const available = allConfigs.map((c) => c.name).join(", ");
+    throw new Error(
+      `No database configuration named "${opts.database}" in environment "${envName}". ` +
+        `Available: ${available || "(none)"}`,
+    );
+  }
+  const multiDb = targets.length > 1;
+  for (const { name, config: rawConfig } of targets) {
+    const raw = normalizeRawConfig(rawConfig);
+    const hashConfig = new HashConfig(envName, name, raw as Record<string, unknown>);
+    const adapter = await connectAdapter(raw);
+    const prefix = multiDb ? `[${name}] ` : "";
+    try {
+      await fn({ adapter, raw, config: hashConfig, name, prefix });
+    } finally {
+      await closeAdapter(adapter);
+    }
+  }
+}
+
+/**
+ * Like forEachDatabase but doesn't connect an adapter — for commands
+ * like `create` and `drop` that need to operate BEFORE the DB exists.
+ */
+async function forEachDatabaseConfig(
+  opts: DatabaseOpts,
+  fn: (ctx: { raw: RawConfig; config: HashConfig; name: string }) => Promise<void>,
+): Promise<void> {
+  const envName = resolveEnv();
+  const allConfigs = await loadAllDatabaseConfigs(envName);
+  const targets = opts.database ? allConfigs.filter((c) => c.name === opts.database) : allConfigs;
+  if (targets.length === 0 && opts.database) {
+    const available = allConfigs.map((c) => c.name).join(", ");
+    throw new Error(
+      `No database configuration named "${opts.database}" in environment "${envName}". ` +
+        `Available: ${available || "(none)"}`,
+    );
+  }
+  for (const { name, config: rawConfig } of targets) {
+    const raw = normalizeRawConfig(rawConfig);
+    const hashConfig = new HashConfig(envName, name, raw as Record<string, unknown>);
+    await fn({ raw, config: hashConfig, name });
+  }
+}
+
 function databaseFromUrl(url: string, adapter?: string): string | undefined {
   try {
     const parsed = new URL(url);
@@ -398,39 +488,37 @@ function displayNameFor(config: HashConfig, raw: RawConfig): string {
   );
 }
 
-async function runCreate(): Promise<void> {
-  const raw = await loadDatabaseConfig();
-  const config = toDbConfig(raw);
-  const displayName = displayNameFor(config, raw);
-  try {
-    await DatabaseTasks.create(config);
-    console.log(`Created database '${displayName}'`);
-  } catch (error) {
-    if (error instanceof DatabaseAlreadyExists) {
-      console.error(`Database '${displayName}' already exists`);
-      return;
+async function runCreate(opts: DatabaseOpts = {}): Promise<void> {
+  await forEachDatabaseConfig(opts, async ({ raw, config }) => {
+    const displayName = displayNameFor(config, raw);
+    try {
+      await DatabaseTasks.create(config);
+      console.log(`Created database '${displayName}'`);
+    } catch (error) {
+      if (error instanceof DatabaseAlreadyExists) {
+        console.error(`Database '${displayName}' already exists`);
+        return;
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }
 
-async function runDrop(): Promise<void> {
-  const raw = normalizeRawConfig(await loadDatabaseConfig());
-  const config = toDbConfig(raw);
-  const displayName = displayNameFor(config, raw);
-  // Rails db:drop is gated on check_protected_environments; we match.
-  // DISABLE_DATABASE_ENVIRONMENT_CHECK=1 is the Rails escape hatch.
-  await runProtectedEnvCheck(config, config.envName);
-  try {
-    await DatabaseTasks.drop(config);
-    console.log(`Dropped database '${displayName}'`);
-  } catch (error) {
-    if (error instanceof NoDatabaseError) {
-      console.error(`Database '${displayName}' does not exist`);
-      return;
+async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
+  await forEachDatabaseConfig(opts, async ({ raw, config }) => {
+    const displayName = displayNameFor(config, raw);
+    await runProtectedEnvCheck(config, config.envName);
+    try {
+      await DatabaseTasks.drop(config);
+      console.log(`Dropped database '${displayName}'`);
+    } catch (error) {
+      if (error instanceof NoDatabaseError) {
+        console.error(`Database '${displayName}' does not exist`);
+        return;
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }
 
 export function dbCommand(): Command {
@@ -439,16 +527,31 @@ export function dbCommand(): Command {
 
   cmd
     .command("migrate")
-    .description("Run pending migrations")
+    .description("Run pending migrations for all databases (or a specific one via --database)")
     .option("--version <version>", "Migrate to a specific version")
+    .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
-      await withAdapter((adapter, raw) => runMigrate(adapter, raw, opts.version));
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+        const mDir = migrationsDirForConfig(name, raw);
+        const migrations = await discoverMigrations(mDir);
+        if (migrations.length === 0) {
+          console.log(`${prefix}No migrations found.`);
+          return;
+        }
+        const migrator = new Migrator(adapter, migrations);
+        await migrator.migrate(opts.version ?? null);
+        for (const line of migrator.output) console.log(`${prefix}${line}`);
+        const pending = await migrator.pendingMigrations();
+        if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
+        await dumpSchemaAfterMigrate(adapter, raw);
+      });
     });
 
   cmd
     .command("rollback")
     .description("Rollback migrations")
     .option("--step <n>", "Number of migrations to rollback", "1")
+    .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       const step = Number(opts.step);
       if (!Number.isInteger(step) || step < 1) {
@@ -456,13 +559,25 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await withAdapter((adapter, raw) => runRollback(adapter, raw, step));
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+        const mDir = migrationsDirForConfig(name, raw);
+        const migrations = await discoverMigrations(mDir);
+        if (migrations.length === 0) {
+          console.log(`${prefix}No migrations found.`);
+          return;
+        }
+        const migrator = new Migrator(adapter, migrations);
+        await migrator.rollback(step);
+        for (const line of migrator.output) console.log(`${prefix}${line}`);
+        await dumpSchemaAfterMigrate(adapter, raw);
+      });
     });
 
   cmd
     .command("forward")
     .description("Move the schema forward N migrations (inverse of rollback)")
     .option("--step <n>", "Number of migrations to apply", "1")
+    .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       const step = Number(opts.step);
       if (!Number.isInteger(step) || step < 1) {
@@ -470,15 +585,16 @@ export function dbCommand(): Command {
         process.exitCode = 1;
         return;
       }
-      await withAdapter(async (adapter, raw) => {
-        const migrations = await discoverMigrations(migrationsDir());
+      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
+        const mDir = migrationsDirForConfig(name, raw);
+        const migrations = await discoverMigrations(mDir);
         if (migrations.length === 0) {
-          console.log("No migrations found.");
+          console.log(`${prefix}No migrations found.`);
           return;
         }
         const migrator = new Migrator(adapter, migrations);
         await migrator.forward(step);
-        for (const line of migrator.output) console.log(line);
+        for (const line of migrator.output) console.log(`${prefix}${line}`);
         await dumpSchemaAfterMigrate(adapter, raw);
       });
     });
@@ -486,17 +602,12 @@ export function dbCommand(): Command {
   cmd
     .command("version")
     .description("Print the current schema version")
-    .action(async () => {
-      // Don't discover or validate migration files — users should be able
-      // to ask for the current version even when the migrations/ directory
-      // has a stale file. Use the read-only currentVersion path so running
-      // `trails db version` on a fresh/production DB doesn't silently
-      // create schema_migrations / ar_internal_metadata as a side effect
-      // (matches Rails' current_version contract).
-      await withAdapter(async (adapter) => {
+    .option("--database <name>", "Target a specific named database")
+    .action(async (opts: DatabaseOpts) => {
+      await forEachDatabase(opts, async ({ adapter, prefix }) => {
         const migrator = new Migrator(adapter, []);
         const version = await migrator.currentVersionReadOnly();
-        console.log(`Current version: ${version}`);
+        console.log(`${prefix}Current version: ${version}`);
       });
     });
 
@@ -723,9 +834,17 @@ export function dbCommand(): Command {
       await runTestLoadSchema({ successMessage: (_d, f) => `Test database prepared (${f})` });
     });
 
-  cmd.command("create").description("Create the database").action(runCreate);
+  cmd
+    .command("create")
+    .description("Create database(s) — all in the env, or a specific one via --database")
+    .option("--database <name>", "Target a specific named database (e.g. primary, animals)")
+    .action(async (opts) => runCreate(opts));
 
-  cmd.command("drop").description("Drop the database").action(runDrop);
+  cmd
+    .command("drop")
+    .description("Drop database(s) — all in the env, or a specific one via --database")
+    .option("--database <name>", "Target a specific named database")
+    .action(async (opts) => runDrop(opts));
 
   cmd
     .command("migrate:status")

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -400,7 +400,13 @@ async function runMigrate(
     return;
   }
 
-  const migrator = new Migrator(adapter, migrations);
+  const envName = resolveEnv();
+  const internalMetadataEnabled =
+    (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
+  const migrator = new Migrator(adapter, migrations, {
+    environment: envName,
+    internalMetadataEnabled,
+  });
   await migrator.migrate(targetVersion ?? null);
 
   for (const line of migrator.output) console.log(line);
@@ -601,7 +607,7 @@ async function withMigratorForDb(
   }
   const migrator = new Migrator(ctx.adapter, migrations, {
     environment: ctx.config.envName,
-    internalMetadataEnabled: (ctx.raw as { useMetadataTable?: boolean }).useMetadataTable !== false,
+    internalMetadataEnabled: ctx.config.useMetadataTable,
   });
   await operation(migrator);
   for (const line of migrator.output) console.log(`${ctx.prefix}${line}`);


### PR DESCRIPTION
## Summary

Rails generates per-name rake tasks via `DatabaseTasks.for_each` (`db:create:<name>`, `db:migrate:<name>`, etc.) so multi-DB apps can target individual databases. Commander doesn't support dynamic subcommands, so trails uses a `--database <name>` flag instead — same intent, CLI-native surface.

- `forEachDatabase(opts, fn)` / `forEachDatabaseConfig(opts, fn)` — iterate every named config in the env (via `loadAllDatabaseConfigs`). When `--database` is given, filters to just that name. Single-DB apps see no output change (prefix is empty when there's one target).
- `migrationsDirForConfig(name, config)` — resolves per-DB migration dirs: `config.migrationsPaths` if set, otherwise `db/migrations` for primary and `db/migrations_<name>` for named secondaries.
- `create`, `drop`, `migrate`, `rollback`, `forward`, `version` all accept `--database` and iterate per-config.
- Output prefixed with `[name]` only when multiple targets are active — single-DB apps don't see clutter.

## Test plan

- [x] `pnpm test` — 17244 passing
- [x] Multi-DB `create` + `migrate`: two sqlite DBs, two separate migration dirs, each gets only its own table, cross-DB isolation verified
- [x] `--database=animals`: only the named DB is migrated; primary stays unmigrated
- [x] Existing single-DB tests pass without output changes (no `[primary]` prefix on single-target runs)