### PR TITLE
feat(activerecord): advisory lock wrapping for concurrent migration safety

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -91,4 +91,22 @@ export interface DatabaseAdapter {
    * begin/commit. Optional — defaults to false when absent.
    */
   supportsDdlTransactions?(): boolean;
+
+  /**
+   * Whether the adapter supports advisory locks for migration
+   * concurrency. Optional — defaults to false when absent.
+   */
+  supportsAdvisoryLocks?(): boolean;
+
+  /**
+   * Acquire an advisory lock. Returns true if the lock was obtained.
+   * Optional — only implemented by adapters that support advisory locks.
+   */
+  getAdvisoryLock?(lockId: number | string): Promise<boolean>;
+
+  /**
+   * Release an advisory lock. Returns true if the lock was released.
+   * Optional — only implemented by adapters that support advisory locks.
+   */
+  releaseAdvisoryLock?(lockId: number | string): Promise<boolean>;
 }

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -569,10 +569,51 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
     return { schema: checkNonEmpty(first.part), table: checkNonEmpty(second.part) };
   }
 
+  supportsAdvisoryLocks(): boolean {
+    return true;
+  }
+
+  // Advisory locks are connection-scoped — pin a dedicated connection
+  // so acquire and release use the same session.
+  private _advisoryLockConn: mysql.PoolConnection | null = null;
+
+  async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+    const conn = await this.pool.getConnection();
+    try {
+      const [rows] = await conn.query("SELECT GET_LOCK(?, 0) AS locked", [String(lockId)]);
+      const locked = (rows as Record<string, unknown>[])[0]?.locked === 1;
+      if (locked) {
+        this._advisoryLockConn = conn;
+      } else {
+        conn.release();
+      }
+      return locked;
+    } catch (error) {
+      conn.release();
+      throw error;
+    }
+  }
+
+  async releaseAdvisoryLock(lockId: number | string): Promise<boolean> {
+    const conn = this._advisoryLockConn;
+    if (!conn) return false;
+    try {
+      const [rows] = await conn.query("SELECT RELEASE_LOCK(?) AS unlocked", [String(lockId)]);
+      return (rows as Record<string, unknown>[])[0]?.unlocked === 1;
+    } finally {
+      this._advisoryLockConn = null;
+      conn.release();
+    }
+  }
+
   /**
    * Close the connection pool.
    */
   async close(): Promise<void> {
+    if (this._advisoryLockConn) {
+      this._advisoryLockConn.release();
+      this._advisoryLockConn = null;
+    }
     if (this._conn) {
       this._conn.release();
       this._conn = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -250,6 +250,10 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * Close the connection pool.
    */
   async close(): Promise<void> {
+    if (this._advisoryLockClient) {
+      this._advisoryLockClient.release();
+      this._advisoryLockClient = null;
+    }
     if (this._client) {
       this._client.release();
       this._client = null;
@@ -419,6 +423,45 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   supportsAdvisoryLocks(): boolean {
     return true;
   }
+
+  // Advisory locks are session-scoped — acquire and release must use the
+  // same connection. We pin a dedicated client from the pool for the
+  // duration of the lock.
+  private _advisoryLockClient: pg.PoolClient | null = null;
+
+  async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+    const client = await this.pool.connect();
+    try {
+      const isNumeric = typeof lockId === "number";
+      const sql = `SELECT pg_try_advisory_lock(${isNumeric ? "$1" : "hashtext($1)"}) AS locked`;
+      const result = await client.query(sql, [isNumeric ? lockId : String(lockId)]);
+      const locked = result.rows[0]?.locked === true;
+      if (locked) {
+        this._advisoryLockClient = client;
+      } else {
+        client.release();
+      }
+      return locked;
+    } catch (error) {
+      client.release();
+      throw error;
+    }
+  }
+
+  async releaseAdvisoryLock(lockId: number | string): Promise<boolean> {
+    const client = this._advisoryLockClient;
+    if (!client) return false;
+    try {
+      const isNumeric = typeof lockId === "number";
+      const sql = `SELECT pg_advisory_unlock(${isNumeric ? "$1" : "hashtext($1)"}) AS unlocked`;
+      const result = await client.query(sql, [isNumeric ? lockId : String(lockId)]);
+      return result.rows[0]?.unlocked === true;
+    } finally {
+      this._advisoryLockClient = null;
+      client.release();
+    }
+  }
+
   supportsExplain(): boolean {
     return true;
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1384,26 +1384,53 @@ export class Migrator {
     return [];
   }
 
+  // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32 of googol)
+  private static readonly _LOCK_ID = 2053462845;
+
+  /**
+   * Wrap a block with an advisory lock to prevent concurrent migrations.
+   * If the adapter doesn't support advisory locks, runs without locking.
+   *
+   * Mirrors: ActiveRecord::Migrator#with_advisory_lock
+   */
+  private async _withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
+    const adapter = this._adapter;
+    if (!adapter.supportsAdvisoryLocks?.() || !adapter.getAdvisoryLock) {
+      return fn();
+    }
+    const locked = await adapter.getAdvisoryLock(Migrator._LOCK_ID);
+    if (!locked) {
+      throw new ConcurrentMigrationError();
+    }
+    try {
+      return await fn();
+    } finally {
+      await adapter.releaseAdvisoryLock?.(Migrator._LOCK_ID);
+    }
+  }
+
   /**
    * Run all pending migrations up, or migrate to a specific version.
    *
    * Mirrors: ActiveRecord::Migrator#migrate
    */
   async migrate(targetVersion?: number | string | null): Promise<void> {
-    await this._ensureSchemaTable();
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
 
-    if (targetVersion !== undefined && targetVersion !== null) {
-      this._validateTargetVersion(targetVersion);
-      const target = BigInt(targetVersion);
-      const current = BigInt(await this.currentVersion());
-      if (target > current) {
-        await this._migrateUp(targetVersion);
-      } else if (target < current) {
-        await this._migrateDown(targetVersion);
+      if (targetVersion !== undefined && targetVersion !== null) {
+        this._validateTargetVersion(targetVersion);
+        const target = BigInt(targetVersion);
+        const current = BigInt(await this.currentVersion());
+        if (target > current) {
+          await this._migrateUp(targetVersion);
+        } else if (target < current) {
+          await this._migrateDown(targetVersion);
+        }
+      } else {
+        await this._migrateUp(null);
       }
-    } else {
-      await this._migrateUp(null);
-    }
+    });
   }
 
   /**
@@ -1412,8 +1439,10 @@ export class Migrator {
    * Mirrors: ActiveRecord::Migrator.up
    */
   async up(targetVersion?: number | string | null): Promise<void> {
-    await this._ensureSchemaTable();
-    await this._migrateUp(targetVersion ?? null);
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
+      await this._migrateUp(targetVersion ?? null);
+    });
   }
 
   /**
@@ -1422,8 +1451,10 @@ export class Migrator {
    * Mirrors: ActiveRecord::Migrator.down
    */
   async down(targetVersion?: number | string | null): Promise<void> {
-    await this._ensureSchemaTable();
-    await this._migrateDown(targetVersion ?? 0);
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
+      await this._migrateDown(targetVersion ?? 0);
+    });
   }
 
   /**
@@ -1435,14 +1466,16 @@ export class Migrator {
     if (!Number.isInteger(steps) || steps < 0) {
       throw new Error(`Invalid steps: ${steps}. Must be a non-negative integer.`);
     }
-    await this._ensureSchemaTable();
-    const applied = await this._appliedVersions();
-    const appliedMigrations = this._migrations.filter((m) => applied.has(m.version)).reverse();
-    const toRollback = appliedMigrations.slice(0, steps);
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
+      const applied = await this._appliedVersions();
+      const appliedMigrations = this._migrations.filter((m) => applied.has(m.version)).reverse();
+      const toRollback = appliedMigrations.slice(0, steps);
 
-    for (const proxy of toRollback) {
-      await this._runMigration(proxy, "down");
-    }
+      for (const proxy of toRollback) {
+        await this._runMigration(proxy, "down");
+      }
+    });
   }
 
   /**
@@ -1454,13 +1487,15 @@ export class Migrator {
     if (!Number.isInteger(steps) || steps < 0) {
       throw new Error(`Invalid steps: ${steps}. Must be a non-negative integer.`);
     }
-    await this._ensureSchemaTable();
-    const pending = await this.pendingMigrations();
-    const toRun = pending.slice(0, steps);
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
+      const pending = await this.pendingMigrations();
+      const toRun = pending.slice(0, steps);
 
-    for (const proxy of toRun) {
-      await this._runMigration(proxy, "up");
-    }
+      for (const proxy of toRun) {
+        await this._runMigration(proxy, "up");
+      }
+    });
   }
 
   /**
@@ -1668,23 +1703,19 @@ export class Migrator {
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<void> {
     this._validateTargetVersion(targetVersion);
-    await this._ensureSchemaTable();
-    // Normalize via BigInt like the constructor does so callers can pass
-    // equivalent forms (leading zeros, `20260101000000` vs the string "20260101000000",
-    // etc.) without hitting a spurious UnknownMigrationVersionError.
-    // The constructor already normalizes every migration's version via
-    // BigInt, so we only need to normalize the incoming targetVersion and
-    // compare directly against the proxy list.
-    const key = String(BigInt(targetVersion));
-    const proxy = this._migrations.find((m) => m.version === key);
-    if (!proxy) {
-      throw new UnknownMigrationVersionError(key);
-    }
-    const applied = await this._appliedVersions();
-    const isApplied = applied.has(key);
-    if (direction === "up" && isApplied) return;
-    if (direction === "down" && !isApplied) return;
-    await this._runMigration(proxy, direction);
+    await this._withAdvisoryLock(async () => {
+      await this._ensureSchemaTable();
+      const key = String(BigInt(targetVersion));
+      const proxy = this._migrations.find((m) => m.version === key);
+      if (!proxy) {
+        throw new UnknownMigrationVersionError(key);
+      }
+      const applied = await this._appliedVersions();
+      const isApplied = applied.has(key);
+      if (direction === "up" && isApplied) return;
+      if (direction === "down" && !isApplied) return;
+      await this._runMigration(proxy, direction);
+    });
   }
 
   private async _migrateUp(targetVersion: number | string | null): Promise<void> {

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -648,3 +648,138 @@ describe("MigratorTest", () => {
     expect(Klass).toBe(Current);
   });
 });
+
+describe("Migrator advisory lock wrapping", () => {
+  it("acquires and releases advisory lock when adapter supports it", async () => {
+    const adapter = createTestAdapter();
+    const lockLog: string[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => {
+      lockLog.push("lock");
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => {
+      lockLog.push("unlock");
+      return true;
+    };
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.migrate();
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("throws ConcurrentMigrationError when lock cannot be acquired", async () => {
+    const { ConcurrentMigrationError } = await import("./migration-errors.js");
+    const adapter = createTestAdapter();
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => false;
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
+  });
+
+  it("releases lock even when migration throws", async () => {
+    const adapter = createTestAdapter();
+    const lockLog: string[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => {
+      lockLog.push("lock");
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => {
+      lockLog.push("unlock");
+      return true;
+    };
+
+    const migrator = new Migrator(adapter, [
+      makeMigration("1", "Boom", async () => {
+        throw new Error("kaboom");
+      }),
+    ]);
+    await expect(migrator.migrate()).rejects.toThrow("kaboom");
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("skips locking when adapter does not support advisory locks", async () => {
+    const adapter = createTestAdapter();
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.migrate();
+    expect(await migrator.currentVersion()).toBe(1);
+  });
+
+  it("wraps rollback in advisory lock", async () => {
+    const adapter = createTestAdapter();
+    const lockLog: string[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => {
+      lockLog.push("lock");
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => {
+      lockLog.push("unlock");
+      return true;
+    };
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.migrate();
+    lockLog.length = 0;
+    await migrator.rollback(1);
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("wraps run in advisory lock", async () => {
+    const adapter = createTestAdapter();
+    const lockLog: string[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => {
+      lockLog.push("lock");
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => {
+      lockLog.push("unlock");
+      return true;
+    };
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.run("up", 1);
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  function lockableAdapter() {
+    const adapter = createTestAdapter();
+    const lockLog: string[] = [];
+    adapter.supportsAdvisoryLocks = () => true;
+    adapter.getAdvisoryLock = async () => {
+      lockLog.push("lock");
+      return true;
+    };
+    adapter.releaseAdvisoryLock = async () => {
+      lockLog.push("unlock");
+      return true;
+    };
+    return { adapter, lockLog };
+  }
+
+  it("wraps up in advisory lock", async () => {
+    const { adapter, lockLog } = lockableAdapter();
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.up();
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("wraps down in advisory lock", async () => {
+    const { adapter, lockLog } = lockableAdapter();
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.up();
+    lockLog.length = 0;
+    await migrator.down(0);
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+
+  it("wraps forward in advisory lock", async () => {
+    const { adapter, lockLog } = lockableAdapter();
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.forward(1);
+    expect(lockLog).toEqual(["lock", "unlock"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap all Migrator operations (`migrate`, `up`, `down`, `rollback`, `forward`, `run`) with advisory locks to prevent concurrent migrations from corrupting schema state — matches Rails' `with_advisory_lock` pattern (since 5.2)
- Added optional `supportsAdvisoryLocks`/`getAdvisoryLock`/`releaseAdvisoryLock` to `DatabaseAdapter` interface
- **PostgreSQL**: `pg_try_advisory_lock` / `pg_advisory_unlock`
- **MySQL**: `GET_LOCK` / `RELEASE_LOCK`
- **SQLite**: no advisory locks (single-writer, not needed)
- Throws `ConcurrentMigrationError` when lock cannot be acquired
- Lock ID matches Rails' `MIGRATOR_SALT` (`2053462845`)

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm vitest run packages/activerecord/src/migrator.test.ts` — 50 pass, 5 skipped
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts` — 153 pass
- [x] CI