### PR TITLE
feat(activerecord): attribute-type wiring PR 3 — route _instantiate through adapter types

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1993,6 +1993,15 @@ export class Base extends Model {
       return instantiateSti(stiBase, row) as InstanceType<T>;
     }
 
+    // Ensure schema reflection has populated _attributeDefinitions with
+    // adapter-resolved cast types before hydrating from the row —
+    // otherwise writeFromDatabase falls back to ValueType and PG OID
+    // casts (uuid/jsonb/hstore/inet/range) are lost. Sync path only
+    // reads an already-populated schema cache; the preceding query
+    // would have populated it.
+
+    (ModelSchema.loadSchema as any).call(this);
+
     const record = new this() as InstanceType<T>;
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {

--- a/packages/activerecord/src/instantiate-schema-types.test.ts
+++ b/packages/activerecord/src/instantiate-schema-types.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
+import { Base } from "./base.js";
+
+// Custom type proves the adapter-resolved cast reaches the record —
+// its deserialize doubles a string so we can assert it ran.
+class DoublingType extends ValueType {
+  override readonly name = "doubling" as unknown as "value";
+  override deserialize(value: unknown): unknown {
+    return typeof value === "string" ? value + value : value;
+  }
+}
+
+function makeAdapter(columns: Record<string, unknown>): unknown {
+  return {
+    schemaCache: {
+      isCached: () => true,
+      getCachedColumnsHash: () => columns,
+      dataSourceExists: async () => true,
+      columnsHash: async () => columns,
+    },
+    lookupCastTypeFromColumn(column: { sqlType: string }) {
+      return column.sqlType === "doubling" ? new DoublingType() : null;
+    },
+  };
+}
+
+describe("_instantiate routes row values through adapter-resolved types", () => {
+  it("applies the schema-reflected cast type's deserialize on hydration", () => {
+    class Widget extends Base {
+      static override tableName = "widgets";
+    }
+    const cols = { payload: { sqlType: "doubling", name: "payload", default: null } };
+    (Widget as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    const rec = Widget._instantiate({ payload: "ab" });
+
+    // DoublingType.deserialize doubled the raw DB value.
+    expect((rec as unknown as { payload: string }).payload).toBe("abab");
+  });
+
+  it("falls back to ValueType when adapter has no cast for the column", () => {
+    class Widget extends Base {
+      static override tableName = "widgets";
+    }
+    const cols = { blob: { sqlType: "unknown", name: "blob", default: null } };
+    (Widget as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+
+    const rec = Widget._instantiate({ blob: "raw" });
+
+    expect((rec as unknown as { blob: string }).blob).toBe("raw");
+  });
+});


### PR DESCRIPTION
## Summary

Final wiring in the attribute-type series (#584 → #587 → this). Ensures rows hydrated by `_instantiate` go through the adapter-resolved cast types that schema reflection installed in \`_attributeDefinitions\`.

Before this PR:
- PR 1 (#584) added \`loadSchemaFromAdapter\` + auto-load on \`set adapter\`.
- PR 2 (#587) reversed \`loadSchema\` direction so \`columnsHash\`/\`columns\` reflect the schema cache.
- But \`_instantiate\` didn't trigger the sync loader itself, so a record hydrated before any user code touched \`columnsHash\`/\`columns\` would hit \`writeFromDatabase\`'s \`ValueType\` fallback — losing PG OID casts (uuid / jsonb / hstore / inet / range).

Change:
- \`_instantiate\` now calls \`loadSchema.call(this)\` before hydrating the row. Sync-only path (no I/O); the preceding query already populated the schema cache.
- Includes an end-to-end test that installs a custom \`DoublingType\` via \`lookupCastTypeFromColumn\` and asserts the record's attribute goes through that type's \`deserialize\` on hydration.

## Test plan

- [x] 2 new unit tests in \`instantiate-schema-types.test.ts\` prove a custom type's \`deserialize\` runs during \`_instantiate\`, and that the \`ValueType\` fallback still applies when the adapter has no cast for a column.
- [x] Full test suite: 17,495 passed / 4,420 skipped — no regressions.
- [x] \`pnpm tsc --noEmit\` clean.