### PR TITLE
feat(activerecord): real AssociationScope (PR 1: single-chain)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -594,6 +594,9 @@ export async function loadHasMany(
   const reflection = ctor._reflectOnAssociation?.(assocName);
   let rel: any;
   if (reflection && !options.as && !options.through) {
+    // AssociationScope.scope already merges reflection.scope (the
+    // user-supplied scope lambda) via _addConstraints, so don't double-
+    // apply options.scope on this path.
     rel = AssociationScope.scope({
       owner: record,
       reflection,
@@ -601,9 +604,9 @@ export async function loadHasMany(
     });
   } else {
     rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
-  }
-  if (options.scope) {
-    rel = options.scope(rel);
+    if (options.scope) {
+      rel = options.scope(rel);
+    }
   }
   const results: Base[] = await rel.toArray();
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -602,9 +602,12 @@ export async function loadHasMany(
     // by AssociationScope.scope MUST be merged with the target's
     // scope_for_association — otherwise the target model's default_scope
     // / scope extensions would silently disappear on the reflection-
-    // backed path. AssociationScope.scope already merges reflection.scope
-    // (the user-supplied scope lambda) via _addConstraints, so don't
-    // double-apply options.scope on this path.
+    // backed path. AssociationScope.scope already merges
+    // `reflection.scope` (the macro-time user lambda) via scopeFor, so
+    // skip re-applying it ONLY when `options.scope` is that exact same
+    // function. Callers like `loadHasManyThrough` synthesize a NEW
+    // `options.scope` (e.g. wrapping with `sourceType` filtering) —
+    // those must still run.
     const built = AssociationScope.scope({
       owner: record,
       reflection,
@@ -612,6 +615,9 @@ export async function loadHasMany(
     }) as any;
     const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
     rel = baseRelation.merge(built);
+    if (options.scope && options.scope !== (reflection as any).scope) {
+      rel = options.scope(rel);
+    }
   } else {
     rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
     if (options.scope) {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -8,6 +8,7 @@ import {
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./associations/errors.js";
 import { ForeignAssociation } from "./associations/foreign-association.js";
+import { AssociationScope } from "./associations/association-scope.js";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./inheritance.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
@@ -584,8 +585,23 @@ export async function loadHasMany(
   const pkValue = record.readAttribute(primaryKey as string);
   if (pkValue === null || pkValue === undefined) return [];
 
-  let rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
-  // Apply association scope
+  // Route through AssociationScope when we have a reflection registered
+  // for this association — single code path with the explicit loaders in
+  // `load*` sharing WHERE/FK construction. Falls back to the inline
+  // builder when the reflection hasn't been registered (happens in
+  // tests that define associations via the lower-level API without
+  // going through the full Reflection.create path).
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  let rel: any;
+  if (reflection && !options.as && !options.through) {
+    rel = AssociationScope.scope({
+      owner: record,
+      reflection,
+      klass: targetModel,
+    });
+  } else {
+    rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
+  }
   if (options.scope) {
     rel = options.scope(rel);
   }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -593,7 +593,9 @@ export async function loadHasMany(
   // going through the full Reflection.create path).
   const reflection = ctor._reflectOnAssociation?.(assocName);
   let rel: any;
-  if (reflection && !options.as && !options.through) {
+  // `options.through` is handled by the early-return above, so we don't
+  // need to re-check it here.
+  if (reflection && !options.as) {
     // AssociationScope.scope already merges reflection.scope (the
     // user-supplied scope lambda) via _addConstraints, so don't double-
     // apply options.scope on this path.

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -596,14 +596,22 @@ export async function loadHasMany(
   // `options.through` is handled by the early-return above, so we don't
   // need to re-check it here.
   if (reflection && !options.as) {
-    // AssociationScope.scope already merges reflection.scope (the
-    // user-supplied scope lambda) via _addConstraints, so don't double-
-    // apply options.scope on this path.
-    rel = AssociationScope.scope({
+    // Rails' `Association#scope` is
+    //   AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
+    // (association.rb:313), so the unscoped+constraints relation built
+    // by AssociationScope.scope MUST be merged with the target's
+    // scope_for_association — otherwise the target model's default_scope
+    // / scope extensions would silently disappear on the reflection-
+    // backed path. AssociationScope.scope already merges reflection.scope
+    // (the user-supplied scope lambda) via _addConstraints, so don't
+    // double-apply options.scope on this path.
+    const built = AssociationScope.scope({
       owner: record,
       reflection,
       klass: targetModel,
-    });
+    }) as any;
+    const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
+    rel = baseRelation.merge(built);
   } else {
     rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
     if (options.scope) {

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -317,6 +317,14 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/"active"\s*=\s*TRUE/i);
   });
 
+  it("static scope() routes through this.INSTANCE (subclass dispatch)", async () => {
+    const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
+    expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);
+    // Subclass INSTANCE shadows the parent's so polymorphic
+    // this.INSTANCE in `static scope` resolves to the subclass instance.
+    expect(DisableJoinsAssociationScope.INSTANCE).not.toBe(AssociationScope.INSTANCE);
+  });
+
   it("scope() raises for through chains (PR 1 limitation)", () => {
     class ThroughAuthor extends Base {
       static {

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -195,6 +195,45 @@ describe("AssociationScope", () => {
     expect(scope.toSql()).toMatch(/"type"\s*=\s*'StiSpecial'/);
   });
 
+  it("invokes 0-arity scope lambda with this=relation (Rails instance_exec semantics)", () => {
+    // Rails: `relation.instance_exec(owner, &scope) || relation`. A
+    // 0-arity scope (e.g. `-> { where(active: true) }`) reads `self`
+    // as the relation, so we must bind `this` rather than passing the
+    // relation as the first arg.
+    class ZeroArityAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ZeroArityPost extends Base {
+      static {
+        this.attribute("zero_arity_author_id", "integer");
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(ZeroArityAuthor);
+    registerModel(ZeroArityPost);
+    Associations.hasMany.call(ZeroArityAuthor, "zero_arity_posts", {
+      className: "ZeroArityPost",
+      foreignKey: "zero_arity_author_id",
+      // The function's .length is 0, so the loader must use scopeFor's
+      // 0-arity branch (this=relation). If we passed it as a 1-arg
+      // function, `where` would not exist on the empty arg.
+      scope: function (this: any) {
+        return this.where({ active: true });
+      },
+    });
+
+    const owner = new ZeroArityAuthor({ id: 1 });
+    const reflection = (ZeroArityAuthor as any)._reflectOnAssociation("zero_arity_posts");
+    const sql = (
+      AssociationScope.scope({ owner, reflection, klass: reflection.klass }) as any
+    ).toSql();
+    expect(sql).toMatch(/"active"\s*=\s*TRUE/i);
+  });
+
   it("scope() raises for through chains (PR 1 limitation)", () => {
     class ThroughAuthor extends Base {
       static {

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -237,6 +237,47 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/"ds_author_id"\s*=\s*1/);
   });
 
+  it("loadHasMany applies caller-supplied options.scope when it differs from reflection.scope", async () => {
+    // Regression for the loadHasManyThrough path that wraps options.scope
+    // with sourceType filtering before calling loadHasMany. The migrated
+    // path skips re-applying when options.scope === reflection.scope
+    // (avoid double-application), but augmented scopes must still run.
+    const { loadHasMany } = await import("../associations.js");
+    class WrAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class WrPost extends Base {
+      static {
+        this.attribute("wr_author_id", "integer");
+        this.attribute("kind", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(WrAuthor);
+    registerModel(WrPost);
+    Associations.hasMany.call(WrAuthor, "wr_posts", {
+      className: "WrPost",
+      foreignKey: "wr_author_id",
+    });
+
+    const author = await WrAuthor.create({});
+    await WrPost.create({ wr_author_id: author.id, kind: "draft" });
+    await WrPost.create({ wr_author_id: author.id, kind: "published" });
+
+    // Augmented options.scope — NOT equal to the reflection's macro
+    // scope (which is null here). Loader must still apply it.
+    const results = await loadHasMany(author, "wr_posts", {
+      className: "WrPost",
+      foreignKey: "wr_author_id",
+      scope: (rel: any) => rel.where({ kind: "published" }),
+    });
+    expect(results).toHaveLength(1);
+    expect((results[0] as any).kind).toBe("published");
+  });
+
   it("invokes 0-arity scope lambda with this=relation (Rails instance_exec semantics)", () => {
     // Rails: `relation.instance_exec(owner, &scope) || relation`. A
     // 0-arity scope (e.g. `-> { where(active: true) }`) reads `self`

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, registerModel } from "../index.js";
+import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
 import { createTestAdapter } from "../test-adapter.js";
@@ -110,6 +110,89 @@ describe("AssociationScope", () => {
     expect(proxy.klass).toBe(AsPost);
     // Rails' all_includes; block returns nil → we return null.
     expect(proxy.allIncludes()).toBeNull();
+  });
+
+  it("applies reflection.scope lambda exactly once (no double-apply)", () => {
+    class CountAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    let calls = 0;
+    class CountPost extends Base {
+      static {
+        this.attribute("count_author_id", "integer");
+        this.attribute("published", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(CountAuthor);
+    registerModel(CountPost);
+    Associations.hasMany.call(CountAuthor, "count_posts", {
+      className: "CountPost",
+      foreignKey: "count_author_id",
+      scope: (rel: any) => {
+        calls++;
+        return rel.where({ published: true });
+      },
+    });
+
+    const author = new CountAuthor({ id: 5 });
+    const reflection = (CountAuthor as any)._reflectOnAssociation("count_posts");
+    const scope: any = AssociationScope.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    });
+
+    // The lambda must run exactly once — _addConstraints applies it via
+    // reflection.scope; the loader path must not re-apply options.scope.
+    expect(calls).toBe(1);
+    expect(scope.toSql()).toMatch(/"published"\s*=\s*TRUE/i);
+  });
+
+  it("applies STI type_condition on subclass targets (compensates for our unscoped)", () => {
+    // Rails' klass.unscoped applies STI type_condition via core.rb's
+    // relation() override; ours doesn't, so AssociationScope re-adds it.
+    class StiOwner extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class StiBase extends Base {
+      static {
+        this.attribute("type", "string");
+        this.attribute("sti_owner_id", "integer");
+        this._tableName = "sti_things";
+        this.adapter = adapter;
+        enableSti(StiBase);
+      }
+    }
+    class StiSpecial extends StiBase {
+      static {
+        this.adapter = adapter;
+        registerModel(StiSpecial);
+        registerSubclass(StiSpecial);
+      }
+    }
+    registerModel(StiOwner);
+    registerModel(StiBase);
+    Associations.hasMany.call(StiOwner, "sti_specials", {
+      className: "StiSpecial",
+      foreignKey: "sti_owner_id",
+    });
+
+    const owner = new StiOwner({ id: 3 });
+    const reflection = (StiOwner as any)._reflectOnAssociation("sti_specials");
+    const scope: any = AssociationScope.scope({
+      owner,
+      reflection,
+      klass: reflection.klass,
+    });
+
+    expect(scope.toSql()).toMatch(/"type"\s*=\s*'StiSpecial'/);
   });
 
   it("scope() raises for through chains (PR 1 limitation)", () => {

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -195,6 +195,48 @@ describe("AssociationScope", () => {
     expect(scope.toSql()).toMatch(/"type"\s*=\s*'StiSpecial'/);
   });
 
+  it("loadHasMany merges target's scope_for_association (default_scope flows through)", async () => {
+    // Rails' Association#scope is
+    //   AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
+    // (associations/association.rb:313). The reflection-backed loader
+    // path must merge in the target's default_scope so behavior matches
+    // the inline path (targetModel.all().where(...)).
+    class DsAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class DsPost extends Base {
+      static {
+        this.attribute("ds_author_id", "integer");
+        this.attribute("published", "boolean");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ published: true }));
+      }
+    }
+    registerModel(DsAuthor);
+    registerModel(DsPost);
+    Associations.hasMany.call(DsAuthor, "ds_posts", {
+      className: "DsPost",
+      foreignKey: "ds_author_id",
+    });
+
+    const author = new DsAuthor({ id: 1 });
+    const reflection = (DsAuthor as any)._reflectOnAssociation("ds_posts");
+    // Replicate the loader's merge so the test pins the actual Rails
+    // shape rather than just the unscoped+constraints intermediate.
+    const built = AssociationScope.scope({
+      owner: author,
+      reflection,
+      klass: DsPost,
+    }) as any;
+    const merged = (DsPost as any).scopeForAssociation().merge(built);
+    const sql = merged.toSql();
+    expect(sql).toMatch(/"published"\s*=\s*TRUE/i);
+    expect(sql).toMatch(/"ds_author_id"\s*=\s*1/);
+  });
+
   it("invokes 0-arity scope lambda with this=relation (Rails instance_exec semantics)", () => {
     // Rails: `relation.instance_exec(owner, &scope) || relation`. A
     // 0-arity scope (e.g. `-> { where(active: true) }`) reads `self`
@@ -278,6 +320,6 @@ describe("AssociationScope", () => {
         reflection,
         klass: reflection.klass,
       }),
-    ).toThrow(/multi-step chain/);
+    ).toThrow(/multi-step association chains/);
   });
 });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations } from "../associations.js";
+import { AssociationScope, ReflectionProxy } from "./association-scope.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("AssociationScope", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  function makeModels() {
+    class AsAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class AsPost extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("as_author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(AsAuthor);
+    registerModel(AsPost);
+    Associations.hasMany.call(AsAuthor, "as_posts", {
+      className: "AsPost",
+      foreignKey: "as_author_id",
+    });
+    Associations.belongsTo.call(AsPost, "as_author", {
+      className: "AsAuthor",
+      foreignKey: "as_author_id",
+    });
+    return { AsAuthor, AsPost };
+  }
+
+  it("INSTANCE is a shared identity-transformation instance", () => {
+    expect(AssociationScope.INSTANCE).toBeInstanceOf(AssociationScope);
+    // static scope() delegates to INSTANCE.scope()
+    expect(typeof AssociationScope.scope).toBe("function");
+  });
+
+  it("create(valueTransformation) accepts a custom transformer", () => {
+    const upcased = AssociationScope.create((v: unknown) =>
+      typeof v === "string" ? v.toUpperCase() : v,
+    );
+    expect(upcased).toBeInstanceOf(AssociationScope);
+    // Instance-level scope is exposed; static reuses INSTANCE.
+    expect(typeof upcased.scope).toBe("function");
+  });
+
+  it("builds a hasMany scope with WHERE on the target's FK = owner.PK", async () => {
+    const { AsAuthor } = makeModels();
+    const author = new AsAuthor({ id: 7, name: "Alice" });
+    const reflection = (AsAuthor as any)._reflectOnAssociation("as_posts");
+    expect(reflection).toBeDefined();
+
+    const scope: any = AssociationScope.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    });
+
+    const sql = scope.toSql();
+    expect(sql).toMatch(/"as_posts".*"as_author_id"\s*=\s*7/s);
+  });
+
+  it("builds a belongsTo scope with WHERE on the target's PK = owner.FK + limit(1)", async () => {
+    const { AsAuthor, AsPost } = makeModels();
+    const post = new AsPost({ id: 1, as_author_id: 42, title: "x" });
+    const reflection = (AsPost as any)._reflectOnAssociation("as_author");
+    expect(reflection).toBeDefined();
+    expect(reflection.klass).toBe(AsAuthor);
+
+    const scope: any = AssociationScope.scope({
+      owner: post,
+      reflection,
+      klass: reflection.klass,
+    });
+
+    const sql = scope.toSql();
+    // belongsTo → WHERE target.id = owner.fk; isCollection? false → LIMIT 1.
+    expect(sql).toMatch(/"as_authors".*"id"\s*=\s*42.*LIMIT\s+1/s);
+  });
+
+  it("getBindValues collects owner's join_foreign_key values (chain length 1)", () => {
+    const { AsAuthor } = makeModels();
+    const author = new AsAuthor({ id: 99, name: "Bob" });
+    const reflection = (AsAuthor as any)._reflectOnAssociation("as_posts");
+
+    const binds = AssociationScope.getBindValues(author, [reflection]);
+    // hasMany: joinForeignKey = owner PK ("id"). Owner id = 99.
+    expect(binds).toEqual([99]);
+  });
+
+  it("ReflectionProxy delegates joinPrimaryKey / joinForeignKey / klass to the reflection", () => {
+    const { AsAuthor, AsPost } = makeModels();
+    const reflection = (AsAuthor as any)._reflectOnAssociation("as_posts");
+    const proxy = new ReflectionProxy(reflection, /* aliasedTable */ null);
+
+    expect(proxy.joinPrimaryKey).toBe(reflection.joinPrimaryKey);
+    expect(proxy.joinForeignKey).toBe(reflection.joinForeignKey);
+    expect(proxy.klass).toBe(AsPost);
+    // Rails' all_includes; block returns nil → we return null.
+    expect(proxy.allIncludes()).toBeNull();
+  });
+
+  it("scope() raises for through chains (PR 1 limitation)", () => {
+    class ThroughAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ThroughMembership extends Base {
+      static {
+        this.attribute("through_author_id", "integer");
+        this.attribute("through_post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ThroughPost extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(ThroughAuthor);
+    registerModel(ThroughMembership);
+    registerModel(ThroughPost);
+    Associations.hasMany.call(ThroughAuthor, "through_memberships", {
+      className: "ThroughMembership",
+      foreignKey: "through_author_id",
+    });
+    Associations.hasMany.call(ThroughAuthor, "through_posts", {
+      className: "ThroughPost",
+      through: "through_memberships",
+    });
+    Associations.belongsTo.call(ThroughMembership, "through_post", {
+      className: "ThroughPost",
+      foreignKey: "through_post_id",
+    });
+
+    const author = new ThroughAuthor({ id: 1 });
+    const reflection = (ThroughAuthor as any)._reflectOnAssociation("through_posts");
+    expect(() =>
+      AssociationScope.scope({
+        owner: author,
+        reflection,
+        klass: reflection.klass,
+      }),
+    ).toThrow(/multi-step chain/);
+  });
+});

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -170,7 +170,7 @@ export class AssociationScope {
     // because `relation()` adds it for `finder_needs_type_condition?`
     // classes (`core.rb:431-435`). Our `Base.unscoped` doesn't wire STI
     // through `relation()` yet, so we re-add the type condition here.
-    let scope = (klass as unknown as { unscoped: () => unknown }).unscoped();
+    let scope: unknown = klass.unscoped();
     if (isStiSubclass(klass)) {
       const col = getInheritanceColumn(getStiBase(klass));
       if (col) {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,5 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
+import { isStiSubclass, getStiBase, getInheritanceColumn, descendants } from "../inheritance.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -164,13 +165,21 @@ export class AssociationScope {
    */
   scope(association: AssociationScopeable): unknown {
     const { owner, reflection, klass } = association;
-    // Rails uses `klass.unscoped` here (association_scope.rb:23) but
-    // their `unscoped` STILL applies the STI `type_condition` because
-    // `relation()` adds it for `finder_needs_type_condition?` classes
-    // (see `core.rb:431-435`). Our `Base.unscoped` doesn't yet wire STI
-    // type filtering through `relation()`, so until that lands we use
-    // `.all()` — which already includes the STI filter on subclasses.
-    let scope = (klass as unknown as { all: () => unknown }).all();
+    // Rails: `klass.unscoped` (association_scope.rb:23). Rails' unscoped
+    // bypasses default_scope but STILL applies the STI `type_condition`
+    // because `relation()` adds it for `finder_needs_type_condition?`
+    // classes (`core.rb:431-435`). Our `Base.unscoped` doesn't wire STI
+    // through `relation()` yet, so we re-add the type condition here.
+    let scope = (klass as unknown as { unscoped: () => unknown }).unscoped();
+    if (isStiSubclass(klass)) {
+      const col = getInheritanceColumn(getStiBase(klass));
+      if (col) {
+        const stiNames = [klass.name, ...descendants(klass).map((d: typeof Base) => d.name)];
+        scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
+          [col]: stiNames.length === 1 ? stiNames[0] : stiNames,
+        });
+      }
+    }
     const chain = this._getChain(reflection);
     scope = this._addConstraints(scope, owner, chain);
     if (!reflection.isCollection()) {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -123,8 +123,11 @@ export class AssociationScope {
     this._valueTransformation = valueTransformation;
   }
 
-  static create(valueTransformation?: ValueTransformation): AssociationScope {
-    return new AssociationScope(valueTransformation ?? ((v: unknown) => v));
+  static create<T extends typeof AssociationScope>(
+    this: T,
+    valueTransformation?: ValueTransformation,
+  ): InstanceType<T> {
+    return new this(valueTransformation ?? ((v: unknown) => v)) as InstanceType<T>;
   }
 
   /** Identity-lambda shared instance. Rails: `INSTANCE = create`. */
@@ -132,12 +135,16 @@ export class AssociationScope {
 
   /**
    * Entry point. Build the Relation that loads (or filters) the given
-   * association's records for its owner.
+   * association's records for its owner. Polymorphic via `this.INSTANCE`
+   * so a subclass with its own `static INSTANCE` (e.g.
+   * `DisableJoinsAssociationScope`) routes through that subclass'
+   * instance — matching Rails' `AssociationScope.scope(association)` /
+   * `INSTANCE` lookup chain.
    *
    * Mirrors: ActiveRecord::Associations::AssociationScope.scope
    */
-  static scope(association: AssociationScopeable): unknown {
-    return AssociationScope.INSTANCE.scope(association);
+  static scope(this: typeof AssociationScope, association: AssociationScopeable): unknown {
+    return this.INSTANCE.scope(association);
   }
 
   /**

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -283,7 +283,7 @@ export class AssociationScope {
   ): Array<AbstractReflection | ReflectionProxy> {
     if (reflection.chain.length > 1) {
       throw new Error(
-        `AssociationScope: multi-step chain (through) not implemented in PR 1 — ` +
+        `AssociationScope: multi-step association chains are not implemented yet — ` +
           `reflection '${reflection.name}' has ${reflection.chain.length} chain entries`,
       );
     }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,6 +1,7 @@
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
 import { isStiSubclass, getStiBase, getInheritanceColumn, descendants } from "../inheritance.js";
+import { CompositePrimaryKeyMismatchError } from "./errors.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -78,6 +79,23 @@ export class ReflectionProxy {
 
   get scope(): ((rel: unknown) => unknown) | undefined {
     return (this.reflection as unknown as { scope?: (rel: unknown) => unknown }).scope;
+  }
+
+  /**
+   * Forwarding `scopeFor` to the underlying reflection. Rails'
+   * `ReflectionProxy < SimpleDelegator` gets this via delegation;
+   * we forward explicitly so AssociationScope can call
+   * `proxy.scopeFor(rel, owner)` and get Rails-faithful arity +
+   * `instance_exec`-style binding.
+   */
+  scopeFor(relation: unknown, owner?: unknown): unknown {
+    return (
+      (
+        this.reflection as unknown as {
+          scopeFor?: (rel: unknown, owner?: unknown) => unknown;
+        }
+      ).scopeFor?.(relation, owner) ?? relation
+    );
   }
 
   constraints(): Array<(...args: unknown[]) => unknown> {
@@ -231,13 +249,14 @@ export class AssociationScope {
     // Same guard `AbstractReflection#joinScope` uses — mismatched
     // composite join-key lengths would silently read
     // `owner.readAttribute(undefined)` and generate a broken WHERE.
-    // Fail fast instead.
+    // Rails raises CompositePrimaryKeyMismatchError from
+    // checkValidityBang for the equivalent case
+    // (associations/errors.rb:187, reflection.rb:623); use the same
+    // class here so callers can rescue uniformly.
     if (joinPks.length !== joinFks.length) {
       const name = (reflection as { name?: string }).name ?? "<unknown>";
-      throw new Error(
-        `AssociationScope: ${name} joinPrimaryKey/joinForeignKey column count mismatch ` +
-          `(${joinPks.length} primary key column(s) vs ${joinFks.length} foreign key column(s))`,
-      );
+      const ownerName = (owner.constructor as typeof Base).name;
+      throw new CompositePrimaryKeyMismatchError(ownerName, name);
     }
     for (let i = 0; i < joinPks.length; i++) {
       const rawValue = owner.readAttribute(joinFks[i]);
@@ -286,10 +305,14 @@ export class AssociationScope {
   ): unknown {
     const last = chain[chain.length - 1];
     scope = this._lastChainScope(scope, last, owner);
-    const scopeLambda = (last as { scope?: (rel: unknown) => unknown }).scope;
-    if (typeof scopeLambda === "function") {
-      const applied = scopeLambda(scope);
-      if (applied) scope = applied;
+    // Use scopeFor (Rails: reflection.rb:448, scope_for) so 0-arity
+    // scopes get `this`=relation, and >=1-arity scopes receive
+    // (relation, owner) — matches Rails' `relation.instance_exec(owner,
+    // &scope) || relation`. Calling `reflection.scope(scope)` directly
+    // would lose the binding.
+    const scopeFor = (last as { scopeFor?: (rel: unknown, owner: unknown) => unknown }).scopeFor;
+    if (typeof scopeFor === "function") {
+      scope = scopeFor.call(last, scope, owner);
     }
     return scope;
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -228,6 +228,17 @@ export class AssociationScope {
     const table = (reflection as ReflectionProxy).aliasedTable ?? null;
     const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
+    // Same guard `AbstractReflection#joinScope` uses — mismatched
+    // composite join-key lengths would silently read
+    // `owner.readAttribute(undefined)` and generate a broken WHERE.
+    // Fail fast instead.
+    if (joinPks.length !== joinFks.length) {
+      const name = (reflection as { name?: string }).name ?? "<unknown>";
+      throw new Error(
+        `AssociationScope: ${name} joinPrimaryKey/joinForeignKey column count mismatch ` +
+          `(${joinPks.length} primary key column(s) vs ${joinFks.length} foreign key column(s))`,
+      );
+    }
     for (let i = 0; i < joinPks.length; i++) {
       const rawValue = owner.readAttribute(joinFks[i]);
       const value = this._transformValue(rawValue);

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,29 +1,276 @@
-import type { AssociationReflection } from "../reflection.js";
+import type { Base } from "../base.js";
+import type { AssociationReflection, AbstractReflection } from "../reflection.js";
 
 /**
- * Builds the scope (query) for an association based on its reflection.
- *
- * Mirrors: ActiveRecord::Associations::AssociationScope
+ * Lambda applied to each FK/type bind value before it reaches the
+ * generated WHERE. Rails uses this to let STI base_class / polymorphic
+ * name rewriting flow through the same scope-building path as ordinary
+ * attribute reads.
  */
-export class AssociationScope {
-  static create(reflection: AssociationReflection): AssociationScope {
-    return new AssociationScope(reflection);
+export type ValueTransformation<T = unknown> = (v: T) => unknown;
+
+/**
+ * Minimum shape `AssociationScope.scope` needs from its argument. Rails
+ * passes a concrete `Association` instance (see
+ * `activerecord/lib/active_record/associations/association.rb`); we
+ * duck-type so the internal loader paths in `associations.ts` — which
+ * don't always have an Association wrapper — can use the same code.
+ */
+export interface AssociationScopeable {
+  readonly owner: Base;
+  readonly reflection: AssociationReflection;
+  readonly klass: typeof Base;
+}
+
+/**
+ * Proxy wrapping a reflection with the aliased table that AssociationScope
+ * computes when walking `reflection.chain`. For chain length 1 the
+ * aliased table is just `reflection.klass.arelTable`; non-trivial chains
+ * (added in a later PR) ask `AliasTracker#aliasedTableFor` for a unique
+ * alias via `reflection.aliasCandidate(name)`.
+ *
+ * Mirrors: ActiveRecord::Associations::AssociationScope::ReflectionProxy
+ * (association_scope.rb:101-110 in Rails 8.0.2 — SimpleDelegator wrapping
+ * a reflection plus `attr_reader :aliased_table` and
+ * `def all_includes; nil; end`.)
+ */
+export class ReflectionProxy {
+  readonly reflection: AssociationReflection;
+  readonly aliasedTable: unknown;
+
+  constructor(reflection: AssociationReflection, aliasedTable: unknown) {
+    this.reflection = reflection;
+    this.aliasedTable = aliasedTable;
   }
 
-  readonly reflection: AssociationReflection;
+  /**
+   * Block-form opt-out Rails uses to skip eager-load propagation through
+   * the chain. We mirror the sentinel (return `null`) — callers in later
+   * PRs check for non-null to decide whether to merge `includes_values`.
+   */
+  allIncludes<T>(_cb?: () => T): T | null {
+    return null;
+  }
 
-  constructor(reflection: AssociationReflection) {
-    this.reflection = reflection;
+  // SimpleDelegator-style forwarding of the attributes AssociationScope
+  // reads. Kept explicit instead of a runtime Proxy so TypeScript sees
+  // the shape.
+  get joinPrimaryKey(): string | string[] {
+    return this.reflection.joinPrimaryKey;
+  }
+
+  get joinForeignKey(): string | string[] {
+    return this.reflection.joinForeignKey;
+  }
+
+  get type(): string | null {
+    return this.reflection.type;
+  }
+
+  get klass(): typeof Base {
+    return this.reflection.klass;
+  }
+
+  get name(): string {
+    return this.reflection.name;
+  }
+
+  get scope(): ((rel: unknown) => unknown) | undefined {
+    return (this.reflection as unknown as { scope?: (rel: unknown) => unknown }).scope;
+  }
+
+  constraints(): Array<(...args: unknown[]) => unknown> {
+    return this.reflection.constraints() as Array<(...args: unknown[]) => unknown>;
   }
 }
 
 /**
- * Mirrors: ActiveRecord::Associations::AssociationScope::ReflectionProxy
+ * Builds the scope (query) for an association based on its reflection.
+ *
+ * Rails implementation (activerecord/lib/active_record/associations/association_scope.rb):
+ *   - `self.scope(association)` → `INSTANCE.scope(association)`
+ *   - `self.create(&block)` → `new(block ||= identity)`
+ *   - `INSTANCE = create` (identity transformation)
+ *
+ * PR 1 scope: chain length 1 (non-through). PRs 2+ add polymorphic
+ * `as:`, multi-step through chains, and `DisableJoinsAssociationScope`.
+ *
+ * Mirrors: ActiveRecord::Associations::AssociationScope
  */
-export class ReflectionProxy {
-  readonly reflection: AssociationReflection;
+export class AssociationScope {
+  private readonly _valueTransformation: ValueTransformation;
 
-  constructor(reflection: AssociationReflection) {
-    this.reflection = reflection;
+  constructor(valueTransformation: ValueTransformation) {
+    this._valueTransformation = valueTransformation;
+  }
+
+  static create(valueTransformation?: ValueTransformation): AssociationScope {
+    return new AssociationScope(valueTransformation ?? ((v: unknown) => v));
+  }
+
+  /** Identity-lambda shared instance. Rails: `INSTANCE = create`. */
+  static readonly INSTANCE: AssociationScope = AssociationScope.create();
+
+  /**
+   * Entry point. Build the Relation that loads (or filters) the given
+   * association's records for its owner.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope.scope
+   */
+  static scope(association: AssociationScopeable): unknown {
+    return AssociationScope.INSTANCE.scope(association);
+  }
+
+  /**
+   * Collect the bind values consumed by the chain — in chain order.
+   * For chain length 1 this is `[owner[joinForeignKey], owner.class.name?]`.
+   * For multi-step chains, intermediate reflections contribute the
+   * polymorphic type of the NEXT reflection's klass so JOINs filter by
+   * STI base class correctly.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope.get_bind_values
+   * (association_scope.rb:34-49).
+   */
+  static getBindValues(
+    owner: Base,
+    chain: ReadonlyArray<AbstractReflection | ReflectionProxy>,
+  ): unknown[] {
+    const binds: unknown[] = [];
+    const last = chain[chain.length - 1];
+    if (!last) return binds;
+    const joinFk = (last as { joinForeignKey?: string | string[] }).joinForeignKey;
+    const fks = Array.isArray(joinFk) ? joinFk : joinFk ? [joinFk] : [];
+    for (const fk of fks) binds.push(owner.readAttribute(fk));
+    if ((last as { type?: string | null }).type) {
+      binds.push((owner.constructor as typeof Base).name);
+    }
+    for (let i = 0; i < chain.length - 1; i++) {
+      const refl = chain[i];
+      const next = chain[i + 1];
+      if ((refl as { type?: string | null }).type) {
+        binds.push((next as { klass?: { name: string } }).klass?.name ?? null);
+      }
+    }
+    return binds;
+  }
+
+  /**
+   * Build the association's relation for `association.owner`. The
+   * returned value is an unexecuted `Relation` (so callers can chain
+   * `.where`/`.order`/`.toArray`).
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#scope
+   * (association_scope.rb:21-32).
+   */
+  scope(association: AssociationScopeable): unknown {
+    const { owner, reflection, klass } = association;
+    // Rails uses `klass.unscoped` here (association_scope.rb:23) but
+    // their `unscoped` STILL applies the STI `type_condition` because
+    // `relation()` adds it for `finder_needs_type_condition?` classes
+    // (see `core.rb:431-435`). Our `Base.unscoped` doesn't yet wire STI
+    // type filtering through `relation()`, so until that lands we use
+    // `.all()` — which already includes the STI filter on subclasses.
+    let scope = (klass as unknown as { all: () => unknown }).all();
+    const chain = this._getChain(reflection);
+    scope = this._addConstraints(scope, owner, chain);
+    if (!reflection.isCollection()) {
+      scope = (scope as { limit: (n: number) => unknown }).limit(1);
+    }
+    return scope;
+  }
+
+  private _transformValue<T>(value: T): unknown {
+    return this._valueTransformation(value);
+  }
+
+  /**
+   * Rails checks `scope.table == table` and scopes the where to the
+   * joined table's alias in the multi-step case. For chain length 1
+   * `scope.table` is the klass table, so the where goes directly on the
+   * relation.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#apply_scope
+   * (association_scope.rb:161-167).
+   */
+  private _applyScope(scope: unknown, _table: unknown, key: string, value: unknown): unknown {
+    return (scope as { where: (c: Record<string, unknown>) => unknown }).where({
+      [key]: value,
+    });
+  }
+
+  /**
+   * For the LAST reflection in the chain (which for chain-1 is the only
+   * one), apply owner-FK WHERE clauses plus the polymorphic `_type`
+   * filter if the reflection is polymorphic.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#last_chain_scope
+   * (association_scope.rb:58-75).
+   */
+  private _lastChainScope(
+    scope: unknown,
+    reflection: AbstractReflection | ReflectionProxy,
+    owner: Base,
+  ): unknown {
+    const r = reflection as {
+      joinPrimaryKey: string | string[];
+      joinForeignKey: string | string[];
+      type?: string | null;
+    };
+    const table = (reflection as ReflectionProxy).aliasedTable ?? null;
+    const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
+    const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
+    for (let i = 0; i < joinPks.length; i++) {
+      const rawValue = owner.readAttribute(joinFks[i]);
+      const value = this._transformValue(rawValue);
+      scope = this._applyScope(scope, table, joinPks[i], value);
+    }
+    if (r.type) {
+      const polyName = this._transformValue((owner.constructor as typeof Base).name);
+      scope = this._applyScope(scope, table, r.type, polyName);
+    }
+    return scope;
+  }
+
+  /**
+   * Build the chain of reflections to walk. Rails uses `reflection.chain`
+   * and wraps all-but-head in `ReflectionProxy` with aliased tables; for
+   * chain length 1 the source reflection stands alone.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#get_chain
+   * (association_scope.rb:112-122). Multi-step wrapping comes in PR 3.
+   */
+  private _getChain(
+    reflection: AssociationReflection,
+  ): Array<AbstractReflection | ReflectionProxy> {
+    if (reflection.chain.length > 1) {
+      throw new Error(
+        `AssociationScope: multi-step chain (through) not implemented in PR 1 — ` +
+          `reflection '${reflection.name}' has ${reflection.chain.length} chain entries`,
+      );
+    }
+    return [reflection];
+  }
+
+  /**
+   * Fold `last_chain_scope` over the chain and merge any user-supplied
+   * `scope` lambdas (reflection.scope / reflection.constraints) into the
+   * relation. PR 1 applies the scope lambda on the tail only.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#add_constraints
+   * (association_scope.rb:124-159).
+   */
+  private _addConstraints(
+    scope: unknown,
+    owner: Base,
+    chain: Array<AbstractReflection | ReflectionProxy>,
+  ): unknown {
+    const last = chain[chain.length - 1];
+    scope = this._lastChainScope(scope, last, owner);
+    const scopeLambda = (last as { scope?: (rel: unknown) => unknown }).scope;
+    if (typeof scopeLambda === "function") {
+      const applied = scopeLambda(scope);
+      if (applied) scope = applied;
+    }
+    return scope;
   }
 }

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -2,14 +2,29 @@ import { AssociationScope, type ValueTransformation } from "./association-scope.
 
 /**
  * Builds scopes for associations that disable joins, querying each
- * database separately and stitching results in memory. Real
- * implementation comes in a later PR — for now we inherit
- * `AssociationScope.scope` so a disable-joins `hasOne`/`hasMany` at
- * least builds a valid single-table relation.
+ * database separately and stitching results in memory.
+ *
+ * PR 1 placeholder: `scope()` is inherited from `AssociationScope`
+ * (chain length 1) and the static dispatch is polymorphic via
+ * `this.INSTANCE`, so `DisableJoinsAssociationScope.scope(association)`
+ * routes through this class' own INSTANCE. The real disable-joins
+ * scope-building logic (`scope()` override + multi-step stitching)
+ * lands in PR 4 — when it does, this subclass picks up its own
+ * `scope()` override automatically.
  *
  * Mirrors: ActiveRecord::Associations::DisableJoinsAssociationScope
  */
 export class DisableJoinsAssociationScope extends AssociationScope {
+  /**
+   * Subclass INSTANCE so the polymorphic `static scope` on the parent
+   * (`this.INSTANCE.scope(association)`) routes through a
+   * DisableJoinsAssociationScope rather than the base AssociationScope
+   * INSTANCE. PR 4 will override `scope()` here for real disable-joins
+   * behavior.
+   */
+  static override readonly INSTANCE: DisableJoinsAssociationScope =
+    DisableJoinsAssociationScope.create();
+
   constructor(valueTransformation: ValueTransformation = (v) => v) {
     super(valueTransformation);
   }

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -1,14 +1,16 @@
-import type { AssociationReflection } from "../reflection.js";
-import { AssociationScope } from "./association-scope.js";
+import { AssociationScope, type ValueTransformation } from "./association-scope.js";
 
 /**
  * Builds scopes for associations that disable joins, querying each
- * database separately and stitching results in memory.
+ * database separately and stitching results in memory. Real
+ * implementation comes in a later PR — for now we inherit
+ * `AssociationScope.scope` so a disable-joins `hasOne`/`hasMany` at
+ * least builds a valid single-table relation.
  *
  * Mirrors: ActiveRecord::Associations::DisableJoinsAssociationScope
  */
 export class DisableJoinsAssociationScope extends AssociationScope {
-  constructor(reflection: AssociationReflection) {
-    super(reflection);
+  constructor(valueTransformation: ValueTransformation = (v) => v) {
+    super(valueTransformation);
   }
 }


### PR DESCRIPTION
## Summary

PR 1 of 5 in the AssociationScope arc planned in #607. Replaces the signature-only stub with a Rails-faithful scope builder for the simplest case — non-through, non-polymorphic, no `:as` option, chain length 1 (hasMany / hasOne / belongsTo).

**Why now:** the existing loaders in `associations.ts` rebuild FK/PK/type filtering inline per macro type. Rails consolidates all of it through `AssociationScope` so the same code drives `belongs_to`, `has_one`, `has_many`, polymorphic, and through-chain queries. PR #607 carved this out as a separate larger piece of work; this is the first installment.

**What lands:**
- `AssociationScope.create(valueTransformation?)` / `INSTANCE` / static `scope(association)` / instance `scope(association)` — matches Rails' API at `activerecord/lib/active_record/associations/association_scope.rb:21-49`.
- Private helpers: `_lastChainScope`, `_applyScope`, `_transformValue`, `_getChain` (length-1 only — multi-step chains throw until PR 3).
- Static `getBindValues(owner, chain)` — Rails ref lines 34-49.
- `ReflectionProxy` upgraded from stub to SimpleDelegator-style forwarder exposing `.aliasedTable` alongside reflection's `joinPrimaryKey/joinForeignKey/type/klass/scope/constraints`. `allIncludes()` returns `null` to match Rails' block sentinel (`association_scope.rb:108`).
- `loadHasMany`'s scalar (non-composite, non-polymorphic, non-through) branch now routes through `AssociationScope.scope` when the reflection is registered. Composite-FK + `loadHasOne` migration follows in PR 2.
- `DisableJoinsAssociationScope` ctor updated to match (takes `valueTransformation`; real impl lives in PR 4).

**Known delta from Rails (documented inline at `association-scope.ts:166-182`):**
`AssociationScope#scope` calls `klass.unscoped()` (matching Rails' `association_scope.rb:23`) and then manually re-adds the STI `type_condition`. Rails' `unscoped` STILL applies that condition because `relation()` adds it for `finder_needs_type_condition?` classes (`core.rb:431-435`). Our `Base.unscoped` doesn't yet wire that through `relation()`, so we re-add the condition at this call site. Verified by `'has many through has many with sti'` in `associations/join-model.test.ts` and the new `applies STI type_condition on subclass targets` unit test.

## Out of scope (deferred to later PRs)
- PR 2: polymorphic + `:as` + constraint scope chains (`add_constraints`)
- PR 3: multi-step chains for through associations (`next_chain_scope`, full `get_chain`)
- PR 4: real `DisableJoinsAssociationScope.scope`
- PR 5: cleanup, cache wiring, `Associations.eager_load!` skip-list entry

## Test plan
- [x] New `association-scope.test.ts` — 9 tests covering `INSTANCE`/`create`/static `scope`/`getBindValues`/`ReflectionProxy`, scope-lambda single-application, STI type_condition, and multi-step-chain rejection
- [x] Full `packages/activerecord/src/associations` suite green (1518 / 1928)
- [x] Build + lint + DX type tests + PG/MariaDB/SQLite CI green