### PR TITLE
refactor(activerecord): match Rails adapter inheritance hierarchy

### DIFF
--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -1,10 +1,8 @@
 import mysql from "mysql2/promise";
 import type { DatabaseAdapter } from "../adapter.js";
-import { DatabaseStatementsMixin } from "../connection-adapters/database-statements-mixin.js";
+import { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql-adapter.js";
 import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
-
-const AdapterBase = DatabaseStatementsMixin(class {});
 
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
@@ -14,10 +12,12 @@ const AdapterBase = DatabaseStatementsMixin(class {});
  * Accepts either a connection URI (`mysql://...`) or a `mysql2` pool config
  * object. Uses a connection pool internally for concurrent access.
  */
-export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
-  readonly adapterName = "Mysql2";
+export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapter {
+  override get adapterName(): string {
+    return "Mysql2";
+  }
 
-  private pool: mysql.Pool;
+  private _driverPool: mysql.Pool;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;
   // Cached capability flag — information_schema.statistics.expression
@@ -29,9 +29,9 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   constructor(config: string | mysql.PoolOptions) {
     super();
     if (typeof config === "string") {
-      this.pool = mysql.createPool({ uri: config });
+      this._driverPool = mysql.createPool({ uri: config });
     } else {
-      this.pool = mysql.createPool(config);
+      this._driverPool = mysql.createPool(config);
     }
   }
 
@@ -41,7 +41,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    */
   private async getConn(): Promise<mysql.PoolConnection> {
     if (this._conn) return this._conn;
-    return this.pool.getConnection();
+    return this._driverPool.getConnection();
   }
 
   /**
@@ -128,7 +128,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    * Begin a transaction. Acquires a dedicated connection from the pool.
    */
   async beginTransaction(): Promise<void> {
-    this._conn = await this.pool.getConnection();
+    this._conn = await this._driverPool.getConnection();
     await this._conn.query("BEGIN");
     this._inTransaction = true;
   }
@@ -578,7 +578,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
   private _advisoryLockConn: mysql.PoolConnection | null = null;
 
   async getAdvisoryLock(lockId: number | string): Promise<boolean> {
-    const conn = await this.pool.getConnection();
+    const conn = await this._driverPool.getConnection();
     try {
       const [rows] = await conn.query("SELECT GET_LOCK(?, 0) AS locked", [String(lockId)]);
       const locked = (rows as Record<string, unknown>[])[0]?.locked === 1;
@@ -618,7 +618,7 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
       this._conn.release();
       this._conn = null;
     }
-    await this.pool.end();
+    await this._driverPool.end();
   }
 
   /**
@@ -637,6 +637,6 @@ export class Mysql2Adapter extends AdapterBase implements DatabaseAdapter {
    * Escape hatch for advanced usage.
    */
   get raw(): mysql.Pool {
-    return this.pool;
+    return this._driverPool;
   }
 }

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -21,7 +21,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return this._driverPool != null;
   }
 
-  private _driverPool: mysql.Pool;
+  private _driverPool: mysql.Pool | null;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;
   // Cached capability flag — information_schema.statistics.expression
@@ -45,6 +45,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   private async getConn(): Promise<mysql.PoolConnection> {
     if (this._conn) return this._conn;
+    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     return this._driverPool.getConnection();
   }
 
@@ -135,6 +136,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Begin a transaction. Acquires a dedicated connection from the pool.
    */
   async beginTransaction(): Promise<void> {
+    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     this._conn = await this._driverPool.getConnection();
     await this._conn.query("BEGIN");
     this._inTransaction = true;
@@ -585,6 +587,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _advisoryLockConn: mysql.PoolConnection | null = null;
 
   async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     const conn = await this._driverPool.getConnection();
     try {
       const [rows] = await conn.query("SELECT GET_LOCK(?, 0) AS locked", [String(lockId)]);
@@ -625,7 +628,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       this._conn.release();
       this._conn = null;
     }
-    await this._driverPool.end();
+    if (this._driverPool) {
+      await this._driverPool.end();
+      this._driverPool = null;
+    }
   }
 
   /**
@@ -644,6 +650,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Escape hatch for advanced usage.
    */
   get raw(): mysql.Pool {
+    if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     return this._driverPool;
   }
 }

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -17,6 +17,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return "Mysql2";
   }
 
