### PR TITLE
feat(activerecord): support explain({ format: :json }) kwarg

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -47,7 +47,15 @@ export function inspectExplainOption(o: unknown): string {
       return v;
     });
   } catch {
-    return String(o);
+    // String(o) would invoke a user-defined toString/valueOf, which can
+    // itself throw — masking the validation error we're here to preserve.
+    // Object.prototype.toString.call(o) is spec-defined to produce
+    // `[object Type]` without consulting user code.
+    try {
+      return Object.prototype.toString.call(o);
+    } catch {
+      return "[object Object]";
+    }
   }
 }
 

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -1,6 +1,18 @@
 import type { Result } from "./result.js";
 
 /**
+ * A single entry in `Relation#explain`'s options list. Either a bare
+ * flag name (`"analyze"`, `"verbose"`) or a keyword hash (`{ format:
+ * "json" }`) — mirrors Rails' `explain(*options)` where options can
+ * be a mix of Symbols and a single Hash. Each adapter decides which
+ * flags / keys it supports and throws on unknown ones.
+ *
+ * Mirrors: the `options` array shape used by Rails'
+ * `ActiveRecord::Relation#explain` and its adapter `build_explain_clause`.
+ */
+export type ExplainOption = string | { format?: string };
+
+/**
  * Database adapter interface — pluggable backends.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter
@@ -64,12 +76,13 @@ export interface DatabaseAdapter {
    * same bind values the adapter would accept on `execute()`, so a
    * captured prepared-statement query re-EXPLAINs cleanly; `options`
    * carries the Rails-style variadic flags (e.g. `analyze`,
-   * `verbose`) for adapters that support them. Both are optional for
-   * adapters that pre-date the options surface.
+   * `verbose`) and keyword options (`{ format: "json" }`) for
+   * adapters that support them. Both are optional for adapters that
+   * pre-date the options surface.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#explain
    */
-  explain?(sql: string, binds?: unknown[], options?: string[]): Promise<string>;
+  explain?(sql: string, binds?: unknown[], options?: ExplainOption[]): Promise<string>;
 
   /**
    * Build the printed header prefix used by `Relation#explain` — e.g.
@@ -80,7 +93,7 @@ export interface DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#build_explain_clause
    */
-  buildExplainClause?(options?: string[]): string;
+  buildExplainClause?(options?: ExplainOption[]): string;
 
   /**
    * Quote a value for inclusion in a SQL literal (e.g. `"'foo'"`,

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -13,6 +13,34 @@ import type { Result } from "./result.js";
 export type ExplainOption = string | { format: string };
 
 /**
+ * Safely stringify an arbitrary value for inclusion in an EXPLAIN
+ * validation error message. Uses `util.inspect` (which handles circular
+ * references), so even objects constructed with `as any` can't crash the
+ * validator before its intended error reaches the caller.
+ */
+export function inspectExplainOption(o: unknown): string {
+  if (o === null) return "null";
+  if (o === undefined) return "undefined";
+  if (typeof o !== "object") return String(o);
+  // JSON.stringify with a circular-ref-safe replacer. `as any` callers
+  // can hand us arbitrary shapes, and a raw JSON.stringify would throw
+  // on self-referencing structures — masking the validation error the
+  // caller actually needs to see.
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(o, (_k, v) => {
+      if (v !== null && typeof v === "object") {
+        if (seen.has(v as object)) return "[Circular]";
+        seen.add(v as object);
+      }
+      return v;
+    });
+  } catch {
+    return String(o);
+  }
+}
+
+/**
  * Database adapter interface — pluggable backends.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -10,7 +10,7 @@ import type { Result } from "./result.js";
  * Mirrors: the `options` array shape used by Rails'
  * `ActiveRecord::Relation#explain` and its adapter `build_explain_clause`.
  */
