### PR TITLE
feat(activerecord): attribute-type wiring PR 2 — sync loadSchema reads schema cache

### DIFF
--- a/packages/activerecord/src/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encrypted-attribute-type.ts
@@ -13,13 +13,22 @@ import type { Encryptor } from "./encryption.js";
 export class EncryptedAttributeType extends Type<unknown> {
   readonly name: string;
   readonly innerType: Type;
-  readonly encryptor: Encryptor;
+  private readonly encryptor: Encryptor;
 
   constructor(innerType: Type, encryptor: Encryptor) {
     super();
     this.innerType = innerType;
     this.encryptor = encryptor;
     this.name = innerType.name;
+  }
+
+  /**
+   * Return a fresh EncryptedAttributeType wrapping `innerType` with the
+   * same encryptor. Used by schema reflection to re-wrap with the
+   * adapter-resolved cast type without exposing the encryptor field.
+   */
+  withInnerType(innerType: Type): EncryptedAttributeType {
+    return new EncryptedAttributeType(innerType, this.encryptor);
   }
 
   cast(value: unknown): unknown {

--- a/packages/activerecord/src/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encrypted-attribute-type.ts
@@ -13,7 +13,7 @@ import type { Encryptor } from "./encryption.js";
 export class EncryptedAttributeType extends Type<unknown> {
   readonly name: string;
   readonly innerType: Type;
-  private readonly encryptor: Encryptor;
+  readonly encryptor: Encryptor;
 
   constructor(innerType: Type, encryptor: Encryptor) {
     super();

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -183,6 +183,26 @@ describe("loadSchemaFromAdapter integration details", () => {
     expect(Post._attributeDefinitions.has("guid")).toBe(true);
   });
 
+  it("preserves user-declared defs for ignoredColumns (only strips accessor)", async () => {
+    class Post extends Base {
+      static override tableName = "posts";
+      static {
+        this.attribute("age", "integer");
+      }
+    }
+    (Post as unknown as { _ignoredColumns: string[] })._ignoredColumns = ["age"];
+
+    const adapter = makeAdapter({ age: { sqlType: "integer" } }, { integer: new UuidType() });
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    await Post.loadSchema();
+
+    // User-declared def survives ignoredColumns.
+    expect(Post._attributeDefinitions.has("age")).toBe(true);
+    expect(Post._attributeDefinitions.get("age")?.userProvided).toBe(true);
+    // Accessor stripped.
+    expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
+  });
+
   it("invalidates _columnsHash and _columns after reflection", async () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -186,6 +186,32 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Circle._attributeDefinitions.has("guid")).toBe(false);
   });
 
+  it("preserves subclass-declared attributes when unifying with STI base map", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {
+      static {
+        // User attribute declared on subclass — forks Circle's map.
+        this.attribute("radius", "integer");
+      }
+    }
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    Circle.columnsHash();
+
+    // Merged: base reflects guid, subclass's radius survives.
+    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Circle._attributeDefinitions.get("radius")?.userProvided).toBe(true);
+    expect(Shape._attributeDefinitions.get("radius")?.userProvided).toBe(true);
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
+  });
+
   it("invalidates subclass-local caches when reflection lands on STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -185,6 +185,28 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Circle._attributeDefinitions.has("guid")).toBe(false);
   });
 
+  it("invalidates subclass-local caches when reflection lands on STI base", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    // Pre-populate stale caches on the subclass.
+    (Circle as unknown as { _columnsHash: unknown })._columnsHash = { stale: true };
+    (Circle as unknown as { _columns: unknown })._columns = ["stale"];
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    Circle.columnsHash();
+
+    expect((Circle as unknown as { _columnsHash: unknown })._columnsHash).toBeUndefined();
+    expect((Circle as unknown as { _columns: unknown })._columns).toBeUndefined();
+  });
+
   it("resetColumnInformation on STI subclass resets the STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -156,6 +156,35 @@ describe("sync loadSchema / columnsHash", () => {
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
   });
 
+  it("resetColumnInformation scrubs schema-sourced defs from a subclass-forked map", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    // Fork the subclass map and put a schema-sourced def in it directly.
+    (Circle as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
+      new Map([
+        [
+          "guid",
+          {
+            name: "guid",
+            type: { name: "uuid" },
+            defaultValue: null,
+            userProvided: false,
+            source: "schema",
+          },
+        ],
+      ]);
+
+    (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
+
+    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
+  });
+
   it("resetColumnInformation on STI subclass resets the STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -230,6 +230,28 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(false);
   });
 
+  it("resetting the STI base propagates to subclasses (no stale _schemaLoaded shadow)", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    // Load via subclass — flag should land on the base only.
+    Circle.columnsHash();
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(false);
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+
+    // Reset base — subclass inherits the reset via prototype chain.
+    (resetColumnInformation as unknown as (this: typeof Base) => void).call(Shape);
+    expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(false);
+  });
+
   it("invalidates subclass-local caches when reflection lands on STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -212,6 +212,24 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
+  it("reflection deletes own-caches on subclass so base rebuilds shine through", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    (Circle as unknown as { _columnsHash: unknown })._columnsHash = { stale: true };
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    Circle.columnsHash();
+
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(false);
+  });
+
   it("invalidates subclass-local caches when reflection lands on STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -107,6 +107,57 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
   });
 