+  override get active(): boolean {
+    return this._driverPool != null;
+  }
+
   private _driverPool: mysql.Pool;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -91,6 +91,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Execute a SELECT query and return rows.
    */
   async execute(sql: string, binds: unknown[] = []): Promise<Record<string, unknown>[]> {
+    await this.materializeTransactions();
     const conn = await this.getConn();
     try {
       const [rows] = await conn.query(this.mysqlQuote(sql), this.mysqlBinds(binds));
@@ -104,9 +105,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Execute an INSERT/UPDATE/DELETE and return affected rows or insert ID.
    */
   async executeMutation(sql: string, binds: unknown[] = []): Promise<number> {
+    await this.materializeTransactions();
     const conn = await this.getConn();
     try {
       const [result] = await conn.query(this.mysqlQuote(sql), this.mysqlBinds(binds));
+      this.dirtyCurrentTransaction();
       const info = result as mysql.ResultSetHeader;
 
       // For INSERT, return the last inserted ID (or affected rows for multi-row)

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -21,6 +21,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return this._driverPool != null;
   }
 
+  // Mirrors Rails' Mysql2Adapter#connected? — null raw connection means
+  // disconnected. (Rails also checks `@raw_connection.closed?`; our
+  // driver pool exposes no such predicate, so we rely on close() nulling
+  // the pool.)
+  override isConnected(): boolean {
+    return this._driverPool != null;
+  }
+
   private _driverPool: mysql.Pool | null;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -563,7 +563,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       const cols = await adapter.columns("defaults");
       const textCol = cols.find((c) => c.name === "text_col");
       expect(textCol).toBeDefined();
-      expect(textCol!.default).toMatch(/some text/);
+      // Domain-typed defaults come back from PG as a double-cast expression
+      // (`('some text'::text)::schema.type`). Rails' extract_value_from_default
+      // strips simple casts but leaves compound domain casts in default_function.
+      // Either slot is acceptable as long as the literal is preserved.
+      const slot = textCol!.default ?? textCol!.defaultFunction ?? "";
+      expect(String(slot)).toMatch(/some text/);
     });
 
     it("default containing quote and colons", async () => {

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -37,7 +37,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const cols = await adapter.columns("postgresql_timestamps");
       const col = cols.find((c) => c.name === "updated_at");
       expect(col).toBeDefined();
-      expect(col!.default).toContain("now");
+      // Rails' Column#default is nil for expression defaults; the SQL
+      // expression itself lives in #default_function (postgresql/column.rb).
+      expect(col!.defaultFunction).toContain("now");
     });
 
     it("timestamp type cast", async () => {
@@ -94,7 +96,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("datetime default", async () => {
       const cols = await adapter.columns("postgresql_timestamps");
       const col = cols.find((c) => c.name === "updated_at");
-      expect(col!.default).toBeTruthy();
+      expect(col!.defaultFunction).toBeTruthy();
     });
 
     it("datetime type cast", async () => {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6502,7 +6502,7 @@ describe("CalculationsTest", () => {
   });
 
   // Rails guide: load_async schedules background load
-  it("loadAsync returns the relation for chaining", () => {
+  it("loadAsync returns the relation for chaining", async () => {
     const adapter = createTestAdapter();
     class User extends Base {
       static {
@@ -6513,6 +6513,9 @@ describe("CalculationsTest", () => {
     }
     const rel = User.where({ id: 1 }).loadAsync();
     expect(rel).toBeDefined();
+    // Drain the background load so it can't outlive this test and fire
+    // against a dropped table in a later test.
+    await rel.toArray();
   });
 
   // Rails guide: clone — shallow clone preserving id

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -638,7 +638,10 @@ export class AbstractAdapter extends AbstractAdapterBase {
 
   async addEnumValue(_enumName: string, _value: string): Promise<void> {}
 
-  async renameEnumValue(_typeName: string, _options: { from: string; to: string }): Promise<void> {}
+  // Rails' `def rename_enum_value(...)` uses a splat so concrete adapters
+  // can define their own signature (PG takes `(type_name, **options)`).
+  // Keep the TS signature permissive to match.
+  async renameEnumValue(..._args: unknown[]): Promise<void> {}
 
   async createVirtualTable(_name: string, _options?: unknown): Promise<void> {}
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -638,7 +638,7 @@ export class AbstractAdapter extends AbstractAdapterBase {
 
   async addEnumValue(_enumName: string, _value: string): Promise<void> {}
 
-  async renameEnumValue(..._args: unknown[]): Promise<void> {}
+  async renameEnumValue(_typeName: string, _options: { from: string; to: string }): Promise<void> {}
 
   async createVirtualTable(_name: string, _options?: unknown): Promise<void> {}
 
@@ -724,12 +724,24 @@ export class AbstractAdapter extends AbstractAdapterBase {
 
   // --- Version introspection ---
 
+  // Rails' `get_database_version` returns whatever the adapter uses to
+  // represent a server version. PG returns the `server_version` integer;
+  // SQLite returns a `Version`. Other adapters may be async (PG's
+  // implementation queries `SHOW server_version_num`).
   getDatabaseVersion(): Version | number | Promise<Version | number> {
     return new Version("0.0.0");
   }
 
-  get databaseVersion(): Version | number | Promise<Version | number> {
-    return this.getDatabaseVersion();
+  // Rails' `database_version` is a sync accessor (`pool.server_version(self)`
+  // caches the result). Overrides may narrow to `Version` or `number`.
+  get databaseVersion(): Version | number {
+    const v = this.getDatabaseVersion();
+    if (v instanceof Promise) {
+      throw new Error(
+        "databaseVersion is only available synchronously after getDatabaseVersion() has resolved; await getDatabaseVersion() first",
+      );
+    }
+    return v;
   }
 
   checkVersion(): void {}

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -8,7 +8,7 @@ import type { DatabaseAdapter } from "../adapter.js";
 import { type Nodes, Visitors } from "@blazetrails/arel";
 import { ReadOnlyError } from "../errors.js";
 import { SchemaCache } from "./schema-cache.js";
-import { isWriteQuerySql, stripSqlComments } from "./sql-classification.js";
+import { stripSqlComments } from "./sql-classification.js";
 import {
   TransactionManager,
   type Transaction,
@@ -24,6 +24,7 @@ import {
   clearQueryCache as clearQueryCacheMixin,
   type QueryCacheHost,
 } from "./abstract/query-cache.js";
+import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -69,10 +70,14 @@ export class Version {
   }
 }
 
+// Rails: `class AbstractAdapter ... include DatabaseStatements`. We achieve
+// the same shape by mixing DatabaseStatements into the base chain here.
+const AbstractAdapterBase = DatabaseStatementsMixin(class {});
+
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter
  */
-export class AbstractAdapter {
+export class AbstractAdapter extends AbstractAdapterBase {
   static readonly Version = Version;
 
   private _connection: DatabaseAdapter | null = null;
@@ -289,10 +294,6 @@ export class AbstractAdapter {
   }
 
   // --- Private helpers ---
-
-  protected isWriteQuery(sql: string): boolean {
-    return isWriteQuerySql(sql);
-  }
 
   protected stripSqlComments(sql: string): string {
     return stripSqlComments(sql);
@@ -637,7 +638,7 @@ export class AbstractAdapter {
 
   async addEnumValue(_enumName: string, _value: string): Promise<void> {}
 
-  async renameEnumValue(_enumName: string, _oldValue: string, _newValue: string): Promise<void> {}
+  async renameEnumValue(..._args: unknown[]): Promise<void> {}
 
   async createVirtualTable(_name: string, _options?: unknown): Promise<void> {}
 
@@ -659,7 +660,7 @@ export class AbstractAdapter {
 
   // --- Extensions & algorithms ---
 
-  get extensions(): string[] {
+  extensions(): string[] | Promise<string[]> {
     return [];
   }
 
@@ -723,11 +724,11 @@ export class AbstractAdapter {
 
   // --- Version introspection ---
 
-  getDatabaseVersion(): Version {
+  getDatabaseVersion(): Version | number | Promise<Version | number> {
     return new Version("0.0.0");
   }
 
-  get databaseVersion(): Version {
+  get databaseVersion(): Version | number | Promise<Version | number> {
     return this.getDatabaseVersion();
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -39,7 +39,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   private static _spCounter = 0;
-  private _driverPool: pg.Pool;
+  private _driverPool: pg.Pool | null;
   private _client: pg.PoolClient | null = null;
   private _inTransaction = false;
   private _databaseVersion: number | null = null;
@@ -312,6 +312,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async getClient(): Promise<pg.PoolClient> {
     if (this._client) return this._client;
+    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     return this._driverPool.connect();
   }
 
@@ -402,6 +403,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
+    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     this._client = await this._driverPool.connect();
     await this._client.query("BEGIN");
     this._inTransaction = true;
@@ -519,7 +521,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._client.release();
       this._client = null;
     }
-    await this._driverPool.end();
+    if (this._driverPool) {
+      await this._driverPool.end();
+      this._driverPool = null;
+    }
   }
 
   /**
@@ -534,6 +539,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Escape hatch for advanced usage.
    */
   get raw(): pg.Pool {
+    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     return this._driverPool;
   }
 
@@ -695,6 +701,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _advisoryLockClient: pg.PoolClient | null = null;
 
   async getAdvisoryLock(lockId: number | string): Promise<boolean> {
+    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     const client = await this._driverPool.connect();
     try {
       const isNumeric = typeof lockId === "number";

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -172,6 +172,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * populates them.
    */
   override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
+    // SELECTs enter here instead of execute(), so we materialize lazy
+    // transactions here too — otherwise SELECTs run against an ad-hoc
+    // pool client while pending-but-not-yet-BEGUN transactions stay
+    // un-materialized. Mirrors Rails' with_raw_connection materializing
+    // every query (abstract_adapter.rb:987).
+    await this.materializeTransactions();
+
     // Release the query client BEFORE any loadAdditionalTypes call —
     // that path re-enters execute() and acquires its own pooled client,
     // and holding both would consume 2 connections per query during

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -38,6 +38,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this._driverPool != null;
   }
 
+  // Mirrors Rails' PostgreSQLAdapter#connected? — checks that the raw
+  // connection (pool in our case) exists and hasn't been finished.
+  override isConnected(): boolean {
+    return this._driverPool != null;
+  }
+
   private static _spCounter = 0;
   private _driverPool: pg.Pool | null;
   private _client: pg.PoolClient | null = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -172,12 +172,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * populates them.
    */
   override async execQuery(sql: string, _name?: string | null, binds?: unknown[]): Promise<Result> {
-    // SELECTs enter here instead of execute(), so we materialize lazy
-    // transactions here too — otherwise SELECTs run against an ad-hoc
-    // pool client while pending-but-not-yet-BEGUN transactions stay
-    // un-materialized. Mirrors Rails' with_raw_connection materializing
-    // every query (abstract_adapter.rb:987).
-    await this.materializeTransactions();
+    // Note: we do NOT call materializeTransactions() here. If a lazy tx
+    // is pending but un-materialized, a SELECT against an ad-hoc pool
+    // client sees pre-tx state — which is correct read-before-write
+    // semantics. If the tx HAS begun, `_client` is set and getClient()
+    // returns it. Forcing materialization here races with the tx
+    // client's lifecycle and can cause double-release on pool clients.
 
     // Release the query client BEFORE any loadAdditionalTypes call —
     // that path re-enters execute() and acquires its own pooled client,
@@ -1168,12 +1168,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
     return rows.map((r) => {
       const sqlType = r.type as string;
-      const defaultExpr = (r.default as string | null) ?? null;
-      const isSerial = typeof defaultExpr === "string" && defaultExpr.startsWith("nextval(");
+      const rawDefault = (r.default as string | null) ?? null;
+      // Mirrors Rails' PG `extract_value_from_default` / `extract_default_function`
+      // split — SQL-expression defaults (nextval, CURRENT_TIMESTAMP,
+      // gen_random_uuid(), etc.) become `defaultFunction`; only literals
+      // become `default`. Without this split, schema reflection would
+      // apply expressions as literal bind values and PG would reject
+      // `nextval(...)` as a bound integer.
+      const { literal, fn } = splitPgDefault(rawDefault);
+      const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
 
       return new Column(
         r.name as string,
-        defaultExpr,
+        literal,
         {
           sqlType,
           oid: r.oid as number,
@@ -1181,6 +1188,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         },
         !(r.notnull as boolean),
         {
+          defaultFunction: fn,
           primaryKey: r.is_primary as boolean,
           serial: isSerial,
           array: sqlType.endsWith("[]"),
@@ -1770,6 +1778,34 @@ export class MoneyDecoder {
  * ValueType. Mapping them to the scalar typname (int4) would
  * incorrectly deserialize array values with a scalar type.
  */
+/**
+ * Parse a raw `pg_attrdef` default expression into a literal value or a
+ * SQL function expression. Mirrors Rails' PG `extract_value_from_default`
+ * / `extract_default_function` split — so schema reflection can carry
+ * expression defaults as `defaultFunction` rather than applying them as
+ * literal bind values.
+ */
+function splitPgDefault(raw: string | null): { literal: unknown; fn: string | null } {
+  if (raw == null) return { literal: null, fn: null };
+  // 'value'::type — quoted literal with an optional cast.
+  const quoted = /^'((?:[^']|'')*)'::[\w"\s.]+$/.exec(raw);
+  if (quoted) return { literal: quoted[1].replace(/''/g, "'"), fn: null };
+  // (N)::type — numeric wrapped in parens with a cast (PG emits this for
+  // things like `DEFAULT 150.55::numeric::money`).
+  const parenNum = /^\((-?\d+(?:\.\d+)?)\)::[\w"\s.]+$/.exec(raw);
+  if (parenNum) return { literal: parenNum[1], fn: null };
+  // N::type — bare numeric with a cast.
+  const castNum = /^(-?\d+(?:\.\d+)?)::[\w"\s.]+$/.exec(raw);
+  if (castNum) return { literal: castNum[1], fn: null };
+  // Bare numeric / boolean / NULL literal.
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) return { literal: raw, fn: null };
+  if (raw === "true" || raw === "false") return { literal: raw === "true", fn: null };
+  if (raw === "NULL") return { literal: null, fn: null };
+  // Everything else (nextval, CURRENT_TIMESTAMP, gen_random_uuid(), etc.)
+  // is a SQL expression.
+  return { literal: null, fn: raw };
+}
+
 function normalizeFormatType(sqlType: string): string {
   if (/\[\]\s*$/.test(sqlType)) return sqlType;
   const base = sqlType

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -324,6 +324,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Execute a SELECT query and return rows.
    */
   async execute(sql: string, binds: unknown[] = []): Promise<Record<string, unknown>[]> {
+    await this.materializeTransactions();
     const client = await this.getClient();
     try {
       const result = await client.query(this.rewriteBinds(sql, binds), binds);
@@ -341,8 +342,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `rowCount` is returned.
    */
   async executeMutation(sql: string, binds: unknown[] = []): Promise<number> {
+    await this.materializeTransactions();
     const client = await this.getClient();
     try {
+      this.dirtyCurrentTransaction();
       const pgSql = this.rewriteBinds(sql, binds);
       const upper = sql.trimStart().toUpperCase();
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -34,6 +34,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return "PostgreSQL";
   }
 
+  override get active(): boolean {
+    return this._driverPool != null;
+  }
+
   private static _spCounter = 0;
   private _driverPool: pg.Pool;
   private _client: pg.PoolClient | null = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1766,19 +1766,6 @@ export class MoneyDecoder {
 }
 
 /**
- * Normalize a `pg_catalog.format_type(...)` string to the typname the
- * static type_map is keyed by. PG returns human-friendly forms like
- * "integer" / "character varying(255)" / "bigint", but we register
- * "int4" / "varchar" / "int8". Strip size modifiers and alias common
- * formatted names so the fallback path in lookupCastTypeFromColumn
- * resolves well-known *scalar* types.
- *
- * Array types (e.g. "integer[]") are deliberately left as-is — they
- * don't have a static registration, so the lookup misses and returns
- * ValueType. Mapping them to the scalar typname (int4) would
- * incorrectly deserialize array values with a scalar type.
- */
-/**
  * Parse a raw `pg_attrdef` default expression into a literal value or a
  * SQL function expression. Mirrors Rails' PG `extract_value_from_default`
  * / `extract_default_function` split — so schema reflection can carry
@@ -1806,6 +1793,19 @@ function splitPgDefault(raw: string | null): { literal: unknown; fn: string | nu
   return { literal: null, fn: raw };
 }
 
+/**
+ * Normalize a `pg_catalog.format_type(...)` string to the typname the
+ * static type_map is keyed by. PG returns human-friendly forms like
+ * "integer" / "character varying(255)" / "bigint", but we register
+ * "int4" / "varchar" / "int8". Strip size modifiers and alias common
+ * formatted names so the fallback path in lookupCastTypeFromColumn
+ * resolves well-known *scalar* types.
+ *
+ * Array types (e.g. "integer[]") are deliberately left as-is — they
+ * don't have a static registration, so the lookup misses and returns
+ * ValueType. Mapping them to the scalar typname (int4) would
+ * incorrectly deserialize array values with a scalar type.
+ */
 function normalizeFormatType(sqlType: string): string {
   if (/\[\]\s*$/.test(sqlType)) return sqlType;
   const base = sqlType

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -19,9 +19,7 @@ import {
   initializeTypeMap as staticInitializeTypeMap,
 } from "./postgresql/type-map-init.js";
 import type { DatabaseAdapter } from "../adapter.js";
-import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
-
-const AdapterBase = DatabaseStatementsMixin(class {});
+import { AbstractAdapter } from "./abstract-adapter.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -31,11 +29,13 @@ const AdapterBase = DatabaseStatementsMixin(class {});
  * Accepts either a connection string (`postgres://...`) or a `pg.PoolConfig`
  * object. Uses a connection pool internally for concurrent access.
  */
-export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
-  readonly adapterName = "PostgreSQL";
+export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapter {
+  override get adapterName(): string {
+    return "PostgreSQL";
+  }
 
   private static _spCounter = 0;
-  private pool: pg.Pool;
+  private _driverPool: pg.Pool;
   private _client: pg.PoolClient | null = null;
   private _inTransaction = false;
   private _databaseVersion: number | null = null;
@@ -44,9 +44,9 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   constructor(config: string | pg.PoolConfig) {
     super();
     if (typeof config === "string") {
-      this.pool = new pg.Pool({ connectionString: config });
+      this._driverPool = new pg.Pool({ connectionString: config });
     } else {
-      this.pool = new pg.Pool(config);
+      this._driverPool = new pg.Pool(config);
     }
   }
 
@@ -308,7 +308,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    */
   private async getClient(): Promise<pg.PoolClient> {
     if (this._client) return this._client;
-    return this.pool.connect();
+    return this._driverPool.connect();
   }
 
   /**
@@ -395,7 +395,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
-    this._client = await this.pool.connect();
+    this._client = await this._driverPool.connect();
     await this._client.query("BEGIN");
     this._inTransaction = true;
   }
@@ -512,7 +512,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
       this._client.release();
       this._client = null;
     }
-    await this.pool.end();
+    await this._driverPool.end();
   }
 
   /**
@@ -527,7 +527,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
    * Escape hatch for advanced usage.
    */
   get raw(): pg.Pool {
-    return this.pool;
+    return this._driverPool;
   }
 
   // ---------------------------------------------------------------------------
@@ -688,7 +688,7 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
   private _advisoryLockClient: pg.PoolClient | null = null;
 
   async getAdvisoryLock(lockId: number | string): Promise<boolean> {
-    const client = await this.pool.connect();
+    const client = await this._driverPool.connect();
     try {
       const isNumeric = typeof lockId === "number";
       const sql = `SELECT pg_try_advisory_lock(${isNumeric ? "$1" : "hashtext($1)"}) AS locked`;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -31,7 +31,6 @@ import {
 } from "@blazetrails/activemodel";
 import { getFs } from "@blazetrails/activesupport";
 import { quoteString, quoteTableName, quoteColumnName } from "./sqlite3/quoting.js";
-import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
 import {
   CheckConstraintDefinition,
   type AddForeignKeyOptions,
@@ -44,10 +43,7 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter
  */
-export class SQLite3Adapter
-  extends DatabaseStatementsMixin(AbstractAdapter)
-  implements DatabaseAdapter
-{
+export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override get adapterName(): string {
     return "SQLite";
   }
@@ -457,6 +453,10 @@ export class SQLite3Adapter
       this._databaseVersion = new Version(row?.v ?? "0.0.0");
     }
     return this._databaseVersion;
+  }
+
+  override get databaseVersion(): Version {
+    return this.getDatabaseVersion();
   }
 
   override checkVersion(): void {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -98,6 +98,7 @@ export class Relation<T extends Base> {
   private _skipQueryCache = false;
   private _loaded = false;
   private _records: T[] = [];
+  private _loadAsyncPromise?: Promise<T[]>;
 
   private _table: Table | null = null;
 
@@ -1157,11 +1158,12 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load_async
    */
   loadAsync(): Relation<T> {
-    // Start loading in background; result is cached when accessed
-    this.toArray().then((records) => {
-      this._loaded = true;
-      this._records = records;
-    });
+    // Kick off the load in the background and stash the in-flight promise.
+    // toArray() already caches _loaded/_records when it resolves, so no
+    // .then bookkeeping is needed. A later `await rel.toArray()` drains
+    // the stashed promise instead of issuing a second query — and carries
+    // any rejection to the awaiter, matching Rails' load_async behavior.
+    this._loadAsyncPromise ??= this.toArray();
     return this;
   }
 
@@ -1340,6 +1342,14 @@ export class Relation<T extends Base> {
   async toArray(): Promise<T[]> {
     if (this._isNone) return [];
     if (this._loaded) return [...this._records];
+    if (this._loadAsyncPromise) {
+      // A prior loadAsync() kicked off the query — hand out the in-flight
+      // promise so callers drain the same query (and carry its errors)
+      // instead of issuing a second one.
+      const p = this._loadAsyncPromise;
+      this._loadAsyncPromise = undefined;
+      return p;
+    }
 
     // Rails: `includes(:assoc).references(:assocs_table)` promotes the
     // matching includes to eager_load so the JOIN is present — otherwise

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1178,9 +1178,15 @@ export class Relation<T extends Base> {
     // in finally) so concurrent callers share the one in-flight query
     // instead of racing to fire additional ones.
     if (!this._loadAsyncPromise && !this._loaded) {
-      this._loadAsyncPromise = this.toArray().finally(() => {
+      const loadPromise = this.toArray().finally(() => {
         this._loadAsyncPromise = undefined;
       });
+      // Attach a no-op rejection handler so a failure here isn't treated
+      // as an unhandled rejection if nothing else awaits the relation.
+      // The stored promise still carries the rejection to explicit
+      // awaiters (.toArray(), etc.) via a separate chain.
+      void loadPromise.catch(() => {});
+      this._loadAsyncPromise = loadPromise;
     }
     return this;
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1127,6 +1127,10 @@ export class Relation<T extends Base> {
   reset(): this {
     this._loaded = false;
     this._records = [];
+    // Drop any in-flight loadAsync() — otherwise a stale load could
+    // resolve after a reset and re-populate stale records via
+    // toArray()'s cache path.
+    this._loadAsyncPromise = undefined;
     return this;
   }
 
@@ -1163,7 +1167,15 @@ export class Relation<T extends Base> {
     // .then bookkeeping is needed. A later `await rel.toArray()` drains
     // the stashed promise instead of issuing a second query — and carries
     // any rejection to the awaiter, matching Rails' load_async behavior.
-    this._loadAsyncPromise ??= this.toArray();
+    //
+    // Keep the promise cached for the full lifetime of the load (clear
+    // in finally) so concurrent callers share the one in-flight query
+    // instead of racing to fire additional ones.
+    if (!this._loadAsyncPromise && !this._loaded) {
+      this._loadAsyncPromise = this.toArray().finally(() => {
+        this._loadAsyncPromise = undefined;
+      });
+    }
     return this;
   }
 
@@ -1343,12 +1355,11 @@ export class Relation<T extends Base> {
     if (this._isNone) return [];
     if (this._loaded) return [...this._records];
     if (this._loadAsyncPromise) {
-      // A prior loadAsync() kicked off the query — hand out the in-flight
+      // A prior loadAsync() kicked off the query — share the in-flight
       // promise so callers drain the same query (and carry its errors)
-      // instead of issuing a second one.
-      const p = this._loadAsyncPromise;
-      this._loadAsyncPromise = undefined;
-      return p;
+      // instead of racing to issue additional ones. The promise clears
+      // itself in loadAsync's .finally once the load settles.
+      return this._loadAsyncPromise;
     }
 
     // Rails: `includes(:assoc).references(:assocs_table)` promotes the

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -99,6 +99,10 @@ export class Relation<T extends Base> {
   private _loaded = false;
   private _records: T[] = [];
   private _loadAsyncPromise?: Promise<T[]>;
+  // Monotonic token bumped on reset()/reload() so an in-flight toArray()
+  // that started before the reset can detect it lost the race and skip
+  // committing stale records/loaded state.
+  private _loadToken = 0;
 
   private _table: Table | null = null;
 
@@ -1127,9 +1131,11 @@ export class Relation<T extends Base> {
   reset(): this {
     this._loaded = false;
     this._records = [];
-    // Drop any in-flight loadAsync() — otherwise a stale load could
-    // resolve after a reset and re-populate stale records via
-    // toArray()'s cache path.
+    // Bump the load token and drop any in-flight loadAsync() promise —
+    // an already-running toArray() checks the token after its await and
+    // will skip committing if it lost the race, so a stale background
+    // load can't re-populate records after a reset.
+    this._loadToken += 1;
     this._loadAsyncPromise = undefined;
     return this;
   }
@@ -1362,21 +1368,30 @@ export class Relation<T extends Base> {
       return this._loadAsyncPromise;
     }
 
+    // Capture the load token before any await so we can detect if a
+    // reset() landed while the query was in flight and bail without
+    // clobbering the fresh state.
+    const token = this._loadToken;
+
     // Rails: `includes(:assoc).references(:assocs_table)` promotes the
     // matching includes to eager_load so the JOIN is present — otherwise
     // a raw where condition referring to that table would fail.
     // See ActiveRecord::Relation#references_eager_loaded_tables?
     const promotedIncludes = this._includesToPromoteFromReferences();
 
-    // Eager load via single JOIN query when eager_load associations are specified
+    let loadedRecords: T[];
     if (this._eagerLoadAssociations.length > 0 || promotedIncludes.length > 0) {
       const allEager = [...new Set([...this._eagerLoadAssociations, ...promotedIncludes])];
       await this._executeEagerLoad(allEager);
+      if (token !== this._loadToken) return [];
+      loadedRecords = this._records;
     } else {
       const sql = this._toSql();
       const result = await this._modelClass.adapter.selectAll(sql, "Load");
+      if (token !== this._loadToken) return [];
       const rows = result.toArray();
-      this._records = this._instrumentInstantiation(rows);
+      loadedRecords = this._instrumentInstantiation(rows);
+      this._records = loadedRecords;
     }
     this._loaded = true;
 
@@ -1400,6 +1415,7 @@ export class Relation<T extends Base> {
     ];
     if (preloadAssocs.length > 0 && this._records.length > 0) {
       await this._preloadAssociationsForRecords(this._records, preloadAssocs);
+      if (token !== this._loadToken) return [];
     }
 
     return [...this._records];


### PR DESCRIPTION
## Summary

Align `ActiveRecord::ConnectionAdapters` with Rails' adapter hierarchy so concrete adapters actually inherit from `AbstractAdapter`, and fix the Rails-fidelity gaps that surfaced along the way.

### Rails hierarchy (v8.0.2)

```
AbstractAdapter (include DatabaseStatements)
├── AbstractMysqlAdapter
│   ├── Mysql2Adapter
│   └── TrilogyAdapter
├── PostgreSQLAdapter
└── SQLite3Adapter
```

Before this PR, `Mysql2Adapter` / `PostgreSQLAdapter` / `SQLite3Adapter` each re-applied `DatabaseStatementsMixin` to a bare `class {}` — so none of them actually inherited from `AbstractAdapter`. Only `AbstractMysqlAdapter` / `TrilogyAdapter` matched Rails.

## Changes

### Inheritance & signatures
- **`AbstractAdapter`**: mix in `DatabaseStatementsMixin` at the class-chain root (mirrors Rails' `include DatabaseStatements` at `abstract_adapter.rb:35`).
- **`Mysql2Adapter`**: `extends AbstractMysqlAdapter`.
- **`PostgreSQLAdapter`**: `extends AbstractAdapter`.
- **`SQLite3Adapter`**: drop the redundant `DatabaseStatementsMixin(AbstractAdapter)` wrap; plain `extends AbstractAdapter`.
- Rename driver-pool fields to `_driverPool` (so they don't shadow `AbstractAdapter#pool` — the connection-pool concept).
- `adapterName` on Mysql2/PG switched from `readonly` property to `override get` (base exposes it as an accessor).
- Drop `AbstractAdapter#isWriteQuery`; let the mixin provide it publicly (matches Rails and `DatabaseAdapter` interface).
- Widen `renameEnumValue` to Rails' splat (`abstract_adapter.rb:592`), `extensions` to method returning `string[] | Promise<string[]>` (matches PG's DB-querying override), and `getDatabaseVersion` to accommodate PG's integer / SQLite's `Version`.

### Correctness fixes surfaced by the new hierarchy
- **Lazy-transaction materialization on writes**: Mysql2/PG `executeMutation` now calls `materializeTransactions()` + `dirtyCurrentTransaction()` on every write. Previously the direct begin/commit/rollback fallback path was sufficient; now that these adapters route through `TransactionManager.withinNewTransaction`, lazy transactions need explicit materialization before the first write (matches SQLite3Adapter and Rails' exec path).
- **`active` / `isConnected` semantics**: override on Mysql2/PG to check `_driverPool != null`, so a closed adapter accurately reports itself as such. Base's accessor used `_connection` (never set on these adapters), so `active`/`isConnected` was silently always false.
- **Close-state safety**: `_driverPool` is now nullable and nulled in `close()`; re-use of a closed adapter throws instead of calling through a stale pool reference.
- **PG column-default split** (Rails-faithful): PG `columns()` now splits `pg_attrdef` output into literal (→ `Column.default`) and SQL-expression (→ `Column.defaultFunction`), mirroring Rails' `extract_value_from_default` / `extract_default_function` (`postgresql/column.rb`). Without this, the new `loadSchemaFromAdapter` (main #584) would apply expressions like `nextval('..._id_seq'::regclass)` as literal bind values — PG rejected as `invalid input syntax for type integer`. Three PG tests that asserted the old (non-Rails) shape now check `defaultFunction` for expression defaults.

### `Relation#loadAsync` hardening
- Share the in-flight promise via `.finally` (so concurrent `toArray()` callers drain the same query instead of racing to fire new ones).
- Attach a no-op `.catch` so a pre-await rejection doesn't surface as an unhandled promise warning (rejection still propagates to explicit awaiters via a separate chain, matching Rails' `load_async`).
- `reset()` bumps a monotonic load token; `toArray()` captures it before each await and bails without committing stale `_records` / `_loaded` if `reset()` lands mid-query.
- Test: `loadAsync returns the relation for chaining` now drains the background load so it can't outlive the test.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm vitest run packages/activerecord` — all green
- [x] MySQL (MariaDB local): `packages/activerecord/src/adapters/mysql2-adapter.test.ts` 39/39
- [x] PG local: 47/47 in `postgresql-adapter.test.ts`, 125/125 across PG-touching suites
- [x] `pnpm run api:compare --package activerecord` — no regression

## Not in scope (separate PRs)
- Convert `DatabaseStatementsMixin` from class-factory to activesupport `include()` pattern (CLAUDE.md preference; hit TS-override friction with PG's `execQuery` override mid-attempt).
- Real `active?` ping semantics (Rails' `active?` queries; ours is `connected?`-style null check).
- `close()` vs `disconnect!` naming — ours matches `disconnect!` behavior; naming drift is pre-existing.