### PR TITLE
feat(activerecord): Phase 1b.5 — --build / composite project support

### DIFF
--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/consumer.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/consumer.ts
@@ -1,0 +1,9 @@
+import { Post } from "./post.js";
+import { Author } from "../models/author.js";
+
+const post = new Post();
+export const title: string = post.title;
+// post.author resolves through the auto-import injected by
+// trails-tsc in post.ts — the `Author` type is reachable via the
+// cross-project `references:` edge.
+export const author: Author | null = post.author;

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/post.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/post.ts
@@ -1,0 +1,11 @@
+import { Base } from "../models/base.js";
+// Cross-project association target: auto-import is scoped per-project,
+// so the user imports `Author` explicitly from the referenced package.
+import type { Author } from "../models/author.js";
+
+export class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.belongsTo("author");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/app/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": []
+  },
+  "references": [{ "path": "../models" }],
+  "include": ["post.ts", "consumer.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/author.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/author.ts
@@ -1,0 +1,7 @@
+import { Base } from "./base.js";
+
+export class Author extends Base {
+  static {
+    this.attribute("name", "string");
+  }
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/base.ts
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/base.ts
@@ -1,0 +1,8 @@
+export class Model {
+  [key: string]: unknown;
+  constructor(_attrs?: Record<string, unknown>) {}
+  static attribute(_name: string, _type: string): void {}
+  static belongsTo(_name: string, _opts?: Record<string, unknown>): void {}
+  static hasMany(_name: string, _opts?: Record<string, unknown>): void {}
+}
+export class Base extends Model {}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/models/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": []
+  },
+  "include": ["base.ts", "author.ts"]
+}

--- a/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/tsconfig.json
+++ b/packages/activerecord/src/tsc-wrapper/__fixtures__/composite/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./models" }, { "path": "./app" }]
+}

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -7,7 +7,6 @@ import { remapDiagnostics } from "./remap.js";
 export interface TrailsSolutionBuilder {
   build(): ts.ExitStatus;
   clean(): ts.ExitStatus;
-  getHostForProject(configPath: string): TrailsCompilerHost | undefined;
 }
 
 export interface TrailsBuildOptions {
@@ -128,6 +127,5 @@ export function createTrailsSolutionBuilder(
   return {
     build: () => builder.build(),
     clean: () => builder.clean(),
-    getHostForProject: (configPath) => hostsByProject.get(path.resolve(configPath)),
   };
 }

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -87,23 +87,31 @@ export function createTrailsSolutionBuilder(
     );
   };
 
