### PR TITLE
docs: epic plans for boundAttributes + cacheableQuery PartialCollector

### DIFF
--- a/docs/cacheable-query-partial-collector.md
+++ b/docs/cacheable-query-partial-collector.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-`cacheableQuery()` currently calls `toSqlAndBinds(arel)` which returns `[sql_string, binds]`, then wraps the SQL string in a `PartialQuery([sql])`. This means the PartialQuery has no Substitute slots — it's just a single-element array containing the full SQL. The bind values exist in the binds array but aren't correlated with positions in the SQL template.
+`cacheableQuery()` currently calls `toSqlAndBinds(arel)` which returns `[sql, binds, preparable, allowRetry]` (a 4-tuple, though callers typically destructure only the first two), then wraps the SQL string in a `PartialQuery([sql])`. This means the PartialQuery has no Substitute slots — it's just a single-element array containing the full SQL. The bind values exist in the binds array but aren't correlated with positions in the SQL template.
 
 In Rails, the unprepared (non-prepared-statement) path compiles the Arel tree with a `PartialQueryCollector` that produces interleaved SQL fragments and Substitute placeholders. This allows `PartialQuery.sqlFor(binds, connection)` to splice quoted bind values into the exact positions where `?` placeholders would go.
 

--- a/docs/cacheable-query-partial-collector.md
+++ b/docs/cacheable-query-partial-collector.md
@@ -49,13 +49,14 @@ Rails' unprepared path:
 
 - `packages/arel/src/visitors/to-sql.ts`
   - `compileWithCollector(node, collector)` — accept an external collector parameter instead of always creating a new `SQLString`
-  - When a `PartialQueryCollector` is passed, the visitor's `visitCasted`/`visitBindParam` call `collector.addBind()` which pushes Substitutes into the parts array
-  - This is partially done — `compileWithCollector` exists but always creates a new `SQLString`. Need to accept an arbitrary collector.
+  - Update `PartialQueryCollector.addBind` to accept the optional `block` argument (`addBind(value, block?)`) so it satisfies the same collector interface Arel visitors expect. Add `addBinds(..., block?)` too.
+  - Update visitor behavior: when compiling with a `PartialQueryCollector`, `visitBindParam`/`visitCasted` must route values through `collector.addBind(...)` instead of appending quoted values directly. The current `_extractBinds` flag controls this — when an external collector is passed, set `_extractBinds = true` so bind values flow through `addBind`.
+  - This is partially done — `compileWithCollector` exists but always creates a new `SQLString`, and the visitor inlines quoted values when `_extractBinds` is false.
 
 - `packages/arel/src/visitors/postgresql.ts`
-  - Same for `PostgreSQLWithBinds` — accept external collector
+  - Same for `PostgreSQLWithBinds` — accept external collector, preserve numbered-bind behavior by honoring the optional `block` argument
 
-**Tests:** Compile an AST with a `PartialQueryCollector`, verify parts array has interleaved strings + Substitutes, binds array has values.
+**Tests:** Compile an AST with an interface-compatible `PartialQueryCollector`, verify parts array has interleaved strings + Substitutes, binds array has values, and PG numbered-bind visitors still work.
 
 ### PR 2: Wire cacheableQuery Through PartialQueryCollector
 

