### PR TITLE
refactor(trailties): route all fs/path/cwd through async activesupport adapters

### DIFF
--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -42,6 +42,8 @@ export interface FsAdapter {
   ): number;
   closeSync(fd: number): void;
   copyFileSync(src: string, dest: string): void;
+  /** Current working directory. */
+  cwd(): string;
   /**
    * Create a unique temp directory (optional — not all filesystems support
    * atomic uniqueness). Only used by server-side database tasks; custom
@@ -107,7 +109,10 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const fs = req("node:fs") as FsAdapter;
+    const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd">;
+    const fs: FsAdapter = Object.assign(nodeFs, {
+      cwd: () => globalThis.process.cwd(),
+    }) as FsAdapter;
     const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;
     const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
     const path: PathAdapter = {
@@ -136,7 +141,10 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
         if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
           return false;
         }
-        const fs = (await import("node:fs")) as unknown as FsAdapter;
+        const nodeFs = (await import("node:fs")) as unknown as Omit<FsAdapter, "cwd">;
+        const fs: FsAdapter = Object.assign(nodeFs, {
+          cwd: () => globalThis.process.cwd(),
+        }) as FsAdapter;
         const nodePath = (await import("node:path")) as unknown as Required<
           Omit<PathAdapter, "pathToFileURL">
         >;

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -62,6 +62,8 @@ export interface PathAdapter {
    * absolute.
    */
   isAbsolute?(p: string): boolean;
+  /** Optional — compute a relative path from `from` to `to`. */
+  relative?(from: string, to: string): string;
   /**
    * Optional — convert an absolute filesystem path to a `file://` URL
    * (RFC 8089). Only used by server-side paths that call dynamic `import()`
@@ -115,6 +117,7 @@ function tryAutoRegisterNode(): boolean {
       resolve: (...parts) => nodePath.resolve(...parts),
       extname: (p) => nodePath.extname(p),
       isAbsolute: (p) => nodePath.isAbsolute(p),
+      relative: (from, to) => nodePath.relative(from, to),
       pathToFileURL: (p) => nodeUrl.pathToFileURL(p),
       sep: nodePath.sep,
     };
@@ -145,6 +148,7 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
           resolve: (...parts) => nodePath.resolve(...parts),
           extname: (p) => nodePath.extname(p),
           isAbsolute: (p) => nodePath.isAbsolute(p),
+          relative: (from, to) => nodePath.relative(from, to),
           pathToFileURL: (p) => nodeUrl.pathToFileURL(p),
           sep: nodePath.sep,
         };

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -113,7 +113,7 @@ function tryAutoRegisterNode(): boolean {
     );
     const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd" | "exists">;
     const fsPromises = req("node:fs/promises") as { access(p: string): Promise<void> };
-    const fs: FsAdapter = Object.assign(nodeFs, {
+    const fs: FsAdapter = Object.assign({}, nodeFs, {
       cwd: () => globalThis.process.cwd(),
       exists: (p: string) =>
         fsPromises.access(p).then(
@@ -153,7 +153,7 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
         const fsPromises = (await import("node:fs/promises")) as unknown as {
           access(p: string): Promise<void>;
         };
-        const fs: FsAdapter = Object.assign(nodeFs, {
+        const fs: FsAdapter = Object.assign({}, nodeFs, {
           cwd: () => globalThis.process.cwd(),
           exists: (p: string) =>
             fsPromises.access(p).then(

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -118,7 +118,11 @@ function tryAutoRegisterNode(): boolean {
       exists: (p: string) =>
         fsPromises.access(p).then(
           () => true,
-          () => false,
+          (error: unknown) => {
+            const code = (error as { code?: string }).code;
+            if (code === "ENOENT" || code === "ENOTDIR") return false;
+            throw error;
+          },
         ),
     }) as FsAdapter;
     const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -44,6 +44,8 @@ export interface FsAdapter {
   copyFileSync(src: string, dest: string): void;
   /** Current working directory. */
   cwd(): string;
