### PR TITLE
fix(quoting): sqlite3 / pg / mysql quotedDate match Rails :db form

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { quote, typeCast } from "./quoting.js";
+import { quote, quotedDate, quotedTimeUtc, typeCast } from "./quoting.js";
 
 describe("MySQL quoting — quote", () => {
   it("returns NULL for null / undefined", () => {
@@ -59,5 +59,25 @@ describe("MySQL quoting — typeCast", () => {
     expect(out.startsWith("'")).toBe(false);
     expect(out.endsWith("'")).toBe(false);
     expect(out).toMatch(/^2026-01-02 12:34:56/);
+  });
+});
+
+describe("MySQL quoting — quotedDate / quotedTimeUtc", () => {
+  it("quotedDate returns the unquoted :db form (Rails quoted_date)", () => {
+    const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+    const out = quotedDate(d);
+    expect(out).toBe("2026-04-18 12:34:56");
+    expect(out.startsWith("'")).toBe(false);
+    expect(out).not.toMatch(/\.000$/);
+  });
+
+  it("quotedDate includes .microseconds when ms > 0", () => {
+    const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 250));
+    expect(quotedDate(d)).toMatch(/^2026-04-18 12:34:56\.\d{6}$/);
+  });
+
+  it("quotedTimeUtc returns the time-only tail", () => {
+    const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+    expect(quotedTimeUtc(d)).toBe("12:34:56");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -57,7 +57,7 @@ export function quotedDate(date: Date): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
  */
 export function quotedTimeUtc(date: Date): string {
-  const full = abstractQuotedDate(date);
+  const full = quotedDate(date);
   const sep = full.indexOf(" ");
   return sep === -1 ? full : full.slice(sep + 1);
 }

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -39,12 +39,27 @@ export function unquotedFalse(): number {
   return 0;
 }
 
+/**
+ * MySQL's DATETIME/TIMESTAMP literal format matches Rails' `:db`
+ * form: unquoted `YYYY-MM-DD HH:MM:SS[.microseconds]`. Fractional
+ * seconds only appear when milliseconds > 0. `quote()` wraps the
+ * result with single quotes.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_date
+ */
 export function quotedDate(date: Date): string {
-  return `'${date.toISOString().split("T")[0]}'`;
+  return abstractQuotedDate(date);
 }
 
+/**
+ * Time-only portion of `quotedDate`. Unquoted.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
+ */
 export function quotedTimeUtc(date: Date): string {
-  return `'${date.toISOString().replace("T", " ").replace("Z", "")}'`;
+  const full = abstractQuotedDate(date);
+  const sep = full.indexOf(" ");
+  return sep === -1 ? full : full.slice(sep + 1);
 }
 
 export function quoteTableName(name: string): string {
@@ -95,12 +110,7 @@ export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
-  // Use abstract's `quotedDate` for the `YYYY-MM-DD HH:MM:SS[.microseconds]`
-  // form (Rails' `:db` format — fractional seconds only when
-  // non-zero), then wrap with single quotes. MySQL's own
-  // `quotedDate` would drop the time; its `quotedTimeUtc` always
-  // trails `.000`.
-  if (value instanceof Date) return `'${abstractQuotedDate(value)}'`;
+  if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (value instanceof Buffer) return quotedBinaryString(value);
   if (typeof value === "symbol") {
     const desc = value.description;
@@ -139,15 +149,9 @@ export function typeCast(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
-  if (value instanceof Date) {
-    // Delegate to abstract's `quotedDate` which renders the
-    // unquoted `YYYY-MM-DD HH:MM:SS[.microseconds]` form (optional
-    // fractional seconds only when non-zero, matching Rails'
-    // `:db`-format output). MySQL's own `quotedTimeUtc` relies on
-    // `toISOString()` which always trails `.000`, and MySQL's
-    // `quotedDate` drops the time. Neither matches Rails here;
-    // the abstract formatter does.
-    return abstractQuotedDate(value);
-  }
+  // Rails' `type_cast` returns `quoted_date(value)` — an unquoted
+  // formatted string. EXPLAIN / log-subscriber renderers want the
+  // primitive, not the Date instance.
+  if (value instanceof Date) return quotedDate(value);
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -13,7 +13,9 @@ import {
   quote,
   quoteDefaultExpression,
   quotedBinary,
+  quotedDate,
   quotedFalse,
+  quotedTimeUtc,
   quotedTrue,
   quoteSchemaName,
   quoteTableNameForAssignment,
@@ -134,6 +136,26 @@ describe("PostgreSQL quoting", () => {
 
     it("rejects SQL injection attempts", () => {
       expect(matcher.test("name; DROP TABLE users")).toBe(false);
+    });
+  });
+
+  describe("quotedDate / quotedTimeUtc", () => {
+    it("quotedDate returns the unquoted :db form (Rails quoted_date)", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      const out = quotedDate(d);
+      expect(out).toBe("2026-04-18 12:34:56");
+      expect(out.startsWith("'")).toBe(false);
+      expect(out).not.toMatch(/\.000$/);
+    });
+
+    it("quotedDate includes .microseconds when ms > 0", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
+      expect(quotedDate(d)).toMatch(/^2026-04-18 12:34:56\.\d{6}$/);
+    });
+
+    it("quotedTimeUtc returns the time-only tail of quotedDate", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      expect(quotedTimeUtc(d)).toBe("12:34:56");
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -7,6 +7,7 @@
 import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
+  quotedDate as abstractQuotedDate,
   quotedFalse as abstractQuotedFalse,
   quotedTrue as abstractQuotedTrue,
   typeCast as abstractTypeCast,
@@ -73,12 +74,27 @@ export function unquotedFalse(): boolean {
   return false;
 }
 
+/**
+ * PostgreSQL timestamp literals match Rails' `:db` form: unquoted
+ * `YYYY-MM-DD HH:MM:SS[.microseconds]`. Fractional seconds only
+ * appear when milliseconds > 0. `quote()` wraps the result with
+ * single quotes (or `timestamp '…'` in context-sensitive callers).
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_date
+ */
 export function quotedDate(date: Date): string {
-  return `'${date.toISOString().split("T")[0]}'`;
+  return abstractQuotedDate(date);
 }
 
+/**
+ * Time-only portion of `quotedDate`. Unquoted.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
+ */
 export function quotedTimeUtc(date: Date): string {
-  return `'${date.toISOString().replace("T", " ").replace("Z", "")}'`;
+  const full = abstractQuotedDate(date);
+  const sep = full.indexOf(" ");
+  return sep === -1 ? full : full.slice(sep + 1);
 }
 
 export function quoteTableName(name: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -92,7 +92,7 @@ export function quotedDate(date: Date): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
  */
 export function quotedTimeUtc(date: Date): string {
-  const full = abstractQuotedDate(date);
+  const full = quotedDate(date);
   const sep = full.indexOf(" ");
   return sep === -1 ? full : full.slice(sep + 1);
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -4,7 +4,9 @@ import {
   columnNameWithOrderMatcher,
   quote,
   quotedBinary,
+  quotedDate,
   quotedTime,
+  quotedTimeUtc,
   quoteDefaultExpression,
   typeCast,
 } from "./quoting.js";
@@ -251,6 +253,32 @@ describe("SQLite3::Quoting", () => {
     it("includes microseconds on Date when milliseconds are non-zero", () => {
       const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
       expect(quote(d)).toMatch(/^'2026-04-18 12:34:56\.\d{6}'$/);
+    });
+  });
+
+  describe("quotedDate / quotedTimeUtc", () => {
+    it("quotedDate returns the unquoted :db form (Rails quoted_date)", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      const out = quotedDate(d);
+      expect(out).toBe("2026-04-18 12:34:56");
+      expect(out.startsWith("'")).toBe(false);
+      expect(out.endsWith("'")).toBe(false);
+      expect(out).not.toMatch(/\.000$/);
+    });
+
+    it("quotedDate includes .microseconds when ms > 0", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
+      expect(quotedDate(d)).toMatch(/^2026-04-18 12:34:56\.\d{6}$/);
+    });
+
+    it("quotedTimeUtc returns the time-only tail of quotedDate", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
+      expect(quotedTimeUtc(d)).toBe("12:34:56");
+    });
+
+    it("quotedTimeUtc carries the microseconds suffix too", () => {
+      const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
+      expect(quotedTimeUtc(d)).toMatch(/^12:34:56\.\d{6}$/);
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -55,7 +55,7 @@ export function quotedDate(date: Date): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
  */
 export function quotedTimeUtc(date: Date): string {
-  const full = abstractQuotedDate(date);
+  const full = quotedDate(date);
   const sep = full.indexOf(" ");
   return sep === -1 ? full : full.slice(sep + 1);
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -34,12 +34,30 @@ export function unquotedFalse(): number {
   return 0;
 }
 
+/**
+ * SQLite stores datetimes as `YYYY-MM-DD HH:MM:SS[.microseconds]`
+ * TEXT, so `quoted_date` returns the unquoted `:db` form (Rails'
+ * default) — fractional seconds only appear when milliseconds > 0.
+ * `quote()` wraps the result with single quotes; callers reaching
+ * for `quotedDate` directly get the raw string.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_date
+ */
 export function quotedDate(date: Date): string {
-  return `'${date.toISOString().split("T")[0]}'`;
+  return abstractQuotedDate(date);
 }
 
+/**
+ * Time-only portion of `quotedDate` — the `HH:MM:SS[.microseconds]`
+ * tail after the leading `YYYY-MM-DD` / space separator. Unquoted;
+ * callers add their own single quotes.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_time
+ */
 export function quotedTimeUtc(date: Date): string {
-  return `'${date.toISOString().replace("T", " ").replace("Z", "")}'`;
+  const full = abstractQuotedDate(date);
+  const sep = full.indexOf(" ");
+  return sep === -1 ? full : full.slice(sep + 1);
 }
 
 export function quoteTableName(name: string): string {
@@ -72,15 +90,7 @@ export function quote(value: unknown): string {
     }
     return quoteString(value.description);
   }
-  if (value instanceof Date) {
-    // Use abstract's `quotedDate` for consistency with
-    // `typeCast(Date)`: `YYYY-MM-DD HH:MM:SS` with optional
-    // `.microseconds` only when ms > 0 (Rails' `:db` format). Local
-    // `quotedTimeUtc` trails `.000` unconditionally via
-    // `toISOString()`; `quote()` wraps the result with single
-    // quotes.
-    return `'${abstractQuotedDate(value)}'`;
-  }
+  if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
     return quotedBinary(value);
   }
@@ -129,14 +139,10 @@ export function typeCast(value: unknown): unknown {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   if (typeof value === "string" || typeof value === "bigint") return value;
   if (typeof value === "symbol") return value.description ?? null;
-  if (value instanceof Date) {
-    // Delegate to abstract's `quotedDate` which renders the
-    // unquoted `YYYY-MM-DD HH:MM:SS[.microseconds]` form (optional
-    // fractional seconds only when non-zero). Matches Rails'
-    // `type_cast` which returns `quoted_date(value)` — a formatted
-    // string, not the Date object itself.
-    return abstractQuotedDate(value);
-  }
+  // Rails' `type_cast` returns `quoted_date(value)` — a formatted
+  // string, not the Date object itself. Callers (EXPLAIN rendering,
+  // bind-value logs) want the primitive, not the Date instance.
+  if (value instanceof Date) return quotedDate(value);
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;
   throw new TypeError(`can't cast ${Object.prototype.toString.call(value)} to a SQLite3 type`);
 }


### PR DESCRIPTION
## Summary

Follow-up to #605. All three adapter-specific `quotedDate` / `quotedTimeUtc` functions were implemented as `'${date.toISOString().split("T")[0]}'` — three separate bugs:

1. **Wrapped with single quotes.** Rails' `quoted_date` returns the unquoted `:db`-form string; `quote()` is responsible for adding the surrounding single quotes. Ours forced callers into an awkward strip-the-quotes-then-rewrap pattern — which is why #605 ended up delegating to abstract's `quotedDate` from the adapter-specific `typeCast` / `quote` bodies to work around this divergence.
2. **Date-only output.** Dropped the time component; JS `Date` always carries one, so a datetime bind silently lost precision.
3. **No optional microseconds.** Rails' `:db` format only shows fractional seconds when present; we had neither present nor absent, we had nothing at all past the date.

Aligned all three adapters with abstract's `quotedDate`/`quotedTimeUtc`:
- `quotedDate` delegates directly to `abstractQuotedDate` (timezone-aware `YYYY-MM-DD HH:MM:SS` with optional `.microseconds` when ms > 0).
- `quotedTimeUtc` returns the time-only tail of that same format.
- Local `quote()` / `typeCast()` Date branches simplified to use the local `quotedDate` — no more importing abstract and wrapping with single quotes by hand.

Zero behavior change at the `typeCast` / `quote` boundary because the workarounds already produced the correct output; this is purely removing the workaround by fixing the underlying functions.

## Rails source

`activerecord/lib/active_record/connection_adapters/abstract/quoting.rb`:

```ruby
def quoted_date(value)
  if value.acts_like?(:time)
    ...
  end
  value.to_formatted_s(:db)  # unquoted
end

def quote(value)
  case value
  when Date, Time then "'#{quoted_date(value)}'"   # quote() adds the single quotes
  ...
  end
end
```

## Test plan

- [x] `pnpm build`
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/**/quoting.test.ts packages/activerecord/src/explain.test.ts` — 124/124
- [x] `TZ=UTC PG_TEST_URL=... pnpm vitest run --no-file-parallelism packages/activerecord` — 9110/9110, zero failures