### PR TITLE
fix(activerecord): render PG FORMAT JSON explain plans as JSON

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -113,7 +113,12 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("explain executes with { format: 'json' } and returns JSON plan", async () => {
       const result = await adapter.explain("SELECT 1", [], [{ format: "json" }]);
-      expect(result).toContain("[");
+      // The prior stringifier rendered pg-auto-parsed plans as
+      // "[object Object]" — assert structure instead of just "[".
+      expect(result).not.toContain("[object Object]");
+      const parsed = JSON.parse(result);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0]).toHaveProperty("Plan");
     });
 
     it.skip("explain options with eager loading", async () => {});

--- a/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
@@ -10,6 +10,12 @@ export class ExplainPrettyPrinter {
 
     const lines = result.map((row) => {
       const queryPlan = row["QUERY PLAN"] ?? row.query_plan ?? row.queryplan ?? "";
+      // `EXPLAIN (FORMAT JSON)` returns the plan as a json/jsonb column
+      // which the pg driver auto-parses to a JS object/array. `String(obj)`
+      // renders "[object Object]"; JSON.stringify preserves the plan.
+      if (queryPlan !== null && typeof queryPlan === "object") {
+        return JSON.stringify(queryPlan, null, 2);
+      }
       return String(queryPlan);
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #608. The pg driver auto-parses json/jsonb columns to JS values, so a row from \`EXPLAIN (FORMAT JSON) ...\` comes back with the QUERY PLAN column as an array/object. The existing pretty printer did \`String(queryPlan)\` — which renders \`[object Object]\` instead of the plan. Stringify object/array plans as JSON so users of \`explain({ format: "json" })\` actually see a plan.

## Test plan

- [ ] PG CI: explain-format-json end-to-end from #608 now produces a real JSON blob rather than \`[object Object]\`