+  /** Async existence check — avoids requiring existsSync in async code paths. */
+  exists(path: string): Promise<boolean>;
   /**
    * Create a unique temp directory (optional — not all filesystems support
    * atomic uniqueness). Only used by server-side database tasks; custom
@@ -109,9 +111,15 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd">;
+    const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd" | "exists">;
+    const fsPromises = req("node:fs/promises") as { access(p: string): Promise<void> };
     const fs: FsAdapter = Object.assign(nodeFs, {
       cwd: () => globalThis.process.cwd(),
+      exists: (p: string) =>
+        fsPromises.access(p).then(
+          () => true,
+          () => false,
+        ),
     }) as FsAdapter;
     const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;
     const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
@@ -141,9 +149,17 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
         if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
           return false;
         }
-        const nodeFs = (await import("node:fs")) as unknown as Omit<FsAdapter, "cwd">;
+        const nodeFs = (await import("node:fs")) as unknown as Omit<FsAdapter, "cwd" | "exists">;
+        const fsPromises = (await import("node:fs/promises")) as unknown as {
+          access(p: string): Promise<void>;
+        };
         const fs: FsAdapter = Object.assign(nodeFs, {
           cwd: () => globalThis.process.cwd(),
+          exists: (p: string) =>
+            fsPromises.access(p).then(
+              () => true,
+              () => false,
+            ),
         }) as FsAdapter;
         const nodePath = (await import("node:path")) as unknown as Required<
           Omit<PathAdapter, "pathToFileURL">

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -496,7 +496,11 @@ async function runSeed(prefix = ""): Promise<void> {
   // without the query string, the second iteration sees a cached module
   // and skips execution entirely. Mirrors Rails' `load` semantics
   // (which always re-evaluates the file).
-  const url = getPath().pathToFileURL!(seedFile);
+  const pathToFileURL = getPath().pathToFileURL;
+  if (!pathToFileURL) {
+    throw new Error("Seed loading requires a path adapter with pathToFileURL support.");
+  }
+  const url = pathToFileURL(seedFile);
   url.searchParams.set("_t", `${++_seedImportCounter}`);
   await import(url.href);
   console.log(`${prefix}Seeds completed.`);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1042,6 +1042,7 @@ export function dbCommand(): Command {
     .option("--format <format>", "Override schema format: ts, js, or sql")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
+      const fs = await getFsAsync();
       await forEachDatabase(opts, async ({ adapter, config, prefix }) => {
         // schema:load is destructive — Rails gates on
         // check_protected_environments.
@@ -1051,7 +1052,7 @@ export function dbCommand(): Command {
         try {
           DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
           const filename = DatabaseTasks.schemaDumpPath(config);
-          if (!(await (await getFsAsync()).exists(filename))) {
+          if (!(await fs.exists(filename))) {
             console.error(`${prefix}No schema file found at ${filename}`);
             process.exitCode = 1;
             return;
@@ -1115,6 +1116,7 @@ export function dbCommand(): Command {
     )
     .action(async () => {
       // Rails: `configurations.configs_for(env_name: env).each { |c| clear_schema_cache(cache_dump_filename(c)) }`.
+      const fs = await getFsAsync();
       const envName = resolveEnv();
       const named = await loadAllDatabaseConfigs(envName);
       const configs = named.map(
@@ -1126,7 +1128,7 @@ export function dbCommand(): Command {
           const filename = DatabaseTasks.cacheDumpFilename(config);
           // clearSchemaCache is a no-op on ENOENT; don't log "Cleared"
           // unless we actually removed something.
-          if (!(await (await getFsAsync()).exists(filename))) continue;
+          if (!(await fs.exists(filename))) continue;
           DatabaseTasks.clearSchemaCache(filename);
           console.log(`Cleared schema cache at ${filename}`);
         }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -61,7 +61,7 @@ function normalizeRawConfig(raw: RawConfig): RawConfig {
 }
 
 function migrationsDir(): string {
-  return getPath().join(process.cwd(), "db", "migrations");
+  return getPath().join(getFs().cwd(), "db", "migrations");
 }
 
 /**
@@ -74,15 +74,15 @@ function migrationsDir(): string {
  */
 function migrationsDirsForConfig(name: string, config: RawConfig): string[] {
   const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
-  if (typeof raw === "string" && raw.length > 0) return [getPath().resolve(process.cwd(), raw)];
+  if (typeof raw === "string" && raw.length > 0) return [getPath().resolve(getFs().cwd(), raw)];
   if (Array.isArray(raw)) {
     const dirs = [
-      ...new Set(raw.filter((p) => p.length > 0).map((p) => getPath().resolve(process.cwd(), p))),
+      ...new Set(raw.filter((p) => p.length > 0).map((p) => getPath().resolve(getFs().cwd(), p))),
     ];
     if (dirs.length > 0) return dirs;
   }
-  if (name === "primary") return [getPath().join(process.cwd(), "db", "migrations")];
-  return [getPath().join(process.cwd(), "db", `migrations_${name}`)];
+  if (name === "primary") return [getPath().join(getFs().cwd(), "db", "migrations")];
+  return [getPath().join(getFs().cwd(), "db", `migrations_${name}`)];
 }
 
 /**
@@ -481,8 +481,8 @@ async function runTestLoadSchema(options: {
 let _seedImportCounter = 0;
 async function runSeed(prefix = ""): Promise<void> {
   const seedCandidates = [
-    getPath().join(process.cwd(), "db", "seeds.ts"),
-    getPath().join(process.cwd(), "db", "seeds.js"),
+    getPath().join(getFs().cwd(), "db", "seeds.ts"),
+    getPath().join(getFs().cwd(), "db", "seeds.js"),
   ];
   const seedFile = seedCandidates.find((f) => getFs().existsSync(f));
   if (!seedFile) {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,7 +1,5 @@
 import { Command } from "commander";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+import { getFs, getPath } from "@blazetrails/activesupport";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,
@@ -63,7 +61,7 @@ function normalizeRawConfig(raw: RawConfig): RawConfig {
 }
 
 function migrationsDir(): string {
-  return path.join(process.cwd(), "db", "migrations");
+  return getPath().join(process.cwd(), "db", "migrations");
 }
 
 /**
@@ -76,15 +74,15 @@ function migrationsDir(): string {
  */
 function migrationsDirsForConfig(name: string, config: RawConfig): string[] {
   const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
-  if (typeof raw === "string" && raw.length > 0) return [path.resolve(process.cwd(), raw)];
+  if (typeof raw === "string" && raw.length > 0) return [getPath().resolve(process.cwd(), raw)];
   if (Array.isArray(raw)) {
     const dirs = [
-      ...new Set(raw.filter((p) => p.length > 0).map((p) => path.resolve(process.cwd(), p))),
+      ...new Set(raw.filter((p) => p.length > 0).map((p) => getPath().resolve(process.cwd(), p))),
     ];
     if (dirs.length > 0) return dirs;
   }
-  if (name === "primary") return [path.join(process.cwd(), "db", "migrations")];
-  return [path.join(process.cwd(), "db", `migrations_${name}`)];
+  if (name === "primary") return [getPath().join(process.cwd(), "db", "migrations")];
+  return [getPath().join(process.cwd(), "db", `migrations_${name}`)];
 }
 
 /**
@@ -459,7 +457,7 @@ async function runTestLoadSchema(options: {
   const config = toDbConfig(raw, "test");
   await runProtectedEnvCheck(config, "test");
   const filename = DatabaseTasks.schemaDumpPath(config);
-  if (!fs.existsSync(filename)) {
+  if (!getFs().existsSync(filename)) {
     console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
     process.exitCode = 1;
     return;
@@ -483,10 +481,10 @@ async function runTestLoadSchema(options: {
 let _seedImportCounter = 0;
 async function runSeed(prefix = ""): Promise<void> {
   const seedCandidates = [
-    path.join(process.cwd(), "db", "seeds.ts"),
-    path.join(process.cwd(), "db", "seeds.js"),
+    getPath().join(process.cwd(), "db", "seeds.ts"),
+    getPath().join(process.cwd(), "db", "seeds.js"),
   ];
-  const seedFile = seedCandidates.find((f) => fs.existsSync(f));
+  const seedFile = seedCandidates.find((f) => getFs().existsSync(f));
   if (!seedFile) {
     console.log(`${prefix}No seeds file found at db/seeds.ts or db/seeds.js`);
     return;
@@ -498,7 +496,7 @@ async function runSeed(prefix = ""): Promise<void> {
   // without the query string, the second iteration sees a cached module
   // and skips execution entirely. Mirrors Rails' `load` semantics
   // (which always re-evaluates the file).
-  const url = pathToFileURL(seedFile);
+  const url = getPath().pathToFileURL!(seedFile);
   url.searchParams.set("_t", `${++_seedImportCounter}`);
   await import(url.href);
   console.log(`${prefix}Seeds completed.`);
@@ -1042,7 +1040,7 @@ export function dbCommand(): Command {
         try {
           DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
           const filename = DatabaseTasks.schemaDumpPath(config);
-          if (!fs.existsSync(filename)) {
+          if (!getFs().existsSync(filename)) {
             console.error(`${prefix}No schema file found at ${filename}`);
             process.exitCode = 1;
             return;
@@ -1117,7 +1115,7 @@ export function dbCommand(): Command {
           const filename = DatabaseTasks.cacheDumpFilename(config);
           // clearSchemaCache is a no-op on ENOENT; don't log "Cleared"
           // unless we actually removed something.
-          if (!fs.existsSync(filename)) continue;
+          if (!getFs().existsSync(filename)) continue;
           DatabaseTasks.clearSchemaCache(filename);
           console.log(`Cleared schema cache at ${filename}`);
         }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { getFs, getPath } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,
@@ -60,8 +60,9 @@ function normalizeRawConfig(raw: RawConfig): RawConfig {
   return normalized as RawConfig;
 }
 
-function migrationsDir(): string {
-  return getPath().join(getFs().cwd(), "db", "migrations");
+async function migrationsDir(): Promise<string> {
+  const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
+  return path.join(fs.cwd(), "db", "migrations");
 }
 
 /**
@@ -72,17 +73,17 @@ function migrationsDir(): string {
  * default to `db/migrations_<name>`. Returns an array because
  * Rails supports multiple directories per config.
  */
