### PR TITLE
feat(activerecord): route STI subclass attribute() through the STI base

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -390,6 +390,17 @@ export class Base extends Model {
     typeName: string,
     options?: { default?: unknown; virtual?: boolean; userProvidedDefault?: boolean },
   ): void {
+    // STI subclasses share the base's `_attributeDefinitions` — matching
+    // Rails' `ActiveRecord::Inheritance` where `attribute_types` is a
+    // shared `class_attribute`. Route the registration through the STI
+    // base so `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
+    // instead of forking a subclass-local map that later schema
+    // reflection on the base wouldn't see.
+    if (isStiSubclass(this)) {
+      const stiBase = getStiBase(this);
+      stiBase.attribute(name, typeName, options);
+      return;
+    }
     super.attribute(name, typeName, options);
     // If we just defined an "id" accessor on a subclass prototype, remove it
     // so Base.prototype.id (which handles CPK) is used instead.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -767,7 +767,16 @@ export class Base extends Model {
   static encrypts(
     ...args: Array<string | { encryptor?: import("./encryption.js").Encryptor }>
   ): void {
-    _encrypts(this, ...args);
+    // Route through the STI base for the same reason `attribute()`
+    // does: Rails' `encrypts` lands on the shared attribute_types map.
+    // Without this, a subclass `encrypts()` would record pending
+    // encryptions on the subclass while the attribute def lives on
+    // the base — the type wrapper would never apply, or
+    // `applyPendingEncryptions` would fork `_attributeDefinitions` on
+    // the subclass and reintroduce the shadowing the STI-routing fix
+    // is trying to eliminate.
+    const target = isStiSubclass(this) ? (getStiBase(this) as typeof Base) : this;
+    _encrypts(target, ...args);
   }
 
   static async suppress<R>(fn: () => R | Promise<R>): Promise<R> {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -624,8 +624,12 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * time in `columnsHash()` (filters the returned hash), but it cannot
  * retroactively remove a prototype accessor already defined on the
  * base — a consequence of TypeScript not having Ruby's method_missing.
- * Subclass `attribute()` calls route through the STI base (`Base.attribute`
- * in base.ts), so there's no forked-map shadowing to worry about.
+ * Subclass `attribute()` and `encrypts()` calls route through the STI
+ * base (see base.ts), so those specific flows don't create forked-map
+ * shadowing. Other decorators that mutate `_attributeDefinitions`
+ * directly on the calling class may still fork until they're routed
+ * through the same shared owner — add them to the STI redirect list
+ * in base.ts when they're introduced.
  */
 function applyColumnsHash(
   host: SchemaHost,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -618,21 +618,14 @@ function getColumnsHash(host: SchemaHost): Record<string, any> {
  * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
  * async `loadSchemaFromAdapter`.
  *
- * STI note 1: for STI subclasses, `host` is the STI base, so the base's
+ * STI note: for STI subclasses, `host` is the STI base, so the base's
  * `_ignoredColumns` governs which columns get accessors on the shared
  * prototype. Per-subclass `ignoredColumns` is still honored at read
  * time in `columnsHash()` (filters the returned hash), but it cannot
  * retroactively remove a prototype accessor already defined on the
  * base — a consequence of TypeScript not having Ruby's method_missing.
- *
- * STI note 2: reflection is applied to the STI base only. If a subclass
- * previously forked `_attributeDefinitions` (via its own `attribute()`,
- * `decorateAttributes`, or `encrypts` call), its forked map shadows the
- * base's, so newly-reflected schema types won't be visible on the
- * subclass. The follow-up fix is to route STI-subclass `attribute()`
- * writes through the base (Rails-faithful: STI subclasses share
- * attribute_types), which belongs in a separate PR that touches
- * Base.attribute and attribute-registration.
+ * Subclass `attribute()` calls route through the STI base (`Base.attribute`
+ * in base.ts), so there's no forked-map shadowing to worry about.
  */
 function applyColumnsHash(
   host: SchemaHost,

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -67,4 +67,50 @@ describe("STI subclass attribute() routing", () => {
     expect(Triangle._attributeDefinitions.get("sides")?.type.name).toBe("integer");
     expect(Shape._attributeDefinitions.get("sides")?.type.name).toBe("integer");
   });
+
+  it("subclass attribute survives schema reflection on the STI base (end-to-end)", async () => {
+    const { loadSchemaFromAdapter } = await import("./model-schema.js");
+    const { ValueType } = await import("@blazetrails/activemodel");
+
+    class UuidT extends ValueType {
+      override readonly name = "uuid" as unknown as "value";
+    }
+
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {
+      static {
+        // Subclass-authored attribute declared BEFORE schema reflection
+        // — the case previously documented as "STI note 2" (subclass
+        // fork would shadow later base reflection). With the routing
+        // fix this lives on the shared base map from the start.
+        this.attribute("radius", "integer");
+      }
+    }
+
+    const adapter = {
+      schemaCache: {
+        dataSourceExists: async () => true,
+        columnsHash: async () => ({ guid: { sqlType: "uuid" } }),
+        getCachedColumnsHash: () => ({ guid: { sqlType: "uuid" } }),
+        isCached: () => true,
+      },
+      lookupCastTypeFromColumn(col: { sqlType: string }) {
+        return col.sqlType === "uuid" ? new UuidT() : null;
+      },
+    };
+    (Shape as unknown as { adapter: unknown }).adapter = adapter;
+
+    await (loadSchemaFromAdapter as unknown as (this: typeof Base) => Promise<void>).call(Shape);
+
+    expect(Shape._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+    expect(Shape._attributeDefinitions.get("guid")?.type.name).toBe("uuid");
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
+    expect(Circle._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+    expect(Circle._attributeDefinitions.get("guid")?.type.name).toBe("uuid");
+  });
 });

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -68,6 +68,36 @@ describe("STI subclass attribute() routing", () => {
     expect(Shape._attributeDefinitions.get("sides")?.type.name).toBe("integer");
   });
 
+  it("STI subclass encrypts() routes pending encryptions to the base", async () => {
+    const { isEncryptedAttribute } = await import("./encryption.js");
+
+    class Animal extends Base {
+      static override tableName = "animals";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("name", "string");
+      }
+    }
+    class Dog extends Animal {
+      static {
+        // Pre-PR: encrypts() on subclass would add to Dog._pendingEncryptions
+        // while the attribute def lived on Animal — wrapper never applied.
+        // Post-PR: encrypts() also routes to the STI base.
+        this.encrypts("name");
+      }
+    }
+
+    // Pending encryption is recorded on the base, not the subclass.
+    expect(Object.prototype.hasOwnProperty.call(Animal, "_pendingEncryptions")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(Dog, "_pendingEncryptions")).toBe(false);
+
+    // Both classes observe the encrypted attribute via the shared map.
+    expect(isEncryptedAttribute(Animal, "name")).toBe(true);
+    expect(isEncryptedAttribute(Dog, "name")).toBe(true);
+    // No fork on the subclass.
+    expect(Dog._attributeDefinitions).toBe(Animal._attributeDefinitions);
+  });
+
   it("subclass attribute survives schema reflection on the STI base (end-to-end)", async () => {
     const { loadSchemaFromAdapter } = await import("./model-schema.js");
     const { ValueType } = await import("@blazetrails/activemodel");

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "./base.js";
+
+describe("STI subclass attribute() routing", () => {
+  it("writes subclass attribute() calls to the STI base's _attributeDefinitions", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {
+      static {
+        this.attribute("radius", "integer");
+      }
+    }
+
+    // Both classes see radius via the shared (base-owned) map.
+    expect(Shape._attributeDefinitions.has("radius")).toBe(true);
+    expect(Circle._attributeDefinitions.has("radius")).toBe(true);
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
+
+    // Circle didn't fork its own map.
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
+  });
+
+  it("still forks the STI base itself (non-subclass) on attribute() — unchanged", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("name", "string");
+      }
+    }
+
+    // Shape IS the STI base (not a subclass), so its map is its own.
+    expect(Object.prototype.hasOwnProperty.call(Shape, "_attributeDefinitions")).toBe(true);
+    expect(Shape._attributeDefinitions.get("name")?.userProvided).toBe(true);
+  });
+
+  it("non-STI classes are unaffected", () => {
+    class Widget extends Base {
+      static {
+        this.attribute("price", "integer");
+      }
+    }
+
+    expect(Object.prototype.hasOwnProperty.call(Widget, "_attributeDefinitions")).toBe(true);
+    expect(Widget._attributeDefinitions.get("price")?.userProvided).toBe(true);
+  });
+
+  it("STI subclass attribute declared AFTER base sees both attrs on the shared map", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("name", "string");
+      }
+    }
+    class Triangle extends Shape {
+      static {
+        this.attribute("sides", "integer");
+      }
+    }
+
+    expect(Triangle._attributeDefinitions.get("name")?.type.name).toBe("string");
+    expect(Triangle._attributeDefinitions.get("sides")?.type.name).toBe("integer");
+    expect(Shape._attributeDefinitions.get("sides")?.type.name).toBe("integer");
+  });
+});