+  // A composite host that delegates `getDeltasForFile` /
+  // `getOriginalText` to whichever per-project host owns a given
+  // absolute path. Lets `remapDiagnostics` remap a diagnostic whose
+  // primary file lives in project A AND whose `relatedInformation`
+  // entries point into project B's virtualized files.
+  const compositeRemapHost = {
+    getDeltasForFile(fileName: string) {
+      for (const host of hostsByProject.values()) {
+        const d = host.getDeltasForFile(fileName);
+        if (d) return d;
+      }
+      return undefined;
+    },
+    getOriginalText(fileName: string) {
+      for (const host of hostsByProject.values()) {
+        const t = host.getOriginalText(fileName);
+        if (t != null) return t;
+      }
+      return undefined;
+    },
+  } as unknown as TrailsCompilerHost;
+
   const reportDiagnostic: ts.DiagnosticReporter = (d) => {
     if (!buildOpts.onDiagnostic) return;
-    // The builder emits diagnostics keyed by file; remap against the
-    // host that owns that file (if any) before handing off.
-    const file = d.file;
-    if (!file) {
-      buildOpts.onDiagnostic(d);
-      return;
-    }
-    const resolved = path.resolve(file.fileName);
-    let remapped: ts.Diagnostic = d;
-    for (const host of hostsByProject.values()) {
-      if (host.getDeltasForFile(resolved)) {
-        remapped = remapDiagnostics([d], host)[0]!;
-        break;
-      }
-    }
+    const remapped = remapDiagnostics([d], compositeRemapHost)[0]!;
     buildOpts.onDiagnostic(remapped);
   };
 

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -47,16 +47,14 @@ export function createTrailsSolutionBuilder(
     projectReferences,
   ) => {
     if (!rootNames || !options) {
-      // Fall back to TS default when the solution builder hasn't
-      // resolved a config (shouldn't happen for well-formed
-      // projects, but keep the contract honest).
-      return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
-        rootNames,
-        options,
-        _defaultHost,
-        oldProgram,
-        configFileParsingDiagnostics,
-        projectReferences,
+      // Reuse the previous builder program if we have one — the
+      // solution builder only invokes createProgram without
+      // resolved inputs on a no-op incremental tick. Otherwise
+      // this is unreachable for a well-formed solution, so fail
+      // loudly rather than passing undefined into the TS factory.
+      if (oldProgram) return oldProgram;
+      throw new Error(
+        "createTrailsSolutionBuilder received unresolved rootNames or compiler options",
       );
     }
 

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -1,0 +1,133 @@
+import ts from "typescript";
+import * as path from "node:path";
+import { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
+import { collectBaseDescendants } from "../type-virtualization/transitive-extends-walker.js";
+import { remapDiagnostics } from "./remap.js";
+
+export interface TrailsSolutionBuilder {
+  build(): ts.ExitStatus;
+  clean(): ts.ExitStatus;
+  getHostForProject(configPath: string): TrailsCompilerHost | undefined;
+}
+
+export interface TrailsBuildOptions {
+  /** Emit solution-builder status messages (e.g., "Building project..."). */
+  verbose?: boolean;
+  /** Called with each diagnostic AFTER virtualized-source remap. */
+  onDiagnostic?: (d: ts.Diagnostic) => void;
+  /** Called with each solution-builder status message. */
+  onStatus?: (d: ts.Diagnostic) => void;
+}
+
+/**
+ * Wrap `ts.createSolutionBuilder` so every project built with `-b`
+ * uses the trails-tsc virtualizing compiler host. Each project is
+ * processed in two passes (plain checker → walker → virtualizing
+ * host) exactly like `createTrailsProgram`, so transitive-extends
+ * and auto-import resolution work per-project.
+ *
+ * Auto-import resolution is scoped to each project's own source
+ * files — cross-project models referenced via `references:` still
+ * resolve through TypeScript's normal project-reference handling
+ * (the referencing project imports them explicitly, either because
+ * the user wrote the import or because the referenced project's
+ * emitted `.d.ts` declares them).
+ */
+export function createTrailsSolutionBuilder(
+  rootConfigs: readonly string[],
+  buildOpts: TrailsBuildOptions = {},
+): TrailsSolutionBuilder {
+  const hostsByProject = new Map<string, TrailsCompilerHost>();
+
+  const createProgram: ts.CreateProgram<ts.EmitAndSemanticDiagnosticsBuilderProgram> = (
+    rootNames,
+    options,
+    _defaultHost,
+    oldProgram,
+    configFileParsingDiagnostics,
+    projectReferences,
+  ) => {
+    if (!rootNames || !options) {
+      // Fall back to TS default when the solution builder hasn't
+      // resolved a config (shouldn't happen for well-formed
+      // projects, but keep the contract honest).
+      return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+        rootNames,
+        options,
+        _defaultHost,
+        oldProgram,
+        configFileParsingDiagnostics,
+        projectReferences,
+      );
+    }
+
+    // Pass 1: plain host — we only need a checker to walk extends
+    // chains and collect the per-project model registry.
+    const pass1Host = ts.createCompilerHost(options, true);
+    const pass1Program = ts.createProgram({
+      rootNames: [...rootNames],
+      options,
+      host: pass1Host,
+      projectReferences: projectReferences ? [...projectReferences] : undefined,
+    });
+    const { baseNames, modelRegistry } = collectBaseDescendants(pass1Program);
+
+    // Pass 2: virtualizing host + registry feed the real builder
+    // program. Cache the host per-project so diagnostics remap can
+    // look up deltas and original text after build completes.
+    const host = buildCompilerHost(options, [...baseNames], modelRegistry);
+    const configFilePath = options.configFilePath;
+    if (typeof configFilePath === "string") {
+      hostsByProject.set(path.resolve(configFilePath), host);
+    }
+    return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+      rootNames,
+      options,
+      host,
+      oldProgram,
+      configFileParsingDiagnostics,
+      projectReferences,
+    );
+  };
+
+  const reportDiagnostic: ts.DiagnosticReporter = (d) => {
+    if (!buildOpts.onDiagnostic) return;
+    // The builder emits diagnostics keyed by file; remap against the
+    // host that owns that file (if any) before handing off.
+    const file = d.file;
+    if (!file) {
+      buildOpts.onDiagnostic(d);
+      return;
+    }
+    const resolved = path.resolve(file.fileName);
+    let remapped: ts.Diagnostic = d;
+    for (const host of hostsByProject.values()) {
+      if (host.getDeltasForFile(resolved)) {
+        remapped = remapDiagnostics([d], host)[0]!;
+        break;
+      }
+    }
+    buildOpts.onDiagnostic(remapped);
+  };
+
+  const reportStatus: ts.DiagnosticReporter = (d) => {
+    buildOpts.onStatus?.(d);
+  };
+
+  const solutionHost = ts.createSolutionBuilderHost(
+    ts.sys,
+    createProgram,
+    reportDiagnostic,
+    reportStatus,
+  );
+
+  const builder = ts.createSolutionBuilder(solutionHost, [...rootConfigs], {
+    verbose: buildOpts.verbose ?? false,
+  });
+
+  return {
+    build: () => builder.build(),
+    clean: () => builder.clean(),
+    getHostForProject: (configPath) => hostsByProject.get(path.resolve(configPath)),
+  };
+}

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -91,27 +91,34 @@ export function createTrailsSolutionBuilder(
   // `getOriginalText` to whichever per-project host owns a given
   // absolute path. Lets `remapDiagnostics` remap a diagnostic whose
   // primary file lives in project A AND whose `relatedInformation`
-  // entries point into project B's virtualized files.
+  // entries point into project B's virtualized files. Results are
+  // memoized per path so large solutions don't re-scan every host
+  // for every diagnostic.
+  const fileOwner = new Map<string, TrailsCompilerHost | null>();
+  const ownerOf = (fileName: string): TrailsCompilerHost | null => {
+    const cached = fileOwner.get(fileName);
+    if (cached !== undefined) return cached;
+    for (const host of hostsByProject.values()) {
+      if (host.getDeltasForFile(fileName) || host.getOriginalText(fileName) != null) {
+        fileOwner.set(fileName, host);
+        return host;
+      }
+    }
+    fileOwner.set(fileName, null);
+    return null;
+  };
   const compositeRemapHost = {
-    getDeltasForFile(fileName: string) {
-      for (const host of hostsByProject.values()) {
-        const d = host.getDeltasForFile(fileName);
-        if (d) return d;
-      }
-      return undefined;
-    },
-    getOriginalText(fileName: string) {
-      for (const host of hostsByProject.values()) {
-        const t = host.getOriginalText(fileName);
-        if (t != null) return t;
-      }
-      return undefined;
-    },
+    getDeltasForFile: (fileName: string) => ownerOf(fileName)?.getDeltasForFile(fileName),
+    getOriginalText: (fileName: string) => ownerOf(fileName)?.getOriginalText(fileName),
   } as unknown as TrailsCompilerHost;
+
+  // Share the original-SourceFile cache across every diagnostic so
+  // we only reparse each virtualized file once per build.
+  const originalSfCache = new Map<string, ts.SourceFile>();
 
   const reportDiagnostic: ts.DiagnosticReporter = (d) => {
     if (!buildOpts.onDiagnostic) return;
-    const remapped = remapDiagnostics([d], compositeRemapHost)[0]!;
+    const remapped = remapDiagnostics([d], compositeRemapHost, originalSfCache)[0]!;
     buildOpts.onDiagnostic(remapped);
   };
 

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -290,6 +290,23 @@ describe("trails-tsc --build composite projects — Phase 1b.5", () => {
     });
   });
 
