### PR TITLE
feat(activerecord): batch INSERT + migration logger integration

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -3,13 +3,14 @@
  * Mirrors: activerecord/test/cases/migration_test.rb
  *          activerecord/test/cases/invertible_migration_test.rb
  */
-import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, afterEach, vi } from "vitest";
 import { Base, MigrationContext, MigrationRunner, Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { createTestAdapter, adapterType } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Migration } from "./migration.js";
+import { Logger } from "@blazetrails/activesupport";
 import { TableDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import { Schema } from "./schema.js";
 
@@ -2381,5 +2382,110 @@ describe("SchemaMigration.assumeMigratedUptoVersion", () => {
     ).rejects.toThrow(/Duplicate migration/);
     const versions = await sm.allVersions();
     expect(versions).toHaveLength(0); // no partial writes
+  });
+});
+
+describe("Migration.logger integration", () => {
+  const originalLogger = Migration.logger;
+  afterEach(() => {
+    Migration.logger = originalLogger;
+  });
+
+  it("write routes output through Migration.logger", () => {
+    const lines: string[] = [];
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+
+    class TestMig extends Migration {
+      static version = "001";
+      async change() {}
+    }
+
+    const m = new TestMig();
+    m.verbose = true;
+    m.write("hello migration");
+    expect(lines).toContain("hello migration\n");
+  });
+
+  it("write is silent when verbose is false", () => {
+    const lines: string[] = [];
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+
+    class TestMig extends Migration {
+      static version = "002";
+      async change() {}
+    }
+
+    const m = new TestMig();
+    m.verbose = false;
+    m.write("should not appear");
+    expect(lines).toHaveLength(0);
+  });
+
+  it("announce formats through logger", () => {
+    const lines: string[] = [];
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+
+    class CreateUsers extends Migration {
+      static version = "20260101";
+      async change() {}
+    }
+
+    const m = new CreateUsers();
+    m.verbose = true;
+    m.announce("migrating");
+    expect(lines[0]).toMatch(/== 20260101 CreateUsers: migrating =+/);
+  });
+
+  it("say and sayWithTime route through logger", async () => {
+    const lines: string[] = [];
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+
+    class TestMig extends Migration {
+      static version = "003";
+      async change() {}
+    }
+
+    const m = new TestMig();
+    m.verbose = true;
+    m.say("creating table");
+    m.say("0.0010s", true);
+    expect(lines[0]).toContain("-- creating table");
+    expect(lines[1]).toContain("   -> 0.0010s");
+  });
+
+  it("suppressMessages temporarily silences output", async () => {
+    const lines: string[] = [];
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+
+    class TestMig extends Migration {
+      static version = "004";
+      async change() {}
+    }
+
+    const m = new TestMig();
+    m.verbose = true;
+    m.write("before");
+    await m.suppressMessages(async () => {
+      m.write("suppressed");
+    });
+    m.write("after");
+    expect(lines.map((l) => l.trim())).toEqual(["before", "after"]);
+  });
+
+  it("logger level filtering works", () => {
+    const lines: string[] = [];
+    const logger = new Logger({ write: (s) => lines.push(s) });
+    logger.level = "warn";
+    Migration.logger = logger;
+
+    class TestMig extends Migration {
+      static version = "005";
+      async change() {}
+    }
+
+    const m = new TestMig();
+    m.verbose = true;
+    m.write("should be filtered");
+    expect(lines).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath } from "@blazetrails/activesupport";
+import { getFs, getPath, Logger } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
   TableDefinition,
@@ -81,6 +81,7 @@ export abstract class Migration {
   private _name?: string;
   private _version?: string;
   verbose = true;
+  static logger: Logger = new Logger();
   private static _disableDdlTransaction = false;
 
   /** Determine adapter type from the adapter class name. */
@@ -763,7 +764,7 @@ export abstract class Migration {
 
   write(text = ""): void {
     if (this.verbose) {
-      process.stdout.write(text + "\n");
+      Migration.logger.info(text);
     }
   }
 
@@ -1343,7 +1344,6 @@ export class Migrator {
   private _environment: string;
   private _strategy: ExecutionStrategy;
   verbose = true;
-  private _output: string[] = [];
 
   constructor(
     adapter: DatabaseAdapter,
@@ -1379,8 +1379,9 @@ export class Migrator {
     return [...this._migrations];
   }
 
+  /** @deprecated Use Migration.logger instead. */
   get output(): readonly string[] {
-    return [...this._output];
+    return [];
   }
 
   /**
@@ -1714,7 +1715,7 @@ export class Migrator {
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
     if (this.verbose) {
       const action = direction === "up" ? "migrating" : "reverting";
-      this._output.push(`== ${proxy.version} ${proxy.name}: ${action} ==`);
+      Migration.logger.info(`== ${proxy.version} ${proxy.name}: ${action} ==`);
     }
 
     const migration = proxy.migration();
@@ -1736,7 +1737,7 @@ export class Migrator {
 
     if (this.verbose) {
       const action = direction === "up" ? "migrated" : "reverted";
-      this._output.push(`== ${proxy.version} ${proxy.name}: ${action} ==`);
+      Migration.logger.info(`== ${proxy.version} ${proxy.name}: ${action} ==`);
     }
   }
 

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { Logger } from "@blazetrails/activesupport";
 import {
   Migrator,
   CheckPending,
@@ -307,18 +308,32 @@ describe("MigratorTest", () => {
   });
 
   it("migrator verbosity", async () => {
-    const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
-    migrator.verbose = true;
-    await migrator.migrate();
-    expect(migrator.output.some((l) => l.includes("CreateUsers"))).toBe(true);
-    expect(migrator.output.some((l) => l.includes("migrating"))).toBe(true);
+    const lines: string[] = [];
+    const origLogger = Migration.logger;
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    try {
+      const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
+      migrator.verbose = true;
+      await migrator.migrate();
+      expect(lines.some((l) => l.includes("CreateUsers"))).toBe(true);
+      expect(lines.some((l) => l.includes("migrating"))).toBe(true);
+    } finally {
+      Migration.logger = origLogger;
+    }
   });
 
   it("migrator verbosity off", async () => {
-    const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
-    migrator.verbose = false;
-    await migrator.migrate();
-    expect(migrator.output).toHaveLength(0);
+    const lines: string[] = [];
+    const origLogger = Migration.logger;
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    try {
+      const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
+      migrator.verbose = false;
+      await migrator.migrate();
+      expect(lines).toHaveLength(0);
+    } finally {
+      Migration.logger = origLogger;
+    }
   });
 
   it("target version zero should run only once", async () => {
@@ -379,20 +394,34 @@ describe("MigratorTest", () => {
   });
 
   it("migrator output when running multiple migrations", async () => {
-    const migrator = new Migrator(adapter, [
-      makeMigration("1", "CreateUsers"),
-      makeMigration("2", "CreatePosts"),
-    ]);
-    await migrator.migrate();
-    expect(migrator.output.filter((l) => l.includes("migrating")).length).toBe(2);
-    expect(migrator.output.filter((l) => l.includes("migrated")).length).toBe(2);
+    const lines: string[] = [];
+    const origLogger = Migration.logger;
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    try {
+      const migrator = new Migrator(adapter, [
+        makeMigration("1", "CreateUsers"),
+        makeMigration("2", "CreatePosts"),
+      ]);
+      await migrator.migrate();
+      expect(lines.filter((l) => l.includes("migrating")).length).toBe(2);
+      expect(lines.filter((l) => l.includes("migrated")).length).toBe(2);
+    } finally {
+      Migration.logger = origLogger;
+    }
   });
 
   it("migrator output when running single migration", async () => {
-    const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
-    await migrator.migrate();
-    expect(migrator.output.filter((l) => l.includes("migrating")).length).toBe(1);
-    expect(migrator.output.filter((l) => l.includes("migrated")).length).toBe(1);
+    const lines: string[] = [];
+    const origLogger = Migration.logger;
+    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    try {
+      const migrator = new Migrator(adapter, [makeMigration("1", "CreateUsers")]);
+      await migrator.migrate();
+      expect(lines.filter((l) => l.includes("migrating")).length).toBe(1);
+      expect(lines.filter((l) => l.includes("migrated")).length).toBe(1);
+    } finally {
+      Migration.logger = origLogger;
+    }
   });
 
   it("migrator rollback", async () => {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -184,14 +184,23 @@ export class SchemaMigration {
       }),
     );
 
+    const toInsert: string[] = [];
     if (!migrated.has(normalized)) {
-      await this.createVersion(normalized);
+      toInsert.push(normalized);
     }
-
     for (const { normalized: n, num } of candidates) {
       if (num < versionNum && !migrated.has(n)) {
-        await this.createVersion(n);
+        toInsert.push(n);
       }
+    }
+
+    if (toInsert.length > 0) {
+      const col = this.arelTable.get(this.primaryKey);
+      const im = new InsertManager(this.arelTable);
+      const rows = toInsert.map((v) => [new Nodes.Quoted(v)]);
+      im.ast.columns = [col];
+      im.values(im.createValuesList(rows));
+      await this._adapter.executeMutation(im.toSql());
     }
   }
 }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync, Logger } from "@blazetrails/activesupport";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,
@@ -12,6 +12,7 @@ import { discoverMigrations } from "../migration-loader.js";
 import {
   DatabaseTasks,
   HashConfig,
+  Migration,
   Migrator,
   DatabaseAlreadyExists,
   NoDatabaseError,
@@ -404,8 +405,6 @@ async function runMigrate(
   const migrator = createMigrator(adapter, migrations, raw);
   await migrator.migrate(targetVersion ?? null);
 
-  for (const line of migrator.output) console.log(line);
-
   const pending = await migrator.pendingMigrations();
   if (pending.length === 0) console.log("All migrations are up to date.");
 
@@ -586,9 +585,8 @@ async function withMigratorForDb(
   operation: (migrator: Migrator) => Promise<void>,
   opts?: {
     skipDump?: boolean;
-    /** Called after migrator.output has been logged — use for
-     *  messages that should appear after the migration output
-     *  (e.g. "All migrations are up to date."). */
+    /** Called after migration completes — use for messages that
+     *  should appear after the migration output. */
     afterOutput?: (migrator: Migrator) => void | Promise<void>;
   },
 ): Promise<void> {
@@ -602,9 +600,18 @@ async function withMigratorForDb(
     environment: ctx.config.envName,
     internalMetadataEnabled: ctx.config.useMetadataTable,
   });
-  await operation(migrator);
-  for (const line of migrator.output) console.log(`${ctx.prefix}${line}`);
-  if (opts?.afterOutput) await opts.afterOutput(migrator);
+  const prevLogger = Migration.logger;
+  if (ctx.prefix) {
+    Migration.logger = new Logger({
+      write: (s) => process.stdout.write(`${ctx.prefix}${s}`),
+    });
+  }
+  try {
+    await operation(migrator);
+    if (opts?.afterOutput) await opts.afterOutput(migrator);
+  } finally {
+    Migration.logger = prevLogger;
+  }
   if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.adapter, ctx.raw, ctx.config);
 }
 
@@ -780,7 +787,6 @@ export function dbCommand(): Command {
         const migrations = await discoverMigrationsFromDirs(mDirs);
         const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("up", opts.version);
-        for (const line of migrator.output) console.log(`${prefix}${line}`);
         await dumpSchemaAfterMigrate(adapter, raw, config);
       });
     });
