### PR TITLE
feat(activerecord): attribute-type wiring PR 1 — schema loader + userProvidedDefault

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -12,7 +12,11 @@ import { buildDefaultAttributes, type AttributeDefinition } from "./attributes.j
  * declaration API. Model already implements this via Model.attribute().
  */
 export interface AttributeRegistrationClassMethods {
-  attribute(name: string, typeName: string, options?: { default?: unknown }): void;
+  attribute(
+    name: string,
+    typeName: string,
+    options?: { default?: unknown; virtual?: boolean; userProvidedDefault?: boolean },
+  ): void;
   _defaultAttributes(): AttributeSet;
   decorateAttributes(names: string[] | null, decorator: (name: string, type: Type) => Type): void;
   attributeTypes(): Record<string, Type>;

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -16,10 +16,14 @@ export interface AttributeDefinition {
    * The distinction controls how defaults are materialized (user default vs.
    * database default) and whether schema reflection is allowed to overwrite
    * the definition — user-provided defs always win.
+   *
+   * Optional for backwards compatibility with downstream consumers that
+   * construct `AttributeDefinition` directly. When absent, treated as
+   * `true` (user-authored) — matching pre-load_schema behavior.
    */
-  userProvided: boolean;
+  userProvided?: boolean;
   /** Provenance tag — matches `userProvided` but kept explicit for clarity. */
-  source: "user" | "schema";
+  source?: "user" | "schema";
 }
 
 /**
@@ -108,8 +112,9 @@ export function attribute(
 export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
   const attrMap = new Map<string, Attribute>();
   for (const [name, def] of defs) {
+    const userProvided = def.userProvided ?? true;
     if (def.defaultValue != null) {
-      if (def.userProvided) {
+      if (userProvided) {
         // Rails: user_provided_default: true → wraps the default so it is
         // cast through the user-type (and procs re-evaluate per instance).
         const base = Attribute.withCastValue(name, null, def.type);

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -8,6 +8,18 @@ export interface AttributeDefinition {
   type: Type;
   defaultValue: unknown;
   virtual?: boolean;
+  /**
+   * True when the attribute was declared via `this.attribute(...)` (user code).
+   * False when registered from schema reflection (`load_schema`).
+   *
+   * Mirrors: Rails' `user_provided_default:` keyword on `define_attribute`.
+   * The distinction controls how defaults are materialized (user default vs.
+   * database default) and whether schema reflection is allowed to overwrite
+   * the definition — user-provided defs always win.
+   */
+  userProvided: boolean;
+  /** Provenance tag — matches `userProvided` but kept explicit for clarity. */
+  source: "user" | "schema";
 }
 
 /**
@@ -41,14 +53,32 @@ export function attribute(
   },
   name: string,
   typeName: string,
-  options?: { default?: unknown; virtual?: boolean },
+  options?: {
+    default?: unknown;
+    virtual?: boolean;
+    /**
+     * Mirrors Rails' `user_provided_default:` keyword. Defaults to true —
+     * any call to `attribute(...)` is treated as user-authored. Internal
+     * schema-reflection paths pass `false` so user-declared attributes win
+     * on re-registration.
+     */
+    userProvidedDefault?: boolean;
+  },
 ): void {
   const type = typeRegistry.lookup(typeName);
   const defaultValue = options?.default ?? null;
+  const userProvided = options?.userProvidedDefault !== false;
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
     this._attributeDefinitions = new Map(this._attributeDefinitions);
   }
