### PR TITLE
feat(activerecord): Phase 1b.6 — virtualized-patterns dx-tests + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:types
 
+  virtualized-dx-type-tests:
+    name: Virtualized DX Type Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test:types:virtualized
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
       - run: pnpm test:types:virtualized
 
   unit-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,8 +353,17 @@ typed instance properties. Narrow at the use site instead:
 `record.id as number`.
 
 See `packages/activerecord/dx-tests/declare-patterns.test-d.ts` for the
-canonical, compiled reference for every pattern.
+canonical manual-`declare` reference (the escape hatch — use when the
+virtualizer doesn't yet produce the declare you need, or when you want
+the shape documented locally).
+
+`packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts`
+is the parallel **zero-declare** reference compiled by `trails-tsc`. It
+shows the Rails-fidelity authoring form (pure `static { this.attribute(...) }`
+blocks) and is the default you should prefer. CI runs it as the
+`Virtualized DX Type Tests` job.
 
 `CollectionProxy<T>` and `AssociationProxy<T>` are both generic in the
-element type. Without the `declare`, any of these runtime-attached
-members still resolves to `unknown`.
+element type. Without the `declare` (manual) or without `trails-tsc`
+compiling the file (virtualized), these runtime-attached members still
+resolve to `unknown`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:types": "vitest run --config vitest.dx-tests.config.ts",
-    "test:types:virtualized": "pnpm --filter @blazetrails/activerecord build && node packages/activerecord/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
+    "test:types:virtualized": "tsc -b packages/activerecord && node packages/activerecord/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:types": "vitest run --config vitest.dx-tests.config.ts",
-    "test:types:virtualized": "node packages/activerecord/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
+    "test:types:virtualized": "pnpm --filter @blazetrails/activerecord build && node packages/activerecord/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:types": "vitest run --config vitest.dx-tests.config.ts",
+    "test:types:virtualized": "node packages/activerecord/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
     "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",

--- a/packages/activerecord/src/type-virtualization/fixtures/19-define-enum-static-block/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/19-define-enum-static-block/expected.ts
@@ -1,0 +1,20 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  declare status: number;
+  declare isDraft: () => boolean;
+  declare draft: () => void;
+  declare draftBang: () => Promise<void>;
+  declare static draft: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notDraft: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare isPublished: () => boolean;
+  declare published: () => void;
+  declare publishedBang: () => Promise<void>;
+  declare static published: () => import("@blazetrails/activerecord").Relation<Article>;
+  declare static notPublished: () => import("@blazetrails/activerecord").Relation<Article>;
+
+  static {
+    this.attribute("status", "integer");
+    defineEnum(this, "status", { draft: 0, published: 1 });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/19-define-enum-static-block/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/19-define-enum-static-block/input.ts
@@ -1,0 +1,8 @@
+import { defineEnum } from "@blazetrails/activerecord";
+
+export class Article extends Base {
+  static {
+    this.attribute("status", "integer");
+    defineEnum(this, "status", { draft: 0, published: 1 });
+  }
+}

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -101,7 +101,17 @@ export function walk(sourceFile: ts.SourceFile, opts: WalkOptions = {}): ClassIn
       if (ts.isClassStaticBlockDeclaration(member)) {
         for (const s of member.body.statements) {
           const call = readThisCall(s);
-          if (call) info.calls.push(call);
+          if (call) {
+            info.calls.push(call);
+            continue;
+          }
+          // Static-block `defineEnum(this, "status", { ... })` —
+          // Rails-idiomatic authoring form (matches Ruby's
+          // `enum :status, ...` inside the class body). Walker also
+          // supports the top-level `defineEnum(ClassName, ...)` form
+          // below.
+          const defineEnumCall = readDefineEnumThisCall(s);
+          if (defineEnumCall) info.calls.push(defineEnumCall);
         }
       }
     }
