### PR TITLE
fix(trailties): resolve --version flag clash and crypto adapter in ESM

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -7,7 +7,7 @@
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
-import { getFs, getPath, getCrypto, getOs } from "@blazetrails/activesupport";
+import { getFs, getPath, getCryptoAsync, getOs } from "@blazetrails/activesupport";
 import { coercePort } from "./task-utils.js";
 
 function sqliteDatabaseFromUrl(url: string): string | undefined {
@@ -742,7 +742,7 @@ export class DatabaseTasks {
     try {
       const { InternalMetadata } = await import("../internal-metadata.js");
       const metadata = new InternalMetadata(adapter);
-      const sha1 = this._schemaSha1(filename);
+      const sha1 = await this._schemaSha1(filename);
       await metadata.createTableAndSetFlags(config.envName, sha1);
     } catch (error) {
       // Best effort — a failed stamp just means schemaUpToDate
@@ -889,13 +889,14 @@ export class DatabaseTasks {
     const storedSha1 = await metadata.get("schema_sha1");
     if (!storedSha1) return false;
 
-    const fileSha1 = this._schemaSha1(filename);
+    const fileSha1 = await this._schemaSha1(filename);
     return storedSha1 === fileSha1;
   }
 
-  private static _schemaSha1(filename: string): string {
+  private static async _schemaSha1(filename: string): Promise<string> {
     const contents = getFs().readFileSync(filename, "utf-8");
-    const hash = getCrypto().createHash("sha1");
+    const crypto = await getCryptoAsync();
+    const hash = crypto.createHash("sha1");
     hash.update(contents);
     return hash.digest("hex");
   }

--- a/packages/activesupport/src/crypto-adapter.ts
+++ b/packages/activesupport/src/crypto-adapter.ts
@@ -170,6 +170,40 @@ export function getCrypto(): CryptoAdapter {
   return resolve();
 }
 
+let nodeAsyncPromise: Promise<boolean> | null = null;
+
+function tryAutoRegisterNodeAsync(): Promise<boolean> {
+  if (registry.has("node")) return Promise.resolve(true);
+  if (!nodeAsyncPromise) {
+    nodeAsyncPromise = (async () => {
+      try {
+        if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
+          return false;
+        }
+        const nodeCrypto = (await import("node:crypto")) as unknown as typeof import("node:crypto");
+        registry.set("node", wrapNodeCrypto(nodeCrypto));
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  return nodeAsyncPromise;
+}
+
+export async function getCryptoAsync(): Promise<CryptoAdapter> {
+  try {
+    return resolve();
+  } catch (error) {
+    if (currentAdapterName) throw error;
+    if (await tryAutoRegisterNodeAsync()) {
+      resolved = registry.get("node")!;
+      return resolved;
+    }
+    throw error;
+  }
+}
+
 export const cryptoAdapterConfig = {
   get adapter(): string | null {
     return currentAdapterName;

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -8,7 +8,12 @@ export {
 } from "./fs-adapter.js";
 export type { FsAdapter, FsStatResult, FsDirent, PathAdapter } from "./fs-adapter.js";
 
-export { registerCryptoAdapter, getCrypto, cryptoAdapterConfig } from "./crypto-adapter.js";
+export {
+  registerCryptoAdapter,
+  getCrypto,
+  getCryptoAsync,
+  cryptoAdapterConfig,
+} from "./crypto-adapter.js";
 export type {
   CryptoAdapter,
   HashAdapter,

--- a/packages/trailties/src/cli.test.ts
+++ b/packages/trailties/src/cli.test.ts
@@ -3,7 +3,7 @@ import { createProgram } from "./cli.js";
 import { VERSION } from "./version.js";
 
 describe("CLI", () => {
-  it("prints version with --version flag", () => {
+  it("prints version with -v flag", () => {
     const program = createProgram();
     program.exitOverride();
     let output = "";
@@ -13,9 +13,9 @@ describe("CLI", () => {
       },
     });
     try {
-      program.parse(["node", "trails", "--version"]);
+      program.parse(["node", "trails", "-v"]);
     } catch (e: any) {
-      // commander throws on --version
+      // commander throws on -v
     }
     expect(output.trim()).toBe(VERSION);
   });

--- a/packages/trailties/src/cli.test.ts
+++ b/packages/trailties/src/cli.test.ts
@@ -3,7 +3,7 @@ import { createProgram } from "./cli.js";
 import { VERSION } from "./version.js";
 
 describe("CLI", () => {
-  it("prints version with -v flag", () => {
+  it("prints version with --version flag", () => {
     const program = createProgram();
     program.exitOverride();
     let output = "";
@@ -13,9 +13,9 @@ describe("CLI", () => {
       },
     });
     try {
-      program.parse(["node", "trails", "-v"]);
+      program.parse(["node", "trails", "--version"]);
     } catch (e: any) {
-      // commander throws on -v
+      // commander throws on --version
     }
     expect(output.trim()).toBe(VERSION);
   });

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -14,7 +14,8 @@ export function createProgram(): Command {
   program
     .name("trails")
     .description("TypeScript framework inspired by Ruby on Rails")
-    .version(VERSION, "-v");
+    .enablePositionalOptions()
+    .version(VERSION, "-v, --version");
 
   program.addCommand(newCommand());
   program.addCommand(generateCommand());

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -14,7 +14,7 @@ export function createProgram(): Command {
   program
     .name("trails")
     .description("TypeScript framework inspired by Ruby on Rails")
-    .version(VERSION, "-v, --version");
+    .version(VERSION, "-v");
 
   program.addCommand(newCommand());
   program.addCommand(generateCommand());


### PR DESCRIPTION
## Summary

- **--version flag clash**: Enabled Commander's `enablePositionalOptions()` on the root program so `--version` on the root (`trails --version`) prints the CLI version while `--version` on migration subcommands (`db migrate:down --version 20260102`) passes the migration version to the action handler. Previously Commander intercepted `--version` at the root level and printed `0.1.0`.
- **Crypto adapter in ESM**: Added `getCryptoAsync()` to activesupport for ESM environments where `require("node:crypto")` isn't available. `DatabaseTasks._schemaSha1` now uses it so `schema:load` SHA1 stamping works under tsx/ESM without the "No crypto adapter configured" warning.

## Test plan

- [x] `pnpm run build` — clean
- [x] 108 tests pass (cli + trailties db)
- [x] Manual CLI test: `trails --version`, `trails -v`, `db migrate:down --version`, `db migrate:up --version`, `db schema:load` all work correctly
- [x] CI