### PR TITLE
feat(activerecord): schema dump polish — sha1 stamp, VERSION env, schema_dump gating

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -915,6 +915,69 @@ describe("DatabaseTasksLoadSchemaTsFormatTest", () => {
   });
 });
 
+describe("DatabaseTasks loadSchema stamps schema_sha1", () => {
+  it("stamps ar_internal_metadata with schema_sha1 after loadSchema", async () => {
+    // Mirrors Rails: load_schema calls
+    // internal_metadata.create_table_and_set_flags(env, schema_sha1(file))
+    // so schemaUpToDate can skip purge+reload on subsequent test:prepare.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
+    const dbFile = path.join(tmp, "sha1.sqlite3");
+    const schemaFile = path.join(tmp, "schema.ts");
+    const markerFile = path.join(tmp, "loaded.txt");
+    fs.writeFileSync(
+      schemaFile,
+      `export default async function defineSchema(ctx) {
+  const fs = await import("node:fs");
+  fs.writeFileSync(${JSON.stringify(markerFile)}, "ok");
+}\n`,
+    );
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    const adapter = new SQLite3Adapter(dbFile);
+    DatabaseTasks.setAdapter(adapter);
+    DatabaseTasks.schemaFormat = "ts";
+    try {
+      const config = new HashConfig("test", "primary", { adapter: "sqlite3" });
+      await DatabaseTasks.loadSchema(config, "ts", schemaFile);
+      // Schema was loaded:
+      expect(fs.existsSync(markerFile)).toBe(true);
+      // schema_sha1 was stamped:
+      const { InternalMetadata } = await import("../internal-metadata.js");
+      const metadata = new InternalMetadata(adapter);
+      const storedSha1 = await metadata.get("schema_sha1");
+      expect(storedSha1).toBeTruthy();
+      // And it matches the actual file hash:
+      expect(storedSha1).toBe(DatabaseTasks["_schemaSha1"](schemaFile));
+    } finally {
+      await adapter.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("DatabaseTasks dumpSchema respects schemaDump gating", () => {
+  it("skips dump when config.schemaDump() returns false", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-gate-"));
+    const dbFile = path.join(tmp, "gate.sqlite3");
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    const adapter = new SQLite3Adapter(dbFile);
+    await adapter.executeMutation("CREATE TABLE items (id INTEGER PRIMARY KEY)");
+    DatabaseTasks.setAdapter(adapter);
+    DatabaseTasks.schemaFormat = "ts";
+    try {
+      const config = new HashConfig("test", "primary", {
+        adapter: "sqlite3",
+        schemaDump: false,
+      });
+      await DatabaseTasks.dumpSchema(config);
+      // Schema file should NOT have been created.
+      expect(fs.existsSync(path.join(tmp, "db", "schema.ts"))).toBe(false);
+    } finally {
+      await adapter.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("DatabaseTasks schema cache", () => {
   it("dumpSchemaCache writes tables from a freshly introspected adapter", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dstasks-"));

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -954,6 +954,44 @@ export default async function defineSchema(ctx) {
       const expectedSha1 = createHash("sha1").update(contents).digest("hex");
       expect(storedSha1).toBe(expectedSha1);
     } finally {
+      DatabaseTasks.setAdapter(null);
+      await adapter.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("stamps schema_sha1 after loadSchema with sql format", async () => {
+    // Covers the sql branch: structureLoad → _stampSchemaSha1.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-sql-"));
+    const dbFile = path.join(tmp, "sha1sql.sqlite3");
+    const structureFile = path.join(tmp, "structure.sql");
+    // Pre-populate a structure.sql with a simple table DDL.
+    fs.writeFileSync(structureFile, "CREATE TABLE gadgets (id INTEGER PRIMARY KEY);\n");
+    const { SQLite3Adapter } = await import("../connection-adapters/sqlite3-adapter.js");
+    const { SQLiteDatabaseTasks } = await import("./sqlite-database-tasks.js");
+    SQLiteDatabaseTasks.register();
+    const adapter = new SQLite3Adapter(dbFile);
+    DatabaseTasks.setAdapter(adapter);
+    try {
+      const config = new HashConfig("test", "primary", { adapter: "sqlite3", database: dbFile });
+      await DatabaseTasks.loadSchema(config, "sql", structureFile);
+      // Table was loaded:
+      const rows = await adapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='gadgets'",
+      );
+      expect(rows).toHaveLength(1);
+      // schema_sha1 was stamped:
+      const { InternalMetadata } = await import("../internal-metadata.js");
+      const metadata = new InternalMetadata(adapter);
+      const storedSha1 = await metadata.get("schema_sha1");
+      expect(storedSha1).toBeTruthy();
+      const { createHash } = await import("node:crypto");
+      const expected = createHash("sha1")
+        .update(fs.readFileSync(structureFile, "utf-8"))
+        .digest("hex");
+      expect(storedSha1).toBe(expected);
+    } finally {
+      DatabaseTasks.setAdapter(null);
       await adapter.close();
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -981,6 +1019,7 @@ describe("DatabaseTasks dumpSchema respects schemaDump gating", () => {
       expect(fs.existsSync(path.join(tmp, "db", "schema.ts"))).toBe(false);
     } finally {
       DatabaseTasks.dbDir = originalDbDir;
+      DatabaseTasks.setAdapter(null);
       await adapter.close();
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -922,12 +922,14 @@ describe("DatabaseTasks loadSchema stamps schema_sha1", () => {
     // so schemaUpToDate can skip purge+reload on subsequent test:prepare.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sha1-"));
     const dbFile = path.join(tmp, "sha1.sqlite3");
-    const schemaFile = path.join(tmp, "schema.ts");
+    // Use .mjs so Node can import it natively without a TS loader —
+    // keeps the test focused on SHA1 stamping, not loader config.
+    const schemaFile = path.join(tmp, "schema.mjs");
     const markerFile = path.join(tmp, "loaded.txt");
     fs.writeFileSync(
       schemaFile,
-      `export default async function defineSchema(ctx) {
-  const fs = await import("node:fs");
+      `import fs from "node:fs";
+export default async function defineSchema(ctx) {
   fs.writeFileSync(${JSON.stringify(markerFile)}, "ok");
 }\n`,
     );
@@ -945,8 +947,12 @@ describe("DatabaseTasks loadSchema stamps schema_sha1", () => {
       const metadata = new InternalMetadata(adapter);
       const storedSha1 = await metadata.get("schema_sha1");
       expect(storedSha1).toBeTruthy();
-      // And it matches the actual file hash:
-      expect(storedSha1).toBe(DatabaseTasks["_schemaSha1"](schemaFile));
+      // Compute the expected SHA1 the same way DatabaseTasks does
+      // (avoid accessing the private _schemaSha1 method directly).
+      const { createHash } = await import("node:crypto");
+      const contents = fs.readFileSync(schemaFile, "utf-8");
+      const expectedSha1 = createHash("sha1").update(contents).digest("hex");
+      expect(storedSha1).toBe(expectedSha1);
     } finally {
       await adapter.close();
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -963,15 +963,18 @@ describe("DatabaseTasks dumpSchema respects schemaDump gating", () => {
     await adapter.executeMutation("CREATE TABLE items (id INTEGER PRIMARY KEY)");
     DatabaseTasks.setAdapter(adapter);
     DatabaseTasks.schemaFormat = "ts";
+    const originalDbDir = DatabaseTasks.dbDir;
+    DatabaseTasks.dbDir = path.join(tmp, "db");
     try {
       const config = new HashConfig("test", "primary", {
         adapter: "sqlite3",
         schemaDump: false,
       });
       await DatabaseTasks.dumpSchema(config);
-      // Schema file should NOT have been created.
+      // Schema file should NOT have been created — gated by schemaDump: false.
       expect(fs.existsSync(path.join(tmp, "db", "schema.ts"))).toBe(false);
     } finally {
+      DatabaseTasks.dbDir = originalDbDir;
       await adapter.close();
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -619,11 +619,15 @@ export class DatabaseTasks {
 
   static async dumpSchema(config: DatabaseConfig): Promise<void> {
     // Rails: `return unless db_config.schema_dump` — lets per-config
-    // `schemaDump: false` suppress dumping (e.g. for read replicas
-    // or external DBs that shouldn't produce a schema file).
-    const cfgWithDump = config as unknown as { schemaDump?: (...args: unknown[]) => unknown };
-    if (typeof cfgWithDump.schemaDump === "function" && cfgWithDump.schemaDump() === false) {
-      return;
+    // `schemaDump: false` (or null) suppress dumping. HashConfig.schemaDump()
+    // returns `string | false | null`; false AND null both mean "don't dump".
+    // Pass the current format so the check matches what's being dumped.
+    const cfgWithDump = config as unknown as {
+      schemaDump?: (format?: string) => string | false | null;
+    };
+    if (typeof cfgWithDump.schemaDump === "function") {
+      const result = cfgWithDump.schemaDump(this.schemaFormat);
+      if (result === false || result === null) return;
     }
     const filename = this.schemaDumpPath(config);
     if (this.schemaFormat === "sql") {
@@ -712,6 +716,10 @@ export class DatabaseTasks {
   private static async _stampSchemaSha1(config: DatabaseConfig, filename: string): Promise<void> {
     const adapter = this._adapterInstance;
     if (!adapter) return;
+    // Respect useMetadataTable opt-out — if the config says don't use
+    // the metadata table, don't create one just to stamp the SHA1.
+    const useMetadata = (config as unknown as { useMetadataTable?: boolean }).useMetadataTable;
+    if (useMetadata === false) return;
     try {
       const { InternalMetadata } = await import("../internal-metadata.js");
       const metadata = new InternalMetadata(adapter);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -728,10 +728,16 @@ export class DatabaseTasks {
       const metadata = new InternalMetadata(adapter);
       const sha1 = this._schemaSha1(filename);
       await metadata.createTableAndSetFlags(config.envName, sha1);
-    } catch {
+    } catch (error) {
       // Best effort — a failed stamp just means schemaUpToDate
       // returns false next time, triggering a full reload instead
-      // of a truncate. No worse than before Phase 15.
+      // of a truncate. No worse than before Phase 15. Log at debug
+      // level so failures are diagnosable without crashing the load.
+
+      console.debug?.(
+        `[trails] _stampSchemaSha1 failed for ${config.envName} (${filename})`,
+        error,
+      );
     }
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -706,8 +706,10 @@ export class DatabaseTasks {
     const { MigrationContext } = await import("../migration.js");
     const ctx = new MigrationContext(adapter);
     await defineSchema(ctx);
-    // Both format branches fall through to here — stamp schema_sha1.
-    await this._stampSchemaSha1(config, filename);
+    // Stamp using the resolved absolute path — `filename` may be
+    // relative and `_schemaSha1` reads the file via getFs(), so the
+    // path must match what was actually imported.
+    await this._stampSchemaSha1(config, absolute);
   }
 
   /**

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -626,7 +626,11 @@ export class DatabaseTasks {
       schemaDump?: (format?: string) => string | false | null;
     };
     if (typeof cfgWithDump.schemaDump === "function") {
-      const result = cfgWithDump.schemaDump(this.schemaFormat);
+      // JS dumps use the same schema file path/config as TS; normalize
+      // so HashConfig.schemaDump (which recognizes ruby/sql/ts but not
+      // js) doesn't return null and accidentally suppress the dump.
+      const format = this.schemaFormat === "js" ? "ts" : this.schemaFormat;
+      const result = cfgWithDump.schemaDump(format);
       if (result === false || result === null) return;
     }
     const filename = this.schemaDumpPath(config);
@@ -718,8 +722,7 @@ export class DatabaseTasks {
     if (!adapter) return;
     // Respect useMetadataTable opt-out — if the config says don't use
     // the metadata table, don't create one just to stamp the SHA1.
-    const useMetadata = (config as unknown as { useMetadataTable?: boolean }).useMetadataTable;
-    if (useMetadata === false) return;
+    if (!config.useMetadataTable) return;
     try {
       const { InternalMetadata } = await import("../internal-metadata.js");
       const metadata = new InternalMetadata(adapter);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -618,6 +618,13 @@ export class DatabaseTasks {
   }
 
   static async dumpSchema(config: DatabaseConfig): Promise<void> {
+    // Rails: `return unless db_config.schema_dump` — lets per-config
+    // `schemaDump: false` suppress dumping (e.g. for read replicas
+    // or external DBs that shouldn't produce a schema file).
+    const cfgWithDump = config as unknown as { schemaDump?: (...args: unknown[]) => unknown };
+    if (typeof cfgWithDump.schemaDump === "function" && cfgWithDump.schemaDump() === false) {
+      return;
+    }
     const filename = this.schemaDumpPath(config);
     if (this.schemaFormat === "sql") {
       const fs = getFs();
@@ -657,6 +664,7 @@ export class DatabaseTasks {
 
     if (format === "sql") {
       await this.structureLoad(config, filename);
+      await this._stampSchemaSha1(config, filename);
       return;
     }
 
@@ -690,6 +698,30 @@ export class DatabaseTasks {
     const { MigrationContext } = await import("../migration.js");
     const ctx = new MigrationContext(adapter);
     await defineSchema(ctx);
+    // Both format branches fall through to here — stamp schema_sha1.
+    await this._stampSchemaSha1(config, filename);
+  }
+
+  /**
+   * After loading a schema file, stamp ar_internal_metadata with the
+   * file's SHA1 so `schemaUpToDate` can skip purge+reload on
+   * subsequent `reconstructFromSchema` calls (the test:prepare fast
+   * path). Mirrors Rails' `load_schema` which calls
+   * `internal_metadata.create_table_and_set_flags(env, schema_sha1(file))`.
+   */
+  private static async _stampSchemaSha1(config: DatabaseConfig, filename: string): Promise<void> {
+    const adapter = this._adapterInstance;
+    if (!adapter) return;
+    try {
+      const { InternalMetadata } = await import("../internal-metadata.js");
+      const metadata = new InternalMetadata(adapter);
+      const sha1 = this._schemaSha1(filename);
+      await metadata.createTableAndSetFlags(config.envName, sha1);
+    } catch {
+      // Best effort — a failed stamp just means schemaUpToDate
+      // returns false next time, triggering a full reload instead
+      // of a truncate. No worse than before Phase 15.
+    }
   }
 
   static async loadSchemaCurrent(

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -637,14 +637,17 @@ export function dbCommand(): Command {
   cmd
     .command("migrate")
     .description("Run pending migrations for all databases (or a specific one via --database)")
-    .option("--version <version>", "Migrate to a specific version")
+    .option("--version <version>", "Migrate to a specific version (also reads VERSION env)")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
+      // Rails: ENV["VERSION"] is an alternative to the --version flag
+      // for CI scripts that set VERSION=20260101000000.
+      const targetVersion = opts.version ?? process.env.VERSION?.trim() ?? null;
       await forEachDatabase(opts, async (ctx) => {
         await withMigratorForDb(
           ctx,
           async (migrator) => {
-            await migrator.migrate(opts.version ?? null);
+            await migrator.migrate(targetVersion);
           },
           {
             afterOutput: async (migrator) => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -641,8 +641,10 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       // Rails: ENV["VERSION"] is an alternative to the --version flag
-      // for CI scripts that set VERSION=20260101000000.
-      const targetVersion = opts.version ?? process.env.VERSION?.trim() ?? null;
+      // for CI scripts that set VERSION=20260101000000. Normalize blank
+      // to null so an empty VERSION="" doesn't fail BigInt parsing.
+      const rawVersion = opts.version ?? process.env.VERSION?.trim();
+      const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
       await forEachDatabase(opts, async (ctx) => {
         await withMigratorForDb(
           ctx,

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -643,7 +643,8 @@ export function dbCommand(): Command {
       // Rails: ENV["VERSION"] is an alternative to the --version flag
       // for CI scripts that set VERSION=20260101000000. Normalize blank
       // to null so an empty VERSION="" doesn't fail BigInt parsing.
-      const rawVersion = opts.version ?? process.env.VERSION?.trim();
+      const rawVersion =
+        opts.version != null ? String(opts.version).trim() : process.env.VERSION?.trim();
       const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
       await forEachDatabase(opts, async (ctx) => {
         await withMigratorForDb(


### PR DESCRIPTION
## Summary

Three small features closing the A- → A+ gap:

**Phase 15 — schema_sha1 stamping after loadSchema:**
Rails' `load_schema` stamps `ar_internal_metadata["schema_sha1"]` with the loaded file's SHA1. Without this, `schemaUpToDate` always returns false and `reconstructFromSchema` always purges+reloads instead of the fast truncate path. Both the ts/js and sql branches now stamp.

**Phase 17 — VERSION env-var:**
Rails' `db:migrate` reads `ENV["VERSION"]` as an alternative to the `--version` flag. Falls back to `process.env.VERSION` when `--version` isn't passed — matches CI workflows that `VERSION=20260101000000 trails db migrate`.

**Phase 22 — schema_dump gating:**
Rails' `dump_schema` returns early when `db_config.schema_dump` is false. `HashConfig.schemaDump()` already existed; now `DatabaseTasks.dumpSchema` checks it so per-config `schemaDump: false` suppresses schema file creation.

## Test plan
- [x] `pnpm test` — 17249 passing
- [x] loadSchema stamps schema_sha1, matches `_schemaSha1(file)` hash
- [x] dumpSchema skips when `config.schemaDump()` returns false