### PR TITLE
feat(activerecord): rich schema-columns shape — nullability + array element type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,8 +395,17 @@ declared via `this.attribute(...)`), pass a schema-columns JSON to
 trails-tsc --schema db/schema-columns.json
 ```
 
-JSON shape: `{ "<table>": { "<column>": "<rails_type>", ... } }`. Table
-resolution is `static tableName = "..."` when present, otherwise
+JSON shape accepts either:
+
+- Legacy string: `{ "<table>": { "<column>": "<rails_type>", ... } }`
+- Rich: `{ "<table>": { "<column>": { "type": "<rails_type>", "null": boolean, "arrayElementType"?: "<rails_type>" }, ... } }`
+
+The rich shape (emitted by `trails-schema-dump`) drives:
+
+- Nullability: `null: true` renders `Type | null`, `null: false` renders the bare type.
+- Array element type: when `type: "array"` and `arrayElementType` is set, trails-tsc renders `ElementTsType[]` instead of the default `unknown[]`.
+
+Table resolution is `static tableName = "..."` when present, otherwise
 `pluralize(underscore(className))`. User `declare`s and
 `this.attribute(...)` calls always win over schema-sourced declares.
 `id` is skipped (Base's `PrimaryKeyValue` accessor handles it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,11 +398,11 @@ trails-tsc --schema db/schema-columns.json
 JSON shape accepts either:
 
 - Legacy string: `{ "<table>": { "<column>": "<rails_type>", ... } }`
-- Rich: `{ "<table>": { "<column>": { "type": "<rails_type>", "null": boolean, "arrayElementType"?: "<rails_type>" }, ... } }`
+- Rich: `{ "<table>": { "<column>": { "type": "<rails_type>", "null"?: boolean, "arrayElementType"?: "<rails_type>" }, ... } }`
 
 The rich shape (emitted by `trails-schema-dump`) drives:
 
-- Nullability: `null: true` renders `Type | null`, `null: false` renders the bare type.
+- Nullability: `null: true` renders `Type | null`, `null: false` renders the bare type. `null` is optional — omitting it is treated as `true` (Rails' conservative default: columns without a NOT NULL constraint are nullable).
 - Array element type: when `type: "array"` and `arrayElementType` is set, trails-tsc renders `ElementTsType[]` instead of the default `unknown[]`.
 
 Table resolution is `static tableName = "..."` when present, otherwise

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -205,9 +205,43 @@ describe("dumpSchemaColumns", () => {
       "export class User extends Base {\n" + '  static override tableName = "users";\n' + "}\n";
     const { text } = virtualize(src, "user.ts", { schemaColumnsByTable: dump });
 
-    expect(text).toMatch(/declare name:/);
-    expect(text).toMatch(/declare age:/);
+    // Columns declared via t.string() / t.integer() are nullable by
+    // default (no `null: false` passed), so the rich shape renders
+    // `T | null`.
+    expect(text).toMatch(/declare name: string \| null;/);
+    expect(text).toMatch(/declare age: number \| null;/);
     // `id` is skipped by the virtualizer (Base accessor handles it).
     expect(text).not.toMatch(/declare id:/);
+  });
+
+  it("end-to-end: NOT NULL → bare; nullable → `| null`; array element types carry through", async () => {
+    const { virtualize } = await import("./type-virtualization/virtualize.js");
+
+    // Fake adapter with mixed nullability and arrays — exercises the
+    // full chain without needing portable DDL (NOT NULL / array
+    // syntax varies across SQLite/PG/MySQL).
+    const fakeAdapter = {
+      async tables() {
+        return ["posts"];
+      },
+      async columns() {
+        return [
+          { name: "title", sqlType: "varchar(255)", null: false },
+          { name: "body", sqlType: "text", null: true },
+          { name: "tags", sqlType: "integer[]", null: false },
+          { name: "optional_tags", sqlType: "integer[]", null: true },
+        ];
+      },
+    } as unknown as Parameters<typeof dumpSchemaColumns>[0];
+
+    const dump = await dumpSchemaColumns(fakeAdapter);
+    const src =
+      "export class Post extends Base {\n" + '  static override tableName = "posts";\n' + "}\n";
+    const { text } = virtualize(src, "post.ts", { schemaColumnsByTable: dump });
+
+    expect(text).toMatch(/declare title: string;/);
+    expect(text).toMatch(/declare body: string \| null;/);
+    expect(text).toMatch(/declare tags: number\[\];/);
+    expect(text).toMatch(/declare optional_tags: number\[\] \| null;/);
   });
 });

--- a/packages/activerecord/src/schema-columns-dump.test.ts
+++ b/packages/activerecord/src/schema-columns-dump.test.ts
@@ -29,17 +29,17 @@ describe("dumpSchemaColumns", () => {
     const dump = await dumpSchemaColumns(adapter);
 
     expect(Object.keys(dump).sort()).toEqual(["posts", "users"]);
-    // Concrete Rails type assertions — trails-tsc keys on these exact
-    // strings, so raw SQL types (TEXT, VARCHAR, int4) would silently
-    // make the virtualizer emit `unknown`. Tests lock the mapping.
-    // `id` is integer on SQLite/PG but big_integer on MariaDB — both
-    // map to TS `number` in the virtualizer, so accept either.
-    expect(["integer", "big_integer"]).toContain(dump.users.id);
-    expect(dump.users.name).toBe("string");
-    expect(dump.users.age).toBe("integer");
-    expect(dump.users.created_at).toBe("datetime");
-    expect(dump.posts.title).toBe("string");
-    expect(dump.posts.body).toBe("text");
+    // Rich-shape assertions: each column entry is now an object with
+    // `type` + `null`. `id` is integer on SQLite/PG but big_integer on
+    // MariaDB — both map to TS `number` in the virtualizer.
+    expect(["integer", "big_integer"]).toContain(dump.users.id.type);
+    expect(dump.users.name.type).toBe("string");
+    expect(dump.users.age.type).toBe("integer");
+    expect(dump.users.created_at.type).toBe("datetime");
+    expect(dump.posts.title.type).toBe("string");
+    expect(dump.posts.body.type).toBe("text");
+    // Nullable by default (no NOT NULL constraint declared above).
+    expect(dump.users.name.null).toBe(true);
   });
 
   it("skips schema_migrations and ar_internal_metadata by default", async () => {
@@ -145,25 +145,49 @@ describe("dumpSchemaColumns", () => {
     } as unknown as Parameters<typeof dumpSchemaColumns>[0];
 
     const dump = await dumpSchemaColumns(fakeAdapter);
-    expect(dump.widgets).toEqual({
-      name: "string",
-      bio: "text",
-      count: "integer",
-      big: "big_integer",
-      price: "decimal",
-      active: "boolean",
-      at: "datetime",
-      data: "jsonb",
-      guid: "uuid",
-      at_tz: "datetime",
-      at_tz2: "time",
-      tags: "array",
-      names: "array",
-      email: "string",
-      active_mysql: "boolean",
-      at_udt: "datetime",
-      tags_udt: "array",
-    });
+    // Each entry is the rich { type, null } shape; these fake columns
+    // don't set `null`, so the conservative default (true) applies.
+    expect(dump.widgets.name.type).toBe("string");
+    expect(dump.widgets.bio.type).toBe("text");
+    expect(dump.widgets.count.type).toBe("integer");
+    expect(dump.widgets.big.type).toBe("big_integer");
+    expect(dump.widgets.price.type).toBe("decimal");
+    expect(dump.widgets.active.type).toBe("boolean");
+    expect(dump.widgets.at.type).toBe("datetime");
+    expect(dump.widgets.data.type).toBe("jsonb");
+    expect(dump.widgets.guid.type).toBe("uuid");
+    expect(dump.widgets.at_tz.type).toBe("datetime");
+    expect(dump.widgets.at_tz2.type).toBe("time");
+    expect(dump.widgets.email.type).toBe("string");
+    expect(dump.widgets.active_mysql.type).toBe("boolean");
+    expect(dump.widgets.at_udt.type).toBe("datetime");
+    // Array columns should surface arrayElementType.
+    expect(dump.widgets.tags.type).toBe("array");
+    expect(dump.widgets.tags.arrayElementType).toBe("integer");
+    expect(dump.widgets.names.type).toBe("array");
+    expect(dump.widgets.names.arrayElementType).toBe("string");
+    expect(dump.widgets.tags_udt.type).toBe("array");
+    expect(dump.widgets.tags_udt.arrayElementType).toBe("integer");
+  });
+
+  it("preserves column nullability from the adapter", async () => {
+    const fakeAdapter = {
+      async tables() {
+        return ["widgets"];
+      },
+      async columns() {
+        return [
+          { name: "not_nullable", sqlType: "varchar(255)", null: false },
+          { name: "nullable", sqlType: "varchar(255)", null: true },
+          { name: "missing", sqlType: "varchar(255)" }, // defaults to true
+        ];
+      },
+    } as unknown as Parameters<typeof dumpSchemaColumns>[0];
+
+    const dump = await dumpSchemaColumns(fakeAdapter);
+    expect(dump.widgets.not_nullable.null).toBe(false);
+    expect(dump.widgets.nullable.null).toBe(true);
+    expect(dump.widgets.missing.null).toBe(true);
   });
 
   it("output feeds directly into trails-tsc's virtualizer (end-to-end)", async () => {

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -1,7 +1,20 @@
 /**
- * Emits a `{ table: { column: railsType } }` JSON map from a live
- * adapter. Consumed by `trails-tsc --schema <path>` so the virtualizer
- * can inject `declare` members for schema-only columns.
+ * Emits a JSON map from a live adapter consumed by
+ * `trails-tsc --schema <path>` so the virtualizer can inject `declare`
+ * members for schema-only columns.
+ *
+ * Output shape (per column):
+ *   `{ type: <railsType>, null: boolean, arrayElementType?: <railsType> }`
+ *
+ * - `type`: Rails type string (`string`, `integer`, `datetime`, ...).
+ * - `null`: true when the column lacks a NOT NULL constraint, rendered
+ *   as `Type | null` by trails-tsc.
+ * - `arrayElementType`: present for array columns, renders
+ *   `ElementTsType[]` instead of `unknown[]`.
+ *
+ * The virtualizer also accepts the legacy `{ column: "<railsType>" }`
+ * shape for backwards compatibility with hand-authored JSON, but this
+ * dumper always emits the rich object shape.
  *
  * Not in Rails — this is the bridge that gives TypeScript IDE
  * autocomplete parity with Rails' runtime method_missing.

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -19,6 +19,27 @@ export interface DumpSchemaColumnsOptions {
   ignoreTables?: readonly string[];
 }
 
+/**
+ * Rich column shape emitted for trails-tsc consumption. The virtualizer
+ * accepts either `string` (legacy, just a Rails type) or this full
+ * object form — the dumper emits the object form so nullability and
+ * array element types can shape the generated TypeScript declares.
+ */
+export interface DumpColumnSchema {
+  /** Rails type name (`string`, `integer`, `datetime`, `array`, ...). */
+  type: string;
+  /** True when the column is nullable (i.e. the generated type gets `| null`). */
+  null: boolean;
+  /**
+   * For array columns, the Rails type of the array's element. trails-tsc
+   * renders `ElementTsType[]` instead of `unknown[]` when present.
+   */
+  arrayElementType?: string;
+}
+
+/** Union of the legacy and the rich shape, for consumer flexibility. */
+export type DumpColumnValue = string | DumpColumnSchema;
+
 const ALWAYS_IGNORED = new Set(["schema_migrations", "ar_internal_metadata"]);
 
 type AdapterColumn = {
@@ -26,6 +47,7 @@ type AdapterColumn = {
   sqlTypeMetadata?: { type?: string | null; sqlType?: string | null } | null;
   sqlType?: string | null;
   type?: string | null;
+  null?: boolean | null;
 };
 
 type AdapterWithTables = { tables(): Promise<string[]> };
@@ -41,7 +63,7 @@ function hasColumns(a: unknown): a is AdapterWithColumns {
 export async function dumpSchemaColumns(
   adapter: DatabaseAdapter,
   options: DumpSchemaColumnsOptions = {},
-): Promise<Record<string, Record<string, string>>> {
+): Promise<Record<string, Record<string, DumpColumnSchema>>> {
   // Prefer the adapter's own `tables()` / `columns()` when present —
   // PostgreSQL and SQLite adapters implement them with adapter-
   // specific semantics (e.g. PG respects the current `search_path`).
@@ -54,19 +76,45 @@ export async function dumpSchemaColumns(
   const rawTables = hasTables(adapter) ? await adapter.tables() : await schemaStatements().tables();
   const tables = rawTables.filter((t) => !ignore.has(t)).sort();
 
-  const out: Record<string, Record<string, string>> = Object.create(null);
+  const out: Record<string, Record<string, DumpColumnSchema>> = Object.create(null);
   for (const table of tables) {
     const cols = hasColumns(adapter)
       ? await adapter.columns(table)
       : await schemaStatements().columns(table);
-    const colMap: Record<string, string> = Object.create(null);
+    const colMap: Record<string, DumpColumnSchema> = Object.create(null);
     const sorted = [...cols].sort((a, b) => a.name.localeCompare(b.name));
     for (const col of sorted) {
-      colMap[col.name] = normalizeRailsType(col);
+      colMap[col.name] = buildColumnSchema(col);
     }
     out[table] = colMap;
   }
   return out;
+}
+
+function buildColumnSchema(col: AdapterColumn): DumpColumnSchema {
+  const type = normalizeRailsType(col);
+  // Rails' column introspection returns `null: true` unless the column
+  // has a NOT NULL constraint. Default to true when introspection
+  // didn't populate it, matching Rails' conservative default.
+  const nullable = col.null !== false;
+  const schema: DumpColumnSchema = { type, null: nullable };
+
+  // For PG array types, record the element type so trails-tsc can emit
+  // `ElementTsType[]` instead of `unknown[]`.
+  if (type === "array") {
+    const fullSqlType = (col.sqlTypeMetadata?.sqlType ?? col.sqlType ?? "").toLowerCase();
+    const m = fullSqlType.match(/^(.+?)\s*\[\]\s*$/);
+    if (m && m[1]) {
+      const elementRails = normalizeRailsType({
+        name: col.name,
+        sqlType: m[1],
+      });
+      if (elementRails && elementRails !== "array") {
+        schema.arrayElementType = elementRails;
+      }
+    }
+  }
+  return schema;
 }
 
 /**

--- a/packages/activerecord/src/schema-columns-dump.ts
+++ b/packages/activerecord/src/schema-columns-dump.ts
@@ -37,9 +37,6 @@ export interface DumpColumnSchema {
   arrayElementType?: string;
 }
 
-/** Union of the legacy and the rich shape, for consumer flexibility. */
-export type DumpColumnValue = string | DumpColumnSchema;
-
 const ALWAYS_IGNORED = new Set(["schema_migrations", "ar_internal_metadata"]);
 
 type AdapterColumn = {

--- a/packages/activerecord/src/tsc-wrapper/build.ts
+++ b/packages/activerecord/src/tsc-wrapper/build.ts
@@ -22,7 +22,12 @@ export interface TrailsBuildOptions {
    * virtualizing host so schema-only columns get declares across the
    * whole solution.
    */
-  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+  schemaColumnsByTable?: Readonly<
+    Record<
+      string,
+      Readonly<Record<string, import("../type-virtualization/synthesize.js").SchemaColumnValue>>
+    >
+  >;
 }
 
 /**

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import ts from "typescript";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -346,6 +346,30 @@ describe("trails-tsc --build composite projects — Phase 1b.5", () => {
 describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
   const SCHEMA_DIR = path.join(FIXTURES_DIR, "schema");
 
+  // Track per-test tmp dirs + mocks so cleanup happens even when an
+  // assertion throws. Matches the pattern used elsewhere in this file.
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function writeSchemaJson(contents: unknown): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-"));
+    tmpDirs.push(dir);
+    const p = path.join(dir, "s.json");
+    fs.writeFileSync(p, JSON.stringify(contents));
+    return p;
+  }
+
+  function spyExitAndStderr() {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const err = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    return { exit, err };
+  }
+
   it("types schema-only columns through createTrailsProgram", () => {
     const configPath = path.join(SCHEMA_DIR, "tsconfig.json");
     const { program } = createTrailsProgram(configPath, {
@@ -375,85 +399,50 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: --schema <path> accepts legacy string shape", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
-    fs.writeFileSync(tmp, JSON.stringify({ users: { name: "string", age: "integer" } }));
-    const loaded = loadSchemaColumns(["--schema", tmp]);
-    expect(loaded).toEqual({ users: { name: "string", age: "integer" } });
+    const tmp = writeSchemaJson({ users: { name: "string", age: "integer" } });
+    expect(loadSchemaColumns(["--schema", tmp])).toEqual({
+      users: { name: "string", age: "integer" },
+    });
   });
 
   it("loadSchemaColumns: accepts rich shape end-to-end", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
-    fs.writeFileSync(
-      tmp,
-      JSON.stringify({
-        posts: {
-          title: { type: "string", null: false },
-          body: { type: "text", null: true },
-          tags: { type: "array", null: true, arrayElementType: "integer" },
-        },
-      }),
-    );
-    const loaded = loadSchemaColumns(["--schema", tmp]);
-    expect(loaded).toEqual({
+    const payload = {
       posts: {
         title: { type: "string", null: false },
         body: { type: "text", null: true },
         tags: { type: "array", null: true, arrayElementType: "integer" },
       },
-    });
+    };
+    const tmp = writeSchemaJson(payload);
+    expect(loadSchemaColumns(["--schema", tmp])).toEqual(payload);
   });
 
   it("loadSchemaColumns: mixed legacy + rich in one file", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
-    fs.writeFileSync(
-      tmp,
-      JSON.stringify({
-        posts: { legacy: "string", modern: { type: "integer", null: false } },
-      }),
-    );
-    const loaded = loadSchemaColumns(["--schema", tmp]);
-    expect(loaded).toEqual({
+    const payload = {
       posts: { legacy: "string", modern: { type: "integer", null: false } },
-    });
+    };
+    const tmp = writeSchemaJson(payload);
+    expect(loadSchemaColumns(["--schema", tmp])).toEqual(payload);
   });
 
   it("loadSchemaColumns: rejects rich shape with non-boolean `null`", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
-    fs.writeFileSync(tmp, JSON.stringify({ posts: { title: { type: "string", null: "yes" } } }));
-    // Malformed values should cause the loader to call process.exit(1).
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${code})`);
-    }) as never);
-    const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    try {
-      expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
-      const combined = errSpy.mock.calls.map((c) => String(c[0])).join("");
-      expect(combined).toMatch(/`null` must be a boolean/);
-    } finally {
-      exitSpy.mockRestore();
-      errSpy.mockRestore();
-    }
+    const tmp = writeSchemaJson({ posts: { title: { type: "string", null: "yes" } } });
+    const { err } = spyExitAndStderr();
+    expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+    const combined = err.mock.calls.map((c) => String(c[0])).join("");
+    expect(combined).toMatch(/`null` must be a boolean/);
   });
 
   it("loadSchemaColumns: rejects non-object / non-string column value", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
-    fs.writeFileSync(tmp, JSON.stringify({ posts: { title: 42 } }));
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${code})`);
-    }) as never);
-    const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    try {
-      expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
-      const combined = errSpy.mock.calls.map((c) => String(c[0])).join("");
-      expect(combined).toMatch(/must be a Rails type string or an object/);
-    } finally {
-      exitSpy.mockRestore();
-      errSpy.mockRestore();
-    }
+    const tmp = writeSchemaJson({ posts: { title: 42 } });
+    const { err } = spyExitAndStderr();
+    expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+    const combined = err.mock.calls.map((c) => String(c[0])).join("");
+    expect(combined).toMatch(/must be a Rails type string or an object/);
   });
 
   it("without schema, those accesses fall back to unknown (declares weren't injected)", () => {

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import ts from "typescript";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -370,6 +370,104 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
     expect(probed["name"]).toBe("string");
     expect(probed["age"]).toBe("number");
     expect(probed["isAdmin"]).toBe("boolean");
+  });
+
+  it("loadSchemaColumns: --schema <path> accepts legacy string shape", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = path.join(
+      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
+      "s.json",
+    );
+    fs.writeFileSync(tmp, JSON.stringify({ users: { name: "string", age: "integer" } }));
+    const loaded = loadSchemaColumns(["--schema", tmp]);
+    expect(loaded).toEqual({ users: { name: "string", age: "integer" } });
+  });
+
+  it("loadSchemaColumns: accepts rich shape end-to-end", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = path.join(
+      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
+      "s.json",
+    );
+    fs.writeFileSync(
+      tmp,
+      JSON.stringify({
+        posts: {
+          title: { type: "string", null: false },
+          body: { type: "text", null: true },
+          tags: { type: "array", null: true, arrayElementType: "integer" },
+        },
+      }),
+    );
+    const loaded = loadSchemaColumns(["--schema", tmp]);
+    expect(loaded).toEqual({
+      posts: {
+        title: { type: "string", null: false },
+        body: { type: "text", null: true },
+        tags: { type: "array", null: true, arrayElementType: "integer" },
+      },
+    });
+  });
+
+  it("loadSchemaColumns: mixed legacy + rich in one file", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = path.join(
+      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
+      "s.json",
+    );
+    fs.writeFileSync(
+      tmp,
+      JSON.stringify({
+        posts: { legacy: "string", modern: { type: "integer", null: false } },
+      }),
+    );
+    const loaded = loadSchemaColumns(["--schema", tmp]);
+    expect(loaded).toEqual({
+      posts: { legacy: "string", modern: { type: "integer", null: false } },
+    });
+  });
+
+  it("loadSchemaColumns: rejects rich shape with non-boolean `null`", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = path.join(
+      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
+      "s.json",
+    );
+    fs.writeFileSync(tmp, JSON.stringify({ posts: { title: { type: "string", null: "yes" } } }));
+    // Malformed values should cause the loader to call process.exit(1).
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+      const combined = errSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(combined).toMatch(/`null` must be a boolean/);
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("loadSchemaColumns: rejects non-object / non-string column value", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = path.join(
+      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
+      "s.json",
+    );
+    fs.writeFileSync(tmp, JSON.stringify({ posts: { title: 42 } }));
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+      const combined = errSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(combined).toMatch(/must be a Rails type string or an object/);
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
   });
 
   it("without schema, those accesses fall back to unknown (declares weren't injected)", () => {

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import ts from "typescript";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import { fileURLToPath } from "node:url";
 import { createTrailsProgram } from "./program.js";
 import { createTrailsSolutionBuilder } from "./build.js";
@@ -374,10 +375,7 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: --schema <path> accepts legacy string shape", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(
-      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
-      "s.json",
-    );
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
     fs.writeFileSync(tmp, JSON.stringify({ users: { name: "string", age: "integer" } }));
     const loaded = loadSchemaColumns(["--schema", tmp]);
     expect(loaded).toEqual({ users: { name: "string", age: "integer" } });
@@ -385,10 +383,7 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: accepts rich shape end-to-end", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(
-      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
-      "s.json",
-    );
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
     fs.writeFileSync(
       tmp,
       JSON.stringify({
@@ -411,10 +406,7 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: mixed legacy + rich in one file", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(
-      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
-      "s.json",
-    );
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
     fs.writeFileSync(
       tmp,
       JSON.stringify({
@@ -429,10 +421,7 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: rejects rich shape with non-boolean `null`", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(
-      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
-      "s.json",
-    );
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
     fs.writeFileSync(tmp, JSON.stringify({ posts: { title: { type: "string", null: "yes" } } }));
     // Malformed values should cause the loader to call process.exit(1).
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -451,10 +440,7 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
 
   it("loadSchemaColumns: rejects non-object / non-string column value", async () => {
     const { loadSchemaColumns } = await import("./cli.js");
-    const tmp = path.join(
-      fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "trails-tsc-")),
-      "s.json",
-    );
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-")), "s.json");
     fs.writeFileSync(tmp, JSON.stringify({ posts: { title: 42 } }));
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -445,6 +445,26 @@ describe("trails-tsc — schemaColumnsByTable (Phase R.3)", () => {
     expect(combined).toMatch(/must be a Rails type string or an object/);
   });
 
+  it("loadSchemaColumns: reports `null` when a column value is null", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = writeSchemaJson({ posts: { title: null } });
+    const { err } = spyExitAndStderr();
+    expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+    const combined = err.mock.calls.map((c) => String(c[0])).join("");
+    expect(combined).toMatch(/\(got null\)/);
+  });
+
+  it("loadSchemaColumns: rejects arrayElementType on non-array type", async () => {
+    const { loadSchemaColumns } = await import("./cli.js");
+    const tmp = writeSchemaJson({
+      posts: { title: { type: "string", arrayElementType: "integer" } },
+    });
+    const { err } = spyExitAndStderr();
+    expect(() => loadSchemaColumns(["--schema", tmp])).toThrow(/process\.exit\(1\)/);
+    const combined = err.mock.calls.map((c) => String(c[0])).join("");
+    expect(combined).toMatch(/`arrayElementType` is only valid when `type` is "array"/);
+  });
+
   it("without schema, those accesses fall back to unknown (declares weren't injected)", () => {
     const configPath = path.join(SCHEMA_DIR, "tsconfig.json");
     const { program } = createTrailsProgram(configPath);

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -7,19 +7,22 @@ import { createTrailsProgram } from "./program.js";
 import { createTrailsSolutionBuilder } from "./build.js";
 import { remapDiagnostics } from "./remap.js";
 import { virtualize } from "../type-virtualization/virtualize.js";
+import type { SchemaColumnValue } from "../type-virtualization/synthesize.js";
 
 /**
  * Load a schema-columns JSON file produced by the schema dumper.
- * Format: `{ "<table>": { "<column>": "<rails_type>", ... }, ... }`.
+ *
+ * Format (either shape per column, may mix in one file):
+ *   `{ "<table>": { "<column>": "<rails_type>", ... }, ... }` — legacy
+ *   `{ "<table>": { "<column>": { "type": "<rails_type>", "null"?: boolean, "arrayElementType"?: string }, ... }, ... }` — rich
+ *
+ * The rich shape — as emitted by `trails-schema-dump` — drives
+ * nullability (`T | null`) and typed array elements (`ElementTsType[]`)
+ * in the generated TypeScript declares.
  */
-type RichColumnValue = {
-  type: string;
-  null?: boolean;
-  arrayElementType?: string;
-};
-type SchemaColumnValue = string | RichColumnValue;
+type RichColumnValue = Extract<SchemaColumnValue, object>;
 
-function loadSchemaColumns(
+export function loadSchemaColumns(
   args: string[],
 ): Record<string, Record<string, SchemaColumnValue>> | undefined {
   let schemaPath: string | undefined;
@@ -328,10 +331,26 @@ function main(): void {
   process.exit(0);
 }
 
-try {
-  main();
-} catch (err: unknown) {
-  const msg = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`trails-tsc: ${msg}\n`);
-  process.exit(1);
+// Run main() only when this module is invoked as a binary, not when
+// imported (e.g. by tests that exercise `loadSchemaColumns` directly).
+// `require.main === module` is the CommonJS form; `import.meta.url`
+// vs `process.argv[1]` covers the ESM form the tsc-wrapper ships.
+const invokedDirectly = (() => {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    return import.meta.url === `file://${path.resolve(entry)}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`trails-tsc: ${msg}\n`);
+    process.exit(1);
+  }
 }

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -126,9 +126,10 @@ function validateColumnValue(
 ): SchemaColumnValue {
   if (typeof raw === "string") return raw;
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    const got = raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw;
     fail(
       `column "${fqColumn}" must be a Rails type string or an object ` +
-        `with at least { type: string } (got ${Array.isArray(raw) ? "array" : typeof raw})`,
+        `with at least { type: string } (got ${got})`,
     );
   }
   const r = raw as Record<string, unknown>;
