### PR TITLE
feat(activerecord): Phase 1b.3 — transitive-extends walker

### DIFF
--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/admin.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/admin.ts
@@ -1,0 +1,7 @@
+import { User } from "./user.js";
+
+export class Admin extends User {
+  static {
+    this.attribute("role", "string");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/base.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/base.ts
@@ -1,0 +1,6 @@
+export class Model {
+  [key: string]: unknown;
+  constructor(_attrs?: Record<string, unknown>) {}
+  static attribute(_name: string, _type: string): void {}
+}
+export class Base extends Model {}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/consumer.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/consumer.ts
@@ -1,0 +1,9 @@
+import { User } from "./user.js";
+import { Admin } from "./admin.js";
+
+const user = new User();
+export const userName: string = user.name;
+
+const admin = new Admin();
+export const adminRole: string = admin.role;
+export const adminName: string = admin.name;

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["base.ts", "user.ts", "admin.ts", "consumer.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/user.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/transitive/user.ts
@@ -1,0 +1,7 @@
+import { Base } from "./base.js";
+
+export class User extends Base {
+  static {
+    this.attribute("name", "string");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -133,3 +133,53 @@ describe("trails-tsc diagnostic remap — Phase 1b.2", () => {
     }
   });
 });
+
+describe("trails-tsc transitive extends — Phase 1b.3", () => {
+  const TRANSITIVE_DIR = path.resolve(FIXTURES_DIR, "transitive");
+
+  it("virtualizes `class Admin extends User` where User extends Base", () => {
+    const configPath = path.join(TRANSITIVE_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const diagnostics = [...ts.getPreEmitDiagnostics(program)];
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("admin.role types as string, admin.name inherited from User types as string", () => {
+    const configPath = path.join(TRANSITIVE_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const checker = program.getTypeChecker();
+
+    const consumerFile = program.getSourceFile(path.join(TRANSITIVE_DIR, "consumer.ts"));
+    expect(consumerFile).toBeDefined();
+
+    const probed: Record<string, string> = {};
+    function visit(node: ts.Node): void {
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        const type = checker.getTypeAtLocation(node.initializer);
+        probed[node.name.text] = checker.typeToString(type);
+      }
+      node.forEachChild(visit);
+    }
+    consumerFile!.forEachChild(visit);
+
+    expect(probed["userName"]).toBe("string");
+    expect(probed["adminRole"]).toBe("string");
+    expect(probed["adminName"]).toBe("string");
+  });
+
+  it("User (direct extends Base) still virtualizes correctly", () => {
+    const configPath = path.join(TRANSITIVE_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const userFile = program.getSourceFile(path.join(TRANSITIVE_DIR, "user.ts"));
+    expect(userFile).toBeDefined();
+    expect(userFile!.text).toContain("declare name: string");
+  });
+
+  it("Admin (transitive via User) gets declares injected", () => {
+    const configPath = path.join(TRANSITIVE_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const adminFile = program.getSourceFile(path.join(TRANSITIVE_DIR, "admin.ts"));
+    expect(adminFile).toBeDefined();
+    expect(adminFile!.text).toContain("declare role: string");
+  });
+});

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -2,7 +2,6 @@ import ts from "typescript";
 import * as path from "node:path";
 import { virtualize, type VirtualizeResult } from "../type-virtualization/virtualize.js";
 
-const BASE_PATTERN = /\bextends\s+Base\b/;
 const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 
 export interface TrailsCompilerHost extends ts.CompilerHost {
@@ -10,14 +9,27 @@ export interface TrailsCompilerHost extends ts.CompilerHost {
   getOriginalText(fileName: string): string | undefined;
 }
 
-export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHost {
+export function buildCompilerHost(
+  options: ts.CompilerOptions,
+  baseNames?: readonly string[],
+): TrailsCompilerHost {
   const baseHost = ts.createCompilerHost(options, true);
   const deltaMap = new Map<string, VirtualizeResult["deltas"]>();
   const virtualizedTextCache = new Map<string, string>();
   const originalTextCache = new Map<string, string>();
 
+  const baseNameSet = new Set(baseNames ?? ["Base"]);
+  // Match valid JS/TS identifiers (including $) after `extends`.
+  const EXTENDS_IDENT = /\bextends\s+([\w$]+)/g;
+
   function shouldVirtualize(text: string): boolean {
-    return BASE_PATTERN.test(text) && STATIC_BLOCK_PATTERN.test(text);
+    if (!STATIC_BLOCK_PATTERN.test(text)) return false;
+    EXTENDS_IDENT.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = EXTENDS_IDENT.exec(text))) {
+      if (baseNameSet.has(match[1]!)) return true;
+    }
+    return false;
   }
 
   function getVirtualizedText(resolved: string): string | undefined {
@@ -28,7 +40,7 @@ export function buildCompilerHost(options: ts.CompilerOptions): TrailsCompilerHo
       virtualizedTextCache.set(resolved, originalText);
       return originalText;
     }
-    const result = virtualize(originalText, resolved);
+    const result = virtualize(originalText, resolved, { baseNames });
     virtualizedTextCache.set(resolved, result.text);
     originalTextCache.set(resolved, originalText);
     deltaMap.set(resolved, result.deltas);

--- a/packages/activerecord/src/tsc-wrapper/program.ts
+++ b/packages/activerecord/src/tsc-wrapper/program.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import * as path from "node:path";
 import { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
+import { collectBaseDescendants } from "../type-virtualization/transitive-extends-walker.js";
 
 export interface TrailsProgram {
   program: ts.Program;
@@ -45,7 +46,29 @@ export function createTrailsProgram(configPath: string): TrailsProgram {
     };
   }
 
-  const host = buildCompilerHost(parsed.options);
+  // Pass 1: create program with default virtualization (literal
+  // `extends Base` only). This gives us a checker to resolve the
+  // full extends chain.
+  const host1 = buildCompilerHost(parsed.options);
+  const program1 = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+    host: host1,
+  });
+
+  // Pass 2: walk the checker to find transitive Base descendants
+  // (e.g. `class Admin extends User extends Base`). If any new names
+  // are found, rebuild with the expanded allow-list so those classes
+  // get virtualized too.
+  const baseNames = collectBaseDescendants(program1);
+  const defaultNames = new Set(["Base"]);
+  const hasNewNames = [...baseNames].some((n) => !defaultNames.has(n));
+
+  if (!hasNewNames) {
+    return { program: program1, host: host1, configDiagnostics: [] };
+  }
+
+  const host = buildCompilerHost(parsed.options, [...baseNames]);
   const program = ts.createProgram({
     rootNames: parsed.fileNames,
     options: parsed.options,

--- a/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
+++ b/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
@@ -1,0 +1,78 @@
+import ts from "typescript";
+
+/**
+ * Walk every top-level class declaration in the program and return
+ * the set of class names whose `extends` chain transitively roots at
+ * one of the configured base names (default: `["Base"]`).
+ *
+ * The result includes the base names themselves, so `virtualize()`
+ * can be called with `{ baseNames: [...result] }` and will handle
+ * both direct and transitive descendants in one pass.
+ *
+ * Only top-level classes are considered — classes nested inside
+ * functions or namespaces are not model declarations in practice.
+ *
+ * Runs once per program — the caller caches the result.
+ */
+export function collectBaseDescendants(
+  program: ts.Program,
+  rootNames: ReadonlySet<string> = new Set(["Base"]),
+): Set<string> {
+  const checker = program.getTypeChecker();
+  const result = new Set<string>(rootNames);
+  const memo = new Map<ts.Symbol, boolean>();
+
+  for (const sf of program.getSourceFiles()) {
+    if (sf.isDeclarationFile) continue;
+    ts.forEachChild(sf, (node) => {
+      if (ts.isClassDeclaration(node) && node.name) {
+        const sym = checker.getSymbolAtLocation(node.name);
+        if (sym) walkClass(sym, checker, rootNames, result, memo);
+      }
+    });
+  }
+
+  return result;
+}
+
+function walkClass(
+  sym: ts.Symbol,
+  checker: ts.TypeChecker,
+  rootNames: ReadonlySet<string>,
+  result: Set<string>,
+  memo: Map<ts.Symbol, boolean>,
+): boolean {
+  const cached = memo.get(sym);
+  if (cached !== undefined) return cached;
+
+  // Tentatively mark false to break cycles.
+  memo.set(sym, false);
+
+  if (rootNames.has(sym.name)) {
+    result.add(sym.name);
+    memo.set(sym, true);
+    return true;
+  }
+
+  const decls = sym.getDeclarations();
+  if (!decls) return false;
+
+  for (const decl of decls) {
+    if (!ts.isClassDeclaration(decl)) continue;
+    for (const heritage of decl.heritageClauses ?? []) {
+      if (heritage.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+      for (const typeNode of heritage.types) {
+        const parentType = checker.getTypeAtLocation(typeNode.expression);
+        const parentSym = parentType.getSymbol();
+        if (!parentSym) continue;
+        if (walkClass(parentSym, checker, rootNames, result, memo)) {
+          result.add(sym.name);
+          memo.set(sym, true);
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

`class Admin extends User` (where `User extends Base`) is now virtualized by `trails-tsc`. Most real codebases have abstract intermediate classes like `ApplicationRecord`; this closes that gap.

## How it works

**Two-pass approach in `createTrailsProgram`:**

1. **Pass 1**: create a program with default virtualization (literal `extends Base` only). This gives us a TypeChecker.
2. **Walk**: `collectBaseDescendants(program)` walks every class in the program via the checker, follows each `extends` clause transitively to its root, and returns the set of class names whose chain ends at `Base`.
3. **Pass 2** (if new names found): rebuild the CompilerHost + program with the expanded allow-list so those classes get virtualized too.

**`buildCompilerHost` now accepts `baseNames`**: the regex pre-filter dynamically matches any of the given names (not just `Base`), and passes the names through to `virtualize()` via `VirtualizeOptions.baseNames`.

## Fixture

Three files across `__fixtures__/transitive/`:
- `base.ts` — exports `Model` + `Base`
- `user.ts` — `class User extends Base { static { this.attribute("name", "string"); } }`
- `admin.ts` — `class Admin extends User { static { this.attribute("role", "string"); } }`
- `consumer.ts` — asserts `user.name`, `admin.role`, `admin.name` all type as `string`

## Test plan

- [x] 4 new tests:
  - Zero diagnostics on transitive fixture
  - Type-checker probes: `userName` → `string`, `adminRole` → `string`, `adminName` → `string`
  - User (direct) gets declares injected
  - Admin (transitive via User) gets declares injected
- [x] Full activerecord suite: **8263/8263**, zero regressions
- [x] `pnpm build` / `pnpm typecheck` / prettier / eslint clean
- [ ] CI

Plan: `docs/virtual-source-files-plan.md` § Phase 1b.3.