--- a/docs/cacheable-query-partial-collector.md
+++ b/docs/cacheable-query-partial-collector.md
@@ -1,0 +1,102 @@
+# cacheableQuery + PartialQueryCollector Compilation
+
+## Problem
+
+`cacheableQuery()` currently calls `toSqlAndBinds(arel)` which returns `[sql_string, binds]`, then wraps the SQL string in a `PartialQuery([sql])`. This means the PartialQuery has no Substitute slots — it's just a single-element array containing the full SQL. The bind values exist in the binds array but aren't correlated with positions in the SQL template.
+
+In Rails, the unprepared (non-prepared-statement) path compiles the Arel tree with a `PartialQueryCollector` that produces interleaved SQL fragments and Substitute placeholders. This allows `PartialQuery.sqlFor(binds, connection)` to splice quoted bind values into the exact positions where `?` placeholders would go.
+
+## Current State
+
+```
+cacheableQuery(klass, arel):
+  [sql, binds] = toSqlAndBinds(arel)    // sql = "SELECT ... WHERE name = ?"
+  return [klass.partialQuery([sql]), binds]  // PartialQuery(["SELECT ... WHERE name = ?"])
+```
+
+The PartialQuery receives the full SQL as one string with no Substitute slots. On `sqlFor(binds, connection)`, it has nothing to substitute — the `?` in the SQL is a literal character, not a Substitute object.
+
+## What Rails Does
+
+```ruby
+def cacheable_query(klass, arel)
+  if prepared_statements
+    sql, binds = visitor.compile(arel.ast, collector)
+    query = klass.query(sql)
+  else
+    collector = klass.partial_query_collector
+    parts, binds = visitor.compile(arel.ast, collector)
+    query = klass.partial_query(parts)
+  end
+  [query, binds]
+end
+```
+
+Rails' unprepared path:
+
+1. Creates a `PartialQueryCollector`
+2. Compiles the Arel AST using this collector
+3. The visitor's `visitBindParam`/`visitCasted` calls `collector.addBind(value)` which pushes a `Substitute` into the parts array and the value into the binds array
+4. The result is `[parts_with_substitutes, bind_values]`
+5. `PartialQuery(parts)` has Substitute slots at the exact positions where values should be interpolated
+6. `PartialQuery.sqlFor(binds, connection)` quotes each bind value and splices it into the corresponding Substitute position
+
+## Implementation Plan
+
+### PR 1: Visitor Compilation with External Collector
+
+**Files:**
+
+- `packages/arel/src/visitors/to-sql.ts`
+  - `compileWithCollector(node, collector)` — accept an external collector parameter instead of always creating a new `SQLString`
+  - When a `PartialQueryCollector` is passed, the visitor's `visitCasted`/`visitBindParam` call `collector.addBind()` which pushes Substitutes into the parts array
+  - This is partially done — `compileWithCollector` exists but always creates a new `SQLString`. Need to accept an arbitrary collector.
+
+- `packages/arel/src/visitors/postgresql.ts`
+  - Same for `PostgreSQLWithBinds` — accept external collector
+
+**Tests:** Compile an AST with a `PartialQueryCollector`, verify parts array has interleaved strings + Substitutes, binds array has values.
+
+### PR 2: Wire cacheableQuery Through PartialQueryCollector
+
+**Files:**
+
+- `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`
+  - `cacheableQuery()`: when `preparedStatements` is false, create a `PartialQueryCollector`, compile the Arel AST through it, and return `PartialQuery(parts)` + binds
+  - When `preparedStatements` is true, compile with `compileWithBinds` and return `Query(sql)` + binds (current behavior)
+  - This requires the visitor to accept an external collector — depends on PR 1
+
+- `packages/activerecord/src/statement-cache.ts`
+  - `PartialQuery.sqlFor(binds, connection)` already handles Substitute slots correctly
+  - Verify it works end-to-end with the collector-produced parts array
+
+**Tests:** `cacheableQuery(StatementCache, arel)` with `preparedStatements = false` → returns `PartialQuery` with Substitute slots. `sqlFor([value], connection)` produces SQL with the value quoted and spliced in.
+
+### PR 3: Integration Tests + Cleanup
+
+**Files:**
+
+- `packages/activerecord/src/statement-cache.test.ts`
+  - End-to-end test: create a `StatementCache` with `preparedStatements = false`, execute with different values, verify interpolated SQL is correct
+  - Test with `preparedStatements = true` — verify `Query` path with parameterized SQL
+
+- Remove the local `quoteValue` fallback in `PartialQuery.sqlFor` if adapter quoting is now always available through the connection parameter
+
+**Tests:** Round-trip with both prepared and unprepared paths on SQLite.
+
+## Dependencies
+
+- PR 1 is standalone (Arel-level change)
+- PR 2 depends on PR 1
+- PR 3 depends on PR 2
+- This epic is independent of the boundAttributes epic but they complement each other — together they complete the StatementCache flow
+
+## Verification
+
+After all 3 PRs:
+
+- `cacheableQuery` with `preparedStatements = false` produces a `PartialQuery` with real Substitute slots
+- `PartialQuery.sqlFor(binds, connection)` correctly interpolates quoted values
+- `cacheableQuery` with `preparedStatements = true` produces a `Query` with parameterized SQL
+- `StatementCache.create → execute` works end-to-end on both paths
+- No regression in existing tests

