### PR TITLE
feat(arel): add bind extraction via compileWithBinds

### DIFF
--- a/packages/arel/src/collectors/bind.ts
+++ b/packages/arel/src/collectors/bind.ts
@@ -15,7 +15,7 @@ export class Bind {
     return this;
   }
 
-  addBind(bind: unknown): this {
+  addBind(bind: unknown, _block?: (index: number) => string): this {
     this.binds.push(bind);
     return this;
   }

--- a/packages/arel/src/collectors/composite.ts
+++ b/packages/arel/src/collectors/composite.ts
@@ -1,6 +1,6 @@
 type CollectorLike = {
   append(str: string): unknown;
-  addBind(value: unknown): unknown;
+  addBind(value: unknown, block?: (index: number) => string): unknown;
   addBinds?(binds: unknown[], procForBinds?: ((v: unknown) => unknown) | null): unknown;
   retryable?: boolean;
   value?: unknown;
@@ -27,8 +27,8 @@ export class Composite {
     return this;
   }
 
-  addBind(value: unknown): this {
-    this.left.addBind(value);
+  addBind(value: unknown, block?: (index: number) => string): this {
+    this.left.addBind(value, block);
     this.right.addBind(value);
     return this;
   }

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -125,6 +125,18 @@ describe("PostgresTest", () => {
       expect(sql).toContain("$1");
       expect(sql).toContain("$2");
     });
+
+    it("compileWithBinds extracts values with $N placeholders", () => {
+      const visitor = new Visitors.PostgreSQLWithBinds();
+      const a = users.get("id").eq(new Nodes.BindParam(42));
+      const b = users.get("name").eq(new Nodes.BindParam("alice"));
+      const [sql, binds] = visitor.compileWithBinds(new Nodes.And([a, b]));
+      expect(sql).toContain("$1");
+      expect(sql).toContain("$2");
+      expect(sql).not.toContain("42");
+      expect(sql).not.toContain("alice");
+      expect(binds).toEqual([42, "alice"]);
+    });
   });
 
   describe("Nodes::RollUp", () => {

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -74,13 +74,15 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compileWithCollector(node);
   }
 
+  override compileWithBinds(node: Node): [string, unknown[]] {
+    this.bindIndex = 0;
+    return super.compileWithBinds(node);
+  }
+
   protected override visitBindParam(node: Nodes.BindParam): SQLString {
-    if (node.value !== undefined) {
-      this.collector.append(this.quote(node.value));
-    } else {
-      this.bindIndex += 1;
-      this.collector.append(`$${this.bindIndex}`);
-    }
+    this.bindIndex += 1;
+    const value = node.value !== undefined ? node.value : node;
+    this.collector.addBind(value, () => `$${this.bindIndex}`);
     return this.collector;
   }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -866,7 +866,41 @@ describe("the to_sql visitor", () => {
   it("works with BindParams", () => {
     const v = new Visitors.ToSql();
     expect(v.compile(new Nodes.BindParam())).toBe("?");
-    expect(v.compile(new Nodes.BindParam(1))).toBe("1");
+    // BindParam with a value still emits a placeholder — the value
+    // is extracted via compileWithBinds, not inlined.
+    expect(v.compile(new Nodes.BindParam(1))).toBe("?");
+  });
+
+  it("compileWithBinds extracts bind values", () => {
+    const v = new Visitors.ToSql();
+    const table = new Table("users");
+    const mgr = table.project(star).where(table.get("id").eq(new Nodes.BindParam(42)));
+    const [sql, binds] = v.compileWithBinds(mgr.ast);
+    expect(sql).toContain("?");
+    expect(sql).not.toContain("42");
+    expect(binds).toEqual([42]);
+  });
+
+  it("compileWithBinds handles multiple bind params", () => {
+    const v = new Visitors.ToSql();
+    const table = new Table("users");
+    const mgr = table
+      .project(star)
+      .where(table.get("name").eq(new Nodes.BindParam("alice")))
+      .where(table.get("age").gt(new Nodes.BindParam(21)));
+    const [sql, binds] = v.compileWithBinds(mgr.ast);
+    expect(sql).toContain("?");
+    expect(sql).not.toContain("alice");
+    expect(sql).not.toContain("21");
+    expect(binds).toEqual(["alice", 21]);
+  });
+
+  it("compileWithBinds with undefined BindParam", () => {
+    const v = new Visitors.ToSql();
+    const node = new Nodes.BindParam();
+    const [sql, binds] = v.compileWithBinds(node);
+    expect(sql).toBe("?");
+    expect(binds).toHaveLength(1);
   });
 
   it("works with lists", () => {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -51,7 +51,8 @@ export class ToSql implements NodeVisitor<SQLString> {
     const bindCollector = new Bind();
     this.collector = new Composite(sqlCollector, bindCollector) as unknown as SQLString;
     this.visit(node);
-    return [sqlCollector.value, bindCollector.value];
+    const binds = bindCollector.value.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
+    return [sqlCollector.value, binds];
   }
 
   visit(node: Node): SQLString {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1,5 +1,7 @@
 import { Node, NodeVisitor } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
+import { Bind } from "../collectors/bind.js";
+import { Composite } from "../collectors/composite.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 
@@ -36,6 +38,20 @@ export class ToSql implements NodeVisitor<SQLString> {
     this.collector = new SQLString();
     this.visit(node);
     return this.collector;
+  }
+
+  /**
+   * Compile an AST node and extract bind values separately.
+   * Returns [sql_with_placeholders, bind_values].
+   *
+   * Mirrors: Rails' compilation with Arel::Collectors::Composite
+   */
+  compileWithBinds(node: Node): [string, unknown[]] {
+    const sqlCollector = new SQLString();
+    const bindCollector = new Bind();
+    this.collector = new Composite(sqlCollector, bindCollector) as unknown as SQLString;
+    this.visit(node);
+    return [sqlCollector.value, bindCollector.value];
   }
 
   visit(node: Node): SQLString {
@@ -909,9 +925,9 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   protected visitBindParam(node: Nodes.BindParam): SQLString {
     if (node.value !== undefined) {
-      this.collector.append(this.quote(node.value));
+      this.collector.addBind(node.value);
     } else {
-      this.collector.append("?");
+      this.collector.addBind(node);
     }
     return this.collector;
   }


### PR DESCRIPTION
## Summary

Foundation for prepared statement support. `visitBindParam` now calls `collector.addBind()` instead of manually appending placeholders, enabling `compileWithBinds()` which produces `[sql_with_placeholders, bind_values[]]` tuples.

- `ToSql.compileWithBinds(node)` — compiles with `Composite(SQLString, Bind)` collector, returns `[string, unknown[]]`
- `PostgreSQLWithBinds.compileWithBinds` — produces `$1, $2, ...` numbered placeholders
- `BindParam` with defined values now emits `?` placeholder instead of inlining — values are extracted via `compileWithBinds`, not baked into SQL
- `Composite.addBind` forwards block param for dialect-specific placeholder formatting
- 4 new tests for bind extraction (single/multiple/undefined/PostgreSQL)

This is PR 1 of the prepared statements epic. No backwards compat path — bind extraction is the way forward.

## Test plan

- [x] `pnpm run build` — clean
- [x] 987 Arel tests pass (0 failures)
- [x] 8435 ActiveRecord tests pass (0 downstream breakage)
- [x] CI