-  this._attributeDefinitions.set(name, { name, type, defaultValue, virtual: options?.virtual });
+  this._attributeDefinitions.set(name, {
+    name,
+    type,
+    defaultValue,
+    virtual: options?.virtual,
+    userProvided,
+    source: userProvided ? "user" : "schema",
+  });
 
   // Mirrors: Rails reset_default_attributes — clear cached AttributeSet
   this._cachedDefaultAttributes = null;

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -108,14 +108,19 @@ export function attribute(
 export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
   const attrMap = new Map<string, Attribute>();
   for (const [name, def] of defs) {
-    const base = Attribute.withCastValue(name, null, def.type);
     if (def.defaultValue != null) {
-      // withUserDefault creates a UserProvidedDefault that preserves function
-      // defaults and re-evaluates them on each deepDup — matching Rails'
-      // PendingDefault behavior where procs are called per-instance.
-      attrMap.set(name, base.withUserDefault(def.defaultValue));
+      if (def.userProvided) {
+        // Rails: user_provided_default: true → wraps the default so it is
+        // cast through the user-type (and procs re-evaluate per instance).
+        const base = Attribute.withCastValue(name, null, def.type);
+        attrMap.set(name, base.withUserDefault(def.defaultValue));
+      } else {
+        // Rails: user_provided_default: false → column default comes from
+        // the database; use fromDatabase so deserialize is applied.
+        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
+      }
     } else {
-      attrMap.set(name, base);
+      attrMap.set(name, Attribute.withCastValue(name, null, def.type));
     }
   }
   return new AttributeSet(attrMap);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -427,6 +427,36 @@ export class Base extends Model {
   static set adapter(adapter: DatabaseAdapter) {
     this._adapter = adapter;
     if (_onAdapterSet) _onAdapterSet(this);
+    // Kick off schema reflection so the adapter's OID-resolved types
+    // populate _attributeDefinitions. Fire-and-forget; await
+    // Model.loadSchema() to synchronize when ordering matters. Errors are
+    // swallowed here (e.g. adapter closed before reflection completes) —
+    // the next Model.loadSchema() await will surface any real problem.
+    const state = this as unknown as { _schemaLoadPromise?: Promise<void> };
+
+    state._schemaLoadPromise = (ModelSchema.loadSchemaFromAdapter as any).call(this).catch(() => {
+      state._schemaLoadPromise = undefined;
+    });
+  }
+
+  /**
+   * Await schema reflection — ensures `_attributeDefinitions` is populated
+   * from the adapter's schema cache before proceeding. Idempotent; cheap
+   * to call repeatedly.
+   *
+   * Mirrors: ActiveRecord::ModelSchema#load_schema (explicit variant).
+   */
+  static async loadSchema(this: typeof Base): Promise<void> {
+    const state = this as unknown as { _schemaLoadPromise?: Promise<void> };
+    if (!state._schemaLoadPromise) {
+      state._schemaLoadPromise = (ModelSchema.loadSchemaFromAdapter as any).call(this);
+    }
+    try {
+      await state._schemaLoadPromise;
+    } catch (e) {
+      state._schemaLoadPromise = undefined;
+      throw e;
+    }
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -385,7 +385,11 @@ export class Base extends Model {
    * any pending encryption decorations (matching Rails' deferred
    * PendingDecorator pattern).
    */
-  static attribute(name: string, typeName: string, options?: { default?: unknown }): void {
+  static attribute(
+    name: string,
+    typeName: string,
+    options?: { default?: unknown; virtual?: boolean; userProvidedDefault?: boolean },
+  ): void {
     super.attribute(name, typeName, options);
     // If we just defined an "id" accessor on a subclass prototype, remove it
     // so Base.prototype.id (which handles CPK) is used instead.

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -59,8 +59,12 @@ export class EncryptableRecord {
           name,
           type: encryptedType,
           defaultValue: existingDef?.defaultValue ?? null,
-          userProvided: existingDef?.userProvided ?? true,
-          source: existingDef?.source ?? "user",
+          // When there's no pre-existing def, this encryption placeholder is
+          // waiting for schema reflection to supply the real cast type.
+          // Mark it schema-sourced so loadSchemaFromAdapter can wrap the
+          // adapter-resolved type (applyPendingEncryptions re-runs after).
+          userProvided: existingDef?.userProvided ?? false,
+          source: existingDef?.source ?? "schema",
         });
       }
 

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -59,6 +59,8 @@ export class EncryptableRecord {
           name,
           type: encryptedType,
           defaultValue: existingDef?.defaultValue ?? null,
+          userProvided: existingDef?.userProvided ?? true,
+          source: existingDef?.source ?? "user",
         });
       }
 

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -144,6 +144,45 @@ describe("loadSchemaFromAdapter integration details", () => {
     expect((rec as unknown as { guid: string }).guid).toBe("abc-123");
   });
 
+  it("skips columns listed in _ignoredColumns (and removes their accessors)", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    (Post as unknown as { _ignoredColumns: string[] })._ignoredColumns = ["secret"];
+    Object.defineProperty(Post.prototype, "secret", {
+      get() {
+        return "leaked";
+      },
+      configurable: true,
+    });
+
+    const adapter = makeAdapter(
+      { guid: { sqlType: "uuid" }, secret: { sqlType: "uuid" } },
+      { uuid: new UuidType() },
+    );
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    expect(Post._attributeDefinitions.has("secret")).toBe(false);
+    expect(Object.getOwnPropertyDescriptor(Post.prototype, "secret")).toBeUndefined();
+    expect(Post._attributeDefinitions.has("guid")).toBe(true);
+  });
+
+  it("invalidates _columnsHash and _columns after reflection", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    (Post as unknown as { _columnsHash: unknown })._columnsHash = { stale: true };
+    (Post as unknown as { _columns: unknown })._columns = ["stale"];
+
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    expect((Post as unknown as { _columnsHash: unknown })._columnsHash).toBeUndefined();
+    expect((Post as unknown as { _columns: unknown })._columns).toBeUndefined();
+  });
+
   it("treats externally-constructed defs without userProvided as user-authored (no overwrite)", async () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ValueType, typeRegistry } from "@blazetrails/activemodel";
