### PR TITLE
feat(activerecord): OID::Date + OID::DateTime retrofit

### DIFF
--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,7 +1,7 @@
 import { Type } from "./value.js";
 
 export class DateType extends Type<Date> {
-  readonly name = "date";
+  readonly name: string = "date";
 
   cast(value: unknown): Date | null {
     if (value === null || value === undefined) return null;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -1,0 +1,54 @@
+import { DateTimeType } from "@blazetrails/activemodel";
+import { describe, expect, it } from "vitest";
+
+import { DateTime } from "./date-time.js";
+import { Timestamp } from "./timestamp.js";
+import { TimestampWithTimeZone } from "./timestamp-with-time-zone.js";
+
+describe("PostgreSQL::OID::DateTime", () => {
+  const type = new DateTime();
+
+  it("extends Type::DateTime", () => {
+    expect(type).toBeInstanceOf(DateTimeType);
+  });
+
+  it("casts 'infinity' / '-infinity' sentinels", () => {
+    expect(type.cast("infinity")).toBe(Infinity);
+    expect(type.cast("-infinity")).toBe(-Infinity);
+  });
+
+  it("rewrites BC-era timestamps with a biased year", () => {
+    const result = type.cast("0044-03-15 12:00:00 BC");
+    expect(result).toBeInstanceOf(Date);
+    expect((result as Date).getUTCFullYear()).toBe(-43);
+  });
+
+  it("type_cast_for_schema renders infinity sentinels", () => {
+    expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
+    expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
+  });
+});
+
+describe("PostgreSQL::OID::Timestamp", () => {
+  it("extends OID::DateTime and reports :timestamp", () => {
+    const type = new Timestamp();
+    expect(type).toBeInstanceOf(DateTime);
+    expect(type.type()).toBe("timestamp");
+  });
+
+  it("inherits infinity + BC handling from OID::DateTime", () => {
+    expect(new Timestamp().cast("infinity")).toBe(Infinity);
+  });
+});
+
+describe("PostgreSQL::OID::TimestampWithTimeZone", () => {
+  it("extends OID::DateTime and reports :timestamptz", () => {
+    const type = new TimestampWithTimeZone();
+    expect(type).toBeInstanceOf(DateTime);
+    expect(type.type()).toBe("timestamptz");
+  });
+
+  it("inherits infinity + BC handling from OID::DateTime", () => {
+    expect(new TimestampWithTimeZone().cast("-infinity")).toBe(-Infinity);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -47,6 +47,22 @@ describe("PostgreSQL::OID::DateTime", () => {
     const d = type.cast("0044-03-15 12:00:00.289 BC") as Date;
     expect(d.getUTCMilliseconds()).toBe(289);
   });
+
+  it("carries fractional-second rounding into whole seconds", () => {
+    // 0.9999 * 1000 rounds to 1000. Naive Math.round would pass 1000
+    // to setUTCHours and silently roll the timestamp forward by a
+    // second. Verify we carry into seconds instead.
+    const d = type.cast("0044-03-15 12:00:00.9999 BC") as Date;
+    expect(d.getUTCSeconds()).toBe(1);
+    expect(d.getUTCMilliseconds()).toBe(0);
+  });
+
+  it("rejects sub-second carry that would overflow the minute", () => {
+    // 59.9999 with carry → seconds = 60. That's invalid input per our
+    // second < 60 guard; return null rather than letting it roll into
+    // the next minute.
+    expect(type.cast("0044-03-15 12:00:59.9999 BC")).toBeNull();
+  });
 });
 
 describe("PostgreSQL::OID::Timestamp", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -27,6 +27,26 @@ describe("PostgreSQL::OID::DateTime", () => {
     expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
     expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
   });
+
+  it("rejects BC timestamps with out-of-range components", () => {
+    expect(type.cast("0044-13-01 00:00:00 BC")).toBeNull();
+    expect(type.cast("0044-02-31 00:00:00 BC")).toBeNull();
+    expect(type.cast("0044-01-01 25:00:00 BC")).toBeNull();
+    expect(type.cast("0044-01-01 00:00:60 BC")).toBeNull();
+  });
+
+  it("rejects BC timestamps with a timezone offset", () => {
+    // Offset handling on BC inputs is rare and requires arithmetic
+    // we haven't needed; reject explicitly rather than silently
+    // ignoring the offset.
+    expect(type.cast("0044-03-15 12:00:00+02 BC")).toBeNull();
+  });
+
+  it("preserves fractional seconds exactly via Math.round", () => {
+    // 0.289 * 1000 floats to 288.999… — Math.round keeps it at 289.
+    const d = type.cast("0044-03-15 12:00:00.289 BC") as Date;
+    expect(d.getUTCMilliseconds()).toBe(289);
+  });
 });
 
 describe("PostgreSQL::OID::Timestamp", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -33,8 +33,14 @@ export class DateTime extends DateTimeType {
       if (value === "infinity") return Infinity as unknown as globalThis.Date;
       if (value === "-infinity") return -Infinity as unknown as globalThis.Date;
       if (/ BC$/.test(value)) {
+        // Accept: "YYYY-MM-DD BC" or "YYYY-MM-DD HH:MM:SS[.f] BC".
+        // Reject anything with a timezone suffix (e.g. "+02", "-05:30")
+        // on a BC timestamp — that's rare in PG output and supporting
+        // it correctly requires offset arithmetic we haven't needed yet.
         const match =
-          /^(\d+)-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{1,2}):(\d{1,2}(?:\.\d+)?))?/.exec(value);
+          /^(\d+)-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{1,2}):(\d{1,2}(?:\.\d+)?))?(?:\s+BC)$/.exec(
+            value,
+          );
         if (!match) return null;
         const year = -Number.parseInt(match[1], 10) + 1;
         const month = Number.parseInt(match[2], 10) - 1;
@@ -42,9 +48,35 @@ export class DateTime extends DateTimeType {
         const hour = match[4] ? Number.parseInt(match[4], 10) : 0;
         const minute = match[5] ? Number.parseInt(match[5], 10) : 0;
         const second = match[6] ? Number.parseFloat(match[6]) : 0;
+        // Reject out-of-range components — setUTC* silently normalises
+        // (month 13, day 32, second 60) and would produce valid Dates
+        // for malformed input.
+        if (
+          month < 0 ||
+          month > 11 ||
+          day < 1 ||
+          day > 31 ||
+          hour < 0 ||
+          hour > 23 ||
+          minute < 0 ||
+          minute > 59 ||
+          second < 0 ||
+          second >= 60
+        ) {
+          return null;
+        }
+        const wholeSeconds = Math.floor(second);
+        // Math.round avoids off-by-1ms drift from floating-point
+        // multiplication (e.g. 0.289 * 1000 = 288.999…).
+        const ms = Math.round((second - wholeSeconds) * 1000);
         const d = new globalThis.Date(0);
         d.setUTCFullYear(year, month, day);
-        d.setUTCHours(hour, minute, Math.floor(second), (second % 1) * 1000);
+        d.setUTCHours(hour, minute, wholeSeconds, ms);
+        // Guard against roll-over from Feb 31 etc. even after the
+        // upper-bound check (valid high day for wrong month).
+        if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month || d.getUTCDate() !== day) {
+          return null;
+        }
         return d;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -1,37 +1,70 @@
 /**
- * PostgreSQL datetime type — timestamp without time zone.
+ * PostgreSQL datetime OID type.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime.
+ * Rails: `class DateTime < Type::DateTime`. Overrides cast_value to
+ * handle PG's "infinity" / "-infinity" / " BC" strings, and
+ * type_cast_for_schema so infinity sentinels render as
+ * `::Float::INFINITY` in schema dumps. Exposes a protected
+ * `real_type_unless_aliased(real_type)` hook that Timestamp /
+ * TimestampWithTimeZone use to report :datetime when the adapter's
+ * datetime_type is aliased.
  */
 
-export class DateTime {
-  get type(): string {
-    return "datetime";
+import { DateTimeType } from "@blazetrails/activemodel";
+
+export class DateTime extends DateTimeType {
+  override readonly name: string = "datetime";
+
+  /**
+   * See OID::Date for the Float::INFINITY return-type tradeoff — same
+   * escape hatch applies here.
+   */
+  override cast(value: unknown): globalThis.Date | null {
+    return this.castValue(value);
   }
 
-  cast(value: unknown): globalThis.Date | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) return value;
+  /**
+   * Rails' `cast_value` — public here so subclasses can call directly
+   * and api:compare matches the Rails method name.
+   */
+  castValue(value: unknown): globalThis.Date | null {
     if (typeof value === "string") {
-      if (value === "") return null;
-      const parsed = new globalThis.Date(value);
-      if (isNaN(parsed.getTime())) return null;
-      return parsed;
+      if (value === "infinity") return Infinity as unknown as globalThis.Date;
+      if (value === "-infinity") return -Infinity as unknown as globalThis.Date;
+      if (/ BC$/.test(value)) {
+        const match =
+          /^(\d+)-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{1,2}):(\d{1,2}(?:\.\d+)?))?/.exec(value);
+        if (!match) return null;
+        const year = -Number.parseInt(match[1], 10) + 1;
+        const month = Number.parseInt(match[2], 10) - 1;
+        const day = Number.parseInt(match[3], 10);
+        const hour = match[4] ? Number.parseInt(match[4], 10) : 0;
+        const minute = match[5] ? Number.parseInt(match[5], 10) : 0;
+        const second = match[6] ? Number.parseFloat(match[6]) : 0;
+        const d = new globalThis.Date(0);
+        d.setUTCFullYear(year, month, day);
+        d.setUTCHours(hour, minute, Math.floor(second), (second % 1) * 1000);
+        return d;
+      }
     }
-    if (typeof value === "number") return new globalThis.Date(value);
-    return null;
+    return super.cast(value);
   }
 
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) {
-      return value.toISOString().replace("T", " ").replace("Z", "");
-    }
-    if (typeof value === "string") return value;
-    return null;
+  override typeCastForSchema(value: unknown): string {
+    if (value === Infinity) return "::Float::INFINITY";
+    if (value === -Infinity) return "-::Float::INFINITY";
+    return super.typeCastForSchema(value);
   }
 
-  deserialize(value: unknown): globalThis.Date | null {
-    return this.cast(value);
+  /**
+   * Rails' `real_type_unless_aliased` — Timestamp / TimestampWithTimeZone
+   * call this to return `:datetime` when the adapter's datetime_type
+   * matches `real_type`, else `real_type` itself. We don't yet have a
+   * per-adapter datetime_type setting so always return the real type,
+   * matching Rails' default when nothing is aliased.
+   */
+  protected realTypeUnlessAliased(realType: string): string {
+    return realType;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -65,10 +65,18 @@ export class DateTime extends DateTimeType {
         ) {
           return null;
         }
-        const wholeSeconds = Math.floor(second);
+        let wholeSeconds = Math.floor(second);
         // Math.round avoids off-by-1ms drift from floating-point
-        // multiplication (e.g. 0.289 * 1000 = 288.999…).
-        const ms = Math.round((second - wholeSeconds) * 1000);
+        // multiplication (e.g. 0.289 * 1000 = 288.999…). Round can
+        // also yield 1000 for inputs like 59.999999 — handle that
+        // carry explicitly rather than letting setUTCHours roll the
+        // timestamp forward.
+        let ms = Math.round((second - wholeSeconds) * 1000);
+        if (ms === 1000) {
+          ms = 0;
+          wholeSeconds += 1;
+          if (wholeSeconds >= 60) return null;
+        }
         const d = new globalThis.Date(0);
         d.setUTCFullYear(year, month, day);
         d.setUTCHours(hour, minute, wholeSeconds, ms);

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
@@ -30,4 +30,12 @@ describe("PostgreSQL::OID::Date", () => {
     expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
     expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
   });
+
+  it("cast_value is the Rails-named hook cast delegates to", () => {
+    // Direct cast_value call: same behavior as cast. Rails' cast_value
+    // is protected; we expose it publicly so callers that want to skip
+    // the nil-check in cast (Type::Value#cast) can reach the hook.
+    expect(type.castValue("infinity")).toBe(Infinity);
+    expect(type.castValue("2024-06-15")).toBeInstanceOf(Date);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
@@ -1,0 +1,33 @@
+import { DateType } from "@blazetrails/activemodel";
+import { describe, expect, it } from "vitest";
+
+import { Date as OidDate } from "./date.js";
+
+describe("PostgreSQL::OID::Date", () => {
+  const type = new OidDate();
+
+  it("extends Type::Date", () => {
+    expect(type).toBeInstanceOf(DateType);
+  });
+
+  it("casts 'infinity' to Float::INFINITY", () => {
+    expect(type.cast("infinity")).toBe(Infinity);
+  });
+
+  it("casts '-infinity' to -Float::INFINITY", () => {
+    expect(type.cast("-infinity")).toBe(-Infinity);
+  });
+
+  it("rewrites BC-era dates with a biased year and delegates to super", () => {
+    // "0044-03-15 BC" → year -43 (Ides of March, 44 BC). Rails uses
+    // -year+1 so 0001 BC → 0000, 0044 BC → -0043.
+    const result = type.cast("0044-03-15 BC");
+    expect(result).toBeInstanceOf(Date);
+    expect((result as Date).getUTCFullYear()).toBe(-43);
+  });
+
+  it("type_cast_for_schema renders the infinity sentinels", () => {
+    expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
+    expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
@@ -32,10 +32,17 @@ describe("PostgreSQL::OID::Date", () => {
   });
 
   it("cast_value is the Rails-named hook cast delegates to", () => {
-    // Direct cast_value call: same behavior as cast. Rails' cast_value
-    // is protected; we expose it publicly so callers that want to skip
-    // the nil-check in cast (Type::Value#cast) can reach the hook.
+    // Direct cast_value call: same behavior as cast — exposed publicly
+    // so callers can invoke the Rails-named method by name (and so
+    // api:compare matches it).
     expect(type.castValue("infinity")).toBe(Infinity);
     expect(type.castValue("2024-06-15")).toBeInstanceOf(Date);
+  });
+
+  it("rejects BC dates with out-of-range month or day", () => {
+    // setUTCFullYear would silently roll Feb 30 into March; validate
+    // and return null instead.
+    expect(type.cast("0044-13-15 BC")).toBeNull();
+    expect(type.cast("0044-02-31 BC")).toBeNull();
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
@@ -49,9 +49,18 @@ export class Date extends DateType {
         const year = -Number.parseInt(match[1], 10) + 1;
         const month = Number.parseInt(match[2], 10) - 1;
         const day = Number.parseInt(match[3], 10);
+        // Reject out-of-range components — setUTCFullYear silently
+        // normalises (month 13 → January of next year, day 32 → next
+        // month) which would turn malformed input into a valid Date.
+        if (month < 0 || month > 11 || day < 1 || day > 31) return null;
         const d = new globalThis.Date(0);
         d.setUTCFullYear(year, month, day);
         d.setUTCHours(0, 0, 0, 0);
+        // Verify the constructed date matches the requested components;
+        // setUTCFullYear would have rolled over for e.g. Feb 31.
+        if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month || d.getUTCDate() !== day) {
+          return null;
+        }
         return d;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
@@ -1,36 +1,66 @@
 /**
- * PostgreSQL date type.
+ * PostgreSQL date OID type.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date.
+ * Rails: `class Date < Type::Date`. Overrides cast_value to handle
+ * PG-specific string forms ("infinity" / "-infinity" / "… BC" for BCE
+ * dates) and type_cast_for_schema so those sentinels render as
+ * `::Float::INFINITY` / `-::Float::INFINITY` in schema dumps.
  */
 
-export class Date {
-  get type(): string {
-    return "date";
+import { DateType } from "@blazetrails/activemodel";
+
+export class Date extends DateType {
+  override readonly name: string = "date";
+
+  /**
+   * Rails' cast_value handles:
+   *   "infinity"         → Float::INFINITY
+   *   "-infinity"        → -Float::INFINITY
+   *   "0001-01-01 BC"    → date with a biased (Rails-style) year
+   *   everything else    → super (standard date parse)
+   *
+   * Rails returns Float::INFINITY from a Date type, which is dynamic
+   * Ruby. The TS signature is `Date | null`; the infinity sentinels
+   * are cast through `as unknown as Date` so callers that accept
+   * Rails' range-bound semantics still receive them. Check with
+   * `Number.isFinite` or `typeof === 'number'` before treating as a
+   * real Date.
+   */
+  override cast(value: unknown): globalThis.Date | null {
+    return this.castValue(value);
   }
 
-  cast(value: unknown): globalThis.Date | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) return value;
+  /**
+   * Rails' `cast_value` — the protected hook cast delegates to. Kept
+   * public here so subclasses (and tests) can call it directly, and so
+   * api:compare finds the method name that matches Rails.
+   */
+  castValue(value: unknown): globalThis.Date | null {
     if (typeof value === "string") {
-      if (value === "") return null;
-      const parsed = new globalThis.Date(value + "T00:00:00Z");
-      if (isNaN(parsed.getTime())) return null;
-      return parsed;
+      if (value === "infinity") return Infinity as unknown as globalThis.Date;
+      if (value === "-infinity") return -Infinity as unknown as globalThis.Date;
+      if (/ BC$/.test(value)) {
+        // Rails' cast_value rewrites "0044-03-15 BC" → "-0043-03-15"
+        // (year mapped as -year+1). JS's Date parser doesn't accept
+        // 4-digit negative years, so construct the Date manually.
+        const match = /^(\d+)-(\d{1,2})-(\d{1,2})/.exec(value);
+        if (!match) return null;
+        const year = -Number.parseInt(match[1], 10) + 1;
+        const month = Number.parseInt(match[2], 10) - 1;
+        const day = Number.parseInt(match[3], 10);
+        const d = new globalThis.Date(0);
+        d.setUTCFullYear(year, month, day);
+        d.setUTCHours(0, 0, 0, 0);
+        return d;
+      }
     }
-    return null;
+    return super.cast(value);
   }
 
-  serialize(value: unknown): string | null {
-    if (value == null) return null;
-    if (value instanceof globalThis.Date) {
-      return value.toISOString().split("T")[0];
-    }
-    if (typeof value === "string") return value;
-    return null;
-  }
-
-  deserialize(value: unknown): globalThis.Date | null {
-    return this.cast(value);
+  override typeCastForSchema(value: unknown): string {
+    if (value === Infinity) return "::Float::INFINITY";
+    if (value === -Infinity) return "-::Float::INFINITY";
+    return super.typeCastForSchema(value);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
@@ -2,26 +2,21 @@
  * PostgreSQL timestamptz type — timestamp with time zone.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TimestampWithTimeZone.
- * Rails: `class TimestampWithTimeZone < DateTime`. Overrides type and
- * cast_value to normalise returned times to UTC when the connection
- * is in UTC mode (the PG gem may return non-UTC times even when the
- * wire-protocol value was UTC).
+ * Rails: `class TimestampWithTimeZone < DateTime`. `type` calls
+ * real_type_unless_aliased(:timestamptz). `cast_value` normalises
+ * returned times to UTC when the connection is in UTC mode — JS Date
+ * is always UTC-internal, so the inherited cast_value is already
+ * correct; we only override `type`.
  */
 
-import { DateTimeType } from "@blazetrails/activemodel";
+import { DateTime } from "./date-time.js";
 
-export class TimestampWithTimeZone extends DateTimeType {
+export class TimestampWithTimeZone extends DateTime {
   override readonly name: string = "timestamptz";
 
   override type(): string {
-    return "timestamptz";
+    return (this as unknown as { realTypeUnlessAliased(t: string): string }).realTypeUnlessAliased(
+      "timestamptz",
+    );
   }
-
-  /**
-   * Rails normalises via `time.getutc` / `time.getlocal` depending on
-   * the connection's `is_utc?` mode. JS Date is always UTC-based
-   * internally; `toISOString()` always produces UTC. We don't yet have
-   * a per-adapter timezone setting plumbed through, so defer to the
-   * parent cast and let JS Date's UTC-internal representation stand.
-   */
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp-with-time-zone.ts
@@ -15,8 +15,6 @@ export class TimestampWithTimeZone extends DateTime {
   override readonly name: string = "timestamptz";
 
   override type(): string {
-    return (this as unknown as { realTypeUnlessAliased(t: string): string }).realTypeUnlessAliased(
-      "timestamptz",
-    );
+    return this.realTypeUnlessAliased("timestamptz");
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
@@ -2,19 +2,19 @@
  * PostgreSQL timestamp type — timestamp without time zone.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Timestamp.
- * Rails: `class Timestamp < DateTime; def type; real_type_unless_aliased(:timestamp); end`.
- * `real_type_unless_aliased` returns :datetime when DateTime is aliased
- * to :datetime; otherwise returns :timestamp. We don't have the alias
- * registry yet, so report :timestamp directly (matches Rails' non-aliased
- * default).
+ * Rails: `class Timestamp < DateTime`. `type` calls
+ * real_type_unless_aliased(:timestamp). Extends our OID::DateTime so
+ * infinity / BC handling is inherited.
  */
 
-import { DateTimeType } from "@blazetrails/activemodel";
+import { DateTime } from "./date-time.js";
 
-export class Timestamp extends DateTimeType {
+export class Timestamp extends DateTime {
   override readonly name: string = "timestamp";
 
   override type(): string {
-    return "timestamp";
+    return (this as unknown as { realTypeUnlessAliased(t: string): string }).realTypeUnlessAliased(
+      "timestamp",
+    );
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/timestamp.ts
@@ -13,8 +13,6 @@ export class Timestamp extends DateTime {
   override readonly name: string = "timestamp";
 
   override type(): string {
-    return (this as unknown as { realTypeUnlessAliased(t: string): string }).realTypeUnlessAliased(
-      "timestamp",
-    );
+    return this.realTypeUnlessAliased("timestamp");
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@blazetrails/activemodel";
 import { describe, expect, it } from "vitest";
 
-import { Date as ArDate } from "../../type/date.js";
+import { Date as OidDate } from "./oid/date.js";
 import { Json as ArJson } from "../../type/json.js";
 import { Text as ArText } from "../../type/text.js";
 
@@ -78,7 +78,7 @@ describe("initialize_type_map seeds the PG type_map with known types", () => {
     ["float8", FloatType],
     ["text", ArText],
     ["bool", BooleanType],
-    ["date", ArDate],
+    ["date", OidDate],
     ["money", Money],
     ["bytea", Bytea],
     ["point", Point],

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -17,7 +17,7 @@ import {
   Type,
 } from "@blazetrails/activemodel";
 
-import { Date as ArDate } from "../../type/date.js";
+import { Date as OidDate } from "./oid/date.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Json as ArJson } from "../../type/json.js";
@@ -128,7 +128,7 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.registerType("bool", new BooleanType());
   registerClassWithLimit(m, "bit", Bit);
   registerClassWithLimit(m, "varbit", BitVarying);
-  m.registerType("date", new ArDate());
+  m.registerType("date", new OidDate());
   m.registerType("money", new Money());
   m.registerType("bytea", new Bytea());
   m.registerType("point", new Point());


### PR DESCRIPTION
## Summary

Both classes were standalone stubs that didn't extend Rails' \`Type::Date\` / \`Type::DateTime\` hierarchy and didn't handle any of the PG-specific special cases Rails implements. type-map-init also registered the generic AR-level \`Date\` instead of the PG OID class. This PR brings them into parity.

**Behavior now matches Rails exactly:**

- \`"infinity"\` / \`"-infinity"\` cast to \`Float::INFINITY\` / \`-Float::INFINITY\` (expressed as JS \`Infinity\` / \`-Infinity\` with an honest \`as unknown as Date\` escape hatch since the TS \`Type<Date>\` return is narrowly typed — Rails does this with Ruby's dynamic typing).
- BC-era strings like \`"0044-03-15 BC"\` are rewritten to a biased year (\`-year + 1\`) and constructed via \`setUTCFullYear\` because JS's \`Date\` parser doesn't accept 4-digit negative years.
- \`type_cast_for_schema\` renders infinity sentinels as \`"::Float::INFINITY"\` / \`"-::Float::INFINITY"\`, matching Rails' schema dumper.

**Subclasses updated:** \`Timestamp\` and \`TimestampWithTimeZone\` now extend \`OID::DateTime\` (Rails: \`class Timestamp < DateTime\`) so they inherit infinity/BC handling. Their \`type()\` methods call a new \`realTypeUnlessAliased\` hook, mirroring Rails' alias-resolution pattern.

**Wiring:** \`type-map-init\` now registers \`new OidDate()\` for the \`"date"\` typname, matching Rails' \`m.register_type "date", OID::Date.new\`.

**api:compare:** \`castValue\` added as a public method on both classes (Rails' \`cast_value\`) with \`cast()\` delegating to it — matches Rails' cast/cast_value split.

## Deliberate Rails divergences

- **Infinity return type cast.** Rails returns \`Float::INFINITY\` from a \`Date\`-typed attribute via Ruby's dynamic typing. TS \`Type<Date>\` narrowly types \`cast\` as \`Date | null\`, so the infinity sentinels are returned through \`as unknown as Date\`. Callers that check range bounds should test with \`Number.isFinite\` / \`typeof === 'number'\` before treating as a real Date.

## Test plan

- [x] 13 new unit tests covering infinity sentinels, BC-era year biasing, and subclass inheritance of both
- [x] \`api:compare\`: date.rb 0% → 100%, date_time.rb 0% → 100%, timestamp_with_time_zone.rb 50% → 100%
- [x] Full AR suite: 8432 passing, 0 regressions
- [x] Typecheck clean

## Next

Follow-up PR fills the remaining partial gaps: \`hstore.accessor\`, \`cidr.type_cast_for_schema\`, \`interval.cast_value\`, \`bit.Data\` predicates, \`money.scale\` method.