+  it("CLI binary --build exits 0 on the composite fixture", async () => {
+    const binPath = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
+    // Same pattern as the Phase 1b.1 binary test: skip when dist
+    // isn't built (e.g., CI jobs that don't run `pnpm build`).
+    if (!fs.existsSync(binPath)) return;
+    const { execFileSync } = await import("node:child_process");
+    withTempComposite((dir) => {
+      const result = execFileSync("node", [binPath, "--build", path.join(dir, "tsconfig.json")], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      // Solution builder prints no output on a clean build.
+      expect(result).toBe("");
+      expect(fs.existsSync(path.join(dir, "app", "dist", "post.d.ts"))).toBe(true);
+    });
+  });
+
   it("re-build after editing a model reflects the new declares in dependents", () => {
     withTempComposite((dir) => {
       const firstDiags: ts.Diagnostic[] = [];

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createTrailsProgram } from "./program.js";
+import { createTrailsSolutionBuilder } from "./build.js";
 import { remapDiagnostics } from "./remap.js";
 
 const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -240,5 +241,86 @@ describe("trails-tsc auto-import — Phase 1b.4", () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("trails-tsc --build composite projects — Phase 1b.5", () => {
+  const COMPOSITE_DIR = path.resolve(FIXTURES_DIR, "composite");
+
+  // Each test copies the fixture into a temp dir so .tsbuildinfo /
+  // dist/ outputs don't leak across runs or into the repo.
+  function withTempComposite(fn: (dir: string) => void): void {
+    const tempDir = fs.mkdtempSync(path.join(FIXTURES_DIR, ".composite-"));
+    try {
+      fs.cpSync(COMPOSITE_DIR, tempDir, { recursive: true });
+      fn(tempDir);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  it("builds a composite solution with a virtualizing host on every project", () => {
+    withTempComposite((dir) => {
+      const diagnostics: ts.Diagnostic[] = [];
+      const builder = createTrailsSolutionBuilder([path.join(dir, "tsconfig.json")], {
+        onDiagnostic: (d) => {
+          diagnostics.push(d);
+          const msg =
+            typeof d.messageText === "string"
+              ? d.messageText
+              : ts.flattenDiagnosticMessageText(d.messageText, "\n");
+          const loc = d.file
+            ? `${path.basename(d.file.fileName)}:${d.file.getLineAndCharacterOfPosition(d.start ?? 0).line + 1}`
+            : "?";
+          console.error(`DIAG [${d.code}] ${loc}: ${msg}`);
+        },
+      });
+      const status = builder.build();
+      expect(diagnostics).toHaveLength(0);
+      expect(status).toBe(ts.ExitStatus.Success);
+
+      // Emitted .d.ts artifacts land under the per-project outDir.
+      expect(fs.existsSync(path.join(dir, "models", "dist", "author.d.ts"))).toBe(true);
+      expect(fs.existsSync(path.join(dir, "app", "dist", "post.d.ts"))).toBe(true);
+
+      // Per-project tsbuildinfo is written (proves incremental build
+      // cache was engaged through the custom host).
+      expect(fs.existsSync(path.join(dir, "models", "dist", "tsconfig.tsbuildinfo"))).toBe(true);
+      expect(fs.existsSync(path.join(dir, "app", "dist", "tsconfig.tsbuildinfo"))).toBe(true);
+    });
+  });
+
+  it("re-build after editing a model reflects the new declares in dependents", () => {
+    withTempComposite((dir) => {
+      const firstDiags: ts.Diagnostic[] = [];
+      const first = createTrailsSolutionBuilder([path.join(dir, "tsconfig.json")], {
+        onDiagnostic: (d) => firstDiags.push(d),
+      });
+      expect(first.build()).toBe(ts.ExitStatus.Success);
+      expect(firstDiags).toHaveLength(0);
+
+      // Add a new attribute on Author; consumer.ts should still
+      // typecheck and the new field should appear on the emitted
+      // .d.ts after rebuild.
+      const authorPath = path.join(dir, "models", "author.ts");
+      const authorSrc = fs.readFileSync(authorPath, "utf8");
+      fs.writeFileSync(
+        authorPath,
+        authorSrc.replace(
+          'this.attribute("name", "string");',
+          'this.attribute("name", "string");\n    this.attribute("bio", "string");',
+        ),
+      );
+
+      const secondDiags: ts.Diagnostic[] = [];
+      const second = createTrailsSolutionBuilder([path.join(dir, "tsconfig.json")], {
+        onDiagnostic: (d) => secondDiags.push(d),
+      });
+      expect(second.build()).toBe(ts.ExitStatus.Success);
+      expect(secondDiags).toHaveLength(0);
+
+      const authorDts = fs.readFileSync(path.join(dir, "models", "dist", "author.d.ts"), "utf8");
+      expect(authorDts).toContain("bio");
+    });
   });
 });

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -89,15 +89,16 @@ function handleBuildMode(args: string[]): void {
     if (arg.startsWith("-")) continue;
     rest.push(arg);
   }
-  const rootConfigs = rest.length > 0 ? rest.map((p) => path.resolve(p)) : [process.cwd()];
+  const rootConfigs =
+    rest.length > 0
+      ? rest.map((p) => path.resolve(p))
+      : [ts.findConfigFile(process.cwd(), ts.sys.fileExists) ?? path.resolve("tsconfig.json")];
 
   const fh = formatHost();
   const pretty = parsePretty(args, {});
-  let diagnostics = 0;
   const builder = createTrailsSolutionBuilder(rootConfigs, {
     verbose,
     onDiagnostic: (d) => {
-      diagnostics++;
       const out = pretty
         ? ts.formatDiagnosticsWithColorAndContext([d], fh)
         : ts.formatDiagnostics([d], fh);
@@ -111,7 +112,10 @@ function handleBuildMode(args: string[]): void {
   });
 
   const status = clean ? builder.clean() : builder.build();
-  process.exit(diagnostics > 0 ? 1 : status === ts.ExitStatus.Success ? 0 : 1);
+  // Preserve TS ExitStatus semantics (Success / DiagnosticsPresent_OutputsSkipped
+  // / InvalidProject_OutputsSkipped / ProjectReferenceCycle_OutputsSkipped) so
+  // callers scripting `trails-tsc --build` can distinguish them exactly like `tsc -b`.
+  process.exit(status);
 }
 
 function main(): void {

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -28,9 +28,29 @@ function handlePrintVirtualized(args: string[]): void {
 }
 
 function parsePretty(args: string[], options: ts.CompilerOptions): boolean {
-  const prettyIndex = args.indexOf("--pretty");
-  const prettyFromArgs =
-    prettyIndex === -1 ? undefined : args[prettyIndex + 1] === "false" ? false : true;
+  // Accept both `--pretty true|false` and `--pretty=true|false`; a
+  // bare `--pretty` with no following value means `true` (matches tsc).
+  const parseValue = (value: string | undefined): boolean | undefined => {
+    if (value === undefined) return true;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    return undefined;
+  };
+  let prettyFromArgs: boolean | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--pretty") {
+      prettyFromArgs = parseValue(args[i + 1]) ?? true;
+      break;
+    }
+    if (arg.startsWith("--pretty=")) {
+      const parsed = parseValue(arg.slice("--pretty=".length));
+      if (parsed !== undefined) {
+        prettyFromArgs = parsed;
+        break;
+      }
+    }
+  }
   const prettyFromOpts = typeof options.pretty === "boolean" ? options.pretty : undefined;
   return prettyFromArgs ?? prettyFromOpts ?? ts.sys.writeOutputIsTTY?.() ?? false;
 }

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -4,6 +4,7 @@ import ts from "typescript";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { createTrailsProgram } from "./program.js";
+import { createTrailsSolutionBuilder } from "./build.js";
 import { remapDiagnostics } from "./remap.js";
 import { virtualize } from "../type-virtualization/virtualize.js";
 
@@ -26,10 +27,68 @@ function handlePrintVirtualized(args: string[]): void {
   process.exit(0);
 }
 
+function parsePretty(args: string[], options: ts.CompilerOptions): boolean {
+  const prettyIndex = args.indexOf("--pretty");
+  const prettyFromArgs =
+    prettyIndex === -1 ? undefined : args[prettyIndex + 1] === "false" ? false : true;
+  const prettyFromOpts = typeof options.pretty === "boolean" ? options.pretty : undefined;
+  return prettyFromArgs ?? prettyFromOpts ?? ts.sys.writeOutputIsTTY?.() ?? false;
+}
+
+function formatHost(): ts.FormatDiagnosticsHost {
+  return {
+    getCurrentDirectory: () => process.cwd(),
+    getCanonicalFileName: (f) => (ts.sys.useCaseSensitiveFileNames ? f : f.toLowerCase()),
+    getNewLine: () => ts.sys.newLine,
+  };
+}
+
+function handleBuildMode(args: string[]): void {
+  // --build / -b must be the first arg for tsc compatibility, but be
+  // lenient: accept it anywhere so users can pass flags in either
+  // order.
+  const buildIdx = args.findIndex((a) => a === "--build" || a === "-b");
+  if (buildIdx === -1) return;
+
+  // Everything after --build that isn't a known solution-builder
+  // flag is treated as a project path. tsc accepts multiple.
+  const verbose = args.includes("--verbose");
+  const clean = args.includes("--clean");
+  const rest = args.filter((a, i) => {
+    if (i === buildIdx) return false;
+    if (a === "--verbose" || a === "--clean") return false;
+    return !a.startsWith("-");
+  });
+  const rootConfigs = rest.length > 0 ? rest.map((p) => path.resolve(p)) : [process.cwd()];
+
+  const fh = formatHost();
+  const pretty = ts.sys.writeOutputIsTTY?.() ?? false;
+  let diagnostics = 0;
+  const builder = createTrailsSolutionBuilder(rootConfigs, {
+    verbose,
+    onDiagnostic: (d) => {
+      diagnostics++;
+      const out = pretty
+        ? ts.formatDiagnosticsWithColorAndContext([d], fh)
+        : ts.formatDiagnostics([d], fh);
+      process.stderr.write(out);
+    },
+    onStatus: (d) => {
+      // Solution-builder status (informational, not diagnostics).
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, ts.sys.newLine);
+      process.stdout.write(`${msg}${ts.sys.newLine}`);
+    },
+  });
+
+  const status = clean ? builder.clean() : builder.build();
+  process.exit(diagnostics > 0 ? 1 : status === ts.ExitStatus.Success ? 0 : 1);
+}
+
 function main(): void {
   const args = process.argv.slice(2);
 
   handlePrintVirtualized(args);
+  handleBuildMode(args);
 
   // Find -p / --project flag; default to ./tsconfig.json.
   // Error if the flag is present but no value follows (matches tsc).
@@ -54,16 +113,12 @@ function main(): void {
 
   const { program, host, configDiagnostics } = createTrailsProgram(configPath);
 
-  const formatHost: ts.FormatDiagnosticsHost = {
-    getCurrentDirectory: () => process.cwd(),
-    getCanonicalFileName: (f) => (ts.sys.useCaseSensitiveFileNames ? f : f.toLowerCase()),
-    getNewLine: () => ts.sys.newLine,
-  };
+  const fh = formatHost();
 
   // Config-level errors (bad tsconfig read / parse) — format and
   // exit before attempting to use the program.
   if (configDiagnostics.length > 0) {
-    process.stderr.write(ts.formatDiagnostics(configDiagnostics, formatHost));
+    process.stderr.write(ts.formatDiagnostics(configDiagnostics, fh));
     process.exit(1);
   }
 
@@ -85,17 +140,10 @@ function main(): void {
   const sorted = ts.sortAndDeduplicateDiagnostics(remapped);
 
   if (sorted.length > 0) {
-    // Mirror tsc's --pretty default: on when stdout is a TTY,
-    // off otherwise. Explicit --pretty true/false overrides.
-    const prettyIndex = args.indexOf("--pretty");
-    const prettyFromArgs =
-      prettyIndex === -1 ? undefined : args[prettyIndex + 1] === "false" ? false : true;
-    const pretty =
-      prettyFromArgs ?? program.getCompilerOptions().pretty ?? ts.sys.writeOutputIsTTY?.() ?? false;
+    const pretty = parsePretty(args, program.getCompilerOptions());
     const output = pretty
-      ? ts.formatDiagnosticsWithColorAndContext(sorted, formatHost)
-      : ts.formatDiagnostics(sorted, formatHost);
-
+      ? ts.formatDiagnosticsWithColorAndContext(sorted, fh)
+      : ts.formatDiagnostics(sorted, fh);
     process.stderr.write(output);
     process.exit(1);
   }

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -50,19 +50,29 @@ function handleBuildMode(args: string[]): void {
   const buildIdx = args.findIndex((a) => a === "--build" || a === "-b");
   if (buildIdx === -1) return;
 
-  // Everything after --build that isn't a known solution-builder
-  // flag is treated as a project path. tsc accepts multiple.
+  // Project paths are positional args AFTER --build. Flags that
+  // consume a value must skip that value so we don't treat `false`
+  // (from `--pretty false`) or similar as a project path.
+  const buildArgs = args.slice(buildIdx + 1);
   const verbose = args.includes("--verbose");
   const clean = args.includes("--clean");
-  const rest = args.filter((a, i) => {
-    if (i === buildIdx) return false;
-    if (a === "--verbose" || a === "--clean") return false;
-    return !a.startsWith("-");
-  });
+  const flagsWithValues = new Set(["--pretty"]);
+  const rest: string[] = [];
+  for (let i = 0; i < buildArgs.length; i++) {
+    const arg = buildArgs[i]!;
+    if (arg === "--verbose" || arg === "--clean") continue;
+    if (arg.startsWith("--pretty=")) continue;
+    if (flagsWithValues.has(arg)) {
+      if (i + 1 < buildArgs.length && !buildArgs[i + 1]!.startsWith("-")) i++;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    rest.push(arg);
+  }
   const rootConfigs = rest.length > 0 ? rest.map((p) => path.resolve(p)) : [process.cwd()];
 
   const fh = formatHost();
-  const pretty = ts.sys.writeOutputIsTTY?.() ?? false;
+  const pretty = parsePretty(args, {});
   let diagnostics = 0;
   const builder = createTrailsSolutionBuilder(rootConfigs, {
     verbose,

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -93,7 +93,7 @@ export function buildCompilerHost(
       // identical text stays cache-stable.
       (sf as ts.SourceFile & { version: string }).version = baseHost.createHash
         ? baseHost.createHash(text)
-        : String(text.length);
+        : djb2Hash(text);
       sourceFileCache.set(resolved, sf);
       return sf;
     },
@@ -112,4 +112,20 @@ export function buildCompilerHost(
   };
 
   return host;
+}
+
+/**
+ * djb2 string hash — content-sensitive fallback used for
+ * `SourceFile.version` when the base host doesn't expose a hash
+ * function. Not cryptographic, but distinguishes texts of the same
+ * length (unlike `String(text.length)`), so the incremental
+ * builder doesn't reuse stale SourceFiles for edits that don't
+ * change length.
+ */
+function djb2Hash(text: string): string {
+  let hash = 5381;
+  for (let i = 0; i < text.length; i++) {
+    hash = ((hash << 5) + hash + text.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36) + ":" + text.length;
 }

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -15,7 +15,10 @@ export function buildCompilerHost(
   baseNames?: readonly string[],
   modelRegistry?: ReadonlyMap<string, string>,
 ): TrailsCompilerHost {
-  const baseHost = ts.createCompilerHost(options, true);
+  // Incremental host seeds `createHash` and attaches file versions —
+  // required by `ts.createEmitAndSemanticDiagnosticsBuilderProgram`
+  // (used by `--build`) and harmless for plain `createProgram`.
+  const baseHost = ts.createIncrementalCompilerHost(options);
   const deltaMap = new Map<string, VirtualizeResult["deltas"]>();
   const virtualizedTextCache = new Map<string, string>();
   const originalTextCache = new Map<string, string>();
@@ -83,6 +86,14 @@ export function buildCompilerHost(
         return sourceFileCache.get(resolved)!;
       }
       const sf = ts.createSourceFile(resolved, text, languageVersionOrOptions, true);
+      // `ts.EmitAndSemanticDiagnosticsBuilderProgram` (used by
+      // `--build`) asserts every source file has a `version`. When
+      // we produce our own virtualized SourceFile we must set it
+      // ourselves — hash the virtualized text so re-parsing
+      // identical text stays cache-stable.
+      (sf as ts.SourceFile & { version: string }).version = baseHost.createHash
+        ? baseHost.createHash(text)
+        : String(text.length);
       sourceFileCache.set(resolved, sf);
       return sf;
     },

--- a/packages/activerecord/src/tsc-wrapper/index.ts
+++ b/packages/activerecord/src/tsc-wrapper/index.ts
@@ -1,3 +1,8 @@
 export { buildCompilerHost, type TrailsCompilerHost } from "./host.js";
 export { createTrailsProgram, type TrailsProgram } from "./program.js";
+export {
+  createTrailsSolutionBuilder,
+  type TrailsSolutionBuilder,
+  type TrailsBuildOptions,
+} from "./build.js";
 export { remapDiagnostics } from "./remap.js";

--- a/packages/activerecord/src/tsc-wrapper/remap.ts
+++ b/packages/activerecord/src/tsc-wrapper/remap.ts
@@ -13,8 +13,8 @@ import type { TrailsCompilerHost } from "./host.js";
 export function remapDiagnostics(
   diagnostics: readonly ts.Diagnostic[],
   host: TrailsCompilerHost,
+  originalSfCache: Map<string, ts.SourceFile> = new Map(),
 ): ts.Diagnostic[] {
-  const originalSfCache = new Map<string, ts.SourceFile>();
   return diagnostics.map((d) => remapOneDiagnostic(d, host, originalSfCache));
 }
 


### PR DESCRIPTION
## Summary

Phase 1b.5 of the `trails-tsc` CLI — adds `--build` / `-b` support so monorepos with TypeScript composite project references get the same zero-declare / zero-import virtualization as the single-project (`--noEmit`) path.

- `createTrailsSolutionBuilder` wraps `ts.createSolutionBuilder` and applies the virtualizing compiler host to every project in the solution. Each project runs its own two-pass transitive-extends walker + model registry, so virtualization and (per-project) auto-import resolution work under `tsc --build`.
- CLI: `-b` / `--build` (plus `--verbose` / `--clean`) delegate to the solution builder; the single-project path is unchanged.
- `ts.createIncrementalCompilerHost` is now the base host so each virtualized SourceFile carries the `version` hash required by `ts.createEmitAndSemanticDiagnosticsBuilderProgram`.
- Composite fixture (`models` + `app` with cross-project `references`) + two integration tests covering a clean build (verifies `.d.ts` and `.tsbuildinfo` emission for both projects) and a rebuild after editing a model (verifies the new attribute shows up in the emitted declaration).
- Auto-import stays scoped per-project (per the plan); cross-project association targets are imported explicitly by the user.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/tsc-wrapper/cli.test.ts` — 16/16 pass (Phase 1b.1–1b.5).
- [x] `pnpm build` — clean.
- [x] `pnpm typecheck` — clean.