### PR TITLE
feat(activerecord): per-client PG StatementPool with named prepared statements

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -36,13 +36,47 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.execute("SELECT $1::int", [1]);
         const pool = adapter._statementPoolForTest()!;
-        // Force eviction by shrinking the pool. Rails uses
-        // statement_limit = 1 in the matching test.
-        (pool as unknown as { _maxSize: number })._maxSize = 1;
+        // Rails' matching test sets statement_limit = 1 and asserts
+        // LRU eviction. setMaxSize immediately evicts excess entries.
+        pool.setMaxSize(1);
         await adapter.execute("SELECT $1::text", ["a"]);
         expect(pool.length).toBe(1);
       } finally {
         await adapter.rollback();
+      }
+    });
+
+    it("statementLimit config resizes the active pool", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [1]);
+        await adapter.execute("SELECT $1::text", ["a"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(2);
+        adapter.statementLimit = 1;
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("executeMutation caches the plan for INSERT (reuses on repeat)", async () => {
+      await adapter.exec(
+        `CREATE TABLE IF NOT EXISTS "sp_exec_mut" ("id" SERIAL PRIMARY KEY, "name" TEXT)`,
+      );
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.executeMutation(`INSERT INTO "sp_exec_mut" ("name") VALUES ($1)`, ["a"]);
+        await adapter.executeMutation(`INSERT INTO "sp_exec_mut" ("name") VALUES ($1)`, ["b"]);
+        const pool = adapter._statementPoolForTest()!;
+        // Both INSERTs share the same SQL template → single cached
+        // plan. Rails exec_cache backs exec_insert the same way.
+        // The statement key is the RETURNING-rewritten form, so only
+        // one entry — the two mutations reused the plan.
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+        await adapter.exec(`DROP TABLE IF EXISTS "sp_exec_mut"`);
       }
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -1,23 +1,93 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    adapter.preparedStatements = true;
   });
   afterEach(async () => {
     await adapter.close();
   });
 
   describe("StatementPoolTest", () => {
-    it.skip("statement pool", async () => {});
-    it.skip("statement pool max", async () => {});
-    it.skip("statement pool clear", async () => {});
-    it.skip("dealloc does not raise on inactive connection", async () => {});
-    it.skip("prepared statements do not get stuck on query interruption", async () => {});
+    it("statement pool", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [1]);
+        await adapter.execute("SELECT $1::int", [2]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool).toBeDefined();
+        expect(pool.length).toBe(1);
+
+        await adapter.execute("SELECT $1::text", ["a"]);
+        expect(pool.length).toBe(2);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("statement pool max", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [1]);
+        const pool = adapter._statementPoolForTest()!;
+        // Force eviction by shrinking the pool. Rails uses
+        // statement_limit = 1 in the matching test.
+        (pool as unknown as { _maxSize: number })._maxSize = 1;
+        await adapter.execute("SELECT $1::text", ["a"]);
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("statement pool clear", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [1]);
+        await adapter.execute("SELECT $1::text", ["a"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(2);
+        pool.clear();
+        expect(pool.length).toBe(0);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("dealloc does not raise on inactive connection", async () => {
+      await adapter.beginDbTransaction();
+      await adapter.execute("SELECT $1::int", [1]);
+      const pool = adapter._statementPoolForTest()!;
+      await adapter.rollback();
+      // Client has been released; DEALLOCATE against a detached pool
+      // must be a no-op rather than an unhandled rejection.
+      expect(() => pool.clear()).not.toThrow();
+    });
+
+    it("prepared statements do not get stuck on query interruption", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        // Simulate an interruption: a prepared statement that errors
+        // (division by zero) must not poison the pool — a subsequent
+        // query on the same text must succeed by re-preparing.
+        await expect(adapter.execute("SELECT 1 / $1::int", [0])).rejects.toThrow();
+        const pool = adapter._statementPoolForTest()!;
+        // The entry still exists in the pool after the error — that's
+        // fine; the server kept the prepared plan. Running the same
+        // statement shape with a valid value succeeds on reuse.
+        const before = pool.length;
+        const rows = await adapter.execute("SELECT 1 / $1::int", [1]);
+        expect(rows[0]).toBeDefined();
+        expect(pool.length).toBeGreaterThanOrEqual(before);
+      } finally {
+        await adapter.rollback();
+      }
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -99,8 +99,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.execute("SELECT $1::int", [1]);
       const pool = adapter._statementPoolForTest()!;
       await adapter.rollback();
-      // Client has been released; DEALLOCATE against a detached pool
-      // must be a no-op rather than an unhandled rejection.
+      await adapter.close();
+      // After close the driver pool has ended the client, so DEALLOCATE
+      // can't route anywhere. The fire-and-forget catch in dealloc()
+      // must swallow the failure rather than surface an unhandled
+      // rejection. Mirrors Rails' PG::StatementPool#dealloc which
+      // rescues PG::InvalidSqlStatementName and connection errors.
       expect(() => pool.clear()).not.toThrow();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -71,23 +71,33 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("prepared statements do not get stuck on query interruption", async () => {
-      await adapter.beginDbTransaction();
-      try {
-        // Simulate an interruption: a prepared statement that errors
-        // (division by zero) must not poison the pool — a subsequent
-        // query on the same text must succeed by re-preparing.
-        await expect(adapter.execute("SELECT 1 / $1::int", [0])).rejects.toThrow();
-        const pool = adapter._statementPoolForTest()!;
-        // The entry still exists in the pool after the error — that's
-        // fine; the server kept the prepared plan. Running the same
-        // statement shape with a valid value succeeds on reuse.
-        const before = pool.length;
-        const rows = await adapter.execute("SELECT 1 / $1::int", [1]);
-        expect(rows[0]).toBeDefined();
-        expect(pool.length).toBeGreaterThanOrEqual(before);
-      } finally {
-        await adapter.rollback();
-      }
+      // Rails' equivalent stubs `get_last_result` to raise after PREPARE,
+      // simulating a lost ack while the server has the statement. pg-js
+      // doesn't expose that hook, so we test the closest observable
+      // property: an execute-time error (outside a transaction, so the
+      // session is still usable) must not prevent a later query from
+      // reusing the prepared plan. Mirrors the spirit of
+      // `test_prepared_statements_do_not_get_stuck_on_query_interruption`
+      // in activerecord/test/cases/adapters/postgresql/statement_pool_test.rb.
+      await expect(adapter.execute("SELECT 1 / $1::int", [0])).rejects.toThrow();
+      // The adapter still serves queries with the same SQL shape after
+      // the error — no pool poisoning, no duplicate-prepared-statement
+      // error on reuse.
+      const rows = await adapter.execute("SELECT 1 / $1::int", [1]);
+      expect(rows[0]).toBeDefined();
+    });
+
+    it("PreparedStatementCacheExpired is exported for txn-retry callers", async () => {
+      // In-txn `exec_cache` can't transparently retry a cached-plan
+      // failure — any error aborts the enclosing txn, so subsequent
+      // commands raise 25P02 InFailedSqlTransaction. Rails raises
+      // `PreparedStatementCacheExpired` for the transaction machinery
+      // to catch and retry the whole txn. Triggering a real 0A000
+      // requires DDL on a referenced object between two queries in
+      // the same txn (covered by txn retry suite); here we just
+      // verify the error class round-trips.
+      const { PreparedStatementCacheExpired } = await import("../../errors.js");
+      expect(new PreparedStatementCacheExpired("test").name).toBe("PreparedStatementCacheExpired");
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -22,6 +22,7 @@ import {
 } from "./postgresql/type-map-init.js";
 import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
+import { PreparedStatementCacheExpired } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
@@ -243,6 +244,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             } catch (e) {
               if (prepare && this._isInvalidCachedPlan(e)) {
                 this._poolFor(client).delete(rewritten);
+                if (this._inTransaction) {
+                  // Rails raises inside a txn because the server has
+                  // aborted it — a retry can only fail with
+                  // InFailedSqlTransaction (25P02). The transaction
+                  // machinery catches this and retries the whole txn.
+                  throw new PreparedStatementCacheExpired(
+                    (e as { message?: string })?.message ?? "cached plan expired",
+                    { cause: e },
+                  );
+                }
                 return await run();
               }
               throw e;
@@ -455,18 +466,32 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * True if a pg driver error indicates the server forgot the
-   * prepared plan (cache invalidation after DDL, backup/restore,
-   * pgbouncer losing the session). Rails retries once in these
-   * cases after purging the pool entry.
+   * True if a pg driver error indicates the cached plan has been
+   * invalidated by DDL on a referenced object (typical: `ALTER TABLE`,
+   * `DROP COLUMN`, schema change). PG emits SQLSTATE `0A000`
+   * FEATURE_NOT_SUPPORTED with the server message "cached plan must
+   * not change result type" — Rails checks the source function
+   * `RevalidateCachedQuery`, which the node-pg driver does not expose,
+   * so we fall back to the message substring.
    *
-   * - `26000` INVALID_SQL_STATEMENT_NAME: the server doesn't know the name
-   * - `0A000` FEATURE_NOT_SUPPORTED: emitted as "cached plan must not
-   *   change result type" after DDL on referenced objects
+   * `26000` (invalid_sql_statement_name) is intentionally NOT included
+   * here: pg-js's own client-side name cache handles the session-lost
+   * case on its own, and retrying behind the driver's back masks
+   * genuine "this name never existed" bugs. Rails' equivalent path
+   * (`exec_cache`) also only retries on cached-plan failure — not on
+   * unknown-statement-name — so this matches the activerecord
+   * contract.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#is_cached_plan_failure?
+   * (postgresql_adapter.rb:901-906).
    */
   private _isInvalidCachedPlan(e: unknown): boolean {
-    const code = (e as { code?: string } | null)?.code;
-    return code === "26000" || code === "0A000";
+    const err = e as { code?: string; message?: string } | null;
+    if (err?.code !== "0A000") return false;
+    // "cached plan must not change result type" is the only
+    // 0A000 subtype we retry on — other FEATURE_NOT_SUPPORTED
+    // errors (e.g. RETURNING on a view) must surface unchanged.
+    return typeof err.message === "string" && err.message.includes("cached plan");
   }
 
   /**
@@ -509,11 +534,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             result = await run();
           } catch (e) {
             if (prepare && this._isInvalidCachedPlan(e)) {
-              // Purge the stale entry and retry once. Rails does the
-              // same in `PostgreSQLAdapter#exec_cache` — the server
-              // forgot the plan (DDL on referenced table, etc.), so
-              // we must let pg re-issue the PREPARE with a fresh name.
+              // Purge the stale entry. Rails' `exec_cache` retries here
+              // when not in a transaction; inside one the retry is
+              // guaranteed to fail with InFailedSqlTransaction (25P02)
+              // since any error aborts the enclosing txn, so we raise
+              // PreparedStatementCacheExpired for the txn machinery to
+              // catch and retry the whole transaction.
               this._poolFor(client).delete(rewritten);
+              if (this._inTransaction) {
+                throw new PreparedStatementCacheExpired(
+                  (e as { message?: string })?.message ?? "cached plan expired",
+                  { cause: e },
+                );
+              }
               result = await run();
             } else {
               throw e;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -91,19 +91,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   set statementLimit(value: number) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new RangeError(
+        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
+      );
+    }
     this._statementLimit = value;
     // Resize the active transaction client's pool immediately so a
-    // mid-session change is visible. Drop references to any other
-    // cached pools so the next `_poolFor` call constructs a fresh
-    // one with the new limit — we can't iterate a WeakMap to resize
-    // them in place, and old entries become unreachable once pg
-    // releases the client anyway.
-    const activeClient = this._client;
-    const activePool = activeClient ? this._statementPools.get(activeClient) : undefined;
-    activePool?.setMaxSize(value);
-    this._statementPools = new WeakMap<pg.PoolClient, StatementPool>();
-    if (activeClient && activePool) {
-      this._statementPools.set(activeClient, activePool);
+    // mid-session change is visible. Non-active pools are synced
+    // lazily in `_poolFor` on next acquisition — we can't iterate a
+    // WeakMap, and dropping entries would orphan their counter /
+    // sql→name mapping while server-side PREPAREd statements still
+    // exist on the reusable pg.PoolClient, risking name collisions.
+    if (this._client) {
+      this._statementPools.get(this._client)?.setMaxSize(value);
     }
   }
 
@@ -440,6 +441,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!pool) {
       pool = new StatementPool(client, this._statementLimit);
       this._statementPools.set(client, pool);
+    } else if (pool.maxSize !== this._statementLimit) {
+      // Lazy sync for a pool that existed before `statementLimit`
+      // changed. Resizing here (instead of clearing the WeakMap on
+      // limit change) preserves the counter and sql→name mapping,
+      // which must stay in step with the still-PREPAREd statements
+      // on the reused pg.PoolClient.
+      pool.setMaxSize(this._statementLimit);
     }
     return pool;
   }
@@ -497,7 +505,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         if (this._inTransaction) {
           throw new PreparedStatementCacheExpired(
             (e as { message?: string })?.message ?? "cached plan expired",
-            { cause: e },
+            { sql, binds, cause: e },
           );
         }
         return await attempt();
@@ -713,7 +721,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async commit(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
-    this._releaseStatementPool(this._client);
+    // Keep the per-client StatementPool attached through the pg.Pool
+    // checkin/checkout cycle. PG prepared statements are session-
+    // scoped, not transaction-scoped (COMMIT/ROLLBACK don't drop
+    // them), so detaching here and rebuilding on next checkout would
+    // reset the counter → `a1` collides with the still-prepared `a1`
+    // on the server. Matches Rails, which only clears its
+    // StatementPool on disconnect, not on commit.
     this._client.release();
     this._client = null;
     this._inTransaction = false;
@@ -729,7 +743,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async rollback(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("ROLLBACK");
-    this._releaseStatementPool(this._client);
+    // See commit() — ROLLBACK doesn't drop server-side prepared
+    // statements, so we keep the pool attached to the pg.PoolClient
+    // for the duration of the connection's life.
     this._client.release();
     this._client = null;
     this._inTransaction = false;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -72,11 +72,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
   // Per-pg.Client statement pool. PG's prepared statements are
-  // session-scoped, so each physical client gets its own pool and
-  // its own counter space. The WeakMap lets pg.Pool reap clients
-  // without us leaking entries.
+  // session-scoped, so each physical client gets its own pool with
+  // its own counter (matching Rails' `PostgreSQL::StatementPool`).
+  // The WeakMap lets pg.Pool reap clients without us leaking entries.
   private _statementPools = new WeakMap<pg.PoolClient, StatementPool>();
-  private _stmtCounter = 0;
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
   private _statementLimit = 1000;
@@ -93,12 +92,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   set statementLimit(value: number) {
     this._statementLimit = value;
-    // Resize the active transaction client's pool immediately. Pools
-    // attached to non-held clients pick up the new limit on next
-    // acquisition via `_poolFor` (they get detached on close /
-    // commit / rollback anyway).
-    if (this._client) {
-      this._statementPools.get(this._client)?.setMaxSize(value);
+    // Resize the active transaction client's pool immediately so a
+    // mid-session change is visible. Drop references to any other
+    // cached pools so the next `_poolFor` call constructs a fresh
+    // one with the new limit — we can't iterate a WeakMap to resize
+    // them in place, and old entries become unreachable once pg
+    // releases the client anyway.
+    const activeClient = this._client;
+    const activePool = activeClient ? this._statementPools.get(activeClient) : undefined;
+    activePool?.setMaxSize(value);
+    this._statementPools = new WeakMap<pg.PoolClient, StatementPool>();
+    if (activeClient && activePool) {
+      this._statementPools.set(activeClient, activePool);
     }
   }
 
@@ -252,37 +257,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       payload,
       async () => {
         try {
-          const r = await this.withClient(async (client) => {
+          const r = await this.withClient(async (client) =>
             // rowMode: "array" returns rows as positional arrays, preserving
             // duplicate column names and matching the field-index order.
-            const prepare = this._shouldPrepare(bindArray);
-            const run = async (): Promise<ArrayQueryResult> =>
-              (await client.query({
-                ...(prepare ? { name: this._preparedNameFor(client, rewritten) } : {}),
-                text: rewritten,
-                values: bindArray,
-                rowMode: "array",
-              })) as unknown as ArrayQueryResult;
-            try {
-              return await run();
-            } catch (e) {
-              if (prepare && this._isInvalidCachedPlan(e)) {
-                this._poolFor(client).delete(rewritten);
-                if (this._inTransaction) {
-                  // Rails raises inside a txn because the server has
-                  // aborted it — a retry can only fail with
-                  // InFailedSqlTransaction (25P02). The transaction
-                  // machinery catches this and retries the whole txn.
-                  throw new PreparedStatementCacheExpired(
-                    (e as { message?: string })?.message ?? "cached plan expired",
-                    { cause: e },
-                  );
-                }
-                return await run();
-              }
-              throw e;
-            }
-          });
+            // Delegates to `_runQuery` so prepared-statement caching and
+            // in-txn / out-of-txn cached-plan handling stay in one place.
+            this._runQuery<ArrayQueryResult>(client, rewritten, bindArray, { rowMode: "array" }),
+          );
           payload.row_count = r.rows?.length ?? 0;
           return r;
         } catch (e: any) {
@@ -491,18 +472,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * from prepared-statement reuse — matches Rails where `exec_cache`
    * backs both exec_query and exec_delete / exec_update / exec_insert.
    */
-  private async _runQuery(
+  private async _runQuery<R = pg.QueryResult>(
     client: pg.PoolClient,
     sql: string,
     binds: unknown[],
-  ): Promise<pg.QueryResult> {
+    extra: { rowMode?: "array" } = {},
+  ): Promise<R> {
     const prepare = this._shouldPrepare(binds);
-    const attempt = async (): Promise<pg.QueryResult> => {
+    const attempt = async (): Promise<R> => {
       if (prepare) {
         const name = this._preparedNameFor(client, sql);
-        return client.query({ name, text: sql, values: binds });
+        return (await client.query({ name, text: sql, values: binds, ...extra })) as R;
       }
-      return client.query(sql, binds);
+      if (extra.rowMode) {
+        return (await client.query({ text: sql, values: binds, ...extra })) as R;
+      }
+      return (await client.query(sql, binds)) as R;
     };
     try {
       return await attempt();
@@ -522,16 +507,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Return the prepared-statement name for `sql` on `client`, issuing
-   * one from `_stmtCounter` on first use. Mirrors the cache behavior
-   * of Rails' `PostgreSQL::StatementPool#[]` / `#[]=` — present key
-   * → cached name, absent → allocate and store.
+   * Return the prepared-statement name for `sql` on `client`. Names
+   * are allocated from the per-pool counter (`StatementPool#nextKey`)
+   * so each session has its own `a1`, `a2`, ... sequence. Mirrors
+   * Rails' `PostgreSQL::StatementPool#[]` / `#[]=` — present key →
+   * cached name, absent → `next_key` + store.
    */
   private _preparedNameFor(client: pg.PoolClient, sql: string): string {
     const pool = this._poolFor(client);
     const existing = pool.get(sql);
     if (existing) return existing.name;
-    const name = `a${++this._stmtCounter}`;
+    const name = pool.nextKey();
     pool.set(sql, { name });
     return name;
   }
@@ -917,9 +903,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._client.release();
       this._client = null;
     }
-    // Detach any lingering pools so late errors don't fire
-    // DEALLOCATE against a pool.end()-ed client. The WeakMap drops
-    // entries once pg releases the client anyway.
+    // Drop adapter-held references to any remaining pools so late
+    // errors can't fire DEALLOCATE against a pool.end()-ed client.
+    // The pool objects become unreachable once pg releases the
+    // corresponding clients anyway — this is about breaking our
+    // own reference, not an explicit detach step per pool.
     this._statementPools = new WeakMap();
     if (this._driverPool) {
       await this._driverPool.end();
@@ -2178,10 +2166,23 @@ export interface PreparedStatement {
  */
 export class StatementPool extends GenericStatementPool<PreparedStatement> {
   private _client: pg.PoolClient | null;
+  // Per-pool counter. Rails' PG StatementPool uses `@counter` on the
+  // pool instance so names are scoped to the session — matches the
+  // session-scoped nature of PG prepared statements and lets the
+  // adapter own zero state about naming.
+  private _counter = 0;
 
   constructor(client: pg.PoolClient, maxSize = 1000) {
     super(maxSize);
     this._client = client;
+  }
+
+  /**
+   * Allocate a fresh prepared-statement name. Rails' equivalent is
+   * `next_key` on `PostgreSQL::StatementPool` — `"a#{@counter += 1}"`.
+   */
+  nextKey(): string {
+    return `a${++this._counter}`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -83,9 +83,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     this._statementLimit = value;
     // Resize the active transaction client's pool immediately so a
-    // mid-session change is visible. Non-active pools are synced
-    // lazily in `_poolFor` on next acquisition — we can't iterate a
-    // WeakMap, and dropping entries would orphan their counter /
+    // mid-session change is visible. Other per-client pools keep the
+    // size they were built with (Rails reads `statement_limit` once
+    // at pool construction). We can't iterate a WeakMap to retrofit
+    // them, and dropping entries would orphan their counter /
     // sql→name mapping while server-side PREPAREd statements still
     // exist on the reusable pg.PoolClient, risking name collisions.
     if (this._client) {
@@ -2214,17 +2215,19 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
   protected override dealloc(stmt: PreparedStatement): void {
     const client = this._client;
     if (!client) return;
-    // Fire-and-forget: eviction can't block the caller that triggered
-    // it (the pg write path), and the server will clean up the
-    // statement when the connection closes anyway. Errors are
-    // intentionally swallowed — Rails' PG::StatementPool#dealloc
-    // likewise rescues PG::InvalidSqlStatementName / connection
-    // errors — and the empty `.catch` also keeps node from treating
-    // a post-close DEALLOCATE as an unhandled rejection.
-    // Use the adapter's PG column-name quoter so any embedded `"` in a
-    // leaked caller-supplied name is escaped rather than raising
-    // synchronously inside `dealloc` — fire-and-forget eviction must
-    // never throw, or it escapes the `.catch(() => {})` below.
+    // Best-effort async cleanup: we don't await DEALLOCATE, but pg
+    // still queues it on this client and it runs before later queries
+    // on the same connection — eviction doesn't block the caller
+    // that triggered it (pg.write path) but it isn't free either.
+    // The server also drops prepared statements on session close, so
+    // a swallowed failure here is safe. Errors are intentionally
+    // ignored — Rails' PG::StatementPool#dealloc likewise rescues
+    // PG::InvalidSqlStatementName / connection errors — and the
+    // empty `.catch` keeps node from treating a post-close
+    // DEALLOCATE as an unhandled rejection.
+    // `pgQuoteColumnName` escapes any embedded `"` instead of
+    // raising, so a leaked caller-supplied name can't produce a
+    // synchronous throw that would escape the `.catch(() => {})`.
     client.query(`DEALLOCATE ${pgQuoteColumnName(stmt.name)}`).catch(() => {});
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -29,9 +29,10 @@ import { typeCastedBinds } from "./abstract/database-statements.js";
 
 /**
  * Quote a PG identifier for DEALLOCATE. The pool only ever stores
- * names it generated itself (`a<counter>`), so a regex check is
- * enough — reject anything that contains a double quote so a leaked
- * caller-supplied name can't escape the quoting.
+ * names it generated itself (`a<counter>`), so this helper just
+ * wraps the name in double quotes after defensively rejecting any
+ * embedded `"` — a leaked caller-supplied name can't escape the
+ * quoting that way.
  */
 function quoteIdentifier(name: string): string {
   if (name.includes('"')) {
@@ -2225,9 +2226,11 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
     if (!client) return;
     // Fire-and-forget: eviction can't block the caller that triggered
     // it (the pg write path), and the server will clean up the
-    // statement when the connection closes anyway. Errors are logged
-    // to a swallowed catch so node doesn't treat them as unhandled
-    // rejections.
+    // statement when the connection closes anyway. Errors are
+    // intentionally swallowed — Rails' PG::StatementPool#dealloc
+    // likewise rescues PG::InvalidSqlStatementName / connection
+    // errors — and the empty `.catch` also keeps node from treating
+    // a post-close DEALLOCATE as an unhandled rejection.
     client.query(`DEALLOCATE ${quoteIdentifier(stmt.name)}`).catch(() => {});
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -441,25 +441,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!pool) {
       pool = new StatementPool(client, this._statementLimit);
       this._statementPools.set(client, pool);
-    } else if (pool.maxSize !== this._statementLimit) {
-      // Lazy sync for a pool that existed before `statementLimit`
-      // changed. Resizing here (instead of clearing the WeakMap on
-      // limit change) preserves the counter and sql→name mapping,
-      // which must stay in step with the still-PREPAREd statements
-      // on the reused pg.PoolClient.
-      pool.setMaxSize(this._statementLimit);
     }
+    // Matches Rails: statement_limit is read at pool construction
+    // time. A mid-session change to `adapter.statementLimit` is
+    // applied to the currently-active pool by the setter; other
+    // per-client pools keep the limit they were built with. Syncing
+    // them here would stomp on direct setMaxSize calls from tests or
+    // callers that want a tighter bound than the adapter default.
     return pool;
   }
 
   /**
-   * Tear down the statement pool attached to `client`. Called on
-   * commit / rollback / close. Detaching stops late DEALLOCATE calls
-   * from racing with a released client, AND we drop the WeakMap entry
-   * so a later checkout that hands back the same pg.PoolClient wrapper
-   * gets a fresh pool. Without the delete, `_poolFor` would return the
-   * silently-detached pool and DEALLOCATE would become a no-op,
-   * leaking server-side prepared statements.
+   * Tear down the statement pool attached to `client`. Called from
+   * `close()` only — commit / rollback intentionally keep the pool
+   * attached because PG prepared statements are session-scoped, not
+   * transaction-scoped (see Rails' PG::StatementPool, which only
+   * clears on disconnect). Detaching here stops late DEALLOCATE
+   * calls from racing with a released client, AND we drop the
+   * WeakMap entry so a later checkout that hands back the same
+   * pg.PoolClient wrapper gets a fresh pool.
    */
   private _releaseStatementPool(client: pg.PoolClient): void {
     const pool = this._statementPools.get(client);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -77,6 +77,30 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // without us leaking entries.
   private _statementPools = new WeakMap<pg.PoolClient, StatementPool>();
   private _stmtCounter = 0;
+  // Rails' `statement_limit` database.yml key — max prepared
+  // statements cached per session before LRU eviction (default 1000).
+  private _statementLimit = 1000;
+
+  /**
+   * Maximum prepared statements cached per connection.
+   *
+   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
+   * `config[:statement_limit]` in PostgreSQLAdapter#initialize.
+   */
+  get statementLimit(): number {
+    return this._statementLimit;
+  }
+
+  set statementLimit(value: number) {
+    this._statementLimit = value;
+    // Resize the active transaction client's pool immediately. Pools
+    // attached to non-held clients pick up the new limit on next
+    // acquisition via `_poolFor` (they get detached on close /
+    // commit / rollback anyway).
+    if (this._client) {
+      this._statementPools.get(this._client)?.setMaxSize(value);
+    }
+  }
 
   constructor(config: string | pg.PoolConfig) {
     super();
@@ -433,10 +457,52 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _poolFor(client: pg.PoolClient): StatementPool {
     let pool = this._statementPools.get(client);
     if (!pool) {
-      pool = new StatementPool(client);
+      pool = new StatementPool(client, this._statementLimit);
       this._statementPools.set(client, pool);
     }
     return pool;
+  }
+
+  /**
+   * Run a query on `client`, routing through the statement pool when
+   * binds are present and `preparedStatements` is on. On Rails-parity
+   * "invalid cached plan" (SQLSTATE 0A000 + "cached plan" in the
+   * message), purges the pool entry and either re-runs once (outside
+   * a txn) or raises `PreparedStatementCacheExpired` (inside one, so
+   * the transaction machinery can retry the whole txn).
+   *
+   * Shared by execute/executeMutation so every bound path benefits
+   * from prepared-statement reuse — matches Rails where `exec_cache`
+   * backs both exec_query and exec_delete / exec_update / exec_insert.
+   */
+  private async _runQuery(
+    client: pg.PoolClient,
+    sql: string,
+    binds: unknown[],
+  ): Promise<pg.QueryResult> {
+    const prepare = this._shouldPrepare(binds);
+    const attempt = async (): Promise<pg.QueryResult> => {
+      if (prepare) {
+        const name = this._preparedNameFor(client, sql);
+        return client.query({ name, text: sql, values: binds });
+      }
+      return client.query(sql, binds);
+    };
+    try {
+      return await attempt();
+    } catch (e) {
+      if (prepare && this._isInvalidCachedPlan(e)) {
+        this._poolFor(client).delete(sql);
+        if (this._inTransaction) {
+          throw new PreparedStatementCacheExpired(
+            (e as { message?: string })?.message ?? "cached plan expired",
+            { cause: e },
+          );
+        }
+        return await attempt();
+      }
+      throw e;
+    }
   }
 
   /**
@@ -521,37 +587,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         return await this.withClient(async (client) => {
-          const prepare = this._shouldPrepare(binds);
-          const run = async (): Promise<pg.QueryResult> => {
-            if (prepare) {
-              const name = this._preparedNameFor(client, rewritten);
-              return client.query({ name, text: rewritten, values: binds });
-            }
-            return client.query(rewritten, binds);
-          };
-          let result: pg.QueryResult;
-          try {
-            result = await run();
-          } catch (e) {
-            if (prepare && this._isInvalidCachedPlan(e)) {
-              // Purge the stale entry. Rails' `exec_cache` retries here
-              // when not in a transaction; inside one the retry is
-              // guaranteed to fail with InFailedSqlTransaction (25P02)
-              // since any error aborts the enclosing txn, so we raise
-              // PreparedStatementCacheExpired for the txn machinery to
-              // catch and retry the whole transaction.
-              this._poolFor(client).delete(rewritten);
-              if (this._inTransaction) {
-                throw new PreparedStatementCacheExpired(
-                  (e as { message?: string })?.message ?? "cached plan expired",
-                  { cause: e },
-                );
-              }
-              result = await run();
-            } else {
-              throw e;
-            }
-          }
+          const result = await this._runQuery(client, rewritten, binds);
           payload.row_count = result.rows.length;
           return result.rows;
         });
@@ -604,7 +640,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             payload.sql = withReturning;
             try {
               if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
-              const result = await client.query(withReturning, binds);
+              const result = await this._runQuery(client, withReturning, binds);
               if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
               payload.row_count = result.rowCount ?? 0;
               if (result.rows.length > 1) {
@@ -621,7 +657,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
                 await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
               }
               payload.sql = pgSql;
-              const result = await client.query(pgSql, binds);
+              const result = await this._runQuery(client, pgSql, binds);
               payload.row_count = result.rowCount ?? 0;
               return result.rowCount ?? 0;
             }
@@ -629,7 +665,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
           // For INSERT with explicit RETURNING
           if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
-            const result = await client.query(pgSql, binds);
+            const result = await this._runQuery(client, pgSql, binds);
             payload.row_count = result.rowCount ?? 0;
             if (result.rows.length > 0) {
               const firstCol = Object.keys(result.rows[0])[0];
@@ -639,7 +675,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           }
 
           // For UPDATE/DELETE, return affected rows
-          const result = await client.query(pgSql, binds);
+          const result = await this._runQuery(client, pgSql, binds);
           payload.row_count = result.rowCount ?? 0;
           return result.rowCount ?? 0;
         });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -464,6 +464,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Tear down the statement pool attached to `client`. Called on
+   * commit / rollback / close. Detaching stops late DEALLOCATE calls
+   * from racing with a released client, AND we drop the WeakMap entry
+   * so a later checkout that hands back the same pg.PoolClient wrapper
+   * gets a fresh pool. Without the delete, `_poolFor` would return the
+   * silently-detached pool and DEALLOCATE would become a no-op,
+   * leaking server-side prepared statements.
+   */
+  private _releaseStatementPool(client: pg.PoolClient): void {
+    const pool = this._statementPools.get(client);
+    if (!pool) return;
+    pool.detach();
+    this._statementPools.delete(client);
+  }
+
+  /**
    * Run a query on `client`, routing through the statement pool when
    * binds are present and `preparedStatements` is on. On Rails-parity
    * "invalid cached plan" (SQLSTATE 0A000 + "cached plan" in the
@@ -711,8 +727,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async commit(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
-    const pool = this._statementPools.get(this._client);
-    if (pool) pool.detach();
+    this._releaseStatementPool(this._client);
     this._client.release();
     this._client = null;
     this._inTransaction = false;
@@ -728,8 +743,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async rollback(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("ROLLBACK");
-    const pool = this._statementPools.get(this._client);
-    if (pool) pool.detach();
+    this._releaseStatementPool(this._client);
     this._client.release();
     this._client = null;
     this._inTransaction = false;
@@ -899,8 +913,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._advisoryLockClient = null;
     }
     if (this._client) {
-      const pool = this._statementPools.get(this._client);
-      if (pool) pool.detach();
+      this._releaseStatementPool(this._client);
       this._client.release();
       this._client = null;
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -23,7 +23,23 @@ import {
 import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
+import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
+
+/**
+ * Quote a PG identifier for DEALLOCATE. The pool only ever stores
+ * names it generated itself (`a<counter>`), so a regex check is
+ * enough — reject anything that contains a double quote so a leaked
+ * caller-supplied name can't escape the quoting.
+ */
+function quoteIdentifier(name: string): string {
+  if (name.includes('"')) {
+    throw new Error(
+      `StatementPool: refusing to DEALLOCATE identifier with embedded quote: ${name}`,
+    );
+  }
+  return `"${name}"`;
+}
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -54,6 +70,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _inTransaction = false;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
+  // Per-pg.Client statement pool. PG's prepared statements are
+  // session-scoped, so each physical client gets its own pool and
+  // its own counter space. The WeakMap lets pg.Pool reap clients
+  // without us leaking entries.
+  private _statementPools = new WeakMap<pg.PoolClient, StatementPool>();
+  private _stmtCounter = 0;
 
   constructor(config: string | pg.PoolConfig) {
     super();
@@ -208,11 +230,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           const r = await this.withClient(async (client) => {
             // rowMode: "array" returns rows as positional arrays, preserving
             // duplicate column names and matching the field-index order.
-            return (await client.query({
-              text: rewritten,
-              values: bindArray,
-              rowMode: "array",
-            })) as unknown as ArrayQueryResult;
+            const prepare = this._shouldPrepare(bindArray);
+            const run = async (): Promise<ArrayQueryResult> =>
+              (await client.query({
+                ...(prepare ? { name: this._preparedNameFor(client, rewritten) } : {}),
+                text: rewritten,
+                values: bindArray,
+                rowMode: "array",
+              })) as unknown as ArrayQueryResult;
+            try {
+              return await run();
+            } catch (e) {
+              if (prepare && this._isInvalidCachedPlan(e)) {
+                this._poolFor(client).delete(rewritten);
+                return await run();
+              }
+              throw e;
+            }
           });
           payload.row_count = r.rows?.length ?? 0;
           return r;
@@ -380,6 +414,62 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Look up the statement pool for `client`, lazily creating it.
+   * Kept per-client because PG prepared statements are session-
+   * scoped — once the client is released back to pg.Pool and
+   * re-acquired, the server state may differ.
+   */
+  private _poolFor(client: pg.PoolClient): StatementPool {
+    let pool = this._statementPools.get(client);
+    if (!pool) {
+      pool = new StatementPool(client);
+      this._statementPools.set(client, pool);
+    }
+    return pool;
+  }
+
+  /**
+   * Return the prepared-statement name for `sql` on `client`, issuing
+   * one from `_stmtCounter` on first use. Mirrors the cache behavior
+   * of Rails' `PostgreSQL::StatementPool#[]` / `#[]=` — present key
+   * → cached name, absent → allocate and store.
+   */
+  private _preparedNameFor(client: pg.PoolClient, sql: string): string {
+    const pool = this._poolFor(client);
+    const existing = pool.get(sql);
+    if (existing) return existing.name;
+    const name = `a${++this._stmtCounter}`;
+    pool.set(sql, { name });
+    return name;
+  }
+
+  /**
+   * True when the adapter should try a named prepared statement for
+   * this call. Rails' gate: `prepared_statements && !binds.empty?`
+   * (there's no point naming an unparameterized statement — the
+   * parse cost is the same either way and the name never gets
+   * reused without binds).
+   */
+  private _shouldPrepare(binds: unknown[]): boolean {
+    return this.preparedStatements && binds.length > 0;
+  }
+
+  /**
+   * True if a pg driver error indicates the server forgot the
+   * prepared plan (cache invalidation after DDL, backup/restore,
+   * pgbouncer losing the session). Rails retries once in these
+   * cases after purging the pool entry.
+   *
+   * - `26000` INVALID_SQL_STATEMENT_NAME: the server doesn't know the name
+   * - `0A000` FEATURE_NOT_SUPPORTED: emitted as "cached plan must not
+   *   change result type" after DDL on referenced objects
+   */
+  private _isInvalidCachedPlan(e: unknown): boolean {
+    const code = (e as { code?: string } | null)?.code;
+    return code === "26000" || code === "0A000";
+  }
+
+  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /
@@ -406,7 +496,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         return await this.withClient(async (client) => {
-          const result = await client.query(rewritten, binds);
+          const prepare = this._shouldPrepare(binds);
+          const run = async (): Promise<pg.QueryResult> => {
+            if (prepare) {
+              const name = this._preparedNameFor(client, rewritten);
+              return client.query({ name, text: rewritten, values: binds });
+            }
+            return client.query(rewritten, binds);
+          };
+          let result: pg.QueryResult;
+          try {
+            result = await run();
+          } catch (e) {
+            if (prepare && this._isInvalidCachedPlan(e)) {
+              // Purge the stale entry and retry once. Rails does the
+              // same in `PostgreSQLAdapter#exec_cache` — the server
+              // forgot the plan (DDL on referenced table, etc.), so
+              // we must let pg re-issue the PREPARE with a fresh name.
+              this._poolFor(client).delete(rewritten);
+              result = await run();
+            } else {
+              throw e;
+            }
+          }
           payload.row_count = result.rows.length;
           return result.rows;
         });
@@ -530,6 +642,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async commit(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("COMMIT");
+    const pool = this._statementPools.get(this._client);
+    if (pool) pool.detach();
     this._client.release();
     this._client = null;
     this._inTransaction = false;
@@ -545,6 +659,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async rollback(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
     await this._client.query("ROLLBACK");
+    const pool = this._statementPools.get(this._client);
+    if (pool) pool.detach();
     this._client.release();
     this._client = null;
     this._inTransaction = false;
@@ -714,13 +830,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._advisoryLockClient = null;
     }
     if (this._client) {
+      const pool = this._statementPools.get(this._client);
+      if (pool) pool.detach();
       this._client.release();
       this._client = null;
     }
+    // Detach any lingering pools so late errors don't fire
+    // DEALLOCATE against a pool.end()-ed client. The WeakMap drops
+    // entries once pg releases the client anyway.
+    this._statementPools = new WeakMap();
     if (this._driverPool) {
       await this._driverPool.end();
       this._driverPool = null;
     }
+  }
+
+  /**
+   * Test-only accessor for the statement pool attached to the
+   * currently-held transaction client. Returns undefined outside a
+   * transaction, because without a held client every adapter call
+   * grabs a fresh pool. Mirrors Rails' `raw_connection
+   * .instance_variable_get(:@statement_pool)` escape hatch used by
+   * `PostgreSQL::StatementPoolTest`.
+   *
+   * @internal
+   */
+  _statementPoolForTest(): StatementPool | undefined {
+    return this._client ? this._statementPools.get(this._client) : undefined;
   }
 
   /**
@@ -1939,7 +2075,61 @@ class SimpleTableBuilder {
   }
 }
 
-export { StatementPool } from "./statement-pool.js";
+/**
+ * A prepared-statement entry tracked in the per-client pool. `name` is
+ * the server-side name passed to `client.query({ name, text, values })`;
+ * pg auto-PREPAREs on first use with that name and EXECUTEs on reuse.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::StatementPool entry shape.
+ */
+export interface PreparedStatement {
+  name: string;
+}
+
+/**
+ * PG-flavored StatementPool. Backs the per-client statement cache;
+ * `dealloc` sends `DEALLOCATE` for the evicted name. PG prepared
+ * statements are session-scoped, so an instance of this pool is
+ * attached per-pg.PoolClient via a WeakMap on the adapter.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::StatementPool
+ */
+export class StatementPool extends GenericStatementPool<PreparedStatement> {
+  private _client: pg.PoolClient | null;
+
+  constructor(client: pg.PoolClient, maxSize = 1000) {
+    super(maxSize);
+    this._client = client;
+  }
+
+  /**
+   * Called when an entry is evicted (LRU overflow or explicit delete).
+   * Rails swallows PG::InvalidSqlStatementName ("prepared statement
+   * does not exist") and errors against a closed connection — the
+   * statement is already gone on the server either way. Node-pg
+   * surfaces the same as error codes / messages.
+   */
+  protected override dealloc(stmt: PreparedStatement): void {
+    const client = this._client;
+    if (!client) return;
+    // Fire-and-forget: eviction can't block the caller that triggered
+    // it (the pg write path), and the server will clean up the
+    // statement when the connection closes anyway. Errors are logged
+    // to a swallowed catch so node doesn't treat them as unhandled
+    // rejections.
+    client.query(`DEALLOCATE ${quoteIdentifier(stmt.name)}`).catch(() => {});
+  }
+
+  /**
+   * Mark the pool detached from its client (e.g. on connection release
+   * or close). Prevents late DEALLOCATE calls from racing with a
+   * client that's already back in the pg.Pool — the server will
+   * discard statements on session end anyway.
+   */
+  detach(): void {
+    this._client = null;
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::MoneyDecoder

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -538,7 +538,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * reused without binds).
    */
   private _shouldPrepare(binds: unknown[]): boolean {
-    return this.preparedStatements && binds.length > 0;
+    // `statementLimit = 0` disables caching (matches Rails: when the
+    // limit is 0, `PostgreSQL::StatementPool#set` is a no-op so
+    // allocating a name would leak unbounded server-side PREPAREs).
+    // Fall through to anonymous parameterized queries in that case.
+    return this.preparedStatements && binds.length > 0 && this._statementLimit > 0;
   }
 
   /**
@@ -661,7 +665,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
                 return Number(result.rows[0][firstCol]);
               }
               return result.rowCount ?? 0;
-            } catch {
+            } catch (err) {
+              // Cached-plan failures must propagate to the
+              // transaction-retry machinery (Rails raises
+              // PreparedStatementCacheExpired for exactly this
+              // reason — retrying inside an aborted txn would fail
+              // with 25P02). Everything else falls through to the
+              // "retry without RETURNING" path this catch was
+              // originally written for.
+              if (err instanceof PreparedStatementCacheExpired) throw err;
               if (useSavepoint) {
                 await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
                 await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
@@ -924,7 +936,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // The pool objects become unreachable once pg releases the
     // corresponding clients anyway — this is about breaking our
     // own reference, not an explicit detach step per pool.
-    this._statementPools = new WeakMap();
+    this._statementPools = new WeakMap<pg.PoolClient, StatementPool>();
     if (this._driverPool) {
       await this._driverPool.end();
       this._driverPool = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -28,22 +28,6 @@ import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 
 /**
- * Quote a PG identifier for DEALLOCATE. The pool only ever stores
- * names it generated itself (`a<counter>`), so this helper just
- * wraps the name in double quotes after defensively rejecting any
- * embedded `"` — a leaked caller-supplied name can't escape the
- * quoting that way.
- */
-function quoteIdentifier(name: string): string {
-  if (name.includes('"')) {
-    throw new Error(
-      `StatementPool: refusing to DEALLOCATE identifier with embedded quote: ${name}`,
-    );
-  }
-  return `"${name}"`;
-}
-
-/**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
@@ -2237,7 +2221,11 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
     // likewise rescues PG::InvalidSqlStatementName / connection
     // errors — and the empty `.catch` also keeps node from treating
     // a post-close DEALLOCATE as an unhandled rejection.
-    client.query(`DEALLOCATE ${quoteIdentifier(stmt.name)}`).catch(() => {});
+    // Use the adapter's PG column-name quoter so any embedded `"` in a
+    // leaked caller-supplied name is escaped rather than raising
+    // synchronously inside `dealloc` — fire-and-forget eviction must
+    // never throw, or it escapes the `.catch(() => {})` below.
+    client.query(`DEALLOCATE ${pgQuoteColumnName(stmt.name)}`).catch(() => {});
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -487,7 +487,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     binds: unknown[],
     extra: { rowMode?: "array" } = {},
   ): Promise<R> {
-    const prepare = this._shouldPrepare(binds);
+    const prepare = this._shouldPrepare(binds, client);
     const attempt = async (): Promise<R> => {
       if (prepare) {
         const name = this._preparedNameFor(client, sql);
@@ -538,12 +538,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * parse cost is the same either way and the name never gets
    * reused without binds).
    */
-  private _shouldPrepare(binds: unknown[]): boolean {
-    // `statementLimit = 0` disables caching (matches Rails: when the
-    // limit is 0, `PostgreSQL::StatementPool#set` is a no-op so
-    // allocating a name would leak unbounded server-side PREPAREs).
-    // Fall through to anonymous parameterized queries in that case.
-    return this.preparedStatements && binds.length > 0 && this._statementLimit > 0;
+  private _shouldPrepare(binds: unknown[], client?: pg.PoolClient): boolean {
+    if (!this.preparedStatements || binds.length === 0) return false;
+    // Gate on the actual pool's maxSize (or the adapter default if
+    // no pool exists yet). A direct `pool.setMaxSize(0)` — by a test
+    // or an operator shrinking one specific session — must reliably
+    // disable preparation for that client, because `StatementPool#set`
+    // is a no-op at maxSize=0 and we'd otherwise keep allocating a
+    // fresh `a<n>` name per execution and leak server-side PREPAREs.
+    const poolLimit = client
+      ? (this._statementPools.get(client)?.maxSize ?? this._statementLimit)
+      : this._statementLimit;
+    return poolLimit > 0;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -130,4 +130,51 @@ describe("SQLite3 StatementPool integration", () => {
       adapter.disconnectBang();
     }
   });
+
+  it("setMaxSize shrinks and evicts LRU entries through dealloc", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool(5);
+    pool.set("a", "stmt_a");
+    pool.set("b", "stmt_b");
+    pool.set("c", "stmt_c");
+    // Touch "a" so it's moved to MRU — LRU order becomes b, c, a.
+    pool.get("a");
+    pool.setMaxSize(1);
+    expect(pool.length).toBe(1);
+    expect(pool.has("a")).toBe(true);
+    expect(dealloced).toEqual(["stmt_b", "stmt_c"]);
+  });
+
+  it("setMaxSize(0) evicts everything and blocks new inserts", () => {
+    const dealloced: string[] = [];
+    class TestPool extends StatementPool<string> {
+      protected dealloc(stmt: string): void {
+        dealloced.push(stmt);
+      }
+    }
+    const pool = new TestPool(5);
+    pool.set("a", "stmt_a");
+    pool.set("b", "stmt_b");
+    pool.setMaxSize(0);
+    expect(pool.length).toBe(0);
+    expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
+    // set() is a no-op when maxSize is 0 — matches Rails' behavior
+    // where statement_limit = 0 disables caching.
+    pool.set("c", "stmt_c");
+    expect(pool.length).toBe(0);
+  });
+
+  it("setMaxSize rejects negative / non-integer values", () => {
+    const pool = new StatementPool<string>(5);
+    expect(() => pool.setMaxSize(-1)).toThrow(RangeError);
+    expect(() => pool.setMaxSize(1.5)).toThrow(RangeError);
+    expect(() => pool.setMaxSize(NaN)).toThrow(RangeError);
+    expect(() => pool.setMaxSize(Infinity)).toThrow(RangeError);
+    expect(pool.maxSize).toBe(5);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -16,6 +16,22 @@ export class StatementPool<T = unknown> {
     return this._statements.size;
   }
 
+  /**
+   * Shrink (or grow) the LRU bound. Shrinking evicts the
+   * least-recently-used statements via `dealloc` — matches Rails'
+   * behavior when `statement_limit` is changed mid-session.
+   */
+  setMaxSize(maxSize: number): void {
+    this._maxSize = maxSize;
+    while (this._statements.size > this._maxSize) {
+      const firstKey = this._statements.keys().next().value;
+      if (firstKey === undefined) break;
+      const evicted = this._statements.get(firstKey)!;
+      this._statements.delete(firstKey);
+      this.dealloc(evicted);
+    }
+  }
+
   get(key: string): T | undefined {
     if (!this._statements.has(key)) return undefined;
     const stmt = this._statements.get(key) as T;

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -16,6 +16,10 @@ export class StatementPool<T = unknown> {
     return this._statements.size;
   }
 
+  get maxSize(): number {
+    return this._maxSize;
+  }
+
   /**
    * Shrink (or grow) the LRU bound. Shrinking evicts the
    * least-recently-used statements via `dealloc` — matches Rails'

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -26,6 +26,11 @@ export class StatementPool<T = unknown> {
    * behavior when `statement_limit` is changed mid-session.
    */
   setMaxSize(maxSize: number): void {
+    if (!Number.isInteger(maxSize) || maxSize < 0) {
+      throw new RangeError(
+        `StatementPool#setMaxSize expected a finite non-negative integer; got ${String(maxSize)}`,
+      );
+    }
     this._maxSize = maxSize;
     while (this._statements.size > this._maxSize) {
       const firstKey = this._statements.keys().next().value;

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -265,11 +265,19 @@ export class PreparedStatementInvalid extends ActiveRecordError {
  * transaction machinery) can catch this and retry the whole
  * transaction.
  *
+ * Extends `StatementInvalid` so handlers that rescue generic statement
+ * failures catch this too — matching Rails' class hierarchy
+ * (`activerecord/lib/active_record/errors.rb:362`,
+ * `PreparedStatementCacheExpired < StatementInvalid`).
+ *
  * Mirrors: ActiveRecord::PreparedStatementCacheExpired
- * (activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:147).
+ * (raised from postgresql/database_statements.rb:147).
  */
-export class PreparedStatementCacheExpired extends ActiveRecordError {
-  constructor(message?: string, options?: ErrorOptions) {
+export class PreparedStatementCacheExpired extends StatementInvalid {
+  constructor(
+    message?: string,
+    options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
+  ) {
     super(message, options);
     this.name = "PreparedStatementCacheExpired";
   }

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -257,6 +257,24 @@ export class PreparedStatementInvalid extends ActiveRecordError {
   }
 }
 
+/**
+ * Raised when the server tells us a cached prepared plan is no longer
+ * valid (usually after DDL on a referenced object) AND we're inside a
+ * transaction so we can't transparently retry — subsequent commands
+ * would raise InFailedSqlTransaction. Callers (typically the
+ * transaction machinery) can catch this and retry the whole
+ * transaction.
+ *
+ * Mirrors: ActiveRecord::PreparedStatementCacheExpired
+ * (activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:147).
+ */
+export class PreparedStatementCacheExpired extends ActiveRecordError {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PreparedStatementCacheExpired";
+  }
+}
+
 export class NoDatabaseError extends StatementInvalid {
   constructor(
     message?: string,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -196,6 +196,7 @@ export {
   DatabaseConnectionError,
   ValueTooLong,
   PreparedStatementInvalid,
+  PreparedStatementCacheExpired,
   NoDatabaseError,
   DatabaseAlreadyExists,
   AttributeAssignmentError,


### PR DESCRIPTION
## Summary

PR 1 of the StatementPool plan. PostgreSQL previously re-exported the generic `StatementPool` without wiring — bound queries went out as anonymous parameterized statements, so prepared-statement reuse was impossible. This PR adds a real PG-flavored pool.

- New `PostgreSQL::StatementPool` subclass with a `DEALLOCATE`-emitting `dealloc` hook (fire-and-forget). Per-pool `nextKey()` counter (Rails' `@counter += 1` on the pool instance), so names are session-scoped and stay in step with server-side PREPAREd statements.
- Per-pg.PoolClient pool via a `WeakMap` on the adapter. PG prepared statements are session-scoped; the pool stays attached for the physical lifetime of the `pg.PoolClient`. `commit()` / `rollback()` release the client back to `pg.Pool` but do **not** detach the pool — matching Rails, where `PG::StatementPool` is only cleared on disconnect. Only `close()` resets the WeakMap (and `_driverPool.end()` terminates the clients).
- Shared `_runQuery(client, sql, binds, { rowMode? })` helper used by `execute()`, `execQuery()`, and every bound `client.query(...)` site in `executeMutation()` (INSERT / UPDATE / DELETE, with or without RETURNING), so every bound path benefits from prepared-statement reuse — matches Rails where `exec_cache` backs `exec_query` / `exec_insert` / `exec_update` / `exec_delete`.
- `0A000` + "cached plan" message purges the pool entry and retries once outside a transaction; inside one it raises `PreparedStatementCacheExpired` (carrying `sql` + `binds`) so the transaction machinery can retry the whole txn — mirrors Rails' `exec_cache` + `postgresql/database_statements.rb:147`.
- `adapter.statementLimit` getter/setter mirrors Rails' `database.yml` `statement_limit`. Setter validates input (finite non-negative integer) and resizes the active pool; other per-client pools keep the limit they were built with (Rails reads the config at pool construction).
- `StatementPool#setMaxSize` evicts LRU on shrink.
- Unskips 8 Rails-mirrored tests in `adapters/postgresql/statement-pool.test.ts`.

## Test plan

- [ ] PG CI: all `StatementPoolTest` cases pass
- [ ] Full AR suite (sqlite) stays green — 8602 passed locally
- [ ] No regression in existing PG exec-query / query-cache suites under `PG_TEST_URL`