### PR TITLE
refactor(activerecord): share adapter introspection between SchemaDumper and dumpSchemaColumns

### DIFF
--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -21,7 +21,7 @@
  */
 
 import type { DatabaseAdapter } from "./adapter.js";
-import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import { introspectTables, introspectColumns } from "./schema-introspection.js";
 
 export interface DumpSchemaColumnsOptions {
   /**
@@ -60,41 +60,21 @@ type AdapterColumn = {
   null?: boolean | null;
 };
 
-type AdapterWithTables = { tables(): Promise<string[]> };
-type AdapterWithColumns = { columns(table: string): Promise<AdapterColumn[]> };
-
-function hasTables(a: unknown): a is AdapterWithTables {
-  return typeof (a as AdapterWithTables).tables === "function";
-}
-function hasColumns(a: unknown): a is AdapterWithColumns {
-  return typeof (a as AdapterWithColumns).columns === "function";
-}
-
 export async function dumpSchemaColumns(
   adapter: DatabaseAdapter,
   options: DumpSchemaColumnsOptions = {},
 ): Promise<Record<string, Record<string, DumpColumnSchema>>> {
-  // Prefer the adapter's own `tables()` / `columns()` when present —
-  // PostgreSQL and SQLite adapters implement them with adapter-
-  // specific semantics (e.g. PG respects the current `search_path`).
-  // SchemaStatements is the portable fallback for adapters that don't.
-  let schema: SchemaStatements | undefined;
-  const schemaStatements = () => (schema ??= new SchemaStatements(adapter));
-
   const ignore = new Set([...ALWAYS_IGNORED, ...(options.ignoreTables ?? [])]);
 
-  const rawTables = hasTables(adapter) ? await adapter.tables() : await schemaStatements().tables();
-  const tables = rawTables.filter((t) => !ignore.has(t)).sort();
+  const tables = (await introspectTables(adapter)).filter((t) => !ignore.has(t)).sort();
 
   const out: Record<string, Record<string, DumpColumnSchema>> = Object.create(null);
   for (const table of tables) {
-    const cols = hasColumns(adapter)
-      ? await adapter.columns(table)
-      : await schemaStatements().columns(table);
+    const cols = await introspectColumns(adapter, table);
     const colMap: Record<string, DumpColumnSchema> = Object.create(null);
     const sorted = [...cols].sort((a, b) => a.name.localeCompare(b.name));
     for (const col of sorted) {
-      colMap[col.name] = buildColumnSchema(col);
+      colMap[col.name] = buildColumnSchema(col as AdapterColumn);
     }
     out[table] = colMap;
   }

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -74,7 +74,7 @@ export async function dumpSchemaColumns(
     const colMap: Record<string, DumpColumnSchema> = Object.create(null);
     const sorted = [...cols].sort((a, b) => a.name.localeCompare(b.name));
     for (const col of sorted) {
-      colMap[col.name] = buildColumnSchema(col as AdapterColumn);
+      colMap[col.name] = buildColumnSchema(col);
     }
     out[table] = colMap;
   }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -16,20 +16,26 @@ import {
   type IndexInfo,
 } from "./connection-adapters/abstract/schema-dumper.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { introspectTables, introspectColumns } from "./schema-introspection.js";
 
 class AdapterSchemaSource implements SchemaSource {
+  private _adapter: DatabaseAdapter;
+  // Only needed for indexes() — tables/columns go through the shared
+  // introspectTables/introspectColumns helpers so the adapter's own
+  // `tables()` / `columns()` are honored (matching `dumpSchemaColumns`).
   private _schema: SchemaStatements;
 
   constructor(adapter: DatabaseAdapter) {
+    this._adapter = adapter;
     this._schema = new SchemaStatements(adapter);
   }
 
   async tables(): Promise<string[]> {
-    return this._schema.tables();
+    return introspectTables(this._adapter);
   }
 
   async columns(tableName: string): Promise<ColumnInfo[]> {
-    const cols = await this._schema.columns(tableName);
+    const cols = await introspectColumns(this._adapter, tableName);
     return cols.map((col) => ({
       name: col.name,
       type: col.sqlType || col.type || "unknown",

--- a/packages/activerecord/src/schema-introspection.test.ts
+++ b/packages/activerecord/src/schema-introspection.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { introspectTables, introspectColumns } from "./schema-introspection.js";
+
+describe("introspectTables", () => {
+  it("uses adapter.tables() when the adapter implements it", async () => {
+    let called = false;
+    const adapter = {
+      async tables() {
+        called = true;
+        return ["users", "posts"];
+      },
+    } as unknown as Parameters<typeof introspectTables>[0];
+
+    const tables = await introspectTables(adapter);
+
+    expect(called).toBe(true);
+    expect(tables).toEqual(["users", "posts"]);
+  });
+
+  it("falls back to SchemaStatements when the adapter doesn't implement tables()", async () => {
+    // No `tables` method — introspectTables must call
+    // `new SchemaStatements(adapter).tables()`, which issues the
+    // portable `SELECT ... FROM information_schema.tables` query via
+    // the adapter's `execute()`. Supplying a stub execute() that
+    // returns the expected shape lets us verify the fallback path
+    // without a real DB connection.
+    const executed: string[] = [];
+    const adapter = {
+      async execute(sql: string): Promise<unknown[]> {
+        executed.push(sql);
+        return [{ name: "widgets" }, { name: "gadgets" }];
+      },
+      // DatabaseAdapter requires misc methods for SchemaStatements'
+      // helpers; supply just the minimum + permissive fallbacks.
+      async selectAll() {
+        return { rows: [] };
+      },
+    } as unknown as Parameters<typeof introspectTables>[0];
+
+    // SchemaStatements.tables() issues an INFORMATION_SCHEMA-style
+    // query; we don't care about the exact SQL, only that it was
+    // called and the rows shape is respected.
+    try {
+      await introspectTables(adapter);
+    } catch {
+      // Adapter type demands more than our stub provides — some
+      // adapters throw before reaching execute(). The important
+      // invariant is "no adapter.tables() shortcut is used": when
+      // the method is absent, fallback is attempted (evidenced by
+      // any side effect OR a thrown error from the fallback path).
+    }
+    // Negative: the adapter had no `tables()`, so no short-circuit.
+    // Positive: if any SQL was issued, it came from SchemaStatements.
+    // Either way, the absence of a `tables()` method is what we're
+    // locking.
+    expect(typeof (adapter as { tables?: unknown }).tables).toBe("undefined");
+  });
+});
+
+describe("introspectColumns", () => {
+  it("uses adapter.columns() when the adapter implements it", async () => {
+    let calledWith: string | undefined;
+    const fakeCols = [{ name: "id" }, { name: "name" }];
+    const adapter = {
+      async columns(table: string): Promise<unknown[]> {
+        calledWith = table;
+        return fakeCols;
+      },
+    } as unknown as Parameters<typeof introspectColumns>[0];
+
+    const cols = await introspectColumns(adapter, "users");
+
+    expect(calledWith).toBe("users");
+    expect(cols).toBe(fakeCols);
+  });
+});

--- a/packages/activerecord/src/schema-introspection.test.ts
+++ b/packages/activerecord/src/schema-introspection.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect } from "vitest";
+import { createTestAdapter } from "./test-adapter.js";
+import { MigrationContext } from "./migration.js";
 import { introspectTables, introspectColumns } from "./schema-introspection.js";
+
+/**
+ * Return a proxy over `adapter` that hides the named methods so the
+ * SchemaStatements fallback path inside `introspect*` runs. Keeping
+ * the real adapter underneath means detectAdapterName + execute()
+ * work, so SchemaStatements' query dispatch can complete.
+ */
+function withoutMethods<A extends object>(adapter: A, hidden: string[]): A {
+  const hiddenSet = new Set(hidden);
+  return new Proxy(adapter, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && hiddenSet.has(prop)) return undefined;
+      return Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      if (typeof prop === "string" && hiddenSet.has(prop)) return false;
+      return Reflect.has(target, prop);
+    },
+  }) as A;
+}
 
 describe("introspectTables", () => {
   it("uses adapter.tables() when the adapter implements it", async () => {
@@ -18,42 +40,18 @@ describe("introspectTables", () => {
   });
 
   it("falls back to SchemaStatements when the adapter doesn't implement tables()", async () => {
-    // No `tables` method — introspectTables must call
-    // `new SchemaStatements(adapter).tables()`, which issues the
-    // portable `SELECT ... FROM information_schema.tables` query via
-    // the adapter's `execute()`. Supplying a stub execute() that
-    // returns the expected shape lets us verify the fallback path
-    // without a real DB connection.
-    const executed: string[] = [];
-    const adapter = {
-      async execute(sql: string): Promise<unknown[]> {
-        executed.push(sql);
-        return [{ name: "widgets" }, { name: "gadgets" }];
-      },
-      // DatabaseAdapter requires misc methods for SchemaStatements'
-      // helpers; supply just the minimum + permissive fallbacks.
-      async selectAll() {
-        return { rows: [] };
-      },
-    } as unknown as Parameters<typeof introspectTables>[0];
+    const realAdapter = createTestAdapter();
+    const ctx = new MigrationContext(realAdapter);
+    await ctx.createTable("widgets", {}, () => {});
+    await ctx.createTable("gadgets", {}, () => {});
 
-    // SchemaStatements.tables() issues an INFORMATION_SCHEMA-style
-    // query; we don't care about the exact SQL, only that it was
-    // called and the rows shape is respected.
-    try {
-      await introspectTables(adapter);
-    } catch {
-      // Adapter type demands more than our stub provides — some
-      // adapters throw before reaching execute(). The important
-      // invariant is "no adapter.tables() shortcut is used": when
-      // the method is absent, fallback is attempted (evidenced by
-      // any side effect OR a thrown error from the fallback path).
-    }
-    // Negative: the adapter had no `tables()`, so no short-circuit.
-    // Positive: if any SQL was issued, it came from SchemaStatements.
-    // Either way, the absence of a `tables()` method is what we're
-    // locking.
-    expect(typeof (adapter as { tables?: unknown }).tables).toBe("undefined");
+    // Strip `tables()` so introspectTables routes through SchemaStatements.
+    const stripped = withoutMethods(realAdapter, ["tables"]);
+
+    const tables = await introspectTables(stripped);
+
+    expect(tables).toContain("widgets");
+    expect(tables).toContain("gadgets");
   });
 });
 
@@ -72,5 +70,22 @@ describe("introspectColumns", () => {
 
     expect(calledWith).toBe("users");
     expect(cols).toBe(fakeCols);
+  });
+
+  it("falls back to SchemaStatements when the adapter doesn't implement columns()", async () => {
+    const realAdapter = createTestAdapter();
+    const ctx = new MigrationContext(realAdapter);
+    await ctx.createTable("widgets", {}, (t) => {
+      t.string("name");
+      t.integer("age");
+    });
+
+    // Strip `columns()` so introspectColumns routes through SchemaStatements.
+    const stripped = withoutMethods(realAdapter, ["columns"]);
+
+    const cols = await introspectColumns(stripped, "widgets");
+    const names = cols.map((c) => c.name).sort();
+
+    expect(names).toEqual(["age", "id", "name"]);
   });
 });

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -27,25 +27,41 @@ function hasColumns(a: unknown): a is AdapterWithColumns {
   return typeof (a as AdapterWithColumns).columns === "function";
 }
 
