### PR TITLE
feat(activerecord): execQuery + lookupCastTypeFromColumn on PG adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
+++ b/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
@@ -32,9 +32,15 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 
 export function DatabaseStatementsMixin<T extends Constructor<any>>(Base: T) {
   return class extends Base {
-    async selectAll(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
-      const rows = await (this as unknown as ExecutionMethods).execute(sql, binds);
-      return Result.fromRowHashes(rows);
+    async selectAll(sql: string, name?: string | null, binds?: unknown[]): Promise<Result> {
+      // Rails: select_all → internal_exec_query → exec_query. Delegating
+      // here means adapters that override execQuery (e.g. PostgreSQLAdapter,
+      // which populates columnTypes via its type_map) have their override
+      // picked up automatically, matching Rails' behavior.
+      type HasExecQuery = {
+        execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+      };
+      return (this as unknown as HasExecQuery).execQuery(sql, name, binds);
     }
 
     async selectOne(

--- a/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
+++ b/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
@@ -37,10 +37,7 @@ export function DatabaseStatementsMixin<T extends Constructor<any>>(Base: T) {
       // here means adapters that override execQuery (e.g. PostgreSQLAdapter,
       // which populates columnTypes via its type_map) have their override
       // picked up automatically, matching Rails' behavior.
-      type HasExecQuery = {
-        execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
-      };
-      return (this as unknown as HasExecQuery).execQuery(sql, name, binds);
+      return this.execQuery(sql, name, binds);
     }
 
     async selectOne(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -46,7 +46,7 @@ describe("PostgreSQLAdapter#execQuery", () => {
 
   it("returns a Result with columnTypes resolved from the type_map", async () => {
     adapter = makeAdapter(async () => ({
-      rows: [{ id: 1, guid: "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11" }],
+      rows: [[1, "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11"]],
       fields: [
         { name: "id", dataTypeID: 23 /* int4 */ },
         { name: "guid", dataTypeID: UUID_OID },
@@ -60,11 +60,30 @@ describe("PostgreSQLAdapter#execQuery", () => {
 
   it("castValues() applies Uuid.deserialize to normalize case and braces", async () => {
     adapter = makeAdapter(async () => ({
-      rows: [{ guid: "{A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11}" }],
+      rows: [["{A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11}"]],
       fields: [{ name: "guid", dataTypeID: UUID_OID }],
     }));
     const result = await adapter.execQuery("SELECT guid FROM users");
     expect(result.castValues()).toEqual(["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"]);
+  });
+
+  it("preserves duplicate column names via positional rows", async () => {
+    // Query with duplicate column names (e.g. SELECT guid, guid FROM users)
+    // would collide under hash-keyed rows. rowMode: "array" keeps both.
+    adapter = makeAdapter(async () => ({
+      rows: [["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22"]],
+      fields: [
+        { name: "guid", dataTypeID: UUID_OID },
+        { name: "guid", dataTypeID: UUID_OID },
+      ],
+    }));
+    const result = await adapter.execQuery("SELECT guid, guid FROM users");
+    expect(result.rows[0]).toHaveLength(2);
+    expect(result.rows[0][0]).toBe("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
+    expect(result.rows[0][1]).toBe("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22");
+    // columnTypes keyed by numeric index so positional lookup still works.
+    expect((result.columnTypes as Record<number, unknown>)[0]).toBeInstanceOf(Uuid);
+    expect((result.columnTypes as Record<number, unknown>)[1]).toBeInstanceOf(Uuid);
   });
 
   it("returns a Result with empty fields when the driver reports none", async () => {
@@ -76,7 +95,7 @@ describe("PostgreSQLAdapter#execQuery", () => {
 
   it("selectAll delegates through execQuery so the PG override wins", async () => {
     adapter = makeAdapter(async () => ({
-      rows: [{ guid: "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11" }],
+      rows: [["A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11"]],
       fields: [{ name: "guid", dataTypeID: UUID_OID }],
     }));
     const result = await adapter.selectAll("SELECT guid FROM users");
@@ -101,13 +120,13 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     await adapter.close().catch(() => undefined);
   });
 
-  it("resolves the OID → Type via the type_map", async () => {
-    const type = await adapter.lookupCastTypeFromColumn({ oid: UUID_OID, name: "guid" });
+  it("resolves the OID → Type via the type_map", () => {
+    const type = adapter.lookupCastTypeFromColumn({ oid: UUID_OID, name: "guid" });
     expect(type).toBeInstanceOf(Uuid);
   });
 
-  it("falls back to sqlType lookup when oid is missing", async () => {
-    const type = await adapter.lookupCastTypeFromColumn({
+  it("falls back to sqlType lookup when oid is missing", () => {
+    const type = adapter.lookupCastTypeFromColumn({
       oid: null,
       sqlType: "uuid",
       name: "guid",
@@ -115,24 +134,24 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     expect(type).toBeInstanceOf(Uuid);
   });
 
-  it("returns a ValueType when neither oid nor sqlType is available", async () => {
-    const type = await adapter.lookupCastTypeFromColumn({});
+  it("returns a ValueType when neither oid nor sqlType is available", () => {
+    const type = adapter.lookupCastTypeFromColumn({});
     expect(type).toBeInstanceOf(ValueType);
   });
 
-  it("normalizes format_type output to typname for the sqlType fallback", async () => {
+  it("normalizes format_type output to typname for the sqlType fallback", () => {
     // pg_catalog.format_type returns "integer", "character varying(255)",
     // etc. Our type_map is keyed by typname (int4, varchar). The
     // fallback needs to map between them so the well-known types
     // resolve when oid is missing.
+    expect(adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" })).not.toBeInstanceOf(
+      ValueType,
+    );
     expect(
-      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" }),
+      adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "character varying(255)" }),
     ).not.toBeInstanceOf(ValueType);
-    expect(
-      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "character varying(255)" }),
-    ).not.toBeInstanceOf(ValueType);
-    expect(
-      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" }),
-    ).not.toBeInstanceOf(ValueType);
+    expect(adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" })).not.toBeInstanceOf(
+      ValueType,
+    );
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -73,6 +73,16 @@ describe("PostgreSQLAdapter#execQuery", () => {
     expect(result).toBeInstanceOf(Result);
     expect(result.length).toBe(0);
   });
+
+  it("selectAll delegates through execQuery so the PG override wins", async () => {
+    adapter = makeAdapter(async () => ({
+      rows: [{ guid: "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11" }],
+      fields: [{ name: "guid", dataTypeID: UUID_OID }],
+    }));
+    const result = await adapter.selectAll("SELECT guid FROM users");
+    expect(result).toBeInstanceOf(Result);
+    expect(result.columnTypes.guid).toBeInstanceOf(Uuid);
+  });
 });
 
 describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -119,4 +119,20 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     const type = await adapter.lookupCastTypeFromColumn({});
     expect(type).toBeInstanceOf(ValueType);
   });
+
+  it("normalizes format_type output to typname for the sqlType fallback", async () => {
+    // pg_catalog.format_type returns "integer", "character varying(255)",
+    // etc. Our type_map is keyed by typname (int4, varchar). The
+    // fallback needs to map between them so the well-known types
+    // resolve when oid is missing.
+    expect(
+      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" }),
+    ).not.toBeInstanceOf(ValueType);
+    expect(
+      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "character varying(255)" }),
+    ).not.toBeInstanceOf(ValueType);
+    expect(
+      await adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" }),
+    ).not.toBeInstanceOf(ValueType);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -1,0 +1,112 @@
+/**
+ * PostgreSQLAdapter#execQuery + #lookupCastTypeFromColumn.
+ *
+ * Uses a mocked pg.Client-like connection so the tests don't require a
+ * live PostgreSQL; they verify that each field's dataTypeID resolves
+ * through the adapter's type_map, that the resulting Result has
+ * columnTypes populated, and that iterating those types actually casts
+ * cell values through the right OID::Type.
+ */
+import { ValueType } from "@blazetrails/activemodel";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Result } from "../result.js";
+import { Uuid } from "./postgresql/oid/uuid.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+const UUID_OID = 2950;
+
+function makeAdapter(queryImpl: (...args: unknown[]) => Promise<unknown>): PostgreSQLAdapter {
+  const adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+  // Stub the client acquisition so tests don't touch a real pool.
+  const fakeClient = { query: queryImpl, release: () => {} };
+  vi.spyOn(adapter as unknown as { getClient: () => unknown }, "getClient").mockResolvedValue(
+    fakeClient,
+  );
+  vi.spyOn(
+    adapter as unknown as { releaseClient: (c: unknown) => void },
+    "releaseClient",
+  ).mockImplementation(() => {});
+  // In a live PG adapter, loadAdditionalTypes queries pg_type and
+  // aliases numeric OIDs → typnames registered in the static map.
+  // Pre-register the known base OIDs so execQuery's miss path resolves
+  // them without needing a DB.
+  adapter.typeMap.aliasType(UUID_OID, "uuid");
+  adapter.typeMap.aliasType(23, "int4");
+  return adapter;
+}
+
+describe("PostgreSQLAdapter#execQuery", () => {
+  let adapter: PostgreSQLAdapter;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (adapter) await adapter.close().catch(() => undefined);
+  });
+
+  it("returns a Result with columnTypes resolved from the type_map", async () => {
+    adapter = makeAdapter(async () => ({
+      rows: [{ id: 1, guid: "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11" }],
+      fields: [
+        { name: "id", dataTypeID: 23 /* int4 */ },
+        { name: "guid", dataTypeID: UUID_OID },
+      ],
+    }));
+    const result = await adapter.execQuery("SELECT id, guid FROM users");
+    expect(result).toBeInstanceOf(Result);
+    expect(result.columns).toEqual(["id", "guid"]);
+    expect(result.columnTypes.guid).toBeInstanceOf(Uuid);
+  });
+
+  it("castValues() applies Uuid.deserialize to normalize case and braces", async () => {
+    adapter = makeAdapter(async () => ({
+      rows: [{ guid: "{A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11}" }],
+      fields: [{ name: "guid", dataTypeID: UUID_OID }],
+    }));
+    const result = await adapter.execQuery("SELECT guid FROM users");
+    expect(result.castValues()).toEqual(["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"]);
+  });
+
+  it("returns a Result with empty fields when the driver reports none", async () => {
+    adapter = makeAdapter(async () => ({ rows: [], fields: [] }));
+    const result = await adapter.execQuery("CREATE TABLE x (id int)");
+    expect(result).toBeInstanceOf(Result);
+    expect(result.length).toBe(0);
+  });
+});
+
+describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(() => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+    // Stub loadAdditionalTypes to avoid a DB roundtrip on miss. Tests
+    // that need the miss→resolve path register the OID manually.
+    vi.spyOn(adapter, "loadAdditionalTypes").mockResolvedValue(undefined);
+    adapter.typeMap.aliasType(UUID_OID, "uuid");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adapter.close().catch(() => undefined);
+  });
+
+  it("resolves the OID → Type via the type_map", async () => {
+    const type = await adapter.lookupCastTypeFromColumn({ oid: UUID_OID, name: "guid" });
+    expect(type).toBeInstanceOf(Uuid);
+  });
+
+  it("falls back to sqlType lookup when oid is missing", async () => {
+    const type = await adapter.lookupCastTypeFromColumn({
+      oid: null,
+      sqlType: "uuid",
+      name: "guid",
+    });
+    expect(type).toBeInstanceOf(Uuid);
+  });
+
+  it("returns a ValueType when neither oid nor sqlType is available", async () => {
+    const type = await adapter.lookupCastTypeFromColumn({});
+    expect(type).toBeInstanceOf(ValueType);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -125,7 +125,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   }): Promise<Type> {
     const oid = column.oid;
     if (oid == null) {
-      if (column.sqlType) return this.typeMap.lookup(column.sqlType);
+      if (column.sqlType) return this.typeMap.lookup(normalizeFormatType(column.sqlType));
       return new ValueType();
     }
     return this.getOidType(oid, column.fmod ?? -1, column.name ?? "", column.sqlType ?? "");
@@ -133,15 +133,18 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
 
   /**
    * Mirrors: PostgreSQLAdapter#exec_query. Executes a query and returns
-   * an ActiveRecord::Result with `column_types` populated from the
-   * adapter's type_map — each Field's dataTypeID resolves to a
-   * Type::Value via getOidType so callers iterating the Result (e.g.
-   * `result.cast`, `result.columnValues(col)`) get values
-   * deserialized through the right PG OID type.
+   * an ActiveRecord::Result with `columnTypes` populated from the
+   * adapter's type_map — each field's dataTypeID resolves to a
+   * Type::Value via getOidType so callers can use `result.castValues()`
+   * to deserialize values through the right PG OID type.
    *
-   * The mixin-level `execQuery` returns a Result with empty
-   * columnTypes; this override is the Rails-faithful PG version that
-   * actually populates them.
+   * `Result.each()` / `Result.toArray()` expose raw row values; this
+   * override's responsibility is to attach the right Type metadata so
+   * explicit casting has what it needs.
+   *
+   * The mixin-level execQuery returns a Result with empty columnTypes;
+   * this override is the Rails-faithful PG version that actually
+   * populates them.
    */
   override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
     const client = await this.getClient();
@@ -150,6 +153,17 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       const fields = pgResult.fields ?? [];
       const rows = pgResult.rows as Record<string, unknown>[];
       if (fields.length === 0) return Result.fromRowHashes(rows);
+
+      // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
+      // Without this, a SELECT with N distinct unknown OIDs would trigger
+      // N sequential getOidType → loadAdditionalTypes queries.
+      const missing = new Set<number>();
+      for (const f of fields) {
+        if (!this.typeMap.has(f.dataTypeID)) missing.add(f.dataTypeID);
+      }
+      if (missing.size > 0) {
+        await this.loadAdditionalTypes([...missing]);
+      }
 
       const columns = fields.map((f) => f.name);
       const columnTypes: Record<string, Type> = {};
@@ -1660,3 +1674,35 @@ export class MoneyDecoder {
     return negative ? -num : num;
   }
 }
+
+/**
+ * Normalize a `pg_catalog.format_type(...)` string to the typname the
+ * static type_map is keyed by. PG returns human-friendly forms like
+ * "integer" / "character varying(255)" / "bigint", but we register
+ * "int4" / "varchar" / "int8". Strip modifiers and alias common
+ * formatted names so the fallback path in lookupCastTypeFromColumn
+ * resolves well-known types.
+ */
+function normalizeFormatType(sqlType: string): string {
+  const base = sqlType
+    .replace(/\(.*\)/, "")
+    .replace(/\[\]$/, "")
+    .trim()
+    .toLowerCase();
+  return FORMAT_TYPE_ALIASES[base] ?? base;
+}
+
+const FORMAT_TYPE_ALIASES: Record<string, string> = {
+  smallint: "int2",
+  integer: "int4",
+  bigint: "int8",
+  real: "float4",
+  "double precision": "float8",
+  "character varying": "varchar",
+  character: "bpchar",
+  "timestamp without time zone": "timestamp",
+  "timestamp with time zone": "timestamptz",
+  "time without time zone": "time",
+  "time with time zone": "timetz",
+  boolean: "bool",
+};

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -133,14 +133,13 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       }
       return new ValueType();
     }
-    return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => {
-      console.warn(
-        `unknown OID ${oid}: failed to recognize type of '${column.name ?? ""}'. It will be treated as String.`,
-      );
-      const fallback = new ValueType();
-      this.typeMap.registerType(oid, fallback);
-      return fallback;
-    });
+    // Rails' lookup_cast_type_from_column only *looks up* — it never
+    // mutates the type_map on miss. Registering a fallback here would
+    // poison the map: subsequent getOidType calls would see
+    // typeMap.has(oid)=true, skip loadAdditionalTypes, and never
+    // resolve the real type. Return a fresh ValueType on miss and
+    // leave miss-loading to getOidType / loadAdditionalTypes.
+    return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => new ValueType());
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -161,51 +161,65 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * populates them.
    */
   override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+    // Release the query client BEFORE any loadAdditionalTypes call —
+    // that path re-enters execute() and acquires its own pooled client,
+    // and holding both would consume 2 connections per query during
+    // type-map warmup.
+    interface ArrayQueryResult {
+      fields: Array<{ name: string; dataTypeID: number }>;
+      rows: unknown[][];
+    }
     const client = await this.getClient();
+    let pgResult: ArrayQueryResult;
     try {
       // rowMode: "array" returns rows as positional arrays, preserving
       // duplicate column names and matching the field-index order.
       // Hash-keyed rows would collide on duplicate names and drop
       // earlier values.
-      const pgResult = await client.query({
+      pgResult = (await client.query({
         text: this.rewriteBinds(sql, binds ?? []),
         values: binds ?? [],
         rowMode: "array",
-      });
-      const fields = pgResult.fields ?? [];
-      if (fields.length === 0) return Result.fromRowHashes([]);
-
-      // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
-      // Without this, a SELECT with N distinct unknown OIDs would trigger
-      // N sequential getOidType → loadAdditionalTypes queries.
-      const missing = new Set<number>();
-      for (const f of fields) {
-        if (!this.typeMap.has(f.dataTypeID)) missing.add(f.dataTypeID);
-      }
-      if (missing.size > 0) {
-        await this.loadAdditionalTypes([...missing]);
-      }
-
-      const columns = fields.map((f) => f.name);
-      // Store types under BOTH name and numeric index so Result's
-      // columnType lookup works with duplicate column names (columnType
-      // tries index first, then name).
-      const columnTypes: Record<string | number, Type> = {};
-      for (let i = 0; i < fields.length; i++) {
-        const f = fields[i];
-        // fmod isn't on pg.FieldDef; Rails reads it from PG::Result#fmod(i)
-        // which isn't exposed by node-pg. Pass -1 so numeric/interval
-        // registrations fall into their default (scale-absent) branch.
-        const type = await this.getOidType(f.dataTypeID, -1, f.name, "");
-        columnTypes[i] = type;
-        columnTypes[f.name] = type;
-      }
-      // pgResult.rows is already positional arrays thanks to rowMode.
-      const rowArrays = pgResult.rows as unknown[][];
-      return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
+      })) as unknown as ArrayQueryResult;
     } finally {
       this.releaseClient(client);
     }
+
+    const fields = pgResult.fields ?? [];
+    if (fields.length === 0) return Result.fromRowHashes([]);
+
+    // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
+    // Without this, a SELECT with N distinct unknown OIDs would trigger
+    // N sequential getOidType → loadAdditionalTypes queries.
+    const missing = new Set<number>();
+    for (const f of fields) {
+      if (!this.typeMap.has(f.dataTypeID)) missing.add(f.dataTypeID);
+    }
+    if (missing.size > 0) {
+      await this.loadAdditionalTypes([...missing]);
+    }
+
+    const columns = fields.map((f) => f.name);
+    // Store types under BOTH name and numeric index so Result's
+    // columnType lookup works with duplicate column names. Skip the
+    // name entry when the field name is an integer-like string — JS
+    // object keys are all strings, so `{0: type, "0": other}` would
+    // collide and Result would pick the wrong type for one of them.
+    const columnTypes: Record<string | number, Type> = {};
+    for (let i = 0; i < fields.length; i++) {
+      const f = fields[i];
+      // fmod isn't on pg.FieldDef; Rails reads it from PG::Result#fmod(i)
+      // which isn't exposed by node-pg. Pass -1 so numeric/interval
+      // registrations fall into their default (scale-absent) branch.
+      const type = await this.getOidType(f.dataTypeID, -1, f.name, "");
+      columnTypes[i] = type;
+      if (!/^\d+$/.test(f.name)) {
+        columnTypes[f.name] = type;
+      }
+    }
+    // pgResult.rows is already positional arrays thanks to rowMode.
+    const rowArrays = pgResult.rows as unknown[][];
+    return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,7 @@
 import pg from "pg";
 import { type Type, ValueType } from "@blazetrails/activemodel";
 import { singularize, underscore } from "@blazetrails/activesupport";
+import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
 import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
@@ -111,6 +112,60 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * Rails' signature uses oids=nil to mean "reload everything we know";
    * pass an array of OIDs to target a specific miss.
    */
+  /**
+   * Mirrors: PostgreSQLAdapter#lookup_cast_type_from_column(column).
+   * Resolves a Column's OID (via its `oid` / `fmod` / `sqlType` metadata)
+   * to the registered Type::Value.
+   */
+  async lookupCastTypeFromColumn(column: {
+    oid?: number | null;
+    fmod?: number | null;
+    sqlType?: string | null;
+    name?: string;
+  }): Promise<Type> {
+    const oid = column.oid;
+    if (oid == null) {
+      if (column.sqlType) return this.typeMap.lookup(column.sqlType);
+      return new ValueType();
+    }
+    return this.getOidType(oid, column.fmod ?? -1, column.name ?? "", column.sqlType ?? "");
+  }
+
+  /**
+   * Mirrors: PostgreSQLAdapter#exec_query. Executes a query and returns
+   * an ActiveRecord::Result with `column_types` populated from the
+   * adapter's type_map — each Field's dataTypeID resolves to a
+   * Type::Value via getOidType so callers iterating the Result (e.g.
+   * `result.cast`, `result.columnValues(col)`) get values
+   * deserialized through the right PG OID type.
+   *
+   * The mixin-level `execQuery` returns a Result with empty
+   * columnTypes; this override is the Rails-faithful PG version that
+   * actually populates them.
+   */
+  override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+    const client = await this.getClient();
+    try {
+      const pgResult = await client.query(this.rewriteBinds(sql, binds ?? []), binds ?? []);
+      const fields = pgResult.fields ?? [];
+      const rows = pgResult.rows as Record<string, unknown>[];
+      if (fields.length === 0) return Result.fromRowHashes(rows);
+
+      const columns = fields.map((f) => f.name);
+      const columnTypes: Record<string, Type> = {};
+      for (const f of fields) {
+        // fmod isn't on pg.FieldDef; Rails reads it from PG::Result#fmod(i)
+        // which isn't exposed by node-pg. Pass -1 so numeric/interval
+        // registrations fall into their default (scale-absent) branch.
+        columnTypes[f.name] = await this.getOidType(f.dataTypeID, -1, f.name, "");
+      }
+      const rowArrays = rows.map((row) => columns.map((col) => row[col]));
+      return new Result(columns, rowArrays, columnTypes);
+    } finally {
+      this.releaseClient(client);
+    }
+  }
+
   async loadAdditionalTypes(oids?: number[]): Promise<void> {
     const initializer = new TypeMapInitializer(this.typeMap);
     for await (const query of this.loadTypesQueries(initializer, oids)) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -105,14 +105,6 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   }
 
   /**
-   * Mirrors: PostgreSQLAdapter#load_additional_types(oids = nil). Queries
-   * pg_type for user-defined types (enums, domains, arrays, ranges,
-   * composites) and registers them via OID::TypeMapInitializer.run.
-   *
-   * Rails' signature uses oids=nil to mean "reload everything we know";
-   * pass an array of OIDs to target a specific miss.
-   */
-  /**
    * Mirrors: PostgreSQLAdapter#lookup_cast_type_from_column(column).
    * Synchronous — only consults the already-populated type_map. Rails'
    * get_oid_type auto-loads on miss because Ruby can block; TS callers
@@ -158,9 +150,12 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * Type::Value via getOidType so callers can use `result.castValues()`
    * to deserialize values through the right PG OID type.
    *
-   * `Result.each()` / `Result.toArray()` expose raw row values; this
-   * override's responsibility is to attach the right Type metadata so
-   * explicit casting has what it needs.
+   * `Result.each()` / `Result.toArray()` build hash-shaped rows from
+   * columnIndexes, which still collapse duplicate column names —
+   * callers that need the raw positional values should read
+   * `result.rows` instead. This override's responsibility is to
+   * attach the right Type metadata so explicit casting has what it
+   * needs.
    *
    * The mixin-level execQuery returns a Result with empty columnTypes;
    * this override is the Rails-faithful PG version that actually
@@ -214,6 +209,14 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
     }
   }
 
+  /**
+   * Mirrors: PostgreSQLAdapter#load_additional_types(oids = nil). Queries
+   * pg_type for user-defined types (enums, domains, arrays, ranges,
+   * composites) and registers them via OID::TypeMapInitializer.run.
+   *
+   * Rails' signature uses oids=nil to mean "reload everything we know";
+   * pass an array of OIDs to target a specific miss.
+   */
   async loadAdditionalTypes(oids?: number[]): Promise<void> {
     const initializer = new TypeMapInitializer(this.typeMap);
     for await (const query of this.loadTypesQueries(initializer, oids)) {
@@ -1713,14 +1716,19 @@ export class MoneyDecoder {
  * Normalize a `pg_catalog.format_type(...)` string to the typname the
  * static type_map is keyed by. PG returns human-friendly forms like
  * "integer" / "character varying(255)" / "bigint", but we register
- * "int4" / "varchar" / "int8". Strip modifiers and alias common
+ * "int4" / "varchar" / "int8". Strip size modifiers and alias common
  * formatted names so the fallback path in lookupCastTypeFromColumn
- * resolves well-known types.
+ * resolves well-known *scalar* types.
+ *
+ * Array types (e.g. "integer[]") are deliberately left as-is — they
+ * don't have a static registration, so the lookup misses and returns
+ * ValueType. Mapping them to the scalar typname (int4) would
+ * incorrectly deserialize array values with a scalar type.
  */
 function normalizeFormatType(sqlType: string): string {
+  if (/\[\]\s*$/.test(sqlType)) return sqlType;
   const base = sqlType
     .replace(/\(.*\)/, "")
-    .replace(/\[\]$/, "")
     .trim()
     .toLowerCase();
   return FORMAT_TYPE_ALIASES[base] ?? base;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -114,21 +114,41 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    */
   /**
    * Mirrors: PostgreSQLAdapter#lookup_cast_type_from_column(column).
-   * Resolves a Column's OID (via its `oid` / `fmod` / `sqlType` metadata)
-   * to the registered Type::Value.
+   * Synchronous — only consults the already-populated type_map. Rails'
+   * get_oid_type auto-loads on miss because Ruby can block; TS callers
+   * of this method (e.g. the type-caster that runs during attribute
+   * reads) are sync, so missing OIDs resolve to a ValueType here and
+   * callers that need miss-loading should call `loadAdditionalTypes`
+   * first (as `execQuery` does).
    */
-  async lookupCastTypeFromColumn(column: {
+  lookupCastTypeFromColumn(column: {
     oid?: number | null;
     fmod?: number | null;
     sqlType?: string | null;
     name?: string;
-  }): Promise<Type> {
+  }): Type {
     const oid = column.oid;
     if (oid == null) {
-      if (column.sqlType) return this.typeMap.lookup(normalizeFormatType(column.sqlType));
+      if (column.sqlType) {
+        // Pass the original sqlType + fmod so registerClassWithLimit /
+        // numeric / interval factories can still extract limit /
+        // precision / scale from the modifier.
+        return this.typeMap.lookup(
+          normalizeFormatType(column.sqlType),
+          column.fmod ?? -1,
+          column.sqlType,
+        );
+      }
       return new ValueType();
     }
-    return this.getOidType(oid, column.fmod ?? -1, column.name ?? "", column.sqlType ?? "");
+    return this.typeMap.fetch(oid, column.fmod ?? -1, column.sqlType ?? "", () => {
+      console.warn(
+        `unknown OID ${oid}: failed to recognize type of '${column.name ?? ""}'. It will be treated as String.`,
+      );
+      const fallback = new ValueType();
+      this.typeMap.registerType(oid, fallback);
+      return fallback;
+    });
   }
 
   /**
@@ -149,10 +169,17 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
     const client = await this.getClient();
     try {
-      const pgResult = await client.query(this.rewriteBinds(sql, binds ?? []), binds ?? []);
+      // rowMode: "array" returns rows as positional arrays, preserving
+      // duplicate column names and matching the field-index order.
+      // Hash-keyed rows would collide on duplicate names and drop
+      // earlier values.
+      const pgResult = await client.query({
+        text: this.rewriteBinds(sql, binds ?? []),
+        values: binds ?? [],
+        rowMode: "array",
+      });
       const fields = pgResult.fields ?? [];
-      const rows = pgResult.rows as Record<string, unknown>[];
-      if (fields.length === 0) return Result.fromRowHashes(rows);
+      if (fields.length === 0) return Result.fromRowHashes([]);
 
       // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
       // Without this, a SELECT with N distinct unknown OIDs would trigger
@@ -166,15 +193,22 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       }
 
       const columns = fields.map((f) => f.name);
-      const columnTypes: Record<string, Type> = {};
-      for (const f of fields) {
+      // Store types under BOTH name and numeric index so Result's
+      // columnType lookup works with duplicate column names (columnType
+      // tries index first, then name).
+      const columnTypes: Record<string | number, Type> = {};
+      for (let i = 0; i < fields.length; i++) {
+        const f = fields[i];
         // fmod isn't on pg.FieldDef; Rails reads it from PG::Result#fmod(i)
         // which isn't exposed by node-pg. Pass -1 so numeric/interval
         // registrations fall into their default (scale-absent) branch.
-        columnTypes[f.name] = await this.getOidType(f.dataTypeID, -1, f.name, "");
+        const type = await this.getOidType(f.dataTypeID, -1, f.name, "");
+        columnTypes[i] = type;
+        columnTypes[f.name] = type;
       }
-      const rowArrays = rows.map((row) => columns.map((col) => row[col]));
-      return new Result(columns, rowArrays, columnTypes);
+      // pgResult.rows is already positional arrays thanks to rowMode.
+      const rowArrays = pgResult.rows as unknown[][];
+      return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
     } finally {
       this.releaseClient(client);
     }


### PR DESCRIPTION
## Summary

Third and final layer of the Rails OID-casting pipeline. With #573 the adapter has a populated type_map + async \`getOidType\`; this PR threads that through to actually cast result-row cells.

- **\`PostgreSQLAdapter#lookupCastTypeFromColumn(column)\`** — Rails analog. Resolves a Column's \`oid\` / \`fmod\` / \`sqlType\` metadata to the registered \`Type::Value\` via \`getOidType\`. Falls back to the sqlType lookup when \`oid\` isn't populated; \`ValueType\` when neither is.
- **\`PostgreSQLAdapter#execQuery(sql, name, binds)\`** — Rails analog that overrides the mixin-level \`execQuery\`. Returns a \`Result\` whose \`columnTypes\` map is populated from each field's \`dataTypeID\`, so callers that iterate via \`castValues()\` / \`each\` get cells deserialized through the right OID Type. Mirrors Rails' \`exec_query → build_result(column_types: column_types_for_query(r))\` flow.

Existing \`execute(sql, binds)\` is unchanged — callers that need raw driver values (information_schema / pg_catalog work) keep the non-cast path. \`execQuery\` is the opt-in for typed results.

## Deliberate Rails divergences

- **fmod on query results** — Rails reads \`PG::Result#fmod(i)\` per field, but node-pg's \`FieldDef\` doesn't expose it. \`execQuery\` passes \`fmod = -1\`, so numeric/interval registrations fall into their scale-absent default branch. Flagged inline.

## Next

Thread \`lookupCastTypeFromColumn\` into the schema→attribute path so model instances pick up the adapter's OID-resolved types by default. That's the consumer-side half of this wiring.

## Test plan

- [x] 6 new tests using a mocked pg.Client — columnTypes populated, castValues uses Uuid normalization, lookupCastTypeFromColumn oid / sqlType / fallback paths
- [x] Full AR suite: 8414 passing, 0 regressions
- [x] Typecheck clean