### PR TITLE
feat(activerecord): implement all missing PostgreSQL quoting methods

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -5,11 +5,18 @@ import { Data as BitData } from "./oid/bit.js";
 import { Range } from "./oid/range.js";
 import { Data as XmlData } from "./oid/xml.js";
 import {
+  checkIntInRange,
   columnNameMatcher,
+  columnNameWithOrderMatcher,
+  IntegerOutOf64BitRange,
+  lookupCastTypeFromColumn,
   quote,
   quoteDefaultExpression,
+  quotedBinary,
   quotedFalse,
   quotedTrue,
+  quoteSchemaName,
+  quoteTableNameForAssignment,
   typeCast,
   unescapeBytea,
 } from "./quoting.js";
@@ -63,6 +70,64 @@ describe("PostgreSQL quoting", () => {
 
   it("unescapes hex bytea values we now own locally", () => {
     expect(unescapeBytea("\\x6869")).toEqual(Buffer.from("hi"));
+  });
+
+  it("quoteTableNameForAssignment drops the table prefix", () => {
+    expect(quoteTableNameForAssignment("users", "name")).toBe('"name"');
+  });
+
+  it("quoteSchemaName delegates to quoteColumnName", () => {
+    expect(quoteSchemaName("public")).toBe('"public"');
+  });
+
+  it("quotedBinary wraps escape_bytea output in SQL quotes", () => {
+    expect(quotedBinary(Buffer.from("ab"))).toBe("'\\x6162'");
+    expect(quotedBinary("ab")).toBe("'\\x6162'");
+  });
+
+  it("checkIntInRange is the Rails name for checkIntegerRange", () => {
+    expect(() => checkIntInRange(BigInt("9223372036854775808"))).toThrow(IntegerOutOf64BitRange);
+    expect(() => checkIntInRange(BigInt("9223372036854775807"))).not.toThrow();
+  });
+
+  it("lookupCastTypeFromColumn forwards oid/fmod/sqlType to the type map", () => {
+    const calls: Array<[number, number, string]> = [];
+    const typeMap = {
+      lookup(oid: number, fmod: number, sqlType: string) {
+        calls.push([oid, fmod, sqlType]);
+        return { sentinel: true };
+      },
+    };
+    const column = { oid: 23, fmod: -1, sqlType: "integer" };
+
+    expect(lookupCastTypeFromColumn(column, typeMap)).toEqual({ sentinel: true });
+    expect(calls).toEqual([[23, -1, "integer"]]);
+  });
+
+  describe("columnNameWithOrderMatcher", () => {
+    const matcher = columnNameWithOrderMatcher();
+
+    it("matches a bare column", () => {
+      expect(matcher.test("name")).toBe(true);
+    });
+
+    it("matches ASC / DESC / NULLS FIRST | LAST", () => {
+      expect(matcher.test("name ASC")).toBe(true);
+      expect(matcher.test("name DESC NULLS LAST")).toBe(true);
+    });
+
+    it("matches quoted collations (Rails-faithful: quoted only)", () => {
+      expect(matcher.test('name COLLATE "C"')).toBe(true);
+    });
+
+    it("rejects unquoted collations, matching Rails", () => {
+      // Rails: (?:\s+COLLATE\s+"\w+")? — quoted identifier only.
+      expect(matcher.test("name COLLATE C")).toBe(false);
+    });
+
+    it("rejects SQL injection attempts", () => {
+      expect(matcher.test("name; DROP TABLE users")).toBe(false);
+    });
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -135,6 +135,30 @@ export function quoteBinaryColumn(value: Buffer): string {
   return `'\\x${value.toString("hex")}'`;
 }
 
+/**
+ * Mirrors: PostgreSQL::Quoting#quote_table_name_for_assignment.
+ * PG's UPDATE ... SET clause references the column without the table prefix.
+ */
+export function quoteTableNameForAssignment(_table: string, attr: string): string {
+  return quoteColumnName(attr);
+}
+
+/**
+ * Mirrors: PostgreSQL::Quoting#quote_schema_name.
+ */
+export function quoteSchemaName(schemaName: string): string {
+  return quoteColumnName(schemaName);
+}
+
+/**
+ * Mirrors: PostgreSQL::Quoting#quoted_binary. Rails passes `value.to_s`
+ * through escape_bytea so the result is always a string wrapped in SQL
+ * quotes, never nil.
+ */
+export function quotedBinary(value: Buffer | Uint8Array | string): string {
+  return `'${escapeBytea(value)}'`;
+}
+
 export function quote(value: unknown): string {
   if (value instanceof XmlData) {
     return `xml ${quoteString(value.toString())}`;
@@ -218,6 +242,46 @@ export function columnNameMatcher(): RegExp {
   // limitation and only allows a bare identifier inside function calls.
   return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)*$/i;
 }
+
+/**
+ * Mirrors: PostgreSQL::Quoting::ClassMethods#column_name_with_order_matcher.
+ * Same core expression as columnNameMatcher plus optional COLLATE/ASC/DESC/
+ * NULLS ordering suffixes. Rails only accepts quoted collation names
+ * (`"\w+"`), so this does too — unquoted `COLLATE C` is rejected, matching
+ * Rails exactly.
+ */
+export function columnNameWithOrderMatcher(): RegExp {
+  return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+COLLATE\s+"\w+")?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+COLLATE\s+"\w+")?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+}
+
+/**
+ * Mirrors: PostgreSQL::Quoting#lookup_cast_type_from_column. Rails reaches
+ * into the adapter's type_map via `type_map.lookup(oid, fmod, sql_type)`.
+ * We accept the TypeMap as a parameter since this module has no adapter
+ * instance.
+ */
+export interface LookupableTypeMap {
+  lookup(oid: number, fmod: number, sqlType: string): unknown;
+}
+
+export interface CastableColumn {
+  oid: number;
+  fmod: number;
+  sqlType: string;
+}
+
+export function lookupCastTypeFromColumn(
+  column: CastableColumn,
+  typeMap: LookupableTypeMap,
+): unknown {
+  return typeMap.lookup(column.oid, column.fmod, column.sqlType);
+}
+
+/**
+ * Mirrors: PostgreSQL::Quoting#check_int_in_range. Rails uses this name;
+ * `checkIntegerRange` is the TS-side alias we already had.
+ */
+export const checkIntInRange = checkIntegerRange;
 
 export function checkIntegerRange(value: bigint | number): void {
   if (typeof value === "number") {


### PR DESCRIPTION
## Summary

Rebased onto main. PR #560 delivered most of the PG quoting surface (abstract delegation, OID wrapper types, BinaryBind typeCast shape, quoteDefaultExpression with type map), so this PR is reduced to the six remaining methods needed for full Rails parity:

- **quoteTableNameForAssignment** — returns the quoted column name (PG drops the table prefix on `UPDATE ... SET`).
- **quoteSchemaName** — delegates to `quoteColumnName`.
- **quotedBinary** — `'#{escape_bytea(value.to_s)}'`.
- **checkIntInRange** — Rails' method name, aliased to the existing `checkIntegerRange`.
- **columnNameWithOrderMatcher** — column matcher + `COLLATE "…"`/`ASC`/`DESC`/`NULLS FIRST|LAST`. Rails-faithful: only quoted collation names are accepted.
- **lookupCastTypeFromColumn** — forwards `oid`/`fmod`/`sqlType` to the type map.

Each method mirrors Rails exactly — references the Rails source in the doc comment.

## Test plan

- [x] 17 quoting tests pass, including new cases for each added method
- [x] Full typecheck clean