@@ -796,7 +802,6 @@ export function dbCommand(): Command {
         const migrations = await discoverMigrationsFromDirs(mDirs);
         const migrator = createMigrator(adapter, migrations, raw);
         await migrator.run("down", opts.version);
-        for (const line of migrator.output) console.log(`${prefix}${line}`);
         await dumpSchemaAfterMigrate(adapter, raw, config);
       });
     });

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -2,8 +2,8 @@ import type { VirtualFS } from "./virtual-fs.js";
 import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
 import type { MigrationProxy, MigrationLike } from "@blazetrails/activerecord/migration";
-import { Migrator } from "@blazetrails/activerecord/migration";
-import { camelize } from "@blazetrails/activesupport";
+import { Migration, Migrator } from "@blazetrails/activerecord/migration";
+import { camelize, Logger } from "@blazetrails/activesupport";
 
 export interface CliResult {
   success: boolean;
@@ -124,7 +124,13 @@ export function createTrailCLI(deps: TrailCliDeps) {
       return;
     }
     const migrator = new Migrator(adapter, proxies);
-    await fn(migrator);
+    const prevLogger = Migration.logger;
+    Migration.logger = new Logger({ write: (s) => log(s.replace(/\n$/, "")) });
+    try {
+      await fn(migrator);
+    } finally {
+      Migration.logger = prevLogger;
+    }
   }
 
   const commands: Record<string, (args: string[], opts: Record<string, string>) => Promise<void>> =