@@ -170,6 +180,25 @@ function recordExistingMember(m: ts.ClassElement, info: ClassInfo): void {
   const isStatic = modifiers?.some((mod) => mod.kind === ts.SyntaxKind.StaticKeyword) ?? false;
   if (isStatic) info.existingStaticMembers.add(name);
   else info.existingMembers.add(name);
+}
+
+function readDefineEnumThisCall(stmt: ts.Statement): DefineEnumCall | null {
+  if (!ts.isExpressionStatement(stmt)) return null;
+  const call = stmt.expression;
+  if (!ts.isCallExpression(call)) return null;
+  if (!ts.isIdentifier(call.expression) || call.expression.text !== "defineEnum") return null;
+  const [targetArg, attrArg, mapArg, optsArg] = call.arguments;
+  if (!targetArg || targetArg.kind !== ts.SyntaxKind.ThisKeyword) return null;
+  if (!attrArg || !ts.isStringLiteralLike(attrArg)) return null;
+  if (!mapArg) return null;
+  const values = readEnumValues(mapArg);
+  if (!values) return null;
+  return {
+    kind: "defineEnum",
+    attr: attrArg.text,
+    values,
+    options: readRecordLiteral(optsArg),
+  };
 }
 
 function readThisCall(stmt: ts.Statement): RuntimeCall | null {

--- a/packages/activerecord/virtualized-dx-tests/README.md
+++ b/packages/activerecord/virtualized-dx-tests/README.md
@@ -22,7 +22,21 @@ Run locally:
 pnpm test:types:virtualized
 ```
 
-CI runs the same command in the `Virtualized DX Type Tests` job.
+The script builds `@blazetrails/activerecord` first (incremental, fast
+after the first run) so `trails-tsc`'s compiled binary is present
+before it's invoked. CI runs the same command in the `Virtualized DX
+Type Tests` job.
+
+## How auto-import is exercised
+
+`Comment` lives in `comment.ts` and is deliberately NOT imported by
+the test fixture. `Author.hasMany("comments")` in
+`virtualized-patterns.test-d.ts` forces the virtualizer to inject
+`import type { Comment } from "./comment.js"` so the injected
+`declare comments: AssociationProxy<Comment>` — and the
+`expectTypeOf(...)<AssociationProxy<Comment>>()` assertions — both
+resolve. A regression in the auto-import pass (missing registry
+entry, wrong relative path, etc.) fails this CI job.
 
 The companion file `../dx-tests/declare-patterns.test-d.ts` is the manual
 escape hatch — useful when a model needs a type declaration the virtualizer

--- a/packages/activerecord/virtualized-dx-tests/README.md
+++ b/packages/activerecord/virtualized-dx-tests/README.md
@@ -1,0 +1,29 @@
+# Virtualized DX type tests
+
+Parallel to `../dx-tests/` but authored in the **zero-declare / zero-import**
+form. Model classes are written as pure Rails-style static blocks:
+
+```ts
+class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.belongsTo("author");
+  }
+}
+```
+
+No `declare` fields, no `import type { Author }` — `trails-tsc` injects both
+at compile time. Plain `tsc` will fail to compile these files; that's the
+whole point of the virtualizer.
+
+Run locally:
+
+```bash
+pnpm test:types:virtualized
+```
+
+CI runs the same command in the `Virtualized DX Type Tests` job.
+
+The companion file `../dx-tests/declare-patterns.test-d.ts` is the manual
+escape hatch — useful when a model needs a type declaration the virtualizer
+doesn't produce yet, or to document the shape for reference.

--- a/packages/activerecord/virtualized-dx-tests/comment.ts
+++ b/packages/activerecord/virtualized-dx-tests/comment.ts
@@ -1,0 +1,13 @@
+import { Base } from "@blazetrails/activerecord";
+
+// Split out so `Author`'s `this.hasMany("comments")` forces the
+// virtualizer's auto-import pass to inject `import type { Comment }`
+// into virtualized-patterns.test-d.ts. A regression in that pass
+// (e.g. the model registry missing an entry, or `Comment` failing
+// to resolve across files) would surface as a type error in CI.
+export class Comment extends Base {
+  static {
+    this.attribute("body", "string");
+    this.attribute("post_id", "integer");
+  }
+}

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@blazetrails/activerecord": ["../src/index.ts"],
+      "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
+      "@blazetrails/arel": ["../../arel/src/index.ts"],
+      "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],
+      "@blazetrails/activesupport/message-verifier": ["../../activesupport/src/message-verifier.ts"]
+    }
+  },
+  "include": ["."]
+}

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -21,20 +21,19 @@ import {
   association,
   defineEnum,
 } from "@blazetrails/activerecord";
+// `Comment` is intentionally NOT imported here — it lives in
+// `comment.ts` and is referenced as the `Author.hasMany("comments")`
+// target. `trails-tsc`'s auto-import pass must inject
+// `import type { Comment } from "./comment.js"` so BOTH the injected
+// `declare comments: AssociationProxy<Comment>` on Author AND the
+// `expectTypeOf(...)<AssociationProxy<Comment>>()` assertions below
+// resolve. If the auto-import pass regresses, this file fails CI.
 
 class User extends Base {
   static {
     this.attribute("name", "string");
     this.attribute("email", "string");
     this.attribute("admin", "boolean", { default: false });
-  }
-}
-
-class Comment extends Base {
-  static {
-    this.attribute("body", "string");
-    this.attribute("post_id", "integer");
-    this.belongsTo("post");
   }
 }
 

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -83,13 +83,9 @@ class Task extends Base {
 class Article extends Base {
   static {
     this.attribute("status", "integer");
+    defineEnum(this, "status", { draft: 0, published: 1 });
   }
 }
-// Top-level `defineEnum(ClassName, ...)` — form the virtualizer walker
-// recognizes. The `defineEnum(this, ...)` static-block form is valid at
-// runtime but not yet picked up by the walker (parallel gap with
-// declare-patterns, which still needs hand-written declares for it).
-defineEnum(Article, "status", { draft: 0, published: 1 });
 
 describe("virtualized patterns — trails-tsc injects declares + auto-imports", () => {
   it("attributes resolve to their declared type", () => {

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -1,0 +1,159 @@
+/**
+ * DX (virtualized form): the SAME patterns as `declare-patterns.test-d.ts`,
+ * but authored with ZERO `declare` lines and ZERO association-target
+ * imports. `trails-tsc` injects the declares and `import type { ... }`
+ * lines at compile time, so the authored source stays Rails-fidelity —
+ * a pure static block with `this.attribute(...)` / `this.hasMany(...)`
+ * etc., matching `class Post < ApplicationRecord; has_many :comments; end`.
+ *
+ * Run with `pnpm test:types:virtualized` (which invokes `trails-tsc
+ * --noEmit` against this directory). Plain `tsc` would fail against
+ * these files — that's by design; the declares only exist after
+ * virtualization.
+ */
+
+import { describe, it, expectTypeOf } from "vitest";
+import {
+  Base,
+  CollectionProxy,
+  AssociationProxy,
+  Relation,
+  association,
+  defineEnum,
+} from "@blazetrails/activerecord";
+
+class User extends Base {
+  static {
+    this.attribute("name", "string");
+    this.attribute("email", "string");
+    this.attribute("admin", "boolean", { default: false });
+  }
+}
+
+class Comment extends Base {
+  static {
+    this.attribute("body", "string");
+    this.attribute("post_id", "integer");
+    this.belongsTo("post");
+  }
+}
+
+class Tag extends Base {
+  static {
+    this.attribute("name", "string");
+  }
+}
+
+class Author extends Base {
+  static {
+    this.attribute("name", "string");
+    this.hasMany("comments");
+    this.hasAndBelongsToMany("tags");
+    this.hasOne("profile");
+  }
+}
+
+class Profile extends Base {
+  static {
+    this.attribute("bio", "string");
+    this.attribute("author_id", "integer");
+    this.belongsTo("author");
+  }
+}
+
+class Post extends Base {
+  static {
+    this.attribute("title", "string");
+    this.attribute("published", "boolean");
+    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
+    this.scope("recent", (rel: Relation<Post>, sinceDays: number) => {
+      void sinceDays;
+      return rel.where({});
+    });
+  }
+}
+
+class Task extends Base {
+  static {
+    this.attribute("status", "integer");
+    this.enum("status", { low: 0, high: 1 });
+  }
+}
+
+class Article extends Base {
+  static {
+    this.attribute("status", "integer");
+  }
+}
+// Top-level `defineEnum(ClassName, ...)` — form the virtualizer walker
+// recognizes. The `defineEnum(this, ...)` static-block form is valid at
+// runtime but not yet picked up by the walker (parallel gap with
+// declare-patterns, which still needs hand-written declares for it).
+defineEnum(Article, "status", { draft: 0, published: 1 });
+
+describe("virtualized patterns — trails-tsc injects declares + auto-imports", () => {
+  it("attributes resolve to their declared type", () => {
+    const u = new User({ name: "dean", email: "d@example.com", admin: false });
+    expectTypeOf(u.name).toBeString();
+    expectTypeOf(u.email).toBeString();
+    expectTypeOf(u.admin).toBeBoolean();
+  });
+
+  it("hasMany resolves to AssociationProxy<Target>", async () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.comments).toEqualTypeOf<AssociationProxy<Comment>>();
+    expectTypeOf(await author.comments).toEqualTypeOf<Comment[]>();
+    expectTypeOf(author.comments.length).toBeNumber();
+    expectTypeOf(author.comments[0]).toEqualTypeOf<Comment | undefined>();
+  });
+
+  it("association() helper keeps the full CollectionProxy API", async () => {
+    const author = new Author({ name: "dean" });
+    const proxy = association<Comment>(author, "comments");
+    expectTypeOf(proxy).toMatchTypeOf<CollectionProxy<Comment>>();
+    expectTypeOf(await proxy.first()).toEqualTypeOf<Comment | null>();
+    expectTypeOf(await proxy.toArray()).toEqualTypeOf<Comment[]>();
+  });
+
+  it("hasAndBelongsToMany mirrors hasMany shape", () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.tags).toEqualTypeOf<AssociationProxy<Tag>>();
+  });
+
+  it("belongsTo resolves to Target | null (synchronous reader)", () => {
+    const profile = new Profile({ bio: "hi", author_id: 1 });
+    expectTypeOf(profile.author).toEqualTypeOf<Author | null>();
+  });
+
+  it("hasOne resolves to Target | null", () => {
+    const author = new Author({ name: "dean" });
+    expectTypeOf(author.profile).toEqualTypeOf<Profile | null>();
+  });
+
+  it("named scope becomes a typed class method", () => {
+    expectTypeOf(Post.published()).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.recent).toEqualTypeOf<(sinceDays: number) => Relation<Post>>();
+  });
+
+  it("Base.enum produces predicates, bang setters, and class scopes", () => {
+    const t = new Task({ status: 0 });
+    expectTypeOf(t.isLow()).toBeBoolean();
+    expectTypeOf(t.lowBang()).toMatchTypeOf<Task>();
+    expectTypeOf(Task.low()).toMatchTypeOf<Relation<Task>>();
+  });
+
+  it("defineEnum adds plain setters, async bangs, and not* scopes", async () => {
+    const a = new Article({ status: 0 });
+    expectTypeOf(a.draft).toEqualTypeOf<() => void>();
+    expectTypeOf(a.draftBang).toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf(await a.draftBang()).toBeVoid();
+    expectTypeOf(Article.notDraft()).toMatchTypeOf<Relation<Article>>();
+  });
+
+  it("loadBelongsTo / loadHasOne overloads narrow by association name", async () => {
+    const profile = new Profile({ bio: "hi", author_id: 1 });
+    expectTypeOf(await profile.loadBelongsTo("author")).toEqualTypeOf<Author | null>();
+    const author = new Author({ name: "dean" });
+    expectTypeOf(await author.loadHasOne("profile")).toEqualTypeOf<Profile | null>();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b.6 closes the Phase 1b loop: a parallel zero-declare DX reference that compiles under `trails-tsc`, wired into CI so virtualizer regressions are caught on every PR.

- `packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts` — mirrors `dx-tests/declare-patterns.test-d.ts` but every model is a pure Rails-style `static { this.attribute(...) }` block with zero `declare` lines and zero association-target imports. 8 model classes (User, Comment, Tag, Author, Profile, Post, Task, Article) exercise attributes, `hasMany`/`belongsTo`/`hasOne`/HABTM, named scopes, `Base.enum` + top-level `defineEnum`, and the `loadBelongsTo`/`loadHasOne` overloads.
- Dedicated `virtualized-dx-tests/tsconfig.json` so plain `tsc` / Vitest typecheck don't try to compile these files (the declares only exist after `trails-tsc`'s text transform).
- New `pnpm test:types:virtualized` script and `Virtualized DX Type Tests` CI job run the binary against the fixture; a regression in the virtualizer (missing declare, wrong type, missing auto-import) now fails the build.
- CLAUDE.md: `declare-patterns` is now positioned as the manual escape hatch; `virtualized-patterns` is the default Rails-fidelity form.

## Test plan

- [x] `pnpm test:types:virtualized` — zero diagnostics against the new fixture.
- [x] `pnpm test:types` — existing DX type tests still pass (63 tests).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm exec vitest run packages/activerecord/src/tsc-wrapper/cli.test.ts` — 17/17 (no regressions from prior phases).