### PR TITLE
chore(activerecord): remove dead Migrator.output and AbstractMysqlAdapter lock stubs

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -181,17 +181,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return exception.errno ?? null;
   }
 
-  async getAdvisoryLock(lockName: string, timeout: number = 0): Promise<boolean> {
-    void lockName;
-    void timeout;
-    return false;
-  }
-
-  async releaseAdvisoryLock(lockName: string): Promise<boolean> {
-    void lockName;
-    return false;
-  }
-
   async disableReferentialIntegrity(): Promise<void> {}
 
   async beginDbTransaction(): Promise<void> {}

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1379,11 +1379,6 @@ export class Migrator {
     return [...this._migrations];
   }
 
-  /** @deprecated Use Migration.logger instead. */
-  get output(): readonly string[] {
-    return [];
-  }
-
   // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32 of googol)
   private static readonly _LOCK_ID = 2053462845;
 


### PR DESCRIPTION
## Summary

- Remove deprecated `Migrator.output` getter — all consumers now use `Migration.logger`
- Remove dead `getAdvisoryLock`/`releaseAdvisoryLock` stubs from `AbstractMysqlAdapter` — `Mysql2Adapter` doesn't extend it

## Test plan

- [x] `pnpm run build` — clean
- [x] 207 migration/migrator tests pass