### PR TITLE
chore(api-compare): extract excluded-files list, skip Ruby-only thread plumbing

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -70,7 +70,7 @@ interface PackageResult {
   percent: number;
   totalFiles: number;
   filesExist: number;
-  excludedFiles: number;
+  excludedFiles: string[];
   files: FileResult[];
 }
 
@@ -486,7 +486,7 @@ function main() {
       percent: pct,
       totalFiles,
       filesExist,
-      excludedFiles: excludedFiles.size,
+      excludedFiles: [...excludedFiles].sort(),
       files: fileResults,
     });
   }
@@ -525,7 +525,7 @@ function printReport(
 
     console.log(`\n${"=".repeat(100)}`);
     const excludedNote =
-      pkg.excludedFiles > 0 ? "  (some intentionally excluded, see excluded-files.ts)" : "";
+      pkg.excludedFiles.length > 0 ? "  (some intentionally excluded, see excluded-files.ts)" : "";
     console.log(
       `  ${pkg.package}  —  ${pkg.matched}/${pkg.totalMethods} methods (${pkg.percent}%)  |  files: ${pkg.filesExist}/${pkg.totalFiles}${excludedNote}`,
     );
@@ -554,11 +554,15 @@ function printReport(
           }
         }
       }
+
+      for (const excluded of pkg.excludedFiles) {
+        console.log(`  ${excluded.padEnd(55)} ${"(excluded)".padEnd(40)}`);
+      }
     }
   }
 