+  it("columnsHash on STI subclass returns cached Column objects from base adapter", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    const hash = Circle.columnsHash();
+    expect(hash.guid).toBe(cols.guid);
+  });
+
+  it("synthesized columnsHash fallback filters ignoredColumns", () => {
+    class Widget extends Base {
+      static override tableName = "widgets";
+      static {
+        this.attribute("name", "string");
+        this.attribute("secret", "string");
+      }
+    }
+    (Widget as unknown as { _ignoredColumns: string[] })._ignoredColumns = ["secret"];
+
+    const hash = Widget.columnsHash();
+    expect(hash.name).toBeDefined();
+    expect(hash.secret).toBeUndefined();
+  });
+
+  it("resetColumnInformation on STI subclass resets the STI base", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    Shape.columnsHash();
+    expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
+
+    (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
+
+    expect(Shape._attributeDefinitions.has("guid")).toBe(false);
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(false);
+  });
+
   it("resetColumnInformation drops schema-sourced defs but preserves user defs", () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -86,6 +86,27 @@ describe("sync loadSchema / columnsHash", () => {
     expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
   });
 
+  it("STI reflection falls back to subclass adapter when base has none", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("type", "string");
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    // Adapter ONLY on the subclass (Shape has none).
+    (Circle as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    Circle.columnsHash();
+
+    // Reflection should have landed on the STI base via subclass adapter.
+    expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
+  });
+
   it("resetColumnInformation drops schema-sourced defs but preserves user defs", () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -78,12 +78,12 @@ describe("sync loadSchema / columnsHash", () => {
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     (Circle as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
 
-    // Trigger load on subclass — must reflect on the STI base, not fork.
+    // Trigger load on subclass — must reflect on the STI base and
+    // subclass shares the base's map (same reference).
     Circle.columnsHash();
 
-    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
     expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
-    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
   it("STI reflection falls back to subclass adapter when base has none", () => {
@@ -102,9 +102,10 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    // Reflection should have landed on the STI base via subclass adapter.
+    // Reflection should have landed on the STI base via subclass adapter;
+    // subclass shares the base's map reference.
     expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
-    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
   it("columnsHash on STI subclass returns cached Column objects from base adapter", () => {

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -64,7 +64,7 @@ describe("sync loadSchema / columnsHash", () => {
     expect(hash.name.type).toBe("string");
   });
 
-  it("does not fork _attributeDefinitions on STI subclasses", () => {
+  it("STI subclass reflection delegates to base, without forking defs", () => {
     class Shape extends Base {
       static override tableName = "shapes";
       static {
@@ -78,16 +78,11 @@ describe("sync loadSchema / columnsHash", () => {
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     (Circle as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
 
-    // Trigger load on subclass first — must be a no-op for reflection.
+    // Trigger load on subclass — must reflect on the STI base, not fork.
     Circle.columnsHash();
 
-    const circleOwn = Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions");
-    expect(circleOwn).toBe(false);
-
-    // Base should still reflect normally.
-    Shape.columnsHash();
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
     expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
-    // Subclass sees the same defs via prototype chain.
     expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
   });
 

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -64,6 +64,33 @@ describe("sync loadSchema / columnsHash", () => {
     expect(hash.name.type).toBe("string");
   });
 
+  it("does not fork _attributeDefinitions on STI subclasses", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("type", "string");
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    (Circle as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    // Trigger load on subclass first — must be a no-op for reflection.
+    Circle.columnsHash();
+
+    const circleOwn = Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions");
+    expect(circleOwn).toBe(false);
+
+    // Base should still reflect normally.
+    Shape.columnsHash();
+    expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
+    // Subclass sees the same defs via prototype chain.
+    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
+  });
+
   it("resetColumnInformation drops schema-sourced defs but preserves user defs", () => {
     class Post extends Base {
       static override tableName = "posts";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
+import { Base } from "./base.js";
+import { resetColumnInformation } from "./model-schema.js";
+
+class UuidType extends ValueType {
+  override readonly name = "uuid" as unknown as "value";
+}
+
+function makeAdapter(columns: Record<string, unknown>): unknown {
+  return {
+    schemaCache: {
+      isCached: () => true,
+      getCachedColumnsHash: () => columns,
+      dataSourceExists: async () => true,
+      columnsHash: async () => columns,
+    },
+    lookupCastTypeFromColumn(column: { sqlType: string }) {
+      return column.sqlType === "uuid" ? new UuidType() : null;
+    },
+  };
+}
+
+describe("sync loadSchema / columnsHash", () => {
+  it("columnsHash returns cached Column objects when schema cache is populated", () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    const hash = Post.columnsHash();
+
+    expect(hash.guid).toBe(cols.guid);
+    expect(Post._attributeDefinitions.get("guid")?.source).toBe("schema");
+  });
+
+  it("columnsHash filters ignoredColumns out of the cached hash", () => {
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    (Post as unknown as { _ignoredColumns: string[] })._ignoredColumns = ["secret"];
+    const cols = {
+      guid: { sqlType: "uuid", name: "guid", default: null },
+      secret: { sqlType: "uuid", name: "secret", default: null },
+    };
+    (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    const hash = Post.columnsHash();
+
+    expect(hash.guid).toBeDefined();
+    expect(hash.secret).toBeUndefined();
+  });
+
+  it("falls back to synthesized hash when no schema cache is available", () => {
+    class Widget extends Base {
+      static override tableName = "widgets";
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    // No adapter — loadSchema's fallback path kicks in.
+    const hash = Widget.columnsHash();
+    expect(hash.name.type).toBe("string");
+  });
+
+  it("resetColumnInformation drops schema-sourced defs but preserves user defs", () => {
+    class Post extends Base {
+      static override tableName = "posts";
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    Post.columnsHash(); // triggers reflection
+
+    expect(Post._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Post._attributeDefinitions.get("title")?.source).toBe("user");
+
+    (resetColumnInformation as any).call(Post);
+
+    expect(Post._attributeDefinitions.has("guid")).toBe(false);
+    expect(Post._attributeDefinitions.get("title")?.source).toBe("user");
+  });
+});

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -138,6 +138,24 @@ describe("sync loadSchema / columnsHash", () => {
     expect(hash.secret).toBeUndefined();
   });
 
+  it("marks STI base as _schemaLoaded when subclass triggered reflection", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    Circle.columnsHash(); // subclass triggers, but work lands on base
+
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+    expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+  });
+
   it("resetColumnInformation on STI subclass resets the STI base", () => {
     class Shape extends Base {
       static override tableName = "shapes";

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -723,6 +723,16 @@ function applyColumnsHash(
   if (originatingHost && originatingHost !== host) invalidate(originatingHost);
 
   applyPendingEncryptions(host);
+
+  // STI: if `encrypts()` was declared on the subclass, its pending
+  // encryptions live on that subclass. Unify the subclass's
+  // _attributeDefinitions with the base's (so the subclass doesn't
+  // shadow the newly reflected defs — STI note 2 in applyColumnsHash
+  // doc), then apply its pending encryptions over the shared map.
+  if (originatingHost && originatingHost !== host) {
+    originatingHost._attributeDefinitions = host._attributeDefinitions;
+    applyPendingEncryptions(originatingHost);
+  }
 }
 
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
@@ -735,6 +745,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const schemaHost = isStiSubclass(klass) ? (getStiBase(klass) as unknown as SchemaHost) : this;
 
   let startingAdapter: SchemaHost["adapter"] | undefined;
+  let adapterOwner: SchemaHost | undefined;
   const candidates: SchemaHost[] = schemaHost === this ? [schemaHost] : [schemaHost, this];
   for (const cand of candidates) {
     try {
@@ -742,9 +753,12 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     } catch {
       startingAdapter = undefined;
     }
-    if (startingAdapter) break;
+    if (startingAdapter) {
+      adapterOwner = cand;
+      break;
+    }
   }
-  if (!startingAdapter) return;
+  if (!startingAdapter || !adapterOwner) return;
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
   const table = (schemaHost as unknown as typeof Base).tableName;
@@ -763,19 +777,17 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (!hash) return;
 
-  // Guard against adapter swaps during the async work above. Check both
-  // candidate hosts — whichever one supplied the adapter must still have it.
+  // Guard against adapter swaps during the async work above. Verify the
+  // *same* host that supplied startingAdapter still has it — checking
+  // other candidates would let a stale reflection slip through if the
+  // adapter moved.
   let currentAdapter: SchemaHost["adapter"] | undefined;
-  for (const cand of candidates) {
-    try {
-      currentAdapter = cand.adapter;
-    } catch {
-      currentAdapter = undefined;
-    }
-    if (currentAdapter === startingAdapter) break;
+  try {
+    currentAdapter = adapterOwner.adapter;
+  } catch {
     currentAdapter = undefined;
   }
-  if (!currentAdapter) return;
+  if (currentAdapter !== startingAdapter) return;
 
   applyColumnsHash(schemaHost, startingAdapter, hash, this);
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -145,13 +145,21 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   }
   loadSchema.call(this as unknown as SchemaHost);
 
-  // Prefer the adapter's schema cache when populated — it carries richer
-  // Column objects than what we can synthesize from attribute defs.
-  let adapter: typeof Base.prototype extends never ? never : typeof this.adapter | null = null;
-  try {
-    adapter = this.adapter;
-  } catch {
-    adapter = null;
+  // STI-aware adapter + table resolution: adapter may live on the base
+  // OR the concrete subclass. Use the same candidate-list logic the
+  // schema loader uses so `Circle.columnsHash()` can still pull the
+  // cached Column objects from Shape's adapter.
+  const klass = this;
+  const stiTarget = isStiSubclass(klass) ? getStiBase(klass) : klass;
+  const candidates = stiTarget === klass ? [klass] : [stiTarget, klass];
+  let adapter: DatabaseAdapterLike | null = null;
+  for (const cand of candidates) {
+    try {
+      adapter = (cand as typeof Base).adapter as unknown as DatabaseAdapterLike;
+    } catch {
+      adapter = null;
+    }
+    if (adapter) break;
   }
   const cache = (adapter as unknown as { schemaCache?: unknown } | null)?.schemaCache as
     | {
@@ -159,8 +167,9 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
         getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined;
       }
     | undefined;
-  if (cache && typeof cache.isCached === "function" && cache.isCached(this.tableName)) {
-    const cached = cache.getCachedColumnsHash?.(this.tableName);
+  const table = stiTarget.tableName;
+  if (cache && typeof cache.isCached === "function" && cache.isCached(table)) {
+    const cached = cache.getCachedColumnsHash?.(table);
     if (cached) {
       const ignored = new Set(this.ignoredColumns ?? []);
       const filtered: Record<string, ColumnLike> = {};
@@ -172,12 +181,18 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
     }
   }
 
+  // Synthesized fallback: filter ignoredColumns to match loadSchema's
+  // fallback and Rails behavior.
+  const ignored = new Set(this.ignoredColumns ?? []);
   const result: Record<string, ColumnLike> = {};
   for (const [name, def] of this._attributeDefinitions) {
+    if (ignored.has(name)) continue;
     result[name] = { name, type: def.type.name, default: def.defaultValue ?? null };
   }
   return result;
 }
+
+type DatabaseAdapterLike = { schemaCache?: unknown };
 
 /**
  * Return content columns (excluding PK, FKs, and timestamps).
@@ -476,6 +491,21 @@ export function symbolColumnToString(this: SchemaHost, name: string): string | u
  * attributes survive reload.
  */
 export function resetColumnInformation(this: SchemaHost): void {
+  // STI subclasses share the base's defs. Redirect the reset to the base
+  // so schema-sourced defs and accessors are actually cleared; clear the
+  // subclass-local caches too so any forked metadata is dropped.
+  if (isStiSubclass(this as unknown as typeof Base)) {
+    const subCaches = this as SchemaHost & { _cachedDefaultAttributes?: unknown };
+    subCaches._columnsHash = undefined;
+    subCaches._columns = undefined;
+    subCaches._attributesBuilder = undefined;
+    subCaches._schemaLoaded = false;
+    subCaches._cachedDefaultAttributes = null;
+    resetColumnInformation.call(
+      getStiBase(this as unknown as typeof Base) as unknown as SchemaHost,
+    );
+    return;
+  }
   this._columnsHash = undefined;
   this._columns = undefined;
   this._attributesBuilder = undefined;
@@ -512,13 +542,16 @@ export function loadSchema(this: SchemaHost): void {
   const reflected = loadSchemaFromCacheSync(this);
   if (reflected) return;
 
-  // Fallback: no schema cache — synthesize a columnsHash view over the
-  // existing attribute definitions so columns()/columnForAttribute()
-  // remain functional for fixture-only models.
-  if (!this._columnsHash && this._attributeDefinitions.size > 0) {
+  // Fallback: no schema cache — synthesize a columnsHash view. For STI
+  // subclasses, synthesize onto the STI base so the subclass doesn't
+  // fork _columnsHash (which would persist past a later base reflection).
+  const fallbackHost = isStiSubclass(this as unknown as typeof Base)
+    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
+    : this;
+  if (!fallbackHost._columnsHash && fallbackHost._attributeDefinitions.size > 0) {
     const hash: Record<string, any> = {};
-    const ignored = new Set(this._ignoredColumns ?? []);
-    for (const [name, def] of this._attributeDefinitions) {
+    const ignored = new Set(fallbackHost._ignoredColumns ?? []);
+    for (const [name, def] of fallbackHost._attributeDefinitions) {
       if (ignored.has(name)) continue;
       hash[name] = {
         name,
@@ -526,7 +559,7 @@ export function loadSchema(this: SchemaHost): void {
         default: def.defaultValue ?? null,
       };
     }
-    this._columnsHash = hash;
+    fallbackHost._columnsHash = hash;
   }
 }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -188,7 +188,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   const result: Record<string, ColumnLike> = {};
   for (const [name, def] of this._attributeDefinitions) {
     if (ignored.has(name)) continue;
-    result[name] = { name, type: def.type.name, default: def.defaultValue ?? null };
+    result[name] = { name, type: def.type?.name ?? null, default: def.defaultValue ?? null };
   }
   return result;
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -662,6 +662,15 @@ function applyColumnsHash(
       if (Object.prototype.hasOwnProperty.call(proto, name)) {
         delete (proto as Record<string, unknown>)[name];
       }
+      // STI: also strip a subclass-owned accessor if the originating
+      // host declared the attribute on itself, or `"col" in record` on
+      // the subclass would still return true.
+      if (originatingHost && originatingHost !== host) {
+        const subProto = (originatingHost as unknown as { prototype: object }).prototype;
+        if (Object.prototype.hasOwnProperty.call(subProto, name)) {
+          delete (subProto as Record<string, unknown>)[name];
+        }
+      }
       const existing = host._attributeDefinitions.get(name);
       if (!existing || (existing.userProvided ?? true) === false) {
         host._attributeDefinitions.delete(name);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -501,6 +501,21 @@ export function resetColumnInformation(this: SchemaHost): void {
     subCaches._attributesBuilder = undefined;
     subCaches._schemaLoaded = false;
     subCaches._cachedDefaultAttributes = null;
+    // Scrub schema-sourced entries from any subclass-forked
+    // _attributeDefinitions too (from a prior attribute() /
+    // decorateAttributes / encrypts call). Without this, schema defs
+    // leak past the reset on subclasses that forked their own map.
+    if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
+      for (const [name, def] of Array.from(this._attributeDefinitions)) {
+        if ((def.userProvided ?? true) === false || def.source === "schema") {
+          this._attributeDefinitions.delete(name);
+          const proto = (this as unknown as { prototype: object }).prototype;
+          if (Object.prototype.hasOwnProperty.call(proto, name)) {
+            delete (proto as Record<string, unknown>)[name];
+          }
+        }
+      }
+    }
     resetColumnInformation.call(
       getStiBase(this as unknown as typeof Base) as unknown as SchemaHost,
     );
@@ -596,15 +611,21 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
  * async `loadSchemaFromAdapter`.
  *
- * STI note: for STI subclasses, `host` is the STI base, so the base's
+ * STI note 1: for STI subclasses, `host` is the STI base, so the base's
  * `_ignoredColumns` governs which columns get accessors on the shared
  * prototype. Per-subclass `ignoredColumns` is still honored at read
  * time in `columnsHash()` (filters the returned hash), but it cannot
  * retroactively remove a prototype accessor already defined on the
  * base — a consequence of TypeScript not having Ruby's method_missing.
- * Rails itself defines `ignored_columns` as a class_attribute that
- * inherits; real divergence between STI base and subclass ignoredColumns
- * is rare, but document the limit so callers aren't surprised.
+ *
+ * STI note 2: reflection is applied to the STI base only. If a subclass
+ * previously forked `_attributeDefinitions` (via its own `attribute()`,
+ * `decorateAttributes`, or `encrypts` call), its forked map shadows the
+ * base's, so newly-reflected schema types won't be visible on the
+ * subclass. The follow-up fix is to route STI-subclass `attribute()`
+ * writes through the base (Rails-faithful: STI subclasses share
+ * attribute_types), which belongs in a separate PR that touches
+ * Base.attribute and attribute-registration.
  */
 function applyColumnsHash(
   host: SchemaHost,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -122,11 +122,6 @@ export function hasAttributeDefinition(this: typeof Base, name: string): boolean
 }
 
 /**
- * Return a hash of column definitions keyed by name.
- *
- * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
- */
-/**
  * Column-like shape returned by `columnsHash`. When the schema cache is
  * populated, entries are the adapter's full Column objects (`sqlType`,
  * `collation`, `comment`, nullable `type`, ...); otherwise a synthesized
@@ -140,6 +135,11 @@ export interface ColumnLike {
   [key: string]: unknown;
 }
 
+/**
+ * Return a hash of column definitions keyed by name.
+ *
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
+ */
 export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   if (this.abstractClass) {
     throw new Error(`Cannot call columnsHash on abstract class ${this.name}`);
@@ -604,18 +604,6 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
 }
 
 /**
- * Register attribute definitions from the adapter's schema cache.
- *
- * Mirrors: ActiveRecord::ModelSchema#load_schema! — walks `columns_hash`
- * and calls `define_attribute(..., user_provided_default: false)` for each
- * column so the cast type comes from the adapter (e.g. PG OID map) rather
- * than the generic ActiveModel type registry.
- *
- * Populates the schema cache if needed (async). User-declared attributes
- * (`userProvided: true`) are NEVER overwritten — matching Rails where
- * `attribute :foo, :bar` always wins over schema-reflected types.
- */
-/**
  * Sync worker: apply a columns hash (already fetched from the schema
  * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
  * async `loadSchemaFromAdapter`.
@@ -685,7 +673,7 @@ function applyColumnsHash(
       const scheme = existing.type.scheme;
       type = new SchemeEncryptedAttributeType({ scheme, castType: type });
     } else if (existing?.type instanceof EncryptorEncryptedAttributeType) {
-      type = new EncryptorEncryptedAttributeType(type, existing.type.encryptor);
+      type = existing.type.withInnerType(type);
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;
@@ -781,6 +769,18 @@ function applyColumnsHash(
   }
 }
 
+/**
+ * Register attribute definitions from the adapter's schema cache.
+ *
+ * Mirrors: ActiveRecord::ModelSchema#load_schema! — walks `columns_hash`
+ * and calls `define_attribute(..., user_provided_default: false)` for each
+ * column so the cast type comes from the adapter (e.g. PG OID map) rather
+ * than the generic ActiveModel type registry.
+ *
+ * Populates the schema cache if needed (async). User-declared attributes
+ * (`userProvided: true`) are NEVER overwritten — matching Rails where
+ * `attribute :foo, :bar` always wins over schema-reflected types.
+ */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (this._abstractClass) return;
   // STI subclasses inherit the base's attribute defs — reflect onto the

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -655,11 +655,18 @@ function applyColumnsHash(
   const ignored = new Set(host._ignoredColumns ?? []);
   for (const [name, column] of Object.entries(hash)) {
     if (ignored.has(name)) {
+      // Remove the prototype accessor unconditionally so `name in record`
+      // respects the ignore. Only drop the attribute def when it's
+      // schema-sourced — user-declared defs survive `ignoredColumns`
+      // per base.test.ts semantics.
       const proto = (host as unknown as { prototype: object }).prototype;
       if (Object.prototype.hasOwnProperty.call(proto, name)) {
         delete (proto as Record<string, unknown>)[name];
       }
-      host._attributeDefinitions.delete(name);
+      const existing = host._attributeDefinitions.get(name);
+      if (!existing || (existing.userProvided ?? true) === false) {
+        host._attributeDefinitions.delete(name);
+      }
       continue;
     }
     const existing = host._attributeDefinitions.get(name);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -497,11 +497,19 @@ export function resetColumnInformation(this: SchemaHost): void {
   // subclass-local caches too so any forked metadata is dropped.
   if (isStiSubclass(this as unknown as typeof Base)) {
     const subCaches = this as SchemaHost & { _cachedDefaultAttributes?: unknown };
-    subCaches._columnsHash = undefined;
-    subCaches._columns = undefined;
-    subCaches._attributesBuilder = undefined;
-    subCaches._schemaLoaded = false;
-    subCaches._cachedDefaultAttributes = null;
+    // Delete own properties rather than assigning undefined/false, so
+    // the subclass inherits the base's freshly-rebuilt caches via the
+    // prototype chain instead of shadowing them.
+    const sub = subCaches as unknown as Record<string, unknown>;
+    for (const key of [
+      "_columnsHash",
+      "_columns",
+      "_attributesBuilder",
+      "_schemaLoaded",
+      "_cachedDefaultAttributes",
+    ]) {
+      if (Object.prototype.hasOwnProperty.call(sub, key)) delete sub[key];
+    }
     // Scrub schema-sourced entries from any subclass-forked
     // _attributeDefinitions too (from a prior attribute() /
     // decorateAttributes / encrypts call). Without this, schema defs
@@ -710,15 +718,29 @@ function applyColumnsHash(
     _columnsHash?: unknown;
     _columns?: unknown;
   };
-  const invalidate = (h: SchemaHost) => {
-    const c = h as unknown as CacheBag;
-    c._attributesBuilder = undefined;
-    c._cachedDefaultAttributes = null;
-    c._columnsHash = undefined;
-    c._columns = undefined;
+  const invalidate = (h: SchemaHost, { deleteOwn }: { deleteOwn: boolean }) => {
+    const c = h as unknown as Record<string, unknown>;
+    if (deleteOwn) {
+      // Delete own properties so `h` inherits freshly-rebuilt caches
+      // from its prototype chain (used for the STI subclass case).
+      for (const key of [
+        "_attributesBuilder",
+        "_cachedDefaultAttributes",
+        "_columnsHash",
+        "_columns",
+      ]) {
+        if (Object.prototype.hasOwnProperty.call(c, key)) delete c[key];
+      }
+      return;
+    }
+    const bag = c as CacheBag;
+    bag._attributesBuilder = undefined;
+    bag._cachedDefaultAttributes = null;
+    bag._columnsHash = undefined;
+    bag._columns = undefined;
   };
-  invalidate(host);
-  if (originatingHost && originatingHost !== host) invalidate(originatingHost);
+  invalidate(host, { deleteOwn: false });
+  if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
 
   applyPendingEncryptions(host);
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -6,6 +6,7 @@ import {
   AttributeSetBuilder,
   YAMLEncoder,
   typeRegistry,
+  type Type,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
@@ -130,6 +131,36 @@ export function columnsHash(
   if (this.abstractClass) {
     throw new Error(`Cannot call columnsHash on abstract class ${this.name}`);
   }
+  loadSchema.call(this as unknown as SchemaHost);
+
+  // Prefer the adapter's schema cache when populated — it carries richer
+  // Column objects (sqlType, collation, comment, ...) than what we can
+  // synthesize from attribute defs.
+  let adapter: typeof Base.prototype extends never ? never : typeof this.adapter | null = null;
+  try {
+    adapter = this.adapter;
+  } catch {
+    adapter = null;
+  }
+  const cache = (adapter as unknown as { schemaCache?: unknown } | null)?.schemaCache as
+    | {
+        isCached?: (t: string) => boolean;
+        getCachedColumnsHash?: (t: string) => Record<string, unknown> | undefined;
+      }
+    | undefined;
+  if (cache && typeof cache.isCached === "function" && cache.isCached(this.tableName)) {
+    const cached = cache.getCachedColumnsHash?.(this.tableName);
+    if (cached) {
+      const ignored = new Set(this.ignoredColumns ?? []);
+      const filtered: Record<string, { name: string; type: string; default: unknown }> = {};
+      for (const [k, v] of Object.entries(cached)) {
+        if (ignored.has(k)) continue;
+        filtered[k] = v as { name: string; type: string; default: unknown };
+      }
+      return filtered;
+    }
+  }
+
   const result: Record<string, { name: string; type: string; default: unknown }> = {};
   for (const [name, def] of this._attributeDefinitions) {
     result[name] = { name, type: def.type.name, default: def.defaultValue ?? null };
@@ -428,23 +459,50 @@ export function symbolColumnToString(this: SchemaHost, name: string): string | u
 
 /**
  * Rails: clears column cache, schema cache, reloads schema.
+ * Drops schema-sourced attribute defs so the next load re-reflects
+ * them; user-declared defs (source === "user") are preserved, matching
+ * Rails' reload_schema_from_cache behavior where user-provided
+ * attributes survive reload.
  */
 export function resetColumnInformation(this: SchemaHost): void {
   this._columnsHash = undefined;
   this._columns = undefined;
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
+  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) return;
+  for (const [name, def] of Array.from(this._attributeDefinitions)) {
+    if ((def.userProvided ?? true) === false || def.source === "schema") {
+      this._attributeDefinitions.delete(name);
+      const proto = (this as unknown as { prototype: object }).prototype;
+      if (Object.prototype.hasOwnProperty.call(proto, name)) {
+        delete (proto as Record<string, unknown>)[name];
+      }
+    }
+  }
 }
 
 /**
- * Rails: loads schema from schema cache if not already loaded.
- * Our schema is defined via attribute() calls, so loading is
- * checking that _columnsHash is populated from attribute definitions.
+ * Mirrors: ActiveRecord::ModelSchema#load_schema
+ *
+ * Sync: consults the adapter's schema cache if it's already populated
+ * (no I/O), and reflects columns into `_attributeDefinitions`. For
+ * models without a backing table (test fixtures with only user
+ * `attribute()` declarations), falls back to synthesizing `_columnsHash`
+ * from existing defs so downstream readers continue to work.
+ *
+ * For a full async reflection (fetching from the adapter if the cache
+ * isn't populated), call `Base.loadSchema()` (base.ts).
  */
 export function loadSchema(this: SchemaHost): void {
   if (this._schemaLoaded) return;
   this._schemaLoaded = true;
 
+  const reflected = loadSchemaFromCacheSync(this);
+  if (reflected) return;
+
+  // Fallback: no schema cache — synthesize a columnsHash view over the
+  // existing attribute definitions so columns()/columnForAttribute()
+  // remain functional for fixture-only models.
   if (!this._columnsHash && this._attributeDefinitions.size > 0) {
     const hash: Record<string, any> = {};
     const ignored = new Set(this._ignoredColumns ?? []);
@@ -479,74 +537,47 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * (`userProvided: true`) are NEVER overwritten — matching Rails where
  * `attribute :foo, :bar` always wins over schema-reflected types.
  */
-export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
-  if (this._abstractClass) return;
-  const startingAdapter = this.adapter;
-  if (!startingAdapter) return;
-  const cache = startingAdapter.schemaCache;
-  if (!cache) return;
-  const table = (this as unknown as typeof Base).tableName;
-  const pool = startingAdapter.pool ?? startingAdapter;
-
-  if (typeof cache.dataSourceExists === "function") {
-    const exists = await cache.dataSourceExists(pool, table);
-    // Only bail on explicit false. `undefined` means the connection
-    // doesn't implement the probe — fall through and let columnsHash
-    // succeed or throw a real error.
-    if (exists === false) return;
+/**
+ * Sync worker: apply a columns hash (already fetched from the schema
+ * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
+ * async `loadSchemaFromAdapter`.
+ */
+function applyColumnsHash(
+  host: SchemaHost,
+  adapter: { lookupCastTypeFromColumn?: (c: unknown) => unknown },
+  hash: Record<string, unknown>,
+): void {
+  if (!Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
+    host._attributeDefinitions = new Map(host._attributeDefinitions);
   }
 
-  let hash: Record<string, unknown> | undefined;
-  if (typeof cache.columnsHash === "function") {
-    hash = await cache.columnsHash(pool, table);
-  } else if (typeof cache.getCachedColumnsHash === "function") {
-    hash = cache.getCachedColumnsHash(table);
-  }
-  if (!hash) return;
-
-  // Guard against adapter swaps during the async work above: if a different
-  // adapter was installed, discard this load rather than writing stale types.
-  if (this.adapter !== startingAdapter) return;
-
-  // Copy-on-write: match the ownership check used elsewhere (attributes.ts,
-  // encryption.ts) so we mutate this class's own map, not the inherited one.
-  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-    this._attributeDefinitions = new Map(this._attributeDefinitions);
-  }
-
-  const ignored = new Set(this._ignoredColumns ?? []);
+  const ignored = new Set(host._ignoredColumns ?? []);
   for (const [name, column] of Object.entries(hash)) {
-    // Honor Base.ignoredColumns — Rails' load_schema! excludes these too.
     if (ignored.has(name)) {
-      const proto = (this as unknown as { prototype: object }).prototype;
+      const proto = (host as unknown as { prototype: object }).prototype;
       if (Object.prototype.hasOwnProperty.call(proto, name)) {
         delete (proto as Record<string, unknown>)[name];
       }
-      this._attributeDefinitions.delete(name);
+      host._attributeDefinitions.delete(name);
       continue;
     }
-    const existing = this._attributeDefinitions.get(name);
-    // Treat absent userProvided as true — externally-constructed defs
-    // (pre-PR shape) are user-authored by definition; schema reflection
-    // must never overwrite them.
+    const existing = host._attributeDefinitions.get(name);
     if (existing && (existing.userProvided ?? true)) continue;
 
     const castType =
-      typeof startingAdapter.lookupCastTypeFromColumn === "function"
-        ? startingAdapter.lookupCastTypeFromColumn(column)
+      typeof adapter.lookupCastTypeFromColumn === "function"
+        ? adapter.lookupCastTypeFromColumn(column)
         : null;
-    let type = castType ?? typeRegistry.lookup("value");
+    let type = (castType as Type | null) ?? typeRegistry.lookup("value");
 
-    // Preserve an existing EncryptedAttributeType wrapper: re-wrap the
-    // fresh adapter-resolved cast type rather than discarding encryption.
     if (existing?.type instanceof EncryptedAttributeType) {
-      const scheme = (existing.type as EncryptedAttributeType).scheme;
+      const scheme = existing.type.scheme;
       type = new EncryptedAttributeType({ scheme, castType: type });
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;
 
-    this._attributeDefinitions.set(name, {
+    host._attributeDefinitions.set(name, {
       name,
       type,
       defaultValue,
@@ -554,21 +585,14 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
       source: "schema",
     });
 
-    // Define the prototype accessor so `record.foo` routes through
-    // readAttribute/writeAttribute. Mirrors what ActiveModel.attribute()
-    // does for user-declared attrs (attributes.ts ~L56).
-    //
-    // Skip "id": Base.prototype.id is an accessor with composite-PK
-    // logic (base.ts). Defining an own "id" on a subclass prototype
-    // would shadow it — Base.attribute has the same skip (base.ts:392).
     if (name === "id") {
-      const proto = (this as unknown as { prototype: object }).prototype;
+      const proto = (host as unknown as { prototype: object }).prototype;
       if (Object.prototype.hasOwnProperty.call(proto, "id")) {
         delete (proto as Record<string, unknown>).id;
       }
       continue;
     }
-    const proto = (this as unknown as { prototype: object }).prototype;
+    const proto = (host as unknown as { prototype: object }).prototype;
     if (!Object.prototype.hasOwnProperty.call(proto, name)) {
       Object.defineProperty(proto, name, {
         get(this: { readAttribute(n: string): unknown }) {
@@ -582,10 +606,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     }
   }
 
-  // Invalidate every cache that derives from _attributeDefinitions —
-  // columns()/columnsHash()/columnForAttribute() would otherwise serve
-  // pre-reflection data forever.
-  const caches = this as unknown as {
+  const caches = host as unknown as {
     _attributesBuilder?: unknown;
     _cachedDefaultAttributes?: unknown;
     _columnsHash?: unknown;
@@ -596,10 +617,64 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   caches._columnsHash = undefined;
   caches._columns = undefined;
 
-  // Re-run pending encryption decorations so `encrypts :foo` declared before
-  // schema load still wraps the adapter-resolved cast type. Mirrors the
-  // applyPendingEncryptions call in Base.attribute (base.ts).
-  applyPendingEncryptions(this);
+  applyPendingEncryptions(host);
+}
+
+export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
+  if (this._abstractClass) return;
+  const startingAdapter = this.adapter;
+  if (!startingAdapter) return;
+  const cache = startingAdapter.schemaCache;
+  if (!cache) return;
+  const table = (this as unknown as typeof Base).tableName;
+  const pool = startingAdapter.pool ?? startingAdapter;
+
+  if (typeof cache.dataSourceExists === "function") {
+    const exists = await cache.dataSourceExists(pool, table);
+    if (exists === false) return;
+  }
+
+  let hash: Record<string, unknown> | undefined;
+  if (typeof cache.columnsHash === "function") {
+    hash = await cache.columnsHash(pool, table);
+  } else if (typeof cache.getCachedColumnsHash === "function") {
+    hash = cache.getCachedColumnsHash(table);
+  }
+  if (!hash) return;
+
+  // Guard against adapter swaps during the async work above.
+  if (this.adapter !== startingAdapter) return;
+
+  applyColumnsHash(this, startingAdapter, hash);
+}
+
+/**
+ * Sync counterpart: consult the already-populated schema cache only.
+ * Returns true if reflection happened; false when the cache is empty
+ * (caller may fall back to attribute-defs-derived metadata).
+ */
+function loadSchemaFromCacheSync(host: SchemaHost): boolean {
+  if (host._abstractClass) return false;
+  // `host.adapter` throws when no pool is configured (fixture-only models).
+  // Treat that as "no adapter, no reflection" rather than propagating.
+  let adapter: SchemaHost["adapter"];
+  try {
+    adapter = host.adapter;
+  } catch {
+    return false;
+  }
+  if (!adapter) return false;
+  const cache = adapter.schemaCache;
+  if (!cache || typeof cache.isCached !== "function") return false;
+  const table = (host as unknown as typeof Base).tableName;
+  if (!cache.isCached(table)) return false;
+  const hash =
+    typeof cache.getCachedColumnsHash === "function"
+      ? cache.getCachedColumnsHash(table)
+      : undefined;
+  if (!hash) return false;
+  applyColumnsHash(host, adapter, hash);
+  return true;
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -12,7 +12,8 @@ import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { applyPendingEncryptions } from "./encryption.js";
-import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
+import { EncryptedAttributeType as SchemeEncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
+import { EncryptedAttributeType as EncryptorEncryptedAttributeType } from "./encrypted-attribute-type.js";
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -631,6 +632,13 @@ function applyColumnsHash(
   host: SchemaHost,
   adapter: { lookupCastTypeFromColumn?: (c: unknown) => unknown },
   hash: Record<string, unknown>,
+  /**
+   * Class the load was originally triggered on. Differs from `host` in
+   * STI: reflection lands on the base, but any caches the subclass
+   * already populated (`_columns`, `_columnsHash`, `_attributesBuilder`)
+   * would otherwise stay stale indefinitely.
+   */
+  originatingHost?: SchemaHost,
 ): void {
   if (!Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
     host._attributeDefinitions = new Map(host._attributeDefinitions);
@@ -655,9 +663,16 @@ function applyColumnsHash(
         : null;
     let type = (castType as Type | null) ?? typeRegistry.lookup("value");
 
-    if (existing?.type instanceof EncryptedAttributeType) {
+    // Preserve encryption wrappers across schema reflection — two
+    // distinct EncryptedAttributeType classes exist (scheme-based
+    // `encrypts()` macro vs encryptor-based internal path); handle both.
+    if (existing?.type instanceof SchemeEncryptedAttributeType) {
       const scheme = existing.type.scheme;
-      type = new EncryptedAttributeType({ scheme, castType: type });
+      type = new SchemeEncryptedAttributeType({ scheme, castType: type });
+    } else if (existing?.type instanceof EncryptorEncryptedAttributeType) {
+      const encryptor = (existing.type as unknown as { encryptor: unknown })
+        .encryptor as ConstructorParameters<typeof EncryptorEncryptedAttributeType>[1];
+      type = new EncryptorEncryptedAttributeType(type, encryptor);
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;
@@ -691,16 +706,21 @@ function applyColumnsHash(
     }
   }
 
-  const caches = host as unknown as {
+  type CacheBag = {
     _attributesBuilder?: unknown;
     _cachedDefaultAttributes?: unknown;
     _columnsHash?: unknown;
     _columns?: unknown;
   };
-  caches._attributesBuilder = undefined;
-  caches._cachedDefaultAttributes = null;
-  caches._columnsHash = undefined;
-  caches._columns = undefined;
+  const invalidate = (h: SchemaHost) => {
+    const c = h as unknown as CacheBag;
+    c._attributesBuilder = undefined;
+    c._cachedDefaultAttributes = null;
+    c._columnsHash = undefined;
+    c._columns = undefined;
+  };
+  invalidate(host);
+  if (originatingHost && originatingHost !== host) invalidate(originatingHost);
 
   applyPendingEncryptions(host);
 }
@@ -757,7 +777,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (!currentAdapter) return;
 
-  applyColumnsHash(schemaHost, startingAdapter, hash);
+  applyColumnsHash(schemaHost, startingAdapter, hash, this);
 }
 
 /**
@@ -796,7 +816,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
       ? cache.getCachedColumnsHash(table)
       : undefined;
   if (!hash) return false;
-  applyColumnsHash(schemaHost, adapter, hash);
+  applyColumnsHash(schemaHost, adapter, hash, host);
   return true;
 }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -447,8 +447,13 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
     }
   }
 
-  this._attributesBuilder = new AttributeSetBuilder(types, defaults);
-  return this._attributesBuilder;
+  // STI: write cache to the base so subclasses inherit via prototype
+  // chain, and a base reset propagates automatically.
+  const cacheHost = isStiSubclass(this as unknown as typeof Base)
+    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
+    : this;
+  cacheHost._attributesBuilder = new AttributeSetBuilder(types, defaults);
+  return cacheHost._attributesBuilder;
 }
 
 /**
@@ -458,8 +463,11 @@ export function columns(this: SchemaHost): any[] {
   if (this._columns) return this._columns;
   loadSchema.call(this);
   const hash = getColumnsHash(this);
-  this._columns = Object.values(hash);
-  return this._columns!;
+  const cacheHost = isStiSubclass(this as unknown as typeof Base)
+    ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
+    : this;
+  cacheHost._columns = Object.values(hash);
+  return cacheHost._columns!;
 }
 
 export function yamlEncoder(this: SchemaHost): YAMLEncoder {
@@ -561,15 +569,18 @@ export function resetColumnInformation(this: SchemaHost): void {
  */
 export function loadSchema(this: SchemaHost): void {
   if (this._schemaLoaded) return;
-  this._schemaLoaded = true;
 
-  // Determine the class that actually owns the schema load — the STI
-  // base when `this` is a subclass. We mark BOTH as loaded so a later
-  // call on the base doesn't redundantly re-run reflection just because
-  // its own `_schemaLoaded` flag was never set.
+  // The class that actually owns the schema load — the STI base when
+  // `this` is a subclass. We set `_schemaLoaded` only on the workHost
+  // so subclasses inherit the flag via the prototype chain. Assigning
+  // on the subclass would shadow the base flag and prevent re-reflection
+  // when the base is reset. Delete any stale own-flag on the subclass.
   const workHost = isStiSubclass(this as unknown as typeof Base)
     ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
     : this;
+  if (workHost !== this && Object.prototype.hasOwnProperty.call(this, "_schemaLoaded")) {
+    delete (this as unknown as Record<string, unknown>)._schemaLoaded;
+  }
 
   const reflected = loadSchemaFromCacheSync(this);
   if (reflected) {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -539,19 +539,27 @@ export function loadSchema(this: SchemaHost): void {
   if (this._schemaLoaded) return;
   this._schemaLoaded = true;
 
-  const reflected = loadSchemaFromCacheSync(this);
-  if (reflected) return;
-
-  // Fallback: no schema cache — synthesize a columnsHash view. For STI
-  // subclasses, synthesize onto the STI base so the subclass doesn't
-  // fork _columnsHash (which would persist past a later base reflection).
-  const fallbackHost = isStiSubclass(this as unknown as typeof Base)
+  // Determine the class that actually owns the schema load — the STI
+  // base when `this` is a subclass. We mark BOTH as loaded so a later
+  // call on the base doesn't redundantly re-run reflection just because
+  // its own `_schemaLoaded` flag was never set.
+  const workHost = isStiSubclass(this as unknown as typeof Base)
     ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
     : this;
-  if (!fallbackHost._columnsHash && fallbackHost._attributeDefinitions.size > 0) {
+
+  const reflected = loadSchemaFromCacheSync(this);
+  if (reflected) {
+    workHost._schemaLoaded = true;
+    return;
+  }
+
+  // Fallback: no schema cache — synthesize a columnsHash view on the
+  // work host so subclasses don't fork _columnsHash (which would persist
+  // past a later base reflection).
+  if (!workHost._columnsHash && workHost._attributeDefinitions.size > 0) {
     const hash: Record<string, any> = {};
-    const ignored = new Set(fallbackHost._ignoredColumns ?? []);
-    for (const [name, def] of fallbackHost._attributeDefinitions) {
+    const ignored = new Set(workHost._ignoredColumns ?? []);
+    for (const [name, def] of workHost._attributeDefinitions) {
       if (ignored.has(name)) continue;
       hash[name] = {
         name,
@@ -559,8 +567,9 @@ export function loadSchema(this: SchemaHost): void {
         default: def.defaultValue ?? null,
       };
     }
-    fallbackHost._columnsHash = hash;
+    workHost._columnsHash = hash;
   }
+  workHost._schemaLoaded = true;
 }
 
 function getColumnsHash(host: SchemaHost): Record<string, any> {
@@ -586,6 +595,16 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * Sync worker: apply a columns hash (already fetched from the schema
  * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
  * async `loadSchemaFromAdapter`.
+ *
+ * STI note: for STI subclasses, `host` is the STI base, so the base's
+ * `_ignoredColumns` governs which columns get accessors on the shared
+ * prototype. Per-subclass `ignoredColumns` is still honored at read
+ * time in `columnsHash()` (filters the returned hash), but it cannot
+ * retroactively remove a prototype accessor already defined on the
+ * base — a consequence of TypeScript not having Ruby's method_missing.
+ * Rails itself defines `ignored_columns` as a class_attribute that
+ * inherits; real divergence between STI base and subclass ignoredColumns
+ * is rare, but document the limit so callers aren't surprised.
  */
 function applyColumnsHash(
   host: SchemaHost,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -622,6 +622,9 @@ function applyColumnsHash(
 
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (this._abstractClass) return;
+  // STI subclasses inherit the base's attribute defs — skip reflection to
+  // avoid forking _attributeDefinitions.
+  if (isStiSubclass(this as unknown as typeof Base)) return;
   const startingAdapter = this.adapter;
   if (!startingAdapter) return;
   const cache = startingAdapter.schemaCache;
@@ -655,6 +658,10 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
  */
 function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (host._abstractClass) return false;
+  // STI subclasses share the base's table and attribute defs. Reflecting
+  // on a subclass would fork _attributeDefinitions into a divergent copy.
+  // Rails' load_schema! runs on the STI base; subclasses inherit.
+  if (isStiSubclass(host as unknown as typeof Base)) return false;
   // `host.adapter` throws when no pool is configured (fixture-only models).
   // Treat that as "no adapter, no reflection" rather than propagating.
   let adapter: SchemaHost["adapter"];

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -480,6 +480,7 @@ export function resetColumnInformation(this: SchemaHost): void {
   this._columns = undefined;
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
+  (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) return;
   for (const [name, def] of Array.from(this._attributeDefinitions)) {
     if ((def.userProvided ?? true) === false || def.source === "schema") {
@@ -633,19 +634,27 @@ function applyColumnsHash(
 
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (this._abstractClass) return;
-  // STI subclasses inherit the base's attribute defs — delegate to the
-  // STI base so `Circle.loadSchema()` still reflects (via Shape) rather
-  // than silently no-op'ing.
+  // STI subclasses inherit the base's attribute defs — reflect onto the
+  // STI base without forking. Use whichever class has the adapter
+  // configured (base in normal Rails setup, but tolerate subclass-only
+  // configuration).
   const klass = this as unknown as typeof Base;
-  if (isStiSubclass(klass)) {
-    await loadSchemaFromAdapter.call(getStiBase(klass) as unknown as SchemaHost);
-    return;
+  const schemaHost = isStiSubclass(klass) ? (getStiBase(klass) as unknown as SchemaHost) : this;
+
+  let startingAdapter: SchemaHost["adapter"] | undefined;
+  const candidates: SchemaHost[] = schemaHost === this ? [schemaHost] : [schemaHost, this];
+  for (const cand of candidates) {
+    try {
+      startingAdapter = cand.adapter;
+    } catch {
+      startingAdapter = undefined;
+    }
+    if (startingAdapter) break;
   }
-  const startingAdapter = this.adapter;
   if (!startingAdapter) return;
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
-  const table = (this as unknown as typeof Base).tableName;
+  const table = (schemaHost as unknown as typeof Base).tableName;
   const pool = startingAdapter.pool ?? startingAdapter;
 
   if (typeof cache.dataSourceExists === "function") {
@@ -661,10 +670,21 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (!hash) return;
 
-  // Guard against adapter swaps during the async work above.
-  if (this.adapter !== startingAdapter) return;
+  // Guard against adapter swaps during the async work above. Check both
+  // candidate hosts — whichever one supplied the adapter must still have it.
+  let currentAdapter: SchemaHost["adapter"] | undefined;
+  for (const cand of candidates) {
+    try {
+      currentAdapter = cand.adapter;
+    } catch {
+      currentAdapter = undefined;
+    }
+    if (currentAdapter === startingAdapter) break;
+    currentAdapter = undefined;
+  }
+  if (!currentAdapter) return;
 
-  applyColumnsHash(this, startingAdapter, hash);
+  applyColumnsHash(schemaHost, startingAdapter, hash);
 }
 
 /**
@@ -675,18 +695,23 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
 function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (host._abstractClass) return false;
   // STI subclasses share the base's table and attribute defs. Reflecting
-  // on a subclass would fork _attributeDefinitions; instead, redirect to
-  // the STI base so subclasses still trigger (and inherit) reflection.
+  // on a subclass would fork _attributeDefinitions; instead, apply
+  // reflection to the STI base so subclasses inherit it.
   const schemaHost = isStiSubclass(host as unknown as typeof Base)
     ? (getStiBase(host as unknown as typeof Base) as unknown as SchemaHost)
     : host;
-  // `host.adapter` throws when no pool is configured (fixture-only models).
-  // Treat that as "no adapter, no reflection" rather than propagating.
-  let adapter: SchemaHost["adapter"];
-  try {
-    adapter = schemaHost.adapter;
-  } catch {
-    return false;
+  // Adapter may be configured on the base OR on the subclass. Try base
+  // first (Rails-normal), fall back to the originating host. Access can
+  // throw when no pool is configured; treat as "no adapter".
+  let adapter: SchemaHost["adapter"] | undefined;
+  const candidates = schemaHost === host ? [schemaHost] : [schemaHost, host];
+  for (const cand of candidates) {
+    try {
+      adapter = cand.adapter;
+    } catch {
+      adapter = undefined;
+    }
+    if (adapter) break;
   }
   if (!adapter) return false;
   const cache = adapter.schemaCache;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -125,17 +125,28 @@ export function hasAttributeDefinition(this: typeof Base, name: string): boolean
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
  */
-export function columnsHash(
-  this: typeof Base,
-): Record<string, { name: string; type: string; default: unknown }> {
+/**
+ * Column-like shape returned by `columnsHash`. When the schema cache is
+ * populated, entries are the adapter's full Column objects (`sqlType`,
+ * `collation`, `comment`, nullable `type`, ...); otherwise a synthesized
+ * shape derived from attribute definitions.
+ */
+export interface ColumnLike {
+  name: string;
+  type?: string | null;
+  sqlType?: string;
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   if (this.abstractClass) {
     throw new Error(`Cannot call columnsHash on abstract class ${this.name}`);
   }
   loadSchema.call(this as unknown as SchemaHost);
 
   // Prefer the adapter's schema cache when populated — it carries richer
-  // Column objects (sqlType, collation, comment, ...) than what we can
-  // synthesize from attribute defs.
+  // Column objects than what we can synthesize from attribute defs.
   let adapter: typeof Base.prototype extends never ? never : typeof this.adapter | null = null;
   try {
     adapter = this.adapter;
@@ -145,23 +156,23 @@ export function columnsHash(
   const cache = (adapter as unknown as { schemaCache?: unknown } | null)?.schemaCache as
     | {
         isCached?: (t: string) => boolean;
-        getCachedColumnsHash?: (t: string) => Record<string, unknown> | undefined;
+        getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined;
       }
     | undefined;
   if (cache && typeof cache.isCached === "function" && cache.isCached(this.tableName)) {
     const cached = cache.getCachedColumnsHash?.(this.tableName);
     if (cached) {
       const ignored = new Set(this.ignoredColumns ?? []);
-      const filtered: Record<string, { name: string; type: string; default: unknown }> = {};
+      const filtered: Record<string, ColumnLike> = {};
       for (const [k, v] of Object.entries(cached)) {
         if (ignored.has(k)) continue;
-        filtered[k] = v as { name: string; type: string; default: unknown };
+        filtered[k] = v;
       }
       return filtered;
     }
   }
 
-  const result: Record<string, { name: string; type: string; default: unknown }> = {};
+  const result: Record<string, ColumnLike> = {};
   for (const [name, def] of this._attributeDefinitions) {
     result[name] = { name, type: def.type.name, default: def.defaultValue ?? null };
   }
@@ -622,9 +633,14 @@ function applyColumnsHash(
 
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (this._abstractClass) return;
-  // STI subclasses inherit the base's attribute defs — skip reflection to
-  // avoid forking _attributeDefinitions.
-  if (isStiSubclass(this as unknown as typeof Base)) return;
+  // STI subclasses inherit the base's attribute defs — delegate to the
+  // STI base so `Circle.loadSchema()` still reflects (via Shape) rather
+  // than silently no-op'ing.
+  const klass = this as unknown as typeof Base;
+  if (isStiSubclass(klass)) {
+    await loadSchemaFromAdapter.call(getStiBase(klass) as unknown as SchemaHost);
+    return;
+  }
   const startingAdapter = this.adapter;
   if (!startingAdapter) return;
   const cache = startingAdapter.schemaCache;
@@ -659,28 +675,30 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
 function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (host._abstractClass) return false;
   // STI subclasses share the base's table and attribute defs. Reflecting
-  // on a subclass would fork _attributeDefinitions into a divergent copy.
-  // Rails' load_schema! runs on the STI base; subclasses inherit.
-  if (isStiSubclass(host as unknown as typeof Base)) return false;
+  // on a subclass would fork _attributeDefinitions; instead, redirect to
+  // the STI base so subclasses still trigger (and inherit) reflection.
+  const schemaHost = isStiSubclass(host as unknown as typeof Base)
+    ? (getStiBase(host as unknown as typeof Base) as unknown as SchemaHost)
+    : host;
   // `host.adapter` throws when no pool is configured (fixture-only models).
   // Treat that as "no adapter, no reflection" rather than propagating.
   let adapter: SchemaHost["adapter"];
   try {
-    adapter = host.adapter;
+    adapter = schemaHost.adapter;
   } catch {
     return false;
   }
   if (!adapter) return false;
   const cache = adapter.schemaCache;
   if (!cache || typeof cache.isCached !== "function") return false;
-  const table = (host as unknown as typeof Base).tableName;
+  const table = (schemaHost as unknown as typeof Base).tableName;
   if (!cache.isCached(table)) return false;
   const hash =
     typeof cache.getCachedColumnsHash === "function"
       ? cache.getCachedColumnsHash(table)
       : undefined;
   if (!hash) return false;
-  applyColumnsHash(host, adapter, hash);
+  applyColumnsHash(schemaHost, adapter, hash);
   return true;
 }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -670,9 +670,7 @@ function applyColumnsHash(
       const scheme = existing.type.scheme;
       type = new SchemeEncryptedAttributeType({ scheme, castType: type });
     } else if (existing?.type instanceof EncryptorEncryptedAttributeType) {
-      const encryptor = (existing.type as unknown as { encryptor: unknown })
-        .encryptor as ConstructorParameters<typeof EncryptorEncryptedAttributeType>[1];
-      type = new EncryptorEncryptedAttributeType(type, encryptor);
+      type = new EncryptorEncryptedAttributeType(type, existing.type.encryptor);
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;
@@ -724,13 +722,32 @@ function applyColumnsHash(
 
   applyPendingEncryptions(host);
 
-  // STI: if `encrypts()` was declared on the subclass, its pending
-  // encryptions live on that subclass. Unify the subclass's
-  // _attributeDefinitions with the base's (so the subclass doesn't
-  // shadow the newly reflected defs — STI note 2 in applyColumnsHash
-  // doc), then apply its pending encryptions over the shared map.
+  // STI: if the subclass previously forked _attributeDefinitions (via
+  // attribute()/decorateAttributes()/encrypts()), carry its entries
+  // into the shared base map before unifying references — naive
+  // reassignment would silently discard subclass-declared attributes.
+  // Precedence: subclass user-provided entries win over base non-user
+  // entries; otherwise base wins (Rails' STI shares attribute_types,
+  // but subclass declarations extend it).
   if (originatingHost && originatingHost !== host) {
-    originatingHost._attributeDefinitions = host._attributeDefinitions;
+    const baseDefs = host._attributeDefinitions;
+    const subDefs = originatingHost._attributeDefinitions;
+    if (
+      baseDefs instanceof Map &&
+      subDefs instanceof Map &&
+      subDefs !== baseDefs &&
+      Object.prototype.hasOwnProperty.call(originatingHost, "_attributeDefinitions")
+    ) {
+      for (const [name, def] of subDefs) {
+        const existing = baseDefs.get(name);
+        const subIsUser = (def.userProvided ?? true) === true;
+        const baseIsUser = existing ? (existing.userProvided ?? true) === true : false;
+        if (!existing || (subIsUser && !baseIsUser)) {
+          baseDefs.set(name, def);
+        }
+      }
+    }
+    originatingHost._attributeDefinitions = baseDefs;
     applyPendingEncryptions(originatingHost);
   }
 }


### PR DESCRIPTION
## Summary

Builds on #584 to reverse `loadSchema`'s direction: `columnsHash` (schema cache) is now the primary source for `_attributeDefinitions`, matching Rails' `load_schema!`. Synthesis from user `attribute()` declarations becomes the fallback, not the primary path.

- Extracted `applyColumnsHash` worker — shared by sync `loadSchema` and async `loadSchemaFromAdapter`. Handles ignoredColumns, user-provided precedence, EncryptedAttributeType preservation, id-accessor skip, and cache invalidation in one place.
- `loadSchema` (sync) now calls `loadSchemaFromCacheSync`: if the schema cache is already populated for the table, reflect it into `_attributeDefinitions` with adapter-resolved cast types. Falls through to the legacy synthesize-from-attribute-defs path only when no schema cache is available (fixture-only models).
- `Base.columnsHash()` prefers the real cached Column objects (`sqlType`, `collation`, etc.) when the schema cache has them; falls back to synthesized `{ name, type, default }` shape.
- `resetColumnInformation` drops `source: "schema"` defs on reload but preserves user-declared defs (Rails' `reload_schema_from_cache` behavior).

## Test plan

- [x] 4 new unit tests in `model-schema-sync-load.test.ts`: cached Column reflection, ignoredColumns filtering, fallback synthesis, selective reset.
- [x] Full test suite: 17,483 passed / 4,420 skipped — no regressions (up from 17,475).
- [x] `pnpm tsc --noEmit` clean.