--- a/docs/cacheable-query-partial-collector.md
+++ b/docs/cacheable-query-partial-collector.md
@@ -10,11 +10,16 @@ In Rails, the unprepared (non-prepared-statement) path compiles the Arel tree wi
 
 ```
 cacheableQuery(klass, arel):
-  [sql, binds] = toSqlAndBinds(arel)    // sql = "SELECT ... WHERE name = ?"
-  return [klass.partialQuery([sql]), binds]  // PartialQuery(["SELECT ... WHERE name = ?"])
+  [sql, binds] = toSqlAndBinds(arel)    // binds is always [] because toSqlAndBinds
+                                         // is called without `this` binding, so it
+                                         // can't see arelVisitor and falls back to
+                                         // node.toSql() which inlines all values
+  return [klass.partialQuery([sql]), binds]  // PartialQuery(["SELECT ... WHERE name = 'foo'"])
 ```
 
-The PartialQuery receives the full SQL as one string with no Substitute slots. On `sqlFor(binds, connection)`, it has nothing to substitute — the `?` in the SQL is a literal character, not a Substitute object.
+Two problems: (1) `toSqlAndBinds` is called without `this` so it never extracts binds, and (2) even if it did, the PartialQuery receives the full SQL as one string with no Substitute slots. On `sqlFor(binds, connection)`, it has nothing to substitute.
+
+This epic needs to fix both: bind `this` in `cacheableQuery` so the adapter's visitor is used, AND compile through `PartialQueryCollector` so Substitute slots are produced.
 
 ## What Rails Does
 
@@ -49,6 +54,8 @@ Rails' unprepared path:
 
 - `packages/arel/src/visitors/to-sql.ts`
   - `compileWithCollector(node, collector)` — accept an external collector parameter instead of always creating a new `SQLString`
+- `packages/activerecord/src/statement-cache.ts`
+  - `PartialQueryCollector` lives here, not under `packages/arel`
   - Update `PartialQueryCollector.addBind` to accept the optional `block` argument (`addBind(value, block?)`) so it satisfies the same collector interface Arel visitors expect. Add `addBinds(..., block?)` too.
   - Update visitor behavior: when compiling with a `PartialQueryCollector`, `visitBindParam`/`visitCasted` must route values through `collector.addBind(...)` instead of appending quoted values directly. The current `_extractBinds` flag controls this — when an external collector is passed, set `_extractBinds = true` so bind values flow through `addBind`.
   - This is partially done — `compileWithCollector` exists but always creates a new `SQLString`, and the visitor inlines quoted values when `_extractBinds` is false.

--- a/docs/relation-bound-attributes.md
+++ b/docs/relation-bound-attributes.md
@@ -64,7 +64,8 @@
   - Update `BindMap` to recognize `QueryAttribute` (not just `Attribute` from activemodel) and call `QueryAttribute.withCastValue()` for rebinding
 
 - `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`
