### PR TITLE
chore(explain): cleanup follow-ups from #583

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -29,8 +29,12 @@ describeIfMysql("Mysql2Adapter", () => {
       // End-to-end: the full ExplainRegistry → ExplainSubscriber →
       // adapter.explain pipeline only works on MySQL if execute()
       // emits sql.active_record. Without that, Relation#explain
-      // silently falls back to toSql() and reports zero collected
-      // queries.
+      // silently falls back to toSql() (which keeps Arel's
+      // double-quoted identifiers) rather than the payload SQL the
+      // driver saw (which goes through `mysqlQuote` → backticks).
+      // Asserting backticks is the thing that discriminates the two
+      // paths — plain "contains the table name" would pass either
+      // way.
       const { Base } = await import("../../index.js");
       class ExRelMysql extends Base {
         static {
@@ -46,8 +50,12 @@ describeIfMysql("Mysql2Adapter", () => {
         await ExRelMysql.create({ name: "r" });
         const plan = await ExRelMysql.all().explain();
         expect(typeof plan).toBe("string");
-        expect(plan.toLowerCase()).toContain("select");
-        expect(plan).toContain("ex_rel_mysqls");
+        // The captured SQL came from `payload.sql` (post-mysqlQuote),
+        // so it uses backtick-quoted identifiers. The fallback
+        // `toSql()` path would emit `"ex_rel_mysqls"` with double
+        // quotes instead.
+        expect(plan).toContain("`ex_rel_mysqls`");
+        expect(plan).not.toMatch(/"ex_rel_mysqls"/);
         // MySQL buildExplainClause header format:
         expect(plan).toMatch(/EXPLAIN.*for:/);
       } finally {
@@ -87,9 +95,17 @@ describeIfMysql("Mysql2Adapter", () => {
 
         const plan = await ExMysqlAuthor.all().preload("exMysqlBooks").explain();
         const blocks = plan.split("\n\n").filter((b) => /EXPLAIN/.test(b));
+        // The fallback path emits exactly one block (toSql() of the
+        // outer relation only, no preload query). Requiring ≥ 2
+        // blocks proves the preload query was captured through
+        // sql.active_record, not substituted from toSql().
         expect(blocks.length).toBeGreaterThanOrEqual(2);
-        expect(plan).toContain("ex_mysql_authors");
-        expect(plan).toContain("ex_mysql_books");
+        // Both blocks came from `payload.sql` and therefore carry
+        // backtick-quoted identifiers — the fallback form would use
+        // double quotes.
+        expect(plan).toContain("`ex_mysql_authors`");
+        expect(plan).toContain("`ex_mysql_books`");
+        expect(plan).not.toMatch(/"ex_mysql_(authors|books)"/);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_books\``);
         await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_authors\``);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -24,5 +24,76 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skip("explain with options as symbol", () => {});
     it.skip("explain with options as strings", () => {});
     it.skip("explain options with eager loading", () => {});
+
+    it("Relation#explain on MySQL captures the SELECT via sql.active_record", async () => {
+      // End-to-end: the full ExplainRegistry → ExplainSubscriber →
+      // adapter.explain pipeline only works on MySQL if execute()
+      // emits sql.active_record. Without that, Relation#explain
+      // silently falls back to toSql() and reports zero collected
+      // queries.
+      const { Base } = await import("../../index.js");
+      class ExRelMysql extends Base {
+        static {
+          this.attribute("name", "string");
+          this.adapter = adapter;
+        }
+      }
+      await adapter.exec(`DROP TABLE IF EXISTS \`ex_rel_mysqls\``);
+      await adapter.exec(
+        `CREATE TABLE \`ex_rel_mysqls\` (\`id\` BIGINT AUTO_INCREMENT PRIMARY KEY, \`name\` VARCHAR(255))`,
+      );
+      try {
+        await ExRelMysql.create({ name: "r" });
+        const plan = await ExRelMysql.all().explain();
+        expect(typeof plan).toBe("string");
+        expect(plan.toLowerCase()).toContain("select");
+        expect(plan).toContain("ex_rel_mysqls");
+        // MySQL buildExplainClause header format:
+        expect(plan).toMatch(/EXPLAIN.*for:/);
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS \`ex_rel_mysqls\``);
+      }
+    });
+
+    it("Relation#explain on MySQL captures preload queries", async () => {
+      const { Base, registerModel } = await import("../../index.js");
+      class ExMysqlAuthor extends Base {
+        static {
+          this.attribute("name", "string");
+          this.adapter = adapter;
+        }
+      }
+      class ExMysqlBook extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("ex_mysql_author_id", "integer");
+          this.adapter = adapter;
+        }
+      }
+      ExMysqlAuthor.hasMany("exMysqlBooks", { className: "ExMysqlBook" });
+      registerModel(ExMysqlAuthor);
+      registerModel(ExMysqlBook);
+      await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_books\``);
+      await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_authors\``);
+      await adapter.exec(
+        `CREATE TABLE \`ex_mysql_authors\` (\`id\` BIGINT AUTO_INCREMENT PRIMARY KEY, \`name\` VARCHAR(255))`,
+      );
+      await adapter.exec(
+        `CREATE TABLE \`ex_mysql_books\` (\`id\` BIGINT AUTO_INCREMENT PRIMARY KEY, \`title\` VARCHAR(255), \`ex_mysql_author_id\` INT)`,
+      );
+      try {
+        const a = (await ExMysqlAuthor.create({ name: "A" })) as any;
+        await ExMysqlBook.create({ title: "B", ex_mysql_author_id: a.id });
+
+        const plan = await ExMysqlAuthor.all().preload("exMysqlBooks").explain();
+        const blocks = plan.split("\n\n").filter((b) => /EXPLAIN/.test(b));
+        expect(blocks.length).toBeGreaterThanOrEqual(2);
+        expect(plan).toContain("ex_mysql_authors");
+        expect(plan).toContain("ex_mysql_books");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_books\``);
+        await adapter.exec(`DROP TABLE IF EXISTS \`ex_mysql_authors\``);
+      }
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -19,14 +19,12 @@ const UUID_OID = 2950;
 function makeAdapter(queryImpl: (...args: unknown[]) => Promise<unknown>): PostgreSQLAdapter {
   const adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
   // Stub the client acquisition so tests don't touch a real pool.
+  // `fakeClient.release` is a no-op; `withClient()` / `execQuery()` call
+  // it directly once the block resolves.
   const fakeClient = { query: queryImpl, release: () => {} };
   vi.spyOn(adapter as unknown as { getClient: () => unknown }, "getClient").mockResolvedValue(
     fakeClient,
   );
-  vi.spyOn(
-    adapter as unknown as { releaseClient: (c: unknown) => void },
-    "releaseClient",
-  ).mockImplementation(() => {});
   // In a live PG adapter, loadAdditionalTypes queries pg_type and
   // aliases numeric OIDs → typnames registered in the static map.
   // Pre-register the known base OIDs so execQuery's miss path resolves

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -377,17 +377,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Legacy release path for the schema-introspection call sites that
-   * still use `getClient()` + `releaseClient()` (synchronous ownership;
-   * not in the commit-race path). New code should reach for
-   * `withClient()` instead.
-   */
-  private releaseClient(client: pg.PoolClient): void {
-    if (client === this._client) return;
-    client.release();
-  }
-
-  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /


### PR DESCRIPTION
## Summary

Two small cleanup items flagged after #583 merged:

- **Delete dead `PostgreSQLAdapter#releaseClient`**. Every site in the adapter migrated to `withClient()` in #583; `releaseClient` was kept only so `postgresql-adapter.exec-query.test.ts` could spy on it. The test's `fakeClient.release` is already a no-op, and `withClient()` calls `client.release()` directly — the spy was dead weight. Removed the method and the spy.
- **Add end-to-end `Relation#explain` regression tests on MySQL**, mirroring the PG ones that landed in #583. Without these, the MySQL explain pipeline (`execute` → `sql.active_record` → `ExplainRegistry` → adapter `explain`) was only unit-tested at the adapter boundary — we had no proof that `Relation#explain` on MySQL actually captured the SELECT, let alone preload queries. Two new tests:
  - `Relation#explain on MySQL captures the SELECT via sql.active_record` — asserts the plan contains the table name + `"EXPLAIN … for:"` header.
  - `Relation#explain on MySQL captures preload queries` — asserts `.preload(...)` produces ≥ 2 EXPLAIN blocks.

## Rails divergences deliberately left as follow-ups

- `explain(format: :json)` — needs a keyword-options surface on `Relation#explain`, not just positional flags. Feature work.
- `auto_explain_threshold_in_seconds` / `warn_on_records_fetched_greater_than` — Rails dev-mode auto-explain middleware. Net-new feature.
- `render_bind(c, attr)` via `connection.quote` — needs `adapter.quote()` with per-adapter string quoting. Feature PR.
- Single-connection `exec_explain` loop — Rails wraps the loop in one `with_connection do … end`; we acquire per-call via `withClient`. Functionally equivalent (withClient is cheap + race-safe), not byte-for-byte Rails.

## Test plan

- [x] `pnpm build`
- [x] `TZ=UTC PG_TEST_URL=... pnpm vitest run --no-file-parallelism packages/activerecord` — 9056 passed, zero failures.
- [x] `MYSQL_TEST_URL=... pnpm vitest run --no-file-parallelism packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts` — 3/3 new tests pass, 3 existing skips preserved.