@@ -138,8 +139,19 @@ function validateColumnValue(
   if (r.null !== undefined && typeof r.null !== "boolean") {
     fail(`column "${fqColumn}" rich shape: \`null\` must be a boolean when present`);
   }
-  if (r.arrayElementType !== undefined && typeof r.arrayElementType !== "string") {
-    fail(`column "${fqColumn}" rich shape: \`arrayElementType\` must be a string when present`);
+  if (r.arrayElementType !== undefined) {
+    if (typeof r.arrayElementType !== "string") {
+      fail(`column "${fqColumn}" rich shape: \`arrayElementType\` must be a string when present`);
+    }
+    // Catch typos / misconfiguration at load time — a non-"array" `type`
+    // would silently ignore `arrayElementType` downstream, leaving the
+    // user with an unexpectedly-untyped declare.
+    if (r.type !== "array") {
+      fail(
+        `column "${fqColumn}" rich shape: \`arrayElementType\` is only valid when ` +
+          `\`type\` is "array" (got type: "${r.type as string}")`,
+      );
+    }
   }
   const out: RichColumnValue = { type: r.type as string };
   if (r.null !== undefined) out.null = r.null as boolean;

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -341,7 +341,18 @@ const invokedDirectly = (() => {
   try {
     const entry = process.argv[1];
     if (!entry) return false;
-    return path.resolve(fileURLToPath(import.meta.url)) === path.resolve(entry);
+    // Resolve both sides through symlinks so package-manager bin
+    // shims (e.g. `node_modules/.bin/trails-tsc` → the real cli.js)
+    // still match. Without realpath, a shim invocation would leave
+    // `main()` unrun and the CLI becomes a no-op.
+    const resolveReal = (p: string): string => {
+      try {
+        return fs.realpathSync(p);
+      } catch {
+        return path.resolve(p);
+      }
+    };
+    return resolveReal(fileURLToPath(import.meta.url)) === resolveReal(entry);
   } catch {
     return false;
   }

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -12,7 +12,16 @@ import { virtualize } from "../type-virtualization/virtualize.js";
  * Load a schema-columns JSON file produced by the schema dumper.
  * Format: `{ "<table>": { "<column>": "<rails_type>", ... }, ... }`.
  */
-function loadSchemaColumns(args: string[]): Record<string, Record<string, string>> | undefined {
+type RichColumnValue = {
+  type: string;
+  null?: boolean;
+  arrayElementType?: string;
+};
+type SchemaColumnValue = string | RichColumnValue;
+
+function loadSchemaColumns(
+  args: string[],
+): Record<string, Record<string, SchemaColumnValue>> | undefined {
   let schemaPath: string | undefined;
   let schemaProvided = false;
   for (let i = 0; i < args.length; i++) {
@@ -67,35 +76,71 @@ function loadSchemaColumns(args: string[]): Record<string, Record<string, string
 // chain — rejected up front rather than trusted from JSON input.
 const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
-function validateSchemaShape(value: unknown, path: string): Record<string, Record<string, string>> {
+function validateSchemaShape(
+  value: unknown,
+  path: string,
+): Record<string, Record<string, SchemaColumnValue>> {
   const fail = (reason: string): never => {
     process.stderr.write(`trails-tsc: --schema file ${path} is malformed: ${reason}\n`);
     process.exit(1);
   };
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    fail("expected a top-level object of { [table]: { [column]: railsType } }");
+    fail("expected a top-level object of { [table]: { [column]: railsType | richValue } }");
   }
   // Use null-prototype maps so untrusted keys from the JSON can't reach
   // Object.prototype. Iterate with Object.keys to skip inherited keys on
   // the input (defense-in-depth; JSON.parse never sets them, but the
   // function signature accepts `unknown`).
-  const out: Record<string, Record<string, string>> = Object.create(null);
+  const out: Record<string, Record<string, SchemaColumnValue>> = Object.create(null);
   for (const table of Object.keys(value as object)) {
     if (UNSAFE_KEYS.has(table)) fail(`table name "${table}" is not allowed`);
     const cols = (value as Record<string, unknown>)[table];
     if (cols === null || typeof cols !== "object" || Array.isArray(cols)) {
       fail(`table "${table}" must map to an object of column definitions`);
     }
-    const colMap: Record<string, string> = Object.create(null);
+    const colMap: Record<string, SchemaColumnValue> = Object.create(null);
     for (const col of Object.keys(cols as object)) {
       if (UNSAFE_KEYS.has(col)) fail(`column name "${table}.${col}" is not allowed`);
-      const railsType = (cols as Record<string, unknown>)[col];
-      if (typeof railsType !== "string") {
-        fail(`column "${table}.${col}" must have a string Rails type (got ${typeof railsType})`);
-      }
-      colMap[col] = railsType as string;
+      const raw = (cols as Record<string, unknown>)[col];
+      colMap[col] = validateColumnValue(raw, `${table}.${col}`, fail);
     }
     out[table] = colMap;
+  }
+  return out;
+}
+
+/**
+ * A column value can be either a Rails type string (legacy) or a rich
+ * object `{ type, null?, arrayElementType? }` emitted by
+ * `dumpSchemaColumns`. Reject anything else with a targeted message so
+ * users see the actual problem instead of a downstream crash.
+ */
+function validateColumnValue(
+  raw: unknown,
+  fqColumn: string,
+  fail: (reason: string) => never,
+): SchemaColumnValue {
+  if (typeof raw === "string") return raw;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    fail(
+      `column "${fqColumn}" must be a Rails type string or an object ` +
+        `with at least { type: string } (got ${Array.isArray(raw) ? "array" : typeof raw})`,
+    );
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r.type !== "string") {
+    fail(`column "${fqColumn}" rich shape requires { type: string } (got ${typeof r.type})`);
+  }
+  if (r.null !== undefined && typeof r.null !== "boolean") {
+    fail(`column "${fqColumn}" rich shape: \`null\` must be a boolean when present`);
+  }
+  if (r.arrayElementType !== undefined && typeof r.arrayElementType !== "string") {
+    fail(`column "${fqColumn}" rich shape: \`arrayElementType\` must be a string when present`);
+  }
+  const out: RichColumnValue = { type: r.type as string };
+  if (r.null !== undefined) out.null = r.null as boolean;
+  if (r.arrayElementType !== undefined) {
+    out.arrayElementType = r.arrayElementType as string;
   }
   return out;
 }

--- a/packages/activerecord/src/tsc-wrapper/cli.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.ts
@@ -3,6 +3,7 @@
 import ts from "typescript";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createTrailsProgram } from "./program.js";
 import { createTrailsSolutionBuilder } from "./build.js";
 import { remapDiagnostics } from "./remap.js";
@@ -333,13 +334,14 @@ function main(): void {
 
 // Run main() only when this module is invoked as a binary, not when
 // imported (e.g. by tests that exercise `loadSchemaColumns` directly).
-// `require.main === module` is the CommonJS form; `import.meta.url`
-// vs `process.argv[1]` covers the ESM form the tsc-wrapper ships.
+// Compare decoded filesystem paths to sidestep URL-encoding pitfalls
+// (spaces, Windows drive letters + backslashes) that would trip up a
+// naive `import.meta.url === "file://" + path.resolve(entry)` check.
 const invokedDirectly = (() => {
   try {
     const entry = process.argv[1];
     if (!entry) return false;
-    return import.meta.url === `file://${path.resolve(entry)}`;
+    return path.resolve(fileURLToPath(import.meta.url)) === path.resolve(entry);
   } catch {
     return false;
   }

--- a/packages/activerecord/src/tsc-wrapper/host.ts
+++ b/packages/activerecord/src/tsc-wrapper/host.ts
@@ -16,7 +16,12 @@ export interface BuildCompilerHostOptions {
    * When supplied, the virtualizer emits `declare <col>: <tsType>` for
    * any column not already declared by hand or via `this.attribute(...)`.
    */
-  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+  schemaColumnsByTable?: Readonly<
+    Record<
+      string,
+      Readonly<Record<string, import("../type-virtualization/synthesize.js").SchemaColumnValue>>
+    >
+  >;
 }
 
 export function buildCompilerHost(

--- a/packages/activerecord/src/tsc-wrapper/program.ts
+++ b/packages/activerecord/src/tsc-wrapper/program.ts
@@ -10,7 +10,12 @@ export interface TrailsProgram {
 }
 
 export interface CreateTrailsProgramOptions {
-  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+  schemaColumnsByTable?: Readonly<
+    Record<
+      string,
+      Readonly<Record<string, import("../type-virtualization/synthesize.js").SchemaColumnValue>>
+    >
+  >;
 }
 
 export function createTrailsProgram(

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -28,8 +28,24 @@ const INDENT = "  ";
 // (see the plan § "Auto-import resolution under Phase 1b").
 const AR_IMPORT = `import("@blazetrails/activerecord")`;
 
+/**
+ * Column value in a schema-columns JSON map. Either:
+ *   - a plain Rails type string (legacy shape, e.g. `"string"`), or
+ *   - a rich shape with nullability and array element info, emitted by
+ *     `dumpSchemaColumns`. trails-tsc renders `Type | null` for
+ *     nullable columns and `ElementTsType[]` for array columns when
+ *     an `arrayElementType` is supplied.
+ */
+export type SchemaColumnValue =
+  | string
+  | {
+      type: string;
+      null?: boolean;
+      arrayElementType?: string;
+    };
+
 export interface SynthesizeOptions {
-  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, SchemaColumnValue>>>>;
 }
 
 export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}): string[] {
@@ -76,18 +92,36 @@ function renderSchemaColumnDeclares(
   // Sort by column name so emitted declares are stable regardless of
   // JSON key insertion order.
   const entries = Object.entries(cols).sort(([a], [b]) => a.localeCompare(b));
-  for (const [col, railsType] of entries) {
+  for (const [col, value] of entries) {
     if (synthesizedInstanceNames.has(col)) continue;
     if (info.existingMembers.has(col)) continue;
     // Skip "id" — Base already defines a PrimaryKeyValue accessor that
     // handles composite keys; re-declaring here would shadow it.
     if (col === "id") continue;
+    const tsType = renderSchemaValueType(value);
     // Emit a bracket-quoted declare for non-identifier / reserved-word
     // names (e.g. `declare "strange-col": string;`). TypeScript allows
     // string-literal class field names, so this is a valid declare.
-    out.push(`${INDENT}declare ${renderDeclaredMemberName(col)}: ${tsTypeFor(railsType)};`);
+    out.push(`${INDENT}declare ${renderDeclaredMemberName(col)}: ${tsType};`);
   }
   return out;
+}
+
+/**
+ * Convert a `SchemaColumnValue` to the TypeScript type text emitted in
+ * the generated `declare`. Handles the rich shape's nullability and
+ * array element types.
+ */
+function renderSchemaValueType(value: SchemaColumnValue): string {
+  if (typeof value === "string") return tsTypeFor(value);
+  let ts = tsTypeFor(value.type);
+  // For array columns with a known element type, render
+  // `ElementTsType[]` instead of the default `unknown[]`.
+  if (value.type === "array" && value.arrayElementType) {
+    ts = `${tsTypeFor(value.arrayElementType)}[]`;
+  }
+  if (value.null !== false) ts = `${ts} | null`;
+  return ts;
 }
 
 function renderDeclaredMemberName(name: string): string {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -166,6 +166,42 @@ describe("virtualize — deltas", () => {
     expect(text).not.toMatch(/declare class: string;/);
   });
 
+  test("schemaColumnsByTable accepts the rich shape (null: true, arrayElementType)", () => {
+    const src = "export class Post extends Base {}\n";
+    const { text } = virtualize(src, "post.ts", {
+      schemaColumnsByTable: {
+        posts: {
+          title: { type: "string", null: false },
+          bio: { type: "string", null: true },
+          tags: { type: "array", null: true, arrayElementType: "integer" },
+          strict_tags: { type: "array", null: false, arrayElementType: "string" },
+        },
+      },
+    });
+    // null: false → no `| null`
+    expect(text).toMatch(/declare title: string;/);
+    // null: true → `| null`
+    expect(text).toMatch(/declare bio: string \| null;/);
+    // array with known element type → `number[] | null`
+    expect(text).toMatch(/declare tags: number\[\] \| null;/);
+    // non-nullable array → `string[]`
+    expect(text).toMatch(/declare strict_tags: string\[\];/);
+  });
+
+  test("schemaColumnsByTable mixing legacy string and rich shape in same table", () => {
+    const src = "export class Post extends Base {}\n";
+    const { text } = virtualize(src, "post.ts", {
+      schemaColumnsByTable: {
+        posts: {
+          legacy: "string", // legacy string — backwards-compat
+          modern: { type: "integer", null: false },
+        },
+      },
+    });
+    expect(text).toMatch(/declare legacy: string;/);
+    expect(text).toMatch(/declare modern: number;/);
+  });
+
   test("schemaColumnsByTable emits columns in stable (sorted) order", () => {
     const src = "export class Post extends Base {}\n";
     const { text } = virtualize(src, "post.ts", {

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -46,8 +46,14 @@ export interface VirtualizeOptions extends WalkOptions {
    * columns come from the migration, not from per-class declarations).
    *
    * Table resolution: `static tableName = "..."` on the class when
-   * present, otherwise `pluralize(underscore(className))`. Each column's
-   * value is a Rails type string.
+   * present, otherwise `pluralize(underscore(className))`.
+   *
+   * Each column's value is a `SchemaColumnValue` — either:
+   *   - a Rails type string (legacy shape, e.g. `"string"`), or
+   *   - a rich object `{ type, null?, arrayElementType? }` as emitted
+   *     by `dumpSchemaColumns`. `null: true` renders `Type | null`;
+   *     `arrayElementType` on an `array` column renders
+   *     `ElementTsType[]` instead of the default `unknown[]`.
    *
    * Caveats:
    * - `id` is skipped (Base's `PrimaryKeyValue` accessor handles it).

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -55,7 +55,9 @@ export interface VirtualizeOptions extends WalkOptions {
    *   fields (`declare "strange-col": string;`).
    * - Columns are emitted in sorted order for stable output.
    */
-  schemaColumnsByTable?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+  schemaColumnsByTable?: Readonly<
+    Record<string, Readonly<Record<string, import("./synthesize.js").SchemaColumnValue>>>
+  >;
 }
 
 export function virtualize(

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -51,8 +51,10 @@ export interface VirtualizeOptions extends WalkOptions {
    * Each column's value is a `SchemaColumnValue` — either:
    *   - a Rails type string (legacy shape, e.g. `"string"`), or
    *   - a rich object `{ type, null?, arrayElementType? }` as emitted
-   *     by `dumpSchemaColumns`. `null: true` renders `Type | null`;
-   *     `arrayElementType` on an `array` column renders
+   *     by `dumpSchemaColumns`. `null: false` renders `Type`;
+   *     `null: true` OR `null` omitted renders `Type | null` (Rails'
+   *     conservative default — columns without a NOT NULL constraint
+   *     are nullable). `arrayElementType` on an `array` column renders
    *     `ElementTsType[]` instead of the default `unknown[]`.
    *
    * Caveats:


### PR DESCRIPTION
## Summary

Closes attr-type-wiring follow-up #3. The schema-columns JSON now carries nullability and (for PG arrays) element-type info, so generated TypeScript declares can be precise.

### Dumper change

\`dumpSchemaColumns\` returns \`Record<table, Record<column, { type, null, arrayElementType? }>>\` instead of \`Record<table, Record<column, string>>\`. PG adapter array detection extracts the element type (e.g. \`integer[]\` → \`{ type: "array", arrayElementType: "integer" }\`).

### Virtualizer change

Accepts BOTH the legacy string shape and the rich object shape (backwards-compat for hand-authored JSON). Rich drives:

- **Nullability** — \`null: true\` → \`Type | null\`; \`null: false\` → bare \`Type\`.
- **Array element type** — \`arrayElementType\` → \`ElementTsType[]\` instead of \`unknown[]\`.

### End-to-end

\`trails-schema-dump --out db/schema-columns.json\` → \`trails-tsc --schema db/schema-columns.json\` now gives:

\`\`\`ts
declare not_null_col: string;
declare nullable_col: string | null;
declare tags: number[] | null;       // PG integer[]
declare strict_tags: string[];       // PG character varying[] NOT NULL
\`\`\`

## Test plan

- [x] 2 new virtualizer tests lock rich-shape handling (nullability, array elements, mixing legacy + rich in one table).
- [x] New dumper test locks nullability pass-through.
- [x] Existing tests updated to assert the new rich shape.
- [x] Full suite: 17,529 passed / 4,421 skipped.
- [x] \`pnpm tsc --noEmit\` clean.