-  - `cacheableQuery()` should compile the Arel tree with `compileWithBinds` and return the bound attributes alongside the query builder
+  - `cacheableQuery()` keeps its current signature — it compiles the Arel tree and returns `[queryBuilder, executionBinds]`
+  - It does NOT return `relation.boundAttributes` — that's read directly by `StatementCache.create` from the relation object, which has access to both the relation and the connection
 
 **Tests:** Full round-trip: `StatementCache.create(conn, (p) => Book.where({name: p.bind()}))` → `cache.execute(["Rails Guide"], conn)` → returns correct records
 

--- a/docs/relation-bound-attributes.md
+++ b/docs/relation-bound-attributes.md
@@ -8,8 +8,8 @@
 
 - `StatementCache.create(connection, (params) => Model.where({name: params.bind()}))` — the `params.bind()` returns a `Substitute` instance
 - `Substitute` reaches `PredicateBuilder` → `BasicObjectHandler` → `Attribute.eq(substitute)` → `buildCasted(substitute)` → `Casted(substitute, attr)`
-- The `Casted` node treats Substitute as a regular value — `visitCasted` calls `valueForDatabase()` on it, which returns the Substitute object itself
-- `BindMap` needs to find Substitute positions in the compiled binds array, but Substitutes are wrapped in Casted nodes and lose their identity after type casting
+- The `Casted` node treats Substitute as a regular value — `visitCasted` calls `valueForDatabase()` which delegates to the attribute caster and may type-cast/serialize/coerce the Substitute
+- `BindMap` needs to find Substitute positions in the compiled binds array, but once a Substitute is wrapped in `Casted`, type casting can change the emitted bind value and the original Substitute identity is no longer reliably preserved
 - `Relation` doesn't track `boundAttributes` — Rails' Relation collects bound attributes during WHERE clause construction so BindMap can index Substitute positions
 
 ## What Rails Does
@@ -61,6 +61,7 @@
   - `create()` calls `callable(new Params())` which returns a relation
   - Extract `relation.boundAttributes` for `BindMap` construction instead of relying on `cacheableQuery` binds
   - `BindMap` scans boundAttributes for Substitute-valued QueryAttributes
+  - Update `BindMap` to recognize `QueryAttribute` (not just `Attribute` from activemodel) and call `QueryAttribute.withCastValue()` for rebinding
 
 - `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`
   - `cacheableQuery()` should compile the Arel tree with `compileWithBinds` and return the bound attributes alongside the query builder