-  // Data layer summary (arel + activemodel + activerecord + activesupport)
-  const DATA_LAYER = new Set(["arel", "activemodel", "activerecord", "activesupport"]);
+  // Data layer summary (arel + activemodel + activerecord)
+  const DATA_LAYER = new Set(["arel", "activemodel", "activerecord"]);
   let dataTotal = 0;
   let dataMatched = 0;
   let dataFiles = 0;

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -19,6 +19,7 @@ import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import { isExcluded } from "./excluded-files.js";
 
 const DETAIL_PACKAGES = new Set([
   "arel",
@@ -30,9 +31,7 @@ const DETAIL_PACKAGES = new Set([
   "actionview",
 ]);
 
-// Ruby files to exclude from comparison — these are features that don't apply
-// pre-1.0 (migration compatibility layers, legacy adapters, etc.)
-const SKIP_FILES = ["migration/compatibility"];
+// Files intentionally excluded from comparison live in excluded-files.ts.
 
 // ---------------------------------------------------------------------------
 // Types
@@ -71,6 +70,7 @@ interface PackageResult {
   percent: number;
   totalFiles: number;
   filesExist: number;
+  excludedFiles: number;
   files: FileResult[];
 }
 
@@ -356,9 +356,13 @@ function main() {
 
     // Group by Ruby file
     const byFile = new Map<string, typeof allRuby>();
+    const excludedFiles = new Set<string>();
     for (const item of allRuby) {
       const file = item.info.file || "unknown.rb";
-      if (SKIP_FILES.some((pattern) => file.includes(pattern))) continue;
+      if (isExcluded(file)) {
+        excludedFiles.add(file);
+        continue;
+      }
       const list = byFile.get(file) || [];
       list.push(item);
       byFile.set(file, list);
@@ -482,6 +486,7 @@ function main() {
       percent: pct,
       totalFiles,
       filesExist,
+      excludedFiles: excludedFiles.size,
       files: fileResults,
     });
   }
@@ -519,8 +524,10 @@ function printReport(
     grandFilesExist += pkg.filesExist;
 
     console.log(`\n${"=".repeat(100)}`);
+    const excludedNote =
+      pkg.excludedFiles > 0 ? "  (some intentionally excluded, see excluded-files.ts)" : "";
     console.log(
-      `  ${pkg.package}  —  ${pkg.matched}/${pkg.totalMethods} methods (${pkg.percent}%)  |  files: ${pkg.filesExist}/${pkg.totalFiles}`,
+      `  ${pkg.package}  —  ${pkg.matched}/${pkg.totalMethods} methods (${pkg.percent}%)  |  files: ${pkg.filesExist}/${pkg.totalFiles}${excludedNote}`,
     );
     console.log(`${"=".repeat(100)}`);
 

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -1,0 +1,44 @@
+// Ruby files intentionally excluded from api:compare.
+//
+// Two kinds of exclusions:
+//   - pre-1.0 scope: features we haven't committed to porting yet
+//     (migration compatibility shims, legacy adapters, etc.)
+//   - not-applicable: Ruby-only concerns that don't map to JS
+//     (thread-pool plumbing, mutex-guarded schedulers, etc.)
+//
+// Patterns are matched as substrings against the Ruby file path reported
+// by extract-ruby-api.rb (e.g. "promise.rb", "migration/compatibility.rb").
+
+export interface ExcludedFile {
+  pattern: string;
+  reason: string;
+}
+
+export const EXCLUDED_FILES: ExcludedFile[] = [
+  {
+    pattern: "migration/compatibility",
+    reason: "Pre-1.0: legacy Rails version migration compatibility shims.",
+  },
+  {
+    pattern: "promise.rb",
+    reason:
+      "Rails Promise wraps a thread-backed FutureResult with a blocking #value. " +
+      "JS is single-threaded; native Promise covers #then. Async methods return Promise<T> directly.",
+  },
+  {
+    pattern: "future_result.rb",
+    reason:
+      "Thread-pool scheduled query with mutex + EventBuffer bridging Ruby's threaded async. " +
+      "Marked :nodoc: in Rails. Collapses to the Promise returned by the adapter's async exec.",
+  },
+  {
+    pattern: "asynchronous_queries_tracker.rb",
+    reason:
+      "Per-thread async session barriers (Concurrent::AtomicBoolean, ReadWriteLock). " +
+      "No equivalent in single-threaded event-loop JS.",
+  },
+];
+
+export function isExcluded(file: string): boolean {
+  return EXCLUDED_FILES.some((e) => file.includes(e.pattern));
+}


### PR DESCRIPTION
## Summary
- Move the exclusion list out of `compare.ts` into `scripts/api-compare/excluded-files.ts`, pairing each entry with a reason.
- Skip three Ruby-only thread-plumbing files whose concerns don't map to a single-threaded JS runtime:
  - `promise.rb` — wraps a thread-backed `FutureResult` with a blocking `#value`; native JS Promise covers `#then`.
  - `future_result.rb` — mutex + EventBuffer thread-pool scheduler (`:nodoc:`); collapses to the Promise returned by the adapter's async exec.
  - `asynchronous_queries_tracker.rb` — per-thread session barriers (`Concurrent::AtomicBoolean`, `ReadWriteLock`); no single-threaded equivalent.
- Per-package header notes `(some intentionally excluded, see excluded-files.ts)` when exclusions applied, and excluded files appear as `(excluded)` rows in the per-file table.
- **Drop `activesupport` from the data-layer summary rollup.** ActiveSupport is a general-purpose utilities library (inflection, caching, notifications, encryption), not part of the ORM data stack — it doesn't belong alongside arel/activemodel/activerecord when measuring data-layer API coverage. Its 24.8% coverage was also masking the real data-layer number. The data-layer rollup now reads 88.5% (arel + activemodel + activerecord); activesupport remains in its own per-package line and in the overall total.

## Test plan
- [x] \`pnpm run api:compare --package activerecord\` runs; header shows the exclusion note.
- [x] Excluded files do not contribute to matched/missing/totalFiles/filesExist — they \`continue\` before entering the match loop.
- [x] Excluded files render as \`(excluded)\` rows beneath the per-file table.
- [x] Data-layer summary excludes activesupport.
- [ ] CI api:compare job passes.