+type Type = ValueType;
+import { Base } from "./base.js";
+import { loadSchemaFromAdapter } from "./model-schema.js";
+
+class UuidType extends ValueType {
+  override readonly name = "uuid" as unknown as "value";
+}
+
+class JsonbType extends ValueType {
+  override readonly name = "jsonb" as unknown as "value";
+}
+
+function makeAdapter(
+  columns: Record<string, { sqlType: string; default?: unknown }>,
+  typeByColumn: Record<string, Type>,
+): unknown {
+  const hash = columns as unknown as Record<string, unknown>;
+  return {
+    schemaCache: {
+      dataSourceExists: async () => true,
+      columnsHash: async () => hash,
+      getCachedColumnsHash: () => hash,
+      isCached: () => true,
+    },
+    lookupCastTypeFromColumn(column: { sqlType: string }) {
+      return typeByColumn[column.sqlType] ?? null;
+    },
+  };
+}
+
+describe("loadSchemaFromAdapter", () => {
+  let Model: typeof Base;
+
+  beforeEach(() => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    Model = Post as typeof Base;
+  });
+
+  it("registers schema-sourced attribute definitions from cached columns", async () => {
+    const adapter = makeAdapter(
+      {
+        guid: { sqlType: "uuid" },
+        payload: { sqlType: "jsonb", default: null },
+      },
+      { uuid: new UuidType(), jsonb: new JsonbType() },
+    );
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    const guid = Model._attributeDefinitions.get("guid");
+    const payload = Model._attributeDefinitions.get("payload");
+    expect(guid?.type.name).toBe("uuid");
+    expect(guid?.userProvided).toBe(false);
+    expect(guid?.source).toBe("schema");
+    expect(payload?.type.name).toBe("jsonb");
+  });
+
+  it("does not overwrite user-declared attributes", async () => {
+    Model.attribute("guid", "string");
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    const def = Model._attributeDefinitions.get("guid");
+    expect(def?.type.name).toBe("string");
+    expect(def?.userProvided).toBe(true);
+    expect(def?.source).toBe("user");
+  });
+
+  it("is a no-op for abstract classes", async () => {
+    (Model as unknown as { _abstractClass: boolean })._abstractClass = true;
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+  });
+
+  it("is a no-op when data source does not exist", async () => {
+    const adapter = {
+      schemaCache: {
+        dataSourceExists: async () => false,
+        columnsHash: async () => ({ guid: { sqlType: "uuid" } }),
+      },
+      lookupCastTypeFromColumn: () => new UuidType(),
+    };
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+  });
+
+  it("falls back to ValueType when adapter has no cast type", async () => {
+    const adapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => ({ mystery: { sqlType: "weird" } }),
+      },
+      lookupCastTypeFromColumn: () => null,
+    };
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    const def = Model._attributeDefinitions.get("mystery");
+    expect(def?.type).toBeInstanceOf(typeRegistry.lookup("value").constructor);
+    expect(def?.source).toBe("schema");
+  });
+
+  it("invalidates the _attributesBuilder cache", async () => {
+    (Model as unknown as { _attributesBuilder?: unknown })._attributesBuilder = {
+      stale: true,
+    };
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    expect(
+      (Model as unknown as { _attributesBuilder: unknown })._attributesBuilder,
+    ).toBeUndefined();
+  });
+});
+
+describe("attribute() userProvidedDefault option", () => {
+  it("defaults to userProvided=true (source=user)", () => {
+    class Foo extends Base {}
+    Foo.attribute("name", "string");
+    const def = Foo._attributeDefinitions.get("name");
+    expect(def?.userProvided).toBe(true);
+    expect(def?.source).toBe("user");
+  });
+
+  it("sets userProvided=false when userProvidedDefault:false is passed", () => {
+    class Foo extends Base {}
+    Foo.attribute("name", "string", { userProvidedDefault: false } as {
+      userProvidedDefault?: boolean;
+    });
+    const def = Foo._attributeDefinitions.get("name");
+    expect(def?.userProvided).toBe(false);
+    expect(def?.source).toBe("schema");
+  });
+});

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -130,6 +130,51 @@ describe("loadSchemaFromAdapter", () => {
   });
 });
 
