### PR TITLE
feat(activerecord): add OID::Uuid and OID::Range Type::Value classes

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/pg-range.ts
+++ b/packages/activerecord/src/adapters/postgresql/pg-range.ts
@@ -3,11 +3,17 @@
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range
  *
- * Rails deserializes PG ranges into Ruby Range objects with typed bounds.
- * We do the same — parseRange returns a Range (from relation.ts) with
- * bounds cast through an optional subtype function, or null for empty ranges.
+ * This is a thin adapter-level helper. The canonical implementation lives
+ * in `connection-adapters/postgresql/oid/range.ts` as `RangeType` — this
+ * function predates that class and is kept for callers that need a plain
+ * parser without constructing a full Type::Value. Both share the
+ * findRangeSeparator / unquoteRangeBound helpers so parsing stays in sync.
  */
 
+import {
+  findRangeSeparator,
+  unquoteRangeBound,
+} from "../../connection-adapters/postgresql/oid/range.js";
 import { Range } from "../../relation.js";
 
 export type SubtypeCast = (value: string) => unknown;
@@ -25,7 +31,7 @@ export function parseRange(input: string, subtype?: SubtypeCast): Range | null {
   const excludeEnd = input[input.length - 1] === ")";
 
   const inner = input.slice(1, -1);
-  const commaIdx = findSeparator(inner);
+  const commaIdx = findRangeSeparator(inner);
 
   let rawBegin: string | null = inner.slice(0, commaIdx).trim();
   let rawEnd: string | null = inner.slice(commaIdx + 1).trim();
@@ -33,8 +39,8 @@ export function parseRange(input: string, subtype?: SubtypeCast): Range | null {
   if (rawBegin === "" || rawBegin === "-infinity") rawBegin = null;
   if (rawEnd === "" || rawEnd === "infinity") rawEnd = null;
 
-  rawBegin = rawBegin && unquoteRange(rawBegin);
-  rawEnd = rawEnd && unquoteRange(rawEnd);
+  rawBegin = rawBegin && unquoteRangeBound(rawBegin);
+  rawEnd = rawEnd && unquoteRangeBound(rawEnd);
 
   if (excludeBegin && rawBegin !== null) {
     throw new Error(
@@ -47,33 +53,4 @@ export function parseRange(input: string, subtype?: SubtypeCast): Range | null {
   const castEnd = rawEnd !== null && subtype ? subtype(rawEnd) : rawEnd;
 
   return new Range(castBegin, castEnd, excludeEnd);
-}
-
-function findSeparator(s: string): number {
-  let inQuote = false;
-  for (let i = 0; i < s.length; i++) {
-    if (s[i] === '"') {
-      let backslashes = 0;
-      let j = i - 1;
-      while (j >= 0 && s[j] === "\\") {
-        backslashes++;
-        j--;
-      }
-      if (backslashes % 2 === 0) inQuote = !inQuote;
-    } else if (!inQuote && s[i] === ",") {
-      return i;
-    }
-  }
-  return s.length;
-}
-
-/**
- * Unquote a range bound value.
- * PG uses "" for literal " and \\\\ for literal \\ inside double-quoted bounds.
- */
-function unquoteRange(s: string): string {
-  if (s.startsWith('"') && s.endsWith('"')) {
-    return s.slice(1, -1).replace(/""/g, '"').replace(/\\\\/g, "\\");
-  }
-  return s;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.test.ts
@@ -82,7 +82,7 @@ describe("PostgreSQL::OID::Range", () => {
 
   it("maps range bounds", () => {
     const type = new RangeType(integerSubtype, "int4range");
-    const range = type.map(new Range(1, 10), (value) => Number(value) + 1);
+    const range = type.map(new Range(1, 10), (value) => Number(value) + 1) as Range;
 
     expect(range.begin).toBe(2);
     expect(range.end).toBe(11);

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -17,6 +17,8 @@
  *     the subtype and emits `Range` instances from `castValue`/`serialize`.
  */
 
+import { Type } from "@blazetrails/activemodel";
+
 export class Range {
   readonly begin: unknown;
   readonly end: unknown;
@@ -39,22 +41,32 @@ export interface RangeSubtype {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.
  */
-export class RangeType {
+export class RangeType extends Type<Range> {
+  readonly name: string;
   readonly subtype: RangeSubtype;
-  readonly type: string;
 
   constructor(subtype: RangeSubtype, type: string = "range") {
+    super();
     this.subtype = subtype;
-    this.type = type;
+    this.name = type;
   }
 
-  typeCastForSchema(value: unknown): string {
+  override type(): string {
+    return this.name;
+  }
+
+  override typeCastForSchema(value: unknown): string {
     return inspect(value).replace(/Infinity/g, "::Float::INFINITY");
   }
 
-  castValue(value: unknown): unknown {
+  castValue(value: unknown): Range | null {
     if (value == null || value === "empty" || value === "") return null;
-    if (typeof value !== "string") return value;
+    // Rails' cast_value passes non-String values through unchanged
+    // (`return value unless value.is_a?(::String)`). The cast is generic in
+    // Ruby so this just trusts the caller. In TS we keep the Rails semantic
+    // but acknowledge the Range | null return type is optimistic for non-
+    // string inputs — callers shouldn't pass garbage here.
+    if (typeof value !== "string") return value as Range | null;
 
     const extracted = this.extractBounds(value);
     const from = this.typeCastSingle(extracted.from);
@@ -70,15 +82,15 @@ export class RangeType {
     return new Range(begin, end, extracted.excludeEnd);
   }
 
-  cast(value: unknown): unknown {
+  cast(value: unknown): Range | null {
     return this.castValue(value);
   }
 
-  deserialize(value: unknown): unknown {
+  override deserialize(value: unknown): Range | null {
     return this.castValue(value);
   }
 
-  serialize(value: unknown): unknown {
+  override serialize(value: unknown): unknown {
     if (!(value instanceof Range)) return value;
     return new Range(
       this.typeCastSingleForDatabase(value.begin),
@@ -87,11 +99,12 @@ export class RangeType {
     );
   }
 
-  map(value: Range, block: (value: unknown) => unknown): Range {
+  override map(value: Range | null, block?: (value: unknown) => unknown): Range | null {
+    if (value == null || !block) return value;
     return new Range(block(value.begin), block(value.end), value.excludeEnd);
   }
 
-  isForceEquality(value: unknown): boolean {
+  override isForceEquality(value: unknown): boolean {
     return value instanceof Range;
   }
 
@@ -114,13 +127,16 @@ export class RangeType {
     excludeEnd: boolean;
   } {
     const fromTo = value.slice(1, -1);
-    const separator = findSeparator(fromTo);
+    const separator = findRangeSeparator(fromTo);
     const from = fromTo.slice(0, separator);
     const to = fromTo.slice(separator + 1);
 
     return {
-      from: from === "" || from === "-infinity" ? this.infinity({ negative: true }) : unquote(from),
-      to: to === "" || to === "infinity" ? this.infinity() : unquote(to),
+      from:
+        from === "" || from === "-infinity"
+          ? this.infinity({ negative: true })
+          : unquoteRangeBound(from),
+      to: to === "" || to === "infinity" ? this.infinity() : unquoteRangeBound(to),
       excludeStart: value.startsWith("("),
       excludeEnd: value.endsWith(")"),
     };
@@ -131,7 +147,13 @@ export class RangeType {
   }
 }
 
-function findSeparator(value: string): number {
+/**
+ * Split a range-literal's inner string (without surrounding `[` / `)`) at
+ * the top-level comma, skipping commas inside double-quoted bounds. PG
+ * range output always uses `""` for an escaped quote, so that's what we
+ * track here — matches Rails' `extract_bounds`.
+ */
+export function findRangeSeparator(value: string): number {
   let inQuotes = false;
   for (let i = 0; i < value.length; i++) {
     const char = value[i];
@@ -148,7 +170,11 @@ function findSeparator(value: string): number {
   return value.length;
 }
 
-function unquote(value: string): string {
+/**
+ * Unquote a range-bound value. PG emits `""` for literal `"` and `\\` for
+ * literal `\` inside double-quoted bounds. Mirrors Rails' `unquote`.
+ */
+export function unquoteRangeBound(value: string): string {
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/""/g, '"').replace(/\\\\/g, "\\");
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { Uuid, isValidUuid, normalizeUuid } from "./uuid.js";
+
+describe("PostgreSQL::OID::Uuid", () => {
+  const type = new Uuid();
+
+  it("reports :uuid as its type", () => {
+    expect(type.type()).toBe("uuid");
+  });
+
+  it("casts a canonical UUID unchanged", () => {
+    expect(type.cast("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")).toBe(
+      "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    );
+  });
+
+  it("normalises an uppercase UUID", () => {
+    expect(type.cast("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11")).toBe(
+      "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    );
+  });
+
+  it("normalises a braced UUID", () => {
+    expect(type.cast("{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}")).toBe(
+      "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    );
+  });
+
+  it("returns null for invalid values", () => {
+    expect(type.cast("not-a-uuid")).toBeNull();
+    expect(type.cast("")).toBeNull();
+  });
+
+  it("rejects UUIDs with unbalanced braces", () => {
+    expect(type.cast("{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")).toBeNull();
+    expect(type.cast("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}")).toBeNull();
+  });
+
+  it("serialize is aliased to deserialize", () => {
+    const value = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    expect(type.serialize(value)).toBe(type.deserialize(value));
+  });
+
+  it("changed? compares by class and value", () => {
+    expect(type.isChanged("a", "a")).toBe(false);
+    expect(type.isChanged("a", "b")).toBe(true);
+    expect(type.isChanged("a", 1)).toBe(true);
+  });
+
+  it("changed_in_place? compares raw old and new", () => {
+    expect(type.isChangedInPlace("a", "a")).toBe(false);
+    expect(type.isChangedInPlace("a", "b")).toBe(true);
+  });
+});
+
+describe("uuid back-compat helpers", () => {
+  it("isValidUuid accepts standard, braced, and compact UUIDs", () => {
+    expect(isValidUuid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")).toBe(true);
+    expect(isValidUuid("{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}")).toBe(true);
+    expect(isValidUuid("a0eebc999c0b4ef8bb6d6bb9bd380a11")).toBe(true);
+  });
+
+  it("normalizeUuid returns null for empty / invalid input", () => {
+    expect(normalizeUuid("")).toBeNull();
+    expect(normalizeUuid("   ")).toBeNull();
+    expect(normalizeUuid("foobar")).toBeNull();
+  });
+
+  it("normalizeUuid canonicalises valid formats", () => {
+    const expected = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    expect(normalizeUuid("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11")).toBe(expected);
+    expect(normalizeUuid("{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}")).toBe(expected);
+    expect(normalizeUuid("a0eebc999c0b4ef8bb6d6bb9bd380a11")).toBe(expected);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
@@ -4,25 +4,85 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid
  */
 
+import { Type } from "@blazetrails/activemodel";
+
+// Rails uses /\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z/ — a conditional
+// pattern that enforces balanced braces. JS regex has no conditional, so
+// express the same constraint via alternation (either both braces or neither).
+export const ACCEPTABLE_UUID = /^(?:\{([a-fA-F0-9]{4}-?){8}\}|([a-fA-F0-9]{4}-?){8})$/;
+export const CANONICAL_UUID = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/;
+
 /**
- * Regex matching all acceptable UUID formats:
- * - Standard: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
- * - Braced:   {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
- * - Compact:  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ * Permissive legacy regex retained so `isValidUuid` / `normalizeUuid`
+ * (used by the adapter-level uuid test suite) keep accepting compact
+ * 32-char UUIDs and unbalanced braces. The OID::Uuid class uses the
+ * strict ACCEPTABLE_UUID above.
  */
 export const ACCEPTABLE_UUID_REGEX =
   /^\{?[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\}?$/i;
 
+export class Uuid extends Type<string> {
+  readonly name = "uuid";
+
+  override type(): string {
+    return "uuid";
+  }
+
+  cast(value: unknown): string | null {
+    return this.castValue(value);
+  }
+
+  override deserialize(value: unknown): string | null {
+    return this.castValue(value);
+  }
+
+  // Rails does `alias :serialize :deserialize` — serialize routes through
+  // the same casting path as deserialize.
+  override serialize(value: unknown): string | null {
+    return this.castValue(value);
+  }
+
+  /**
+   * Mirrors Rails' Uuid#changed? — compares by class and value.
+   */
+  override isChanged(
+    oldValue: unknown,
+    newValue: unknown,
+    _newValueBeforeTypeCast?: unknown,
+  ): boolean {
+    return oldValue?.constructor !== newValue?.constructor || newValue !== oldValue;
+  }
+
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+    return rawOldValue?.constructor !== newValue?.constructor || newValue !== rawOldValue;
+  }
+
+  private castValue(value: unknown): string | null {
+    if (value == null) return null;
+    const str = String(value);
+    if (!ACCEPTABLE_UUID.test(str)) return null;
+    return this.formatUuid(str);
+  }
+
+  private formatUuid(uuid: string): string {
+    if (CANONICAL_UUID.test(uuid)) return uuid;
+    const stripped = uuid.replace(/[{}-]/g, "").toLowerCase();
+    return `${stripped.slice(0, 8)}-${stripped.slice(8, 12)}-${stripped.slice(12, 16)}-${stripped.slice(16, 20)}-${stripped.slice(20)}`;
+  }
+}
+
 /**
- * Check if a string is a valid UUID in any accepted format.
+ * Check if a string is a valid UUID in any accepted format. Back-compat
+ * helper for the adapter-level uuid test suite — accepts compact 32-char
+ * UUIDs (legacy behavior).
  */
 export function isValidUuid(value: string): boolean {
   return ACCEPTABLE_UUID_REGEX.test(value.trim());
 }
 
 /**
- * Normalize a UUID to standard lowercase hyphenated format.
- * Returns null if the input is not a valid UUID.
+ * Normalize a UUID to standard lowercase hyphenated format. Back-compat
+ * helper; returns null for invalid or empty input.
  */
 export function normalizeUuid(value: string | null | undefined): string | null {
   if (value == null) return null;


### PR DESCRIPTION
## Summary

Rebased onto main (PR #560 landed the OID::Range split so this PR is reduced to the delta). Adds the missing `OID::Uuid` Type::Value class, and tightens the OID::RangeType merged in #560 to extend the ActiveModel Type::Value base and share parsing helpers with `pg-range.ts`.

- **OID::Uuid** — new `Type::Value` class (was only helper functions). `type`, `cast`, `deserialize`, `serialize` (aliased), `isChanged`, `isChangedInPlace`. `ACCEPTABLE_UUID` enforces balanced braces via alternation, matching Rails' conditional regex `/\A(\{)?(...){8}(?(1)\}|)\z/` (JS regex has no conditional pattern). Permissive `isValidUuid`/`normalizeUuid` helpers kept for the adapter-level uuid test suite.
- **OID::RangeType extends Type\<Range\>** — inherits the full ActiveModel Type::Value surface (assertValidValue, asJson, isBinary, etc.) rather than standing alone. Overrides only what Rails overrides: `type`, `typeCastForSchema`, `deserialize`, `serialize`, `map`, `isForceEquality`.
- **Shared range helpers** — `findRangeSeparator` / `unquoteRangeBound` extracted from `oid/range.ts` and reused from `adapters/postgresql/pg-range.ts`, eliminating duplicated PG range-literal parsing.

No TypeMapInitializer wiring for Uuid — Rails registers `uuid` in the PG adapter's `initialize_type_map`, not in TMI, so wiring it through TMI would diverge from Rails. Adapter init hook is future work.

## Test plan

- [x] 12 new Uuid tests + extended coverage
- [x] Full AR suite: 8346 passing, 0 regressions
- [x] Typecheck clean
- [x] \`api:compare\`: uuid.rb 0% → 100% (3/3), range.rb stays 100%