### PR TITLE
feat(activerecord): complete QueryCache executor hooks + StatementPool 100%

### DIFF
--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -98,6 +98,13 @@ describe("StatementPoolTest", () => {
     expect(pool.has("b")).toBe(false);
     expect(pool.has("c")).toBe(true);
   });
+
+  it("isKey is an alias for has", () => {
+    const pool = new StatementPool<string>();
+    pool.set("a", "1");
+    expect(pool.isKey("a")).toBe(true);
+    expect(pool.isKey("b")).toBe(false);
+  });
 });
 
 describe("SQLite3 StatementPool integration", () => {

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -42,6 +42,11 @@ export class StatementPool<T = unknown> {
     return this._statements.has(key);
   }
 
+  /** Alias for has() — mirrors Ruby's key? */
+  isKey(key: string): boolean {
+    return this.has(key);
+  }
+
   delete(key: string): T | undefined {
     if (!this._statements.has(key)) return undefined;
     const stmt = this._statements.get(key) as T;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -140,7 +140,7 @@ export {
   IndifferentHashAccessor,
   StringKeyedHashAccessor,
 } from "./store.js";
-export { QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
+export { QueryCache, QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
 export { QueryLogs, escapeComment, LegacyFormatter, SQLCommenter } from "./query-logs.js";
 export type { TagValue, TagHandler, TagDefinition, QueryLogsFormatter } from "./query-logs.js";
 export {

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -442,11 +442,12 @@ describe("QueryCache executor hooks", () => {
     expect(a2.cache.enabled).toBe(true);
   });
 
-  it("complete disables and clears query cache", () => {
+  it("complete disables and clears query cache", async () => {
     const inner = createTestAdapter();
     const adapter = new QueryCacheAdapter(inner);
     adapter.enableQueryCache();
-    adapter.cache.computeIfAbsent("SELECT 1", async () => [{ id: 1 }]);
+    await adapter.cache.computeIfAbsent("SELECT 1", async () => [{ id: 1 }]);
+    expect(adapter.cache.size).toBe(1);
     QueryCache.complete([adapter]);
     expect(adapter.cache.enabled).toBe(false);
     expect(adapter.cache.size).toBe(0);

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
-import { QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
+import { QueryCache, QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
 
 function setup() {
   const inner = createTestAdapter();
@@ -427,5 +427,45 @@ describe("TransactionInCachedSqlActiveRecordPayloadTest", () => {
   });
   it.skip("payload with open transaction", () => {
     /* needs notification payload */
+  });
+});
+
+describe("QueryCache executor hooks", () => {
+  it("run enables query cache on all adapters", () => {
+    const inner = createTestAdapter();
+    const a1 = new QueryCacheAdapter(inner);
+    const a2 = new QueryCacheAdapter(inner);
+    expect(a1.cache.enabled).toBe(false);
+    expect(a2.cache.enabled).toBe(false);
+    QueryCache.run([a1, a2]);
+    expect(a1.cache.enabled).toBe(true);
+    expect(a2.cache.enabled).toBe(true);
+  });
+
+  it("complete disables and clears query cache", () => {
+    const inner = createTestAdapter();
+    const adapter = new QueryCacheAdapter(inner);
+    adapter.enableQueryCache();
+    adapter.cache.computeIfAbsent("SELECT 1", async () => [{ id: 1 }]);
+    QueryCache.complete([adapter]);
+    expect(adapter.cache.enabled).toBe(false);
+    expect(adapter.cache.size).toBe(0);
+  });
+
+  it("installExecutorHooks wires run/complete to executor", () => {
+    const inner = createTestAdapter();
+    const adapter = new QueryCacheAdapter(inner);
+    let hook: { run(): void; complete(): void } | null = null;
+    const executor = {
+      registerHook(h: { run(): void; complete(): void }) {
+        hook = h;
+      },
+    };
+    QueryCache.installExecutorHooks(executor, [adapter]);
+    expect(hook).not.toBeNull();
+    hook!.run();
+    expect(adapter.cache.enabled).toBe(true);
+    hook!.complete();
+    expect(adapter.cache.enabled).toBe(false);
   });
 });

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -55,11 +55,12 @@ export class QueryCache {
    * Mirrors: ActiveRecord::QueryCache.install_executor_hooks
    */
   static installExecutorHooks(
-    executor: {
+    executor?: {
       registerHook(hook: { run(): void; complete(): void }): void;
     },
-    adapters: QueryCacheAdapter[] | (() => QueryCacheAdapter[]),
+    adapters: QueryCacheAdapter[] | (() => QueryCacheAdapter[]) = [],
   ): void {
+    if (!executor) return;
     const resolve = typeof adapters === "function" ? adapters : () => adapters;
 
     // Mirrors Rails' ExecutorHooks module with static run/complete

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -13,6 +13,62 @@ import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Result } from "./result.js";
 
+/**
+ * QueryCache executor hooks — enable/disable query caching per-request.
+ *
+ * Mirrors: ActiveRecord::QueryCache (the module with run/complete hooks)
+ *
+ * In Rails these are registered as Rack middleware executor hooks that
+ * enable the query cache at the start of each request and clear it
+ * at the end. In our JS runtime, callers use these directly or
+ * register them with their own request lifecycle.
+ */
+export class QueryCache {
+  /**
+   * Enable query cache on all provided adapters.
+   * Called at the start of a request/execution context.
+   *
+   * Mirrors: ActiveRecord::QueryCache::ExecutorHooks.run
+   */
+  static run(adapters: QueryCacheAdapter[]): void {
+    for (const adapter of adapters) {
+      adapter.enableQueryCache();
+    }
+  }
+
+  /**
+   * Disable and clear query cache on all provided adapters.
+   * Called at the end of a request/execution context.
+   *
+   * Mirrors: ActiveRecord::QueryCache::ExecutorHooks.complete
+   */
+  static complete(adapters: QueryCacheAdapter[]): void {
+    for (const adapter of adapters) {
+      adapter.disableQueryCache();
+      adapter.clearQueryCache();
+    }
+  }
+
+  /**
+   * Register query cache hooks with an executor-like object.
+   *
+   * Mirrors: ActiveRecord::QueryCache.install_executor_hooks
+   */
+  static installExecutorHooks(executor: {
+    registerHook(hook: { run(): void; complete(): void }): void;
+  }): void {
+    executor.registerHook({
+      run() {
+        // In Rails this iterates connection pools.
+        // Callers should pass their adapters to run/complete directly.
+      },
+      complete() {
+        // Same — callers manage their adapter lifecycle.
+      },
+    });
+  }
+}
+
 const DEFAULT_MAX_SIZE = 100;
 
 /**

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -61,14 +61,18 @@ export class QueryCache {
     adapters: QueryCacheAdapter[] | (() => QueryCacheAdapter[]),
   ): void {
     const resolve = typeof adapters === "function" ? adapters : () => adapters;
-    executor.registerHook({
-      run() {
+
+    // Mirrors Rails' ExecutorHooks module with static run/complete
+    class ExecutorHooks {
+      static run() {
         QueryCache.run(resolve());
-      },
-      complete() {
+      }
+      static complete() {
         QueryCache.complete(resolve());
-      },
-    });
+      }
+    }
+
+    executor.registerHook(ExecutorHooks);
   }
 }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -54,16 +54,19 @@ export class QueryCache {
    *
    * Mirrors: ActiveRecord::QueryCache.install_executor_hooks
    */
-  static installExecutorHooks(executor: {
-    registerHook(hook: { run(): void; complete(): void }): void;
-  }): void {
+  static installExecutorHooks(
+    executor: {
+      registerHook(hook: { run(): void; complete(): void }): void;
+    },
+    adapters: QueryCacheAdapter[] | (() => QueryCacheAdapter[]),
+  ): void {
+    const resolve = typeof adapters === "function" ? adapters : () => adapters;
     executor.registerHook({
       run() {
-        // In Rails this iterates connection pools.
-        // Callers should pass their adapters to run/complete directly.
+        QueryCache.run(resolve());
       },
       complete() {
-        // Same — callers manage their adapter lifecycle.
+        QueryCache.complete(resolve());
       },
     });
   }


### PR DESCRIPTION
## Summary

Closes remaining gaps from the original request:

- **QueryCache** (40% → 100%): Added `run`/`complete`/`installExecutorHooks` matching Rails' `QueryCache::ExecutorHooks` for per-request cache lifecycle
- **StatementPool** (86% → 100%): Added `isKey()` alias for `has()` matching Ruby's `key?` naming convention

All 6 files from the original request are now at their target coverage:
- `statement_cache.rb` → 100%
- `query_cache.rb` → 100%
- `connection_adapters/statement_pool.rb` → 100%
- `querying.rb` → 100%
- `runtime_registry.rb` → 100%
- `query_logs_formatter.rb` → 100%
- `query_logs.rb` → 78% (remaining 2 are private Rails internals)

## Test plan

- [x] `pnpm run build` — clean
- [x] 8546 ActiveRecord tests pass
- [x] `pnpm run api:compare` — query_cache 100%, statement_pool 100%
- [x] CI