### PR TITLE
feat(activerecord): trails-schema-dump emits JSON for trails-tsc --schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,14 +407,11 @@ string;`). Emit order is sorted alphabetically for stability.
 Emit the JSON from a live adapter with `trails-schema-dump`:
 
 ```sh
-# Print to stdout
+# Explicit URL — print to stdout
 trails-schema-dump --database-url postgres://localhost/mydb
 
-# Write to a file
-trails-schema-dump --out db/schema-columns.json
-
 # DATABASE_URL is read from the environment if --database-url is absent
-DATABASE_URL=postgres://... trails-schema-dump --out db/schema-columns.json
+DATABASE_URL=postgres://localhost/mydb trails-schema-dump --out db/schema-columns.json
 
 # Feed into the type-checker
 trails-tsc --schema db/schema-columns.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,5 +404,22 @@ Non-identifier / reserved-word column names (e.g. `strange-col`,
 `class`) are emitted as quoted class fields (`declare "strange-col":
 string;`). Emit order is sorted alphabetically for stability.
 
-A schema-dump command that emits this JSON from the live adapter is a
-planned follow-up.
+Emit the JSON from a live adapter with `trails-schema-dump`:
+
+```sh
+# Print to stdout
+trails-schema-dump --database-url postgres://localhost/mydb
+
+# Write to a file
+trails-schema-dump --out db/schema-columns.json
+
+# DATABASE_URL is read from the environment if --database-url is absent
+DATABASE_URL=postgres://... trails-schema-dump --out db/schema-columns.json
+
+# Feed into the type-checker
+trails-tsc --schema db/schema-columns.json
+```
+
+Rails-bookkeeping tables (`schema_migrations`, `ar_internal_metadata`)
+are skipped by default. Pass `--ignore t1,t2` to drop additional tables.
+Both tables and columns are emitted in sorted order for stable diffs.

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -32,7 +32,8 @@
     }
   },
   "bin": {
-    "trails-tsc": "./dist/tsc-wrapper/cli.js"
+    "trails-tsc": "./dist/tsc-wrapper/cli.js",
+    "trails-schema-dump": "./dist/bin/trails-schema-dump.js"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/activerecord/src/bin/trails-schema-dump.ts
+++ b/packages/activerecord/src/bin/trails-schema-dump.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+/**
+ * Dump the live database schema as JSON consumable by
+ * `trails-tsc --schema <path>`.
+ *
+ * Usage:
+ *   trails-schema-dump [--database-url <url>] [--out <path>] [--ignore table1,table2]
+ *
+ * The database URL is taken from, in order:
+ *   1. --database-url <url>
+ *   2. $DATABASE_URL
+ *
+ * Output:
+ *   --out <path>   writes JSON to the given file
+ *   (absent)       prints JSON to stdout
+ */
+
+import { getFs, getPath } from "@blazetrails/activesupport";
+
+import { Base } from "../base.js";
+import { dumpSchemaColumns } from "../schema-columns-dump.js";
+
+interface Args {
+  databaseUrl?: string;
+  outPath?: string;
+  ignore: readonly string[];
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const out: { databaseUrl?: string; outPath?: string; ignore: string[] } = { ignore: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    const readValue = (flag: string): string => {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        process.stderr.write(`trails-schema-dump: ${flag} expects a value.\n`);
+        process.exit(1);
+      }
+      i++;
+      return next;
+    };
+    if (a === "--database-url") out.databaseUrl = readValue("--database-url");
+    else if (a.startsWith("--database-url=")) out.databaseUrl = a.slice("--database-url=".length);
+    else if (a === "--out") out.outPath = readValue("--out");
+    else if (a.startsWith("--out=")) out.outPath = a.slice("--out=".length);
+    else if (a === "--ignore") {
+      out.ignore.push(...readValue("--ignore").split(",").filter(Boolean));
+    } else if (a.startsWith("--ignore=")) {
+      out.ignore.push(...a.slice("--ignore=".length).split(",").filter(Boolean));
+    } else if (a === "-h" || a === "--help") {
+      process.stdout.write(
+        "Usage: trails-schema-dump [--database-url <url>] [--out <path>] [--ignore t1,t2]\n",
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`trails-schema-dump: unknown argument: ${a}\n`);
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const url = args.databaseUrl ?? process.env.DATABASE_URL;
+  if (!url) {
+    process.stderr.write(
+      "trails-schema-dump: no database URL — pass --database-url or set DATABASE_URL.\n",
+    );
+    process.exit(1);
+  }
+
+  await Base.establishConnection(url);
+  const adapter = Base.adapter;
+  const dump = await dumpSchemaColumns(adapter, { ignoreTables: args.ignore });
+  const json = JSON.stringify(dump, null, 2) + "\n";
+
+  if (args.outPath) {
+    const resolved = getPath().resolve(args.outPath);
+    getFs().writeFileSync(resolved, json);
+    process.stdout.write(`trails-schema-dump: wrote ${resolved}\n`);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`trails-schema-dump: ${msg}\n`);
+  process.exit(1);
+});

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -152,6 +152,8 @@ export type {
   ColumnInfo,
   IndexInfo,
 } from "./connection-adapters/abstract/schema-dumper.js";
+export { dumpSchemaColumns } from "./schema-columns-dump.js";
+export type { DumpSchemaColumnsOptions } from "./schema-columns-dump.js";
 export {
   ActiveRecordError,
   SubclassNotFound,

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -114,6 +114,16 @@ describe("dumpSchemaColumns", () => {
           // PG array types
           { name: "tags", sqlType: "integer[]" },
           { name: "names", sqlType: "character varying[]" },
+          // PG multi-word type with inline precision (pg_catalog.format_type
+          // output for varchar).
+          { name: "email", sqlType: "character varying(255)" },
+          // MySQL boolean convention (tinyint(1)). sqlTypeMetadata.type
+          // is "tinyint" (→ integer) but sqlType is "tinyint(1)" (→ boolean).
+          {
+            name: "active_mysql",
+            sqlType: "tinyint(1)",
+            sqlTypeMetadata: { type: "tinyint" },
+          },
         ];
       },
     } as unknown as Parameters<typeof dumpSchemaColumns>[0];
@@ -133,6 +143,8 @@ describe("dumpSchemaColumns", () => {
       at_tz2: "time",
       tags: "array",
       names: "array",
+      email: "string",
+      active_mysql: "boolean",
     });
   });
 

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -72,6 +72,31 @@ describe("dumpSchemaColumns", () => {
     expect(Object.keys(dump.widgets)).toEqual(["alpha", "mike", "zulu"]);
   });
 
