### PR TITLE
feat(activerecord): implement RuntimeRegistry and complete Querying module

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -141,6 +141,8 @@ export {
 export { QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
 export { QueryLogs, escapeComment, LegacyFormatter, SQLCommenter } from "./query-logs.js";
 export type { TagValue, TagHandler, TagDefinition, QueryLogsFormatter } from "./query-logs.js";
+export * as RuntimeRegistry from "./runtime-registry.js";
+export { Stats as RuntimeStats } from "./runtime-registry.js";
 export { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 export { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 export type {

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -84,3 +84,42 @@ export function asyncCountBySql(
 ): Promise<number> {
   return countBySql.call(this, sql);
 }
+
+/**
+ * Internal: execute a raw SQL query through the adapter.
+ * Mirrors: ActiveRecord::Querying._query_by_sql
+ */
+export async function _queryBySql(
+  this: typeof Base,
+  sql: string | [string, ...unknown[]],
+  binds: unknown[] = [],
+): Promise<Record<string, unknown>[]> {
+  let sanitized: string;
+  if (Array.isArray(sql)) {
+    sanitized = sanitizeSql(sql);
+  } else if (binds.length > 0) {
+    sanitized = sanitizeSql([sql, ...binds] as [string, ...unknown[]]);
+  } else {
+    sanitized = sql;
+  }
+  return this.adapter.execute(sanitized);
+}
+
+/**
+ * Internal: instantiate model objects from a result set.
+ * Mirrors: ActiveRecord::Querying._load_from_sql
+ */
+export function _loadFromSql<T extends typeof Base>(
+  this: T,
+  rows: Record<string, unknown>[],
+  block?: (record: InstanceType<T>) => void,
+): InstanceType<T>[] {
+  if (rows.length === 0) return [];
+
+  const payload = { record_count: rows.length, class_name: this.name };
+  const records = Notifications.instrument("instantiation.active_record", payload, () =>
+    rows.map((row) => this._instantiate(row)),
+  );
+  if (block) records.forEach(block);
+  return records;
+}

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -19,25 +19,12 @@ export async function findBySql<T extends typeof Base>(
   binds: unknown[] = [],
   block?: (record: InstanceType<T>) => void,
 ): Promise<InstanceType<T>[]> {
-  // Rails passes binds to the connection for prepared statements.
-  // Our adapter uses string substitution, so merge binds into the SQL.
-  let sanitized: string;
-  if (Array.isArray(sql)) {
-    sanitized = sanitizeSql(sql);
-  } else if (binds.length > 0) {
-    sanitized = sanitizeSql([sql, ...binds] as [string, ...unknown[]]);
-  } else {
-    sanitized = sql;
-  }
-  const rows = await this.adapter.execute(sanitized);
-  if (rows.length === 0) return [];
-
-  const payload = { record_count: rows.length, class_name: this.name };
-  const records = Notifications.instrument("instantiation.active_record", payload, () =>
-    rows.map((row) => this._instantiate(row)),
+  const rows = await _queryBySql.call(this, sql, binds);
+  return _loadFromSql.call<T, [Record<string, unknown>[], typeof block], InstanceType<T>[]>(
+    this,
+    rows,
+    block,
   );
-  if (block) records.forEach(block);
-  return records;
 }
 
 /**

--- a/packages/activerecord/src/runtime-registry.test.ts
+++ b/packages/activerecord/src/runtime-registry.test.ts
@@ -77,7 +77,7 @@ describe("RuntimeRegistryTest", () => {
     Notifications.instrument("sql.active_record", { name: "User Load" }, () => {
       // simulate query work
     });
-    expect(stats().queriesCount).toBeGreaterThanOrEqual(1);
+    expect(stats().queriesCount).toBe(1);
     expect(stats().sqlRuntime).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/activerecord/src/runtime-registry.test.ts
+++ b/packages/activerecord/src/runtime-registry.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Stats, record, stats, reset } from "./runtime-registry.js";
+import { Notifications } from "@blazetrails/activesupport";
+
+describe("RuntimeRegistryTest", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("sql runtime defaults to zero", () => {
+    expect(stats().sqlRuntime).toBe(0);
+  });
+
+  it("record increments sql runtime", () => {
+    record("User Load", 5.0);
+    expect(stats().sqlRuntime).toBe(5.0);
+  });
+
+  it("record increments queries count", () => {
+    record("User Load", 1.0);
+    record("Post Load", 2.0);
+    expect(stats().queriesCount).toBe(2);
+  });
+
+  it("record does not count TRANSACTION queries", () => {
+    record("TRANSACTION", 1.0);
+    expect(stats().queriesCount).toBe(0);
+    expect(stats().sqlRuntime).toBe(1.0);
+  });
+
+  it("record does not count SCHEMA queries", () => {
+    record("SCHEMA", 1.0);
+    expect(stats().queriesCount).toBe(0);
+  });
+
+  it("record increments cached queries count when cached", () => {
+    record("User Load", 0.1, { cached: true });
+    expect(stats().cachedQueriesCount).toBe(1);
+    expect(stats().queriesCount).toBe(1);
+  });
+
+  it("record tracks async sql runtime separately", () => {
+    record("User Load", 10.0, { async: true, lockWait: 3.0 });
+    expect(stats().asyncSqlRuntime).toBe(7.0);
+    expect(stats().sqlRuntime).toBe(10.0);
+  });
+
+  it("resetRuntimes returns previous sql runtime and resets", () => {
+    record("User Load", 5.0);
+    record("Post Load", 3.0, { async: true });
+    const was = stats().resetRuntimes();
+    expect(was).toBe(8.0);
+    expect(stats().sqlRuntime).toBe(0);
+    expect(stats().asyncSqlRuntime).toBe(0);
+    // queries count is not reset by resetRuntimes
+    expect(stats().queriesCount).toBe(2);
+  });
+
+  it("reset clears all stats", () => {
+    record("User Load", 5.0);
+    record("Post Load", 1.0, { cached: true });
+    reset();
+    expect(stats().sqlRuntime).toBe(0);
+    expect(stats().queriesCount).toBe(0);
+    expect(stats().cachedQueriesCount).toBe(0);
+  });
+
+  it("Stats class initializes with zeros", () => {
+    const s = new Stats();
+    expect(s.sqlRuntime).toBe(0);
+    expect(s.asyncSqlRuntime).toBe(0);
+    expect(s.queriesCount).toBe(0);
+    expect(s.cachedQueriesCount).toBe(0);
+  });
+
+  it("notification subscription records sql.active_record events", () => {
+    Notifications.instrument("sql.active_record", { name: "User Load" }, () => {
+      // simulate query work
+    });
+    expect(stats().queriesCount).toBeGreaterThanOrEqual(1);
+    expect(stats().sqlRuntime).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/activerecord/src/runtime-registry.ts
+++ b/packages/activerecord/src/runtime-registry.ts
@@ -102,9 +102,10 @@ export function resetCachedQueriesCount(): number {
 // Subscribe to sql.active_record notifications, matching Rails:
 // ActiveSupport::Notifications.monotonic_subscribe("sql.active_record", ActiveRecord::RuntimeRegistry)
 Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+  const lockWait = event.payload.lock_wait ?? event.payload.lockWait;
   record(event.payload.name as string | undefined, event.duration, {
     cached: event.payload.cached as boolean | undefined,
     async: event.payload.async as boolean | undefined,
-    lockWait: event.payload.lock_wait as number | undefined,
+    lockWait: lockWait === undefined ? undefined : Number(lockWait),
   });
 });

--- a/packages/activerecord/src/runtime-registry.ts
+++ b/packages/activerecord/src/runtime-registry.ts
@@ -1,0 +1,110 @@
+/**
+ * RuntimeRegistry — thread-local runtime statistics for Active Record.
+ *
+ * Mirrors: ActiveRecord::RuntimeRegistry
+ *
+ * Tracks SQL execution time and query counts for the current execution
+ * context. In Rails this uses thread-local storage; in our single-threaded
+ * JS environment we use module-level state (equivalent to a single
+ * IsolatedExecutionState slot).
+ */
+
+import { Notifications, type NotificationEvent } from "@blazetrails/activesupport";
+
+export class Stats {
+  sqlRuntime = 0.0;
+  asyncSqlRuntime = 0.0;
+  queriesCount = 0;
+  cachedQueriesCount = 0;
+
+  resetRuntimes(): number {
+    const was = this.sqlRuntime;
+    this.sqlRuntime = 0.0;
+    this.asyncSqlRuntime = 0.0;
+    return was;
+  }
+
+  reset(): void {
+    this.sqlRuntime = 0.0;
+    this.asyncSqlRuntime = 0.0;
+    this.queriesCount = 0;
+    this.cachedQueriesCount = 0;
+  }
+}
+
+let _stats: Stats | null = null;
+
+function getStats(): Stats {
+  if (!_stats) _stats = new Stats();
+  return _stats;
+}
+
+/**
+ * Record a query's runtime and update counters.
+ * Mirrors: ActiveRecord::RuntimeRegistry.record
+ */
+export function record(
+  queryName: string | undefined,
+  runtime: number,
+  options: { cached?: boolean; async?: boolean; lockWait?: number } = {},
+): void {
+  const s = getStats();
+
+  if (queryName !== "TRANSACTION" && queryName !== "SCHEMA") {
+    s.queriesCount += 1;
+    if (options.cached) s.cachedQueriesCount += 1;
+  }
+
+  if (options.async) {
+    s.asyncSqlRuntime += runtime - (options.lockWait ?? 0);
+  }
+  s.sqlRuntime += runtime;
+}
+
+/**
+ * Get the current execution context's stats.
+ * Mirrors: ActiveRecord::RuntimeRegistry.stats
+ */
+export function stats(): Stats {
+  return getStats();
+}
+
+/**
+ * Reset all stats for the current execution context.
+ * Mirrors: ActiveRecord::RuntimeRegistry.reset
+ */
+export function reset(): void {
+  getStats().reset();
+}
+
+/**
+ * Reset queries count and return previous value.
+ * Mirrors: ActiveRecord::RuntimeRegistry.reset_queries_count
+ */
+export function resetQueriesCount(): number {
+  const s = getStats();
+  const was = s.queriesCount;
+  s.queriesCount = 0;
+  return was;
+}
+
+/**
+ * Reset cached queries count and return previous value.
+ * Mirrors: ActiveRecord::RuntimeRegistry.reset_cached_queries_count
+ */
+export function resetCachedQueriesCount(): number {
+  const s = getStats();
+  const was = s.cachedQueriesCount;
+  s.cachedQueriesCount = 0;
+  return was;
+}
+
+// Subscribe to sql.active_record notifications, matching Rails:
+// ActiveSupport::Notifications.monotonic_subscribe("sql.active_record", ActiveRecord::RuntimeRegistry)
+Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+  record(event.payload.name as string | undefined, event.duration, {
+    cached: event.payload.cached as boolean | undefined,
+    async: event.payload.async as boolean | undefined,
+    lockWait: event.payload.lock_wait as number | undefined,
+  });
+});

--- a/packages/activerecord/src/runtime-registry.ts
+++ b/packages/activerecord/src/runtime-registry.ts
@@ -102,10 +102,9 @@ export function resetCachedQueriesCount(): number {
 // Subscribe to sql.active_record notifications, matching Rails:
 // ActiveSupport::Notifications.monotonic_subscribe("sql.active_record", ActiveRecord::RuntimeRegistry)
 Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
-  const lockWait = event.payload.lock_wait ?? event.payload.lockWait;
   record(event.payload.name as string | undefined, event.duration, {
     cached: event.payload.cached as boolean | undefined,
     async: event.payload.async as boolean | undefined,
-    lockWait: lockWait === undefined ? undefined : Number(lockWait),
+    lockWait: event.payload.lockWait as number | undefined,
   });
 });


### PR DESCRIPTION
## Summary

- **RuntimeRegistry** (0% → 100%): Full implementation with Stats tracking (sqlRuntime, asyncSqlRuntime, queriesCount, cachedQueriesCount), reset/resetRuntimes/resetQueriesCount/resetCachedQueriesCount, and automatic subscription to `sql.active_record` notifications
- **Querying** (67% → 100%): Added `_queryBySql` and `_loadFromSql` internal helpers matching Rails' `_query_by_sql` and `_load_from_sql`
- 11 new tests for RuntimeRegistry

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm vitest run packages/activerecord/src/runtime-registry.test.ts` — 11 pass
- [x] `pnpm run api:compare` — runtime_registry 100%, querying 100%
- [x] CI