### PR TITLE
feat(activerecord): complete QueryLogs, QueryLogsFormatter, and StatementPool

### DIFF
--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -1,5 +1,100 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { StatementPool } from "./statement-pool.js";
 
 describe("StatementPoolTest", () => {
-  it.skip("#delete doesn't call dealloc if the statement didn't exist", () => {});
+  it("#delete doesn't call dealloc if the statement didn't exist", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool();
+    pool.delete("nonexistent");
+    expect(dealloced).toHaveLength(0);
+  });
+
+  it("#delete calls dealloc when statement exists", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool();
+    pool.set("key", "prepared_stmt");
+    pool.delete("key");
+    expect(dealloced).toEqual(["prepared_stmt"]);
+    expect(pool.length).toBe(0);
+  });
+
+  it("clear calls dealloc for each statement", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool();
+    pool.set("a", "stmt_a");
+    pool.set("b", "stmt_b");
+    pool.clear();
+    expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
+    expect(pool.length).toBe(0);
+  });
+
+  it("reset clears without calling dealloc", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool();
+    pool.set("a", "stmt_a");
+    pool.set("b", "stmt_b");
+    pool.reset();
+    expect(dealloced).toHaveLength(0);
+    expect(pool.length).toBe(0);
+  });
+
+  it("each iterates over all entries", () => {
+    const pool = new StatementPool<string>();
+    pool.set("a", "1");
+    pool.set("b", "2");
+    const entries: [string, string][] = [];
+    pool.each((key, stmt) => entries.push([key, stmt]));
+    expect(entries).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+    ]);
+  });
+
+  it("evicts oldest when exceeding max size", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool(2);
+    pool.set("a", "1");
+    pool.set("b", "2");
+    pool.set("c", "3");
+    expect(pool.length).toBe(2);
+    expect(pool.has("a")).toBe(false);
+    expect(pool.has("b")).toBe(true);
+    expect(pool.has("c")).toBe(true);
+  });
+
+  it("LRU: get moves entry to end", () => {
+    const pool = new StatementPool<string>(2);
+    pool.set("a", "1");
+    pool.set("b", "2");
+    pool.get("a"); // touch a, making b the oldest
+    pool.set("c", "3"); // should evict b, not a
+    expect(pool.has("a")).toBe(true);
+    expect(pool.has("b")).toBe(false);
+    expect(pool.has("c")).toBe(true);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -85,6 +85,7 @@ describe("StatementPoolTest", () => {
     expect(pool.has("a")).toBe(false);
     expect(pool.has("b")).toBe(true);
     expect(pool.has("c")).toBe(true);
+    expect(dealloced).toEqual(["1"]);
   });
 
   it("LRU: get moves entry to end", () => {

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -28,9 +28,12 @@ export class StatementPool<T = unknown> {
   set(key: string, stmt: T): void {
     if (this._maxSize <= 0) return;
     this._statements.delete(key);
-    if (this._statements.size >= this._maxSize) {
+    while (this._statements.size >= this._maxSize) {
       const firstKey = this._statements.keys().next().value;
-      if (firstKey !== undefined) this._statements.delete(firstKey);
+      if (firstKey === undefined) break;
+      const evicted = this._statements.get(firstKey)!;
+      this._statements.delete(firstKey);
+      this.dealloc(evicted);
     }
     this._statements.set(key, stmt);
   }

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -39,15 +39,54 @@ export class StatementPool<T = unknown> {
     return this._statements.has(key);
   }
 
-  delete(key: string): boolean {
-    return this._statements.delete(key);
+  delete(key: string): T | undefined {
+    const stmt = this._statements.get(key);
+    if (stmt !== undefined) {
+      this._statements.delete(key);
+      this.dealloc(stmt);
+    }
+    return stmt;
   }
 
   clear(): void {
+    for (const stmt of this._statements.values()) {
+      this.dealloc(stmt);
+    }
     this._statements.clear();
+  }
+
+  /**
+   * Clear without deallocating — only safe when the server has
+   * independently deallocated all statements (e.g. reconnect, DISCARD ALL).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool#reset
+   */
+  reset(): void {
+    this._statements.clear();
+  }
+
+  /**
+   * Iterate over all [key, statement] pairs.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool#each (Enumerable)
+   */
+  each(fn: (key: string, stmt: T) => void): void {
+    for (const [key, stmt] of this._statements) {
+      fn(key, stmt);
+    }
   }
 
   get keys(): string[] {
     return [...this._statements.keys()];
+  }
+
+  /**
+   * Deallocate a prepared statement. Subclasses override this to
+   * release adapter-specific resources (e.g. PG DEALLOCATE).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool#dealloc
+   */
+  protected dealloc(_stmt: T): void {
+    // Base implementation is a no-op; adapter-specific pools override.
   }
 }

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -43,11 +43,10 @@ export class StatementPool<T = unknown> {
   }
 
   delete(key: string): T | undefined {
-    const stmt = this._statements.get(key);
-    if (stmt !== undefined) {
-      this._statements.delete(key);
-      this.dealloc(stmt);
-    }
+    if (!this._statements.has(key)) return undefined;
+    const stmt = this._statements.get(key) as T;
+    this._statements.delete(key);
+    this.dealloc(stmt);
     return stmt;
   }
 

--- a/packages/activerecord/src/query-logs-formatter.ts
+++ b/packages/activerecord/src/query-logs-formatter.ts
@@ -1,0 +1,47 @@
+/**
+ * Query log formatters — format key/value pairs for SQL comment annotations.
+ *
+ * Mirrors: ActiveRecord::QueryLogs::LegacyFormatter
+ *          ActiveRecord::QueryLogs::SQLCommenter
+ */
+
+export type TagValue = string | number | boolean | null | undefined;
+
+export interface QueryLogsFormatter {
+  format(key: string, value: TagValue): string;
+  join(pairs: string[]): string;
+}
+
+/**
+ * Legacy Rails format: key:value pairs separated by commas.
+ * Example: application:MyApp,controller:users
+ *
+ * Mirrors: ActiveRecord::QueryLogs::LegacyFormatter
+ */
+export const LegacyFormatter: QueryLogsFormatter = {
+  format(key: string, value: TagValue): string {
+    return `${key}:${value}`;
+  },
+  join(pairs: string[]): string {
+    return pairs.join(",");
+  },
+};
+
+/**
+ * SQLCommenter format (OpenTelemetry standard).
+ * Example: application='MyApp',controller='users'
+ *
+ * Mirrors: ActiveRecord::QueryLogs::SQLCommenter
+ */
+export const SQLCommenter: QueryLogsFormatter = {
+  format(key: string, value: TagValue): string {
+    return `${sqlCommenterEncode(key)}='${sqlCommenterEncode(String(value))}'`;
+  },
+  join(pairs: string[]): string {
+    return pairs.join(",");
+  },
+};
+
+function sqlCommenterEncode(value: string): string {
+  return encodeURIComponent(value).replace(/'/g, "%27");
+}

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -8,41 +8,14 @@
  */
 
 import { ConfigurationError } from "./errors.js";
+import { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
+import type { TagValue, QueryLogsFormatter } from "./query-logs-formatter.js";
 
-export type TagValue = string | number | boolean | null | undefined;
+export { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
+export type { TagValue, QueryLogsFormatter } from "./query-logs-formatter.js";
+
 export type TagHandler = (context?: Record<string, TagValue>) => TagValue;
 export type TagDefinition = string | TagHandler | Record<string, TagValue | TagHandler>;
-
-export interface QueryLogsFormatter {
-  format(key: string, value: TagValue): string;
-  join(pairs: string[]): string;
-}
-
-/**
- * Legacy Rails format: key:value pairs.
- * Example: /* application:MyApp, controller:users * /
- */
-export const LegacyFormatter: QueryLogsFormatter = {
-  format(key: string, value: TagValue): string {
-    return `${key}:${value}`;
-  },
-  join(pairs: string[]): string {
-    return pairs.join(", ");
-  },
-};
-
-/**
- * SQLCommenter format (OpenTelemetry standard).
- * Example: /* application='MyApp',controller='users' * /
- */
-export const SQLCommenter: QueryLogsFormatter = {
-  format(key: string, value: TagValue): string {
-    return `${sqlCommenterEncode(key)}='${sqlCommenterEncode(String(value))}'`;
-  },
-  join(pairs: string[]): string {
-    return pairs.join(",");
-  },
-};
 
 /**
  * QueryLogs configuration and SQL comment generation.
@@ -62,6 +35,14 @@ export class QueryLogs {
   set tags(tags: TagDefinition[]) {
     this._tags = tags;
     this._cachedComment = undefined;
+  }
+
+  /**
+   * Alias for tags setter — Rails deprecated taggings= in favor of tags=.
+   * Mirrors: ActiveRecord::QueryLogs.taggings=
+   */
+  set taggings(tags: TagDefinition[]) {
+    this.tags = tags;
   }
 
   get prependComment(): boolean {
@@ -122,18 +103,36 @@ export class QueryLogs {
     this._cachedComment = undefined;
   }
 
-  private comment(): string | null {
-    if (this._cacheEnabled && this._cachedComment !== undefined) {
-      return this._cachedComment;
+  /**
+   * Return the source location of the query caller.
+   * In Rails this walks the call stack to find the first non-framework
+   * caller. In JS we use Error.stack parsing.
+   *
+   * Mirrors: ActiveRecord::QueryLogs.query_source_location
+   */
+  querySourceLocation(): string | null {
+    const stack = new Error().stack;
+    if (!stack) return null;
+    const lines = stack.split("\n").slice(2);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (
+        !trimmed.includes("node_modules") &&
+        !trimmed.includes("query-logs") &&
+        !trimmed.includes("activerecord/dist")
+      ) {
+        const match = trimmed.match(/at\s+(?:.*?\s+\()?(.*?):(\d+):(\d+)\)?$/);
+        if (match) return `${match[1]}:${match[2]}`;
+      }
     }
-    const result = this.uncachedComment();
-    if (this._cacheEnabled) {
-      this._cachedComment = result;
-    }
-    return result;
+    return null;
   }
 
-  private uncachedComment(): string | null {
+  /**
+   * Build the tag content string from current tags and context.
+   * Mirrors: ActiveRecord::QueryLogs.tag_content
+   */
+  tagContent(): string | null {
     const pairs: string[] = [];
     for (const tag of this._tags) {
       if (typeof tag === "string") {
@@ -156,17 +155,29 @@ export class QueryLogs {
       }
     }
     if (pairs.length === 0) return null;
-    const content = this._formatter.join(pairs);
+    return this._formatter.join(pairs);
+  }
+
+  /**
+   * Build the full SQL comment from tags.
+   * Mirrors: ActiveRecord::QueryLogs.comment
+   */
+  comment(): string | null {
+    if (this._cacheEnabled && this._cachedComment !== undefined) {
+      return this._cachedComment;
+    }
+    const result = this.uncachedComment();
+    if (this._cacheEnabled) {
+      this._cachedComment = result;
+    }
+    return result;
+  }
+
+  private uncachedComment(): string | null {
+    const content = this.tagContent();
+    if (!content) return null;
     return `/*${escapeComment(content)}*/`;
   }
-}
-
-/**
- * Encode a value for SQLCommenter format.
- * Uses encodeURIComponent plus additional escaping for single quotes.
- */
-function sqlCommenterEncode(value: string): string {
-  return encodeURIComponent(value).replace(/'/g, "%27");
 }
 
 /**

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -121,7 +121,7 @@ export class QueryLogs {
         !trimmed.includes("query-logs") &&
         !trimmed.includes("activerecord/dist")
       ) {
-        const match = trimmed.match(/at\s+(?:.*?\s+\()?(.*?):(\d+):(\d+)\)?$/);
+        const match = trimmed.match(/at\s+(?:.*?\s+\()?(.+):(\d+):\d+\)?$/);
         if (match) return `${match[1]}:${match[2]}`;
       }
     }


### PR DESCRIPTION
## Summary

- **QueryLogsFormatter** (0% → 100%): New file with LegacyFormatter and SQLCommenter matching Rails' `query_logs_formatter.rb`. Moved implementations out of `query-logs.ts` to match Rails file organization.
- **QueryLogs** (56% → 78%): Added `taggings` setter, public `comment`/`tagContent`/`querySourceLocation` methods. Refactored `uncachedComment` to delegate to `tagContent`.
- **StatementPool** (57% → 86%): Added `reset` (clear without dealloc), `each` (iteration), `dealloc` (subclass hook). `delete`/`clear` now call `dealloc` on removed statements matching Rails.
- 7 new StatementPool tests covering dealloc on delete/clear, reset without dealloc, iteration, LRU eviction

## Test plan

- [x] `pnpm run build` — clean
- [x] 30 tests pass (query-logs + statement-pool)
- [x] `pnpm run api:compare` — formatter 100%, query-logs 78%, statement-pool 86%
- [x] CI