### PR TITLE
refactor(activerecord): unify EncryptedAttributeType preservation via withInnerType

### DIFF
--- a/packages/activerecord/src/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encrypted-attribute-type.ts
@@ -1,5 +1,6 @@
 import { Type } from "@blazetrails/activemodel";
 import type { Encryptor } from "./encryption.js";
+import type { WrappedType } from "./encryption/wrapped-type.js";
 
 /**
  * Type decorator that transparently encrypts/decrypts attribute values.
@@ -10,7 +11,7 @@ import type { Encryptor } from "./encryption.js";
  * and decrypted on read (deserialize → decrypt). The inner type handles
  * normal casting; this layer adds the encryption envelope.
  */
-export class EncryptedAttributeType extends Type<unknown> {
+export class EncryptedAttributeType extends Type<unknown> implements WrappedType {
   readonly name: string;
   readonly innerType: Type;
   private readonly encryptor: Encryptor;

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -35,6 +35,25 @@ export class EncryptedAttributeType extends Type {
     this._encryptor = options.scheme.encryptor;
   }
 
+  /**
+   * Return a fresh EncryptedAttributeType wrapping `innerType` with the
+   * same scheme. Used by schema reflection to re-wrap with the
+   * adapter-resolved cast type without reconstructing scheme/options.
+   *
+   * Shared contract with the simpler Encryptor-based
+   * EncryptedAttributeType in the parent directory — both classes
+   * expose `withInnerType` so consumers can unify on a single duck-typed
+   * check instead of branching on `instanceof`.
+   */
+  withInnerType(innerType: Type): EncryptedAttributeType {
+    return new EncryptedAttributeType({
+      scheme: this.scheme,
+      castType: innerType,
+      previousType: this._previousType,
+      default: this._default,
+    });
+  }
+
   cast(value: unknown): unknown {
     return this.castType.cast(value);
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -1,6 +1,7 @@
 import { Type, StringType } from "@blazetrails/activemodel";
 import type { Scheme } from "./scheme.js";
 import type { Encryptor } from "./encryptor.js";
+import type { WrappedType } from "./wrapped-type.js";
 import { isEncryptionDisabled, isProtectedMode } from "./context.js";
 import { Configurable } from "./configurable.js";
 import { Encryption as EncryptionError } from "./errors.js";
@@ -12,7 +13,7 @@ import { Encryption as EncryptionError } from "./errors.js";
  *
  * Mirrors: ActiveRecord::Encryption::EncryptedAttributeType
  */
-export class EncryptedAttributeType extends Type {
+export class EncryptedAttributeType extends Type implements WrappedType {
   readonly name = "encrypted";
   readonly scheme: Scheme;
   readonly castType: Type;

--- a/packages/activerecord/src/encryption/wrapped-type.ts
+++ b/packages/activerecord/src/encryption/wrapped-type.ts
@@ -1,4 +1,4 @@
-import type { Type } from "@blazetrails/activemodel";
+import { Type } from "@blazetrails/activemodel";
 
 /**
  * Shared contract for types that wrap an inner cast type (e.g.
@@ -6,6 +6,12 @@ import type { Type } from "@blazetrails/activemodel";
  * `applyColumnsHash` — can preserve such wrappers across
  * adapter-resolved type changes by calling `withInnerType(newInner)`
  * without knowing the concrete class.
+ *
+ * Extends `Type` so consumers can assign the result back into any
+ * Type-typed slot without assertions. `withInnerType` returns `Type`
+ * (rather than `WrappedType`) because the replacement is conceptually
+ * "a Type that happens to still wrap" — narrowing back to the wrapper
+ * isn't what callers need.
  *
  * Both EncryptedAttributeType variants implement this:
  *   - `packages/activerecord/src/encrypted-attribute-type.ts`
@@ -16,15 +22,13 @@ import type { Type } from "@blazetrails/activemodel";
  * Future consolidation onto a single Rails-faithful class is tracked
  * in the attr-type-wiring follow-ups memory note.
  */
-export interface WrappedType {
-  withInnerType(innerType: Type): WrappedType;
+export interface WrappedType extends Type {
+  withInnerType(innerType: Type): Type;
 }
 
 /** Duck-typed predicate — narrows `t` to a `WrappedType`. */
 export function isWrappedType(t: unknown): t is WrappedType {
   return (
-    typeof t === "object" &&
-    t !== null &&
-    typeof (t as { withInnerType?: unknown }).withInnerType === "function"
+    t instanceof Type && typeof (t as { withInnerType?: unknown }).withInnerType === "function"
   );
 }

--- a/packages/activerecord/src/encryption/wrapped-type.ts
+++ b/packages/activerecord/src/encryption/wrapped-type.ts
@@ -1,0 +1,30 @@
+import type { Type } from "@blazetrails/activemodel";
+
+/**
+ * Shared contract for types that wrap an inner cast type (e.g.
+ * encryption wrappers). Consumers — notably schema reflection in
+ * `applyColumnsHash` — can preserve such wrappers across
+ * adapter-resolved type changes by calling `withInnerType(newInner)`
+ * without knowing the concrete class.
+ *
+ * Both EncryptedAttributeType variants implement this:
+ *   - `packages/activerecord/src/encrypted-attribute-type.ts`
+ *     (encryptor-based; used by `Base.encrypts()`)
+ *   - `packages/activerecord/src/encryption/encrypted-attribute-type.ts`
+ *     (scheme-based; used by `EncryptableRecord.encrypts()`)
+ *
+ * Future consolidation onto a single Rails-faithful class is tracked
+ * in the attr-type-wiring follow-ups memory note.
+ */
+export interface WrappedType {
+  withInnerType(innerType: Type): WrappedType;
+}
+
+/** Duck-typed predicate — narrows `t` to a `WrappedType`. */
+export function isWrappedType(t: unknown): t is WrappedType {
+  return (
+    typeof t === "object" &&
+    t !== null &&
+    typeof (t as { withInnerType?: unknown }).withInnerType === "function"
+  );
+}

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -3,6 +3,7 @@ import { ValueType, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
+import type { WrappedType } from "./encryption/wrapped-type.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -308,12 +309,11 @@ describe("set adapter auto-loads schema", () => {
 
 describe("schema reflection preserves any wrapper with withInnerType", () => {
   it("calls withInnerType on an existing non-user-provided wrapped type", async () => {
-    // Custom duck-typed wrapper — not an EncryptedAttributeType, just
-    // exposes the shared withInnerType contract. applyColumnsHash
-    // should route through it when preserving the wrapper on reflect.
-    const rewrappedWith: unknown[] = [];
-    class WrapperType extends ValueType {
-      override readonly name = "wrapper" as unknown as "value";
+    // Custom wrapper — not an EncryptedAttributeType, just implements
+    // the shared WrappedType contract. applyColumnsHash should route
+    // through it when preserving the wrapper on reflect.
+    const rewrappedWith: Type[] = [];
+    class WrapperType extends ValueType implements WrappedType {
       withInnerType(innerType: Type): WrapperType {
         rewrappedWith.push(innerType);
         return new WrapperType();

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -306,6 +306,52 @@ describe("set adapter auto-loads schema", () => {
   });
 });
 
+describe("schema reflection preserves any wrapper with withInnerType", () => {
+  it("calls withInnerType on an existing non-user-provided wrapped type", async () => {
+    // Custom duck-typed wrapper — not an EncryptedAttributeType, just
+    // exposes the shared withInnerType contract. applyColumnsHash
+    // should route through it when preserving the wrapper on reflect.
+    const rewrappedWith: unknown[] = [];
+    class WrapperType extends ValueType {
+      override readonly name = "wrapper" as unknown as "value";
+      withInnerType(innerType: Type): WrapperType {
+        rewrappedWith.push(innerType);
+        return new WrapperType();
+      }
+    }
+
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const adapter = makeAdapter({ payload: { sqlType: "uuid" } }, { uuid: new UuidType() });
+    // Set adapter first (it resets column info), THEN seed a
+    // schema-sourced wrapper so the adapter-setter's reset doesn't
+    // clobber it before reflection runs.
+    (Post as unknown as { adapter: unknown }).adapter = adapter;
+    (Post as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
+      new Map([
+        [
+          "payload",
+          {
+            name: "payload",
+            type: new WrapperType(),
+            defaultValue: null,
+            userProvided: false,
+            source: "schema",
+          },
+        ],
+      ]);
+
+    await loadSchemaFromAdapter.call(Post);
+
+    // The wrapper's withInnerType received the freshly-reflected
+    // UuidType, and the wrapper was preserved on the def.
+    expect(rewrappedWith).toHaveLength(1);
+    expect((rewrappedWith[0] as ValueType).name).toBe("uuid");
+    expect(Post._attributeDefinitions.get("payload")?.type).toBeInstanceOf(WrapperType);
+  });
+});
+
 describe("attribute() userProvidedDefault option", () => {
   it("defaults to userProvided=true (source=user)", () => {
     class Foo extends Base {}

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -12,23 +12,7 @@ import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { applyPendingEncryptions } from "./encryption.js";
-import type { Type as AttributeTypeT } from "@blazetrails/activemodel";
-
-/**
- * Duck-type predicate: does `t` expose the shared
- * `withInnerType(type): this` contract both EncryptedAttributeType
- * variants implement? Narrows so schema reflection can preserve any
- * encryption wrapper without branching on concrete classes.
- */
-function hasWithInnerType(
-  t: unknown,
-): t is { withInnerType(innerType: AttributeTypeT): AttributeTypeT } {
-  return (
-    typeof t === "object" &&
-    t !== null &&
-    typeof (t as { withInnerType?: unknown }).withInnerType === "function"
-  );
-}
+import { isWrappedType } from "./encryption/wrapped-type.js";
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -702,12 +686,11 @@ function applyColumnsHash(
     let type = (castType as Type | null) ?? typeRegistry.lookup("value");
 
     // Preserve encryption wrappers across schema reflection. Both
-    // EncryptedAttributeType variants (encryptor-based / scheme-based)
-    // expose `withInnerType(type)` so we don't need to branch on
-    // `instanceof` here — duck-typing keeps us class-agnostic and
-    // consumers of either `encrypts()` entry point are preserved.
-    if (hasWithInnerType(existing?.type)) {
-      type = existing.type.withInnerType(type);
+    // EncryptedAttributeType variants implement `WrappedType`; any
+    // future type implementing the same contract is automatically
+    // supported. No `instanceof` branching on concrete classes.
+    if (isWrappedType(existing?.type)) {
+      type = existing.type.withInnerType(type) as typeof type;
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -12,8 +12,23 @@ import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { applyPendingEncryptions } from "./encryption.js";
-import { EncryptedAttributeType as SchemeEncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
-import { EncryptedAttributeType as EncryptorEncryptedAttributeType } from "./encrypted-attribute-type.js";
+import type { Type as AttributeTypeT } from "@blazetrails/activemodel";
+
+/**
+ * Duck-type predicate: does `t` expose the shared
+ * `withInnerType(type): this` contract both EncryptedAttributeType
+ * variants implement? Narrows so schema reflection can preserve any
+ * encryption wrapper without branching on concrete classes.
+ */
+function hasWithInnerType(
+  t: unknown,
+): t is { withInnerType(innerType: AttributeTypeT): AttributeTypeT } {
+  return (
+    typeof t === "object" &&
+    t !== null &&
+    typeof (t as { withInnerType?: unknown }).withInnerType === "function"
+  );
+}
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -686,13 +701,12 @@ function applyColumnsHash(
         : null;
     let type = (castType as Type | null) ?? typeRegistry.lookup("value");
 
-    // Preserve encryption wrappers across schema reflection — two
-    // distinct EncryptedAttributeType classes exist (scheme-based
-    // `encrypts()` macro vs encryptor-based internal path); handle both.
-    if (existing?.type instanceof SchemeEncryptedAttributeType) {
-      const scheme = existing.type.scheme;
-      type = new SchemeEncryptedAttributeType({ scheme, castType: type });
-    } else if (existing?.type instanceof EncryptorEncryptedAttributeType) {
+    // Preserve encryption wrappers across schema reflection. Both
+    // EncryptedAttributeType variants (encryptor-based / scheme-based)
+    // expose `withInnerType(type)` so we don't need to branch on
+    // `instanceof` here — duck-typing keeps us class-agnostic and
+    // consumers of either `encrypts()` entry point are preserved.
+    if (hasWithInnerType(existing?.type)) {
       type = existing.type.withInnerType(type);
     }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -689,8 +689,9 @@ function applyColumnsHash(
     // EncryptedAttributeType variants implement `WrappedType`; any
     // future type implementing the same contract is automatically
     // supported. No `instanceof` branching on concrete classes.
-    if (isWrappedType(existing?.type)) {
-      type = existing.type.withInnerType(type) as typeof type;
+    const existingType = existing?.type;
+    if (isWrappedType(existingType)) {
+      type = existingType.withInnerType(type);
     }
 
     const defaultValue = (column as { default?: unknown }).default ?? null;


### PR DESCRIPTION
## Summary

Both \`EncryptedAttributeType\` variants — the Encryptor-based one at \`packages/activerecord/src/encrypted-attribute-type.ts\` (used by \`Base.encrypts()\`) and the Scheme-based one at \`packages/activerecord/src/encryption/encrypted-attribute-type.ts\` (scaffolding for the richer Rails path) — now expose a shared \`withInnerType(innerType)\` method.

\`applyColumnsHash\` in \`model-schema.ts\` collapsed from a dual \`instanceof\` branch to a single duck-typed check, so schema reflection no longer needs to know about either class concretely. If a future third wrapper implements the same contract, it's automatically supported.

### What this PR does NOT do

Full consolidation of the two classes onto a single implementation. Their constructor shapes and internal \`Encryptor\` dependencies differ significantly; that's a larger Rails-fidelity migration tracked in the attribute-wiring follow-ups memory note.

## Test plan

- [x] Full test suite: 17,525 passed / 4,421 skipped — no regressions.
- [x] \`pnpm tsc --noEmit\` clean.