--- a/docs/relation-bound-attributes.md
+++ b/docs/relation-bound-attributes.md
@@ -1,0 +1,84 @@
+# Relation boundAttributes + Substitute → BindParam Pipeline
+
+## Problem
+
+`StatementCache.create` works today with manual `BindMap` construction, but the full Rails flow — `where({name: params.bind()})` producing `BindParam(Substitute)` nodes in the Arel tree — isn't wired. This means `StatementCache.create` can't build a cached statement from a relation-building callback the way Rails does.
+
+## Current State
+
+- `StatementCache.create(connection, (params) => Model.where({name: params.bind()}))` — the `params.bind()` returns a `Substitute` instance
+- `Substitute` reaches `PredicateBuilder` → `BasicObjectHandler` → `Attribute.eq(substitute)` → `buildCasted(substitute)` → `Casted(substitute, attr)`
+- The `Casted` node treats Substitute as a regular value — `visitCasted` calls `valueForDatabase()` on it, which returns the Substitute object itself
+- `BindMap` needs to find Substitute positions in the compiled binds array, but Substitutes are wrapped in Casted nodes and lose their identity after type casting
+- `Relation` doesn't track `boundAttributes` — Rails' Relation collects bound attributes during WHERE clause construction so BindMap can index Substitute positions
+
+## What Rails Does
+
+1. `params.bind()` returns `StatementCache::Substitute`
+2. `where({name: substitute})` → PredicateBuilder registers a handler for Substitute
+3. The handler wraps the value as a `Relation::QueryAttribute` with the Substitute as its value
+4. The QueryAttribute is stored in `relation.bound_attributes`
+5. When `cacheableQuery` compiles the Arel tree, the bound_attributes array contains QueryAttribute objects with Substitute values
+6. `BindMap` scans bound_attributes for Substitute-valued entries and records their positions
+7. On `execute(values)`, `BindMap.bind(values)` calls `QueryAttribute#with_cast_value(value)` to replace Substitutes with real values
+
+## Implementation Plan
+
+### PR 1: PredicateBuilder Substitute Handler
+
+**Files:**
+
+- `packages/activerecord/src/relation/predicate-builder.ts`
+  - Add a handler registration for `Substitute` class
+  - When a Substitute value is encountered in `build()`, wrap in `BindParam(Substitute)` instead of routing through `BasicObjectHandler` → `Casted`
+  - This produces `Equality(attr, BindParam(Substitute))` in the Arel tree
+
+- `packages/arel/src/attributes/attribute.ts`
+  - `buildCasted` already passes through `Node` instances — `BindParam` extends `Node`, so if the PredicateBuilder creates a `BindParam` before calling `eq()`, it'll pass through correctly
+
+**Tests:** `Model.where({name: new Substitute()})` → verify Arel tree contains `BindParam(Substitute)`, not `Casted(Substitute, attr)`
+
+### PR 2: Relation boundAttributes Tracking
+
+**Files:**
+
+- `packages/activerecord/src/relation.ts`
+  - Add `_boundAttributes: unknown[]` array
+  - During `where()` clause construction, collect `QueryAttribute` instances (or raw bind objects) into `_boundAttributes`
+  - Expose via `get boundAttributes(): unknown[]`
+
+- `packages/activerecord/src/relation/query-attribute.ts`
+  - Already exists with `valueForDatabase()` and memoized casting
+  - Verify `withCastValue(value)` works for BindMap rebinding
+
+**Tests:** `Model.where({name: "foo"})` → `relation.boundAttributes` contains a QueryAttribute with value "foo"
+
+### PR 3: Wire StatementCache.create Through Relation
+
+**Files:**
+
+- `packages/activerecord/src/statement-cache.ts`
+  - `create()` calls `callable(new Params())` which returns a relation
+  - Extract `relation.boundAttributes` for `BindMap` construction instead of relying on `cacheableQuery` binds
+  - `BindMap` scans boundAttributes for Substitute-valued QueryAttributes
+
+- `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`
+  - `cacheableQuery()` should compile the Arel tree with `compileWithBinds` and return the bound attributes alongside the query builder
+
+**Tests:** Full round-trip: `StatementCache.create(conn, (p) => Book.where({name: p.bind()}))` → `cache.execute(["Rails Guide"], conn)` → returns correct records
+
+## Dependencies
+
+- PR 1 depends on nothing (can start now)
+- PR 2 depends on PR 1 (Substitute must produce BindParam for boundAttributes to be meaningful)
+- PR 3 depends on PR 2
+
+## Verification
+
+After all 3 PRs:
+
+- `StatementCache.create(connection, (params) => Model.where({name: params.bind()}))` works
+- The Arel tree has `BindParam(Substitute)` nodes, not `Casted(Substitute)`
+- `relation.boundAttributes` tracks QueryAttribute objects
+- `BindMap` finds Substitute positions and rebinds with real values on execute
+- Existing tests continue to pass


### PR DESCRIPTION
## Summary

Two follow-up epic plans from the prepared statements work:

1. **`relation-bound-attributes.md`** (3 PRs) — Wire `Substitute → BindParam` through PredicateBuilder, add `boundAttributes` tracking to Relation, complete `StatementCache.create` with `where({name: params.bind()})` flow

2. **`cacheable-query-partial-collector.md`** (3 PRs) — Compile Arel through `PartialQueryCollector` so `cacheableQuery` produces `PartialQuery` with real Substitute slots instead of wrapping raw SQL strings

Together these complete the StatementCache pipeline to match Rails' full prepared/unprepared statement caching behavior.