### PR DESCRIPTION
## Summary

Closes attr-type-wiring follow-up #1. STI siblings now share \`_attributeDefinitions\` — matching Rails' \`ActiveRecord::Inheritance\` where \`attribute_types\` is a shared \`class_attribute\`.

Previously \`Circle.attribute("radius", ...)\` forked a subclass-local \`_attributeDefinitions\` map, and a later schema reflection on the STI base couldn't see or update the subclass's view. That was documented as "STI note 2" in \`applyColumnsHash\` — now obsolete.

### Changes

- \`Base.attribute\` detects STI subclasses via \`isStiSubclass(this)\` and delegates to \`getStiBase(this).attribute(...)\` so the registration lands on the base.
- \`Base.encrypts\` does the same (otherwise a subclass \`encrypts("...")\` would record pending encryptions on the subclass while the attribute def lives on the base — the type wrapper would never apply).
- Non-STI classes and the STI base itself are unaffected.

### Scope note

Any future decorator that mutates \`_attributeDefinitions\` directly on the calling class needs to be added to the STI redirect list in \`base.ts\`. Documented in the STI note in \`applyColumnsHash\`.

## Test plan

- [x] 6 tests in \`sti-attribute-routing.test.ts\`: subclass routes to base, base still forks its own map, non-STI unaffected, subclass + base attrs both visible on shared map, STI subclass \`encrypts()\` routes pending encryptions to base, end-to-end subclass attribute survives schema reflection on the STI base.
- [x] Full suite: 17,532 passed / 4,421 skipped.
- [x] \`pnpm tsc --noEmit\` clean.