### PR TITLE
feat(activerecord,arel): BasicObjectHandler routes through QueryAttribute binds

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Table, Visitors, Nodes } from "@blazetrails/arel";
 import { PredicateBuilder } from "./predicate-builder.js";
+import { Substitute } from "../statement-cache.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 
 describe("PredicateBuilderTest", () => {
@@ -104,6 +105,47 @@ describe("PredicateBuilderTest", () => {
       const sql = compile(node);
       expect(sql).toContain('"posts"."author_id"');
       expect(sql).toContain("7");
+    });
+  });
+
+  describe("QueryAttribute bind handling", () => {
+    it("buildBindAttribute creates a QueryAttribute", () => {
+      const table = new Table("users");
+      const builder = new PredicateBuilder(table);
+      const qa = builder.buildBindAttribute("name", "alice");
+      expect(qa.name).toBe("name");
+      expect(qa.value).toBe("alice");
+    });
+
+    it("BasicObjectHandler routes through buildBindAttribute", () => {
+      const table = new Table("users");
+      const builder = new PredicateBuilder(table);
+      const node = builder.build(table.get("name"), "alice");
+      const visitor = new Visitors.ToSql();
+      const [sql, binds] = visitor.compileWithBinds(node);
+      expect(sql).toContain('"users"."name" = ?');
+      expect(binds).toHaveLength(1);
+    });
+
+    it("Substitute flows through as BindParam via QueryAttribute", () => {
+      const table = new Table("users");
+      const builder = new PredicateBuilder(table);
+      const node = builder.build(table.get("name"), new Substitute());
+      const visitor = new Visitors.ToSql();
+      const [sql, binds] = visitor.compileWithBinds(node);
+      expect(sql).toContain('"users"."name" = ?');
+      expect(binds).toHaveLength(1);
+      expect((binds[0] as any).valueBeforeTypeCast).toBeInstanceOf(Substitute);
+    });
+
+    it("compile inlines QueryAttribute values for display SQL", () => {
+      const table = new Table("users");
+      const builder = new PredicateBuilder(table);
+      const node = builder.build(table.get("name"), "alice");
+      const visitor = new Visitors.ToSql();
+      const sql = visitor.compile(node);
+      expect(sql).toContain('"users"."name"');
+      expect(sql).toContain("alice");
     });
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -135,7 +135,9 @@ describe("PredicateBuilderTest", () => {
       const [sql, binds] = visitor.compileWithBinds(node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
-      expect((binds[0] as any).valueBeforeTypeCast).toBeInstanceOf(Substitute);
+      // The bind is the Substitute itself (unwrapped from QueryAttribute
+      // via valueForDatabase → identity type serialize)
+      expect(binds[0]).toBeInstanceOf(Substitute);
     });
 
     it("compile inlines QueryAttribute values for display SQL", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -1,5 +1,6 @@
 import { Table, Nodes, sql as arelSql } from "@blazetrails/arel";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
+import { QueryAttribute } from "./query-attribute.js";
 import { ArrayHandler } from "./predicate-builder/array-handler.js";
 import { RangeHandler } from "./predicate-builder/range-handler.js";
 import { BasicObjectHandler } from "./predicate-builder/basic-object-handler.js";
@@ -31,7 +32,7 @@ export class PredicateBuilder {
     this.table = table;
     this.arrayHandler = new ArrayHandler(this);
     this.rangeHandler = new RangeHandler();
-    this.basicObjectHandler = new BasicObjectHandler();
+    this.basicObjectHandler = new BasicObjectHandler(this);
     this.relationHandler = new RelationHandler();
   }
 
@@ -223,9 +224,12 @@ export class PredicateBuilder {
     this.handlers.push([klass, handler]);
   }
 
-  buildBindAttribute(columnName: string, value: unknown): Nodes.Node {
-    const attr = this.resolveColumn(columnName);
-    return this.build(attr, value);
+  buildBindAttribute(columnName: string, value: unknown): QueryAttribute {
+    const type = this.table.typeForAttribute(columnName) as
+      | { cast(v: unknown): unknown; serialize(v: unknown): unknown }
+      | undefined;
+    const castType = type ?? { cast: (v: unknown) => v, serialize: (v: unknown) => v };
+    return new QueryAttribute(columnName, value, castType);
   }
 
   resolveArelAttribute(tableName: string, columnName: string): Nodes.Attribute {

--- a/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
@@ -2,19 +2,28 @@ import { Nodes } from "@blazetrails/arel";
 
 /**
  * Handles basic scalar values (strings, numbers, booleans) in where
- * conditions by building simple equality predicates.
+ * conditions by building simple equality predicates via bind attributes.
  *
  * Mirrors: ActiveRecord::PredicateBuilder::BasicObjectHandler
  *
- * Examples:
- *   where({ name: "dean" })  → name = 'dean'
- *   where({ age: 30 })       → age = 30
- *   where({ active: true })  → active = true
+ * In Rails, this wraps the value in a QueryAttribute via
+ * predicateBuilder.buildBindAttribute, then passes the bind
+ * object to attribute.eq. This produces BindParam nodes in the
+ * Arel tree for proper bind parameter extraction.
  */
 export class BasicObjectHandler {
-  constructor() {}
+  private _predicateBuilder: {
+    buildBindAttribute(columnName: string, value: unknown): unknown;
+  };
+
+  constructor(predicateBuilder: {
+    buildBindAttribute(columnName: string, value: unknown): unknown;
+  }) {
+    this._predicateBuilder = predicateBuilder;
+  }
 
   call(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
-    return attribute.eq(value);
+    const bind = this._predicateBuilder.buildBindAttribute(attribute.name, value);
+    return attribute.eq(bind);
   }
 }

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -184,6 +184,13 @@ function equalities(predicates: Nodes.Node[]): Nodes.Node[] {
 function extractNodeValue(node: unknown): unknown {
   if (node instanceof Nodes.Quoted) return node.value;
   if (node instanceof Nodes.Casted) return node.valueForDatabase();
+  if (node instanceof Nodes.BindParam) {
+    const val = node.value;
+    if (val && typeof val === "object" && "value" in val) {
+      return (val as { value: unknown }).value;
+    }
+    return val;
+  }
   if (Array.isArray(node)) return node.map((v) => extractNodeValue(v));
   return node;
 }

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -17,6 +17,7 @@ import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
 import { Quoted, Casted } from "../nodes/casted.js";
+import { BindParam } from "../nodes/bind-param.js";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";
 import { Or } from "../nodes/or.js";
@@ -108,6 +109,12 @@ export class Attribute extends Node {
   private buildCasted(value: unknown): Node {
     if (value instanceof Node) return value;
     if (value === null || value === undefined) return new Quoted(null);
+    // QueryAttribute and similar bind objects have valueForDatabase —
+    // wrap them in BindParam so the visitor extracts them as binds
+    // rather than inlining via Casted.
+    if (value && typeof value === "object" && "valueForDatabase" in value && "name" in value) {
+      return new BindParam(value);
+    }
     return new Casted(value, this);
   }
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -112,7 +112,12 @@ export class Attribute extends Node {
     // QueryAttribute and similar bind objects have valueForDatabase —
     // wrap them in BindParam so the visitor extracts them as binds
     // rather than inlining via Casted.
-    if (value && typeof value === "object" && "valueForDatabase" in value && "name" in value) {
+    if (
+      value &&
+      typeof value === "object" &&
+      typeof (value as Record<string, unknown>).valueForDatabase === "function" &&
+      typeof (value as Record<string, unknown>).name === "string"
+    ) {
       return new BindParam(value);
     }
     return new Casted(value, this);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -95,7 +95,14 @@ export class PostgreSQLWithBinds extends PostgreSQL {
       const value = node.value !== undefined ? node.value : node;
       this.collector.addBind(value, () => `$${this.bindIndex}`);
     } else if (node.value !== undefined) {
-      this.collector.append(this.quote(node.value));
+      const val =
+        node.value &&
+        typeof node.value === "object" &&
+        "valueForDatabase" in node.value &&
+        typeof (node.value as Record<string, unknown>).valueForDatabase === "function"
+          ? (node.value as { valueForDatabase(): unknown }).valueForDatabase()
+          : node.value;
+      this.collector.append(this.quote(val));
     } else {
       this.bindIndex += 1;
       this.collector.append(`$${this.bindIndex}`);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -934,7 +934,15 @@ export class ToSql implements NodeVisitor<SQLString> {
     if (this._extractBinds) {
       this.collector.addBind(node.value !== undefined ? node.value : node);
     } else if (node.value !== undefined) {
-      this.collector.append(this.quote(node.value));
+      // Extract the database value from bind objects (QueryAttribute etc.)
+      const val =
+        node.value &&
+        typeof node.value === "object" &&
+        "valueForDatabase" in node.value &&
+        typeof (node.value as Record<string, unknown>).valueForDatabase === "function"
+          ? (node.value as { valueForDatabase(): unknown }).valueForDatabase()
+          : node.value;
+      this.collector.append(this.quote(val));
     } else {
       this.collector.addBind(node);
     }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -57,7 +57,18 @@ export class ToSql implements NodeVisitor<SQLString> {
     } finally {
       this._extractBinds = false;
     }
-    const binds = bindCollector.value.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
+    const binds = bindCollector.value.map((b) => {
+      const val = b instanceof Nodes.BindParam ? b.value : b;
+      if (
+        val &&
+        typeof val === "object" &&
+        "valueForDatabase" in val &&
+        typeof (val as Record<string, unknown>).valueForDatabase === "function"
+      ) {
+        return (val as { valueForDatabase(): unknown }).valueForDatabase();
+      }
+      return val;
+    });
     return [sqlCollector.value, binds];
   }
 


### PR DESCRIPTION
## Summary

PR 1 of the boundAttributes epic. Matches Rails' PredicateBuilder flow where all WHERE values go through `buildBindAttribute` → `QueryAttribute` → `BindParam`.

- **BasicObjectHandler**: Now accepts predicateBuilder and calls `buildBindAttribute(name, value)` to create a `QueryAttribute`, then passes it to `attribute.eq(bind)` — matching Rails' `BasicObjectHandler#call`
- **buildBindAttribute**: Creates `QueryAttribute(name, value, type)` instead of delegating to `build()` — matching Rails' `build_bind_attribute`
- **Attribute.buildCasted**: Recognizes bind objects (with `valueForDatabase` + `name`) and wraps in `BindParam` instead of `Casted`
- **visitBindParam**: Extracts `valueForDatabase()` for display SQL (compile path)
- **WhereClause.extractNodeValue**: Handles `BindParam` containing `QueryAttribute` for `scopeForCreate`/`whereValuesHash`
- **Substitute flow**: `Substitute` → `QueryAttribute(name, Substitute, type)` → `BindParam(QueryAttribute)` — naturally handled by the same pipeline

4 new tests covering buildBindAttribute, BasicObjectHandler routing, Substitute flow, and compile display SQL.

## Test plan

- [x] `pnpm run build` — clean
- [x] 9603 tests pass (arel + activerecord, 0 failures)
- [x] CI