+describe("loadSchemaFromAdapter integration details", () => {
+  it("defines prototype accessors so record.column works", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    const rec = new Post();
+    rec.writeAttribute("guid", "abc-123");
+    expect((rec as unknown as { guid: string }).guid).toBe("abc-123");
+  });
+
+  it("discards the load if the adapter is swapped mid-flight (race guard)", async () => {
+    // Plain host object — avoids Base's adapter getter/setter side effects.
+    let resolveColumns: (v: Record<string, unknown>) => void = () => {};
+    const columnsPromise = new Promise<Record<string, unknown>>((r) => {
+      resolveColumns = r;
+    });
+    const firstAdapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: () => columnsPromise,
+      },
+      lookupCastTypeFromColumn: () => new UuidType(),
+    };
+    const secondAdapter = makeAdapter({}, {});
+    const host = {
+      adapter: firstAdapter,
+      tableName: "posts",
+      _attributeDefinitions: new Map(),
+      prototype: {},
+    };
+
+    const inflight = (loadSchemaFromAdapter as any).call(host);
+
+    host.adapter = secondAdapter as unknown as typeof host.adapter;
+    resolveColumns({ guid: { sqlType: "uuid" } });
+    await inflight;
+
+    expect(host._attributeDefinitions.has("guid")).toBe(false);
+  });
+});
+
 describe("set adapter auto-loads schema", () => {
   it("awaiting Base.loadSchema() populates schema-sourced defs end-to-end", async () => {
     class Post extends Base {

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -83,7 +83,7 @@ describe("loadSchemaFromAdapter", () => {
     expect(Model._attributeDefinitions.has("guid")).toBe(false);
   });
 
-  it("is a no-op when data source does not exist", async () => {
+  it("is a no-op when data source does not exist (explicit false)", async () => {
     const adapter = {
       schemaCache: {
         dataSourceExists: async () => false,
@@ -96,6 +96,21 @@ describe("loadSchemaFromAdapter", () => {
     await loadSchemaFromAdapter.call(Model);
 
     expect(Model._attributeDefinitions.has("guid")).toBe(false);
+  });
+
+  it("falls through when dataSourceExists returns undefined (probe not implemented)", async () => {
+    const adapter = {
+      schemaCache: {
+        dataSourceExists: async () => undefined,
+        columnsHash: async () => ({ guid: { sqlType: "uuid" } }),
+      },
+      lookupCastTypeFromColumn: () => new UuidType(),
+    };
+    (Model as unknown as { adapter: unknown }).adapter = adapter;
+
+    await loadSchemaFromAdapter.call(Model);
+
+    expect(Model._attributeDefinitions.get("guid")?.source).toBe("schema");
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -144,6 +144,22 @@ describe("loadSchemaFromAdapter integration details", () => {
     expect((rec as unknown as { guid: string }).guid).toBe("abc-123");
   });
 
+  it("does not shadow Base.prototype.id when reflecting an id column", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const adapter = makeAdapter({ id: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
+    expect(Post._attributeDefinitions.get("id")?.source).toBe("schema");
+
+    const rec = new Post();
+    rec.writeAttribute("id", "abc-123");
+    expect((rec as unknown as { id: string }).id).toBe("abc-123");
+  });
+
   it("discards the load if the adapter is swapped mid-flight (race guard)", async () => {
     // Plain host object — avoids Base's adapter getter/setter side effects.
     let resolveColumns: (v: Record<string, unknown>) => void = () => {};

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -144,6 +144,31 @@ describe("loadSchemaFromAdapter integration details", () => {
     expect((rec as unknown as { guid: string }).guid).toBe("abc-123");
   });
 
+  it("treats externally-constructed defs without userProvided as user-authored (no overwrite)", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    // Simulate a downstream-style def that predates the userProvided field.
+    (Post as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
+      new Map([
+        [
+          "guid",
+          {
+            name: "guid",
+            type: typeRegistry.lookup("string"),
+            defaultValue: null,
+          },
+        ],
+      ]);
+
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    const def = Post._attributeDefinitions.get("guid");
+    expect(def?.type.name).toBe("string");
+  });
+
   it("does not shadow Base.prototype.id when reflecting an id column", async () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -130,6 +130,22 @@ describe("loadSchemaFromAdapter", () => {
   });
 });
 
+describe("set adapter auto-loads schema", () => {
+  it("awaiting Base.loadSchema() populates schema-sourced defs end-to-end", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+
+    await Post.loadSchema();
+
+    const def = Post._attributeDefinitions.get("guid");
+    expect(def?.type.name).toBe("uuid");
+    expect(def?.source).toBe("schema");
+  });
+});
+
 describe("attribute() userProvidedDefault option", () => {
   it("defaults to userProvided=true (source=user)", () => {
     class Foo extends Base {}

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -511,7 +511,17 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     this._attributeDefinitions = new Map(this._attributeDefinitions);
   }
 
+  const ignored = new Set(this._ignoredColumns ?? []);
   for (const [name, column] of Object.entries(hash)) {
+    // Honor Base.ignoredColumns — Rails' load_schema! excludes these too.
+    if (ignored.has(name)) {
+      const proto = (this as unknown as { prototype: object }).prototype;
+      if (Object.prototype.hasOwnProperty.call(proto, name)) {
+        delete (proto as Record<string, unknown>)[name];
+      }
+      this._attributeDefinitions.delete(name);
+      continue;
+    }
     const existing = this._attributeDefinitions.get(name);
     // Treat absent userProvided as true — externally-constructed defs
     // (pre-PR shape) are user-authored by definition; schema reflection
@@ -569,9 +579,19 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     }
   }
 
-  // Invalidate caches that derive from _attributeDefinitions.
-  this._attributesBuilder = undefined;
-  (this as unknown as { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  // Invalidate every cache that derives from _attributeDefinitions —
+  // columns()/columnsHash()/columnForAttribute() would otherwise serve
+  // pre-reflection data forever.
+  const caches = this as unknown as {
+    _attributesBuilder?: unknown;
+    _cachedDefaultAttributes?: unknown;
+    _columnsHash?: unknown;
+    _columns?: unknown;
+  };
+  caches._attributesBuilder = undefined;
+  caches._cachedDefaultAttributes = null;
+  caches._columnsHash = undefined;
+  caches._columns = undefined;
 
   // Re-run pending encryption decorations so `encrypts :foo` declared before
   // schema load still wraps the adapter-resolved cast type. Mirrors the

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -11,6 +11,7 @@ import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { applyPendingEncryptions } from "./encryption.js";
+import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -518,7 +519,15 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
       typeof startingAdapter.lookupCastTypeFromColumn === "function"
         ? startingAdapter.lookupCastTypeFromColumn(column)
         : null;
-    const type = castType ?? typeRegistry.lookup("value");
+    let type = castType ?? typeRegistry.lookup("value");
+
+    // Preserve an existing EncryptedAttributeType wrapper: re-wrap the
+    // fresh adapter-resolved cast type rather than discarding encryption.
+    if (existing?.type instanceof EncryptedAttributeType) {
+      const scheme = (existing.type as EncryptedAttributeType).scheme;
+      type = new EncryptedAttributeType({ scheme, castType: type });
+    }
+
     const defaultValue = (column as { default?: unknown }).default ?? null;
 
     this._attributeDefinitions.set(name, {
@@ -532,6 +541,17 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     // Define the prototype accessor so `record.foo` routes through
     // readAttribute/writeAttribute. Mirrors what ActiveModel.attribute()
     // does for user-declared attrs (attributes.ts ~L56).
+    //
+    // Skip "id": Base.prototype.id is an accessor with composite-PK
+    // logic (base.ts). Defining an own "id" on a subclass prototype
+    // would shadow it — Base.attribute has the same skip (base.ts:392).
+    if (name === "id") {
+      const proto = (this as unknown as { prototype: object }).prototype;
+      if (Object.prototype.hasOwnProperty.call(proto, "id")) {
+        delete (proto as Record<string, unknown>).id;
+      }
+      continue;
+    }
     const proto = (this as unknown as { prototype: object }).prototype;
     if (!Object.prototype.hasOwnProperty.call(proto, name)) {
       Object.defineProperty(proto, name, {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,7 +1,12 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import { Attribute, AttributeSetBuilder, YAMLEncoder } from "@blazetrails/activemodel";
+import {
+  Attribute,
+  AttributeSetBuilder,
+  YAMLEncoder,
+  typeRegistry,
+} from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
@@ -461,6 +466,71 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
 }
 
 /**
+ * Register attribute definitions from the adapter's schema cache.
+ *
+ * Mirrors: ActiveRecord::ModelSchema#load_schema! — walks `columns_hash`
+ * and calls `define_attribute(..., user_provided_default: false)` for each
+ * column so the cast type comes from the adapter (e.g. PG OID map) rather
+ * than the generic ActiveModel type registry.
+ *
+ * Populates the schema cache if needed (async). User-declared attributes
+ * (`userProvided: true`) are NEVER overwritten — matching Rails where
+ * `attribute :foo, :bar` always wins over schema-reflected types.
+ */
+export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
+  if (this._abstractClass) return;
+  const adapter = this.adapter;
+  if (!adapter) return;
+  const cache = adapter.schemaCache;
+  if (!cache) return;
+  const table = (this as unknown as typeof Base).tableName;
+  const pool = adapter.pool ?? adapter;
+
+  if (typeof cache.dataSourceExists === "function") {
+    const exists = await cache.dataSourceExists(pool, table);
+    if (!exists) return;
+  }
+
+  let hash: Record<string, unknown> | undefined;
+  if (typeof cache.columnsHash === "function") {
+    hash = await cache.columnsHash(pool, table);
+  } else if (typeof cache.getCachedColumnsHash === "function") {
+    hash = cache.getCachedColumnsHash(table);
+  }
+  if (!hash) return;
+
+  // Copy-on-write: match the ownership check used elsewhere (attributes.ts,
+  // encryption.ts) so we mutate this class's own map, not the inherited one.
+  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
+    this._attributeDefinitions = new Map(this._attributeDefinitions);
+  }
+
+  for (const [name, column] of Object.entries(hash)) {
+    const existing = this._attributeDefinitions.get(name);
+    if (existing?.userProvided) continue;
+
+    const castType =
+      typeof adapter.lookupCastTypeFromColumn === "function"
+        ? adapter.lookupCastTypeFromColumn(column)
+        : null;
+    const type = castType ?? typeRegistry.lookup("value");
+    const defaultValue = (column as { default?: unknown }).default ?? null;
+
+    this._attributeDefinitions.set(name, {
+      name,
+      type,
+      defaultValue,
+      userProvided: false,
+      source: "schema",
+    });
+  }
+
+  // Invalidate caches that derive from _attributeDefinitions.
+  this._attributesBuilder = undefined;
+  (this as unknown as { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+}
+
+/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  *
  * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention: a Concern
@@ -500,4 +570,5 @@ export const ClassMethods = {
   symbolColumnToString,
   resetColumnInformation,
   _returningColumnsForInsert,
+  loadSchemaFromAdapter,
 };

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -513,7 +513,10 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
 
   for (const [name, column] of Object.entries(hash)) {
     const existing = this._attributeDefinitions.get(name);
-    if (existing?.userProvided) continue;
+    // Treat absent userProvided as true — externally-constructed defs
+    // (pre-PR shape) are user-authored by definition; schema reflection
+    // must never overwrite them.
+    if (existing && (existing.userProvided ?? true)) continue;
 
     const castType =
       typeof startingAdapter.lookupCastTypeFromColumn === "function"

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -10,6 +10,7 @@ import {
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
+import { applyPendingEncryptions } from "./encryption.js";
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -479,12 +480,12 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (this._abstractClass) return;
-  const adapter = this.adapter;
-  if (!adapter) return;
-  const cache = adapter.schemaCache;
+  const startingAdapter = this.adapter;
+  if (!startingAdapter) return;
+  const cache = startingAdapter.schemaCache;
   if (!cache) return;
   const table = (this as unknown as typeof Base).tableName;
-  const pool = adapter.pool ?? adapter;
+  const pool = startingAdapter.pool ?? startingAdapter;
 
   if (typeof cache.dataSourceExists === "function") {
     const exists = await cache.dataSourceExists(pool, table);
@@ -499,6 +500,10 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (!hash) return;
 
+  // Guard against adapter swaps during the async work above: if a different
+  // adapter was installed, discard this load rather than writing stale types.
+  if (this.adapter !== startingAdapter) return;
+
   // Copy-on-write: match the ownership check used elsewhere (attributes.ts,
   // encryption.ts) so we mutate this class's own map, not the inherited one.
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
@@ -510,8 +515,8 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     if (existing?.userProvided) continue;
 
     const castType =
-      typeof adapter.lookupCastTypeFromColumn === "function"
-        ? adapter.lookupCastTypeFromColumn(column)
+      typeof startingAdapter.lookupCastTypeFromColumn === "function"
+        ? startingAdapter.lookupCastTypeFromColumn(column)
         : null;
     const type = castType ?? typeRegistry.lookup("value");
     const defaultValue = (column as { default?: unknown }).default ?? null;
@@ -523,11 +528,32 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
       userProvided: false,
       source: "schema",
     });
+
+    // Define the prototype accessor so `record.foo` routes through
+    // readAttribute/writeAttribute. Mirrors what ActiveModel.attribute()
+    // does for user-declared attrs (attributes.ts ~L56).
+    const proto = (this as unknown as { prototype: object }).prototype;
+    if (!Object.prototype.hasOwnProperty.call(proto, name)) {
+      Object.defineProperty(proto, name, {
+        get(this: { readAttribute(n: string): unknown }) {
+          return this.readAttribute(name);
+        },
+        set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
+          this.writeAttribute(name, value);
+        },
+        configurable: true,
+      });
+    }
   }
 
   // Invalidate caches that derive from _attributeDefinitions.
   this._attributesBuilder = undefined;
   (this as unknown as { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+
+  // Re-run pending encryption decorations so `encrypts :foo` declared before
+  // schema load still wraps the adapter-resolved cast type. Mirrors the
+  // applyPendingEncryptions call in Base.attribute (base.ts).
+  applyPendingEncryptions(this);
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -490,7 +490,10 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
 
   if (typeof cache.dataSourceExists === "function") {
     const exists = await cache.dataSourceExists(pool, table);
-    if (!exists) return;
+    // Only bail on explicit false. `undefined` means the connection
+    // doesn't implement the probe — fall through and let columnsHash
+    // succeed or throw a real error.
+    if (exists === false) return;
   }
 
   let hash: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

Groundwork for the Rails `load_schema` flow that makes `columnsHash` the source of truth for attribute cast types. This PR lands the loader **and** wires it to the adapter lifecycle, so schema reflection starts automatically when an adapter is attached.

- `AttributeDefinition` gains `userProvided: boolean` and `source: "user" | "schema"`.
- `attribute()` accepts `{ userProvidedDefault?: boolean }`, mirroring Rails' `user_provided_default:` keyword. Defaults to `true` (any user call is user-authored).
- `buildDefaultAttributes` branches on `userProvided`: user → `withUserDefault` (casts via user type), schema → `Attribute.fromDatabase` (deserializes DB value) — mirrors Rails.
- `loadSchemaFromAdapter()`: async loader that walks `adapter.schemaCache.columnsHash(table)` and registers schema-sourced defs whose cast types come from `adapter.lookupCastTypeFromColumn(column)` (the PG OID pipeline). User-declared attributes are never overwritten. Defines prototype getter/setter for each reflected column. Re-runs `applyPendingEncryptions` so `encrypts()` declared before schema load still wraps adapter-resolved types. Captures the adapter at entry and aborts if it was swapped mid-flight (race guard).
- `Base.set adapter` kicks off `loadSchemaFromAdapter` as fire-and-forget (errors swallowed; stored as `_schemaLoadPromise`).
- `Base.loadSchema()` static awaits the cached promise for explicit synchronization.

What this PR does NOT do yet: rewire `columnsHash()` / `columns()` to derive from the schema cache (PR 2), or route `_instantiate`'s read path through the new types (PR 3). The loader runs and registers defs; downstream consumers still work off the old path.

## Test plan

- [x] 11 unit tests in `model-schema-load.test.ts` cover: schema-sourced registration, user override precedence, abstract-class no-op, missing data source, ValueType fallback, cache invalidation, prototype accessor generation, adapter-swap race guard, end-to-end `set adapter` → `Model.loadSchema()`, and both `userProvidedDefault` branches.
- [x] Full test suite: 17,470 passed / 4,420 skipped — no regressions.
- [x] `pnpm tsc --noEmit` clean.