### PR TITLE
feat(activerecord): Phase 1b.2 — diagnostic range remap + --print-virtualized

### DIFF
--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/post-with-error.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/post-with-error.ts
@@ -1,0 +1,12 @@
+import { Base } from "./model.js";
+
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+  }
+
+  greet(): string {
+    const x: number = "not a number";
+    return x.toString();
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/tsconfig-with-error.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/tsconfig-with-error.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["model.ts", "post-with-error.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import ts from "typescript";
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createTrailsProgram } from "./program.js";
+import { remapDiagnostics } from "./remap.js";
 
 const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.resolve(CURRENT_DIR, "__fixtures__");
@@ -58,7 +60,6 @@ describe("trails-tsc CLI — Phase 1b.1", () => {
   });
 
   it("CLI binary exits 0 on clean fixture", async () => {
-    const fs = await import("node:fs");
     const binPath = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
     // Skip if dist hasn't been built (CI test jobs that skip `pnpm build`).
     // The programmatic API tests above cover the same behavior; this test
@@ -75,5 +76,60 @@ describe("trails-tsc CLI — Phase 1b.1", () => {
     );
     // Clean exit — no output expected on success.
     expect(result).toBe("");
+  });
+});
+
+describe("trails-tsc diagnostic remap — Phase 1b.2", () => {
+  it("remaps error line from virtualized coordinates to original source line", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig-with-error.json");
+    const { program, host } = createTrailsProgram(configPath);
+    const diagnostics = [...ts.getPreEmitDiagnostics(program)];
+
+    // The error is TS2322 (Type 'string' is not assignable to type 'number')
+    // on the line `const x: number = "not a number";`.
+    // In the ORIGINAL file, that's line 9 (0-indexed: 8).
+    // The virtualizer injects declares after the class `{`, shifting lines.
+    expect(diagnostics.length).toBeGreaterThan(0);
+
+    const errorDiag = diagnostics.find((d) => d.code === 2322);
+    expect(errorDiag).toBeDefined();
+    expect(errorDiag!.file).toBeDefined();
+
+    // Virtualized line (shifted by injected declares)
+    const virtualLine = errorDiag!.file!.getLineAndCharacterOfPosition(errorDiag!.start!).line;
+
+    // Read the original source to find the real line
+    const originalText = fs.readFileSync(path.join(FIXTURES_DIR, "post-with-error.ts"), "utf8");
+    const originalLines = originalText.split("\n");
+    const errorLineIdx = originalLines.findIndex((l) => l.includes('"not a number"'));
+    expect(errorLineIdx).toBeGreaterThan(-1);
+
+    // The virtualized line should be HIGHER than the original (shifted down)
+    expect(virtualLine).toBeGreaterThan(errorLineIdx);
+
+    // After remap, the reported line should match the original
+    const remapped = remapDiagnostics(diagnostics, host);
+    const remappedDiag = remapped.find((d) => d.code === 2322);
+    expect(remappedDiag).toBeDefined();
+    const remappedLine = remappedDiag!.file!.getLineAndCharacterOfPosition(
+      remappedDiag!.start!,
+    ).line;
+    expect(remappedLine).toBe(errorLineIdx);
+  });
+
+  it("non-virtualized file diagnostics pass through unchanged", () => {
+    const configPath = path.join(FIXTURES_DIR, "tsconfig-with-error.json");
+    const { program, host } = createTrailsProgram(configPath);
+    const diagnostics = [...ts.getPreEmitDiagnostics(program)];
+    const remapped = remapDiagnostics(diagnostics, host);
+    // Every diagnostic without deltas should have the same start position
+    for (let i = 0; i < diagnostics.length; i++) {
+      const d = diagnostics[i]!;
+      if (!d.file) continue;
+      const deltas = host.getDeltasForFile(path.resolve(d.file.fileName));
+      if (!deltas || deltas.length === 0) {
+        expect(remapped[i]!.start).toBe(d.start);
+      }
+    }
   });
 });

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -2,10 +2,34 @@
 
 import ts from "typescript";
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { createTrailsProgram } from "./program.js";
+import { remapDiagnostics } from "./remap.js";
+import { virtualize } from "../type-virtualization/virtualize.js";
+
+function handlePrintVirtualized(args: string[]): void {
+  const idx = args.indexOf("--print-virtualized");
+  if (idx === -1) return;
+  const filePath = args[idx + 1];
+  if (!filePath) {
+    process.stderr.write("trails-tsc: --print-virtualized expects a file path.\n");
+    process.exit(1);
+  }
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    process.stderr.write(`trails-tsc: File not found: ${resolved}\n`);
+    process.exit(1);
+  }
+  const text = fs.readFileSync(resolved, "utf8");
+  const { text: virtualized } = virtualize(text, resolved);
+  process.stdout.write(virtualized);
+  process.exit(0);
+}
 
 function main(): void {
   const args = process.argv.slice(2);
+
+  handlePrintVirtualized(args);
 
   // Find -p / --project flag; default to ./tsconfig.json.
   // Error if the flag is present but no value follows (matches tsc).
@@ -28,7 +52,7 @@ function main(): void {
     configPath = path.resolve(configPath);
   }
 
-  const { program, configDiagnostics } = createTrailsProgram(configPath);
+  const { program, host, configDiagnostics } = createTrailsProgram(configPath);
 
   const formatHost: ts.FormatDiagnosticsHost = {
     getCurrentDirectory: () => process.cwd(),
@@ -55,8 +79,10 @@ function main(): void {
     diagnostics.push(...emitResult.diagnostics);
   }
 
-  // Sort + deduplicate to match tsc output ordering and avoid dupes.
-  const sorted = ts.sortAndDeduplicateDiagnostics(diagnostics);
+  // Remap diagnostic positions from virtualized-source coordinates back
+  // to the user's original lines, then sort + deduplicate.
+  const remapped = remapDiagnostics(diagnostics, host);
+  const sorted = ts.sortAndDeduplicateDiagnostics(remapped);
 
   if (sorted.length > 0) {
     // Mirror tsc's --pretty default: on when stdout is a TTY,

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -7,12 +7,14 @@ const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
   getDeltasForFile(fileName: string): VirtualizeResult["deltas"] | undefined;
+  getOriginalText(fileName: string): string | undefined;
 }
 
 export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHost {
   const baseHost = ts.createCompilerHost(options, true);
   const deltaMap = new Map<string, VirtualizeResult["deltas"]>();
   const virtualizedTextCache = new Map<string, string>();
+  const originalTextCache = new Map<string, string>();
 
   function shouldVirtualize(text: string): boolean {
     return BASE_PATTERN.test(text) && STATIC_BLOCK_PATTERN.test(text);
@@ -28,6 +30,7 @@ export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHo
     }
     const result = virtualize(originalText, resolved);
     virtualizedTextCache.set(resolved, result.text);
+    originalTextCache.set(resolved, originalText);
     deltaMap.set(resolved, result.deltas);
     return result.text;
   }
@@ -45,6 +48,7 @@ export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHo
       // so we re-read, re-virtualize, and re-parse.
       if (shouldCreateNewSourceFile) {
         virtualizedTextCache.delete(resolved);
+        originalTextCache.delete(resolved);
         deltaMap.delete(resolved);
         sourceFileCache.delete(resolved);
       }
@@ -72,6 +76,10 @@ export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHo
 
     getDeltasForFile(fileName) {
       return deltaMap.get(path.resolve(fileName));
+    },
+
+    getOriginalText(fileName) {
+      return originalTextCache.get(path.resolve(fileName));
     },
   };
 

--- a/packages/activerecord/src/tsc-wrapper/index.ts
+++ b/packages/activerecord/src/tsc-wrapper/index.ts
@@ -1,2 +1,3 @@
 export { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
 export { createTrailsProgram, type TrailsProgram } from "./program.js";
+export { remapDiagnostics } from "./remap.js";

--- a/packages/activerecord/src/tsc-wrapper/remap.ts
+++ b/packages/activerecord/src/tsc-wrapper/remap.ts
@@ -1,0 +1,81 @@
+import ts from "typescript";
+import * as path from "node:path";
+import { remapLine } from "../type-virtualization/virtualize.js";
+import type { TrailsCompilerHost } from "./host.js";
+
+/**
+ * Remap diagnostics from virtualized-source coordinates back to the
+ * user's original source. For each diagnostic in a virtualized file,
+ * creates a SourceFile from the original (non-virtualized) text and
+ * computes the correct position, so ts.formatDiagnostics shows the
+ * user's real line numbers.
+ */
+export function remapDiagnostics(
+  diagnostics: readonly ts.Diagnostic[],
+  host: TrailsCompilerHost,
+): ts.Diagnostic[] {
+  const originalSfCache = new Map<string, ts.SourceFile>();
+  return diagnostics.map((d) => remapOneDiagnostic(d, host, originalSfCache));
+}
+
+function getOrCreateOriginalSf(
+  resolved: string,
+  virtualSf: ts.SourceFile,
+  host: TrailsCompilerHost,
+  cache: Map<string, ts.SourceFile>,
+): ts.SourceFile | undefined {
+  if (cache.has(resolved)) return cache.get(resolved)!;
+  const originalText = host.getOriginalText(resolved);
+  if (originalText == null) return undefined;
+  const sf = ts.createSourceFile(virtualSf.fileName, originalText, virtualSf.languageVersion, true);
+  cache.set(resolved, sf);
+  return sf;
+}
+
+function remapOneDiagnostic(
+  d: ts.Diagnostic,
+  host: TrailsCompilerHost,
+  originalSfCache: Map<string, ts.SourceFile>,
+): ts.Diagnostic {
+  // Always remap relatedInformation entries — they may point into
+  // virtualized files even when the parent diagnostic doesn't.
+  const remappedRelated = d.relatedInformation?.map(
+    (ri) =>
+      remapOneDiagnostic(
+        ri as ts.Diagnostic,
+        host,
+        originalSfCache,
+      ) as ts.DiagnosticRelatedInformation,
+  );
+
+  if (!d.file || d.start == null) {
+    return remappedRelated ? { ...d, relatedInformation: remappedRelated } : d;
+  }
+
+  const resolved = path.resolve(d.file.fileName);
+  const deltas = host.getDeltasForFile(resolved);
+  if (!deltas || deltas.length === 0) {
+    return remappedRelated ? { ...d, relatedInformation: remappedRelated } : d;
+  }
+
+  const virtualSf = d.file;
+  const { line: virtualLine, character } = virtualSf.getLineAndCharacterOfPosition(d.start);
+  const originalLine = remapLine(virtualLine, deltas);
+  if (originalLine === null || originalLine === virtualLine) {
+    return remappedRelated ? { ...d, relatedInformation: remappedRelated } : d;
+  }
+
+  const originalSf = getOrCreateOriginalSf(resolved, virtualSf, host, originalSfCache);
+  if (!originalSf) {
+    return remappedRelated ? { ...d, relatedInformation: remappedRelated } : d;
+  }
+
+  const newStart = originalSf.getPositionOfLineAndCharacter(originalLine, character);
+
+  return {
+    ...d,
+    file: originalSf,
+    start: newStart,
+    ...(remappedRelated ? { relatedInformation: remappedRelated } : {}),
+  };
+}

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -79,7 +79,7 @@ export function virtualize(
  * line in the ORIGINAL source — or `null` if the position is inside an
  * injected block.
  */
-export function remapLine(virtualLine: number, deltas: LineDelta[]): number | null {
+export function remapLine(virtualLine: number, deltas: readonly LineDelta[]): number | null {
   let line = virtualLine;
   for (let i = deltas.length - 1; i >= 0; i--) {
     const d = deltas[i];


### PR DESCRIPTION
## Summary

Error messages from `trails-tsc` now reference the user's original line numbers instead of the virtualized (shifted) ones. Also adds `--print-virtualized <file>` for debugging the synthesized source.

## How it works

For each diagnostic in a virtualized file:
1. Look up the file's `LineDelta[]` from the CompilerHost.
2. Use `remapLine(virtualLine, deltas)` to compute the original line.
3. Create a SourceFile from the **original** (non-virtualized) text.
4. Compute the correct character position via `getPositionOfLineAndCharacter` on the original SourceFile.
5. Return a new diagnostic pointing at the original SourceFile + remapped position.

`ts.formatDiagnostics` then naturally reports the user's real line numbers.

## Example

```ts
// post.ts (user writes — NO declares)
export class Post extends Base {
  static { this.attribute("title", "string"); }
  greet(): string {
    const x: number = "not a number";  // ← line 9 in original
    return x.toString();
  }
}
```

The virtualizer injects `declare title: string;` after the class `{`, shifting the error to line 10+. Without remap: `post.ts(10,11)`. With remap: `post.ts(9,11)` — matches what the user sees in their editor.

## Files

| File | Change |
| ---- | ------ |
| `packages/activerecord/src/tsc-wrapper/remap.ts` | New — `remapDiagnostics()` + original-SourceFile caching |
| `packages/activerecord/src/tsc-wrapper/host.ts` | `getOriginalText(fileName)` + `originalTextCache` |
| `packages/activerecord/src/tsc-wrapper/cli.ts` | Pipes diagnostics through `remapDiagnostics` before formatting; `--print-virtualized <file>` subcommand |
| `packages/activerecord/src/tsc-wrapper/index.ts` | Barrel export for `remapDiagnostics` |
| `packages/activerecord/src/type-virtualization/virtualize.ts` | `remapLine` param relaxed to `readonly LineDelta[]` |

## Test plan

- [x] 2 new remap tests:
  - Error at original line 8 remapped correctly from virtualized line 10
  - Non-virtualized diagnostics pass through unchanged
- [x] Full activerecord suite: **8259/8259**, zero regressions
- [x] `pnpm build` / `pnpm typecheck` / prettier / eslint clean
- [ ] CI

Plan: `docs/virtual-source-files-plan.md` § Phase 1b.2.