### PR TITLE
feat(api-compare): exclude Ruby-only serialization rubyisms from api+test compare

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -554,10 +554,6 @@ function printReport(
           }
         }
       }
-
-      for (const excluded of pkg.excludedFiles) {
-        console.log(`  ${excluded.padEnd(55)} ${"(excluded)".padEnd(40)}`);
-      }
     }
   }
 

--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -1,16 +1,20 @@
-// Ruby files intentionally excluded from api:compare.
+// Ruby files intentionally excluded from api:compare / test:compare.
 //
 // Two kinds of exclusions:
 //   - pre-1.0 scope: features we haven't committed to porting yet
 //     (migration compatibility shims, legacy adapters, etc.)
 //   - not-applicable: Ruby-only concerns that don't map to JS
-//     (thread-pool plumbing, mutex-guarded schedulers, etc.)
+//     (thread-pool plumbing, Marshal/Psych/MessagePack formats, etc.)
 //
-// Patterns are matched as substrings against the Ruby file path reported
-// by extract-ruby-api.rb (e.g. "promise.rb", "migration/compatibility.rb").
+// `pattern` matches against the Ruby source file path from extract-ruby-api.rb
+// (e.g. "promise.rb", "coders/yaml_column.rb").
+// `testFile` (optional) matches against the Ruby test file path from
+// extract-ruby-tests.rb (e.g. "message_pack_test.rb"). Omit when there is
+// no corresponding test file in the Rails suite.
 
 export interface ExcludedFile {
   pattern: string;
+  testFile?: string;
   reason: string;
 }
 
@@ -33,12 +37,45 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
   },
   {
     pattern: "asynchronous_queries_tracker.rb",
+    testFile: "asynchronous_queries_test.rb",
     reason:
       "Per-thread async session barriers (Concurrent::AtomicBoolean, ReadWriteLock). " +
       "No equivalent in single-threaded event-loop JS.",
+  },
+  {
+    pattern: "marshalling.rb",
+    testFile: "marshal_serialization_test.rb",
+    reason:
+      "Ruby's Marshal binary format (Marshal.dump/load). No JS equivalent; " +
+      "JS cache/session layers use JSON or structured clone.",
+  },
+  {
+    pattern: "message_pack.rb",
+    testFile: "message_pack_test.rb",
+    reason:
+      "Rails-integrated MessagePack (:nodoc:) registers AR records with " +
+      "ActiveSupport::MessagePack encoder/decoder. Ruby-only coupling; " +
+      "MessagePack-the-format exists in JS but this file is the Marshal bridge, not a reusable impl.",
+  },
+  {
+    pattern: "legacy_yaml_adapter.rb",
+    reason:
+      "Migrates Psych::Coder YAML format versions (:nodoc:). Psych is Ruby-only; " +
+      "JS doesn't use YAML for AR column serialization.",
+  },
+  {
+    pattern: "coders/yaml_column.rb",
+    testFile: "coders/yaml_column_test.rb",
+    reason:
+      "YAML column coder built on Psych. `serialize :col, coder: YAMLColumn` has " +
+      "no natural JS analog; JSON is the default column coder instead.",
   },
 ];
 
 export function isExcluded(file: string): boolean {
   return EXCLUDED_FILES.some((e) => file.includes(e.pattern));
+}
+
+export function isTestExcluded(testFile: string): boolean {
+  return EXCLUDED_FILES.some((e) => e.testFile && testFile.includes(e.testFile));
 }

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -502,7 +502,7 @@ function main() {
 
     results.push({
       package: pkg,
-      rubyFiles: pkgInfo.files.length,
+      rubyFiles: pkgInfo.files.filter((f) => !isTestExcluded(f.file)).length,
       tsMapped,
       tsUnmapped,
       totalRubyTests: totalRuby,

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -27,6 +27,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { TestManifest } from "./types.js";
+import { isTestExcluded } from "../api-compare/excluded-files.js";
 
 const SCRIPT_DIR = __dirname;
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
@@ -258,6 +259,7 @@ function main() {
     const rubyPathToFileCount = new Map<string, number>();
     const rubyDescToFileCount = new Map<string, number>();
     for (const file of pkgInfo.files) {
+      if (isTestExcluded(file.file)) continue;
       const seenPaths = new Set<string>();
       const seenDescs = new Set<string>();
       for (const tc of file.testCases) {
@@ -283,6 +285,7 @@ function main() {
     let tsUnmapped = 0;
 
     for (const file of pkgInfo.files) {
+      if (isTestExcluded(file.file)) continue;
       const conventionTs = rubyToConventionTs(file.file, pkg);
       const exists = lookup.allFiles.has(conventionTs);
 


### PR DESCRIPTION
## Summary
Add four ActiveRecord rubyism exclusions — files whose entire purpose is Ruby-specific serialization formats with no JS analog:

- **marshalling.rb** — Ruby `Marshal.dump`/`load` binary format
- **message_pack.rb** (`:nodoc:`) — Rails MessagePack / Marshal bridge (registers AR types with `ActiveSupport::MessagePack`)
- **legacy_yaml_adapter.rb** (`:nodoc:`) — Psych `Coder` YAML version migration
- **coders/yaml_column.rb** — YAML column coder built on Psych

Extend `excluded-files.ts` with an optional `testFile` pattern per entry and an `isTestExcluded()` helper. Wire `test:compare` to skip corresponding test files (`marshal_serialization_test.rb`, `message_pack_test.rb`, `coders/yaml_column_test.rb`, `asynchronous_queries_test.rb`) so our test-coverage % reflects intentional scope.

Drop the `(excluded)` rows from `api:compare` output — the per-package header note already conveys it without cluttering the table.

## Test plan
- [x] `pnpm run api:compare --package activerecord` — no `(excluded)` rows; 4 fewer files counted.
- [x] `pnpm run test:compare --package activerecord` — excluded test files skipped; encryption files with `message_pack` as substring (e.g. `message_pack_message_serializer_test.rb`) correctly NOT skipped.
- [ ] CI passes.