+// Memoize `SchemaStatements` per-adapter so the fallback path doesn't
+// reinstantiate on every call (and per-table when `adapter.columns()`
+// is absent). WeakMap lets GC reclaim the helper when the adapter is
+// disposed.
+const SCHEMA_STATEMENTS = new WeakMap<object, SchemaStatements>();
+function schemaStatementsFor(adapter: DatabaseAdapter): SchemaStatements {
+  const key = adapter as unknown as object;
+  let s = SCHEMA_STATEMENTS.get(key);
+  if (!s) {
+    s = new SchemaStatements(adapter);
+    SCHEMA_STATEMENTS.set(key, s);
+  }
+  return s;
+}
+
 /**
  * Return the table names reported by the adapter. Uses
  * `adapter.tables()` when the adapter implements it, else falls back
- * to `SchemaStatements.tables(adapter)`.
+ * to `new SchemaStatements(adapter).tables()` (memoized per adapter).
  */
 export async function introspectTables(adapter: DatabaseAdapter): Promise<string[]> {
   if (hasTables(adapter)) return adapter.tables();
-  return new SchemaStatements(adapter).tables();
+  return schemaStatementsFor(adapter).tables();
 }
 
 /**
  * Return the Column objects for `table`. Uses `adapter.columns()`
  * when implemented, else falls back to
- * `SchemaStatements.columns(adapter, table)`.
+ * `new SchemaStatements(adapter).columns(table)` (memoized per adapter
+ * so a loop that dumps many tables reuses a single helper).
  */
 export async function introspectColumns(
   adapter: DatabaseAdapter,
   table: string,
 ): Promise<Column[]> {
   if (hasColumns(adapter)) return adapter.columns(table);
-  return new SchemaStatements(adapter).columns(table);
+  return schemaStatementsFor(adapter).columns(table);
 }

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared adapter-introspection helpers used by schema dumpers.
+ *
+ * Both `SchemaDumper` (DSL output — schema.ts/schema.js) and
+ * `dumpSchemaColumns` (JSON output for trails-tsc --schema) need the
+ * same "prefer the adapter's own tables() / columns() when available,
+ * fall back to the portable SchemaStatements queries otherwise"
+ * pattern. PostgreSQL and SQLite adapters implement these with
+ * adapter-specific semantics (e.g. PG respects the current
+ * `search_path`); SchemaStatements is the portable fallback.
+ *
+ * Keeping this in one module means future changes to introspection
+ * semantics stay in one place and can't drift between the two dumpers.
+ */
+
+import type { DatabaseAdapter } from "./adapter.js";
+import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import type { Column } from "./connection-adapters/column.js";
+
+type AdapterWithTables = { tables(): Promise<string[]> };
+type AdapterWithColumns = { columns(table: string): Promise<Column[]> };
+
+function hasTables(a: unknown): a is AdapterWithTables {
+  return typeof (a as AdapterWithTables).tables === "function";
+}
+function hasColumns(a: unknown): a is AdapterWithColumns {
+  return typeof (a as AdapterWithColumns).columns === "function";
+}
+
+/**
+ * Return the table names reported by the adapter. Uses
+ * `adapter.tables()` when the adapter implements it, else falls back
+ * to `SchemaStatements.tables(adapter)`.
+ */
+export async function introspectTables(adapter: DatabaseAdapter): Promise<string[]> {
+  if (hasTables(adapter)) return adapter.tables();
+  return new SchemaStatements(adapter).tables();
+}
+
+/**
+ * Return the Column objects for `table`. Uses `adapter.columns()`
+ * when implemented, else falls back to
+ * `SchemaStatements.columns(adapter, table)`.
+ */
+export async function introspectColumns(
+  adapter: DatabaseAdapter,
+  table: string,
+): Promise<Column[]> {
+  if (hasColumns(adapter)) return adapter.columns(table);
+  return new SchemaStatements(adapter).columns(table);
+}


### PR DESCRIPTION
## Summary

Closes attr-type-wiring follow-up #2. Both dumpers now go through a shared \`schema-introspection.ts\` helper pair:

- \`introspectTables(adapter)\` — uses \`adapter.tables()\` if implemented, falls back to \`SchemaStatements\`.
- \`introspectColumns(adapter, table)\` — same pattern.

Previously \`SchemaDumper\` (DSL output) went straight through \`SchemaStatements\`, missing adapter-specific semantics like PG's \`search_path\` filtering. \`dumpSchemaColumns\` (JSON output for trails-tsc) already had the fallback pattern — the helper factors it out so the two can't drift.

## Test plan

- [x] Full suite: 17,526 passed / 4,421 skipped — no regressions.
- [x] \`pnpm tsc --noEmit\` clean.
- [x] No behavior change for test fixtures — both dumpers exercise the same paths.