-function migrationsDirsForConfig(name: string, config: RawConfig): string[] {
+async function migrationsDirsForConfig(name: string, config: RawConfig): Promise<string[]> {
+  const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
+  const cwd = fs.cwd();
   const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
-  if (typeof raw === "string" && raw.length > 0) return [getPath().resolve(getFs().cwd(), raw)];
+  if (typeof raw === "string" && raw.length > 0) return [path.resolve(cwd, raw)];
   if (Array.isArray(raw)) {
-    const dirs = [
-      ...new Set(raw.filter((p) => p.length > 0).map((p) => getPath().resolve(getFs().cwd(), p))),
-    ];
+    const dirs = [...new Set(raw.filter((p) => p.length > 0).map((p) => path.resolve(cwd, p)))];
     if (dirs.length > 0) return dirs;
   }
-  if (name === "primary") return [getPath().join(getFs().cwd(), "db", "migrations")];
-  return [getPath().join(getFs().cwd(), "db", `migrations_${name}`)];
+  if (name === "primary") return [path.join(cwd, "db", "migrations")];
+  return [path.join(cwd, "db", `migrations_${name}`)];
 }
 
 /**
@@ -394,7 +395,7 @@ async function runMigrate(
   targetVersion?: string,
   options: RunOptions = {},
 ): Promise<void> {
-  const migrations = await discoverMigrations(migrationsDir());
+  const migrations = await discoverMigrations(await migrationsDir());
   if (migrations.length === 0) {
     console.log("No migrations found.");
     return;
@@ -457,7 +458,8 @@ async function runTestLoadSchema(options: {
   const config = toDbConfig(raw, "test");
   await runProtectedEnvCheck(config, "test");
   const filename = DatabaseTasks.schemaDumpPath(config);
-  if (!getFs().existsSync(filename)) {
+  const fs = await getFsAsync();
+  if (!(await fs.exists(filename))) {
     console.error(`No schema file found at ${filename}. Run \`trails db schema:dump\` first.`);
     process.exitCode = 1;
     return;
@@ -480,11 +482,16 @@ async function runTestLoadSchema(options: {
 
 let _seedImportCounter = 0;
 async function runSeed(prefix = ""): Promise<void> {
-  const seedCandidates = [
-    getPath().join(getFs().cwd(), "db", "seeds.ts"),
-    getPath().join(getFs().cwd(), "db", "seeds.js"),
-  ];
-  const seedFile = seedCandidates.find((f) => getFs().existsSync(f));
+  const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
+  const cwd = fs.cwd();
+  const seedCandidates = [path.join(cwd, "db", "seeds.ts"), path.join(cwd, "db", "seeds.js")];
+  let seedFile: string | undefined;
+  for (const f of seedCandidates) {
+    if (await fs.exists(f)) {
+      seedFile = f;
+      break;
+    }
+  }
   if (!seedFile) {
     console.log(`${prefix}No seeds file found at db/seeds.ts or db/seeds.js`);
     return;
@@ -496,7 +503,7 @@ async function runSeed(prefix = ""): Promise<void> {
   // without the query string, the second iteration sees a cached module
   // and skips execution entirely. Mirrors Rails' `load` semantics
   // (which always re-evaluates the file).
-  const pathToFileURL = getPath().pathToFileURL;
+  const pathToFileURL = path.pathToFileURL;
   if (!pathToFileURL) {
     throw new Error("Seed loading requires a path adapter with pathToFileURL support.");
   }
@@ -585,7 +592,7 @@ async function withMigratorForDb(
     afterOutput?: (migrator: Migrator) => void | Promise<void>;
   },
 ): Promise<void> {
-  const mDirs = migrationsDirsForConfig(ctx.name, ctx.raw);
+  const mDirs = await migrationsDirsForConfig(ctx.name, ctx.raw);
   const migrations = await discoverMigrationsFromDirs(mDirs);
   if (migrations.length === 0) {
     console.log(`${ctx.prefix}No migrations found.`);
@@ -731,7 +738,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
-        const mDirs = migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(name, raw);
         const migrations = await discoverMigrationsFromDirs(mDirs);
         if (migrations.length === 0) return;
         const migrator = createMigrator(adapter, migrations, raw);
@@ -769,7 +776,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDirs = migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(name, raw);
         const migrations = await discoverMigrationsFromDirs(mDirs);
         const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("up", opts.version);
@@ -785,7 +792,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDirs = migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(name, raw);
         const migrations = await discoverMigrationsFromDirs(mDirs);
         const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("down", opts.version);
@@ -919,7 +926,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
-        const mDirs = migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(name, raw);
         const migrations = await discoverMigrationsFromDirs(mDirs);
         if (migrations.length === 0) {
           console.log(`${prefix}No migrations found.`);
@@ -1044,7 +1051,7 @@ export function dbCommand(): Command {
         try {
           DatabaseTasks.schemaFormat = await resolveSchemaFormat(opts);
           const filename = DatabaseTasks.schemaDumpPath(config);
-          if (!getFs().existsSync(filename)) {
+          if (!(await (await getFsAsync()).exists(filename))) {
             console.error(`${prefix}No schema file found at ${filename}`);
             process.exitCode = 1;
             return;
@@ -1119,7 +1126,7 @@ export function dbCommand(): Command {
           const filename = DatabaseTasks.cacheDumpFilename(config);
           // clearSchemaCache is a no-op on ENOENT; don't log "Cleared"
           // unless we actually removed something.
-          if (!getFs().existsSync(filename)) continue;
+          if (!(await (await getFsAsync()).exists(filename))) continue;
           DatabaseTasks.clearSchemaCache(filename);
           console.log(`Cleared schema cache at ${filename}`);
         }

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,6 +1,4 @@
-import * as path from "node:path";
-import * as fs from "node:fs";
-import { pathToFileURL } from "node:url";
+import { getFs, getPath } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
@@ -91,15 +89,15 @@ export async function loadDatabaseConfigModule(
 ): Promise<{ path: string; module: DatabaseConfigModule } | null> {
   // Prefer .ts (source of truth) over .js (compiled)
   const candidates = [
-    path.join(cwd, "config", "database.ts"),
-    path.join(cwd, "config", "database.js"),
-    path.join(cwd, "src", "config", "database.ts"),
-    path.join(cwd, "src", "config", "database.js"),
+    getPath().join(cwd, "config", "database.ts"),
+    getPath().join(cwd, "config", "database.js"),
+    getPath().join(cwd, "src", "config", "database.ts"),
+    getPath().join(cwd, "src", "config", "database.js"),
   ];
 
   let configPath: string | undefined;
   for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
+    if (getFs().existsSync(candidate)) {
       configPath = candidate;
       break;
     }
@@ -108,9 +106,9 @@ export async function loadDatabaseConfigModule(
 
   let mod: { default?: unknown } & Record<string, unknown>;
   try {
-    mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
+    mod = (await import(getPath().pathToFileURL!(configPath).href)) as typeof mod;
   } catch (error: unknown) {
-    const rel = path.relative(cwd, configPath) || configPath;
+    const rel = getPath().relative!(cwd, configPath) || configPath;
     // Extract a useful message even when user code throws a non-Error
     // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
     // would produce `undefined` or crash. Route non-Errors through
@@ -133,7 +131,7 @@ export async function loadDatabaseConfigModule(
   // with the offending value's repr.
   const candidate = mod.default ?? mod;
   if (candidate === null || (typeof candidate !== "object" && typeof candidate !== "function")) {
-    const rel = path.relative(cwd, configPath) || configPath;
+    const rel = getPath().relative!(cwd, configPath) || configPath;
     throw new Error(
       `Invalid database config in "${rel}": expected an object, got ${formatUnknown(candidate)}.`,
     );
@@ -403,14 +401,14 @@ export async function resolveSchemaFormat(
     // empty string) is a misconfig that should throw, not silently fall
     // through to inference. Use a relative path in the error source so
     // it stays short and consistent with other config-loading errors.
-    const loadedRel = path.relative(cwd, loaded.path) || loaded.path;
+    const loadedRel = getPath().relative!(cwd, loaded.path) || loaded.path;
     return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loadedRel}`);
   }
 
-  const dbDir = path.join(cwd, "db");
-  if (fs.existsSync(path.join(dbDir, "structure.sql"))) return "sql";
-  if (fs.existsSync(path.join(dbDir, "schema.js"))) return "js";
-  if (fs.existsSync(path.join(dbDir, "schema.ts"))) return "ts";
+  const dbDir = getPath().join(cwd, "db");
+  if (getFs().existsSync(getPath().join(dbDir, "structure.sql"))) return "sql";
+  if (getFs().existsSync(getPath().join(dbDir, "schema.js"))) return "js";
+  if (getFs().existsSync(getPath().join(dbDir, "schema.ts"))) return "ts";
   return "ts";
 }
 

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -85,7 +85,7 @@ function formatUnknown(value: unknown): string {
  * downstream code doesn't need to defensively guard every key lookup.
  */
 export async function loadDatabaseConfigModule(
-  cwd: string = process.cwd(),
+  cwd: string = getFs().cwd(),
 ): Promise<{ path: string; module: DatabaseConfigModule } | null> {
   // Prefer .ts (source of truth) over .js (compiled)
   const candidates = [
@@ -149,7 +149,7 @@ export async function loadDatabaseConfigModule(
  */
 export async function loadDatabaseConfig(
   env?: string,
-  cwd: string = process.cwd(),
+  cwd: string = getFs().cwd(),
 ): Promise<DatabaseConfig> {
   const resolvedEnv = env ?? resolveEnv();
   const loaded = await loadDatabaseConfigModule(cwd);
@@ -278,7 +278,7 @@ export interface NamedDatabaseConfig {
  */
 export async function loadAllDatabaseConfigs(
   env?: string,
-  cwd: string = process.cwd(),
+  cwd: string = getFs().cwd(),
 ): Promise<NamedDatabaseConfig[]> {
   const resolvedEnv = env ?? resolveEnv();
   const loaded = await loadDatabaseConfigModule(cwd);
@@ -354,7 +354,7 @@ export type SchemaFormat = "ts" | "js" | "sql";
  */
 export async function resolveSchemaFormat(
   opts: { format?: string } = {},
-  cwd: string = process.cwd(),
+  cwd: string = getFs().cwd(),
 ): Promise<SchemaFormat> {
   const normalize = (raw: unknown, source: string): SchemaFormat => {
     // `schemaFormat` in config/database.ts is user-authored with only

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -106,9 +106,13 @@ export async function loadDatabaseConfigModule(
 
   let mod: { default?: unknown } & Record<string, unknown>;
   try {
-    mod = (await import(getPath().pathToFileURL!(configPath).href)) as typeof mod;
+    const pathToFileURL = getPath().pathToFileURL;
+    if (!pathToFileURL) {
+      throw new Error("Config loading requires a path adapter with pathToFileURL support.");
+    }
+    mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
   } catch (error: unknown) {
-    const rel = getPath().relative!(cwd, configPath) || configPath;
+    const rel = getPath().relative?.(cwd, configPath) || configPath;
     // Extract a useful message even when user code throws a non-Error
     // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
     // would produce `undefined` or crash. Route non-Errors through
@@ -131,7 +135,7 @@ export async function loadDatabaseConfigModule(
   // with the offending value's repr.
   const candidate = mod.default ?? mod;
   if (candidate === null || (typeof candidate !== "object" && typeof candidate !== "function")) {
-    const rel = getPath().relative!(cwd, configPath) || configPath;
+    const rel = getPath().relative?.(cwd, configPath) || configPath;
     throw new Error(
       `Invalid database config in "${rel}": expected an object, got ${formatUnknown(candidate)}.`,
     );
@@ -401,7 +405,7 @@ export async function resolveSchemaFormat(
     // empty string) is a misconfig that should throw, not silently fall
     // through to inference. Use a relative path in the error source so
     // it stays short and consistent with other config-loading errors.
-    const loadedRel = getPath().relative!(cwd, loaded.path) || loaded.path;
+    const loadedRel = getPath().relative?.(cwd, loaded.path) || loaded.path;
     return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loadedRel}`);
   }
 

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 export interface DatabaseConfig {
@@ -85,19 +85,23 @@ function formatUnknown(value: unknown): string {
  * downstream code doesn't need to defensively guard every key lookup.
  */
 export async function loadDatabaseConfigModule(
-  cwd: string = getFs().cwd(),
+  cwd?: string,
 ): Promise<{ path: string; module: DatabaseConfigModule } | null> {
+  const fs = await getFsAsync();
+  const path = await getPathAsync();
+  const resolvedCwd = cwd ?? fs.cwd();
+
   // Prefer .ts (source of truth) over .js (compiled)
   const candidates = [
-    getPath().join(cwd, "config", "database.ts"),
-    getPath().join(cwd, "config", "database.js"),
-    getPath().join(cwd, "src", "config", "database.ts"),
-    getPath().join(cwd, "src", "config", "database.js"),
+    path.join(resolvedCwd, "config", "database.ts"),
+    path.join(resolvedCwd, "config", "database.js"),
+    path.join(resolvedCwd, "src", "config", "database.ts"),
+    path.join(resolvedCwd, "src", "config", "database.js"),
   ];
 
   let configPath: string | undefined;
   for (const candidate of candidates) {
-    if (getFs().existsSync(candidate)) {
+    if (await fs.exists(candidate)) {
       configPath = candidate;
       break;
     }
@@ -106,20 +110,13 @@ export async function loadDatabaseConfigModule(
 
   let mod: { default?: unknown } & Record<string, unknown>;
   try {
-    const pathToFileURL = getPath().pathToFileURL;
+    const pathToFileURL = path.pathToFileURL;
     if (!pathToFileURL) {
       throw new Error("Config loading requires a path adapter with pathToFileURL support.");
     }
     mod = (await import(pathToFileURL(configPath).href)) as typeof mod;
   } catch (error: unknown) {
-    const rel = getPath().relative?.(cwd, configPath) || configPath;
-    // Extract a useful message even when user code throws a non-Error
-    // (e.g. `throw "boom"` or `throw null`) — `(error as Error).message`
-    // would produce `undefined` or crash. Route non-Errors through
-    // formatUnknown so a thrown object with a poisoned toString()
-    // can't bring down the fallback path too.
-    // Strip trailing punctuation from the inner message so the final
-    // string doesn't end up with a double period like "...message..".
+    const rel = path.relative?.(resolvedCwd, configPath) || configPath;
     const rawMessage = error instanceof Error ? error.message : formatUnknown(error);
     const message = rawMessage.replace(/[.!?]+$/, "");
     const enhanced = new Error(
@@ -129,28 +126,24 @@ export async function loadDatabaseConfigModule(
     (enhanced as { cause?: unknown }).cause = error;
     throw enhanced;
   }
-  // `export default "oops"` loads fine but leaves us with a non-object
-  // default that will crash downstream `in` / Object.keys lookups with
-  // a confusing TypeError. Check up front and throw a clear message
-  // with the offending value's repr.
-  const candidate = mod.default ?? mod;
-  if (candidate === null || (typeof candidate !== "object" && typeof candidate !== "function")) {
-    const rel = getPath().relative?.(cwd, configPath) || configPath;
+  const candidateVal = mod.default ?? mod;
+  if (
+    candidateVal === null ||
+    (typeof candidateVal !== "object" && typeof candidateVal !== "function")
+  ) {
+    const rel = path.relative?.(resolvedCwd, configPath) || configPath;
     throw new Error(
-      `Invalid database config in "${rel}": expected an object, got ${formatUnknown(candidate)}.`,
+      `Invalid database config in "${rel}": expected an object, got ${formatUnknown(candidateVal)}.`,
     );
   }
-  return { path: configPath, module: candidate as DatabaseConfigModule };
+  return { path: configPath, module: candidateVal as DatabaseConfigModule };
 }
 
 /**
  * Load the database configuration for the given environment.
  * Looks for config/database.ts or src/config/database.ts in the cwd.
  */
-export async function loadDatabaseConfig(
-  env?: string,
-  cwd: string = getFs().cwd(),
-): Promise<DatabaseConfig> {
+export async function loadDatabaseConfig(env?: string, cwd?: string): Promise<DatabaseConfig> {
   const resolvedEnv = env ?? resolveEnv();
   const loaded = await loadDatabaseConfigModule(cwd);
   if (!loaded) {
@@ -278,7 +271,7 @@ export interface NamedDatabaseConfig {
  */
 export async function loadAllDatabaseConfigs(
   env?: string,
-  cwd: string = getFs().cwd(),
+  cwd?: string,
 ): Promise<NamedDatabaseConfig[]> {
   const resolvedEnv = env ?? resolveEnv();
   const loaded = await loadDatabaseConfigModule(cwd);
@@ -354,7 +347,7 @@ export type SchemaFormat = "ts" | "js" | "sql";
  */
 export async function resolveSchemaFormat(
   opts: { format?: string } = {},
-  cwd: string = getFs().cwd(),
+  cwd?: string,
 ): Promise<SchemaFormat> {
   const normalize = (raw: unknown, source: string): SchemaFormat => {
     // `schemaFormat` in config/database.ts is user-authored with only
@@ -399,20 +392,24 @@ export async function resolveSchemaFormat(
   // both call sites through one function keeps error handling (the
   // "failed to load config" rethrow) in one place and surfaces real
   // import failures instead of silently falling through to inference.
-  const loaded = await loadDatabaseConfigModule(cwd);
+  const fs = await getFsAsync();
+  const path = await getPathAsync();
+  const resolvedCwd = cwd ?? fs.cwd();
+
+  const loaded = await loadDatabaseConfigModule(resolvedCwd);
   if (loaded && "schemaFormat" in loaded.module) {
     // Presence-based: an explicitly-set-but-garbage value (including an
     // empty string) is a misconfig that should throw, not silently fall
     // through to inference. Use a relative path in the error source so
     // it stays short and consistent with other config-loading errors.
-    const loadedRel = getPath().relative?.(cwd, loaded.path) || loaded.path;
+    const loadedRel = path.relative?.(resolvedCwd, loaded.path) || loaded.path;
     return normalize(loaded.module.schemaFormat ?? "", `schemaFormat in ${loadedRel}`);
   }
 
-  const dbDir = getPath().join(cwd, "db");
-  if (getFs().existsSync(getPath().join(dbDir, "structure.sql"))) return "sql";
-  if (getFs().existsSync(getPath().join(dbDir, "schema.js"))) return "js";
-  if (getFs().existsSync(getPath().join(dbDir, "schema.ts"))) return "ts";
+  const dbDir = path.join(resolvedCwd, "db");
+  if (await fs.exists(path.join(dbDir, "structure.sql"))) return "sql";
+  if (await fs.exists(path.join(dbDir, "schema.js"))) return "js";
+  if (await fs.exists(path.join(dbDir, "schema.ts"))) return "ts";
   return "ts";
 }
 

--- a/packages/website/src/lib/frontiers/vfs-generator.ts
+++ b/packages/website/src/lib/frontiers/vfs-generator.ts
@@ -66,6 +66,9 @@ function createVfsFsAdapter(vfs: VirtualFS): FsAdapter {
     cwd(): string {
       return "/";
     },
+    exists(path: string): Promise<boolean> {
+      return Promise.resolve(vfs.exists(path));
+    },
   };
 }
 

--- a/packages/website/src/lib/frontiers/vfs-generator.ts
+++ b/packages/website/src/lib/frontiers/vfs-generator.ts
@@ -63,6 +63,9 @@ function createVfsFsAdapter(vfs: VirtualFS): FsAdapter {
     statSync(): { isDirectory(): boolean; isFile(): boolean } {
       return { isDirectory: () => false, isFile: () => true };
     },
+    cwd(): string {
+      return "/";
+    },
   };
 }
 

--- a/packages/website/src/lib/frontiers/vfs-generator.ts
+++ b/packages/website/src/lib/frontiers/vfs-generator.ts
@@ -60,8 +60,15 @@ function createVfsFsAdapter(vfs: VirtualFS): FsAdapter {
     rmSync(): void {
       // no-op
     },
-    statSync(): { isDirectory(): boolean; isFile(): boolean } {
-      return { isDirectory: () => false, isFile: () => true };
+    statSync(path: string) {
+      const entry = vfs.read(path);
+      const content = entry?.content ?? "";
+      return {
+        isDirectory: () => false,
+        isFile: () => entry !== undefined,
+        size: content.length,
+        mtime: new Date(0),
+      };
     },
     cwd(): string {
       return "/";


### PR DESCRIPTION
## Summary

- Replaced all `node:fs`, `node:path`, and `node:url` imports in trailties with activesupport's `getFsAsync()` / `getPathAsync()` adapters
- Switched from sync `getFs()`/`getPath()` to async `getFsAsync()`/`getPathAsync()` exclusively — no sync Node APIs remain in trailties database/CLI code
- Replaced `existsSync` with new async `FsAdapter.exists()` backed by `fs/promises.access`
- Added `FsAdapter.cwd()` so trailties no longer references `process.cwd()` directly
- Extended `PathAdapter` with optional `relative()` method
- Guarded optional adapter methods (`pathToFileURL`, `relative`) with proper checks instead of non-null assertions
- Fixed ESM namespace safety: spread into fresh `{}` instead of mutating imported module objects

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm vitest run packages/trailties/src/commands/db.test.ts` — 99 tests pass
- [x] CI