### PR TITLE
feat(arel,activerecord): Attribute.eq produces Casted nodes, wire bind extraction

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -96,8 +96,11 @@ export function toSqlAndBinds(
       );
     }
     const visitor = (this as any)?.arelVisitor as Visitors.ToSql | undefined;
-    const sql =
-      visitor && node instanceof Nodes.Node ? visitor.compile(node) : (node as any).toSql();
+    if (visitor && node instanceof Nodes.Node) {
+      const [sql, extractedBinds] = visitor.compileWithBinds(node);
+      return [sql, extractedBinds, preparable, allowRetry];
+    }
+    const sql = (node as any).toSql();
     return [sql, [], preparable, allowRetry];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -57,6 +57,25 @@ export function toSql(
   arel: unknown,
   binds: unknown[] = [],
 ): string {
+  if (typeof arel === "string") return arel;
+
+  // Unwrap TreeManager → Node
+  let node = arel;
+  if (node && (node as any).ast != null && typeof (node as any).ast === "object") {
+    node = (node as any).ast;
+  }
+
+  // Use compile() (inlines values) for display SQL, matching Rails'
+  // to_sql under unprepared_statement. toSqlAndBinds uses
+  // compileWithBinds for execution (placeholders + bind array).
+  const visitor = (this as any)?.arelVisitor as Visitors.ToSql | undefined;
+  if (visitor && node instanceof Nodes.Node) {
+    return visitor.compile(node);
+  }
+  if (node && typeof (node as any).toSql === "function") {
+    return (node as any).toSql();
+  }
+
   const [sql] = toSqlAndBinds.call(this, arel, binds);
   return sql;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,7 @@
 import pg from "pg";
 import { type Type, ValueType } from "@blazetrails/activemodel";
 import { singularize, underscore } from "@blazetrails/activesupport";
+import { Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
@@ -668,6 +669,10 @@ export class PostgreSQLAdapter extends AdapterBase implements DatabaseAdapter {
 
   indexAlgorithms(): Record<string, string> {
     return { concurrently: "CONCURRENTLY" };
+  }
+
+  get arelVisitor(): Visitors.ToSql {
+    return new Visitors.PostgreSQLWithBinds();
   }
 
   supportsDdlTransactions(): boolean {

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -183,6 +183,7 @@ function equalities(predicates: Nodes.Node[]): Nodes.Node[] {
 
 function extractNodeValue(node: unknown): unknown {
   if (node instanceof Nodes.Quoted) return node.value;
+  if (node instanceof Nodes.Casted) return node.valueForDatabase();
   if (Array.isArray(node)) return node.map((v) => extractNodeValue(v));
   return node;
 }

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -16,7 +16,7 @@ import { NotIn } from "../nodes/binary.js";
 import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-operation.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
-import { Quoted } from "../nodes/casted.js";
+import { Quoted, Casted } from "../nodes/casted.js";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";
 import { Or } from "../nodes/or.js";
@@ -112,30 +112,36 @@ export class Attribute extends Node {
     return value;
   }
 
+  private buildCasted(value: unknown): Node {
+    if (value instanceof Node) return value;
+    if (value === null || value === undefined) return new Quoted(value);
+    return new Casted(value, this);
+  }
+
   // -- Predicates --
 
   eq(other: unknown): Equality {
-    return new Equality(this, buildQuoted(this.castValue(other)));
+    return new Equality(this, this.buildCasted(other));
   }
 
   notEq(other: unknown): NotEqual {
-    return new NotEqual(this, buildQuoted(this.castValue(other)));
+    return new NotEqual(this, this.buildCasted(other));
   }
 
   gt(other: unknown): GreaterThan {
-    return new GreaterThan(this, buildQuoted(other));
+    return new GreaterThan(this, this.buildCasted(other));
   }
 
   gteq(other: unknown): GreaterThanOrEqual {
-    return new GreaterThanOrEqual(this, buildQuoted(other));
+    return new GreaterThanOrEqual(this, this.buildCasted(other));
   }
 
   lt(other: unknown): LessThan {
-    return new LessThan(this, buildQuoted(other));
+    return new LessThan(this, this.buildCasted(other));
   }
 
   lteq(other: unknown): LessThanOrEqual {
-    return new LessThanOrEqual(this, buildQuoted(other));
+    return new LessThanOrEqual(this, this.buildCasted(other));
   }
 
   matches(
@@ -144,7 +150,7 @@ export class Attribute extends Node {
     caseSensitive = false,
   ): Matches {
     const right =
-      typeof pattern === "string" ? buildQuoted(pattern) : (pattern as { ast: Node }).ast;
+      typeof pattern === "string" ? this.buildCasted(pattern) : (pattern as { ast: Node }).ast;
     return new Matches(this, right, escape, caseSensitive);
   }
 
@@ -154,16 +160,16 @@ export class Attribute extends Node {
     caseSensitive = false,
   ): DoesNotMatch {
     const right =
-      typeof pattern === "string" ? buildQuoted(pattern) : (pattern as { ast: Node }).ast;
+      typeof pattern === "string" ? this.buildCasted(pattern) : (pattern as { ast: Node }).ast;
     return new DoesNotMatch(this, right, escape, caseSensitive);
   }
 
   matchesRegexp(pattern: string, caseSensitive = true): RegexpNode {
-    return new RegexpNode(this, buildQuoted(pattern), caseSensitive);
+    return new RegexpNode(this, this.buildCasted(pattern), caseSensitive);
   }
 
   doesNotMatchRegexp(pattern: string, caseSensitive = true): NotRegexp {
-    return new NotRegexp(this, buildQuoted(pattern), caseSensitive);
+    return new NotRegexp(this, this.buildCasted(pattern), caseSensitive);
   }
 
   in(values: unknown[] | { ast: Node }): In {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -105,16 +105,9 @@ export class Attribute extends Node {
       : false;
   }
 
-  private castValue(value: unknown): unknown {
-    if (value instanceof SqlLiteral) return value;
-    if (value instanceof Node) return value;
-    if (this.caster) return this.caster.typeCastForDatabase(value);
-    return value;
-  }
-
   private buildCasted(value: unknown): Node {
     if (value instanceof Node) return value;
-    if (value === null || value === undefined) return new Quoted(value);
+    if (value === null || value === undefined) return new Quoted(null);
     return new Casted(value, this);
   }
 

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -26,9 +26,13 @@ export class Casted extends Node {
 
   valueForDatabase(): unknown {
     const attr = this.attribute as unknown as {
+      caster?: { typeCastForDatabase(v: unknown): unknown };
       isAbleToTypeCast?: () => boolean;
       typeCastForDatabase?: (v: unknown) => unknown;
     };
+    if (attr?.caster?.typeCastForDatabase) {
+      return attr.caster.typeCastForDatabase(this.value);
+    }
     if (attr?.isAbleToTypeCast?.() && attr.typeCastForDatabase) {
       return attr.typeCastForDatabase(this.value);
     }

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -79,6 +79,16 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compileWithBinds(node);
   }
 
+  protected override visitCasted(node: Nodes.Casted): SQLString {
+    if (this._extractBinds) {
+      this.bindIndex += 1;
+      this.collector.addBind(node.valueForDatabase(), () => `$${this.bindIndex}`);
+    } else {
+      this.collector.append(this.quote(node.valueForDatabase()));
+    }
+    return this.collector;
+  }
+
   protected override visitBindParam(node: Nodes.BindParam): SQLString {
     if (this._extractBinds) {
       this.bindIndex += 1;

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -80,9 +80,16 @@ export class PostgreSQLWithBinds extends PostgreSQL {
   }
 
   protected override visitBindParam(node: Nodes.BindParam): SQLString {
-    this.bindIndex += 1;
-    const value = node.value !== undefined ? node.value : node;
-    this.collector.addBind(value, () => `$${this.bindIndex}`);
+    if (this._extractBinds) {
+      this.bindIndex += 1;
+      const value = node.value !== undefined ? node.value : node;
+      this.collector.addBind(value, () => `$${this.bindIndex}`);
+    } else if (node.value !== undefined) {
+      this.collector.append(this.quote(node.value));
+    } else {
+      this.bindIndex += 1;
+      this.collector.append(`$${this.bindIndex}`);
+    }
     return this.collector;
   }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -866,9 +866,8 @@ describe("the to_sql visitor", () => {
   it("works with BindParams", () => {
     const v = new Visitors.ToSql();
     expect(v.compile(new Nodes.BindParam())).toBe("?");
-    // BindParam with a value still emits a placeholder — the value
-    // is extracted via compileWithBinds, not inlined.
-    expect(v.compile(new Nodes.BindParam(1))).toBe("?");
+    // compile() inlines values (like Rails' to_sql under unprepared_statement)
+    expect(v.compile(new Nodes.BindParam(1))).toBe("1");
   });
 
   it("compileWithBinds extracts bind values", () => {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1240,7 +1240,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitCasted(node: Nodes.Casted): SQLString {
+  protected visitCasted(node: Nodes.Casted): SQLString {
     const value = node.valueForDatabase();
     if (this._extractBinds) {
       this.collector.addBind(value);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -27,6 +27,7 @@ export class NotImplementedError extends Error {
 export class ToSql implements NodeVisitor<SQLString> {
   protected collector!: SQLString;
   private _inUpdateSet = false;
+  protected _extractBinds = false;
 
   compile(node: Node): string {
     this.collector = new SQLString();
@@ -50,7 +51,12 @@ export class ToSql implements NodeVisitor<SQLString> {
     const sqlCollector = new SQLString();
     const bindCollector = new Bind();
     this.collector = new Composite(sqlCollector, bindCollector) as unknown as SQLString;
-    this.visit(node);
+    this._extractBinds = true;
+    try {
+      this.visit(node);
+    } finally {
+      this._extractBinds = false;
+    }
     const binds = bindCollector.value.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
     return [sqlCollector.value, binds];
   }
@@ -925,8 +931,10 @@ export class ToSql implements NodeVisitor<SQLString> {
   // -- BindParam --
 
   protected visitBindParam(node: Nodes.BindParam): SQLString {
-    if (node.value !== undefined) {
-      this.collector.addBind(node.value);
+    if (this._extractBinds) {
+      this.collector.addBind(node.value !== undefined ? node.value : node);
+    } else if (node.value !== undefined) {
+      this.collector.append(this.quote(node.value));
     } else {
       this.collector.addBind(node);
     }
@@ -1233,7 +1241,12 @@ export class ToSql implements NodeVisitor<SQLString> {
   }
 
   private visitCasted(node: Nodes.Casted): SQLString {
-    this.collector.append(this.quote(node.value));
+    const value = node.valueForDatabase();
+    if (this._extractBinds) {
+      this.collector.addBind(value);
+    } else {
+      this.collector.append(this.quote(value));
+    }
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary

Stop string-stuffing. Attribute comparison methods now produce `Casted` nodes instead of `Quoted` nodes, carrying type metadata for proper bind parameter casting. The execution path extracts real bind values.

**Arel layer:**
- `Attribute.eq/notEq/gt/lt/gteq/lteq/matches/doesNotMatch/matchesRegexp/doesNotMatchRegexp` → `Casted(value, attribute)` instead of `Quoted(castValue(value))`
- `null`/`undefined` values stay as `Quoted` (for IS NULL/IS NOT NULL)
- `visitCasted`: uses `addBind(valueForDatabase())` when extracting binds, `quote(value)` when inlining
- `_extractBinds` flag: `compile()` inlines (like Rails' `to_sql` under `unprepared_statement`), `compileWithBinds()` extracts (like Rails' execution path)
- `Casted.valueForDatabase()` checks `attribute.caster` for type casting

**ActiveRecord layer:**
- `toSqlAndBinds()` calls `compileWithBinds()` to extract real bind values from Arel AST
- PostgreSQL adapter overrides `arelVisitor` → `PostgreSQLWithBinds` (produces `$1, $2, ...`)
- `WhereClause.extractNodeValue` handles `Casted` nodes for `scopeForCreate`/`whereValuesHash`

This is PR 2 of the prepared statements epic.

## Test plan

- [x] `pnpm run build` — clean
- [x] 987 Arel tests pass (0 failures)
- [x] 8487 ActiveRecord tests pass (0 failures)
- [x] CI