### PR TITLE
feat(activerecord): wire PG adapter type_map + getOidType

### DIFF
--- a/packages/activemodel/src/type/big-integer.ts
+++ b/packages/activemodel/src/type/big-integer.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class BigIntegerType extends Type<bigint> {
-  readonly name = "big_integer";
+  readonly name: string = "big_integer";
 
   cast(value: unknown): bigint | null {
     if (value === null || value === undefined) return null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2,6 +2,7 @@ import pg from "pg";
 import { type Type, ValueType } from "@blazetrails/activemodel";
 import { singularize, underscore } from "@blazetrails/activesupport";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
+import { getDefaultTimezone } from "../type/internal/timezone.js";
 import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
 import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
@@ -66,7 +67,12 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   get typeMap(): HashLookupTypeMap {
     if (this._typeMap == null) {
       this._typeMap = new HashLookupTypeMap();
-      initializeInstanceTypeMap(this._typeMap);
+      // Rails threads @default_timezone into the instance initializer so
+      // time / timestamp registrations use the connection's timezone
+      // preference. We read the repo-wide default here so that
+      // setDefaultTimezone() is honored consistently with the quoting
+      // path.
+      initializeInstanceTypeMap(this._typeMap, getDefaultTimezone());
     }
     return this._typeMap;
   }
@@ -126,7 +132,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       "SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput,",
       "       r.rngsubtype, t.typtype, t.typbasetype",
       "FROM pg_type as t",
-      "LEFT JOIN pg_range as r ON oid = rngtypid",
+      "LEFT JOIN pg_range as r ON t.oid = r.rngtypid",
     ].join("\n");
 
     if (oids && oids.length > 0) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -112,22 +112,26 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * pass an array of OIDs to target a specific miss.
    */
   async loadAdditionalTypes(oids?: number[]): Promise<void> {
-    const initializer = new TypeMapInitializer(
-      this.typeMap as unknown as ConstructorParameters<typeof TypeMapInitializer>[0],
-    );
-    for (const query of this.loadTypesQueries(initializer, oids)) {
+    const initializer = new TypeMapInitializer(this.typeMap);
+    for await (const query of this.loadTypesQueries(initializer, oids)) {
       const rows = (await this.execute(query)) as unknown as PgTypeRow[];
       initializer.run(rows);
     }
   }
 
   /**
-   * Mirrors: PostgreSQLAdapter#load_types_queries(initializer, oids).
-   * Builds the SQL queries that feed TypeMapInitializer.run. For a
-   * specific OID list emits one query; for a full reload emits three
-   * (by typname, typtype, array-of-known).
+   * Mirrors: PostgreSQLAdapter#load_types_queries(initializer, oids). For a
+   * specific OID list yields one query; for a full reload yields three
+   * (by typname, typtype, array-of-known) — **in order**, because
+   * `queryConditionsForArrayTypes` depends on numeric OIDs registered
+   * by the first query (`aliasType(row.oid, row.typname)`). Ruby does
+   * this with `yield` inside a method; we use an async generator so
+   * each query is built fresh after the prior one has run.
    */
-  private loadTypesQueries(initializer: TypeMapInitializer, oids?: number[]): string[] {
+  private async *loadTypesQueries(
+    initializer: TypeMapInitializer,
+    oids?: number[],
+  ): AsyncGenerator<string, void, void> {
     const baseQuery = [
       "SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput,",
       "       r.rngsubtype, t.typtype, t.typbasetype",
@@ -136,13 +140,26 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     ].join("\n");
 
     if (oids && oids.length > 0) {
-      return [`${baseQuery}\nWHERE t.oid IN (${oids.join(", ")})`];
+      // Validate every OID is a finite integer before interpolating
+      // into SQL. loadAdditionalTypes is public, so untrusted input
+      // could reach us.
+      const safe = oids.map((oid) => {
+        const n = Number(oid);
+        if (!Number.isInteger(n) || n < 0) {
+          throw new Error(`loadAdditionalTypes: invalid OID ${String(oid)}`);
+        }
+        return n;
+      });
+      yield `${baseQuery}\nWHERE t.oid IN (${safe.join(", ")})`;
+      return;
     }
-    return [
-      `${baseQuery}\n${initializer.queryConditionsForKnownTypeNames()}`,
-      `${baseQuery}\n${initializer.queryConditionsForKnownTypeTypes()}`,
-      `${baseQuery}\n${initializer.queryConditionsForArrayTypes()}`,
-    ];
+    yield `${baseQuery}\n${initializer.queryConditionsForKnownTypeNames()}`;
+    yield `${baseQuery}\n${initializer.queryConditionsForKnownTypeTypes()}`;
+    // Generated AFTER the prior two yields have been awaited and run,
+    // so the initializer has already registered numeric OIDs via
+    // aliasType. If we computed this up front, the array query would
+    // typically be empty and fall through to `WHERE 1=0`.
+    yield `${baseQuery}\n${initializer.queryConditionsForArrayTypes()}`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,5 +1,7 @@
 import pg from "pg";
+import { type Type, ValueType } from "@blazetrails/activemodel";
 import { singularize, underscore } from "@blazetrails/activesupport";
+import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
 import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
@@ -8,6 +10,10 @@ import {
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
 } from "./postgresql/quoting.js";
+import {
+  initializeInstanceTypeMap,
+  initializeTypeMap as staticInitializeTypeMap,
+} from "./postgresql/type-map-init.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
 
@@ -29,6 +35,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   private _client: pg.PoolClient | null = null;
   private _inTransaction = false;
   private _databaseVersion: number | null = null;
+  private _typeMap: HashLookupTypeMap | null = null;
 
   constructor(config: string | pg.PoolConfig) {
     super();
@@ -37,6 +44,49 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     } else {
       this.pool = new pg.Pool(config);
     }
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter.initialize_type_map (class method).
+   * Seeds a HashLookupTypeMap with the ~30 known PG types by typname.
+   * Exposed as a static so tests and external callers can build their
+   * own type_map without instantiating the adapter.
+   */
+  static initializeTypeMap(m: HashLookupTypeMap): void {
+    staticInitializeTypeMap(m);
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#type_map. Lazily builds and caches the
+   * adapter's HashLookupTypeMap on first access. The map is populated
+   * by the instance-level initializer which layers `time`, `timestamp`,
+   * `timestamptz` (timezone-aware) on top of the class-level base.
+   */
+  get typeMap(): HashLookupTypeMap {
+    if (this._typeMap == null) {
+      this._typeMap = new HashLookupTypeMap();
+      initializeInstanceTypeMap(this._typeMap);
+    }
+    return this._typeMap;
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#get_oid_type(oid, fmod, column_name, sql_type).
+   * Looks up the Type::Value registered for a column's OID. User-defined
+   * types would be loaded via OID::TypeMapInitializer.run on miss (Rails'
+   * `load_additional_types`); for now we delegate to the registered
+   * fallback, which surfaces the missing type rather than silently
+   * treating it as a string.
+   */
+  getOidType(oid: number, fmod: number, columnName: string, sqlType: string = ""): Type {
+    return this.typeMap.fetch(oid, fmod, sqlType, () => {
+      console.warn(
+        `unknown OID ${oid}: failed to recognize type of '${columnName}'. It will be treated as String.`,
+      );
+      const fallback = new ValueType();
+      this.typeMap.registerType(oid, fallback);
+      return fallback;
+    });
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -10,6 +10,7 @@ import {
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
 } from "./postgresql/quoting.js";
+import { TypeMapInitializer, type PgTypeRow } from "./postgresql/oid/type-map-initializer.js";
 import {
   initializeInstanceTypeMap,
   initializeTypeMap as staticInitializeTypeMap,
@@ -72,13 +73,20 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
 
   /**
    * Mirrors: PostgreSQLAdapter#get_oid_type(oid, fmod, column_name, sql_type).
-   * Looks up the Type::Value registered for a column's OID. User-defined
-   * types would be loaded via OID::TypeMapInitializer.run on miss (Rails'
-   * `load_additional_types`); for now we delegate to the registered
-   * fallback, which surfaces the missing type rather than silently
-   * treating it as a string.
+   * On miss, queries pg_type via `loadAdditionalTypes([oid])` and retries
+   * before falling back to a ValueType. Rails' get_oid_type is sync
+   * because Ruby's PG gem blocks; in Node we return a Promise so the
+   * underlying pg_type query can be awaited.
    */
-  getOidType(oid: number, fmod: number, columnName: string, sqlType: string = ""): Type {
+  async getOidType(
+    oid: number,
+    fmod: number,
+    columnName: string,
+    sqlType: string = "",
+  ): Promise<Type> {
+    if (!this.typeMap.has(oid)) {
+      await this.loadAdditionalTypes([oid]);
+    }
     return this.typeMap.fetch(oid, fmod, sqlType, () => {
       console.warn(
         `unknown OID ${oid}: failed to recognize type of '${columnName}'. It will be treated as String.`,
@@ -87,6 +95,59 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       this.typeMap.registerType(oid, fallback);
       return fallback;
     });
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#load_additional_types(oids = nil). Queries
+   * pg_type for user-defined types (enums, domains, arrays, ranges,
+   * composites) and registers them via OID::TypeMapInitializer.run.
+   *
+   * Rails' signature uses oids=nil to mean "reload everything we know";
+   * pass an array of OIDs to target a specific miss.
+   */
+  async loadAdditionalTypes(oids?: number[]): Promise<void> {
+    const initializer = new TypeMapInitializer(
+      this.typeMap as unknown as ConstructorParameters<typeof TypeMapInitializer>[0],
+    );
+    for (const query of this.loadTypesQueries(initializer, oids)) {
+      const rows = (await this.execute(query)) as unknown as PgTypeRow[];
+      initializer.run(rows);
+    }
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#load_types_queries(initializer, oids).
+   * Builds the SQL queries that feed TypeMapInitializer.run. For a
+   * specific OID list emits one query; for a full reload emits three
+   * (by typname, typtype, array-of-known).
+   */
+  private loadTypesQueries(initializer: TypeMapInitializer, oids?: number[]): string[] {
+    const baseQuery = [
+      "SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput,",
+      "       r.rngsubtype, t.typtype, t.typbasetype",
+      "FROM pg_type as t",
+      "LEFT JOIN pg_range as r ON oid = rngtypid",
+    ].join("\n");
+
+    if (oids && oids.length > 0) {
+      return [`${baseQuery}\nWHERE t.oid IN (${oids.join(", ")})`];
+    }
+    return [
+      `${baseQuery}\n${initializer.queryConditionsForKnownTypeNames()}`,
+      `${baseQuery}\n${initializer.queryConditionsForKnownTypeTypes()}`,
+      `${baseQuery}\n${initializer.queryConditionsForArrayTypes()}`,
+    ];
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#reload_type_map. Clears the memoized
+   * type_map and re-runs the instance initializer, matching Rails'
+   * reload_type_map behavior when new user-defined types have been
+   * created (CREATE TYPE, CREATE DOMAIN, etc).
+   */
+  async reloadTypeMap(): Promise<void> {
+    this._typeMap = null;
+    await this.loadAdditionalTypes();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -41,24 +41,44 @@ describe("PostgreSQLAdapter#getOidType", () => {
     await adapter.close().catch(() => undefined);
   });
 
-  it("returns the registered type for a known OID", () => {
+  it("returns the registered type for a known OID", async () => {
     // Register a fake OID → Uuid mapping (the adapter type_map is keyed
     // by both string typnames and integer OIDs, matching Rails Hash
     // semantics).
     adapter.typeMap.registerType(2950, new Uuid());
-    const type = adapter.getOidType(2950, -1, "guid");
+    const type = await adapter.getOidType(2950, -1, "guid");
     expect(type).toBeInstanceOf(Uuid);
   });
 
-  it("warns and registers a fallback ValueType for an unknown OID", () => {
+  it("warns and registers a fallback ValueType for an unknown OID", async () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const type = adapter.getOidType(999_999, -1, "mystery_column");
+    // Stub loadAdditionalTypes so the test doesn't hit a real DB. The
+    // stub leaves the type_map unchanged, simulating "pg_type has no
+    // matching row for this oid".
+    vi.spyOn(adapter, "loadAdditionalTypes").mockResolvedValue(undefined);
+
+    const type = await adapter.getOidType(999_999, -1, "mystery_column");
     expect(type).toBeInstanceOf(ValueType);
     expect(spy).toHaveBeenCalledWith(expect.stringContaining("unknown OID 999999"));
     // Subsequent lookup returns the same fallback without re-warning.
     spy.mockClear();
-    const second = adapter.getOidType(999_999, -1, "mystery_column");
+    const second = await adapter.getOidType(999_999, -1, "mystery_column");
     expect(second).toBeInstanceOf(ValueType);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("loads the type from pg_type on miss before falling back", async () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Simulate the miss path: loadAdditionalTypes gets called, then
+    // registers the type via the initializer. Here we just register
+    // directly in the mock.
+    const loadSpy = vi.spyOn(adapter, "loadAdditionalTypes").mockImplementation(async () => {
+      adapter.typeMap.registerType(987_654, new Uuid());
+    });
+    const type = await adapter.getOidType(987_654, -1, "user_defined_column");
+    expect(loadSpy).toHaveBeenCalledWith([987_654]);
+    expect(type).toBeInstanceOf(Uuid);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -1,0 +1,65 @@
+import { StringType, ValueType } from "@blazetrails/activemodel";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
+import { Uuid } from "./postgresql/oid/uuid.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+describe("PostgreSQLAdapter#typeMap", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(() => {
+    // No real connection needed — we never execute SQL in these tests.
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+  });
+
+  afterEach(async () => {
+    await adapter.close().catch(() => undefined);
+  });
+
+  it("is a HashLookupTypeMap populated with known PG types", () => {
+    expect(adapter.typeMap).toBeInstanceOf(HashLookupTypeMap);
+    expect(adapter.typeMap.lookup("uuid")).toBeInstanceOf(Uuid);
+    expect(adapter.typeMap.lookup("text")).toBeInstanceOf(StringType);
+  });
+
+  it("is memoized across calls", () => {
+    const first = adapter.typeMap;
+    const second = adapter.typeMap;
+    expect(first).toBe(second);
+  });
+});
+
+describe("PostgreSQLAdapter#getOidType", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(() => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+  });
+
+  afterEach(async () => {
+    await adapter.close().catch(() => undefined);
+  });
+
+  it("returns the registered type for a known OID", () => {
+    // Register a fake OID → Uuid mapping (the adapter type_map is keyed
+    // by both string typnames and integer OIDs, matching Rails Hash
+    // semantics).
+    adapter.typeMap.registerType(2950, new Uuid());
+    const type = adapter.getOidType(2950, -1, "guid");
+    expect(type).toBeInstanceOf(Uuid);
+  });
+
+  it("warns and registers a fallback ValueType for an unknown OID", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const type = adapter.getOidType(999_999, -1, "mystery_column");
+    expect(type).toBeInstanceOf(ValueType);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("unknown OID 999999"));
+    // Subsequent lookup returns the same fallback without re-warning.
+    spy.mockClear();
+    const second = adapter.getOidType(999_999, -1, "mystery_column");
+    expect(second).toBeInstanceOf(ValueType);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -38,6 +38,7 @@ describe("PostgreSQLAdapter#getOidType", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await adapter.close().catch(() => undefined);
   });
 
@@ -51,7 +52,7 @@ describe("PostgreSQLAdapter#getOidType", () => {
   });
 
   it("warns and registers a fallback ValueType for an unknown OID", async () => {
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     // Stub loadAdditionalTypes so the test doesn't hit a real DB. The
     // stub leaves the type_map unchanged, simulating "pg_type has no
     // matching row for this oid".
@@ -59,17 +60,16 @@ describe("PostgreSQLAdapter#getOidType", () => {
 
     const type = await adapter.getOidType(999_999, -1, "mystery_column");
     expect(type).toBeInstanceOf(ValueType);
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining("unknown OID 999999"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("unknown OID 999999"));
     // Subsequent lookup returns the same fallback without re-warning.
-    spy.mockClear();
+    warn.mockClear();
     const second = await adapter.getOidType(999_999, -1, "mystery_column");
     expect(second).toBeInstanceOf(ValueType);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("loads the type from pg_type on miss before falling back", async () => {
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     // Simulate the miss path: loadAdditionalTypes gets called, then
     // registers the type via the initializer. Here we just register
     // directly in the mock.
@@ -79,7 +79,6 @@ describe("PostgreSQLAdapter#getOidType", () => {
     const type = await adapter.getOidType(987_654, -1, "user_defined_column");
     expect(loadSpy).toHaveBeenCalledWith([987_654]);
     expect(type).toBeInstanceOf(Uuid);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.test.ts
@@ -13,7 +13,7 @@ describe("PostgreSQL::OID::Array", () => {
   it("delegates type to the subtype", () => {
     const type = new OidArray(stringSubtype);
 
-    expect(type.type).toBe("string");
+    expect(type.type()).toBe("string");
   });
 
   it("casts scalar values through the subtype", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -2,7 +2,10 @@
  * PostgreSQL array type — casts between PG array literals and JS arrays.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+ * (Rails: `class Array < Type::Value; include Helpers::Mutable`).
  */
+
+import { Type } from "@blazetrails/activemodel";
 
 function stableStringify(value: unknown): string {
   try {
@@ -21,20 +24,31 @@ export interface ArraySubtype {
   map?(value: unknown, block?: (value: unknown) => unknown): unknown;
 }
 
-export class Array {
+export class Array extends Type<unknown> {
+  readonly name: string = "array";
   readonly subtype: ArraySubtype;
   readonly delimiter: string;
 
   constructor(subtype: ArraySubtype, delimiter: string = ",") {
+    super();
     this.subtype = subtype;
     this.delimiter = delimiter;
   }
 
-  get type(): string {
+  /**
+   * Rails: `delegate :type, ... to: :subtype`. Array's type() returns
+   * the subtype's type — e.g. an int4 array reports :integer.
+   */
+  override type(): string {
     const subtypeType = this.subtype.type;
     if (typeof subtypeType === "function") return subtypeType.call(this.subtype);
     if (typeof subtypeType === "string") return subtypeType;
     return "array";
+  }
+
+  /** Rails' Helpers::Mutable. */
+  override isMutable(): boolean {
+    return true;
   }
 
   cast(value: unknown): unknown {
@@ -44,13 +58,13 @@ export class Array {
     return this.typeCastArray(value, "cast");
   }
 
-  serialize(value: unknown): unknown {
+  override serialize(value: unknown): unknown {
     if (value == null) return null;
     if (!globalThis.Array.isArray(value)) return value;
     return new Data(this, this.typeCastArray(value, "serialize") as unknown[]);
   }
 
-  deserialize(value: unknown): unknown {
+  override deserialize(value: unknown): unknown {
     if (value == null) return null;
     if (value instanceof Data) return this.typeCastArray(value.values, "deserialize") as unknown[];
     if (typeof value === "string") return this.parseArray(value, "deserialize");
@@ -156,7 +170,7 @@ export class Array {
     }
   }
 
-  typeCastForSchema(value: unknown): string {
+  override typeCastForSchema(value: unknown): string {
     if (!globalThis.Array.isArray(value)) return this.formatValueForSchema(value);
     return `[${value.map((item) => this.formatValueForSchema(item)).join(", ")}]`;
   }
@@ -166,12 +180,12 @@ export class Array {
     return this.subtype.map ? this.subtype.map(value, block) : block ? block(value) : value;
   }
 
-  isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const oldValue = this.deserialize(rawOldValue);
     return stableStringify(oldValue) !== stableStringify(newValue);
   }
 
-  isForceEquality(value: unknown): boolean {
+  override isForceEquality(value: unknown): boolean {
     return globalThis.Array.isArray(value);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -27,7 +27,13 @@ export interface PgTypeRow {
   typdelim: string;
   typtype: string;
   typbasetype: number | string;
-  typarray: number | string;
+  /**
+   * typarray is a column on pg_type but Rails' load_types_queries
+   * doesn't SELECT it and TypeMapInitializer doesn't read it. Keep it
+   * optional so PgTypeRow matches the adapter-fetched row shape
+   * (otherwise callers get a silent `undefined` at runtime).
+   */
+  typarray?: number | string;
   typinput?: string;
   rngsubtype?: number | string;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
@@ -1,20 +1,35 @@
 /**
- * PostgreSQL vector type — used for pgvector extension.
+ * PostgreSQL vector type — used for composite/pgvector columns.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Vector
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Vector.
+ * Rails: `class Vector < Type::Value`. Only implements cast (as identity
+ * — the class carries the FIXME that it should split on delim and use
+ * subtype.cast, but current Rails behavior is the raw passthrough).
  */
 
-export class Vector {
+import { Type } from "@blazetrails/activemodel";
+
+export class Vector extends Type<unknown> {
+  readonly name: string = "vector";
   readonly delim: string;
   readonly subtype: unknown;
 
   constructor(delim: string, subtype: unknown) {
+    super();
     this.delim = delim;
     this.subtype = subtype;
   }
 
+  override type(): string {
+    // Rails doesn't override `def type` on Vector; it inherits from
+    // Type::Value which returns nil. Return "vector" here so TS
+    // callers that inspect type() get a useful identifier.
+    return "vector";
+  }
+
   cast(value: unknown): unknown {
-    // Rails currently leaves composite/vector values untouched.
+    // Rails: `def cast(value); value; end`. Matches the FIXME'd
+    // passthrough exactly.
     return value;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
@@ -20,12 +20,12 @@ export class Vector extends Type<unknown> {
     this.subtype = subtype;
   }
 
-  override type(): string {
-    // Rails doesn't override `def type` on Vector; it inherits from
-    // Type::Value which returns nil. Return "vector" here so TS
-    // callers that inspect type() get a useful identifier.
-    return "vector";
-  }
+  // Rails' Vector inherits Type::Value#type which is `def type; end`
+  // (returns nil). Don't override — let the base class' type() return
+  // this.name ("vector"), matching Rails' effective behavior for
+  // callers that coerce nil to a typname string. If Rails-accurate
+  // `nil` is ever required, the base's return type needs widening
+  // first.
 
   cast(value: unknown): unknown {
     // Rails: `def cast(value); value; end`. Matches the FIXME'd

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
@@ -1,13 +1,15 @@
 import {
   BigIntegerType,
   BooleanType,
-  DateType,
   FloatType,
   IntegerType,
-  JsonType,
   StringType,
 } from "@blazetrails/activemodel";
 import { describe, expect, it } from "vitest";
+
+import { Date as ArDate } from "../../type/date.js";
+import { Json as ArJson } from "../../type/json.js";
+import { Text as ArText } from "../../type/text.js";
 
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Bit } from "./oid/bit.js";
@@ -74,14 +76,14 @@ describe("initialize_type_map seeds the PG type_map with known types", () => {
     ["oid", Oid],
     ["float4", FloatType],
     ["float8", FloatType],
-    ["text", StringType],
+    ["text", ArText],
     ["bool", BooleanType],
-    ["date", DateType],
+    ["date", ArDate],
     ["money", Money],
     ["bytea", Bytea],
     ["point", Point],
     ["hstore", Hstore],
-    ["json", JsonType],
+    ["json", ArJson],
     ["jsonb", Jsonb],
     ["cidr", Cidr],
     ["inet", Inet],

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
@@ -1,0 +1,147 @@
+import {
+  BigIntegerType,
+  BooleanType,
+  DateType,
+  FloatType,
+  IntegerType,
+  JsonType,
+  StringType,
+} from "@blazetrails/activemodel";
+import { describe, expect, it } from "vitest";
+
+import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
+import { Bit } from "./oid/bit.js";
+import { BitVarying } from "./oid/bit-varying.js";
+import { Bytea } from "./oid/bytea.js";
+import { Cidr } from "./oid/cidr.js";
+import { Decimal } from "./oid/decimal.js";
+import { Hstore } from "./oid/hstore.js";
+import { Inet } from "./oid/inet.js";
+import { Interval } from "./oid/interval.js";
+import { Jsonb } from "./oid/jsonb.js";
+import { Macaddr } from "./oid/macaddr.js";
+import { Money } from "./oid/money.js";
+import { Oid } from "./oid/oid.js";
+import { Point } from "./oid/point.js";
+import { SpecializedString } from "./oid/specialized-string.js";
+import { Timestamp } from "./oid/timestamp.js";
+import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
+import { Uuid } from "./oid/uuid.js";
+import { Xml } from "./oid/xml.js";
+import {
+  extractLimit,
+  extractPrecision,
+  extractScale,
+  initializeInstanceTypeMap,
+  initializeTypeMap,
+} from "./type-map-init.js";
+
+describe("extract_limit / extract_precision / extract_scale", () => {
+  it("extracts a single integer from sql_type like varchar(255)", () => {
+    expect(extractLimit("varchar(255)")).toBe(255);
+    expect(extractLimit("varchar")).toBeUndefined();
+    expect(extractLimit(undefined)).toBeUndefined();
+  });
+
+  it("extracts precision from numeric(10,2) or numeric(10)", () => {
+    expect(extractPrecision("numeric(10,2)")).toBe(10);
+    expect(extractPrecision("numeric(10)")).toBe(10);
+    expect(extractPrecision("numeric")).toBeUndefined();
+  });
+
+  it("extracts scale only from numeric(p,s)", () => {
+    expect(extractScale("numeric(10,2)")).toBe(2);
+    expect(extractScale("numeric(10)")).toBeUndefined();
+  });
+});
+
+describe("initialize_type_map seeds the PG type_map with known types", () => {
+  const m = new HashLookupTypeMap();
+  initializeTypeMap(m);
+
+  it.each([
+    ["int2", IntegerType],
+    ["int4", IntegerType],
+    ["int8", BigIntegerType],
+    ["oid", Oid],
+    ["float4", FloatType],
+    ["float8", FloatType],
+    ["text", StringType],
+    ["bool", BooleanType],
+    ["date", DateType],
+    ["money", Money],
+    ["bytea", Bytea],
+    ["point", Point],
+    ["hstore", Hstore],
+    ["json", JsonType],
+    ["jsonb", Jsonb],
+    ["cidr", Cidr],
+    ["inet", Inet],
+    ["uuid", Uuid],
+    ["xml", Xml],
+    ["macaddr", Macaddr],
+  ])("registers %s → %s", (typname, klass) => {
+    expect(m.lookup(typname)).toBeInstanceOf(klass);
+  });
+
+  it("aliases char / name / bpchar → varchar", () => {
+    expect(m.lookup("char")).toBeInstanceOf(StringType);
+    expect(m.lookup("name")).toBeInstanceOf(StringType);
+    expect(m.lookup("bpchar")).toBeInstanceOf(StringType);
+  });
+
+  it("registers varchar with limit extracted from sql_type", () => {
+    const type = m.lookup("varchar", 0, "varchar(255)") as StringType;
+    expect(type).toBeInstanceOf(StringType);
+    expect(type.limit).toBe(255);
+  });
+
+  it("registers bit / varbit with limit", () => {
+    expect(m.lookup("bit", 0, "bit(8)")).toBeInstanceOf(Bit);
+    expect(m.lookup("varbit", 0, "bit varying(16)")).toBeInstanceOf(BitVarying);
+  });
+
+  it("registers the specialized-string types with their type symbol", () => {
+    for (const name of [
+      "tsvector",
+      "citext",
+      "ltree",
+      "line",
+      "lseg",
+      "box",
+      "path",
+      "polygon",
+      "circle",
+    ]) {
+      const type = m.lookup(name) as SpecializedString;
+      expect(type).toBeInstanceOf(SpecializedString);
+      expect(type.type()).toBe(name);
+    }
+  });
+
+  it("registers numeric as Decimal with precision and scale", () => {
+    const type = m.lookup("numeric", 0, "numeric(10,2)") as Decimal;
+    expect(type).toBeInstanceOf(Decimal);
+    expect(type.precision).toBe(10);
+    expect(type.scale).toBe(2);
+  });
+
+  it("registers interval as Interval with precision", () => {
+    const type = m.lookup("interval", 0, "interval(3)") as Interval;
+    expect(type).toBeInstanceOf(Interval);
+    expect(type.precision).toBe(3);
+  });
+});
+
+describe("initialize_instance_type_map layers timestamp + time on top", () => {
+  const m = new HashLookupTypeMap();
+  initializeInstanceTypeMap(m);
+
+  it("registers timestamp → Timestamp", () => {
+    expect(m.lookup("timestamp")).toBeInstanceOf(Timestamp);
+  });
+
+  it("registers timestamptz → TimestampWithTimeZone", () => {
+    expect(m.lookup("timestamptz")).toBeInstanceOf(TimestampWithTimeZone);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
@@ -53,6 +53,13 @@ describe("extract_limit / extract_precision / extract_scale", () => {
     expect(extractScale("numeric(10,2)")).toBe(2);
     expect(extractScale("numeric(10)")).toBeUndefined();
   });
+
+  it("tolerates whitespace inside the parens, like Rails' to_i", () => {
+    // Rails' /\((.*)\)/ + to_i accepts "varchar( 255 )" and "numeric(10, 2)".
+    expect(extractLimit("varchar( 255 )")).toBe(255);
+    expect(extractPrecision("numeric(10, 2)")).toBe(10);
+    expect(extractScale("numeric(10, 2)")).toBe(2);
+  });
 });
 
 describe("initialize_type_map seeds the PG type_map with known types", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
@@ -14,6 +14,7 @@ import { Bit } from "./oid/bit.js";
 import { BitVarying } from "./oid/bit-varying.js";
 import { Bytea } from "./oid/bytea.js";
 import { Cidr } from "./oid/cidr.js";
+import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { Decimal } from "./oid/decimal.js";
 import { Hstore } from "./oid/hstore.js";
 import { Inet } from "./oid/inet.js";
@@ -131,6 +132,15 @@ describe("initialize_type_map seeds the PG type_map with known types", () => {
     expect(type).toBeInstanceOf(Decimal);
     expect(type.precision).toBe(10);
     expect(type.scale).toBe(2);
+  });
+
+  it("registers numeric as DecimalWithoutScale when fmod scale bits are zero", () => {
+    // Rails: `if fmod && (fmod - 4 & 0xffff).zero?` — a scale-less NUMERIC(10)
+    // stores atttypmod where the low 16 bits of (fmod - 4) are zero.
+    // fmod = 4 → (4-4)&0xffff = 0 → DecimalWithoutScale.
+    const type = m.lookup("numeric", 4, "numeric(10)") as DecimalWithoutScale;
+    expect(type).toBeInstanceOf(DecimalWithoutScale);
+    expect(type.precision).toBe(10);
   });
 
   it("registers interval as Interval with precision", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -19,6 +19,7 @@ import {
   Type,
 } from "@blazetrails/activemodel";
 
+import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Bit } from "./oid/bit.js";
 import { BitVarying } from "./oid/bit-varying.js";
@@ -46,7 +47,10 @@ import { Xml } from "./oid/xml.js";
  */
 export function extractLimit(sqlType: string | undefined): number | undefined {
   if (!sqlType) return undefined;
-  const match = /\(([^)]*)\)/.exec(sqlType);
+  // Rails uses a greedy `/\((.*)\)/` — captures to the LAST `)`. JS
+  // regexes are greedy by default; mirror that here rather than
+  // stopping at the first close paren.
+  const match = /\((.*)\)/.exec(sqlType);
   if (!match) return undefined;
   // Ruby's String#to_i returns 0 for empty / non-numeric leading chars.
   // Preserve that: parens present → always returns a number (0 on garbage);
@@ -146,11 +150,23 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.registerType("circle", new SpecializedString("circle"));
 
   // Numeric: Rails picks Decimal vs DecimalWithoutScale based on fmod.
-  // We don't have DecimalWithoutScale yet; always use Decimal — matches
-  // Rails' non-integer numeric path.
+  //   if fmod && (fmod - 4 & 0xffff).zero?
+  //     Type::DecimalWithoutScale.new(precision: precision)
+  //   else
+  //     OID::Decimal.new(precision: precision, scale: scale)
+  //   end
+  // The scale bits of a numeric column's atttypmod live in the lower 16
+  // bits of (fmod - 4); when those are zero the column was declared
+  // with no scale (NUMERIC(p) / NUMERIC) and should use the integer-
+  // flavored DecimalWithoutScale.
   m.registerType("numeric", (_key, ...args) => {
+    const fmod = fmodFromArgs(args);
     const sqlType = sqlTypeFromArgs(args);
-    return new Decimal({ precision: extractPrecision(sqlType), scale: extractScale(sqlType) });
+    const precision = extractPrecision(sqlType);
+    if (fmod != null && ((fmod - 4) & 0xffff) === 0) {
+      return new DecimalWithoutScale({ precision }) as unknown as Decimal;
+    }
+    return new Decimal({ precision, scale: extractScale(sqlType) });
   });
 
   m.registerType("interval", (_key, ...args) => {
@@ -188,6 +204,18 @@ export function initializeInstanceTypeMap(
 function sqlTypeFromArgs(args: unknown[]): string | undefined {
   for (let i = args.length - 1; i >= 0; i--) {
     if (typeof args[i] === "string") return args[i] as string;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the fmod arg from `(fmod, sql_type)` — HashLookupTypeMap
+ * forwards `(oid, fmod, sql_type)` to the registered block. The first
+ * numeric positional is fmod.
+ */
+function fmodFromArgs(args: unknown[]): number | undefined {
+  for (const a of args) {
+    if (typeof a === "number") return a;
   }
   return undefined;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -10,17 +10,18 @@
 import {
   BigIntegerType,
   BooleanType,
-  DateType,
   FloatType,
   IntegerType,
-  JsonType,
   StringType,
   TimeType,
   Type,
 } from "@blazetrails/activemodel";
 
+import { Date as ArDate } from "../../type/date.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
+import { Json as ArJson } from "../../type/json.js";
+import { Text as ArText } from "../../type/text.js";
 import { Bit } from "./oid/bit.js";
 import { BitVarying } from "./oid/bit-varying.js";
 import { Bytea } from "./oid/bytea.js";
@@ -119,7 +120,7 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.registerType("oid", new Oid());
   m.registerType("float4", new FloatType({ limit: 24 }));
   m.registerType("float8", new FloatType());
-  m.registerType("text", new StringType());
+  m.registerType("text", new ArText());
   registerClassWithLimit(m, "varchar", StringType);
   m.aliasType("char", "varchar");
   m.aliasType("name", "varchar");
@@ -127,12 +128,12 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.registerType("bool", new BooleanType());
   registerClassWithLimit(m, "bit", Bit);
   registerClassWithLimit(m, "varbit", BitVarying);
-  m.registerType("date", new DateType());
+  m.registerType("date", new ArDate());
   m.registerType("money", new Money());
   m.registerType("bytea", new Bytea());
   m.registerType("point", new Point());
   m.registerType("hstore", new Hstore());
-  m.registerType("json", new JsonType());
+  m.registerType("json", new ArJson());
   m.registerType("jsonb", new Jsonb());
   m.registerType("cidr", new Cidr());
   m.registerType("inet", new Inet());

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -48,8 +48,11 @@ export function extractLimit(sqlType: string | undefined): number | undefined {
   if (!sqlType) return undefined;
   const match = /\(([^)]*)\)/.exec(sqlType);
   if (!match) return undefined;
+  // Ruby's String#to_i returns 0 for empty / non-numeric leading chars.
+  // Preserve that: parens present → always returns a number (0 on garbage);
+  // no parens → returns undefined (distinct from "0").
   const n = Number.parseInt(match[1].trim(), 10);
-  return Number.isNaN(n) ? undefined : n;
+  return Number.isNaN(n) ? 0 : n;
 }
 
 /** Mirrors: PostgreSQLAdapter.extract_precision — first number in `(p,s)` or `(p)`. */

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -1,0 +1,178 @@
+/**
+ * PostgreSQL static type_map initialization + column-metadata helpers.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter's class-level
+ * `initialize_type_map(m)` (postgresql_adapter.rb lines ~676–739) and the
+ * `extract_limit` / `extract_precision` / `extract_scale` / `register_class_with_limit`
+ * / `register_class_with_precision` helpers.
+ */
+
+import {
+  BigIntegerType,
+  BooleanType,
+  DateType,
+  FloatType,
+  IntegerType,
+  JsonType,
+  StringType,
+  TimeType,
+  Type,
+} from "@blazetrails/activemodel";
+
+import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
+import { Bit } from "./oid/bit.js";
+import { BitVarying } from "./oid/bit-varying.js";
+import { Bytea } from "./oid/bytea.js";
+import { Cidr } from "./oid/cidr.js";
+import { Decimal } from "./oid/decimal.js";
+import { Hstore } from "./oid/hstore.js";
+import { Inet } from "./oid/inet.js";
+import { Interval } from "./oid/interval.js";
+import { Jsonb } from "./oid/jsonb.js";
+import { Macaddr } from "./oid/macaddr.js";
+import { Money } from "./oid/money.js";
+import { Oid } from "./oid/oid.js";
+import { Point } from "./oid/point.js";
+import { SpecializedString } from "./oid/specialized-string.js";
+import { Timestamp } from "./oid/timestamp.js";
+import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
+import { Uuid } from "./oid/uuid.js";
+import { Xml } from "./oid/xml.js";
+
+/** Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`. */
+export function extractLimit(sqlType: string | undefined): number | undefined {
+  if (!sqlType) return undefined;
+  const match = /\((\d+)\)/.exec(sqlType);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** Mirrors: PostgreSQLAdapter.extract_precision — first number in `(p,s)` or `(p)`. */
+export function extractPrecision(sqlType: string | undefined): number | undefined {
+  if (!sqlType) return undefined;
+  const match = /\((\d+)(?:,\d+)?\)/.exec(sqlType);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** Mirrors: PostgreSQLAdapter.extract_scale — second number in `(p,s)`. */
+export function extractScale(sqlType: string | undefined): number | undefined {
+  if (!sqlType) return undefined;
+  const match = /\(\d+,(\d+)\)/.exec(sqlType);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/**
+ * Mirrors: PostgreSQLAdapter.register_class_with_limit(mapping, key, klass).
+ * Registers a block that extracts `limit` from the column's `sql_type`.
+ */
+export function registerClassWithLimit(
+  mapping: HashLookupTypeMap,
+  key: string,
+  klass: new (options?: { limit?: number }) => Type,
+): void {
+  mapping.registerType(key, (_key, ...args) => {
+    const sqlType = sqlTypeFromArgs(args);
+    return new klass({ limit: extractLimit(sqlType) });
+  });
+}
+
+/**
+ * Mirrors: PostgreSQLAdapter.register_class_with_precision(mapping, key, klass, **opts).
+ * Registers a block that extracts `precision` from the column's `sql_type`.
+ */
+export function registerClassWithPrecision(
+  mapping: HashLookupTypeMap,
+  key: string,
+  klass: new (options: { precision?: number } & Record<string, unknown>) => Type,
+  extraOptions: Record<string, unknown> = {},
+): void {
+  mapping.registerType(key, (_key, ...args) => {
+    const sqlType = sqlTypeFromArgs(args);
+    return new klass({ precision: extractPrecision(sqlType), ...extraOptions });
+  });
+}
+
+/**
+ * Mirrors: PostgreSQLAdapter.initialize_type_map(m) — the class method that
+ * seeds the type_map with ~30 known PG types by typname. User-defined types
+ * (arrays, ranges, enums, domains, composites) are layered on top at runtime
+ * via OID::TypeMapInitializer.
+ *
+ * Registrations are 1:1 with Rails postgresql_adapter.rb lines 676–739.
+ */
+export function initializeTypeMap(m: HashLookupTypeMap): void {
+  m.registerType("int2", new IntegerType({ limit: 2 }));
+  m.registerType("int4", new IntegerType({ limit: 4 }));
+  m.registerType("int8", new BigIntegerType({ limit: 8 }));
+  m.registerType("oid", new Oid());
+  m.registerType("float4", new FloatType({ limit: 24 }));
+  m.registerType("float8", new FloatType());
+  m.registerType("text", new StringType());
+  registerClassWithLimit(m, "varchar", StringType);
+  m.aliasType("char", "varchar");
+  m.aliasType("name", "varchar");
+  m.aliasType("bpchar", "varchar");
+  m.registerType("bool", new BooleanType());
+  registerClassWithLimit(m, "bit", Bit);
+  registerClassWithLimit(m, "varbit", BitVarying);
+  m.registerType("date", new DateType());
+  m.registerType("money", new Money());
+  m.registerType("bytea", new Bytea());
+  m.registerType("point", new Point());
+  m.registerType("hstore", new Hstore());
+  m.registerType("json", new JsonType());
+  m.registerType("jsonb", new Jsonb());
+  m.registerType("cidr", new Cidr());
+  m.registerType("inet", new Inet());
+  m.registerType("uuid", new Uuid());
+  m.registerType("xml", new Xml());
+  m.registerType("tsvector", new SpecializedString("tsvector"));
+  m.registerType("macaddr", new Macaddr());
+  m.registerType("citext", new SpecializedString("citext"));
+  m.registerType("ltree", new SpecializedString("ltree"));
+  m.registerType("line", new SpecializedString("line"));
+  m.registerType("lseg", new SpecializedString("lseg"));
+  m.registerType("box", new SpecializedString("box"));
+  m.registerType("path", new SpecializedString("path"));
+  m.registerType("polygon", new SpecializedString("polygon"));
+  m.registerType("circle", new SpecializedString("circle"));
+
+  // Numeric: Rails picks Decimal vs DecimalWithoutScale based on fmod.
+  // We don't have DecimalWithoutScale yet; always use Decimal — matches
+  // Rails' non-integer numeric path.
+  m.registerType("numeric", (_key, ...args) => {
+    const sqlType = sqlTypeFromArgs(args);
+    return new Decimal({ precision: extractPrecision(sqlType), scale: extractScale(sqlType) });
+  });
+
+  m.registerType("interval", (_key, ...args) => {
+    const sqlType = sqlTypeFromArgs(args);
+    return new Interval({ precision: extractPrecision(sqlType) });
+  });
+}
+
+/**
+ * Instance-level registrations that mirror Rails' instance
+ * `initialize_type_map(m = type_map)` at lines 744–749. These depend on
+ * the connection's `default_timezone`, so take it as an argument.
+ */
+export function initializeInstanceTypeMap(
+  m: HashLookupTypeMap,
+  defaultTimezone: "utc" | "local" = "utc",
+): void {
+  initializeTypeMap(m);
+  registerClassWithPrecision(m, "time", TimeType, { timezone: defaultTimezone });
+  registerClassWithPrecision(m, "timestamp", Timestamp, { timezone: defaultTimezone });
+  registerClassWithPrecision(m, "timestamptz", TimestampWithTimeZone);
+}
+
+/**
+ * TypeMapInitializer registrations pass `(oid, fmod, sql_type)` to the
+ * block; our fetch signature is `(lookupKey, ...args)`. Grab the last
+ * string arg as sql_type to match Rails' `|*args, sql_type|` pattern.
+ */
+function sqlTypeFromArgs(args: unknown[]): string | undefined {
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (typeof args[i] === "string") return args[i] as string;
+  }
+  return undefined;
+}

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -39,24 +39,30 @@ import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
 import { Xml } from "./oid/xml.js";
 
-/** Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`. */
+/**
+ * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.
+ * Rails captures everything between parens and lets `to_i` parse leading digits;
+ * that tolerates whitespace, trailing text, and comma-separated precision/scale.
+ */
 export function extractLimit(sqlType: string | undefined): number | undefined {
   if (!sqlType) return undefined;
-  const match = /\((\d+)\)/.exec(sqlType);
-  return match ? Number.parseInt(match[1], 10) : undefined;
+  const match = /\(([^)]*)\)/.exec(sqlType);
+  if (!match) return undefined;
+  const n = Number.parseInt(match[1].trim(), 10);
+  return Number.isNaN(n) ? undefined : n;
 }
 
 /** Mirrors: PostgreSQLAdapter.extract_precision — first number in `(p,s)` or `(p)`. */
 export function extractPrecision(sqlType: string | undefined): number | undefined {
   if (!sqlType) return undefined;
-  const match = /\((\d+)(?:,\d+)?\)/.exec(sqlType);
+  const match = /\(\s*(\d+)\s*(?:,\s*\d+\s*)?\)/.exec(sqlType);
   return match ? Number.parseInt(match[1], 10) : undefined;
 }
 
 /** Mirrors: PostgreSQLAdapter.extract_scale — second number in `(p,s)`. */
 export function extractScale(sqlType: string | undefined): number | undefined {
   if (!sqlType) return undefined;
-  const match = /\(\d+,(\d+)\)/.exec(sqlType);
+  const match = /\(\s*\d+\s*,\s*(\d+)\s*\)/.exec(sqlType);
   return match ? Number.parseInt(match[1], 10) : undefined;
 }
 
@@ -152,14 +158,20 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
 
 /**
  * Instance-level registrations that mirror Rails' instance
- * `initialize_type_map(m = type_map)` at lines 744–749. These depend on
- * the connection's `default_timezone`, so take it as an argument.
+ * `initialize_type_map(m = type_map)` at lines 744–749. Rails passes
+ * `timezone: @default_timezone` into `time` / `timestamp`; in TS the
+ * ActiveModel Type constructors don't yet thread a timezone option
+ * through, so the value is recorded on the registration but not acted
+ * on until the Type classes are extended. Signature kept for Rails
+ * parity and future plumbing.
  */
 export function initializeInstanceTypeMap(
   m: HashLookupTypeMap,
   defaultTimezone: "utc" | "local" = "utc",
 ): void {
   initializeTypeMap(m);
+  // TODO: activemodel Type classes don't yet honor `timezone` — these
+  // options are ignored until TimeType / Timestamp are extended.
   registerClassWithPrecision(m, "time", TimeType, { timezone: defaultTimezone });
   registerClassWithPrecision(m, "timestamp", Timestamp, { timezone: defaultTimezone });
   registerClassWithPrecision(m, "timestamptz", TimestampWithTimeZone);

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -164,7 +164,7 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
     const sqlType = sqlTypeFromArgs(args);
     const precision = extractPrecision(sqlType);
     if (fmod != null && ((fmod - 4) & 0xffff) === 0) {
-      return new DecimalWithoutScale({ precision }) as unknown as Decimal;
+      return new DecimalWithoutScale({ precision });
     }
     return new Decimal({ precision, scale: extractScale(sqlType) });
   });

--- a/packages/activerecord/src/type/decimal-without-scale.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.ts
@@ -1,11 +1,23 @@
 /**
  * Mirrors: ActiveRecord::Type::DecimalWithoutScale
+ *
+ * Rails: `class DecimalWithoutScale < ActiveModel::Type::BigInteger;
+ * def type; :decimal; end; def type_cast_for_schema(value);
+ * value.to_s.inspect; end`. Used for NUMERIC columns declared without
+ * a scale — the value is an integer but reports as a decimal.
  */
+
 import { BigIntegerType } from "@blazetrails/activemodel";
 
-export class DecimalWithoutScale extends (BigIntegerType as new () => Omit<
-  BigIntegerType,
-  "name"
-> & { name: string }) {
-  readonly name = "decimal";
+export class DecimalWithoutScale extends BigIntegerType {
+  override readonly name: string = "decimal";
+
+  override type(): string {
+    return "decimal";
+  }
+
+  override typeCastForSchema(value: unknown): string {
+    // Rails: `value.to_s.inspect` — double-quoted Ruby string literal.
+    return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
 }

--- a/packages/activerecord/src/type/decimal-without-scale.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.ts
@@ -26,7 +26,10 @@ export class DecimalWithoutScale extends BigIntegerType {
   override typeCastForSchema(value: unknown): string {
     // Rails: `value.to_s.inspect`. nil.to_s is "", so null/undefined
     // should render as "" (quoted empty string), not "null"/"undefined".
+    // Use JSON.stringify so control chars (newline, tab, etc.) get
+    // escaped the same way Ruby's inspect does, rather than leaking
+    // literal characters into the schema dump.
     const s = value == null ? "" : String(value);
-    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return JSON.stringify(s);
   }
 }

--- a/packages/activerecord/src/type/decimal-without-scale.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.ts
@@ -1,10 +1,17 @@
 /**
- * Mirrors: ActiveRecord::Type::DecimalWithoutScale
+ * Mirrors: ActiveRecord::Type::DecimalWithoutScale.
  *
- * Rails: `class DecimalWithoutScale < ActiveModel::Type::BigInteger;
- * def type; :decimal; end; def type_cast_for_schema(value);
- * value.to_s.inspect; end`. Used for NUMERIC columns declared without
- * a scale — the value is an integer but reports as a decimal.
+ * Used for NUMERIC columns declared without a scale — the value is an
+ * integer but the type reports as `:decimal` for schema purposes.
+ *
+ * Rails:
+ *
+ * ```ruby
+ * class DecimalWithoutScale < ActiveModel::Type::BigInteger
+ *   def type; :decimal; end
+ *   def type_cast_for_schema(value); value.to_s.inspect; end
+ * end
+ * ```
  */
 
 import { BigIntegerType } from "@blazetrails/activemodel";

--- a/packages/activerecord/src/type/decimal-without-scale.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.ts
@@ -17,7 +17,9 @@ export class DecimalWithoutScale extends BigIntegerType {
   }
 
   override typeCastForSchema(value: unknown): string {
-    // Rails: `value.to_s.inspect` — double-quoted Ruby string literal.
-    return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    // Rails: `value.to_s.inspect`. nil.to_s is "", so null/undefined
+    // should render as "" (quoted empty string), not "null"/"undefined".
+    const s = value == null ? "" : String(value);
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
 }


### PR DESCRIPTION
## Summary

Completes the three-layer OID wiring from Rails' PG adapter. With #568/#571 every OID class descends from \`ActiveModel::Type::Value\`; this PR stands up the adapter-side plumbing that actually uses them.

**Layer 1 — static type_map seeding.** \`connection-adapters/postgresql/type-map-init.ts\` mirrors Rails' class-level \`initialize_type_map(m)\` (postgresql_adapter.rb lines 676–739) 1:1:
- ~30 registrations by typname with the Rails-matched OID class. \`text\` / \`date\` / \`json\` use the AR-level Type subclasses (consistent with the SQLite adapter and Rails' \`Type::Text\` / \`Type::Date\` / \`Type::Json\`).
- \`extract_limit\` / \`extract_precision\` / \`extract_scale\` helpers matching Rails' regex-based parsers (greedy `/\((.*)\)/`, whitespace-tolerant, `to_i`-style 0-on-garbage).
- \`register_class_with_limit\` / \`register_class_with_precision\` registration helpers.
- \`numeric\` registered as a block that picks \`DecimalWithoutScale\` vs \`OID::Decimal\` based on fmod, matching Rails' \`(fmod - 4 & 0xffff).zero?\` gate. \`DecimalWithoutScale\` implemented as a proper \`BigIntegerType\` subclass with \`type() → :decimal\` and \`type_cast_for_schema\` matching Ruby's \`value.to_s.inspect\` (control chars escaped via \`JSON.stringify\`, nil → \`""\`).

**Layer 2 — dynamic types via \`pg_type\`.** New adapter methods:
- \`loadAdditionalTypes(oids?)\` mirrors Rails' method of the same name; queries \`pg_type\` joined with \`pg_range\` and feeds rows to \`OID::TypeMapInitializer.run\`. OID inputs validated as non-negative integers before SQL interpolation.
- \`loadTypesQueries(initializer, oids)\` is an async generator that yields queries in sequence (Rails' \`yield\`-per-query structure) so \`queryConditionsForArrayTypes\` builds after \`queryConditionsForKnownTypeNames\` has registered the typname→OID aliases it depends on.
- \`reloadTypeMap()\` mirrors Rails' method; clears the memoized map and re-runs the initializer for post-DDL refresh.

**Layer 3 — per-column lookup.** \`PostgreSQLAdapter\` now exposes:
- **\`static initializeTypeMap(m)\`** — mirrors Rails' class method.
- **\`get typeMap()\`** — lazy \`HashLookupTypeMap\`, populated by \`initializeInstanceTypeMap\` (layers \`time\` / \`timestamp\` / \`timestamptz\` on top of the base, mirroring Rails' instance init; threads \`getDefaultTimezone()\` so \`setDefaultTimezone()\` is honored).
- **\`getOidType(oid, fmod, columnName, sqlType)\`** — mirrors \`get_oid_type\`: misses call \`loadAdditionalTypes([oid])\` before falling through to a \`ValueType\` fallback + Rails' "treated as String" warning. Async because Node-pg queries block on the event loop; Rails is sync because Ruby's PG gem blocks.

OID classes retrofitted to extend \`Type::Value\` as part of this PR: \`Array\` (Rails: \`< Type::Value\` + \`Helpers::Mutable\`), \`Vector\` (Rails: \`< Type::Value\`).

## Deliberate Rails divergences

- \`getOidType\` is async; Rails is sync. Node-pg forces this.
- \`Vector.type()\` returns \`this.name\` ("vector") via the inherited base — Rails' \`Type::Value#type\` returns nil. TS base is typed \`string\`; widening the contract would cascade. Noted inline.
- \`time\` / \`timestamp\` registrations pass \`timezone\` into \`TimeType\`/\`Timestamp\` constructors, but the ActiveModel Type classes don't thread it through yet. Signature kept for Rails parity; TODO noted in code.

## Test plan

- [x] 32 unit tests on \`type-map-init\` (registrations, helpers, aliases, parameter extraction, \`DecimalWithoutScale\` fmod branch)
- [x] 5 adapter-level tests for \`typeMap\` memoization + \`getOidType\` hit/miss/load-on-miss
- [x] Full AR suite: 8408 passing, 0 regressions
- [x] Typecheck clean
- [x] \`api:compare\`: \`postgresql_adapter.rb\` 75%

## Next

Result-row casting — running each query result cell through the registered \`Type.deserialize\` — is the follow-up. The adapter now has a real type_map to consult; that PR will thread it through \`execute\`.