-export type ExplainOption = string | { format?: string };
+export type ExplainOption = string | { format: string };
 
 /**
  * Database adapter interface — pluggable backends.

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -13,22 +13,33 @@ import type { Result } from "./result.js";
 export type ExplainOption = string | { format: string };
 
 /**
- * Safely stringify an arbitrary value for inclusion in an EXPLAIN
- * validation error message. Uses `util.inspect` (which handles circular
- * references), so even objects constructed with `as any` can't crash the
- * validator before its intended error reaches the caller.
+ * Stringify an arbitrary value for inclusion in an EXPLAIN validation
+ * error message. `as any` callers can hand us arbitrary shapes —
+ * circular objects, BigInts, Symbols, functions — and a raw
+ * `JSON.stringify` either throws or silently drops non-JSON values,
+ * masking the validation error the caller actually needs to see.
+ *
+ * Uses `JSON.stringify` with a custom replacer that:
+ *   - replaces circular refs with `"[Circular]"` (WeakSet-tracked)
+ *   - renders `BigInt` as `"123n"`, `Symbol` as `"Symbol(desc)"`, and
+ *     `function` as `"[Function: name]"` so the shape is visible
+ *
+ * `util.inspect` would be the idiomatic choice but is forbidden by the
+ * repo's `blazetrails/no-node-builtins` rule (browser compat).
  */
 export function inspectExplainOption(o: unknown): string {
   if (o === null) return "null";
   if (o === undefined) return "undefined";
+  if (typeof o === "bigint") return `${o}n`;
+  if (typeof o === "symbol") return o.toString();
+  if (typeof o === "function") return `[Function: ${o.name || "anonymous"}]`;
   if (typeof o !== "object") return String(o);
-  // JSON.stringify with a circular-ref-safe replacer. `as any` callers
-  // can hand us arbitrary shapes, and a raw JSON.stringify would throw
-  // on self-referencing structures — masking the validation error the
-  // caller actually needs to see.
   const seen = new WeakSet<object>();
   try {
     return JSON.stringify(o, (_k, v) => {
+      if (typeof v === "bigint") return `${v}n`;
+      if (typeof v === "symbol") return v.toString();
+      if (typeof v === "function") return `[Function: ${v.name || "anonymous"}]`;
       if (v !== null && typeof v === "object") {
         if (seen.has(v as object)) return "[Circular]";
         seen.add(v as object);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -25,6 +25,26 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skip("explain with options as strings", () => {});
     it.skip("explain options with eager loading", () => {});
 
+    it("buildExplainClause renders FORMAT=JSON without parens for { format: 'json' }", () => {
+      const clause = adapter.buildExplainClause([{ format: "json" }]);
+      expect(clause).toBe("EXPLAIN FORMAT=JSON for:");
+    });
+
+    it("buildExplainClause combines string flag and format hash space-separated", () => {
+      const clause = adapter.buildExplainClause(["analyze", { format: "json" }]);
+      expect(clause).toBe("EXPLAIN ANALYZE FORMAT=JSON for:");
+    });
+
+    it("buildExplainClause rejects unknown format", () => {
+      expect(() => adapter.buildExplainClause([{ format: "bogus" }])).toThrow();
+    });
+
+    it("explain executes with { format: 'json' } and returns JSON plan", async () => {
+      const result = await adapter.explain("SELECT 1", [], [{ format: "json" }]);
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    });
+
     it("Relation#explain on MySQL captures the SELECT via sql.active_record", async () => {
       // End-to-end: the full ExplainRegistry → ExplainSubscriber →
       // adapter.explain pipeline only works on MySQL if execute()

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -1,6 +1,6 @@
 import mysql from "mysql2/promise";
 import { Notifications } from "@blazetrails/activesupport";
-import type { DatabaseAdapter } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql-adapter.js";
 import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
@@ -295,7 +295,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * prepared-statement SQL with `?` placeholders re-EXPLAINs
    * correctly.
    */
-  async explain(sql: string, binds: unknown[] = [], options: string[] = []): Promise<string> {
+  async explain(
+    sql: string,
+    binds: unknown[] = [],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     const conn = await this.getConn();
     try {
       const clause = this._explainStatementClause(options);
@@ -319,10 +323,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
    */
-  buildExplainClause(options: string[] = []): string {
+  buildExplainClause(options: ExplainOption[] = []): string {
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) => o.toUpperCase()).join(" ");
-    return `EXPLAIN ${parts} for:`;
+    return `EXPLAIN ${this._validateExplainOptions(options).join(" ")} for:`;
   }
 
   // `quote()` and `typeCast()` are inherited from AbstractMysqlAdapter,
@@ -330,21 +333,40 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // needed — they'd be duplicates.
 
   /**
-   * Set of MySQL EXPLAIN flags that are safe to interpolate into the
-   * EXPLAIN clause. MySQL 8.0.18+ supports `EXPLAIN ANALYZE`; older
-   * versions and MariaDB support at least `EXTENDED`. Anything else is
-   * rejected — options come from user code via `Relation#explain(...)`
-   * and unsanitized interpolation would be a SQL injection vector.
+   * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
+   * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
+   * and `PARTITIONS`. Format is handled separately via the
+   * `{ format: ... }` hash since it requires a value.
    */
-  private static readonly EXPLAIN_OPTIONS = new Set(["analyze", "extended", "partitions"]);
+  private static readonly EXPLAIN_FLAGS = new Set(["analyze", "extended", "partitions"]);
 
-  private _validateExplainOptions(options: string[]): string[] {
+  /**
+   * Allowed values for the `format` keyword. MySQL 5.6+ supports
+   * `TRADITIONAL` (default) and `JSON`; 8.0.16+ adds `TREE`. Values
+   * come from user code, so the allowlist guards the SQL clause.
+   */
+  private static readonly EXPLAIN_FORMATS = new Set(["traditional", "json", "tree"]);
+
+  private _validateExplainOptions(options: ExplainOption[]): string[] {
     return options.map((o) => {
-      const key = String(o).toLowerCase();
-      if (!Mysql2Adapter.EXPLAIN_OPTIONS.has(key)) {
-        throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
+      if (typeof o === "string") {
+        const key = o.toLowerCase();
+        if (!Mysql2Adapter.EXPLAIN_FLAGS.has(key)) {
+          throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
+        }
+        return key.toUpperCase();
       }
-      return key.toUpperCase();
+      if (o.format !== undefined) {
+        const fmt = String(o.format).toLowerCase();
+        if (!Mysql2Adapter.EXPLAIN_FORMATS.has(fmt)) {
+          throw new Error(
+            `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
+          );
+        }
+        // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
+        return `FORMAT=${fmt.toUpperCase()}`;
+      }
+      throw new Error(`Unknown MySQL EXPLAIN option: ${JSON.stringify(o)}`);
     });
   }
 
@@ -354,7 +376,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Options are validated against the adapter's allowlist before
    * interpolation.
    */
-  private _explainStatementClause(options: string[]): string {
+  private _explainStatementClause(options: ExplainOption[]): string {
     if (options.length === 0) return "EXPLAIN";
     return `EXPLAIN ${this._validateExplainOptions(options).join(" ")}`;
   }

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -317,69 +317,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }
   }
 
-  /**
-   * Build the printed header prefix used by `Relation#explain`
-   * (e.g. `"EXPLAIN for:"` / `"EXPLAIN ANALYZE for:"`).
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
-   */
-  buildExplainClause(options: ExplainOption[] = []): string {
-    if (options.length === 0) return "EXPLAIN for:";
-    return `EXPLAIN ${this._validateExplainOptions(options).join(" ")} for:`;
-  }
-
   // `quote()` and `typeCast()` are inherited from AbstractMysqlAdapter,
   // which delegates to `mysql/quoting.ts`. No Mysql2-specific override
   // needed — they'd be duplicates.
-
-  /**
-   * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
-   * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
-   * and `PARTITIONS`. Format is handled separately via the
-   * `{ format: ... }` hash since it requires a value.
-   */
-  private static readonly EXPLAIN_FLAGS = new Set(["analyze", "extended", "partitions"]);
-
-  /**
-   * Allowed values for the `format` keyword. MySQL 5.6+ supports
-   * `TRADITIONAL` (default) and `JSON`; 8.0.16+ adds `TREE`. Values
-   * come from user code, so the allowlist guards the SQL clause.
-   */
-  private static readonly EXPLAIN_FORMATS = new Set(["traditional", "json", "tree"]);
-
-  private _validateExplainOptions(options: ExplainOption[]): string[] {
-    return options.map((o) => {
-      if (typeof o === "string") {
-        const key = o.toLowerCase();
-        if (!Mysql2Adapter.EXPLAIN_FLAGS.has(key)) {
-          throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
-        }
-        return key.toUpperCase();
-      }
-      if (o.format !== undefined) {
-        const fmt = String(o.format).toLowerCase();
-        if (!Mysql2Adapter.EXPLAIN_FORMATS.has(fmt)) {
-          throw new Error(
-            `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
-          );
-        }
-        // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
-        return `FORMAT=${fmt.toUpperCase()}`;
-      }
-      throw new Error(`Unknown MySQL EXPLAIN option: ${JSON.stringify(o)}`);
-    });
-  }
-
-  /**
-   * Compose the actual `EXPLAIN ...` SQL clause that prefixes the query —
-   * distinct from `buildExplainClause`, which builds the printed header.
-   * Options are validated against the adapter's allowlist before
-   * interpolation.
-   */
-  private _explainStatementClause(options: ExplainOption[]): string {
-    if (options.length === 0) return "EXPLAIN";
-    return `EXPLAIN ${this._validateExplainOptions(options).join(" ")}`;
-  }
+  //
+  // `buildExplainClause` / `_validateExplainOptions` / `_explainStatementClause`
+  // and the EXPLAIN_FLAGS / EXPLAIN_FORMATS allowlists live on
+  // AbstractMysqlAdapter so TrilogyAdapter inherits the same MySQL
+  // clause shape.
 
   /**
    * Execute raw SQL (for DDL and other non-query statements).

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -97,6 +97,25 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result).toContain("Result");
     });
 
+    it("buildExplainClause renders FORMAT JSON for { format: 'json' }", () => {
+      const clause = adapter.buildExplainClause([{ format: "json" }]);
+      expect(clause).toBe("EXPLAIN (FORMAT JSON) for:");
+    });
+
+    it("buildExplainClause combines string flags and format hash", () => {
+      const clause = adapter.buildExplainClause(["analyze", { format: "json" }]);
+      expect(clause).toBe("EXPLAIN (ANALYZE, FORMAT JSON) for:");
+    });
+
+    it("buildExplainClause rejects unknown format", () => {
+      expect(() => adapter.buildExplainClause([{ format: "bogus" }])).toThrow();
+    });
+
+    it("explain executes with { format: 'json' } and returns JSON plan", async () => {
+      const result = await adapter.explain("SELECT 1", [], [{ format: "json" }]);
+      expect(result).toContain("[");
+    });
+
     it.skip("explain options with eager loading", async () => {});
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter
  */
 
+import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { type Nodes, Visitors } from "@blazetrails/arel";
 import { ReadOnlyError } from "../errors.js";
@@ -113,7 +114,7 @@ export class AbstractAdapter extends AbstractAdapterBase {
         return `FORMAT ${o.format.toUpperCase()}`;
       }
       throw new TypeError(
-        `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+        `EXPLAIN option hash requires a string 'format'; got ${inspectExplainOption(o)}`,
       );
     });
     return `EXPLAIN (${parts.join(", ")}) for:`;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -107,9 +107,15 @@ export class AbstractAdapter extends AbstractAdapterBase {
    */
   buildExplainClause(options: ExplainOption[] = []): string {
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) =>
-      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
-    );
+    const parts = options.map((o) => {
+      if (typeof o === "string") return o.toUpperCase();
+      if (o && typeof o === "object" && typeof o.format === "string") {
+        return `FORMAT ${o.format.toUpperCase()}`;
+      }
+      throw new TypeError(
+        `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+      );
+    });
     return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter
  */
 
-import type { DatabaseAdapter } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { type Nodes, Visitors } from "@blazetrails/arel";
 import { ReadOnlyError } from "../errors.js";
 import { SchemaCache } from "./schema-cache.js";
@@ -105,10 +105,12 @@ export class AbstractAdapter extends AbstractAdapterBase {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#build_explain_clause
    */
-  buildExplainClause(options: string[] = []): string {
+  buildExplainClause(options: ExplainOption[] = []): string {
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) => o.toUpperCase()).join(", ");
-    return `EXPLAIN (${parts}) for:`;
+    const parts = options.map((o) =>
+      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
+    );
+    return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -522,26 +522,37 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   protected _validateExplainOptions(options: ExplainOption[]): string[] {
     const ctor = this.constructor as typeof AbstractMysqlAdapter;
-    return options.map((o) => {
+    const flags: string[] = [];
+    let formatClause: string | undefined;
+    for (const o of options) {
       if (typeof o === "string") {
         const key = o.toLowerCase();
         if (!ctor.EXPLAIN_FLAGS.has(key)) {
           throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
         }
-        return key.toUpperCase();
+        flags.push(key.toUpperCase());
+        continue;
       }
-      if (o.format !== undefined) {
-        const fmt = String(o.format).toLowerCase();
-        if (!ctor.EXPLAIN_FORMATS.has(fmt)) {
-          throw new Error(
-            `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
-          );
-        }
-        // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
-        return `FORMAT=${fmt.toUpperCase()}`;
+      if (typeof o.format !== "string") {
+        throw new Error(
+          `Unknown MySQL EXPLAIN option: ${JSON.stringify(o)} (hash requires a string 'format')`,
+        );
       }
-      throw new Error(`Unknown MySQL EXPLAIN option: ${JSON.stringify(o)}`);
-    });
+      if (formatClause !== undefined) {
+        throw new Error("MySQL EXPLAIN accepts at most one FORMAT option");
+      }
+      const fmt = o.format.toLowerCase();
+      if (!ctor.EXPLAIN_FORMATS.has(fmt)) {
+        throw new Error(
+          `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
+        );
+      }
+      // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
+      // FORMAT must come last in MySQL syntax; flags-first normalization
+      // prevents `EXPLAIN FORMAT=JSON ANALYZE ...` (invalid).
+      formatClause = `FORMAT=${fmt.toUpperCase()}`;
+    }
+    return formatClause === undefined ? flags : [...flags, formatClause];
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -533,9 +533,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         flags.push(key.toUpperCase());
         continue;
       }
-      if (typeof o.format !== "string") {
+      if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new Error(
-          `Unknown MySQL EXPLAIN option: ${JSON.stringify(o)} (hash requires a string 'format')`,
+          `Unknown MySQL EXPLAIN option: ${JSON.stringify(o)} (expected a string flag or an object with a string 'format')`,
         );
       }
       if (formatClause !== undefined) {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -8,6 +8,7 @@
  * transaction handling, and advisory lock support.
  */
 
+import { inspectExplainOption } from "../adapter.js";
 import type { ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Nodes } from "@blazetrails/arel";
@@ -535,7 +536,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       }
       if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new Error(
-          `Unknown MySQL EXPLAIN option: ${JSON.stringify(o)} (expected a string flag or an object with a string 'format')`,
+          `Unknown MySQL EXPLAIN option: ${inspectExplainOption(o)} (expected a string flag or an object with a string 'format')`,
         );
       }
       if (formatClause !== undefined) {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -8,6 +8,7 @@
  * transaction handling, and advisory lock support.
  */
 
+import type { ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Nodes } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
@@ -491,6 +492,66 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_QUERY_INTERRUPTED = ER_QUERY_INTERRUPTED;
   static readonly ER_QUERY_TIMEOUT = ER_QUERY_TIMEOUT;
   static readonly ER_TABLE_EXISTS = ER_TABLE_EXISTS;
+
+  /**
+   * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
+   * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
+   * and `PARTITIONS`. Format is handled separately via the
+   * `{ format: ... }` hash since it requires a value.
+   */
+  protected static readonly EXPLAIN_FLAGS = new Set(["analyze", "extended", "partitions"]);
+
+  /**
+   * Allowed values for the `format` keyword. MySQL 5.6+ supports
+   * `TRADITIONAL` (default) and `JSON`; 8.0.16+ adds `TREE`. Values
+   * come from user code, so the allowlist guards the SQL clause.
+   */
+  protected static readonly EXPLAIN_FORMATS = new Set(["traditional", "json", "tree"]);
+
+  /**
+   * Build the printed header prefix used by `Relation#explain` on MySQL
+   * (`"EXPLAIN ANALYZE FORMAT=JSON for:"`). Shared by Mysql2 and Trilogy
+   * adapters — the clause shape is driver-independent.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
+   */
+  override buildExplainClause(options: ExplainOption[] = []): string {
+    if (options.length === 0) return "EXPLAIN for:";
+    return `EXPLAIN ${this._validateExplainOptions(options).join(" ")} for:`;
+  }
+
+  protected _validateExplainOptions(options: ExplainOption[]): string[] {
+    const ctor = this.constructor as typeof AbstractMysqlAdapter;
+    return options.map((o) => {
+      if (typeof o === "string") {
+        const key = o.toLowerCase();
+        if (!ctor.EXPLAIN_FLAGS.has(key)) {
+          throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
+        }
+        return key.toUpperCase();
+      }
+      if (o.format !== undefined) {
+        const fmt = String(o.format).toLowerCase();
+        if (!ctor.EXPLAIN_FORMATS.has(fmt)) {
+          throw new Error(
+            `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
+          );
+        }
+        // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
+        return `FORMAT=${fmt.toUpperCase()}`;
+      }
+      throw new Error(`Unknown MySQL EXPLAIN option: ${JSON.stringify(o)}`);
+    });
+  }
+
+  /**
+   * Compose the actual `EXPLAIN ...` SQL clause that prefixes the query —
+   * distinct from `buildExplainClause`, which builds the printed header.
+   */
+  protected _explainStatementClause(options: ExplainOption[]): string {
+    if (options.length === 0) return "EXPLAIN";
+    return `EXPLAIN ${this._validateExplainOptions(options).join(" ")}`;
+  }
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -618,7 +618,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_explain_clause
    */
-  buildExplainClause(options: ExplainOption[] = []): string {
+  override buildExplainClause(options: ExplainOption[] = []): string {
     if (options.length === 0) return "EXPLAIN for:";
     const parts = this._validateExplainOptions(options);
     return `EXPLAIN (${parts.join(", ")}) for:`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -20,7 +20,7 @@ import {
   initializeInstanceTypeMap,
   initializeTypeMap as staticInitializeTypeMap,
 } from "./postgresql/type-map-init.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 
@@ -591,7 +591,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * prepared-statement query re-EXPLAINs cleanly without pg
    * rejecting it for "no parameter $1".
    */
-  async explain(sql: string, binds: unknown[] = [], options: string[] = []): Promise<string> {
+  async explain(
+    sql: string,
+    binds: unknown[] = [],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     return this.withClient(async (client) => {
       const clause = this._explainStatementClause(options);
       // Rewrite `?` → `$1` the same way execute/execQuery do, so a
@@ -606,30 +610,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
   }
 
-  // Note: PG's `buildExplainClause` — `"EXPLAIN for:"` /
-  // `"EXPLAIN (ANALYZE, VERBOSE) for:"` — is inherited from
-  // AbstractAdapter#buildExplainClause, which encodes the Rails default
-  // that happens to match PG's format. MySQL and SQLite override with
-  // adapter-specific flags.
+  /**
+   * Build the printed header prefix used by `Relation#explain`. PG
+   * accepts the boolean flags in `EXPLAIN_FLAGS` plus a `format`
+   * keyword (`{ format: "json" }`), composed into the same clause shape
+   * the adapter sends to the server: `EXPLAIN (ANALYZE, FORMAT JSON) for:`.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_explain_clause
+   */
+  buildExplainClause(options: ExplainOption[] = []): string {
+    if (options.length === 0) return "EXPLAIN for:";
+    const parts = this._validateExplainOptions(options);
+    return `EXPLAIN (${parts.join(", ")}) for:`;
+  }
 
   /**
-   * Set of PG EXPLAIN flags that are safe to interpolate into the
-   * EXPLAIN clause. Rails' `PostgreSQL::DatabaseStatements#explain`
-   * accepts symbols (`:analyze`, `:verbose`, `:costs`, `:buffers`,
-   * `:settings`, `:wal`, `:timing`, `:summary`, `:format`); we restrict
-   * to the same set and uppercase for the SQL clause. Everything else
-   * throws — options come from `Relation#explain(...args)` which is
-   * user-supplied, so unsanitized interpolation would be a SQL injection
-   * vector.
+   * Boolean PG EXPLAIN flags. Rails' `PostgreSQL::DatabaseStatements#explain`
+   * accepts the Symbols `:analyze :verbose :costs :buffers :settings
+   * :wal :timing :summary`; `format` is handled separately as a
+   * key/value hash entry (`{ format: "json" }`) because it requires a
+   * value.
    */
-  // PG's `FORMAT` flag is intentionally excluded — it's a key/value
-  // option (`FORMAT JSON` / `FORMAT YAML`), not a boolean toggle, so
-  // including it would generate invalid `EXPLAIN (FORMAT) ...` SQL.
-  // Rails supports it via a keyword arg (`explain(format: :json)`)
-  // rather than a positional flag; we can add that surface when the
-  // Relation#explain API is extended — for now the boolean-only flags
-  // below match what `Relation#explain("analyze", "verbose")` accepts.
-  private static readonly EXPLAIN_OPTIONS = new Set([
+  private static readonly EXPLAIN_FLAGS = new Set([
     "analyze",
     "verbose",
     "costs",
@@ -640,13 +642,34 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     "summary",
   ]);
 
-  private _validateExplainOptions(options: string[]): string[] {
+  /**
+   * Allowed values for the `format` keyword option. PG supports
+   * `TEXT` (default), `XML`, `JSON`, `YAML` — see
+   * https://www.postgresql.org/docs/current/sql-explain.html.
+   * Values come from user code via `Relation#explain(...)`, so
+   * interpolation has to be allowlisted.
+   */
+  private static readonly EXPLAIN_FORMATS = new Set(["text", "xml", "json", "yaml"]);
+
+  private _validateExplainOptions(options: ExplainOption[]): string[] {
     return options.map((o) => {
-      const key = String(o).toLowerCase();
-      if (!PostgreSQLAdapter.EXPLAIN_OPTIONS.has(key)) {
-        throw new Error(`Unknown PostgreSQL EXPLAIN option: ${o}`);
+      if (typeof o === "string") {
+        const key = o.toLowerCase();
+        if (!PostgreSQLAdapter.EXPLAIN_FLAGS.has(key)) {
+          throw new Error(`Unknown PostgreSQL EXPLAIN option: ${o}`);
+        }
+        return key.toUpperCase();
       }
-      return key.toUpperCase();
+      if (o.format !== undefined) {
+        const fmt = String(o.format).toLowerCase();
+        if (!PostgreSQLAdapter.EXPLAIN_FORMATS.has(fmt)) {
+          throw new Error(
+            `Unknown PostgreSQL EXPLAIN format: ${o.format}. Allowed: text, xml, json, yaml.`,
+          );
+        }
+        return `FORMAT ${fmt.toUpperCase()}`;
+      }
+      throw new Error(`Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)}`);
     });
   }
 
@@ -656,7 +679,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * printed header. Options are validated against the adapter's
    * allowlist before interpolation.
    */
-  private _explainStatementClause(options: string[]): string {
+  private _explainStatementClause(options: ExplainOption[]): string {
     if (options.length === 0) return "EXPLAIN";
     const validated = this._validateExplainOptions(options);
     return `EXPLAIN (${validated.join(", ")})`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -652,25 +652,35 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private static readonly EXPLAIN_FORMATS = new Set(["text", "xml", "json", "yaml"]);
 
   private _validateExplainOptions(options: ExplainOption[]): string[] {
-    return options.map((o) => {
+    const parts: string[] = [];
+    let seenFormat = false;
+    for (const o of options) {
       if (typeof o === "string") {
         const key = o.toLowerCase();
         if (!PostgreSQLAdapter.EXPLAIN_FLAGS.has(key)) {
           throw new Error(`Unknown PostgreSQL EXPLAIN option: ${o}`);
         }
-        return key.toUpperCase();
+        parts.push(key.toUpperCase());
+        continue;
       }
-      if (o.format !== undefined) {
-        const fmt = String(o.format).toLowerCase();
-        if (!PostgreSQLAdapter.EXPLAIN_FORMATS.has(fmt)) {
-          throw new Error(
-            `Unknown PostgreSQL EXPLAIN format: ${o.format}. Allowed: text, xml, json, yaml.`,
-          );
-        }
-        return `FORMAT ${fmt.toUpperCase()}`;
+      if (typeof o.format !== "string") {
+        throw new Error(
+          `Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)} (hash requires a string 'format')`,
+        );
       }
-      throw new Error(`Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)}`);
-    });
+      if (seenFormat) {
+        throw new Error("PostgreSQL EXPLAIN accepts at most one FORMAT option");
+      }
+      const fmt = o.format.toLowerCase();
+      if (!PostgreSQLAdapter.EXPLAIN_FORMATS.has(fmt)) {
+        throw new Error(
+          `Unknown PostgreSQL EXPLAIN format: ${o.format}. Allowed: text, xml, json, yaml.`,
+        );
+      }
+      parts.push(`FORMAT ${fmt.toUpperCase()}`);
+      seenFormat = true;
+    }
+    return parts;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -20,6 +20,7 @@ import {
   initializeInstanceTypeMap,
   initializeTypeMap as staticInitializeTypeMap,
 } from "./postgresql/type-map-init.js";
+import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
@@ -665,7 +666,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
       if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new Error(
-          `Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)} (expected a string flag or an object with a string 'format')`,
+          `Unknown PostgreSQL EXPLAIN option: ${inspectExplainOption(o)} (expected a string flag or an object with a string 'format')`,
         );
       }
       if (seenFormat) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -663,9 +663,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         parts.push(key.toUpperCase());
         continue;
       }
-      if (typeof o.format !== "string") {
+      if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new Error(
-          `Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)} (hash requires a string 'format')`,
+          `Unknown PostgreSQL EXPLAIN option: ${JSON.stringify(o)} (expected a string flag or an object with a string 'format')`,
         );
       }
       if (seenFormat) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -301,7 +301,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#build_explain_clause
    */
-  buildExplainClause(_options: ExplainOption[] = []): string {
+  override buildExplainClause(_options: ExplainOption[] = []): string {
     return "EXPLAIN QUERY PLAN for:";
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { Visitors } from "@blazetrails/arel";
-import type { DatabaseAdapter } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
@@ -284,7 +284,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * signature parity with `Relation#explain` but ignored — SQLite
    * has no equivalent to PG's `:analyze` / `:verbose` toggles.
    */
-  async explain(sql: string, binds: unknown[] = [], _options: string[] = []): Promise<string> {
+  async explain(
+    sql: string,
+    binds: unknown[] = [],
+    _options: ExplainOption[] = [],
+  ): Promise<string> {
     const rows = this.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...binds) as Record<
       string,
       unknown
@@ -297,7 +301,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#build_explain_clause
    */
-  buildExplainClause(_options: string[] = []): string {
+  buildExplainClause(_options: ExplainOption[] = []): string {
     return "EXPLAIN QUERY PLAN for:";
   }
 

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -280,6 +280,20 @@ describe("ExplainTest", () => {
     expect(rendered).toBe('["raw", 42]');
   });
 
+  it("rejects multiple hash options (Rails extract_options! semantics)", async () => {
+    const { Post } = makeModel();
+    await expect(
+      Post.all().explain({ format: "json" }, { format: "xml" } as never),
+    ).rejects.toThrow(/at most one option hash/);
+  });
+
+  it("rejects a non-trailing hash option", async () => {
+    const { Post } = makeModel();
+    await expect(Post.all().explain({ format: "json" } as never, "analyze")).rejects.toThrow(
+      /last argument/,
+    );
+  });
+
   it("isolates concurrent explain() calls via AsyncLocalStorage scopes", async () => {
     // Two parallel explain() calls must not trample each other's
     // collected queries. Without async-context isolation a global

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -14,7 +14,7 @@ export type { LoadedRelation } from "./relation.js";
 export { QueryAttribute } from "./relation/query-attribute.js";
 export { InsertAll, Builder as InsertAllBuilder } from "./insert-all.js";
 export type { InsertAllOptions } from "./insert-all.js";
-export type { DatabaseAdapter } from "./adapter.js";
+export type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 export { Migration, MigrationContext } from "./migration.js";
 export {
   TableDefinition,

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -10,7 +10,7 @@
  */
 
 import { Notifications } from "@blazetrails/activesupport";
-import type { DatabaseAdapter } from "./adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { Result } from "./result.js";
 
 const DEFAULT_MAX_SIZE = 100;
@@ -278,9 +278,13 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return this.inner.inTransaction;
   }
 
-  async explain(sql: string, binds: unknown[] = [], options: string[] = []): Promise<string> {
+  async explain(
+    sql: string,
+    binds: unknown[] = [],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     const inner = this.inner as {
-      explain?: (sql: string, binds?: unknown[], options?: string[]) => Promise<string>;
+      explain?: (sql: string, binds?: unknown[], options?: ExplainOption[]) => Promise<string>;
     };
     if (typeof inner.explain === "function") {
       // Forward binds/options so `Relation#explain("analyze", ...)` and
@@ -292,14 +296,16 @@ export class QueryCacheAdapter implements DatabaseAdapter {
     return "EXPLAIN is not supported by the underlying adapter";
   }
 
-  buildExplainClause(options: string[] = []): string {
-    const inner = this.inner as { buildExplainClause?: (options: string[]) => string };
+  buildExplainClause(options: ExplainOption[] = []): string {
+    const inner = this.inner as { buildExplainClause?: (options: ExplainOption[]) => string };
     if (typeof inner.buildExplainClause === "function") {
       return inner.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) => o.toUpperCase()).join(", ");
-    return `EXPLAIN (${parts}) for:`;
+    const parts = options.map((o) =>
+      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
+    );
+    return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 
   quote(value: unknown): string {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -302,13 +302,15 @@ export class QueryCacheAdapter implements DatabaseAdapter {
       return inner.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    if (options.some((o) => typeof o !== "string")) {
-      throw new Error(
-        "QueryCacheAdapter.buildExplainClause: wrapped adapter does not implement " +
-          "buildExplainClause() — non-string options cannot be rendered safely.",
-      );
-    }
-    const parts = options.map((o) => (o as string).toUpperCase());
+    // Wrapped adapter lacks buildExplainClause — we can safely render
+    // bare string flags, but the keyword hash shape is adapter-specific
+    // (PG: `FORMAT JSON`, MySQL: `FORMAT=JSON`) and we don't know which
+    // this adapter would accept. Drop the hash from the printed header
+    // rather than throw; `Relation#explain` can still succeed via the
+    // adapter's `explain(sql, binds, options)` if that's implemented.
+    const stringOptions = options.filter((o): o is string => typeof o === "string");
+    if (stringOptions.length === 0) return "EXPLAIN for:";
+    const parts = stringOptions.map((o) => o.toUpperCase());
     return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -302,9 +302,13 @@ export class QueryCacheAdapter implements DatabaseAdapter {
       return inner.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) =>
-      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
-    );
+    if (options.some((o) => typeof o !== "string")) {
+      throw new Error(
+        "QueryCacheAdapter.buildExplainClause: wrapped adapter does not implement " +
+          "buildExplainClause() — non-string options cannot be rendered safely.",
+      );
+    }
+    const parts = options.map((o) => (o as string).toUpperCase());
     return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -45,6 +45,7 @@ import { WhereClause, predicatesWithWrappedSqlLiterals } from "./relation/where-
 import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import { touchAttributesWithTime } from "./timestamp.js";
 import { ExplainRegistry } from "./explain-registry.js";
+import { inspectExplainOption } from "./adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
 
@@ -1859,7 +1860,7 @@ export class Relation<T extends Base> {
       if (typeof o === "string") return o.toUpperCase();
       if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new TypeError(
-          `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+          `EXPLAIN option hash requires a string 'format'; got ${inspectExplainOption(o)}`,
         );
       }
       return `FORMAT ${o.format.toUpperCase()}`;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -76,6 +76,11 @@ function validateExplainOptions(options: ExplainOption[]): void {
       }
       continue;
     }
+    if (!o || typeof o !== "object") {
+      throw new TypeError(
+        `EXPLAIN option must be a string flag or an options hash; got ${String(o)}`,
+      );
+    }
     if (seenHash) {
       throw new Error("EXPLAIN accepts at most one option hash");
     }
@@ -1852,7 +1857,7 @@ export class Relation<T extends Base> {
     if (options.length === 0) return "EXPLAIN for:";
     const parts = options.map((o) => {
       if (typeof o === "string") return o.toUpperCase();
-      if (typeof o.format !== "string") {
+      if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new TypeError(
           `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
         );

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -45,7 +45,7 @@ import { WhereClause, predicatesWithWrappedSqlLiterals } from "./relation/where-
 import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import { touchAttributesWithTime } from "./timestamp.js";
 import { ExplainRegistry } from "./explain-registry.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
 
 /**
@@ -1637,13 +1637,20 @@ export class Relation<T extends Base> {
    * subscriber captures every `sql.active_record` notification, and
    * `exec_explain` runs EXPLAIN against each captured SQL.
    *
-   * `options` mirrors Rails' variadic symbols (e.g. `explain("analyze",
-   * "verbose")` → `EXPLAIN (ANALYZE, VERBOSE) ...`) and is forwarded to
-   * the adapter's `buildExplainClause` / `explain` implementations.
+   * `options` mirrors Rails' variadic form — a mix of flag strings and
+   * a trailing keyword hash. The keyword hash currently supports
+   * `format: "json" | "yaml" | "xml" | "text"` on PG / MySQL; adapters
+   * that don't support a key throw. Examples:
+   *
+   *     await Post.all().explain("analyze", "verbose")
+   *     // → EXPLAIN (ANALYZE, VERBOSE) for: SELECT …
+   *
+   *     await Post.all().explain("analyze", { format: "json" })
+   *     // → EXPLAIN (ANALYZE, FORMAT JSON) for: SELECT …
    *
    * Mirrors: ActiveRecord::Relation#explain
    */
-  async explain(...options: string[]): Promise<string> {
+  async explain(...options: ExplainOption[]): Promise<string> {
     const { queries } = await ExplainRegistry.collectingQueries(() => this.toArray());
     return this._execExplain(queries, options);
   }
@@ -1657,7 +1664,10 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#exec_explain
    * @internal
    */
-  async _execExplain(queries: [string, unknown[]][], options: string[] = []): Promise<string> {
+  async _execExplain(
+    queries: [string, unknown[]][],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     const adapter = this._modelClass.adapter;
     if (typeof adapter?.explain !== "function") {
       return "EXPLAIN not supported by this adapter";
@@ -1804,13 +1814,15 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#build_explain_clause
    */
-  private _buildExplainClause(adapter: DatabaseAdapter, options: string[]): string {
+  private _buildExplainClause(adapter: DatabaseAdapter, options: ExplainOption[]): string {
     if (typeof adapter.buildExplainClause === "function") {
       return adapter.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) => o.toUpperCase()).join(", ");
-    return `EXPLAIN (${parts}) for:`;
+    const parts = options.map((o) =>
+      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
+    );
+    return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 
   // count, sum, average, minimum, maximum are mixed in via

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -58,6 +58,32 @@ import { rubyInspectArray } from "./relation/ruby-inspect.js";
 export type LoadedRelation<R> = Omit<R, "then">;
 
 /**
+ * Enforce Rails' `extract_options!` shape on variadic `explain(...)`
+ * inputs: at most one hash option, and if present it must be the last
+ * positional argument. This keeps adapters (especially MySQL, whose
+ * `EXPLAIN FORMAT=X ANALYZE` is invalid) from receiving orderings they
+ * can't render.
+ */
+function validateExplainOptions(options: ExplainOption[]): void {
+  let seenHash = false;
+  for (let i = 0; i < options.length; i++) {
+    const o = options[i];
+    if (typeof o === "string") {
+      if (seenHash) {
+        throw new Error(
+          "EXPLAIN option hash must be the last argument (Rails' extract_options! semantics)",
+        );
+      }
+      continue;
+    }
+    if (seenHash) {
+      throw new Error("EXPLAIN accepts at most one option hash");
+    }
+    seenHash = true;
+  }
+}
+
+/**
  * Relation — the lazy, chainable query interface.
  *
  * Mirrors: ActiveRecord::Relation
@@ -1637,20 +1663,25 @@ export class Relation<T extends Base> {
    * subscriber captures every `sql.active_record` notification, and
    * `exec_explain` runs EXPLAIN against each captured SQL.
    *
-   * `options` mirrors Rails' variadic form — a mix of flag strings and
-   * a trailing keyword hash. The keyword hash currently supports
-   * `format: "json" | "yaml" | "xml" | "text"` on PG / MySQL; adapters
-   * that don't support a key throw. Examples:
+   * `options` is a mix of flag strings and an optional trailing keyword
+   * hash. Supported keyword options are adapter-specific — PG and MySQL
+   * each allowlist their own set of `format` values, SQLite ignores
+   * options entirely. Ruby's `extract_options!` allows at most one
+   * trailing Hash; we enforce the same shape here so MySQL's
+   * order-sensitive SQL (`EXPLAIN FORMAT=JSON ANALYZE` is invalid) can't
+   * be produced by accident. Examples:
    *
    *     await Post.all().explain("analyze", "verbose")
    *     // → EXPLAIN (ANALYZE, VERBOSE) for: SELECT …
    *
    *     await Post.all().explain("analyze", { format: "json" })
-   *     // → EXPLAIN (ANALYZE, FORMAT JSON) for: SELECT …
+   *     // → EXPLAIN (ANALYZE, FORMAT JSON) for: SELECT …  (PG)
+   *     // → EXPLAIN ANALYZE FORMAT=JSON for: SELECT …     (MySQL)
    *
    * Mirrors: ActiveRecord::Relation#explain
    */
   async explain(...options: ExplainOption[]): Promise<string> {
+    validateExplainOptions(options);
     const { queries } = await ExplainRegistry.collectingQueries(() => this.toArray());
     return this._execExplain(queries, options);
   }
@@ -1819,9 +1850,15 @@ export class Relation<T extends Base> {
       return adapter.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) =>
-      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
-    );
+    const parts = options.map((o) => {
+      if (typeof o === "string") return o.toUpperCase();
+      if (typeof o.format !== "string") {
+        throw new TypeError(
+          `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+        );
+      }
+      return `FORMAT ${o.format.toUpperCase()}`;
+    });
     return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -16,6 +16,7 @@
  * creation from model definitions — not SQL guessing.
  */
 
+import { inspectExplainOption } from "./adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { DatabaseStatementsMixin } from "./connection-adapters/database-statements-mixin.js";
 import { _setOnAdapterSetHook } from "./base.js";
@@ -695,7 +696,7 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
       if (typeof o === "string") return o.toUpperCase();
       if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new TypeError(
-          `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+          `EXPLAIN option hash requires a string 'format'; got ${inspectExplainOption(o)}`,
         );
       }
       return `FORMAT ${o.format.toUpperCase()}`;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -691,9 +691,15 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
       return inner.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) =>
-      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
-    );
+    const parts = options.map((o) => {
+      if (typeof o === "string") return o.toUpperCase();
+      if (typeof o.format !== "string") {
+        throw new TypeError(
+          `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
+        );
+      }
+      return `FORMAT ${o.format.toUpperCase()}`;
+    });
     return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -693,7 +693,7 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
     if (options.length === 0) return "EXPLAIN for:";
     const parts = options.map((o) => {
       if (typeof o === "string") return o.toUpperCase();
-      if (typeof o.format !== "string") {
+      if (!o || typeof o !== "object" || typeof o.format !== "string") {
         throw new TypeError(
           `EXPLAIN option hash requires a string 'format'; got ${JSON.stringify(o)}`,
         );

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -16,7 +16,7 @@
  * creation from model definitions — not SQL guessing.
  */
 
-import type { DatabaseAdapter } from "./adapter.js";
+import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { DatabaseStatementsMixin } from "./connection-adapters/database-statements-mixin.js";
 import { _setOnAdapterSetHook } from "./base.js";
 
@@ -672,22 +672,29 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
     return execDdlWithSavepoint(this.inner, sql);
   }
 
-  async explain(sql: string, binds: unknown[] = [], options: string[] = []): Promise<string> {
+  async explain(
+    sql: string,
+    binds: unknown[] = [],
+    options: ExplainOption[] = [],
+  ): Promise<string> {
     await this.setup();
     const inner = this.inner as {
-      explain?: (sql: string, binds?: unknown[], options?: string[]) => Promise<string>;
+      explain?: (sql: string, binds?: unknown[], options?: ExplainOption[]) => Promise<string>;
     };
     if (inner.explain) return inner.explain(sql, binds, options);
     return `EXPLAIN not supported`;
   }
 
-  buildExplainClause(options: string[] = []): string {
-    const inner = this.inner as { buildExplainClause?: (options: string[]) => string };
+  buildExplainClause(options: ExplainOption[] = []): string {
+    const inner = this.inner as { buildExplainClause?: (options: ExplainOption[]) => string };
     if (typeof inner.buildExplainClause === "function") {
       return inner.buildExplainClause(options);
     }
     if (options.length === 0) return "EXPLAIN for:";
-    return `EXPLAIN (${options.map((o) => o.toUpperCase()).join(", ")}) for:`;
+    const parts = options.map((o) =>
+      typeof o === "string" ? o.toUpperCase() : `FORMAT ${String(o.format).toUpperCase()}`,
+    );
+    return `EXPLAIN (${parts.join(", ")}) for:`;
   }
 
   quote(value: unknown): string {


### PR DESCRIPTION
## Summary

Rails' `Relation#explain` accepts a trailing hash (`{ format: :json }`) in addition to positional flag symbols. This PR extends the adapter contract to model that shape and emits dialect-appropriate EXPLAIN syntax.

Note: Rails 8.0.2 itself doesn't actually render the hash meaningfully — `PostgreSQL#build_explain_clause` is `options.join(", ").upcase`, `MySQL#build_explain_clause` is `options.join(" ").upcase`. Passing `{format: :json}` to stock Rails produces garbage. This PR is a forward-looking extension with tighter runtime shape than Rails.

- New `ExplainOption = string | { format: string }` type in `adapter.ts`, threaded through `Relation#explain`, `_execExplain`, `buildExplainClause`, and each adapter's `explain`.
- `Relation#explain` validates Rails' `extract_options!` shape — at most one hash, must be last positional arg.
- PostgreSQL: `EXPLAIN (ANALYZE, FORMAT JSON) <sql>` — comma-separated in parens, `FORMAT JSON` with a space. Rejects duplicate `FORMAT`.
- MySQL (Mysql2/Trilogy via AbstractMysqlAdapter): `EXPLAIN ANALYZE FORMAT=JSON <sql>` — space-separated, no parens, `FORMAT=JSON` with `=`. Flags collected first, `FORMAT=X` appended last (MySQL grammar). Rejects duplicate `FORMAT`.
- SQLite: `EXPLAIN QUERY PLAN <sql>` — options ignored (SQLite has no flags).
- Per-adapter allowlists for flags and formats (PG: `text/xml/json/yaml`; MySQL: `traditional/json/tree`) block SQL injection through user-supplied values.
- All fallback `buildExplainClause` paths (Relation, AbstractAdapter, SchemaAdapter) guard against null / non-object hash entries so `as any` bypasses produce a clear validation error instead of a raw TypeError. QueryCacheAdapter drops unknown-shape hashes from the printed header and defers to the wrapped adapter's `explain(sql, binds, options)`.

## Test plan

- [x] SQLite: explain.test.ts (25 tests) passes — includes multi-hash + non-trailing-hash rejection
- [x] PG (CI): format-hash clause + end-to-end JSON plan tests
- [x] MySQL (CI): format-hash clause + end-to-end JSON tests
- [x] Unknown format rejected per-adapter