### PR TITLE
feat(activerecord): Phase 1b.4 — auto-import resolution for association targets

### DIFF
--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/author.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/author.ts
@@ -1,0 +1,7 @@
+import { Base } from "./base.js";
+
+export class Author extends Base {
+  static {
+    this.attribute("name", "string");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/base.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/base.ts
@@ -1,0 +1,8 @@
+export class Model {
+  [key: string]: unknown;
+  constructor(_attrs?: Record<string, unknown>) {}
+  static attribute(_name: string, _type: string): void {}
+  static belongsTo(_name: string, _opts?: Record<string, unknown>): void {}
+  static hasMany(_name: string, _opts?: Record<string, unknown>): void {}
+}
+export class Base extends Model {}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/consumer.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/consumer.ts
@@ -1,0 +1,8 @@
+import { Post } from "./post.js";
+import { Author } from "./author.js";
+
+const post = new Post();
+export const title: string = post.title;
+// post.author is typed as `Author | null` via the auto-imported
+// declare in post.ts — this just verifies it resolves.
+export const author: Author | null = post.author;

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/post.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/post.ts
@@ -1,0 +1,8 @@
+import { Base } from "./base.js";
+
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.belongsTo("author");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/auto-import/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["base.ts", "author.ts", "post.ts", "consumer.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/auto-import.ts
+++ b/packages/activerecord/src/tsc-wrapper/auto-import.ts
@@ -47,7 +47,13 @@ function collectTargetNames(info: ClassInfo, out: Set<string>): void {
       call.kind === "belongsTo" ||
       call.kind === "hasOne"
     ) {
-      out.add(resolveAssociationTarget(call as AssociationCall));
+      const assocCall = call as AssociationCall;
+      // Polymorphic belongsTo emits `Base` (not a user class) in
+      // `synthesize.ts`, so auto-injecting `import type { <Target> }`
+      // would be unused and can trigger noUnusedLocals/lint errors
+      // in user projects.
+      if (call.kind === "belongsTo" && assocCall.options["polymorphic"] === "true") continue;
+      out.add(resolveAssociationTarget(assocCall));
     }
   }
 }

--- a/packages/activerecord/src/tsc-wrapper/auto-import.ts
+++ b/packages/activerecord/src/tsc-wrapper/auto-import.ts
@@ -58,14 +58,15 @@ function collectNamesInScope(sf: ts.SourceFile): Set<string> {
   for (const stmt of sf.statements) {
     if (ts.isImportDeclaration(stmt) && stmt.importClause) {
       const clause = stmt.importClause;
+      // Default and named imports introduce type-namespace bindings.
+      // Skip namespace imports (`import * as X from "..."`) — `X` is a
+      // namespace value, not a type-namespace binding that can satisfy
+      // an association target type reference, so we still need to
+      // auto-inject `import type { X }` in that case.
       if (clause.name) names.add(clause.name.text);
-      if (clause.namedBindings) {
-        if (ts.isNamedImports(clause.namedBindings)) {
-          for (const el of clause.namedBindings.elements) {
-            names.add(el.name.text);
-          }
-        } else if (ts.isNamespaceImport(clause.namedBindings)) {
-          names.add(clause.namedBindings.name.text);
+      if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const el of clause.namedBindings.elements) {
+          names.add(el.name.text);
         }
       }
       continue;

--- a/packages/activerecord/src/tsc-wrapper/auto-import.ts
+++ b/packages/activerecord/src/tsc-wrapper/auto-import.ts
@@ -36,6 +36,11 @@ export function resolveAutoImports(
     imports.push(`import type { ${name} } from "${relativePath}";`);
   }
 
+  // Sort for determinism — iteration order of `neededNames` depends
+  // on association discovery order, which shouldn't affect the
+  // virtualized text / line deltas.
+  imports.sort((a, b) => a.localeCompare(b));
+
   return imports;
 }
 
@@ -64,15 +69,21 @@ function collectNamesInScope(sf: ts.SourceFile): Set<string> {
   for (const stmt of sf.statements) {
     if (ts.isImportDeclaration(stmt) && stmt.importClause) {
       const clause = stmt.importClause;
-      // Default and named imports introduce type-namespace bindings.
-      // Skip namespace imports (`import * as X from "..."`) — `X` is a
-      // namespace value, not a type-namespace binding that can satisfy
-      // an association target type reference, so we still need to
-      // auto-inject `import type { X }` in that case.
+      // Any local import binding (default, named, OR namespace)
+      // suppresses auto-import generation for the same name. Even
+      // though `import * as X from "..."` binds `X` as a namespace
+      // (not a type-namespace binding that can satisfy the association
+      // target type), auto-injecting `import type { X }` next to it
+      // would produce a duplicate-identifier error, which is worse
+      // than the user-fixable "can't use namespace as type" diagnostic.
       if (clause.name) names.add(clause.name.text);
-      if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
-        for (const el of clause.namedBindings.elements) {
-          names.add(el.name.text);
+      if (clause.namedBindings) {
+        if (ts.isNamedImports(clause.namedBindings)) {
+          for (const el of clause.namedBindings.elements) {
+            names.add(el.name.text);
+          }
+        } else if (ts.isNamespaceImport(clause.namedBindings)) {
+          names.add(clause.namedBindings.name.text);
         }
       }
       continue;

--- a/packages/activerecord/src/tsc-wrapper/auto-import.ts
+++ b/packages/activerecord/src/tsc-wrapper/auto-import.ts
@@ -1,0 +1,116 @@
+import ts from "typescript";
+import * as path from "node:path";
+import { walk, type ClassInfo, type AssociationCall } from "../type-virtualization/walker.js";
+import { classify } from "@blazetrails/activesupport";
+
+/**
+ * For each file being virtualized, compute the set of target class
+ * names referenced by association calls that are NOT already in scope,
+ * look them up in the model registry, and return `import type` lines
+ * to prepend.
+ */
+export function resolveAutoImports(
+  originalText: string,
+  fileName: string,
+  modelRegistry: ReadonlyMap<string, string>,
+  baseNames?: readonly string[],
+): string[] {
+  const sf = ts.createSourceFile(fileName, originalText, ts.ScriptTarget.ES2022, true);
+  const classes = walk(sf, { baseNames });
+
+  const neededNames = new Set<string>();
+  for (const info of classes) {
+    collectTargetNames(info, neededNames);
+  }
+
+  if (neededNames.size === 0) return [];
+
+  const inScope = collectNamesInScope(sf);
+  const imports: string[] = [];
+
+  for (const name of neededNames) {
+    if (inScope.has(name)) continue;
+    const targetPath = modelRegistry.get(name);
+    if (!targetPath) continue;
+    const relativePath = computeRelativeImport(fileName, targetPath);
+    imports.push(`import type { ${name} } from "${relativePath}";`);
+  }
+
+  return imports;
+}
+
+function collectTargetNames(info: ClassInfo, out: Set<string>): void {
+  for (const call of info.calls) {
+    if (
+      call.kind === "hasMany" ||
+      call.kind === "hasAndBelongsToMany" ||
+      call.kind === "belongsTo" ||
+      call.kind === "hasOne"
+    ) {
+      const assocCall = call as AssociationCall;
+      const explicit = assocCall.options["className"];
+      const target = explicit ? stripQuotes(explicit) : classify(assocCall.name);
+      out.add(target);
+    }
+  }
+}
+
+function collectNamesInScope(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+
+  for (const stmt of sf.statements) {
+    if (ts.isImportDeclaration(stmt) && stmt.importClause) {
+      const clause = stmt.importClause;
+      if (clause.name) names.add(clause.name.text);
+      if (clause.namedBindings) {
+        if (ts.isNamedImports(clause.namedBindings)) {
+          for (const el of clause.namedBindings.elements) {
+            names.add(el.name.text);
+          }
+        } else if (ts.isNamespaceImport(clause.namedBindings)) {
+          names.add(clause.namedBindings.name.text);
+        }
+      }
+      continue;
+    }
+
+    if (ts.isImportEqualsDeclaration(stmt)) {
+      names.add(stmt.name.text);
+      continue;
+    }
+
+    // Only type-namespace declarations suppress auto-imports. Value-
+    // only declarations (functions, variables) don't introduce types.
+    if (
+      (ts.isClassDeclaration(stmt) ||
+        ts.isInterfaceDeclaration(stmt) ||
+        ts.isTypeAliasDeclaration(stmt) ||
+        ts.isEnumDeclaration(stmt)) &&
+      stmt.name
+    ) {
+      names.add(stmt.name.text);
+    }
+  }
+
+  return names;
+}
+
+function computeRelativeImport(fromFile: string, toFile: string): string {
+  const fromDir = path.dirname(fromFile);
+  let rel = path.relative(fromDir, toFile);
+  // Normalize Windows backslashes to POSIX forward slashes.
+  rel = rel.replace(/\\/g, "/");
+  // Ensure it starts with ./ or ../
+  if (!rel.startsWith(".")) rel = "./" + rel;
+  // Replace .ts extension with .js for ESM TypeScript imports
+  rel = rel.replace(/\.tsx?$/, ".js");
+  return rel;
+}
+
+function stripQuotes(s: string): string {
+  const first = s.charAt(0);
+  if ((first === '"' || first === "'" || first === "`") && s.endsWith(first)) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/packages/activerecord/src/tsc-wrapper/auto-import.ts
+++ b/packages/activerecord/src/tsc-wrapper/auto-import.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import * as path from "node:path";
 import { walk, type ClassInfo, type AssociationCall } from "../type-virtualization/walker.js";
-import { classify } from "@blazetrails/activesupport";
+import { resolveAssociationTarget } from "../type-virtualization/resolve-target.js";
 
 /**
  * For each file being virtualized, compute the set of target class
@@ -47,10 +47,7 @@ function collectTargetNames(info: ClassInfo, out: Set<string>): void {
       call.kind === "belongsTo" ||
       call.kind === "hasOne"
     ) {
-      const assocCall = call as AssociationCall;
-      const explicit = assocCall.options["className"];
-      const target = explicit ? stripQuotes(explicit) : classify(assocCall.name);
-      out.add(target);
+      out.add(resolveAssociationTarget(call as AssociationCall));
     }
   }
 }
@@ -105,12 +102,4 @@ function computeRelativeImport(fromFile: string, toFile: string): string {
   // Replace .ts extension with .js for ESM TypeScript imports
   rel = rel.replace(/\.tsx?$/, ".js");
   return rel;
-}
-
-function stripQuotes(s: string): string {
-  const first = s.charAt(0);
-  if ((first === '"' || first === "'" || first === "`") && s.endsWith(first)) {
-    return s.slice(1, -1);
-  }
-  return s;
 }

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -183,3 +183,62 @@ describe("trails-tsc transitive extends — Phase 1b.3", () => {
     expect(adminFile!.text).toContain("declare role: string");
   });
 });
+
+describe("trails-tsc auto-import — Phase 1b.4", () => {
+  const AUTO_IMPORT_DIR = path.resolve(FIXTURES_DIR, "auto-import");
+
+  it("auto-injects `import type { Author }` into post.ts (no user-written import)", () => {
+    const configPath = path.join(AUTO_IMPORT_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+
+    const postFile = program.getSourceFile(path.join(AUTO_IMPORT_DIR, "post.ts"));
+    expect(postFile).toBeDefined();
+    expect(postFile!.text).toContain("import type { Author }");
+  });
+
+  it("zero diagnostics — auto-imported Author resolves for the belongsTo declare", () => {
+    const configPath = path.join(AUTO_IMPORT_DIR, "tsconfig.json");
+    const { program } = createTrailsProgram(configPath);
+    const diagnostics = [...ts.getPreEmitDiagnostics(program)];
+
+    for (const d of diagnostics) {
+      const msg = typeof d.messageText === "string" ? d.messageText : JSON.stringify(d.messageText);
+      const loc = d.file
+        ? `${path.basename(d.file.fileName)}:${d.file.getLineAndCharacterOfPosition(d.start ?? 0).line + 1}`
+        : "?";
+      console.error(`DIAG [${d.code}] ${loc}: ${msg}`);
+    }
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("user-written import for Author prevents duplicate auto-import", () => {
+    // Create a temp copy of the fixture with an explicit Author import
+    // already in post.ts, then verify the virtualizer doesn't inject
+    // a second one.
+    const tempDir = fs.mkdtempSync(path.join(AUTO_IMPORT_DIR, ".dup-test-"));
+    try {
+      for (const f of fs.readdirSync(AUTO_IMPORT_DIR)) {
+        const src = path.join(AUTO_IMPORT_DIR, f);
+        if (fs.statSync(src).isFile()) {
+          fs.copyFileSync(src, path.join(tempDir, f));
+        }
+      }
+      const postPath = path.join(tempDir, "post.ts");
+      const postSource = fs.readFileSync(postPath, "utf8");
+      const explicitImport = 'import type { Author } from "./author.js";\n';
+      if (!postSource.includes(explicitImport)) {
+        fs.writeFileSync(postPath, explicitImport + postSource);
+      }
+
+      const configPath = path.join(tempDir, "tsconfig.json");
+      const { program } = createTrailsProgram(configPath);
+      const postFile = program.getSourceFile(path.resolve(postPath));
+      expect(postFile).toBeDefined();
+
+      const matches = postFile!.text.match(/import type\s*\{\s*Author\s*\}/g) ?? [];
+      expect(matches).toHaveLength(1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import * as path from "node:path";
 import { virtualize, type VirtualizeResult } from "../type-virtualization/virtualize.js";
+import { resolveAutoImports } from "./auto-import.js";
 
 const STATIC_BLOCK_PATTERN = /\bstatic\s*\{/;
 
@@ -12,6 +13,7 @@ export interface TrailsCompilerHost extends ts.CompilerHost {
 export function buildCompilerHost(
   options: ts.CompilerOptions,
   baseNames?: readonly string[],
+  modelRegistry?: ReadonlyMap<string, string>,
 ): TrailsCompilerHost {
   const baseHost = ts.createCompilerHost(options, true);
   const deltaMap = new Map<string, VirtualizeResult["deltas"]>();
@@ -40,7 +42,10 @@ export function buildCompilerHost(
       virtualizedTextCache.set(resolved, originalText);
       return originalText;
     }
-    const result = virtualize(originalText, resolved, { baseNames });
+    const prependImports = modelRegistry
+      ? resolveAutoImports(originalText, resolved, modelRegistry, baseNames)
+      : undefined;
+    const result = virtualize(originalText, resolved, { baseNames, prependImports });
     virtualizedTextCache.set(resolved, result.text);
     originalTextCache.set(resolved, originalText);
     deltaMap.set(resolved, result.deltas);

--- a/packages/activerecord/src/tsc-wrapper/program.ts
+++ b/packages/activerecord/src/tsc-wrapper/program.ts
@@ -46,10 +46,11 @@ export function createTrailsProgram(configPath: string): TrailsProgram {
     };
   }
 
-  // Pass 1: create program with default virtualization (literal
-  // `extends Base` only). This gives us a checker to resolve the
-  // full extends chain.
-  const host1 = buildCompilerHost(parsed.options);
+  // Pass 1: create program with a plain compiler host (no
+  // virtualization / auto-import). We only need the checker here to
+  // resolve the full extends chain — doing the text transform twice
+  // would be wasted work.
+  const host1 = ts.createCompilerHost(parsed.options, true);
   const program1 = ts.createProgram({
     rootNames: parsed.fileNames,
     options: parsed.options,

--- a/packages/activerecord/src/tsc-wrapper/program.ts
+++ b/packages/activerecord/src/tsc-wrapper/program.ts
@@ -56,19 +56,15 @@ export function createTrailsProgram(configPath: string): TrailsProgram {
     host: host1,
   });
 
-  // Pass 2: walk the checker to find transitive Base descendants
-  // (e.g. `class Admin extends User extends Base`). If any new names
-  // are found, rebuild with the expanded allow-list so those classes
-  // get virtualized too.
-  const baseNames = collectBaseDescendants(program1);
-  const defaultNames = new Set(["Base"]);
-  const hasNewNames = [...baseNames].some((n) => !defaultNames.has(n));
+  // Pass 2: walk the checker to find transitive Base descendants and
+  // build the model registry (className → absolutePath) for
+  // auto-import resolution.
+  const { baseNames, modelRegistry } = collectBaseDescendants(program1);
 
-  if (!hasNewNames) {
-    return { program: program1, host: host1, configDiagnostics: [] };
-  }
-
-  const host = buildCompilerHost(parsed.options, [...baseNames]);
+  // Rebuild with the full allow-list + model registry so transitive
+  // classes are virtualized AND missing `import type` lines are
+  // auto-injected.
+  const host = buildCompilerHost(parsed.options, [...baseNames], modelRegistry);
   const program = ts.createProgram({
     rootNames: parsed.fileNames,
     options: parsed.options,

--- a/packages/activerecord/src/type-virtualization/resolve-target.ts
+++ b/packages/activerecord/src/type-virtualization/resolve-target.ts
@@ -1,0 +1,22 @@
+// Shared helper for resolving the target class name of an association
+// call. Used by both `synthesize.ts` (to emit `declare` types) and
+// `tsc-wrapper/auto-import.ts` (to decide which `import type` lines to
+// inject). Keeping the logic in one place ensures the emitted declares
+// and the auto-imports can't drift.
+
+import { classify } from "@blazetrails/activesupport";
+import type { AssociationCall } from "./walker.js";
+
+export function resolveAssociationTarget(call: AssociationCall): string {
+  const explicit = call.options["className"];
+  if (explicit) return stripQuotes(explicit);
+  return classify(call.name);
+}
+
+export function stripQuotes(source: string): string {
+  const first = source.charAt(0);
+  if ((first === '"' || first === "'" || first === "`") && source.endsWith(first)) {
+    return source.slice(1, -1);
+  }
+  return source;
+}

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -4,7 +4,8 @@
 // user has already declared by hand. Output is plain text — the splicer
 // in virtualize.ts inserts it verbatim after the class body's opening `{`.
 
-import { classify, camelize } from "@blazetrails/activesupport";
+import { camelize } from "@blazetrails/activesupport";
+import { resolveAssociationTarget, stripQuotes } from "./resolve-target.js";
 import type {
   ClassInfo,
   RuntimeCall,
@@ -212,17 +213,7 @@ function readAffix(raw: string | undefined, attr: string, side: "prefix" | "suff
 }
 
 function resolveTarget(call: AssociationCall): string {
-  const explicit = call.options["className"];
-  if (explicit) return stripQuotes(explicit);
-  return classify(call.name);
-}
-
-function stripQuotes(source: string): string {
-  const first = source.charAt(0);
-  if ((first === '"' || first === "'" || first === "`") && source.endsWith(first)) {
-    return source.slice(1, -1);
-  }
-  return source;
+  return resolveAssociationTarget(call);
 }
 
 function pascal(s: string): string {

--- a/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
+++ b/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
@@ -14,12 +14,19 @@ import ts from "typescript";
  *
  * Runs once per program — the caller caches the result.
  */
+export interface WalkerResult {
+  baseNames: Set<string>;
+  /** className → absolute source file path */
+  modelRegistry: Map<string, string>;
+}
+
 export function collectBaseDescendants(
   program: ts.Program,
   rootNames: ReadonlySet<string> = new Set(["Base"]),
-): Set<string> {
+): WalkerResult {
   const checker = program.getTypeChecker();
-  const result = new Set<string>(rootNames);
+  const baseNames = new Set<string>(rootNames);
+  const modelRegistry = new Map<string, string>();
   const memo = new Map<ts.Symbol, boolean>();
 
   for (const sf of program.getSourceFiles()) {
@@ -27,12 +34,19 @@ export function collectBaseDescendants(
     ts.forEachChild(sf, (node) => {
       if (ts.isClassDeclaration(node) && node.name) {
         const sym = checker.getSymbolAtLocation(node.name);
-        if (sym) walkClass(sym, checker, rootNames, result, memo);
+        if (sym && walkClass(sym, checker, rootNames, baseNames, memo)) {
+          // If there's a name collision, pick the closest file by
+          // path length (heuristic for "least nested").
+          const existing = modelRegistry.get(sym.name);
+          if (!existing || sf.fileName.length < existing.length) {
+            modelRegistry.set(sym.name, sf.fileName);
+          }
+        }
       }
     });
   }
 
-  return result;
+  return { baseNames, modelRegistry };
 }
 
 function walkClass(

--- a/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
+++ b/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
@@ -1,13 +1,17 @@
 import ts from "typescript";
 
 /**
- * Walk every top-level class declaration in the program and return
- * the set of class names whose `extends` chain transitively roots at
- * one of the configured base names (default: `["Base"]`).
+ * Walk every top-level class declaration in the program and return a
+ * `WalkerResult` with:
  *
- * The result includes the base names themselves, so `virtualize()`
- * can be called with `{ baseNames: [...result] }` and will handle
- * both direct and transitive descendants in one pass.
+ * - `baseNames` — the set of class names whose `extends` chain
+ *   transitively roots at one of the configured base names (default:
+ *   `["Base"]`). Includes the root names themselves, so
+ *   `virtualize()` can be called with `{ baseNames: [...baseNames] }`
+ *   and will handle both direct and transitive descendants in one pass.
+ * - `modelRegistry` — a `className → absolute source file path` map
+ *   used by the auto-import resolver to inject `import type { ... }`
+ *   lines for association targets referenced by name.
  *
  * Only top-level classes are considered — classes nested inside
  * functions or namespaces are not model declarations in practice.

--- a/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
+++ b/packages/activerecord/src/type-virtualization/transitive-extends-walker.ts
@@ -39,10 +39,17 @@ export function collectBaseDescendants(
       if (ts.isClassDeclaration(node) && node.name) {
         const sym = checker.getSymbolAtLocation(node.name);
         if (sym && walkClass(sym, checker, rootNames, baseNames, memo)) {
-          // If there's a name collision, pick the closest file by
-          // path length (heuristic for "least nested").
+          // If there's a name collision, pick the shortest path
+          // (heuristic for "least nested"), breaking ties
+          // lexicographically so the winner is deterministic across
+          // environments and TS versions that may iterate source
+          // files in different orders.
           const existing = modelRegistry.get(sym.name);
-          if (!existing || sf.fileName.length < existing.length) {
+          if (
+            !existing ||
+            sf.fileName.length < existing.length ||
+            (sf.fileName.length === existing.length && sf.fileName < existing)
+          ) {
             modelRegistry.set(sym.name, sf.fileName);
           }
         }

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -145,6 +145,27 @@ describe("virtualize — prependImports", () => {
     // The original file's first line (line 0) is now at virtual line 2.
     expect(remapLine(2, deltas)).toBe(0);
   });
+
+  test("remapLine preserves leading-directive lines when imports are inserted after them", () => {
+    const src =
+      "#!/usr/bin/env node\n" + //         L0 (original & virtual)
+      "// @ts-nocheck\n" + //              L1
+      "\n" + //                            L2
+      "export class Post extends Base {\n" + // L3
+      '  static { this.attribute("title", "string"); }\n' + // L4
+      "}\n"; //                            L5
+    const { deltas } = virtualize(src, "post.ts", {
+      prependImports: ['import type { Author } from "./author.js";'],
+    });
+    // Directive lines remain at their original line indices.
+    expect(remapLine(0, deltas)).toBe(0);
+    expect(remapLine(1, deltas)).toBe(1);
+    expect(remapLine(2, deltas)).toBe(2);
+    // The injected import sits at virtual line 3 — inside the block.
+    expect(remapLine(3, deltas)).toBeNull();
+    // Virtual line 4 is now the `export class Post...` line.
+    expect(remapLine(4, deltas)).toBe(3);
+  });
 });
 
 describe("virtualize — multiple classes", () => {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -147,6 +147,39 @@ describe("virtualize — prependImports", () => {
   });
 });
 
+describe("virtualize — multiple classes", () => {
+  test("remapLine is correct for lines after the second injected block", () => {
+    // Two Base-descendant classes in one file. Each gets its own
+    // declare block injected after `{`. `remapLine` for user-written
+    // lines inside the SECOND class must account for BOTH blocks
+    // having shifted the file down.
+    const src =
+      "export class Post extends Base {\n" + //           L0
+      '  static { this.attribute("title", "string"); }\n' + // L1
+      "}\n" + //                                           L2
+      "\n" + //                                            L3
+      "export class Comment extends Base {\n" + //         L4
+      '  static { this.attribute("body", "string"); }\n' + //  L5
+      "}\n"; //                                            L6
+    const { text, deltas } = virtualize(src, "file.ts");
+    expect(deltas).toHaveLength(2);
+
+    const vLines = text.split("\n");
+    const commentBraceVLine = vLines.findIndex((l) => l.startsWith("export class Comment"));
+    expect(commentBraceVLine).toBeGreaterThan(4);
+    expect(remapLine(commentBraceVLine, deltas)).toBe(4);
+
+    // A line inside the Comment body (original line 5) should also
+    // remap correctly after both injections.
+    const commentBodyVLine = vLines.findIndex((l) => l.includes('this.attribute("body"'));
+    expect(remapLine(commentBodyVLine, deltas)).toBe(5);
+
+    // Injected lines (inside either block) return null.
+    expect(remapLine(deltas[0]!.insertedAtLine + 1, deltas)).toBeNull();
+    expect(remapLine(deltas[1]!.insertedAtLine + 1, deltas)).toBeNull();
+  });
+});
+
 describe("virtualize — idempotence", () => {
   test("re-virtualizing the output skips members already declared", () => {
     const src =

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -98,6 +98,56 @@ describe("remapLine", () => {
   });
 });
 
+describe("virtualize — prependImports", () => {
+  test("prepends import type lines at the top of the file", () => {
+    const src =
+      "export class Post extends Base {\n" +
+      '  static { this.attribute("title", "string"); }\n' +
+      "}\n";
+    const { text } = virtualize(src, "post.ts", {
+      prependImports: ['import type { Author } from "./author.js";'],
+    });
+    expect(text.startsWith('import type { Author } from "./author.js";')).toBe(true);
+  });
+
+  test("inserts after leading directives (shebang, triple-slash, @ts-nocheck)", () => {
+    const src =
+      "#!/usr/bin/env node\n" +
+      "// @ts-nocheck\n" +
+      "/// <reference types='node' />\n" +
+      "\n" +
+      "export class Post extends Base {\n" +
+      '  static { this.attribute("title", "string"); }\n' +
+      "}\n";
+    const { text } = virtualize(src, "post.ts", {
+      prependImports: ['import type { Author } from "./author.js";'],
+    });
+    const lines = text.split("\n");
+    // Directives should come first, then import, then the class.
+    expect(lines[0]).toBe("#!/usr/bin/env node");
+    expect(lines[1]).toBe("// @ts-nocheck");
+    expect(lines[2]).toBe("/// <reference types='node' />");
+    expect(lines[3]).toBe("");
+    expect(lines[4]).toBe('import type { Author } from "./author.js";');
+  });
+
+  test("remapLine accounts for prepended lines", () => {
+    const src =
+      "export class Post extends Base {\n" +
+      '  static { this.attribute("title", "string"); }\n' +
+      "}\n";
+    const { deltas } = virtualize(src, "post.ts", {
+      prependImports: ['import type { A } from "./a.js";', 'import type { B } from "./b.js";'],
+    });
+    // 2 prepended lines → virtual line 2 is original line 0
+    expect(remapLine(0, deltas)).toBeNull(); // inside prepended block
+    expect(remapLine(1, deltas)).toBeNull(); // inside prepended block
+    // The original file's first line (line 0) is now at virtual line 2
+    // (after the 2 prepended import lines). It may also be shifted by
+    // declare injection, but the prepend delta alone maps line 2 → 0.
+  });
+});
+
 describe("virtualize — idempotence", () => {
   test("re-virtualizing the output skips members already declared", () => {
     const src =

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -142,9 +142,8 @@ describe("virtualize — prependImports", () => {
     // 2 prepended lines → virtual line 2 is original line 0
     expect(remapLine(0, deltas)).toBeNull(); // inside prepended block
     expect(remapLine(1, deltas)).toBeNull(); // inside prepended block
-    // The original file's first line (line 0) is now at virtual line 2
-    // (after the 2 prepended import lines). It may also be shifted by
-    // declare injection, but the prepend delta alone maps line 2 → 0.
+    // The original file's first line (line 0) is now at virtual line 2.
+    expect(remapLine(2, deltas)).toBe(0);
   });
 });
 

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -13,13 +13,18 @@ import { synthesizeDeclares } from "./synthesize.js";
 
 export interface LineDelta {
   /**
-   * 0-indexed line in the ORIGINAL source where the injected block
-   * begins. The sentinel value `-1` means the block was prepended
-   * ABOVE line 0 (used by `prependImports` for auto-imports), so
-   * virtual lines `0..lineCount-1` are inside the injected range and
-   * virtual line `lineCount` maps back to original line 0.
-   * Diagnostics reported at line > insertedAtLine + lineCount map back
-   * by subtracting lineCount.
+   * 0-indexed line in the VIRTUALIZED text where the injected block
+   * begins. The injected range spans
+   * `insertedAtLine + 1 .. insertedAtLine + lineCount`, and those
+   * virtual lines have no corresponding line in the original source.
+   *
+   * To map a later virtual line back to the original source,
+   * `remapLine` subtracts `lineCount` once the line is after the
+   * injected block; deltas are stacked in ascending virtual order so
+   * multi-class files and prepended imports compose correctly.
+   *
+   * The sentinel value `-1` means the block was prepended ABOVE
+   * virtual line 0 (used by `prependImports` for auto-imports).
    */
   insertedAtLine: number;
   /** Number of lines the injected block spans. */
@@ -72,10 +77,18 @@ export function virtualize(
     text = text.slice(0, e.pos) + e.text + text.slice(e.pos);
   }
 
-  const deltas: LineDelta[] = edits
-    .slice()
-    .sort((a, b) => a.originalLine - b.originalLine)
-    .map((e) => ({ insertedAtLine: e.originalLine, lineCount: e.lineCount }));
+  // Convert each edit's originalLine into a VIRTUAL line by accumulating
+  // the lineCount of all earlier injections. `remapLine` expects
+  // `insertedAtLine` to be a virtual coordinate so multi-class files
+  // (two injected declare blocks) remap correctly for lines after the
+  // second block.
+  const sortedEdits = edits.slice().sort((a, b) => a.originalLine - b.originalLine);
+  let cumulative = 0;
+  const deltas: LineDelta[] = sortedEdits.map((e) => {
+    const d: LineDelta = { insertedAtLine: e.originalLine + cumulative, lineCount: e.lineCount };
+    cumulative += e.lineCount;
+    return d;
+  });
 
   // Insert auto-imported `import type` lines AFTER any leading
   // directives (shebangs, triple-slash refs, @ts-nocheck) that must

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -97,16 +97,19 @@ export function virtualize(
   if (prependImports && prependImports.length > 0) {
     const importBlock = prependImports.join("\n") + "\n";
     const insertPos = findDirectiveEnd(text);
+    // Compute the virtual line BEFORE which the import block is
+    // inserted: `-1` if the block is truly at the start of the file,
+    // otherwise the line index of the last directive/blank line that
+    // precedes the insertion point. This preserves `remapLine` for
+    // any leading directives (shebang / @ts-nocheck / triple-slash).
+    const insertedAtLine =
+      insertPos === 0 ? -1 : text.slice(0, insertPos).split(/\r?\n/).length - 2;
     text = text.slice(0, insertPos) + importBlock + text.slice(insertPos);
-    // Shift all existing deltas down by the number of prepended lines.
     const prependedLines = prependImports.length;
     for (const d of deltas) {
       d.insertedAtLine += prependedLines;
     }
-    // Use insertedAtLine: -1 so remapLine correctly treats virtual
-    // lines 0..prependedLines-1 as "inside the injected range" (null)
-    // and virtual line prependedLines as original line 0.
-    deltas.unshift({ insertedAtLine: -1, lineCount: prependedLines });
+    deltas.unshift({ insertedAtLine, lineCount: prependedLines });
   }
 
   return { text, deltas };
@@ -120,10 +123,18 @@ export function virtualize(
  * file-leading semantics.
  */
 function findDirectiveEnd(text: string): number {
+  // Scan line-by-line preserving the actual line terminator width
+  // (`\n` or `\r\n`) so the returned offset is a valid index in
+  // `text`. Stops at the first non-directive, non-blank line; also
+  // stops if the file ends without a trailing newline so we never
+  // overshoot `text.length`.
+  const lineRe = /([^\r\n]*)(\r?\n|$)/g;
   let pos = 0;
-  const lines = text.split("\n");
-  for (const line of lines) {
-    const trimmed = line.trimStart();
+  let match: RegExpExecArray | null;
+  while ((match = lineRe.exec(text)) !== null) {
+    const [full, line, terminator] = match;
+    if (terminator === "" && line === "") break;
+    const trimmed = line!.trimStart();
     if (
       trimmed.startsWith("#!") ||
       trimmed.startsWith("/// <") ||
@@ -131,7 +142,8 @@ function findDirectiveEnd(text: string): number {
       trimmed.startsWith("/* @ts-") ||
       trimmed === ""
     ) {
-      pos += line.length + 1; // +1 for \n
+      pos += full!.length;
+      if (terminator === "") break;
     } else {
       break;
     }

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -27,7 +27,9 @@ export interface VirtualizeResult {
   deltas: LineDelta[];
 }
 
-export type VirtualizeOptions = WalkOptions;
+export interface VirtualizeOptions extends WalkOptions {
+  prependImports?: readonly string[];
+}
 
 export function virtualize(
   originalText: string,
@@ -71,7 +73,53 @@ export function virtualize(
     .sort((a, b) => a.originalLine - b.originalLine)
     .map((e) => ({ insertedAtLine: e.originalLine, lineCount: e.lineCount }));
 
+  // Insert auto-imported `import type` lines AFTER any leading
+  // directives (shebangs, triple-slash refs, @ts-nocheck) that must
+  // stay at the top of the file. Erased at runtime (type-only).
+  const prependImports = options.prependImports;
+  if (prependImports && prependImports.length > 0) {
+    const importBlock = prependImports.join("\n") + "\n";
+    const insertPos = findDirectiveEnd(text);
+    text = text.slice(0, insertPos) + importBlock + text.slice(insertPos);
+    // Shift all existing deltas down by the number of prepended lines.
+    const prependedLines = prependImports.length;
+    for (const d of deltas) {
+      d.insertedAtLine += prependedLines;
+    }
+    // Use insertedAtLine: -1 so remapLine correctly treats virtual
+    // lines 0..prependedLines-1 as "inside the injected range" (null)
+    // and virtual line prependedLines as original line 0.
+    deltas.unshift({ insertedAtLine: -1, lineCount: prependedLines });
+  }
+
   return { text, deltas };
+}
+
+/**
+ * Find the character offset AFTER any leading directives that must
+ * stay at the top of the file: shebangs (`#!`), triple-slash refs
+ * (`/// <reference ...>`), and TS comment directives (`// @ts-nocheck`
+ * etc.). Auto-imports are inserted at this offset so they don't break
+ * file-leading semantics.
+ */
+function findDirectiveEnd(text: string): number {
+  let pos = 0;
+  const lines = text.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (
+      trimmed.startsWith("#!") ||
+      trimmed.startsWith("/// <") ||
+      trimmed.startsWith("// @ts-") ||
+      trimmed.startsWith("/* @ts-") ||
+      trimmed === ""
+    ) {
+      pos += line.length + 1; // +1 for \n
+    } else {
+      break;
+    }
+  }
+  return pos;
 }
 
 /**

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -101,9 +101,15 @@ export function virtualize(
     // inserted: `-1` if the block is truly at the start of the file,
     // otherwise the line index of the last directive/blank line that
     // precedes the insertion point. This preserves `remapLine` for
-    // any leading directives (shebang / @ts-nocheck / triple-slash).
+    // any leading directives (shebang / @ts-nocheck / triple-slash)
+    // — including the edge case where the file ends at a directive
+    // with no trailing newline (in which case `split(/\r?\n/)`
+    // wouldn't produce a final empty element, so subtracting 2 would
+    // be off by one).
+    const before = text.slice(0, insertPos);
+    const newlineCount = (before.match(/\r?\n/g) ?? []).length;
     const insertedAtLine =
-      insertPos === 0 ? -1 : text.slice(0, insertPos).split(/\r?\n/).length - 2;
+      insertPos === 0 ? -1 : before.endsWith("\n") ? newlineCount - 1 : newlineCount;
     text = text.slice(0, insertPos) + importBlock + text.slice(insertPos);
     const prependedLines = prependImports.length;
     for (const d of deltas) {

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -141,11 +141,26 @@ function findDirectiveEnd(text: string): number {
     const [full, line, terminator] = match;
     if (terminator === "" && line === "") break;
     const trimmed = line!.trimStart();
+    // File-leading directives we preserve above the auto-import block:
+    //   - shebangs (`#!...`)
+    //   - triple-slash reference directives (`/// <reference ...>`)
+    //   - whole-file TS pragmas `// @ts-nocheck` / `// @ts-check`
+    //     (NOT `// @ts-ignore` / `// @ts-expect-error`, which apply to
+    //     the NEXT statement — injecting imports between the pragma
+    //     and the statement would change behavior)
+    //   - single-line block-comment form `/* @ts-nocheck */` /
+    //     `/* @ts-check */` (multi-line `/* ... */` would require
+    //     scanning to `*/` to avoid splicing into the comment body)
+    //   - blank lines in between
+    const isSingleLineBlockPragma =
+      (trimmed.startsWith("/* @ts-nocheck") || trimmed.startsWith("/* @ts-check")) &&
+      trimmed.includes("*/");
     if (
       trimmed.startsWith("#!") ||
       trimmed.startsWith("/// <") ||
-      trimmed.startsWith("// @ts-") ||
-      trimmed.startsWith("/* @ts-") ||
+      trimmed.startsWith("// @ts-nocheck") ||
+      trimmed.startsWith("// @ts-check") ||
+      isSingleLineBlockPragma ||
       trimmed === ""
     ) {
       pos += full!.length;

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -82,7 +82,12 @@ export function virtualize(
   // `insertedAtLine` to be a virtual coordinate so multi-class files
   // (two injected declare blocks) remap correctly for lines after the
   // second block.
-  const sortedEdits = edits.slice().sort((a, b) => a.originalLine - b.originalLine);
+  // Sort by (originalLine, pos) so multiple injections on the same
+  // line (e.g., two one-line class declarations) compose in stable,
+  // file-order delta-cumulation for remapLine.
+  const sortedEdits = edits
+    .slice()
+    .sort((a, b) => a.originalLine - b.originalLine || a.pos - b.pos);
   let cumulative = 0;
   const deltas: LineDelta[] = sortedEdits.map((e) => {
     const d: LineDelta = { insertedAtLine: e.originalLine + cumulative, lineCount: e.lineCount };

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -13,9 +13,13 @@ import { synthesizeDeclares } from "./synthesize.js";
 
 export interface LineDelta {
   /**
-   * 0-indexed line in the ORIGINAL source where the injected block begins.
-   * Diagnostics reported at line > insertedAtLine + lineCount map back by
-   * subtracting lineCount.
+   * 0-indexed line in the ORIGINAL source where the injected block
+   * begins. The sentinel value `-1` means the block was prepended
+   * ABOVE line 0 (used by `prependImports` for auto-imports), so
+   * virtual lines `0..lineCount-1` are inside the injected range and
+   * virtual line `lineCount` maps back to original line 0.
+   * Diagnostics reported at line > insertedAtLine + lineCount map back
+   * by subtracting lineCount.
    */
   insertedAtLine: number;
   /** Number of lines the injected block spans. */


### PR DESCRIPTION
## Summary

Zero-declare AND zero-import model files. Users write `this.belongsTo("author")` with no import for `Author`; `trails-tsc` auto-injects `import type { Author } from "./author.js";` into the virtualized source.

```ts
// post.ts — user writes (NO declares, NO import for Author)
import { Base } from "@blazetrails/activerecord";
class Post extends Base {
  static {
    this.attribute("title", "string");
    this.belongsTo("author");
  }
}

// trails-tsc sees:
import type { Author } from "./author.js";  // ← auto-injected
import { Base } from "@blazetrails/activerecord";
class Post extends Base {
  declare title: string;
  declare author: Author | null;
  declare loadBelongsTo: (name: "author") => Promise<Author | null>;
  static { ... }
}
```

## How it works

1. **Model registry** — the transitive-extends walker (`collectBaseDescendants`) now returns `WalkerResult` with both `baseNames` and `modelRegistry: Map<className, absolutePath>`. Every Base-rooted class in the program is registered.

2. **Per-file auto-import resolver** (`auto-import.ts`) — for each virtualized file:
   - Collects target class names from association calls (`hasMany`, `belongsTo`, `hasOne`, `hasAndBelongsToMany`)
   - Subtracts names already in scope (existing imports, local class declarations)
   - Looks remaining names up in the registry
   - Computes relative paths (`.ts` → `.js` for ESM)
   - Returns `import type { Name } from "./relative.js";` lines

3. **`virtualize()` gains `prependImports`** — splices the import lines at the top of the file before other transformations, with `LineDelta` accounting so diagnostic remap stays accurate.

4. **`import type` keeps imports erased at runtime** — no module-load cycles possible.

## Edge cases

- **Name collisions** (two `Comment` classes in different paths): walker picks shortest path (least-nested heuristic).
- **Class not in program**: no auto-import; TS surfaces `Cannot find name 'X'`.
- **User already imports the class**: their import wins; resolver subtracts it from the needed set.

## Test plan

- [x] 3 new tests:
  - `import type { Author }` visible in post.ts virtualized text
  - Zero diagnostics (Author resolves)
  - Files with existing imports don't get duplicates
- [x] Full activerecord suite: **8266/8266**, zero regressions
- [x] `pnpm build` / `pnpm typecheck` / prettier / eslint clean
- [ ] CI

Plan: `docs/virtual-source-files-plan.md` § Phase 1b.4.