### PR TITLE
feat(activerecord): PG schema_search_path in structure dump + dumpSchemas config

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -118,8 +118,13 @@ export class DatabaseTasks {
    * - `"schema_search_path"` (default): use config's `schemaSearchPath`
    * - `"all"`: dump all schemas (no `--schema=` filter)
    * - Any other string: treat as a comma-separated list of schema names
+   *
+   * Typed as `DumpSchemasMode` — a union of the two known modes plus
+   * `string & {}` for custom comma-separated lists. A typo like
+   * "schema_serach_path" still compiles (it's a valid string) but
+   * IDE autocompletion surfaces the two recognized modes.
    */
-  static dumpSchemas: string = "schema_search_path";
+  static dumpSchemas: "schema_search_path" | "all" | (string & {}) = "schema_search_path";
 
   private static _registeredTasks: Array<{
     pattern: RegExp | string;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -120,9 +120,9 @@ export class DatabaseTasks {
    * - Any other string: treat as a comma-separated list of schema names
    *
    * Typed as a union of the two known modes plus `string & {}` for
-   * custom comma-separated lists. A typo like "schema_serach_path"
-   * still compiles (it's a valid string) but IDE autocompletion
-   * surfaces the two recognized modes.
+   * custom comma-separated lists. A misspelled mode still compiles
+   * (it's a valid string) but IDE autocompletion surfaces the two
+   * recognized modes first.
    */
   static dumpSchemas: "schema_search_path" | "all" | (string & {}) = "schema_search_path";
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -111,6 +111,15 @@ export class DatabaseTasks {
   static dumpSchemaAfterMigration: boolean = true;
   static structureDumpFlags: string | string[] | Record<string, string | string[]> | null = null;
   static structureLoadFlags: string | string[] | Record<string, string | string[]> | null = null;
+  /**
+   * Controls which PostgreSQL schemas pg_dump includes in a structure dump.
+   *
+   * Mirrors Rails' `ActiveRecord.dump_schemas` (default `:schema_search_path`):
+   * - `"schema_search_path"` (default): use config's `schemaSearchPath`
+   * - `"all"`: dump all schemas (no `--schema=` filter)
+   * - Any other string: treat as a comma-separated list of schema names
+   */
+  static dumpSchemas: string = "schema_search_path";
 
   private static _registeredTasks: Array<{
     pattern: RegExp | string;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -119,10 +119,10 @@ export class DatabaseTasks {
    * - `"all"`: dump all schemas (no `--schema=` filter)
    * - Any other string: treat as a comma-separated list of schema names
    *
-   * Typed as `DumpSchemasMode` — a union of the two known modes plus
-   * `string & {}` for custom comma-separated lists. A typo like
-   * "schema_serach_path" still compiles (it's a valid string) but
-   * IDE autocompletion surfaces the two recognized modes.
+   * Typed as a union of the two known modes plus `string & {}` for
+   * custom comma-separated lists. A typo like "schema_serach_path"
+   * still compiles (it's a valid string) but IDE autocompletion
+   * surfaces the two recognized modes.
    */
   static dumpSchemas: "schema_search_path" | "all" | (string & {}) = "schema_search_path";
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -97,4 +97,28 @@ describe("PostgreSQLDatabaseTasks", () => {
 
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
+
+  describe("structureDump schema filtering", () => {
+    it("normalizes $user and quoted entries out of --schema= args", () => {
+      // The schema_search_path normalization logic strips surrounding
+      // quotes and drops $user (not a real schema — PG resolves it at
+      // runtime). Verify the normalization directly since pg_dump
+      // can't run in CI without a PG instance.
+      const raw = "'$user', public, \"custom\"";
+      const schemas = raw
+        .split(",")
+        .map((s) => s.trim())
+        .map((s) => {
+          if (
+            s.length >= 2 &&
+            ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
+          ) {
+            return s.slice(1, -1).trim();
+          }
+          return s;
+        })
+        .filter((s) => s.length > 0 && s !== "$user");
+      expect(schemas).toEqual(["public", "custom"]);
+    });
+  });
 });

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { PostgreSQLDatabaseTasks } from "./postgresql-database-tasks.js";
+import { PostgreSQLDatabaseTasks, normalizeSchemaSearchPath } from "./postgresql-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 
@@ -100,25 +100,16 @@ describe("PostgreSQLDatabaseTasks", () => {
 
   describe("structureDump schema filtering", () => {
     it("normalizes $user and quoted entries out of --schema= args", () => {
-      // The schema_search_path normalization logic strips surrounding
-      // quotes and drops $user (not a real schema — PG resolves it at
-      // runtime). Verify the normalization directly since pg_dump
-      // can't run in CI without a PG instance.
-      const raw = "'$user', public, \"custom\"";
-      const schemas = raw
-        .split(",")
-        .map((s) => s.trim())
-        .map((s) => {
-          if (
-            s.length >= 2 &&
-            ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
-          ) {
-            return s.slice(1, -1).trim();
-          }
-          return s;
-        })
-        .filter((s) => s.length > 0 && s !== "$user");
-      expect(schemas).toEqual(["public", "custom"]);
+      // Uses the exported normalizeSchemaSearchPath helper — same code
+      // path structureDump calls, so the test can't drift.
+      expect(normalizeSchemaSearchPath("'$user', public, \"custom\"")).toEqual([
+        "public",
+        "custom",
+      ]);
+    });
+
+    it("handles empty and whitespace-only entries", () => {
+      expect(normalizeSchemaSearchPath("  , public, ,")).toEqual(["public"]);
     });
   });
 });

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -142,8 +142,57 @@ export class PostgreSQLDatabaseTasks {
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
+
+    // Rails: reads ActiveRecord.dump_schemas to decide which PG schemas
+    // to include in the dump. Can be :schema_search_path (use config's
+    // schema_search_path), :all (no filter), or a specific string.
+    // Trails' equivalent: DatabaseTasks.dumpSchemas (default:
+    // "schema_search_path"). If the config has a schemaSearchPath, split
+    // on commas and add --schema= per entry so pg_dump only includes
+    // those schemas instead of the entire database.
+    const { DatabaseTasks } = await import("./database-tasks.js");
+    const dumpSchemas = DatabaseTasks.dumpSchemas;
+    let searchPath: string | undefined;
+    if (dumpSchemas === "schema_search_path") {
+      searchPath =
+        (this.configurationHash.schemaSearchPath as string | undefined) ??
+        (this.configurationHash.schema_search_path as string | undefined);
+    } else if (dumpSchemas === "all") {
+      searchPath = undefined;
+    } else if (typeof dumpSchemas === "string") {
+      searchPath = dumpSchemas;
+    }
+    if (searchPath && searchPath.trim().length > 0) {
+      for (const schema of searchPath.split(",")) {
+        const trimmed = schema.trim();
+        if (trimmed.length > 0) args.push(`--schema=${trimmed}`);
+      }
+    }
+
+    // Rails: applies SchemaDumper.ignore_tables as -T exclusions.
+    const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
+    const ignoreTables = SchemaDumper.ignoreTables;
+    if (ignoreTables.length > 0) {
+      for (const pattern of ignoreTables) {
+        if (typeof pattern === "string") {
+          args.push("-T", pattern);
+        }
+        // Regex patterns can't be expressed as pg_dump -T flags;
+        // they're handled by the Ruby-side adapter in Rails too,
+        // not the CLI. Skip them here.
+      }
+    }
+
     await this.runCmd("pg_dump", args, "dumping");
     await this.removeSqlHeaderComments(filename);
+
+    // Rails: appends `SET search_path TO <path>;` at the end of the
+    // dump so loading it restores the session search_path to what
+    // the app expects. Only when a search_path was configured.
+    if (searchPath && searchPath.trim().length > 0) {
+      const fs = getFs();
+      fs.appendFileSync(filename, `SET search_path TO ${searchPath.trim()};\n\n`);
+    }
   }
 
   async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -146,8 +146,8 @@ export class PostgreSQLDatabaseTasks {
     // Rails: reads ActiveRecord.dump_schemas to decide which PG schemas
     // pg_dump includes. Trails equivalent: DatabaseTasks.dumpSchemas.
     //
-    // The configured search_path (from config.schemaSearchPath or
-    // config.schema_search_path) is used for TWO purposes:
+    // The configured search_path (from config.schemaSearchPath) is
+    // used for TWO purposes:
     // 1. --schema= filter args for pg_dump (when dumpSchemas isn't "all")
     // 2. SET search_path footer appended to the dump file
     // These are separated so dumpSchemas="all" still appends the footer.
@@ -202,7 +202,10 @@ export class PostgreSQLDatabaseTasks {
     // configured search_path (not the filtered schema list) so
     // dumpSchemas="all" still appends when a search_path is set.
     if (configuredSearchPath && configuredSearchPath.trim().length > 0) {
-      getFs().appendFileSync(filename, `SET search_path TO ${configuredSearchPath.trim()};\n\n`);
+      const sanitized = configuredSearchPath.trim().replace(/[;\n\r]/g, "");
+      if (sanitized.length > 0) {
+        getFs().appendFileSync(filename, `SET search_path TO ${sanitized};\n\n`);
+      }
     }
   }
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -403,7 +403,11 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
         s.length >= 2 &&
         ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
       ) {
-        return s.slice(1, -1).trim();
+        const quote = s[0];
+        const inner = s.slice(1, -1).trim();
+        // Unescape doubled quotes inside quoted identifiers:
+        // "we""ird" → we"ird, 'it''s' → it's
+        return quote === '"' ? inner.replace(/""/g, '"') : inner.replace(/''/g, "'");
       }
       return s;
     })

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -166,24 +166,7 @@ export class PostgreSQLDatabaseTasks {
     }
 
     if (schemaFilter && schemaFilter.trim().length > 0) {
-      // Normalize entries: strip surrounding quotes, drop $user
-      // (not a real schema name — PG resolves it at runtime), and
-      // skip empty entries. spawnSync passes args without shell
-      // expansion, so literal '$user' would make pg_dump fail.
-      const schemas = schemaFilter
-        .split(",")
-        .map((s) => s.trim())
-        .map((s) => {
-          if (
-            s.length >= 2 &&
-            ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
-          ) {
-            return s.slice(1, -1).trim();
-          }
-          return s;
-        })
-        .filter((s) => s.length > 0 && s !== "$user");
-      for (const schema of schemas) {
+      for (const schema of normalizeSchemaSearchPath(schemaFilter)) {
         args.push(`--schema=${schema}`);
       }
     }
@@ -402,4 +385,27 @@ function formatCmdError(
     `Make sure \`${cmd}\` is installed in your PATH and has proper permissions.\n` +
     `(action: ${action})`
   );
+}
+
+/**
+ * Normalize a PG schema_search_path string into an array of schema
+ * names suitable for pg_dump `--schema=` args. Strips surrounding
+ * quotes, drops `$user` (PG runtime variable, not a real schema),
+ * and filters empties. Exported so the test can exercise the same
+ * code path instead of reimplementing the logic.
+ */
+export function normalizeSchemaSearchPath(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .map((s) => {
+      if (
+        s.length >= 2 &&
+        ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
+      ) {
+        return s.slice(1, -1).trim();
+      }
+      return s;
+    })
+    .filter((s) => s.length > 0 && s !== "$user");
 }

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -144,54 +144,64 @@ export class PostgreSQLDatabaseTasks {
     }
 
     // Rails: reads ActiveRecord.dump_schemas to decide which PG schemas
-    // to include in the dump. Can be :schema_search_path (use config's
-    // schema_search_path), :all (no filter), or a specific string.
-    // Trails' equivalent: DatabaseTasks.dumpSchemas (default:
-    // "schema_search_path"). If the config has a schemaSearchPath, split
-    // on commas and add --schema= per entry so pg_dump only includes
-    // those schemas instead of the entire database.
-    const { DatabaseTasks } = await import("./database-tasks.js");
+    // pg_dump includes. Trails equivalent: DatabaseTasks.dumpSchemas.
+    //
+    // The configured search_path (from config.schemaSearchPath or
+    // config.schema_search_path) is used for TWO purposes:
+    // 1. --schema= filter args for pg_dump (when dumpSchemas isn't "all")
+    // 2. SET search_path footer appended to the dump file
+    // These are separated so dumpSchemas="all" still appends the footer.
+    const configuredSearchPath = this.configurationHash.schemaSearchPath as string | undefined;
+
     const dumpSchemas = DatabaseTasks.dumpSchemas;
-    let searchPath: string | undefined;
+    let schemaFilter: string | undefined;
     if (dumpSchemas === "schema_search_path") {
-      searchPath =
-        (this.configurationHash.schemaSearchPath as string | undefined) ??
-        (this.configurationHash.schema_search_path as string | undefined);
+      schemaFilter = configuredSearchPath;
     } else if (dumpSchemas === "all") {
-      searchPath = undefined;
+      schemaFilter = undefined;
     } else if (typeof dumpSchemas === "string") {
-      searchPath = dumpSchemas;
+      schemaFilter = dumpSchemas;
     }
-    if (searchPath && searchPath.trim().length > 0) {
-      for (const schema of searchPath.split(",")) {
-        const trimmed = schema.trim();
-        if (trimmed.length > 0) args.push(`--schema=${trimmed}`);
+
+    if (schemaFilter && schemaFilter.trim().length > 0) {
+      // Normalize entries: strip surrounding quotes, drop $user
+      // (not a real schema name — PG resolves it at runtime), and
+      // skip empty entries. spawnSync passes args without shell
+      // expansion, so literal '$user' would make pg_dump fail.
+      const schemas = schemaFilter
+        .split(",")
+        .map((s) => s.trim())
+        .map((s) => {
+          if (
+            s.length >= 2 &&
+            ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"')))
+          ) {
+            return s.slice(1, -1).trim();
+          }
+          return s;
+        })
+        .filter((s) => s.length > 0 && s !== "$user");
+      for (const schema of schemas) {
+        args.push(`--schema=${schema}`);
       }
     }
 
     // Rails: applies SchemaDumper.ignore_tables as -T exclusions.
     const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
-    const ignoreTables = SchemaDumper.ignoreTables;
-    if (ignoreTables.length > 0) {
-      for (const pattern of ignoreTables) {
-        if (typeof pattern === "string") {
-          args.push("-T", pattern);
-        }
-        // Regex patterns can't be expressed as pg_dump -T flags;
-        // they're handled by the Ruby-side adapter in Rails too,
-        // not the CLI. Skip them here.
-      }
+    for (const pattern of SchemaDumper.ignoreTables) {
+      if (typeof pattern === "string") args.push("-T", pattern);
+      // Regex patterns can't be expressed as pg_dump -T flags.
     }
 
     await this.runCmd("pg_dump", args, "dumping");
     await this.removeSqlHeaderComments(filename);
 
     // Rails: appends `SET search_path TO <path>;` at the end of the
-    // dump so loading it restores the session search_path to what
-    // the app expects. Only when a search_path was configured.
-    if (searchPath && searchPath.trim().length > 0) {
-      const fs = getFs();
-      fs.appendFileSync(filename, `SET search_path TO ${searchPath.trim()};\n\n`);
+    // dump so loading it restores the session search_path. Uses the
+    // configured search_path (not the filtered schema list) so
+    // dumpSchemas="all" still appends when a search_path is set.
+    if (configuredSearchPath && configuredSearchPath.trim().length > 0) {
+      getFs().appendFileSync(filename, `SET search_path TO ${configuredSearchPath.trim()};\n\n`);
     }
   }
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -152,7 +152,8 @@ export class PostgreSQLDatabaseTasks {
     // 2. SET search_path footer appended to the dump file
     // These are separated so dumpSchemas="all" still appends the footer.
     // Trails uses camelCase config keys throughout; no snake_case fallback.
-    const configuredSearchPath = this.configurationHash.schemaSearchPath as string | undefined;
+    const rawSearchPath = this.configurationHash.schemaSearchPath;
+    const configuredSearchPath = typeof rawSearchPath === "string" ? rawSearchPath : undefined;
 
     const dumpSchemas = DatabaseTasks.dumpSchemas;
     let schemaFilter: string | undefined;

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -151,6 +151,7 @@ export class PostgreSQLDatabaseTasks {
     // 1. --schema= filter args for pg_dump (when dumpSchemas isn't "all")
     // 2. SET search_path footer appended to the dump file
     // These are separated so dumpSchemas="all" still appends the footer.
+    // Trails uses camelCase config keys throughout; no snake_case fallback.
     const configuredSearchPath = this.configurationHash.schemaSearchPath as string | undefined;
 
     const dumpSchemas = DatabaseTasks.dumpSchemas;


### PR DESCRIPTION
## Summary

**Phase 16**: PostgreSQL `structureDump` now respects `schema_search_path`, matching Rails' `structure_dump` behavior.

Rails reads `ActiveRecord.dump_schemas` to decide which PG schemas `pg_dump` includes. Trails' equivalent: `DatabaseTasks.dumpSchemas` (default: `"schema_search_path"`). Three modes:
- `"schema_search_path"` (default): reads `config.schemaSearchPath`, splits on commas, adds `--schema=` per entry
- `"all"`: no filter — dumps everything
- Any other string: treated as a comma-separated schema list

Also:
- Applies `SchemaDumper.ignoreTables` as `-T` exclusions (string patterns; regex patterns can't be expressed as pg_dump flags, matching Rails)
- Appends `SET search_path TO <path>;` at the end of the dump so loading restores the session search_path

**Phase 21**: Already implemented — PG `psqlEnv` (PGSSLMODE/PGSSLCERT/etc.) and MySQL `prepareCommandOptions` (--ssl-*) shipped in Phase 1.

## Test plan
- [x] `pnpm test` — 17258 passing
- [x] Existing PG structure dump tests pass (describeIfPg, auto-skip without PG)
- [x] Build passes clean