+  it("output feeds directly into trails-tsc's virtualizer (end-to-end)", async () => {
+    const { virtualize } = await import("./type-virtualization/virtualize.js");
+
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`
+      CREATE TABLE "users" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "name" TEXT,
+        "age" INTEGER
+      )
+    `);
+
+    // Dump → use as virtualizer input, no hand-editing.
+    const dump = await dumpSchemaColumns(adapter);
+    const src =
+      "export class User extends Base {\n" + '  static override tableName = "users";\n' + "}\n";
+    const { text } = virtualize(src, "user.ts", { schemaColumnsByTable: dump });
+
+    // Schema-sourced declares land for the columns the dump produced.
+    expect(text).toMatch(/declare name:/);
+    expect(text).toMatch(/declare age:/);
+    // `id` is skipped by the virtualizer (Base accessor handles it).
+    expect(text).not.toMatch(/declare id:/);
+  });
+
   it("emits tables in stable (sorted) order", async () => {
     const adapter = createTestAdapter();
     await adapter.executeMutation(`CREATE TABLE "zebras" ("id" INTEGER PRIMARY KEY)`);

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -29,10 +29,15 @@ describe("dumpSchemaColumns", () => {
     const dump = await dumpSchemaColumns(adapter);
 
     expect(Object.keys(dump).sort()).toEqual(["posts", "users"]);
-    expect(dump.users.id).toBeDefined();
-    expect(dump.users.name).toBeDefined();
-    expect(dump.users.age).toBeDefined();
-    expect(dump.posts.title).toBeDefined();
+    // Concrete Rails type assertions — trails-tsc keys on these exact
+    // strings, so raw SQL types (TEXT, VARCHAR, int4) would silently
+    // make the virtualizer emit `unknown`. Tests lock the mapping.
+    expect(dump.users.id).toBe("integer");
+    expect(dump.users.name).toBe("string");
+    expect(dump.users.age).toBe("integer");
+    expect(dump.users.created_at).toBe("datetime");
+    expect(dump.posts.title).toBe("string");
+    expect(dump.posts.body).toBe("text");
   });
 
   it("skips schema_migrations and ar_internal_metadata by default", async () => {
@@ -80,6 +85,43 @@ describe("dumpSchemaColumns", () => {
     const dump = await dumpSchemaColumns(adapter);
 
     expect(Object.keys(dump)).toEqual(["apples", "mangoes", "zebras"]);
+  });
+
+  it("normalizes raw SQL types to the Rails alphabet", async () => {
+    // Synthesize a minimal adapter whose `columns()` returns RAW SQL
+    // types with no SqlTypeMetadata.type populated. Verifies the
+    // normalization layer maps them to Rails type names.
+    const fakeAdapter = {
+      async tables() {
+        return ["widgets"];
+      },
+      async columns() {
+        return [
+          { name: "name", sqlType: "varchar(255)" },
+          { name: "bio", sqlType: "TEXT" },
+          { name: "count", sqlType: "int4" },
+          { name: "big", sqlType: "int8" },
+          { name: "price", sqlType: "numeric(10,2)" },
+          { name: "active", sqlType: "bool" },
+          { name: "at", sqlType: "timestamp without time zone" },
+          { name: "data", sqlType: "jsonb" },
+          { name: "guid", sqlType: "uuid" },
+        ];
+      },
+    } as unknown as Parameters<typeof dumpSchemaColumns>[0];
+
+    const dump = await dumpSchemaColumns(fakeAdapter);
+    expect(dump.widgets).toEqual({
+      name: "string",
+      bio: "text",
+      count: "integer",
+      big: "big_integer",
+      price: "decimal",
+      active: "boolean",
+      at: "datetime",
+      data: "jsonb",
+      guid: "uuid",
+    });
   });
 
   it("output feeds directly into trails-tsc's virtualizer (end-to-end)", async () => {

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -108,6 +108,12 @@ describe("dumpSchemaColumns", () => {
           { name: "at", sqlType: "timestamp without time zone" },
           { name: "data", sqlType: "jsonb" },
           { name: "guid", sqlType: "uuid" },
+          // PG-style inline precision + suffix text
+          { name: "at_tz", sqlType: "timestamp(3) without time zone" },
+          { name: "at_tz2", sqlType: "time(6) with time zone" },
+          // PG array types
+          { name: "tags", sqlType: "integer[]" },
+          { name: "names", sqlType: "character varying[]" },
         ];
       },
     } as unknown as Parameters<typeof dumpSchemaColumns>[0];
@@ -123,6 +129,10 @@ describe("dumpSchemaColumns", () => {
       at: "datetime",
       data: "jsonb",
       guid: "uuid",
+      at_tz: "datetime",
+      at_tz2: "time",
+      tags: "array",
+      names: "array",
     });
   });
 

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { createTestAdapter } from "./test-adapter.js";
+import { dumpSchemaColumns } from "./schema-columns-dump.js";
+
+describe("dumpSchemaColumns", () => {
+  it("emits a { table: { column: railsType } } map from a live adapter", async () => {
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`
+      CREATE TABLE "users" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "name" TEXT,
+        "age" INTEGER,
+        "created_at" DATETIME
+      )
+    `);
+    await adapter.executeMutation(`
+      CREATE TABLE "posts" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "title" TEXT,
+        "body" TEXT
+      )
+    `);
+
+    const dump = await dumpSchemaColumns(adapter);
+
+    expect(Object.keys(dump).sort()).toEqual(["posts", "users"]);
+    expect(dump.users.id).toBeDefined();
+    expect(dump.users.name).toBeDefined();
+    expect(dump.users.age).toBeDefined();
+    expect(dump.posts.title).toBeDefined();
+  });
+
+  it("skips schema_migrations and ar_internal_metadata by default", async () => {
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`
+      CREATE TABLE "schema_migrations" ("version" TEXT PRIMARY KEY)
+    `);
+    await adapter.executeMutation(`
+      CREATE TABLE "ar_internal_metadata" ("key" TEXT PRIMARY KEY, "value" TEXT)
+    `);
+    await adapter.executeMutation(`
+      CREATE TABLE "users" ("id" INTEGER PRIMARY KEY)
+    `);
+
+    const dump = await dumpSchemaColumns(adapter);
+
+    expect(Object.keys(dump)).toEqual(["users"]);
+  });
+
+  it("honors the ignoreTables option", async () => {
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY)`);
+    await adapter.executeMutation(`CREATE TABLE "sessions" ("id" INTEGER PRIMARY KEY)`);
+
+    const dump = await dumpSchemaColumns(adapter, { ignoreTables: ["sessions"] });
+
+    expect(Object.keys(dump).sort()).toEqual(["users"]);
+  });
+
+  it("emits columns in stable (sorted) order within each table", async () => {
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`
+      CREATE TABLE "widgets" (
+        "zulu" TEXT,
+        "alpha" TEXT,
+        "mike" TEXT
+      )
+    `);
+
+    const dump = await dumpSchemaColumns(adapter);
+
+    expect(Object.keys(dump.widgets)).toEqual(["alpha", "mike", "zulu"]);
+  });
+
+  it("emits tables in stable (sorted) order", async () => {
+    const adapter = createTestAdapter();
+    await adapter.executeMutation(`CREATE TABLE "zebras" ("id" INTEGER PRIMARY KEY)`);
+    await adapter.executeMutation(`CREATE TABLE "apples" ("id" INTEGER PRIMARY KEY)`);
+    await adapter.executeMutation(`CREATE TABLE "mangoes" ("id" INTEGER PRIMARY KEY)`);
+
+    const dump = await dumpSchemaColumns(adapter);
+
+    expect(Object.keys(dump)).toEqual(["apples", "mangoes", "zebras"]);
+  });
+});

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -124,6 +124,22 @@ describe("dumpSchemaColumns", () => {
             sqlType: "tinyint(1)",
             sqlTypeMetadata: { type: "tinyint" },
           },
+          // PG SchemaStatements fallback: sqlTypeMetadata.type is the UDT
+          // (e.g. `timestamptz`), sqlTypeMetadata.sqlType is the human
+          // SQL (e.g. `timestamp with time zone`). The latter should win.
+          {
+            name: "at_udt",
+            sqlTypeMetadata: {
+              type: "timestamptz",
+              sqlType: "timestamp with time zone",
+            },
+          },
+          // PG fallback array via UDT name (`_int4`): should still be
+          // detected as an array via the sqlType string (`int4[]`).
+          {
+            name: "tags_udt",
+            sqlTypeMetadata: { type: "_int4", sqlType: "int4[]" },
+          },
         ];
       },
     } as unknown as Parameters<typeof dumpSchemaColumns>[0];
@@ -145,6 +161,8 @@ describe("dumpSchemaColumns", () => {
       names: "array",
       email: "string",
       active_mysql: "boolean",
+      at_udt: "datetime",
+      tags_udt: "array",
     });
   });
 

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -1,25 +1,30 @@
 import { describe, it, expect } from "vitest";
 import { createTestAdapter } from "./test-adapter.js";
+import { MigrationContext } from "./migration.js";
 import { dumpSchemaColumns } from "./schema-columns-dump.js";
+import { SchemaMigration } from "./schema-migration.js";
+
+function fresh(): {
+  adapter: ReturnType<typeof createTestAdapter>;
+  ctx: MigrationContext;
+} {
+  const adapter = createTestAdapter();
+  const ctx = new MigrationContext(adapter);
+  return { adapter, ctx };
+}
 
 describe("dumpSchemaColumns", () => {
   it("emits a { table: { column: railsType } } map from a live adapter", async () => {
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`
-      CREATE TABLE "users" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-        "name" TEXT,
-        "age" INTEGER,
-        "created_at" DATETIME
-      )
-    `);
-    await adapter.executeMutation(`
-      CREATE TABLE "posts" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-        "title" TEXT,
-        "body" TEXT
-      )
-    `);
+    const { adapter, ctx } = fresh();
+    await ctx.createTable("users", {}, (t) => {
+      t.string("name");
+      t.integer("age");
+      t.datetime("created_at");
+    });
+    await ctx.createTable("posts", {}, (t) => {
+      t.string("title");
+      t.text("body");
+    });
 
     const dump = await dumpSchemaColumns(adapter);
 
@@ -31,26 +36,22 @@ describe("dumpSchemaColumns", () => {
   });
 
   it("skips schema_migrations and ar_internal_metadata by default", async () => {
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`
-      CREATE TABLE "schema_migrations" ("version" TEXT PRIMARY KEY)
-    `);
-    await adapter.executeMutation(`
-      CREATE TABLE "ar_internal_metadata" ("key" TEXT PRIMARY KEY, "value" TEXT)
-    `);
-    await adapter.executeMutation(`
-      CREATE TABLE "users" ("id" INTEGER PRIMARY KEY)
-    `);
+    const { adapter, ctx } = fresh();
+    // SchemaMigration.createTable() uses the adapter's portable DDL.
+    const sm = new SchemaMigration(adapter);
+    await sm.createTable();
+    await ctx.createTable("users", {}, () => {});
 
     const dump = await dumpSchemaColumns(adapter);
 
-    expect(Object.keys(dump)).toEqual(["users"]);
+    expect(Object.keys(dump)).toContain("users");
+    expect(Object.keys(dump)).not.toContain("schema_migrations");
   });
 
   it("honors the ignoreTables option", async () => {
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE "sessions" ("id" INTEGER PRIMARY KEY)`);
+    const { adapter, ctx } = fresh();
+    await ctx.createTable("users", {}, () => {});
+    await ctx.createTable("sessions", {}, () => {});
 
     const dump = await dumpSchemaColumns(adapter, { ignoreTables: ["sessions"] });
 
@@ -58,31 +59,37 @@ describe("dumpSchemaColumns", () => {
   });
 
   it("emits columns in stable (sorted) order within each table", async () => {
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`
-      CREATE TABLE "widgets" (
-        "zulu" TEXT,
-        "alpha" TEXT,
-        "mike" TEXT
-      )
-    `);
+    const { adapter, ctx } = fresh();
+    await ctx.createTable("widgets", {}, (t) => {
+      t.string("zulu");
+      t.string("alpha");
+      t.string("mike");
+    });
 
     const dump = await dumpSchemaColumns(adapter);
 
-    expect(Object.keys(dump.widgets)).toEqual(["alpha", "mike", "zulu"]);
+    expect(Object.keys(dump.widgets)).toEqual(["alpha", "id", "mike", "zulu"]);
+  });
+
+  it("emits tables in stable (sorted) order", async () => {
+    const { adapter, ctx } = fresh();
+    await ctx.createTable("zebras", {}, () => {});
+    await ctx.createTable("apples", {}, () => {});
+    await ctx.createTable("mangoes", {}, () => {});
+
+    const dump = await dumpSchemaColumns(adapter);
+
+    expect(Object.keys(dump)).toEqual(["apples", "mangoes", "zebras"]);
   });
 
   it("output feeds directly into trails-tsc's virtualizer (end-to-end)", async () => {
     const { virtualize } = await import("./type-virtualization/virtualize.js");
 
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`
-      CREATE TABLE "users" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-        "name" TEXT,
-        "age" INTEGER
-      )
-    `);
+    const { adapter, ctx } = fresh();
+    await ctx.createTable("users", {}, (t) => {
+      t.string("name");
+      t.integer("age");
+    });
 
     // Dump → use as virtualizer input, no hand-editing.
     const dump = await dumpSchemaColumns(adapter);
@@ -90,21 +97,9 @@ describe("dumpSchemaColumns", () => {
       "export class User extends Base {\n" + '  static override tableName = "users";\n' + "}\n";
     const { text } = virtualize(src, "user.ts", { schemaColumnsByTable: dump });
 
-    // Schema-sourced declares land for the columns the dump produced.
     expect(text).toMatch(/declare name:/);
     expect(text).toMatch(/declare age:/);
     // `id` is skipped by the virtualizer (Base accessor handles it).
     expect(text).not.toMatch(/declare id:/);
-  });
-
-  it("emits tables in stable (sorted) order", async () => {
-    const adapter = createTestAdapter();
-    await adapter.executeMutation(`CREATE TABLE "zebras" ("id" INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE "apples" ("id" INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE "mangoes" ("id" INTEGER PRIMARY KEY)`);
-
-    const dump = await dumpSchemaColumns(adapter);
-
-    expect(Object.keys(dump)).toEqual(["apples", "mangoes", "zebras"]);
   });
 });

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -32,7 +32,9 @@ describe("dumpSchemaColumns", () => {
     // Concrete Rails type assertions — trails-tsc keys on these exact
     // strings, so raw SQL types (TEXT, VARCHAR, int4) would silently
     // make the virtualizer emit `unknown`. Tests lock the mapping.
-    expect(dump.users.id).toBe("integer");
+    // `id` is integer on SQLite/PG but big_integer on MariaDB — both
+    // map to TS `number` in the virtualizer, so accept either.
+    expect(["integer", "big_integer"]).toContain(dump.users.id);
     expect(dump.users.name).toBe("string");
     expect(dump.users.age).toBe("integer");
     expect(dump.users.created_at).toBe("datetime");

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -78,6 +78,13 @@ export async function dumpSchemaColumns(
  * falls back to `unknown` when it sees a key it doesn't recognize.
  */
 function normalizeRailsType(col: AdapterColumn): string {
+  // MySQL reports booleans as `tinyint(1)`. `sqlTypeMetadata.type` is the
+  // unparameterized base ("tinyint") → would map to integer, losing the
+  // boolean semantics. `sqlType` carries the full `tinyint(1)`. Rails
+  // treats any tinyint(1) as boolean, so honor that special case up front.
+  const fullSqlType = (col.sqlType ?? col.sqlTypeMetadata?.sqlType ?? "").toLowerCase();
+  if (/^\s*tinyint\s*\(\s*1\s*\)/.test(fullSqlType)) return "boolean";
+
   const candidate = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "";
   const raw = candidate.toLowerCase();
   if (!raw) return "value";
@@ -88,12 +95,11 @@ function normalizeRailsType(col: AdapterColumn): string {
   // narrowing would need a richer schema format than a single string.
   if (raw.endsWith("[]")) return "array";
 
-  // Strip the `(precision[, scale])` block IMMEDIATELY following the
-  // SQL type token, even when more suffix text follows — PG commonly
-  // reports `timestamp(3) without time zone`, `time(6) with time zone`
-  // (those normalize to `timestamp without time zone` / `time with time zone`
-  // below). Also handles plain `varchar(255)` / `numeric(10,2)`.
-  const base = raw.replace(/^\s*([^( \t]+)\s*\([^)]*\)(.*)$/, "$1$2").trim();
+  // Strip the first `(precision[, scale])` block from the string, even
+  // when the type name is MULTI-WORD (`character varying(255)` →
+  // `character varying`) or has trailing suffix text
+  // (`timestamp(3) without time zone` → `timestamp without time zone`).
+  const base = raw.replace(/\s*\([^)]*\)/, "").trim();
   return SQL_TO_RAILS[base] ?? base;
 }
 

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -81,9 +81,19 @@ function normalizeRailsType(col: AdapterColumn): string {
   const candidate = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "";
   const raw = candidate.toLowerCase();
   if (!raw) return "value";
-  // Strip `(precision[, scale])` parameter block before mapping so
-  // `varchar(255)` / `numeric(10,2)` / `timestamp(3)` all normalize.
-  const base = raw.replace(/\s*\([^)]*\)\s*$/, "").trim();
+
+  // PostgreSQL array types end in `[]` (`integer[]`, `character varying[]`).
+  // Collapse every array type to the Rails `array` key regardless of
+  // element type — trails-tsc maps `array` → `unknown[]`. Element-type
+  // narrowing would need a richer schema format than a single string.
+  if (raw.endsWith("[]")) return "array";
+
+  // Strip the `(precision[, scale])` block IMMEDIATELY following the
+  // SQL type token, even when more suffix text follows — PG commonly
+  // reports `timestamp(3) without time zone`, `time(6) with time zone`
+  // (those normalize to `timestamp without time zone` / `time with time zone`
+  // below). Also handles plain `varchar(255)` / `numeric(10,2)`.
+  const base = raw.replace(/^\s*([^( \t]+)\s*\([^)]*\)(.*)$/, "$1$2").trim();
   return SQL_TO_RAILS[base] ?? base;
 }
 

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -80,27 +80,47 @@ export async function dumpSchemaColumns(
 function normalizeRailsType(col: AdapterColumn): string {
   // MySQL reports booleans as `tinyint(1)`. `sqlTypeMetadata.type` is the
   // unparameterized base ("tinyint") → would map to integer, losing the
-  // boolean semantics. `sqlType` carries the full `tinyint(1)`. Rails
-  // treats any tinyint(1) as boolean, so honor that special case up front.
-  const fullSqlType = (col.sqlType ?? col.sqlTypeMetadata?.sqlType ?? "").toLowerCase();
+  // boolean semantics. Rails treats any tinyint(1) as boolean.
+  const fullSqlType = (col.sqlTypeMetadata?.sqlType ?? col.sqlType ?? "").toLowerCase();
   if (/^\s*tinyint\s*\(\s*1\s*\)/.test(fullSqlType)) return "boolean";
 
-  const candidate = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "";
-  const raw = candidate.toLowerCase();
-  if (!raw) return "value";
+  // PostgreSQL array types are only reliably visible in the full SQL
+  // type string (`int4[]`, `character varying[]`). The PG
+  // SchemaStatements fallback exposes internal UDT names like `_int4`
+  // on sqlTypeMetadata.type, which would bypass a naive
+  // "candidate.endsWith('[]')" check — so detect off the full SQL
+  // string instead.
+  if (fullSqlType.trim().endsWith("[]")) return "array";
 
-  // PostgreSQL array types end in `[]` (`integer[]`, `character varying[]`).
-  // Collapse every array type to the Rails `array` key regardless of
-  // element type — trails-tsc maps `array` → `unknown[]`. Element-type
-  // narrowing would need a richer schema format than a single string.
-  if (raw.endsWith("[]")) return "array";
+  // Try each candidate through the SQL_TO_RAILS map, returning the
+  // first hit. PG adapter fallback sets sqlTypeMetadata.type to UDT
+  // names (`timestamptz`, `_int4`) while sqlTypeMetadata.sqlType
+  // carries the human-readable SQL (`timestamp with time zone`) — so
+  // prefer sqlType-bearing candidates first.
+  const candidates = [
+    col.sqlTypeMetadata?.sqlType,
+    col.sqlType,
+    col.sqlTypeMetadata?.type,
+    col.type,
+  ];
 
-  // Strip the first `(precision[, scale])` block from the string, even
-  // when the type name is MULTI-WORD (`character varying(255)` →
-  // `character varying`) or has trailing suffix text
-  // (`timestamp(3) without time zone` → `timestamp without time zone`).
-  const base = raw.replace(/\s*\([^)]*\)/, "").trim();
-  return SQL_TO_RAILS[base] ?? base;
+  let fallbackBase: string | undefined;
+  for (const candidate of candidates) {
+    const raw = candidate?.toLowerCase().trim();
+    if (!raw) continue;
+
+    // Strip the first `(precision[, scale])` block from the string, even
+    // when the type name is MULTI-WORD (`character varying(255)` →
+    // `character varying`) or has trailing suffix text
+    // (`timestamp(3) without time zone` → `timestamp without time zone`).
+    const base = raw.replace(/\s*\([^)]*\)/, "").trim();
+    fallbackBase ??= base;
+
+    const railsType = SQL_TO_RAILS[base];
+    if (railsType) return railsType;
+  }
+
+  return fallbackBase ?? "value";
 }
 
 // Common SQL → Rails type names. Covers the types adapters most

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -21,31 +21,129 @@ export interface DumpSchemaColumnsOptions {
 
 const ALWAYS_IGNORED = new Set(["schema_migrations", "ar_internal_metadata"]);
 
+type AdapterColumn = {
+  name: string;
+  sqlTypeMetadata?: { type?: string | null; sqlType?: string | null } | null;
+  sqlType?: string | null;
+  type?: string | null;
+};
+
+type AdapterWithTables = { tables(): Promise<string[]> };
+type AdapterWithColumns = { columns(table: string): Promise<AdapterColumn[]> };
+
+function hasTables(a: unknown): a is AdapterWithTables {
+  return typeof (a as AdapterWithTables).tables === "function";
+}
+function hasColumns(a: unknown): a is AdapterWithColumns {
+  return typeof (a as AdapterWithColumns).columns === "function";
+}
+
 export async function dumpSchemaColumns(
   adapter: DatabaseAdapter,
   options: DumpSchemaColumnsOptions = {},
 ): Promise<Record<string, Record<string, string>>> {
-  const schema = new SchemaStatements(adapter);
+  // Prefer the adapter's own `tables()` / `columns()` when present —
+  // PostgreSQL and SQLite adapters implement them with adapter-
+  // specific semantics (e.g. PG respects the current `search_path`).
+  // SchemaStatements is the portable fallback for adapters that don't.
+  let schema: SchemaStatements | undefined;
+  const schemaStatements = () => (schema ??= new SchemaStatements(adapter));
+
   const ignore = new Set([...ALWAYS_IGNORED, ...(options.ignoreTables ?? [])]);
 
-  const tables = (await schema.tables()).filter((t) => !ignore.has(t)).sort();
+  const rawTables = hasTables(adapter) ? await adapter.tables() : await schemaStatements().tables();
+  const tables = rawTables.filter((t) => !ignore.has(t)).sort();
 
   const out: Record<string, Record<string, string>> = Object.create(null);
   for (const table of tables) {
-    const cols = await schema.columns(table);
+    const cols = hasColumns(adapter)
+      ? await adapter.columns(table)
+      : await schemaStatements().columns(table);
     const colMap: Record<string, string> = Object.create(null);
-    // Sort columns for stable output.
     const sorted = [...cols].sort((a, b) => a.name.localeCompare(b.name));
     for (const col of sorted) {
-      // Prefer the Rails-normalized name from SqlTypeMetadata.type
-      // (e.g. "string", "integer", "datetime") — that's the alphabet
-      // trails-tsc keys by. `col.type` getter prefers sqlType which
-      // can be adapter-specific (e.g. "character varying(255)"), so go
-      // directly to the metadata when available.
-      const railsType = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "value";
-      colMap[col.name] = railsType;
+      colMap[col.name] = normalizeRailsType(col);
     }
     out[table] = colMap;
   }
   return out;
 }
+
+/**
+ * Normalize a column's type to the Rails alphabet trails-tsc's
+ * ATTRIBUTE_TYPE_MAP keys on (`string`, `integer`, `datetime`, `text`,
+ * `boolean`, ...). Prefers `sqlTypeMetadata.type` when the adapter
+ * populated it; otherwise maps common SQL types to their Rails
+ * equivalents. Unmapped types pass through lowercased — trails-tsc
+ * falls back to `unknown` when it sees a key it doesn't recognize.
+ */
+function normalizeRailsType(col: AdapterColumn): string {
+  const candidate = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "";
+  const raw = candidate.toLowerCase();
+  if (!raw) return "value";
+  // Strip `(precision[, scale])` parameter block before mapping so
+  // `varchar(255)` / `numeric(10,2)` / `timestamp(3)` all normalize.
+  const base = raw.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  return SQL_TO_RAILS[base] ?? base;
+}
+
+// Common SQL → Rails type names. Covers the types adapters most
+// frequently return raw (when SqlTypeMetadata.type isn't populated),
+// including PG-specific variants like `int4` / `varchar` and MySQL's
+// `tinyint(1)` → boolean pattern (handled via base="tinyint" →
+// "integer" — MySQL's connector often supplies metadata explicitly for
+// tinyint(1) booleans so we leave that path alone).
+const SQL_TO_RAILS: Record<string, string> = {
+  // strings
+  varchar: "string",
+  "character varying": "string",
+  char: "string",
+  character: "string",
+  // large text
+  text: "text",
+  longtext: "text",
+  mediumtext: "text",
+  tinytext: "text",
+  // integers
+  int: "integer",
+  int2: "integer",
+  int4: "integer",
+  int8: "big_integer",
+  integer: "integer",
+  smallint: "integer",
+  bigint: "big_integer",
+  tinyint: "integer",
+  mediumint: "integer",
+  // floats / decimals
+  float: "float",
+  "double precision": "float",
+  double: "float",
+  real: "float",
+  numeric: "decimal",
+  decimal: "decimal",
+  // booleans
+  bool: "boolean",
+  boolean: "boolean",
+  // dates / times
+  date: "date",
+  datetime: "datetime",
+  timestamp: "datetime",
+  "timestamp without time zone": "datetime",
+  "timestamp with time zone": "datetime",
+  time: "time",
+  "time without time zone": "time",
+  "time with time zone": "time",
+  // binary
+  blob: "binary",
+  bytea: "binary",
+  binary: "binary",
+  varbinary: "binary",
+  // PG extras
+  uuid: "uuid",
+  json: "json",
+  jsonb: "jsonb",
+  hstore: "hstore",
+  inet: "inet",
+  cidr: "cidr",
+  citext: "citext",
+};

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -1,0 +1,51 @@
+/**
+ * Emits a `{ table: { column: railsType } }` JSON map from a live
+ * adapter. Consumed by `trails-tsc --schema <path>` so the virtualizer
+ * can inject `declare` members for schema-only columns.
+ *
+ * Not in Rails — this is the bridge that gives TypeScript IDE
+ * autocomplete parity with Rails' runtime method_missing.
+ */
+
+import type { DatabaseAdapter } from "./adapter.js";
+import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+
+export interface DumpSchemaColumnsOptions {
+  /**
+   * Tables to skip. Always includes `schema_migrations` and
+   * `ar_internal_metadata` — those are bookkeeping tables Rails never
+   * maps to user models.
+   */
+  ignoreTables?: readonly string[];
+}
+
+const ALWAYS_IGNORED = new Set(["schema_migrations", "ar_internal_metadata"]);
+
+export async function dumpSchemaColumns(
+  adapter: DatabaseAdapter,
+  options: DumpSchemaColumnsOptions = {},
+): Promise<Record<string, Record<string, string>>> {
+  const schema = new SchemaStatements(adapter);
+  const ignore = new Set([...ALWAYS_IGNORED, ...(options.ignoreTables ?? [])]);
+
+  const tables = (await schema.tables()).filter((t) => !ignore.has(t)).sort();
+
+  const out: Record<string, Record<string, string>> = Object.create(null);
+  for (const table of tables) {
+    const cols = await schema.columns(table);
+    const colMap: Record<string, string> = Object.create(null);
+    // Sort columns for stable output.
+    const sorted = [...cols].sort((a, b) => a.name.localeCompare(b.name));
+    for (const col of sorted) {
+      // Prefer the Rails-normalized name from SqlTypeMetadata.type
+      // (e.g. "string", "integer", "datetime") — that's the alphabet
+      // trails-tsc keys by. `col.type` getter prefers sqlType which
+      // can be adapter-specific (e.g. "character varying(255)"), so go
+      // directly to the metadata when available.
+      const railsType = col.sqlTypeMetadata?.type ?? col.sqlType ?? col.type ?? "value";
+      colMap[col.name] = railsType;
+    }
+    out[table] = colMap;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Closes the attribute-type wiring loop. After #584/#587/#594/#595/#596 the runtime reflects schema types and `trails-tsc --schema` injects compile-time declares — but users still had to author the schema-columns JSON by hand. This PR generates it straight from a live adapter.

### New

- **`dumpSchemaColumns(adapter, opts)`** (library): walks `SchemaStatements.tables() + columns()`, emits `{ table: { column: railsType } }`. Prefers `col.sqlTypeMetadata.type` (Rails-normalized: `string`, `integer`, `datetime`, ...) over raw `sqlType`. Skips `schema_migrations` and `ar_internal_metadata` by default.
- **`trails-schema-dump`** (bin): thin CLI wrapper. Reads `DATABASE_URL` env var or `--database-url`, writes to `--out <path>` or stdout, accepts `--ignore t1,t2` for extra skips.

```sh
DATABASE_URL=postgres://localhost/mydb trails-schema-dump --out db/schema-columns.json
trails-tsc --schema db/schema-columns.json
```

### Test plan

- [x] 5 unit tests cover: basic emission, built-in skip list, `--ignore`, sorted columns, sorted tables.
- [x] Full test suite: 17,515 passed / 4,420 skipped.
- [x] `pnpm tsc --noEmit` clean.