@@ -174,7 +180,6 @@ export function createTrailCLI(deps: TrailCliDeps) {
         const version = opts.version && opts.version !== "true" ? opts.version : null;
         await withMigrator(async (migrator) => {
           await migrator.migrate(version);
-          for (const line of migrator.output) log(line);
           const pending = await migrator.pendingMigrations();
           log(
             pending.length === 0
@@ -189,7 +194,6 @@ export function createTrailCLI(deps: TrailCliDeps) {
         const step = Number.isNaN(parsed) ? 1 : parsed;
         await withMigrator(async (migrator) => {
           await migrator.rollback(step);
-          for (const line of migrator.output) log(line);
         });
       },
 


### PR DESCRIPTION
## Summary

- **Batch INSERT**: `assumeMigratedUptoVersion` collects all missing versions into a single multi-row INSERT via Arel ValuesList, matching Rails' `insert_versions_sql` approach
- **Logger integration**: `Migration#write` and Migrator output route through `Migration.logger` (ActiveSupport Logger) instead of `process.stdout` / internal `_output` array — intentional deviation from Rails (which uses `puts`) to support browser/non-Node environments and structured logging
- **Removed `Migrator._output`**: All migration output now flows through `Migration.logger`. Removed `migrator.output` reads from trailties `db.ts` and website `trail-cli.ts`
- **Tests**: 6 new logger tests in `migration.test.ts` + updated 4 existing tests in `migrator.test.ts` to capture via `Migration.logger`

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts` — 153 pass
- [x] `pnpm vitest run packages/activerecord/src/migrator.test.ts` — 45 pass
- [x] `pnpm vitest run packages/trailties/src/commands/db.test.ts` — 99 pass
- [x] CI