### PR TITLE
feat(activerecord): render explain binds via adapter.typeCast + Ruby-inspect

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -106,7 +106,10 @@ export interface DatabaseAdapter {
    *   (`"YYYY-MM-DD HH:MM:SS"` — matches Rails'
    *   `value.to_formatted_s(:db)`). `quote()` is responsible for
    *   wrapping it in single quotes.
-   * - **null / undefined**: returned unchanged.
+   * - **null**: returned unchanged.
+   * - **undefined**: adapter-dependent — SQLite coerces to `null`
+   *   to match its nullable-column semantics; PG / MySQL /
+   *   abstract pass through unchanged.
    * - **strings / numbers / bigints / symbols**: passed through
    *   (symbols coerce to their description).
    *

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -103,15 +103,18 @@ export interface DatabaseAdapter {
    * - **booleans**: SQLite / MySQL collapse to `1` / `0`; PostgreSQL
    *   keeps them as `true` / `false`.
    * - **Date**: returned as an **unquoted** formatted string
-   *   (`"YYYY-MM-DD HH:MM:SS"` — matches Rails'
-   *   `value.to_formatted_s(:db)`). `quote()` is responsible for
-   *   wrapping it in single quotes.
+   *   (`"YYYY-MM-DD HH:MM:SS"` with optional `.microseconds` when
+   *   milliseconds > 0 — matches Rails' `value.to_formatted_s(:db)`).
+   *   `quote()` is responsible for wrapping it in single quotes.
    * - **null**: returned unchanged.
    * - **undefined**: adapter-dependent — SQLite coerces to `null`
    *   to match its nullable-column semantics; PG / MySQL /
    *   abstract pass through unchanged.
-   * - **strings / numbers / bigints / symbols**: passed through
-   *   (symbols coerce to their description).
+   * - **strings / numbers / bigints**: passed through.
+   * - **symbols**: adapter-dependent — abstract / MySQL / PG use
+   *   the symbol's description when present and fall back to
+   *   `String(symbol)` otherwise; SQLite coerces description-less
+   *   symbols to `null`.
    *
    * Rails' `render_bind` uses this rather than `quote()` so EXPLAIN
    * headers show the actual bind values instead of their SQL-literal

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -82,6 +82,17 @@ export interface DatabaseAdapter {
    */
   buildExplainClause?(options?: string[]): string;
 
+  /**
+   * Quote a value for inclusion in a SQL literal (e.g. `"'foo'"`,
+   * `"42"`, `"NULL"`, `"x'DEADBEEF'"`). Concrete adapters override to
+   * use their own string-escape rules — SQLite: `'' only`; PG: `E'\\'`
+   * form when backslash present; MySQL: `\0 \n \r \Z \\` via
+   * MYSQL_ESCAPE_MAP.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote
+   */
+  quote?(value: unknown): string;
+
   // --- DatabaseStatements (Rails mixin) ---
   // Mirrors ActiveRecord::ConnectionAdapters::DatabaseStatements.
   // Default implementations delegate to execute()/executeMutation().

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -94,12 +94,25 @@ export interface DatabaseAdapter {
   quote?(value: unknown): string;
 
   /**
-   * Cast a value to the primitive form drivers expect for binds
-   * (booleans → `0/1`, Dates → quoted date string, etc). Distinct
-   * from `quote()` — returns an unquoted primitive suitable for
-   * passing as a bind value, not a SQL literal. Rails' `render_bind`
-   * uses this rather than `quote()` so EXPLAIN headers show the
-   * actual bind values instead of their SQL-literal form.
+   * Cast a value to the primitive form drivers expect for binds.
+   * Returns an **unquoted** primitive suitable for passing as a bind
+   * value — distinct from `quote()`, which returns a SQL literal
+   * with its surrounding quotes already attached.
+   *
+   * Adapter-specific behavior (mirrors Rails):
+   * - **booleans**: SQLite / MySQL collapse to `1` / `0`; PostgreSQL
+   *   keeps them as `true` / `false`.
+   * - **Date**: returned as an **unquoted** formatted string
+   *   (`"YYYY-MM-DD HH:MM:SS"` — matches Rails'
+   *   `value.to_formatted_s(:db)`). `quote()` is responsible for
+   *   wrapping it in single quotes.
+   * - **null / undefined**: returned unchanged.
+   * - **strings / numbers / bigints / symbols**: passed through
+   *   (symbols coerce to their description).
+   *
+   * Rails' `render_bind` uses this rather than `quote()` so EXPLAIN
+   * headers show the actual bind values instead of their SQL-literal
+   * form.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#type_cast
    */

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -93,6 +93,18 @@ export interface DatabaseAdapter {
    */
   quote?(value: unknown): string;
 
+  /**
+   * Cast a value to the primitive form drivers expect for binds
+   * (booleans → `0/1`, Dates → quoted date string, etc). Distinct
+   * from `quote()` — returns an unquoted primitive suitable for
+   * passing as a bind value, not a SQL literal. Rails' `render_bind`
+   * uses this rather than `quote()` so EXPLAIN headers show the
+   * actual bind values instead of their SQL-literal form.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#type_cast
+   */
+  typeCast?(value: unknown): unknown;
+
   // --- DatabaseStatements (Rails mixin) ---
   // Mirrors ActiveRecord::ConnectionAdapters::DatabaseStatements.
   // Default implementations delegate to execute()/executeMutation().

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -6,10 +6,6 @@ import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "../connection-adapters/mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "../connection-adapters/abstract/database-statements.js";
-import {
-  quote as mysqlQuote,
-  typeCast as mysqlTypeCast,
-} from "../connection-adapters/mysql/quoting.js";
 
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
@@ -329,20 +325,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return `EXPLAIN ${parts} for:`;
   }
 
-  /**
-   * Quote a value for inclusion in a SQL literal. Uses MySQL-specific
-   * string escaping (`'' ` + `\0 \n \r \Z \\` via MYSQL_ESCAPE_MAP)
-   * and `1/0` booleans.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#quote
-   */
-  override quote(value: unknown): string {
-    return mysqlQuote(value);
-  }
-
-  override typeCast(value: unknown): unknown {
-    return mysqlTypeCast(value);
-  }
+  // `quote()` and `typeCast()` are inherited from AbstractMysqlAdapter,
+  // which delegates to `mysql/quoting.ts`. No Mysql2-specific override
+  // needed — they'd be duplicates.
 
   /**
    * Set of MySQL EXPLAIN flags that are safe to interpolate into the

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -6,6 +6,7 @@ import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "../connection-adapters/mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "../connection-adapters/abstract/database-statements.js";
+import { quote as mysqlQuote } from "../connection-adapters/mysql/quoting.js";
 
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
@@ -323,6 +324,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (options.length === 0) return "EXPLAIN for:";
     const parts = options.map((o) => o.toUpperCase()).join(" ");
     return `EXPLAIN ${parts} for:`;
+  }
+
+  /**
+   * Quote a value for inclusion in a SQL literal. Uses MySQL-specific
+   * string escaping (`'' ` + `\0 \n \r \Z \\` via MYSQL_ESCAPE_MAP)
+   * and `1/0` booleans.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#quote
+   */
+  override quote(value: unknown): string {
+    return mysqlQuote(value);
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -6,7 +6,10 @@ import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "../connection-adapters/mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "../connection-adapters/abstract/database-statements.js";
-import { quote as mysqlQuote } from "../connection-adapters/mysql/quoting.js";
+import {
+  quote as mysqlQuote,
+  typeCast as mysqlTypeCast,
+} from "../connection-adapters/mysql/quoting.js";
 
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
@@ -335,6 +338,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   override quote(value: unknown): string {
     return mysqlQuote(value);
+  }
+
+  override typeCast(value: unknown): unknown {
+    return mysqlTypeCast(value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -126,11 +126,21 @@ export class AbstractAdapter extends AbstractAdapterBase {
   }
 
   /**
-   * Cast a value to the primitive form the driver expects for binds
-   * (booleans → `0/1`, Dates → quoted date string, etc). Distinct from
-   * `quote()` — returns an unquoted primitive suitable for passing as
-   * a bind value, not a SQL literal. Used by `Relation#_renderExplainBinds`
-   * to mirror Rails' `render_bind(c, attr)` which does
+   * Cast a value to the primitive form drivers expect for binds.
+   * Returns an **unquoted** primitive suitable for passing as a bind
+   * value (distinct from `quote()`, which returns a SQL literal with
+   * surrounding quotes attached).
+   *
+   * Abstract defaults mirror `abstract/quoting.ts`:
+   * - booleans pass through as `true` / `false` (adapters override —
+   *   SQLite / MySQL collapse to `1` / `0`, PG keeps `true` / `false`)
+   * - Date → unquoted `"YYYY-MM-DD HH:MM:SS"` (no surrounding quotes;
+   *   matches Rails' `value.to_formatted_s(:db)`)
+   * - null / undefined → returned unchanged
+   * - strings / numbers / bigints → passed through
+   *
+   * Used by `Relation#_renderExplainBinds` to mirror Rails'
+   * `render_bind(c, attr)` which does
    * `connection.type_cast(attr.value_for_database)`.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#type_cast

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -25,7 +25,7 @@ import {
   type QueryCacheHost,
 } from "./abstract/query-cache.js";
 import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
-import { quote as abstractQuote } from "./abstract/quoting.js";
+import { quote as abstractQuote, typeCast as abstractTypeCast } from "./abstract/quoting.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -123,6 +123,20 @@ export class AbstractAdapter extends AbstractAdapterBase {
    */
   quote(value: unknown): string {
     return abstractQuote(value);
+  }
+
+  /**
+   * Cast a value to the primitive form the driver expects for binds
+   * (booleans → `0/1`, Dates → quoted date string, etc). Distinct from
+   * `quote()` — returns an unquoted primitive suitable for passing as
+   * a bind value, not a SQL literal. Used by `Relation#_renderExplainBinds`
+   * to mirror Rails' `render_bind(c, attr)` which does
+   * `connection.type_cast(attr.value_for_database)`.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#type_cast
+   */
+  typeCast(value: unknown): unknown {
+    return abstractTypeCast(value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -136,7 +136,9 @@ export class AbstractAdapter extends AbstractAdapterBase {
    *   SQLite / MySQL collapse to `1` / `0`, PG keeps `true` / `false`)
    * - Date → unquoted `"YYYY-MM-DD HH:MM:SS"` (no surrounding quotes;
    *   matches Rails' `value.to_formatted_s(:db)`)
-   * - null / undefined → returned unchanged
+   * - null → returned unchanged; undefined passes through too at
+   *   the abstract level (SQLite overrides to coerce `undefined →
+   *   null` for its nullable-column semantics)
    * - strings / numbers / bigints → passed through
    *
    * Used by `Relation#_renderExplainBinds` to mirror Rails'

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -25,6 +25,7 @@ import {
   type QueryCacheHost,
 } from "./abstract/query-cache.js";
 import { DatabaseStatementsMixin } from "./database-statements-mixin.js";
+import { quote as abstractQuote } from "./abstract/quoting.js";
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
@@ -108,6 +109,20 @@ export class AbstractAdapter extends AbstractAdapterBase {
     if (options.length === 0) return "EXPLAIN for:";
     const parts = options.map((o) => o.toUpperCase()).join(", ");
     return `EXPLAIN (${parts}) for:`;
+  }
+
+  /**
+   * Quote a value for inclusion in a SQL literal. Concrete adapters
+   * override to use their own string-escape rules (SQLite: `'' only`;
+   * PG: `E'\\' escape form`; MySQL: escapes `\0 \n \r \Z \\`). The
+   * abstract default is SQL-92 with `'' only`, suitable for
+   * identifier-quoting tests and for adapters that haven't specialized
+   * yet.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote
+   */
+  quote(value: unknown): string {
+    return abstractQuote(value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -134,7 +134,8 @@ export class AbstractAdapter extends AbstractAdapterBase {
    * Abstract defaults mirror `abstract/quoting.ts`:
    * - booleans pass through as `true` / `false` (adapters override —
    *   SQLite / MySQL collapse to `1` / `0`, PG keeps `true` / `false`)
-   * - Date → unquoted `"YYYY-MM-DD HH:MM:SS"` (no surrounding quotes;
+   * - Date → unquoted `"YYYY-MM-DD HH:MM:SS"` with optional
+   *   `.microseconds` when milliseconds > 0 (no surrounding quotes;
    *   matches Rails' `value.to_formatted_s(:db)`)
    * - null → returned unchanged; undefined passes through too at
    *   the abstract level (SQLite overrides to coerce `undefined →

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -11,7 +11,11 @@
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Nodes } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
-import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
+import {
+  quoteString as mysqlQuoteString,
+  quote as mysqlQuote,
+  typeCast as mysqlTypeCast,
+} from "./mysql/quoting.js";
 
 const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
@@ -51,6 +55,33 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   get adapterName(): string {
     return "Mysql2";
+  }
+
+  /**
+   * Quote a value using MySQL-family escape rules (`\0 \n \r \Z \\ ''`
+   * via MYSQL_ESCAPE_MAP, booleans as `1/0`, Dates as
+   * `'YYYY-MM-DD HH:MM:SS[.microseconds]'`). Defined here so every
+   * MySQL-family adapter (Mysql2, Trilogy) inherits MySQL semantics
+   * by default without needing to override themselves; without this,
+   * Trilogy would fall through to the abstract SQL-92 defaults
+   * (booleans → `TRUE/FALSE`, plain `''` string escaping) and
+   * diverge from Rails.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#quote
+   */
+  override quote(value: unknown): string {
+    return mysqlQuote(value);
+  }
+
+  /**
+   * Cast a value to the primitive form MySQL drivers expect for
+   * binds. Same motivation as `quote()` above — inherited by
+   * Trilogy so it gets MySQL semantics automatically.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#type_cast
+   */
+  override typeCast(value: unknown): unknown {
+    return mysqlTypeCast(value);
   }
 
   isMariadb(): boolean {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { quote, typeCast } from "./quoting.js";
+
+describe("MySQL quoting — quote", () => {
+  it("returns NULL for null / undefined", () => {
+    expect(quote(null)).toBe("NULL");
+    expect(quote(undefined)).toBe("NULL");
+  });
+
+  it("renders booleans as 1 / 0 (MySQL convention)", () => {
+    expect(quote(true)).toBe("1");
+    expect(quote(false)).toBe("0");
+  });
+
+  it("renders numbers / bigints bare", () => {
+    expect(quote(42)).toBe("42");
+    expect(quote(BigInt("9007199254740993"))).toBe("9007199254740993");
+  });
+
+  it("renders Date values as the full datetime (YYYY-MM-DD HH:MM:SS…), not date-only", () => {
+    // JS `Date` always carries a time component. Matches Rails' MySQL
+    // adapter treating JS datetimes as full timestamps rather than
+    // dropping the time to the `quotedDate` form.
+    const d = new Date(Date.UTC(2026, 0, 2, 12, 34, 56));
+    const out = quote(d);
+    expect(out).toMatch(/^'2026-01-02 12:34:56/);
+    expect(out.endsWith("'")).toBe(true);
+  });
+
+  it("quotes strings with MySQL-specific escapes (\\n, \\0, \\Z, \\\\)", () => {
+    expect(quote("a\nb")).toBe("'a\\nb'");
+    expect(quote("null\0byte")).toBe("'null\\0byte'");
+    expect(quote("with 'quote'")).toBe("'with ''quote'''");
+  });
+});
+
+describe("MySQL quoting — typeCast", () => {
+  it("returns null / undefined unchanged for nil-like values", () => {
+    expect(typeCast(null)).toBe(null);
+    expect(typeCast(undefined)).toBe(undefined);
+  });
+
+  it("collapses booleans to 1 / 0 (MySQL convention)", () => {
+    expect(typeCast(true)).toBe(1);
+    expect(typeCast(false)).toBe(0);
+  });
+
+  it("passes strings, numbers, bigints through unchanged", () => {
+    expect(typeCast("foo")).toBe("foo");
+    expect(typeCast(42)).toBe(42);
+    expect(typeCast(BigInt(9))).toBe(BigInt(9));
+  });
+
+  it("returns Date as the full unquoted datetime string (no surrounding quotes)", () => {
+    // typeCast's contract: unquoted primitive suitable as a bind
+    // value. It's `quote()`'s job to add the surrounding quotes.
+    const d = new Date(Date.UTC(2026, 0, 2, 12, 34, 56));
+    const out = typeCast(d) as string;
+    expect(out.startsWith("'")).toBe(false);
+    expect(out.endsWith("'")).toBe(false);
+    expect(out).toMatch(/^2026-01-02 12:34:56/);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -8,6 +8,8 @@
  * the pattern used by the PostgreSQL and SQLite3 adapters.
  */
 
+import { quotedDate as abstractQuotedDate } from "../abstract/quoting.js";
+
 export interface Quoting {
   quotedTrue(): string;
   unquotedTrue(): number;
@@ -93,11 +95,12 @@ export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
-  // JS `Date` always carries a time component, so render the full
-  // `YYYY-MM-DD HH:MM:SS` form (via `quotedTimeUtc`) rather than the
-  // date-only `quotedDate`. Time-only values have no dedicated JS type
-  // here — callers who want date-only can pass a pre-formatted string.
-  if (value instanceof Date) return quotedTimeUtc(value);
+  // Use abstract's `quotedDate` for the `YYYY-MM-DD HH:MM:SS[.microseconds]`
+  // form (Rails' `:db` format — fractional seconds only when
+  // non-zero), then wrap with single quotes. MySQL's own
+  // `quotedDate` would drop the time; its `quotedTimeUtc` always
+  // trails `.000`.
+  if (value instanceof Date) return `'${abstractQuotedDate(value)}'`;
   if (value instanceof Buffer) return quotedBinaryString(value);
   if (typeof value === "symbol") {
     const desc = value.description;
@@ -137,13 +140,14 @@ export function typeCast(value: unknown): unknown {
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
   if (value instanceof Date) {
-    // Use the full `YYYY-MM-DD HH:MM:SS` form from `quotedTimeUtc` —
-    // JS `Date` always has a time component; `quotedDate` would drop
-    // it. Strip the surrounding single quotes that `quotedTimeUtc`
-    // adds to honor typeCast's unquoted-primitive contract (quote()
-    // adds the quotes back).
-    const quoted = quotedTimeUtc(value);
-    return quoted.startsWith("'") && quoted.endsWith("'") ? quoted.slice(1, -1) : quoted;
+    // Delegate to abstract's `quotedDate` which renders the
+    // unquoted `YYYY-MM-DD HH:MM:SS[.microseconds]` form (optional
+    // fractional seconds only when non-zero, matching Rails'
+    // `:db`-format output). MySQL's own `quotedTimeUtc` relies on
+    // `toISOString()` which always trails `.000`, and MySQL's
+    // `quotedDate` drops the time. Neither matches Rails here;
+    // the abstract formatter does.
+    return abstractQuotedDate(value);
   }
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
 }

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -85,6 +85,28 @@ export function quotedBinaryString(value: Buffer): string {
 }
 
 /**
+ * Quote a value for inclusion in a SQL literal.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#quote
+ */
+export function quote(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value instanceof Date) return quotedDate(value);
+  if (value instanceof Buffer) return quotedBinaryString(value);
+  if (typeof value === "symbol") {
+    const desc = value.description;
+    if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
+    return quoteString(desc);
+  }
+  if (typeof value === "string") return quoteString(value);
+  // Rails: when Class then "'#{value}'"
+  if (typeof value === "function" && value.name) return `'${value.name}'`;
+  throw new TypeError(`can't quote ${(value as object).constructor?.name ?? typeof value}`);
+}
+
+/**
  * Type-cast a value for use as a column default in DDL.
  * MySQL represents booleans as 1/0 integers.
  */

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -115,3 +115,21 @@ export function typecastForDatabase(value: unknown): unknown {
   if (value === false) return 0;
   return value;
 }
+
+/**
+ * Cast a value to the primitive form MySQL drivers expect for binds.
+ * Booleans become 1/0, Dates are rendered as date strings, strings
+ * and numbers pass through unchanged.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#type_cast
+ */
+export function typeCast(value: unknown): unknown {
+  if (typeof value === "symbol") return value.description ?? String(value);
+  if (value === true) return unquotedTrue();
+  if (value === false) return unquotedFalse();
+  if (value === null || value === undefined) return value;
+  if (typeof value === "number" || typeof value === "bigint") return value;
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return quotedDate(value);
+  throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
+}

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -118,8 +118,10 @@ export function typecastForDatabase(value: unknown): unknown {
 
 /**
  * Cast a value to the primitive form MySQL drivers expect for binds.
- * Booleans become 1/0, Dates are rendered as date strings, strings
- * and numbers pass through unchanged.
+ * Booleans become 1/0, Dates are rendered as an **unquoted**
+ * `YYYY-MM-DD HH:MM:SS` string (Rails' `value.to_formatted_s(:db)`
+ * form — it's `quote()`'s job to add the surrounding single quotes,
+ * not `typeCast`'s), strings and numbers pass through unchanged.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#type_cast
  */
@@ -130,6 +132,11 @@ export function typeCast(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
-  if (value instanceof Date) return quotedDate(value);
+  if (value instanceof Date) {
+    // MySQL's `quotedDate` wraps with single quotes; strip them for the
+    // unquoted-primitive contract that typeCast guarantees.
+    const quoted = quotedDate(value);
+    return quoted.startsWith("'") && quoted.endsWith("'") ? quoted.slice(1, -1) : quoted;
+  }
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
 }

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -93,7 +93,11 @@ export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
-  if (value instanceof Date) return quotedDate(value);
+  // JS `Date` always carries a time component, so render the full
+  // `YYYY-MM-DD HH:MM:SS` form (via `quotedTimeUtc`) rather than the
+  // date-only `quotedDate`. Time-only values have no dedicated JS type
+  // here — callers who want date-only can pass a pre-formatted string.
+  if (value instanceof Date) return quotedTimeUtc(value);
   if (value instanceof Buffer) return quotedBinaryString(value);
   if (typeof value === "symbol") {
     const desc = value.description;
@@ -133,9 +137,12 @@ export function typeCast(value: unknown): unknown {
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
   if (value instanceof Date) {
-    // MySQL's `quotedDate` wraps with single quotes; strip them for the
-    // unquoted-primitive contract that typeCast guarantees.
-    const quoted = quotedDate(value);
+    // Use the full `YYYY-MM-DD HH:MM:SS` form from `quotedTimeUtc` —
+    // JS `Date` always has a time component; `quotedDate` would drop
+    // it. Strip the surrounding single quotes that `quotedTimeUtc`
+    // adds to honor typeCast's unquoted-primitive contract (quote()
+    // adds the quotes back).
+    const quoted = quotedTimeUtc(value);
     return quoted.startsWith("'") && quoted.endsWith("'") ? quoted.slice(1, -1) : quoted;
   }
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -9,6 +9,7 @@ import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
 import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
 import {
+  quote as pgQuote,
   quoteTableName as pgQuoteTableName,
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
@@ -991,6 +992,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   quoteTableName(name: string): string {
     return pgQuoteTableName(name);
+  }
+
+  /**
+   * Quote a value for inclusion in a SQL literal. PG-specific branches
+   * (XmlData, BitData, Range, ArrayData) fall through to the base
+   * dispatch, and strings use PG's `E'\\\\'`-escape form when a
+   * backslash is present.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote
+   */
+  override quote(value: unknown): string {
+    return pgQuote(value);
   }
 
   columnsForDistinct(columns: string, orders: string[]): string {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -10,6 +10,7 @@ import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
 import {
   quote as pgQuote,
+  typeCast as pgTypeCast,
   quoteTableName as pgQuoteTableName,
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
@@ -1004,6 +1005,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override quote(value: unknown): string {
     return pgQuote(value);
+  }
+
+  override typeCast(value: unknown): unknown {
+    return pgTypeCast(value);
   }
 
   columnsForDistinct(columns: string, orders: string[]): string {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -33,6 +33,7 @@ import { getFs, Notifications } from "@blazetrails/activesupport";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 import {
   quote as sqliteQuote,
+  typeCast as sqliteTypeCast,
   quoteString,
   quoteTableName,
   quoteColumnName,
@@ -309,6 +310,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   override quote(value: unknown): string {
     return sqliteQuote(value);
+  }
+
+  override typeCast(value: unknown): unknown {
+    return sqliteTypeCast(value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -31,7 +31,12 @@ import {
 } from "@blazetrails/activemodel";
 import { getFs, Notifications } from "@blazetrails/activesupport";
 import { typeCastedBinds } from "./abstract/database-statements.js";
-import { quoteString, quoteTableName, quoteColumnName } from "./sqlite3/quoting.js";
+import {
+  quote as sqliteQuote,
+  quoteString,
+  quoteTableName,
+  quoteColumnName,
+} from "./sqlite3/quoting.js";
 import {
   CheckConstraintDefinition,
   type AddForeignKeyOptions,
@@ -293,6 +298,17 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   buildExplainClause(_options: string[] = []): string {
     return "EXPLAIN QUERY PLAN for:";
+  }
+
+  /**
+   * Quote a value for inclusion in a SQL literal. SQLite uses plain
+   * `'' ` string escaping (no backslash escapes), `1/0` for booleans,
+   * and `x'hex'` for binary.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting#quote
+   */
+  override quote(value: unknown): string {
+    return sqliteQuote(value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -220,5 +220,37 @@ describe("SQLite3::Quoting", () => {
     it("throws on unsupported types", () => {
       expect(() => typeCast({})).toThrow(TypeError);
     });
+
+    it("formats Date as the unquoted :db form (no surrounding quotes, no trailing .000)", () => {
+      // typeCast's contract is to return an **unquoted** primitive;
+      // `quote()` adds the surrounding single quotes. Delegates to
+      // `abstract/quoting.ts:quotedDate` so fractional seconds show
+      // up only when ms > 0 (Rails' `:db` behavior) rather than
+      // always `.000` like `toISOString`.
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      const out = typeCast(d) as string;
+      expect(out.startsWith("'")).toBe(false);
+      expect(out.endsWith("'")).toBe(false);
+      expect(out).toBe("2026-04-18 12:34:56");
+      expect(out).not.toMatch(/\.000$/);
+    });
+
+    it("includes microseconds on Date when milliseconds are non-zero", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
+      const out = typeCast(d) as string;
+      expect(out).toMatch(/^2026-04-18 12:34:56\.\d{6}$/);
+    });
+  });
+
+  describe("quote(Date)", () => {
+    it("wraps the :db form with single quotes (consistent with typeCast)", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      expect(quote(d)).toBe("'2026-04-18 12:34:56'");
+    });
+
+    it("includes microseconds on Date when milliseconds are non-zero", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
+      expect(quote(d)).toMatch(/^'2026-04-18 12:34:56\.\d{6}'$/);
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -4,6 +4,8 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting
  */
 
+import { quotedDate as abstractQuotedDate } from "../abstract/quoting.js";
+
 export interface Quoting {
   quotedTrue(): string;
   unquotedTrue(): number;
@@ -119,8 +121,15 @@ export function typeCast(value: unknown): unknown {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   if (typeof value === "string" || typeof value === "bigint") return value;
   if (typeof value === "symbol") return value.description ?? null;
-  if (value instanceof Date || value instanceof Uint8Array || value instanceof ArrayBuffer)
-    return value;
+  if (value instanceof Date) {
+    // Delegate to abstract's `quotedDate` which renders the
+    // unquoted `YYYY-MM-DD HH:MM:SS[.microseconds]` form (optional
+    // fractional seconds only when non-zero). Matches Rails'
+    // `type_cast` which returns `quoted_date(value)` — a formatted
+    // string, not the Date object itself.
+    return abstractQuotedDate(value);
+  }
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;
   throw new TypeError(`can't cast ${Object.prototype.toString.call(value)} to a SQLite3 type`);
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -72,7 +72,15 @@ export function quote(value: unknown): string {
     }
     return quoteString(value.description);
   }
-  if (value instanceof Date) return quotedTimeUtc(value);
+  if (value instanceof Date) {
+    // Use abstract's `quotedDate` for consistency with
+    // `typeCast(Date)`: `YYYY-MM-DD HH:MM:SS` with optional
+    // `.microseconds` only when ms > 0 (Rails' `:db` format). Local
+    // `quotedTimeUtc` trails `.000` unconditionally via
+    // `toISOString()`; `quote()` wraps the result with single
+    // quotes.
+    return `'${abstractQuotedDate(value)}'`;
+  }
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
     return quotedBinary(value);
   }

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -241,6 +241,45 @@ describe("ExplainTest", () => {
     expect(plan.length).toBeGreaterThan(0);
   });
 
+  it("renders binary binds as '<N bytes of binary data>' (Rails parity)", async () => {
+    // Rails' `render_bind` special-cases binary-typed attrs:
+    //   "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
+    // We reach the same result structurally — after typeCast, any
+    // Buffer / Uint8Array / ArrayBuffer bind gets normalized to the
+    // same byte-count string before rubyInspect sees it, so an
+    // EXPLAIN over a BYTEA/BLOB column doesn't dump the raw buffer.
+    const { Post } = makeModel();
+    const rel = Post.all() as unknown as {
+      _renderExplainBinds: (a: DatabaseAdapter, binds: unknown[]) => string;
+    };
+    const buf = Buffer.from("hello world"); // 11 bytes
+    const u8 = new Uint8Array([1, 2, 3, 4, 5]); // 5 bytes
+    const rendered = rel._renderExplainBinds(adapter, [buf, u8]);
+    expect(rendered).toBe('["<11 bytes of binary data>", "<5 bytes of binary data>"]');
+  });
+
+  it("unwraps PG-style { value, format } bind shapes when rendering", async () => {
+    // PG's `typeCast(BinaryData)` returns `{ value, format }` — the
+    // raw wrapper would stringify to "[object Object]" via
+    // `rubyInspect`'s object fallback. Normalization recurses on
+    // `.value` so we show the actual payload instead of the envelope.
+    const { Post } = makeModel();
+    const rel = Post.all() as unknown as {
+      _renderExplainBinds: (a: DatabaseAdapter, binds: unknown[]) => string;
+    };
+    // Skip typeCast here — we're testing the normalization of a
+    // pre-cast bind-wrapper value. The inner adapter.typeCast call
+    // would pass these objects through unchanged on non-PG adapters.
+    const stub = {
+      typeCast: (v: unknown) => v,
+    } as unknown as DatabaseAdapter;
+    const rendered = rel._renderExplainBinds(stub, [
+      { value: "raw", format: 1 },
+      { value: 42, format: 0 },
+    ]);
+    expect(rendered).toBe('["raw", 42]');
+  });
+
   it("isolates concurrent explain() calls via AsyncLocalStorage scopes", async () => {
     // Two parallel explain() calls must not trample each other's
     // collected queries. Without async-context isolation a global

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -215,23 +215,27 @@ describe("ExplainTest", () => {
     expect(plan.toLowerCase()).toContain("select");
   });
 
-  it("renders binds via adapter.quote() with SQL-literal output", async () => {
-    // _renderExplainBinds now delegates to the adapter's own
-    // `quote()` so binds come out in adapter-correct SQL-literal
-    // form: strings get adapter-specific escaping, bigints pass
-    // through as `String(value)`, nulls render as `NULL`. That
-    // matches Rails' `render_bind(c, attr)` pattern, which also
-    // quotes via the connection. The BigInt case is the one that
-    // used to crash raw `JSON.stringify`.
+  it("renders binds via adapter.typeCast + Ruby-inspect form", async () => {
+    // Mirrors Rails' `exec_explain`:
+    //   binds.map { |attr| render_bind(c, attr) }.inspect
+    // where `render_bind` does
+    // `connection.type_cast(attr.value_for_database)`. That produces
+    // Ruby's `Array#inspect` output: strings double-quoted, numbers
+    // bare, nil as `nil`, booleans as `true/false`. The BigInt case
+    // is the one that used to crash raw `JSON.stringify`.
     const { Post } = makeModel();
     const rel = Post.all() as unknown as {
-      _renderExplainBinds: (adapter: { quote?(v: unknown): string }, binds: unknown[]) => string;
+      _renderExplainBinds: (a: DatabaseAdapter, binds: unknown[]) => string;
     };
-    const ad = adapter as { quote?(v: unknown): string };
-    expect(rel._renderExplainBinds(ad, [BigInt(42), "str", 7, null])).toBe("[42, 'str', 7, NULL]");
-    // Make sure the end-to-end path still returns output (no crash
-    // even when binds are absent — this is the path `Relation#explain`
-    // actually takes on sqlite).
+    // Booleans go through the adapter's typeCast: SQLite collapses
+    // them to 1/0, PG/MySQL keep them as true/false. So the rendered
+    // form differs by backend; assert both halves independently.
+    const rendered = rel._renderExplainBinds(adapter, [BigInt(42), "str", 7, null, true, false]);
+    expect(rendered.startsWith('[42, "str", 7, nil, ')).toBe(true);
+    expect(rendered).toMatch(/\b(1, 0|true, false)\]$/);
+    // End-to-end on sqlite: where-literals are interpolated into the
+    // SQL (no binds reach the adapter), so the round-trip still
+    // returns non-empty output.
     await Post.create({ title: "x" });
     const plan = await Post.all().explain();
     expect(plan.length).toBeGreaterThan(0);

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -215,20 +215,20 @@ describe("ExplainTest", () => {
     expect(plan.toLowerCase()).toContain("select");
   });
 
-  it("renders BigInt binds without JSON.stringify crashing", async () => {
-    // _renderExplainBinds is the thing we're guarding — plain
-    // `JSON.stringify(BigInt(...))` throws TypeError; the replacer
-    // coerces bigints to their string form, so `[BigInt(42)]` renders
-    // as `["42"]` (quoted, matching log-subscriber.ts's
-    // `safeJsonStringify`). `Relation#explain` on sqlite interpolates
-    // where-literals into the SQL rather than issuing prepared-
-    // statement binds, so we verify the rendering helper directly —
-    // that's the surface this test is guarding.
+  it("renders binds via adapter.quote() with SQL-literal output", async () => {
+    // _renderExplainBinds now delegates to the adapter's own
+    // `quote()` so binds come out in adapter-correct SQL-literal
+    // form: strings get adapter-specific escaping, bigints pass
+    // through as `String(value)`, nulls render as `NULL`. That
+    // matches Rails' `render_bind(c, attr)` pattern, which also
+    // quotes via the connection. The BigInt case is the one that
+    // used to crash raw `JSON.stringify`.
     const { Post } = makeModel();
     const rel = Post.all() as unknown as {
-      _renderExplainBinds: (binds: unknown[]) => string;
+      _renderExplainBinds: (adapter: { quote?(v: unknown): string }, binds: unknown[]) => string;
     };
-    expect(rel._renderExplainBinds([BigInt(42), "str", 7])).toBe('["42","str",7]');
+    const ad = adapter as { quote?(v: unknown): string };
+    expect(rel._renderExplainBinds(ad, [BigInt(42), "str", 7, null])).toBe("[42, 'str', 7, NULL]");
     // Make sure the end-to-end path still returns output (no crash
     // even when binds are absent — this is the path `Relation#explain`
     // actually takes on sqlite).

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -308,6 +308,12 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return value === null || value === undefined ? "NULL" : String(value);
   }
 
+  typeCast(value: unknown): unknown {
+    const inner = this.inner as { typeCast?: (v: unknown) => unknown };
+    if (typeof inner.typeCast === "function") return inner.typeCast(value);
+    return value;
+  }
+
   // --- DatabaseStatements ---
   // Read methods go through this.execute() to leverage the query cache.
   // Write methods go through this.executeMutation() to clear the cache.

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -305,13 +305,21 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   quote(value: unknown): string {
     const inner = this.inner as { quote?: (v: unknown) => string };
     if (typeof inner.quote === "function") return inner.quote(value);
-    return value === null || value === undefined ? "NULL" : String(value);
+    // `String(value)` is NOT a safe SQL literal (doesn't escape, doesn't
+    // wrap strings in quotes, doesn't format Dates). Throw instead of
+    // returning unsafe output — every wrapped adapter we ship implements
+    // `quote()`.
+    throw new Error(
+      `QueryCacheAdapter.quote: wrapped ${this.inner.adapterName} does not implement quote()`,
+    );
   }
 
   typeCast(value: unknown): unknown {
     const inner = this.inner as { typeCast?: (v: unknown) => unknown };
     if (typeof inner.typeCast === "function") return inner.typeCast(value);
-    return value;
+    throw new Error(
+      `QueryCacheAdapter.typeCast: wrapped ${this.inner.adapterName} does not implement typeCast()`,
+    );
   }
 
   // --- DatabaseStatements ---

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -302,6 +302,12 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return `EXPLAIN (${parts}) for:`;
   }
 
+  quote(value: unknown): string {
+    const inner = this.inner as { quote?: (v: unknown) => string };
+    if (typeof inner.quote === "function") return inner.quote(value);
+    return value === null || value === undefined ? "NULL" : String(value);
+  }
+
   // --- DatabaseStatements ---
   // Read methods go through this.execute() to leverage the query cache.
   // Write methods go through this.executeMutation() to clear the cache.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1694,12 +1694,78 @@ export class Relation<T extends Base> {
    * bind is an Attribute object; `ExplainRegistry` collects plain
    * values (no Attribute wrappers here), so we emit the value-only
    * form — same shape, just without the `[name, value]` tuples.
+   *
+   * Some adapters' `typeCast` can legitimately return non-primitive
+   * shapes (PG's `BinaryData` comes out as `{ value, format }`);
+   * `_normalizeExplainBindValue` below reduces those to something
+   * rubyInspect can render cleanly, and handles binary data the way
+   * Rails' `render_bind` does: `<N bytes of binary data>`.
    */
   private _renderExplainBinds(adapter: DatabaseAdapter, binds: unknown[]): string {
-    const casted = binds.map((b) =>
-      typeof adapter.typeCast === "function" ? adapter.typeCast(b) : b,
-    );
+    const casted = binds.map((b) => {
+      const value = typeof adapter.typeCast === "function" ? adapter.typeCast(b) : b;
+      return this._normalizeExplainBindValue(value);
+    });
     return rubyInspectArray(casted);
+  }
+
+  /**
+   * Reduce a typeCast'd bind value to a form `rubyInspect` can render
+   * as a primitive:
+   *   - binary (Buffer / Uint8Array / ArrayBuffer) → `"<N bytes of
+   *     binary data>"`, matching Rails' `render_bind` binary branch.
+   *   - PG-style bind wrappers (`{ value, format }` from
+   *     `pg/quoting.ts`'s `BinaryBind` shape) → unwrap `.value` and
+   *     normalize recursively.
+   *   - Dates / primitives (including symbols handled by typeCast
+   *     earlier) → pass through.
+   *   - Anything else → `JSON.stringify`, falling back to
+   *     `Object.prototype.toString.call` when non-serializable.
+   *
+   * Mirrors: the binary branch of
+   * ActiveRecord::Relation#render_bind.
+   */
+  private _normalizeExplainBindValue(value: unknown): unknown {
+    if (
+      value === null ||
+      value === undefined ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "bigint" ||
+      typeof value === "boolean"
+    ) {
+      return value;
+    }
+    const binaryBytes = this._binaryByteLength(value);
+    if (binaryBytes !== null) return `<${binaryBytes} bytes of binary data>`;
+    if (typeof value === "object") {
+      // Bind-wrapper objects like PG's BinaryBind (`{ value, format }`)
+      // — recurse on `.value` so the inspected form shows the payload
+      // rather than the wrapper envelope.
+      const keys = Object.keys(value as object);
+      if (
+        "value" in (value as object) &&
+        keys.length > 0 &&
+        keys.every((k) => k === "value" || k === "format")
+      ) {
+        return this._normalizeExplainBindValue((value as { value: unknown }).value);
+      }
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return Object.prototype.toString.call(value);
+      }
+    }
+    return String(value);
+  }
+
+  private _binaryByteLength(value: unknown): number | null {
+    if (typeof Buffer !== "undefined" && value instanceof Buffer) return value.byteLength;
+    if (typeof ArrayBuffer !== "undefined") {
+      if (value instanceof ArrayBuffer) return value.byteLength;
+      if (ArrayBuffer.isView(value)) return (value as ArrayBufferView).byteLength;
+    }
+    return null;
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -46,6 +46,7 @@ import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import { touchAttributesWithTime } from "./timestamp.js";
 import { ExplainRegistry } from "./explain-registry.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { rubyInspectArray } from "./relation/ruby-inspect.js";
 
 /**
  * A Relation returned from `load()` / `reload()` — a normal Relation with
@@ -1679,29 +1680,26 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Render a bind array for the EXPLAIN header using the adapter's
-   * own `quote()` — produces a SQL-literal list like
-   * `['foo', 42, NULL]` with adapter-specific string escaping
-   * (`'' ` on SQLite, MySQL's `\0/\n/\r/\Z` escapes, PG's `E'…\\…'`
-   * form, etc). Falls back to a BigInt-safe JSON form when the
-   * adapter doesn't implement `quote()`.
+   * Render a bind array for the EXPLAIN header. Mirrors Rails'
+   * `exec_explain` rendering:
    *
-   * Mirrors Rails' `exec_explain` rendering:
-   * `binds.map { |attr| render_bind(c, attr) }.inspect` — a
-   * positional list formatted via the connection's quoting rules.
-   * Rails' `render_bind` returns `[name, value]` pairs for
-   * Attribute-backed binds; we collect plain values at this layer
-   * (no attribute names), so the list is just values — same shape,
-   * less metadata.
+   *     msg << binds.map { |attr| render_bind(c, attr) }.inspect
+   *
+   * where `render_bind` does `connection.type_cast(attr.value_for_database)`
+   * — so each bind comes out as its primitive DB-cast value, then
+   * Ruby's `Array#inspect` formats the list (strings double-quoted,
+   * numbers bare, nil as `nil`).
+   *
+   * Rails' `render_bind` returns `[attr.name, value]` pairs when the
+   * bind is an Attribute object; `ExplainRegistry` collects plain
+   * values (no Attribute wrappers here), so we emit the value-only
+   * form — same shape, just without the `[name, value]` tuples.
    */
   private _renderExplainBinds(adapter: DatabaseAdapter, binds: unknown[]): string {
-    if (typeof adapter.quote !== "function") {
-      // Adapter hasn't implemented quote() — fall back to the BigInt-
-      // safe JSON form so we don't crash on BigIntegerType columns.
-      return JSON.stringify(binds, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
-    }
-    const pieces = binds.map((b) => adapter.quote!(b));
-    return `[${pieces.join(", ")}]`;
+    const casted = binds.map((b) =>
+      typeof adapter.typeCast === "function" ? adapter.typeCast(b) : b,
+    );
+    return rubyInspectArray(casted);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1716,8 +1716,17 @@ export class Relation<T extends Base> {
       // on buffer shapes because they're not bindable primitives.
       const binaryBytes = this._binaryByteLength(b);
       if (binaryBytes !== null) return `<${binaryBytes} bytes of binary data>`;
-      const value = typeof adapter.typeCast === "function" ? adapter.typeCast(b) : b;
-      return this._normalizeExplainBindValue(value);
+      if (typeof adapter.typeCast !== "function") {
+        // Match the "throw loudly" contract the SchemaAdapter /
+        // QueryCacheAdapter wrappers use — a silent fallback would
+        // make EXPLAIN output depend on whether the adapter
+        // happens to implement `typeCast`, and nothing we ship does
+        // without it.
+        throw new Error(
+          `Relation#explain: adapter ${this._modelClass.adapter.adapterName} does not implement typeCast()`,
+        );
+      }
+      return this._normalizeExplainBindValue(adapter.typeCast(b));
     });
     return rubyInspectArray(casted);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1703,6 +1703,19 @@ export class Relation<T extends Base> {
    */
   private _renderExplainBinds(adapter: DatabaseAdapter, binds: unknown[]): string {
     const casted = binds.map((b) => {
+      // Rails' `render_bind` short-circuits binary-typed binds BEFORE
+      // calling type_cast:
+      //   if attr.type.binary? && attr.value
+      //     "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
+      //   else
+      //     connection.type_cast(attr.value_for_database)
+      //   end
+      // We don't have attribute types at this layer, so we detect
+      // binary structurally (Buffer / Uint8Array / ArrayBuffer) before
+      // handing the value to typeCast — some adapters' typeCast throws
+      // on buffer shapes because they're not bindable primitives.
+      const binaryBytes = this._binaryByteLength(b);
+      if (binaryBytes !== null) return `<${binaryBytes} bytes of binary data>`;
       const value = typeof adapter.typeCast === "function" ? adapter.typeCast(b) : b;
       return this._normalizeExplainBindValue(value);
     });
@@ -1736,6 +1749,12 @@ export class Relation<T extends Base> {
     ) {
       return value;
     }
+    // Dates CAN slip past typeCast if an adapter returns them
+    // unchanged (e.g. a future adapter that skips Date formatting).
+    // Coerce to ISO-ish string so rubyInspect renders
+    // `"2026-01-02T12:34:56.000Z"` rather than `"[object Date]"`
+    // via JSON.stringify (which would double-quote the date).
+    if (value instanceof Date) return value.toISOString();
     const binaryBytes = this._binaryByteLength(value);
     if (binaryBytes !== null) return `<${binaryBytes} bytes of binary data>`;
     if (typeof value === "object") {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1671,7 +1671,7 @@ export class Relation<T extends Base> {
     const parts: string[] = [];
     for (const [sql, binds] of effective) {
       let msg = `${clause} ${sql}`;
-      if (binds.length > 0) msg += ` ${this._renderExplainBinds(binds)}`;
+      if (binds.length > 0) msg += ` ${this._renderExplainBinds(adapter, binds)}`;
       const plan = await adapter.explain(sql, binds, options);
       parts.push(`${msg}\n${plan}`);
     }
@@ -1679,24 +1679,29 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Render a bind array for the EXPLAIN header. Reuses the BigInt-safe
-   * replacer from `log-subscriber.ts`'s `safeJsonStringify` so a bigint
-   * (from trails' `BigIntegerType`) coerces to its string form in the
-   * output — `["1"]` — rather than throwing, the way raw
-   * `JSON.stringify` would.
+   * Render a bind array for the EXPLAIN header using the adapter's
+   * own `quote()` — produces a SQL-literal list like
+   * `['foo', 42, NULL]` with adapter-specific string escaping
+   * (`'' ` on SQLite, MySQL's `\0/\n/\r/\Z` escapes, PG's `E'…\\…'`
+   * form, etc). Falls back to a BigInt-safe JSON form when the
+   * adapter doesn't implement `quote()`.
    *
-   * This is a positional-values-only rendering, deliberately simpler
-   * than LogSubscriber's output: LogSubscriber formats each bind as a
-   * `[name, type_casted_value]` pair (the attribute-name prefix lets
-   * you read the log against the query text). `exec_explain` doesn't
-   * carry attribute names down to this point, and the Rails
-   * equivalent — `render_bind(c, attr).inspect` on the values — is
-   * also a positional list. So we match Rails' shape, not
-   * LogSubscriber's, and the log/explain outputs are intentionally
-   * different at this site.
+   * Mirrors Rails' `exec_explain` rendering:
+   * `binds.map { |attr| render_bind(c, attr) }.inspect` — a
+   * positional list formatted via the connection's quoting rules.
+   * Rails' `render_bind` returns `[name, value]` pairs for
+   * Attribute-backed binds; we collect plain values at this layer
+   * (no attribute names), so the list is just values — same shape,
+   * less metadata.
    */
-  private _renderExplainBinds(binds: unknown[]): string {
-    return JSON.stringify(binds, (_key, v) => (typeof v === "bigint" ? v.toString() : v));
+  private _renderExplainBinds(adapter: DatabaseAdapter, binds: unknown[]): string {
+    if (typeof adapter.quote !== "function") {
+      // Adapter hasn't implemented quote() — fall back to the BigInt-
+      // safe JSON form so we don't crash on BigIntegerType columns.
+      return JSON.stringify(binds, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
+    }
+    const pieces = binds.map((b) => adapter.quote!(b));
+    return `[${pieces.join(", ")}]`;
   }
 
   /**

--- a/packages/activerecord/src/relation/ruby-inspect.test.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.test.ts
@@ -34,6 +34,17 @@ describe("rubyInspect", () => {
     expect(rubyInspectArray([true, false, 0])).toBe("[true, false, 0]");
   });
 
+  it("escapes common control characters the way Ruby's String#inspect does", () => {
+    expect(rubyInspect("line1\nline2")).toBe('"line1\\nline2"');
+    expect(rubyInspect("col1\tcol2")).toBe('"col1\\tcol2"');
+    expect(rubyInspect("cr\r\n")).toBe('"cr\\r\\n"');
+    expect(rubyInspect("null\0char")).toBe('"null\\0char"');
+    expect(rubyInspect("esc\x1bseq")).toBe('"esc\\eseq"');
+    // Output stays single-line so an EXPLAIN header can't span
+    // multiple lines based on bind contents.
+    expect(rubyInspect("a\nb")).not.toContain("\n");
+  });
+
   it("handles nested arrays", () => {
     expect(
       rubyInspectArray([

--- a/packages/activerecord/src/relation/ruby-inspect.test.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { rubyInspect, rubyInspectArray } from "./ruby-inspect.js";
+
+describe("rubyInspect", () => {
+  it("renders nil / undefined as 'nil'", () => {
+    expect(rubyInspect(null)).toBe("nil");
+    expect(rubyInspect(undefined)).toBe("nil");
+  });
+
+  it("renders booleans as 'true' / 'false'", () => {
+    expect(rubyInspect(true)).toBe("true");
+    expect(rubyInspect(false)).toBe("false");
+  });
+
+  it("renders numbers bare (no quotes)", () => {
+    expect(rubyInspect(42)).toBe("42");
+    expect(rubyInspect(3.14)).toBe("3.14");
+    expect(rubyInspect(-7)).toBe("-7");
+  });
+
+  it("renders bigints as their decimal string (matches Ruby's Integer#inspect)", () => {
+    expect(rubyInspect(BigInt("9007199254740993"))).toBe("9007199254740993");
+  });
+
+  it('renders strings with double-quotes, escaping embedded " and \\', () => {
+    expect(rubyInspect("foo")).toBe('"foo"');
+    expect(rubyInspect('he said "hi"')).toBe('"he said \\"hi\\""');
+    expect(rubyInspect("back\\slash")).toBe('"back\\\\slash"');
+  });
+
+  it("rubyInspectArray joins with ', ' and wraps in []", () => {
+    expect(rubyInspectArray([1, "foo", null])).toBe('[1, "foo", nil]');
+    expect(rubyInspectArray([])).toBe("[]");
+    expect(rubyInspectArray([true, false, 0])).toBe("[true, false, 0]");
+  });
+
+  it("handles nested arrays", () => {
+    expect(
+      rubyInspectArray([
+        [1, 2],
+        ["a", "b"],
+      ]),
+    ).toBe('[[1, 2], ["a", "b"]]');
+  });
+});

--- a/packages/activerecord/src/relation/ruby-inspect.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.ts
@@ -24,8 +24,25 @@ export function rubyInspect(value: unknown): string {
   if (typeof value === "number") return String(value);
   if (typeof value === "bigint") return String(value);
   if (typeof value === "string") {
-    // Ruby's string inspect: wrap in `"`, escape `"` and `\`.
-    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    // Ruby's String#inspect: wrap in `"`, escape `"` and `\`, plus the
+    // common control characters (`\n`, `\r`, `\t`, `\f`, `\b`, `\v`,
+    // `\0`, `\a`, `\e`). Without these, a bind containing a literal
+    // newline would render across multiple lines in the EXPLAIN
+    // header and diverge from Ruby's single-line output.
+    /* eslint-disable no-control-regex */
+    return `"${value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")
+      .replace(/\t/g, "\\t")
+      .replace(/\f/g, "\\f")
+      .replace(/\x08/g, "\\b")
+      .replace(/\v/g, "\\v")
+      .replace(/\0/g, "\\0")
+      .replace(/\x07/g, "\\a")
+      .replace(/\x1b/g, "\\e")}"`;
+    /* eslint-enable no-control-regex */
   }
   if (Array.isArray(value)) return rubyInspectArray(value);
   // Fallback — matches Ruby's `Object#inspect` which gives `#<Class …>`

--- a/packages/activerecord/src/relation/ruby-inspect.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.ts
@@ -45,8 +45,8 @@ export function rubyInspect(value: unknown): string {
     /* eslint-enable no-control-regex */
   }
   if (Array.isArray(value)) return rubyInspectArray(value);
-  // Fallback — matches Ruby's `Object#inspect` which gives `#<Class …>`
-  // but we just toString for anything unhandled.
+  // Fallback — Ruby's `Object#inspect` gives `#<Class …>`; here we
+  // just call `String(value)` for anything unhandled.
   return String(value);
 }
 

--- a/packages/activerecord/src/relation/ruby-inspect.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.ts
@@ -1,0 +1,38 @@
+/**
+ * Small subset of Ruby's `Object#inspect` output — enough for
+ * rendering an array of type-cast bind values the way Rails' `inspect`
+ * would. Used by `Relation#_renderExplainBinds` to match Rails'
+ * `binds.map { |attr| render_bind(c, attr) }.inspect` output shape.
+ *
+ * Ruby conventions this needs to honor:
+ *   - `nil.inspect == "nil"`
+ *   - `"foo".inspect == "\"foo\""` (double-quoted, escapes embedded `"` and `\`)
+ *   - `42.inspect == "42"`, `BigInt(42).inspect == "42"`
+ *   - `true.inspect == "true"`, `false.inspect == "false"`
+ *   - `[1, "foo", nil].inspect == "[1, \"foo\", nil]"`
+ *
+ * Intentionally minimal: no Hash, no nested containers beyond simple
+ * pass-through for string/number/bigint/null/boolean/array — the
+ * bind-list domain is narrow.
+ *
+ * Mirrors: Ruby's `Object#inspect` / `Array#inspect` via
+ * `Kernel#p`-style output.
+ */
+export function rubyInspect(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "bigint") return String(value);
+  if (typeof value === "string") {
+    // Ruby's string inspect: wrap in `"`, escape `"` and `\`.
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  if (Array.isArray(value)) return rubyInspectArray(value);
+  // Fallback — matches Ruby's `Object#inspect` which gives `#<Class …>`
+  // but we just toString for anything unhandled.
+  return String(value);
+}
+
+export function rubyInspectArray(values: unknown[]): string {
+  return `[${values.map(rubyInspect).join(", ")}]`;
+}

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -693,16 +693,21 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
   quote(value: unknown): string {
     const inner = this.inner as { quote?: (v: unknown) => string };
     if (typeof inner.quote === "function") return inner.quote(value);
-    // Fallback shouldn't fire in practice — every adapter we wrap has
-    // quote() — but keep explain from crashing if somebody ever points
-    // SchemaAdapter at a bare mock.
-    return value === null || value === undefined ? "NULL" : String(value);
+    // `String(value)` is NOT a safe SQL literal for strings / Dates,
+    // and silently using it would produce broken or unsafe SQL. Throw
+    // loudly so the gap surfaces — every adapter we wrap in practice
+    // implements `quote()`.
+    throw new Error(
+      `SchemaAdapter.quote: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement quote()`,
+    );
   }
 
   typeCast(value: unknown): unknown {
     const inner = this.inner as { typeCast?: (v: unknown) => unknown };
     if (typeof inner.typeCast === "function") return inner.typeCast(value);
-    return value;
+    throw new Error(
+      `SchemaAdapter.typeCast: wrapped ${(this.inner as { adapterName?: string }).adapterName ?? "adapter"} does not implement typeCast()`,
+    );
   }
 
   async cleanup(): Promise<void> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -690,6 +690,15 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
     return `EXPLAIN (${options.map((o) => o.toUpperCase()).join(", ")}) for:`;
   }
 
+  quote(value: unknown): string {
+    const inner = this.inner as { quote?: (v: unknown) => string };
+    if (typeof inner.quote === "function") return inner.quote(value);
+    // Fallback shouldn't fire in practice — every adapter we wrap has
+    // quote() — but keep explain from crashing if somebody ever points
+    // SchemaAdapter at a bare mock.
+    return value === null || value === undefined ? "NULL" : String(value);
+  }
+
   async cleanup(): Promise<void> {
     await dropAllTables(this.inner);
   }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -699,6 +699,12 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
     return value === null || value === undefined ? "NULL" : String(value);
   }
 
+  typeCast(value: unknown): unknown {
+    const inner = this.inner as { typeCast?: (v: unknown) => unknown };
+    if (typeof inner.typeCast === "function") return inner.typeCast(value);
+    return value;
+  }
+
   async cleanup(): Promise<void> {
     await dropAllTables(this.inner);
   }


### PR DESCRIPTION
## Summary

Closes the `render_bind` divergence noted as a follow-up in #583. Rails' `exec_explain` renders the bind list via:

```ruby
msg << binds.map { |attr| render_bind(c, attr) }.inspect
```

where `render_bind` does `connection.type_cast(attr.value_for_database)` and then `Array#inspect` is Ruby's standard positional-list formatter (strings double-quoted, nil as `nil`, booleans as `true`/`false`). Previously we `JSON.stringify`'d — strings were `"foo"` either way, but nil became `null` and booleans passed through unchanged regardless of adapter.

### Changes

- **`typeCast(value)` method on each adapter class.** `AbstractAdapter` delegates to `abstract/quoting.ts`'s module-level `typeCast`; `SQLite3Adapter` / `PostgreSQLAdapter` override to their own modules. `Mysql2Adapter` gets a new module-level `typeCast()` in `mysql/quoting.ts`. Per-adapter semantics match Rails:
  - **SQLite / MySQL**: booleans collapse to `1 / 0` (via `unquotedTrue/False`).
  - **PostgreSQL**: booleans stay as `true / false`.
  - **All adapters**: `Date` → **unquoted** string (the full `YYYY-MM-DD HH:MM:SS` form on MySQL — JS `Date` always carries a time component); it's `quote()`'s job to add the surrounding single quotes.
- **`quote(value)` method also added** on each adapter. It's a legitimate Rails surface (other Rails code reaches for it) and belongs on the adapter contract regardless of which method `render_bind` happens to use.
- **`DatabaseAdapter.quote?(value) / typeCast?(value)`** on the interface; forwarded through `SchemaAdapter` (test-adapter.ts) and `QueryCacheAdapter` so `Relation#explain` works the same whether or not a wrapper sits in front of the real adapter. Wrapper fallbacks **throw** when the wrapped adapter doesn't implement `quote`/`typeCast` — `String(value)` is not a safe SQL literal and silent fallbacks hide missing support.
- **New `relation/ruby-inspect.ts`** — minimal `rubyInspect` / `rubyInspectArray` helper that mirrors Ruby's `Object#inspect` output: `nil`, `true`/`false`, bare numbers/bigints, double-quoted strings with `\` / `"` plus the common control characters (`\n \r \t \f \b \v \0 \a \e`) escaped so EXPLAIN output stays single-line regardless of bind contents. Nine-test unit suite.
- **`Relation#_renderExplainBinds`** switched from `JSON.stringify` to `adapter.typeCast(b)` per bind, normalized through `_normalizeExplainBindValue`, then rendered via `rubyInspectArray(casted)`. The normalizer handles:
  - Binary binds (`Buffer` / `Uint8Array` / `ArrayBuffer`) → `"<N bytes of binary data>"`, matching Rails' `render_bind` binary branch.
  - PG-style bind wrappers (`{ value, format }` from `BinaryBind`) → unwrap `.value` and recurse so EXPLAIN shows the payload, not the envelope.
  - Fall back to `JSON.stringify` for any other object, then `Object.prototype.toString`.

### Rails source

`activerecord/lib/active_record/relation.rb#exec_explain`:
```ruby
msg << " "
msg << binds.map { |attr| render_bind(c, attr) }.inspect
```

`render_bind`:
```ruby
value = if attr.type.binary? && attr.value
  "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
else
  connection.type_cast(attr.value_for_database)
end
[attr.name, value]
```

(Rails' `render_bind` returns `[attr.name, value]` pairs; `ExplainRegistry` collects plain values — no Attribute wrappers — so we emit the value-only form.)

## Test plan

- [x] `pnpm build`
- [x] `pnpm vitest run packages/activerecord/src/relation/ruby-inspect.test.ts` — 9/9
- [x] `pnpm vitest run packages/activerecord/src/explain.test.ts` — 23/23 (SQLite + PG)
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/mysql/quoting.test.ts` — 9/9
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/**/quoting.test.ts` — 88/88
- [x] `TZ=UTC PG_TEST_URL=... pnpm vitest run --no-file-parallelism packages/activerecord` — 9064/9064