### PR TITLE
refactor(activerecord): retrofit batch-2 PG OID classes to extend Type::Value

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class DateTimeType extends Type<Date> {
-  readonly name = "datetime";
+  readonly name: string = "datetime";
 
   cast(value: unknown): Date | null {
     if (value === null || value === undefined) return null;

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class DecimalType extends Type<string> {
-  readonly name = "decimal";
+  readonly name: string = "decimal";
 
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class IntegerType extends Type<number> {
-  readonly name = "integer";
+  readonly name: string = "integer";
   private readonly _range: [number, number];
 
   constructor(options?: { precision?: number; scale?: number; limit?: number }) {

--- a/packages/activemodel/src/type/json.ts
+++ b/packages/activemodel/src/type/json.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class JsonType extends Type<unknown> {
-  readonly name = "json";
+  readonly name: string = "json";
 
   cast(value: unknown): unknown | null {
     if (value === null || value === undefined) return null;

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -10,7 +10,7 @@ export class StringType extends Type<string> {
     return String(value);
   }
 
-  serialize(value: unknown): string | null {
+  serialize(value: unknown): unknown {
     return this.cast(value);
   }
 

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -3,7 +3,7 @@ import { Type } from "./value.js";
 import { ImmutableStringType } from "./immutable-string.js";
 
 export class StringType extends Type<string> {
-  readonly name = "string";
+  readonly name: string = "string";
 
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -447,7 +447,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("multiline", () => {
-      expect(parseHstore('"a"=>"b\\nc"')).toEqual({ a: "b\nc" });
+      // Rails' test_multiline does assert_cycle({"a\nb" => "c\nd"}). PG
+      // stores the newline as a literal character inside the quoted
+      // value, not as a \n escape. Round-trip through serializeHstore /
+      // parseHstore and assert the value is preserved.
+      const input = { "a\nb": "c\nd" };
+      expect(parseHstore(serializeHstore(input))).toEqual(input);
     });
 
     it.skip("hstore with serialized attributes", () => {

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
-import { parseHstore, serializeHstore } from "../../connection-adapters/postgresql/oid/hstore.js";
+import {
+  Hstore,
+  parseHstore,
+  serializeHstore,
+} from "../../connection-adapters/postgresql/oid/hstore.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -467,5 +471,22 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("schema dump with shorthand", async () => {
       /* needs schema dumper */
     });
+  });
+});
+
+// Unit-level tests against Hstore — no DB required. Rails test names.
+describe("PostgresqlHstoreTest", () => {
+  it("deserialize", () => {
+    const type = new Hstore();
+    expect(type.deserialize('"a"=>"b", "c"=>"d"')).toEqual({ a: "b", c: "d" });
+    expect(type.deserialize('"a"=>NULL')).toEqual({ a: null });
+    expect(type.deserialize(null)).toBeNull();
+  });
+
+  it("serialize", () => {
+    const type = new Hstore();
+    expect(type.serialize({ a: "b" })).toBe('"a"=>"b"');
+    expect(type.serialize({ a: null })).toBe('"a"=>NULL');
+    expect(type.serialize({ a: "" })).toBe('"a"=>""');
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -1,7 +1,9 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/interval_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Duration } from "@blazetrails/activesupport";
+import { Interval } from "../../connection-adapters/postgresql/oid/interval.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -27,5 +29,25 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("interval type cast string and numeric from user", () => {});
     it.skip("average interval type", () => {});
     it.skip("schema dump with default value", () => {});
+  });
+});
+
+// Unit-level tests against the Interval type directly — no DB required.
+// Rails test names so api:compare matches.
+describe("PostgresqlIntervalTest", () => {
+  it("interval type", () => {
+    expect(new Interval().type()).toBe("interval");
+  });
+
+  it("interval type cast from invalid string", () => {
+    // Rails: invalid ISO8601 returns nil.
+    expect(new Interval().cast("not a duration")).toBeNull();
+  });
+
+  it("interval type cast from numeric", () => {
+    // Rails: numeric seconds go through Duration.build and round-trip
+    // via iso8601.
+    const serialized = new Interval().serialize(3600);
+    expect(serialized).toBe(Duration.build(3600).iso8601());
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -45,9 +45,13 @@ describe("PostgresqlIntervalTest", () => {
   });
 
   it("interval type cast from numeric", () => {
-    // Rails: numeric seconds go through Duration.build and round-trip
-    // via iso8601.
-    const serialized = new Interval().serialize(3600);
-    expect(serialized).toBe(Duration.build(3600).iso8601());
+    // Rails: numeric seconds round-trip through Duration.build and iso8601.
+    // Verify both cast (FromUser path) and serialize (direct-to-DB path)
+    // handle the numeric case consistently.
+    const type = new Interval();
+    const cast = type.cast(3600);
+    expect(cast).toBeInstanceOf(Duration);
+    expect(type.serialize(cast)).toBe(Duration.build(3600).iso8601());
+    expect(type.serialize(3600)).toBe(Duration.build(3600).iso8601());
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/money_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Money } from "../../connection-adapters/postgresql/oid/money.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -211,5 +212,26 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       expect(Number(rows[0].wealth)).toBeCloseTo(123.45, 2);
     });
+  });
+});
+
+// Unit-level tests that don't need a live PG connection — Rails test
+// names so api:compare matches.
+describe("PostgresqlMoneyTest", () => {
+  it("money type cast", () => {
+    const type = new Money();
+    for (const [str, num] of [
+      ["12,345,678.12", 12345678.12],
+      ["12.345.678,12", 12345678.12],
+      ["0.12", 0.12],
+      ["0,12", 0.12],
+    ] as const) {
+      expect(Number(type.cast(str))).toBeCloseTo(num);
+      expect(Number(type.cast(`$${str}`))).toBeCloseTo(num);
+      expect(Number(type.cast(`-${str}`))).toBeCloseTo(-num);
+      expect(Number(type.cast(`-$${str}`))).toBeCloseTo(-num);
+      expect(Number(type.cast(`(${str})`))).toBeCloseTo(-num);
+      expect(Number(type.cast(`($${str})`))).toBeCloseTo(-num);
+    }
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -1,26 +1,23 @@
 /**
  * PostgreSQL enum OID type — casts PostgreSQL enum column values.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum.
+ * Rails: `class Enum < Type::Value; def type; :enum; end;
+ * def cast_value(value); value.to_s; end`.
  */
 
-export class Enum {
-  get type(): string {
+import { Type } from "@blazetrails/activemodel";
+
+export class Enum extends Type<string> {
+  readonly name: string = "enum";
+
+  override type(): string {
     return "enum";
   }
 
+  /** Rails' cast_value is `value.to_s` — matches `String(value)` here. */
   cast(value: unknown): string | null {
     if (value == null) return null;
-    if (typeof value === "string") return value === "" ? null : value;
     return String(value);
-  }
-
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    return String(value);
-  }
-
-  deserialize(value: unknown): string | null {
-    return this.cast(value);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -24,8 +24,16 @@ export class Hstore extends Type<Record<string, string | null>> {
     return true;
   }
 
+  /**
+   * Rails' Helpers::Mutable overrides cast as `deserialize(serialize(value))`,
+   * producing a fresh hash so in-place mutations on a subsequent value
+   * don't leak into the attribute's cached representation.
+   */
   cast(value: unknown): Record<string, string | null> | null {
-    return this.deserialize(value);
+    if (value == null) return null;
+    const serialized = this.serialize(value);
+    if (typeof serialized !== "string") return null;
+    return this.deserialize(serialized);
   }
 
   override deserialize(value: unknown): Record<string, string | null> | null {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -42,18 +42,21 @@ export class Hstore extends Type<Record<string, string | null>> {
       // Rails: `return value unless value.is_a?(::String)`.
       return value as Record<string, string | null>;
     }
+    if (value.trim() === "") return {};
     return parseHstoreString(value);
   }
 
   override serialize(value: unknown): string | null {
     if (value == null) return null;
-    if (typeof value === "object" && !Array.isArray(value)) {
+    // Rails: `if value.is_a?(::Hash)` — only treat plain objects as a Hash.
+    // Date/Map/class instances fall through to super (identity) so they
+    // aren't accidentally stringified as an empty hstore.
+    if (isPlainObject(value)) {
       const hash = value as Record<string, unknown>;
       return Object.entries(hash)
         .map(([k, v]) => `${escapeHstore(k)}=>${escapeHstore(v as string | null)}`)
         .join(", ");
     }
-    // Rails falls through to super when not a Hash.
     return super.serialize(value) as string | null;
   }
 
@@ -67,6 +70,13 @@ export class Hstore extends Type<Record<string, string | null>> {
     if (oldHash == null || newValue == null) return true;
     return !hashesEqual(oldHash, newValue as Record<string, unknown>);
   }
+}
+
+function isPlainObject(value: unknown): boolean {
+  if (value == null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 function hashesEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -49,8 +49,8 @@ export class Hstore extends Type<Record<string, string | null>> {
   override serialize(value: unknown): string | null {
     if (value == null) return null;
     // Rails: `if value.is_a?(::Hash)` — only treat plain objects as a Hash.
-    // Date/Map/class instances fall through to super (identity) so they
-    // aren't accidentally stringified as an empty hstore.
+    // Date/Map/class instances are rejected by the else branch below
+    // rather than stringified as an empty hstore.
     if (isPlainObject(value)) {
       const hash = value as Record<string, unknown>;
       return Object.entries(hash)

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -57,7 +57,11 @@ export class Hstore extends Type<Record<string, string | null>> {
         .map(([k, v]) => `${escapeHstore(k)}=>${escapeHstore(v as string | null)}`)
         .join(", ");
     }
-    return super.serialize(value) as string | null;
+    // Rails' else branch returns value unchanged. Our declared return is
+    // string | null, so pass through only when it's already a string;
+    // anything else can't honestly satisfy the contract.
+    if (typeof value === "string") return value;
+    return null;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -1,90 +1,166 @@
 /**
- * PostgreSQL hstore parsing and serialization.
+ * PostgreSQL hstore type — key/value string hash.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore.
+ * Rails: `class Hstore < Type::Value; include Helpers::Mutable`.
+ * Deserialize parses the PG text format into a Hash; serialize renders
+ * a Hash back to the text format. changed_in_place? compares the
+ * deserialized hashes so key-order churn doesn't mark the attribute
+ * dirty.
  */
 
+import { Type } from "@blazetrails/activemodel";
+
+const HSTORE_ERROR = "Invalid Hstore document: %s";
+
+export class Hstore extends Type<Record<string, string | null>> {
+  readonly name: string = "hstore";
+
+  override type(): string {
+    return "hstore";
+  }
+
+  override isMutable(): boolean {
+    return true;
+  }
+
+  cast(value: unknown): Record<string, string | null> | null {
+    return this.deserialize(value);
+  }
+
+  override deserialize(value: unknown): Record<string, string | null> | null {
+    if (value == null) return null;
+    if (typeof value !== "string") {
+      // Rails: `return value unless value.is_a?(::String)`.
+      return value as Record<string, string | null>;
+    }
+    return parseHstoreString(value);
+  }
+
+  override serialize(value: unknown): string | null {
+    if (value == null) return null;
+    if (typeof value === "object" && !Array.isArray(value)) {
+      const hash = value as Record<string, unknown>;
+      return Object.entries(hash)
+        .map(([k, v]) => `${escapeHstore(k)}=>${escapeHstore(v as string | null)}`)
+        .join(", ");
+    }
+    // Rails falls through to super when not a Hash.
+    return super.serialize(value) as string | null;
+  }
+
+  /**
+   * Rails' Hstore#changed_in_place? compares hashes (not raw strings)
+   * so key-order differences don't dirty the attribute.
+   */
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+    const oldHash = this.deserialize(rawOldValue);
+    if (oldHash == null && newValue == null) return false;
+    if (oldHash == null || newValue == null) return true;
+    return !hashesEqual(oldHash, newValue as Record<string, unknown>);
+  }
+}
+
+function hashesEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
 /**
- * Parse a PG hstore string into a JS object.
- * Format: "key1"=>"val1", "key2"=>"val2"
- * NULL values (unquoted) become null.
+ * Back-compat parser — direct string parse, used by the adapter-level
+ * hstore test suite. Prefer `new Hstore().deserialize(value)` in new
+ * code.
  */
 export function parseHstore(input: string): Record<string, string | null> {
   if (!input || input.trim() === "") return {};
-
-  const result: Record<string, string | null> = {};
-  let i = 0;
-
-  while (i < input.length) {
-    // Skip whitespace and commas
-    while (i < input.length && (input[i] === " " || input[i] === ",")) i++;
-    if (i >= input.length) break;
-
-    // Parse key (always quoted)
-    const key = parseQuotedString();
-    if (key === null) break;
-
-    // Skip =>
-    while (i < input.length && input[i] === " ") i++;
-    if (input[i] === "=" && input[i + 1] === ">") i += 2;
-    while (i < input.length && input[i] === " ") i++;
-
-    // Parse value (quoted or NULL)
-    if (input.substring(i, i + 4) === "NULL") {
-      result[key] = null;
-      i += 4;
-    } else {
-      const value = parseQuotedString();
-      result[key] = value;
-    }
-  }
-
-  return result;
-
-  function parseQuotedString(): string | null {
-    if (i >= input.length || input[i] !== '"') return null;
-    i++; // skip opening quote
-    let s = "";
-    while (i < input.length && input[i] !== '"') {
-      if (input[i] === "\\") {
-        i++;
-        if (i < input.length) {
-          if (input[i] === "n") {
-            s += "\n";
-          } else if (input[i] === "r") {
-            s += "\r";
-          } else if (input[i] === "t") {
-            s += "\t";
-          } else {
-            s += input[i];
-          }
-        }
-      } else {
-        s += input[i];
-      }
-      i++;
-    }
-    i++; // skip closing quote
-    return s;
-  }
+  return parseHstoreString(input);
 }
 
 /**
- * Serialize a JS object to PG hstore string literal.
+ * Back-compat serializer — direct object → string, used by the
+ * adapter-level hstore test suite.
  */
 export function serializeHstore(obj: Record<string, string | null>): string {
-  const pairs: string[] = [];
-  for (const [key, value] of Object.entries(obj)) {
-    const quotedKey = `"${escapeHstore(key)}"`;
-    if (value === null) {
-      pairs.push(`${quotedKey}=>NULL`);
-    } else {
-      pairs.push(`${quotedKey}=>"${escapeHstore(value)}"`);
-    }
-  }
-  return pairs.join(", ");
+  return Object.entries(obj)
+    .map(([k, v]) => `${escapeHstore(k)}=>${escapeHstore(v)}`)
+    .join(", ");
 }
 
-function escapeHstore(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+/**
+ * Mirrors Rails' Hstore#escape_hstore:
+ *   nil             → NULL
+ *   ""              → "" (empty quoted string)
+ *   "foo"           → quoted, with backslashes and double-quotes escaped
+ */
+function escapeHstore(value: string | null | undefined): string {
+  if (value == null) return "NULL";
+  if (value === "") return '""';
+  return `"${String(value).replace(/(["\\])/g, "\\$1")}"`;
+}
+
+/**
+ * Token-by-token parser mirroring Rails' StringScanner-based approach
+ * in Hstore#deserialize.
+ */
+function parseHstoreString(value: string): Record<string, string | null> {
+  const hash: Record<string, string | null> = {};
+  let i = 0;
+
+  while (i < value.length) {
+    if (value[i] !== '"') throw hstoreError(value);
+    i += 1;
+
+    const keyStart = i;
+    while (i < value.length && value[i] !== '"') {
+      if (value[i] === "\\" && i + 1 < value.length) i += 2;
+      else i += 1;
+    }
+    if (i >= value.length) throw hstoreError(value);
+    const rawKey = value.slice(keyStart, i);
+    i += 1;
+
+    // Rails accepts both "=>" and "=>".
+    if (value[i] !== "=" || value[i + 1] !== ">") throw hstoreError(value);
+    i += 2;
+
+    let rawValue: string | null;
+    if (value.slice(i, i + 4) === "NULL") {
+      rawValue = null;
+      i += 4;
+    } else {
+      if (value[i] !== '"') throw hstoreError(value);
+      i += 1;
+      const valueStart = i;
+      while (i < value.length && value[i] !== '"') {
+        if (value[i] === "\\" && i + 1 < value.length) i += 2;
+        else i += 1;
+      }
+      if (i >= value.length) throw hstoreError(value);
+      rawValue = unescapeHstore(value.slice(valueStart, i));
+      i += 1;
+    }
+
+    hash[unescapeHstore(rawKey)] = rawValue;
+
+    if (i < value.length) {
+      if (value[i] !== "," || value[i + 1] !== " ") throw hstoreError(value);
+      i += 2;
+    }
+  }
+
+  return hash;
+}
+
+function unescapeHstore(raw: string): string {
+  return raw.replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+}
+
+function hstoreError(input: string): Error {
+  return new Error(HSTORE_ERROR.replace("%s", JSON.stringify(input)));
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -143,7 +143,6 @@ function parseHstoreString(value: string): Record<string, string | null> {
     const rawKey = value.slice(keyStart, i);
     i += 1;
 
-    // Rails accepts both "=>" and "=>".
     if (value[i] !== "=" || value[i + 1] !== ">") throw hstoreError(value);
     i += 2;
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -31,6 +31,13 @@ export class Interval extends Type<Duration> {
         return null;
       }
     }
+    if (typeof value === "number") {
+      // Rails' cast_value lets numeric inputs fall through to super (identity),
+      // then serialize converts. TS is typed `Duration | null`, so we upgrade
+      // numeric seconds into a Duration here — same observable behaviour
+      // through the cast → serialize pipeline.
+      return Duration.build(value);
+    }
     return null;
   }
 
@@ -40,11 +47,13 @@ export class Interval extends Type<Duration> {
       return value.iso8601({ precision: this.precision ?? null });
     }
     if (typeof value === "number") {
-      // Rails: `Time - Time` yields a Float seconds count; build a Duration
-      // and ISO8601-serialize it so numeric inputs round-trip consistently.
+      // Rails: `Time - Time` yields a Float seconds count that reaches
+      // serialize directly (without going through cast). Keep a numeric
+      // branch so that path still round-trips.
       return Duration.build(value).iso8601({ precision: this.precision ?? null });
     }
-    return super.serialize(value) as string | null;
+    if (typeof value === "string") return value;
+    return null;
   }
 
   override typeCastForSchema(value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -1,86 +1,56 @@
 /**
  * PostgreSQL interval type — represents a time duration.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval.
+ * Rails: `class Interval < Type::Value`. cast_value accepts Duration
+ * or ISO8601 string; serialize emits ISO8601; type_cast_for_schema
+ * inspects the serialized form.
  */
 
+import { Type } from "@blazetrails/activemodel";
 import { Duration } from "@blazetrails/activesupport";
 
-export interface IntervalValue {
-  years?: number;
-  months?: number;
-  days?: number;
-  hours?: number;
-  minutes?: number;
-  seconds?: number;
-}
+export class Interval extends Type<Duration> {
+  readonly name: string = "interval";
 
-export class Interval {
-  get type(): string {
+  constructor(options?: { precision?: number }) {
+    super(options);
+  }
+
+  override type(): string {
     return "interval";
   }
 
-  cast(value: unknown): IntervalValue | null {
+  cast(value: unknown): Duration | null {
     if (value == null) return null;
-    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      return value as IntervalValue;
-    }
+    if (value instanceof Duration) return value;
     if (typeof value === "string") {
-      if (value === "") return null;
-      return this.parseInterval(value);
+      try {
+        return Duration.parse(value);
+      } catch {
+        return null;
+      }
     }
     return null;
   }
 
-  serialize(value: unknown): string | null {
+  override serialize(value: unknown): string | null {
     if (value == null) return null;
     if (value instanceof Duration) {
-      return value.iso8601();
+      return value.iso8601({ precision: this.precision ?? null });
     }
     if (typeof value === "number") {
-      return Duration.build(value).iso8601();
+      // Rails: `Time - Time` yields a Float seconds count; build a Duration
+      // and ISO8601-serialize it so numeric inputs round-trip consistently.
+      return Duration.build(value).iso8601({ precision: this.precision ?? null });
     }
-    if (typeof value === "string") return value;
-    if (typeof value === "object" && value !== null) {
-      const v = value as IntervalValue;
-      const parts: string[] = [];
-      if (v.years) parts.push(`${v.years} years`);
-      if (v.months) parts.push(`${v.months} months`);
-      if (v.days) parts.push(`${v.days} days`);
-      if (v.hours || v.minutes || v.seconds) {
-        const h = String(v.hours ?? 0).padStart(2, "0");
-        const m = String(v.minutes ?? 0).padStart(2, "0");
-        const s = String(v.seconds ?? 0).padStart(2, "0");
-        parts.push(`${h}:${m}:${s}`);
-      }
-      return parts.join(" ") || "00:00:00";
-    }
-    return null;
+    return super.serialize(value) as string | null;
   }
 
-  deserialize(value: unknown): IntervalValue | null {
-    return this.cast(value);
-  }
-
-  private parseInterval(str: string): IntervalValue {
-    const result: IntervalValue = {};
-
-    const yearMatch = str.match(/(-?\d+)\s*years?/i);
-    if (yearMatch) result.years = parseInt(yearMatch[1]);
-
-    const monthMatch = str.match(/(-?\d+)\s*mons?(?:ths?)?/i);
-    if (monthMatch) result.months = parseInt(monthMatch[1]);
-
-    const dayMatch = str.match(/(-?\d+)\s*days?/i);
-    if (dayMatch) result.days = parseInt(dayMatch[1]);
-
-    const timeMatch = str.match(/(-?\d{1,2}):(\d{2}):(\d{2}(?:\.\d+)?)/);
-    if (timeMatch) {
-      result.hours = parseInt(timeMatch[1]);
-      result.minutes = parseInt(timeMatch[2]);
-      result.seconds = parseFloat(timeMatch[3]);
-    }
-
-    return result;
+  override typeCastForSchema(value: unknown): string {
+    const serialized = this.serialize(value);
+    if (serialized == null) return "nil";
+    // Rails: `serialize(value).inspect` — quote the string for schema dump.
+    return `"${serialized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
@@ -8,6 +8,8 @@
 import { JsonType } from "@blazetrails/activemodel";
 
 export class Jsonb extends JsonType {
+  override readonly name: string = "jsonb";
+
   override type(): string {
     return "jsonb";
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/jsonb.ts
@@ -1,34 +1,14 @@
 /**
  * PostgreSQL jsonb type — binary JSON storage.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb.
+ * Rails: `class Jsonb < Type::Json`. Only overrides `type` to return :jsonb.
  */
 
-export class Jsonb {
-  get type(): string {
+import { JsonType } from "@blazetrails/activemodel";
+
+export class Jsonb extends JsonType {
+  override type(): string {
     return "jsonb";
-  }
-
-  cast(value: unknown): unknown {
-    if (value == null) return null;
-    if (typeof value === "string") {
-      if (value === "") return null;
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
-    }
-    return value;
-  }
-
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (typeof value === "string") return value;
-    return JSON.stringify(value);
-  }
-
-  deserialize(value: unknown): unknown {
-    return this.cast(value);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
@@ -1,49 +1,48 @@
 /**
  * PostgreSQL money type — currency amount.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Money
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Money.
+ * Rails: `class Money < Type::Decimal`. Hard-codes scale to 2 and parses
+ * locale-formatted money strings before delegating to Decimal#cast_value.
  */
 
-export class Money {
-  get type(): string {
-    return "decimal";
+import { DecimalType } from "@blazetrails/activemodel";
+
+export class Money extends DecimalType {
+  override type(): string {
+    return "money";
   }
 
-  get precision(): number | undefined {
-    return undefined;
+  constructor(options?: { precision?: number; limit?: number }) {
+    // Rails hard-codes `def scale; 2; end`. Pass scale=2 into the base
+    // options so precision-aware helpers see the right value. The base
+    // Type stores `scale` as a readonly field; in Ruby it's a method but
+    // semantically both resolve the same way at the call site.
+    super({ ...options, scale: 2 });
   }
 
-  get scale(): number {
-    return 2;
-  }
+  /**
+   * Rails' OID::Money#cast_value handles four locale-formatted shapes:
+   *   (1) $12,345,678.12    (US-style)
+   *   (2) $12.345.678,12    (EU-style with period grouping, comma decimal)
+   *   (3) -$2.55            (negative with leading minus)
+   *   (4) ($2.55)           (accounting-style parentheses)
+   * then delegates to super(value) which strips currency chars and casts.
+   */
+  override cast(value: unknown): string | null {
+    if (typeof value !== "string") return super.cast(value);
 
-  cast(value: unknown): number | null {
-    if (value == null) return null;
-    if (typeof value === "number") return value;
-    if (typeof value === "string") {
-      if (value === "") return null;
-      let str = value.trim();
-      let negative = false;
-      if (str.startsWith("(") && str.endsWith(")")) {
-        negative = true;
-        str = str.slice(1, -1).trim();
-      }
-      const cleaned = str.replace(/[$,\s]/g, "");
-      const parsed = parseFloat(cleaned);
-      if (isNaN(parsed)) return null;
-      return negative ? -parsed : parsed;
+    // (4) (2.55) → -2.55
+    let str = value.replace(/^\((.+)\)$/, "-$1");
+
+    if (/^-?\D*[\d,]+\.\d{2}$/.test(str)) {
+      // (1) US format: keep digits/minus/dot, drop everything else.
+      str = str.replace(/[^\-0-9.]/g, "");
+    } else if (/^-?\D*[\d.]+,\d{2}$/.test(str)) {
+      // (2) EU format: drop non-digit/minus/comma, then comma → dot.
+      str = str.replace(/[^\-0-9,]/g, "").replace(/,/g, ".");
     }
-    return null;
-  }
 
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (typeof value === "number") return value.toFixed(2);
-    if (typeof value === "string") return value;
-    return null;
-  }
-
-  deserialize(value: unknown): number | null {
-    return this.cast(value);
+    return super.cast(str);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
@@ -9,6 +9,8 @@
 import { DecimalType } from "@blazetrails/activemodel";
 
 export class Money extends DecimalType {
+  override readonly name: string = "money";
+
   override type(): string {
     return "money";
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
@@ -9,8 +9,18 @@
 
 import { IntegerType } from "@blazetrails/activemodel";
 
+const PG_OID_MAX = 0xffffffff;
+
 export class Oid extends IntegerType {
   override readonly name: string = "oid";
+
+  constructor(options?: { limit?: number }) {
+    // PG OIDs are unsigned 32-bit. IntegerType's default signed range
+    // (limit=4 → max 2^31-1) rejects half the valid OID space at
+    // serialize time. Use limit=8 so the base range check permits the
+    // full unsigned-32 window; we clamp to it explicitly below.
+    super({ limit: options?.limit ?? 8 });
+  }
 
   override type(): string {
     return "oid";
@@ -19,7 +29,13 @@ export class Oid extends IntegerType {
   override cast(value: unknown): number | null {
     const cast = super.cast(value);
     // Rails' UnsignedInteger rejects negatives; PG OIDs are unsigned 32-bit.
-    if (cast != null && cast < 0) return null;
+    if (cast == null) return cast;
+    if (cast < 0 || cast > PG_OID_MAX) return null;
+    return cast;
+  }
+
+  override serialize(value: unknown): unknown {
+    const cast = this.cast(value);
     return cast;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
@@ -35,7 +35,17 @@ export class Oid extends IntegerType {
   }
 
   override serialize(value: unknown): unknown {
-    const cast = this.cast(value);
-    return cast;
+    return this.cast(value);
+  }
+
+  /**
+   * IntegerType.isSerializable only checks the signed range for the
+   * expanded limit=8 — it'd green-light negatives and values past
+   * 0xffffffff, which cast would then turn into null. Gate both on
+   * the unsigned-32 window.
+   */
+  override isSerializable(value: unknown): boolean {
+    if (value == null) return true;
+    return this.cast(value) != null;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
@@ -1,31 +1,25 @@
 /**
  * PostgreSQL OID type — object identifier.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Oid
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Oid.
+ * Rails: `class Oid < Type::UnsignedInteger`. We don't yet have an
+ * UnsignedIntegerType in activemodel, so extend IntegerType and add a
+ * signed-range rejection in cast to approximate unsigned semantics.
  */
 
-export class Oid {
-  get type(): string {
-    return "integer";
+import { IntegerType } from "@blazetrails/activemodel";
+
+export class Oid extends IntegerType {
+  override readonly name: string = "oid";
+
+  override type(): string {
+    return "oid";
   }
 
-  cast(value: unknown): number | null {
-    if (value == null) return null;
-    if (typeof value === "number") return Math.trunc(value);
-    if (typeof value === "string") {
-      if (value === "") return null;
-      const parsed = parseInt(value, 10);
-      if (isNaN(parsed)) return null;
-      return parsed;
-    }
-    return null;
-  }
-
-  serialize(value: unknown): number | null {
-    return this.cast(value);
-  }
-
-  deserialize(value: unknown): number | null {
-    return this.cast(value);
+  override cast(value: unknown): number | null {
+    const cast = super.cast(value);
+    // Rails' UnsignedInteger rejects negatives; PG OIDs are unsigned 32-bit.
+    if (cast != null && cast < 0) return null;
+    return cast;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -79,14 +79,17 @@ export class Point extends Type<PointValue> {
       return `(${numberForPoint(value.x)},${numberForPoint(value.y)})`;
     }
     if (globalThis.Array.isArray(value)) {
-      if (value.length !== 2) return super.serialize(value) as string | null;
+      if (value.length !== 2) return null;
       return this.serialize(this.buildPoint(value[0], value[1]));
     }
     if (typeof value === "object") {
       const [x, y] = valuesArrayFromHash(value as Record<string, unknown>);
       return this.serialize(this.buildPoint(x, y));
     }
-    return super.serialize(value) as string | null;
+    // Rails falls through to Type::Value#serialize (identity) for unknown
+    // inputs, but our declared return type is string | null — return null
+    // rather than lie about the runtime shape.
+    return null;
   }
 
   override typeCastForSchema(value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -35,6 +35,15 @@ export class Point extends Type<PointValue> {
     return true;
   }
 
+  /**
+   * Rails' Mutable compares serialized forms so in-place mutation on a
+   * returned Point (e.g. a stored value being modified via reference)
+   * correctly marks the attribute dirty.
+   */
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+    return rawOldValue !== this.serialize(newValue);
+  }
+
   cast(value: unknown): PointValue | null {
     if (value == null) return null;
     if (value instanceof PointValue) return value;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -86,9 +86,12 @@ export class Point extends Type<PointValue> {
       const [x, y] = valuesArrayFromHash(value as Record<string, unknown>);
       return this.serialize(this.buildPoint(x, y));
     }
-    // Rails falls through to Type::Value#serialize (identity) for unknown
-    // inputs, but our declared return type is string | null — return null
-    // rather than lie about the runtime shape.
+    // Rails' else branch is `super` → Type::Value#serialize (identity).
+    // Pass through string inputs (e.g. migration defaults like
+    // "(12.2,13.3)") so quoteDefaultExpression doesn't turn them into
+    // DEFAULT NULL. Other scalars can't honestly satisfy the string | null
+    // contract, so null them out.
+    if (typeof value === "string") return value;
     return null;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -48,15 +48,20 @@ export class Point extends Type<PointValue> {
     if (value == null) return null;
     if (value instanceof PointValue) return value;
     if (typeof value === "string") {
-      if (value.trim() === "") return null;
-      let inner = value;
+      const trimmed = value.trim();
+      if (trimmed === "") return null;
+      let inner = trimmed;
       if (inner.startsWith("(") && inner.endsWith(")")) {
         inner = inner.slice(1, -1);
       }
-      const [x, y] = inner.split(",");
-      return this.buildPoint(x, y);
+      const parts = inner.split(",");
+      if (parts.length !== 2) return null;
+      return this.buildPoint(parts[0], parts[1]);
     }
     if (globalThis.Array.isArray(value)) {
+      // Rails: `when ::Array then build_point(*value)` — ArgumentError on
+      // non-2-element arrays. Mirror that by returning null.
+      if (value.length !== 2) return null;
       return this.buildPoint(value[0], value[1]);
     }
     if (typeof value === "object") {
@@ -74,6 +79,7 @@ export class Point extends Type<PointValue> {
       return `(${numberForPoint(value.x)},${numberForPoint(value.y)})`;
     }
     if (globalThis.Array.isArray(value)) {
+      if (value.length !== 2) return super.serialize(value) as string | null;
       return this.serialize(this.buildPoint(value[0], value[1]));
     }
     if (typeof value === "object") {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -1,58 +1,101 @@
 /**
- * PostgreSQL point type — geometric point as { x, y } object.
+ * PostgreSQL point type — geometric (x, y) point.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Point
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Point.
+ * Rails: `class Point < Type::Value; include Helpers::Mutable`. Plus a
+ * `ActiveRecord::Point = Struct.new(:x, :y)` value struct at the outer
+ * namespace. In TS we expose both as a `PointValue` class (Rails'
+ * struct) and the `Point` Type::Value (the OID class).
  */
 
-export interface PointValue {
-  x: number;
-  y: number;
+import { Type } from "@blazetrails/activemodel";
+
+/**
+ * Mirrors Rails' `ActiveRecord::Point = Struct.new(:x, :y)`.
+ */
+export class PointValue {
+  readonly x: number;
+  readonly y: number;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
 }
 
-export class Point {
-  get type(): string {
+export class Point extends Type<PointValue> {
+  readonly name: string = "point";
+
+  override type(): string {
     return "point";
+  }
+
+  /** Rails' Helpers::Mutable sets mutable? = true. */
+  override isMutable(): boolean {
+    return true;
   }
 
   cast(value: unknown): PointValue | null {
     if (value == null) return null;
-    if (typeof value === "object" && value !== null && "x" in value && "y" in value) {
-      return { x: Number((value as PointValue).x), y: Number((value as PointValue).y) };
-    }
-    if (globalThis.Array.isArray(value) && value.length === 2) {
-      return { x: Number(value[0]), y: Number(value[1]) };
-    }
+    if (value instanceof PointValue) return value;
     if (typeof value === "string") {
-      if (value === "") return null;
-      return this.parsePoint(value);
+      if (value.trim() === "") return null;
+      let inner = value;
+      if (inner.startsWith("(") && inner.endsWith(")")) {
+        inner = inner.slice(1, -1);
+      }
+      const [x, y] = inner.split(",");
+      return this.buildPoint(x, y);
+    }
+    if (globalThis.Array.isArray(value)) {
+      return this.buildPoint(value[0], value[1]);
+    }
+    if (typeof value === "object") {
+      const hash = value as Record<string, unknown>;
+      if (Object.keys(hash).length === 0) return null;
+      const [x, y] = valuesArrayFromHash(hash);
+      return this.buildPoint(x, y);
     }
     return null;
   }
 
-  serialize(value: unknown): string | null {
+  override serialize(value: unknown): string | null {
     if (value == null) return null;
-    if (typeof value === "object" && value !== null && "x" in value && "y" in value) {
-      const p = value as PointValue;
-      return `(${p.x},${p.y})`;
+    if (value instanceof PointValue) {
+      return `(${numberForPoint(value.x)},${numberForPoint(value.y)})`;
     }
-    if (globalThis.Array.isArray(value) && value.length === 2) {
-      return `(${value[0]},${value[1]})`;
+    if (globalThis.Array.isArray(value)) {
+      return this.serialize(this.buildPoint(value[0], value[1]));
     }
-    if (typeof value === "string") return value;
-    return null;
+    if (typeof value === "object") {
+      const [x, y] = valuesArrayFromHash(value as Record<string, unknown>);
+      return this.serialize(this.buildPoint(x, y));
+    }
+    return super.serialize(value) as string | null;
   }
 
-  deserialize(value: unknown): PointValue | null {
-    return this.cast(value);
+  override typeCastForSchema(value: unknown): string {
+    if (value instanceof PointValue) {
+      return `[${value.x}, ${value.y}]`;
+    }
+    return super.typeCastForSchema(value);
   }
 
-  private parsePoint(str: string): PointValue | null {
-    const cleaned = str.replace(/[()]/g, "").trim();
-    const parts = cleaned.split(",").map((s) => s.trim());
-    if (parts.length !== 2) return null;
-    const x = parseFloat(parts[0]);
-    const y = parseFloat(parts[1]);
-    if (isNaN(x) || isNaN(y)) return null;
-    return { x, y };
+  private buildPoint(x: unknown, y: unknown): PointValue | null {
+    const fx = Number(x);
+    const fy = Number(y);
+    if (Number.isNaN(fx) || Number.isNaN(fy)) return null;
+    return new PointValue(fx, fy);
   }
+}
+
+/** Mirrors Rails' `number.to_s.delete_suffix(".0")` — drop trailing .0 on ints. */
+function numberForPoint(n: number): string {
+  const s = String(n);
+  return s.endsWith(".0") ? s.slice(0, -2) : s;
+}
+
+/** Mirrors Rails' `value.values_at(:x, "x").compact.first` for both keys. */
+function valuesArrayFromHash(hash: Record<string, unknown>): [unknown, unknown] {
+  return [hash.x ?? hash["x"], hash.y ?? hash["y"]];
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -99,10 +99,21 @@ export class Point extends Type<PointValue> {
     return super.typeCastForSchema(value);
   }
 
+  /**
+   * Rails uses `Float(x)` which raises on empty / whitespace input. JS
+   * `Number("")` returns 0, so `(,)` or `['', '']` would cast to `(0,0)`
+   * without this guard. Reject blank coordinates explicitly.
+   */
+  private toCoordinate(value: unknown): number | null {
+    if (typeof value === "string" && value.trim() === "") return null;
+    const n = Number(value);
+    return Number.isNaN(n) ? null : n;
+  }
+
   private buildPoint(x: unknown, y: unknown): PointValue | null {
-    const fx = Number(x);
-    const fy = Number(y);
-    if (Number.isNaN(fx) || Number.isNaN(fy)) return null;
+    const fx = this.toCoordinate(x);
+    const fy = this.toCoordinate(y);
+    if (fx == null || fy == null) return null;
     return new PointValue(fx, fy);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/specialized-string.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/specialized-string.ts
@@ -1,32 +1,27 @@
 /**
- * PostgreSQL specialized string type — for types like xml, tsvector, etc.
- * that are stored as strings but have a specific type name.
+ * PostgreSQL specialized string type — for types like tsvector, ltree,
+ * citext, line, lseg, box, path, polygon, circle that are stored as
+ * strings but report a specific type symbol.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::SpecializedString
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::SpecializedString.
+ * Rails: `class SpecializedString < Type::String; attr_reader :type;
+ * def initialize(type, **options); @type = type; super(**options); end`.
  */
 
-export class SpecializedString {
-  readonly typeName: string;
+import { StringType } from "@blazetrails/activemodel";
 
-  constructor(typeName: string = "string") {
-    this.typeName = typeName;
+export class SpecializedString extends StringType {
+  private readonly _type: string;
+
+  constructor(
+    type: string = "string",
+    options?: { precision?: number; limit?: number; scale?: number },
+  ) {
+    super(options);
+    this._type = type;
   }
 
-  get type(): string {
-    return this.typeName;
-  }
-
-  cast(value: unknown): string | null {
-    if (value == null) return null;
-    return String(value);
-  }
-
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    return String(value);
-  }
-
-  deserialize(value: unknown): string | null {
-    return this.cast(value);
+  override type(): string {
+    return this._type;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
@@ -1,22 +1,27 @@
 /**
  * PostgreSQL timestamptz type — timestamp with time zone.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TimestampWithTimeZone
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TimestampWithTimeZone.
+ * Rails: `class TimestampWithTimeZone < DateTime`. Overrides type and
+ * cast_value to normalise returned times to UTC when the connection
+ * is in UTC mode (the PG gem may return non-UTC times even when the
+ * wire-protocol value was UTC).
  */
 
-import { Timestamp } from "./timestamp.js";
+import { DateTimeType } from "@blazetrails/activemodel";
 
-export class TimestampWithTimeZone extends Timestamp {
-  override get type(): string {
+export class TimestampWithTimeZone extends DateTimeType {
+  override readonly name: string = "timestamptz";
+
+  override type(): string {
     return "timestamptz";
   }
 
-  override serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) {
-      return value.toISOString();
-    }
-    if (typeof value === "string") return value;
-    return null;
-  }
+  /**
+   * Rails normalises via `time.getutc` / `time.getlocal` depending on
+   * the connection's `is_utc?` mode. JS Date is always UTC-based
+   * internally; `toISOString()` always produces UTC. We don't yet have
+   * a per-adapter timezone setting plumbed through, so defer to the
+   * parent cast and let JS Date's UTC-internal representation stand.
+   */
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
@@ -1,37 +1,20 @@
 /**
  * PostgreSQL timestamp type — timestamp without time zone.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Timestamp
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Timestamp.
+ * Rails: `class Timestamp < DateTime; def type; real_type_unless_aliased(:timestamp); end`.
+ * `real_type_unless_aliased` returns :datetime when DateTime is aliased
+ * to :datetime; otherwise returns :timestamp. We don't have the alias
+ * registry yet, so report :timestamp directly (matches Rails' non-aliased
+ * default).
  */
 
-export class Timestamp {
-  get type(): string {
-    return "datetime";
-  }
+import { DateTimeType } from "@blazetrails/activemodel";
 
-  cast(value: unknown): globalThis.Date | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) return value;
-    if (typeof value === "string") {
-      if (value === "" || value === "infinity" || value === "-infinity") return null;
-      const parsed = new globalThis.Date(value);
-      if (isNaN(parsed.getTime())) return null;
-      return parsed;
-    }
-    if (typeof value === "number") return new globalThis.Date(value);
-    return null;
-  }
+export class Timestamp extends DateTimeType {
+  override readonly name: string = "timestamp";
 
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) {
-      return value.toISOString().replace("T", " ").replace("Z", "");
-    }
-    if (typeof value === "string") return value;
-    return null;
-  }
-
-  deserialize(value: unknown): globalThis.Date | null {
-    return this.cast(value);
+  override type(): string {
+    return "timestamp";
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/xml.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/xml.ts
@@ -31,11 +31,9 @@ export class Xml extends StringType {
    * Rails: `Data.new(super) if value`. super is Type::String#serialize
    * which stringifies the value; nil passes through. We return a Data
    * instance so quoting.ts' `value instanceof Data` check routes PG's
-   * `xml '...'` prefix correctly. TS-side the return type differs from
-   * StringType's `string | null`, so the override signature is widened
-   * to Data-or-null.
+   * `xml '...'` prefix correctly. StringType.serialize is typed as
+   * `unknown` so wrapper returns like this don't need suppression.
    */
-  // @ts-expect-error narrowed return: Xml serialises into a Data wrapper.
   override serialize(value: unknown): Data | null {
     if (value == null) return null;
     if (value instanceof Data) return value;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/xml.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/xml.ts
@@ -1,10 +1,12 @@
 /**
  * PostgreSQL xml type.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Xml
- *
- * Also exports Data class for XML value representation.
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Xml.
+ * Rails: `class Xml < Type::String`. Overrides type and serialize, with
+ * a nested Data class wrapping the serialized output.
  */
+
+import { StringType } from "@blazetrails/activemodel";
 
 export class Data {
   readonly value: string;
@@ -18,25 +20,26 @@ export class Data {
   }
 }
 
-export class Xml {
-  get type(): string {
+export class Xml extends StringType {
+  override readonly name: string = "xml";
+
+  override type(): string {
     return "xml";
   }
 
-  cast(value: unknown): string | null {
+  /**
+   * Rails: `Data.new(super) if value`. super is Type::String#serialize
+   * which stringifies the value; nil passes through. We return a Data
+   * instance so quoting.ts' `value instanceof Data` check routes PG's
+   * `xml '...'` prefix correctly. TS-side the return type differs from
+   * StringType's `string | null`, so the override signature is widened
+   * to Data-or-null.
+   */
+  // @ts-expect-error narrowed return: Xml serialises into a Data wrapper.
+  override serialize(value: unknown): Data | null {
     if (value == null) return null;
-    if (value instanceof Data) return value.value;
-    if (typeof value === "string") return value === "" ? null : value;
-    return null;
-  }
-
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (value instanceof Data) return value.value;
-    return String(value);
-  }
-
-  deserialize(value: unknown): string | null {
-    return this.cast(value);
+    if (value instanceof Data) return value;
+    const cast = this.cast(value);
+    return cast == null ? null : new Data(cast);
   }
 }


### PR DESCRIPTION
## Summary

Second batch of retrofits toward a Rails-faithful PG adapter type_map. With #568 this completes the OID class hierarchy — every PostgreSQL OID class now descends from \`ActiveModel::Type::Value\`, matching Rails' class tree 1:1. This is the final prerequisite before wiring \`initialize_type_map\` into the adapter.

**Retrofits (inheritance matches Rails):**

- **OID::Jsonb** extends \`JsonType\` (Rails: \`< Type::Json\`).
- **OID::Xml** extends \`StringType\` (Rails: \`< Type::String\`) — \`Data\` wrapper mirrors Rails' nested class.
- **OID::Money** extends \`DecimalType\` (Rails: \`< Type::Decimal\`) — scale hard-coded to 2 via constructor options; cast parses four locale money formats (US, EU, leading minus, accounting parens) then delegates to Decimal.
- **OID::Point** extends \`Type<PointValue>\` (Rails: \`< Type::Value\` with \`Helpers::Mutable\`). Adds \`PointValue\` mirroring Rails' \`ActiveRecord::Point = Struct.new(:x, :y)\`. Accepts String / Array / Hash / PointValue inputs; serialize drops trailing \`.0\` like Rails' \`number_for_point\`.
- **OID::Oid** extends \`IntegerType\` (Rails: \`< Type::UnsignedInteger\`) — rejects negatives to approximate unsigned semantics (no \`UnsignedIntegerType\` in activemodel yet).
- **OID::SpecializedString** extends \`StringType\` (Rails: \`< Type::String\`) — takes type symbol in constructor like Rails' \`attr_reader :type\`.
- **OID::Timestamp** extends \`DateTimeType\` (Rails: \`< DateTime\`) — reports \`:timestamp\` (no alias registry yet).
- **OID::TimestampWithTimeZone** extends \`DateTimeType\` (Rails: \`< DateTime\`) — reports \`:timestamptz\`. JS \`Date\` is UTC-internal so Rails' \`getutc\` normalisation is a no-op.
- **OID::Interval** extends \`Type<Duration>\` (Rails: \`< Type::Value\`) — cast via \`Duration.parse\`, serialize via \`iso8601\`, \`type_cast_for_schema\` quotes the serialized form.
- **OID::Hstore** extends \`Type<Record<string, string|null>>\` (Rails: \`< Type::Value\` with \`Helpers::Mutable\`). Full deserialize/serialize token parser mirroring Rails' StringScanner approach. \`changed_in_place?\` compares hashes, not strings, so key-order churn doesn't dirty.
- **OID::Enum** extends \`Type<string>\` (Rails: \`< Type::Value\`) — cast via \`String()\` mirroring Rails' \`value.to_s\`.

**Plumbing:** widen \`readonly name\` to \`name: string\` on \`StringType\`, \`JsonType\`, \`DateTimeType\`, \`IntegerType\`, \`DecimalType\` in activemodel so subclass overrides (\`Macaddr\`, \`Jsonb\`, \`Timestamp\`, \`Oid\`, \`Money\`) type-check.

**Tests:** unit-level Rails-named tests added where Rails has a counterpart:
- \`test_money_type_cast\` (money.test.ts)
- \`test_interval_type\`, \`test_interval_type_cast_from_invalid_string\`, \`test_interval_type_cast_from_numeric\` (interval.test.ts)
- \`test_deserialize\`, \`test_serialize\` (hstore.test.ts)

## Test plan

- [x] Full AR suite: 8358 passing, 0 regressions
- [x] Typecheck clean
- [x] \`api:compare\`: enum/jsonb/oid/point/specialized_string/timestamp all 100%; hstore 0% → 80%; interval 50% → 75%; timestamp_with_time_zone 50%; money 33% (base \`scale\` field isn't visible to api:compare's method extraction — Rails defines it as \`def scale; 2; end\`)

## Next

With every OID class now a proper \`Type::Value\`, the follow-up PR wires \`initialize_type_map(m)\` on \`PostgreSQLAdapter\` and adds \`getOidType\` / result-row casting, completing the \`initialize_type_map\` → TMI → \`get_oid_type\` Rails integration path.