### PR TITLE
feat(activerecord): wire cacheableQuery + StatementCache.create round-trip

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -117,7 +117,20 @@ export function toSqlAndBinds(
     const visitor = (this as any)?.arelVisitor as Visitors.ToSql | undefined;
     if (visitor && node instanceof Nodes.Node) {
       const [sql, extractedBinds] = visitor.compileWithBinds(node);
-      return [sql, extractedBinds, preparable, allowRetry];
+      // Type-cast bind objects (QueryAttribute) to primitive values
+      // for adapter execution, matching Rails' type_casted_binds
+      const castedBinds = extractedBinds.map((b) => {
+        if (
+          b &&
+          typeof b === "object" &&
+          "valueForDatabase" in b &&
+          typeof (b as Record<string, unknown>).valueForDatabase === "function"
+        ) {
+          return (b as { valueForDatabase(): unknown }).valueForDatabase();
+        }
+        return b;
+      });
+      return [sql, castedBinds, preparable, allowRetry];
     }
     const sql = (node as any).toSql();
     return [sql, [], preparable, allowRetry];
@@ -142,7 +155,28 @@ export function cacheableQuery(
   arel: unknown,
 ): [unknown, unknown[]] {
   const host = this as DatabaseStatementsHost;
-  const [sql, binds] = toSqlAndBinds(arel);
+  // Use compileWithBinds directly to get raw binds (QueryAttribute
+  // objects with Substitute values) that BindMap needs for indexing.
+  // toSqlAndBinds would type-cast them to primitives, losing Substitute.
+  const visitor = (host as any)?.arelVisitor as Visitors.ToSql | undefined;
+  let sql: string;
+  let binds: unknown[];
+
+  // Unwrap TreeManager → Node
+  let node = arel;
+  if (node && (node as any).ast != null && typeof (node as any).ast === "object") {
+    node = (node as any).ast;
+  }
+
+  if (visitor && node instanceof Nodes.Node) {
+    [sql, binds] = visitor.compileWithBinds(node);
+  } else if (typeof arel === "string") {
+    sql = arel;
+    binds = [];
+  } else {
+    sql = (node as any).toSql?.() ?? String(node);
+    binds = [];
+  }
 
   if (host?.preparedStatements && klass.query) {
     return [klass.query(sql), binds as unknown[]];

--- a/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
+++ b/packages/activerecord/src/connection-adapters/database-statements-mixin.ts
@@ -9,6 +9,7 @@
 
 import { isWriteQuerySql } from "./sql-classification.js";
 import { Result } from "../result.js";
+import { cacheableQuery } from "./abstract/database-statements.js";
 
 /**
  * Minimum interface required by the mixin — the base class must provide
@@ -94,6 +95,17 @@ export function DatabaseStatementsMixin<T extends Constructor<any>>(Base: T) {
 
     emptyInsertStatementValue(_pk?: string | null): string {
       return "DEFAULT VALUES";
+    }
+
+    cacheableQuery(
+      klass: {
+        query?(sql: string): unknown;
+        partialQuery?(parts: unknown): unknown;
+        partialQueryCollector?(): unknown;
+      },
+      arel: unknown,
+    ): [unknown, unknown[]] {
+      return cacheableQuery.call(this as any, klass, arel);
     }
   };
 }

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -81,15 +81,13 @@ export async function _queryBySql(
   sql: string | [string, ...unknown[]],
   binds: unknown[] = [],
 ): Promise<Record<string, unknown>[]> {
-  let sanitized: string;
   if (Array.isArray(sql)) {
-    sanitized = sanitizeSql(sql);
-  } else if (binds.length > 0) {
-    sanitized = sanitizeSql([sql, ...binds] as [string, ...unknown[]]);
-  } else {
-    sanitized = sql;
+    // Array form [sql, ...values] — interpolate into the string
+    return this.adapter.execute(sanitizeSql(sql));
   }
-  return this.adapter.execute(sanitized);
+  // String SQL with separate binds — pass directly to adapter
+  // (matching Rails where binds go to connection.select_all)
+  return this.adapter.execute(sql, binds);
 }
 
 /**

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -135,9 +135,9 @@ describe("PredicateBuilderTest", () => {
       const [sql, binds] = visitor.compileWithBinds(node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
-      // The bind is the Substitute itself (unwrapped from QueryAttribute
-      // via valueForDatabase → identity type serialize)
-      expect(binds[0]).toBeInstanceOf(Substitute);
+      // The bind is the raw QueryAttribute wrapping the Substitute —
+      // compileWithBinds preserves bind objects for BindMap indexing
+      expect((binds[0] as any).valueBeforeTypeCast).toBeInstanceOf(Substitute);
     });
 
     it("compile inlines QueryAttribute values for display SQL", () => {

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -134,4 +134,10 @@ describe("StatementCacheTest", () => {
       adapter.disconnectBang();
     }
   });
+
+  it.skip("StatementCache.create compiles via cacheableQuery", () => {
+    // Full round-trip requires findBySql to pass binds directly to the
+    // adapter without going through sanitizeSql string interpolation.
+    // That's a separate change to the execution path.
+  });
 });

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -135,9 +135,40 @@ describe("StatementCacheTest", () => {
     }
   });
 
-  it.skip("StatementCache.create compiles via cacheableQuery", () => {
-    // Full round-trip requires findBySql to pass binds directly to the
-    // adapter without going through sanitizeSql string interpolation.
-    // That's a separate change to the execution path.
+  it("StatementCache.create → execute round-trip with Substitute", async () => {
+    await import("./relation.js");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    const { Base } = await import("./base.js");
+
+    const adapter = new SQLite3Adapter(":memory:");
+    try {
+      await adapter.executeMutation(
+        'CREATE TABLE "authors" ("id" INTEGER PRIMARY KEY, "name" TEXT)',
+      );
+      await adapter.executeMutation('INSERT INTO "authors" ("name") VALUES (?)', ["Matz"]);
+      await adapter.executeMutation('INSERT INTO "authors" ("name") VALUES (?)', ["DHH"]);
+
+      class Author extends Base {
+        static {
+          this.tableName = "authors";
+          this.adapter = adapter;
+        }
+      }
+
+      adapter.preparedStatements = true;
+      const cache = StatementCache.create(adapter, (params) => {
+        return Author.where({ name: params.bind() }) as any;
+      });
+
+      const r1 = await cache.execute(["Matz"], adapter);
+      expect(r1).toHaveLength(1);
+      expect(r1[0].readAttribute("name")).toBe("Matz");
+
+      const r2 = await cache.execute(["DHH"], adapter);
+      expect(r2).toHaveLength(1);
+      expect(r2[0].readAttribute("name")).toBe("DHH");
+    } finally {
+      adapter.disconnectBang();
+    }
   });
 });

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -130,9 +130,14 @@ export class BindMap {
     this._indexes = [];
     for (let i = 0; i < boundAttributes.length; i++) {
       const attr = boundAttributes[i];
-      if (attr instanceof Substitute) {
-        this._indexes.push(i);
-      } else if (attr instanceof Attribute && attr.value instanceof Substitute) {
+      const isSubstitute =
+        attr instanceof Substitute ||
+        (attr instanceof Attribute && attr.value instanceof Substitute) ||
+        (attr !== null &&
+          typeof attr === "object" &&
+          "valueBeforeTypeCast" in (attr as Record<string, unknown>) &&
+          (attr as any).valueBeforeTypeCast instanceof Substitute);
+      if (isSubstitute) {
         this._indexes.push(i);
       }
     }
@@ -145,6 +150,12 @@ export class BindMap {
       const attr = bas[offset];
       if (attr instanceof Attribute) {
         bas[offset] = attr.withCastValue(values[i]);
+      } else if (
+        attr !== null &&
+        typeof attr === "object" &&
+        typeof (attr as any).withCastValue === "function"
+      ) {
+        bas[offset] = (attr as { withCastValue(v: unknown): unknown }).withCastValue(values[i]);
       } else {
         bas[offset] = values[i];
       }
@@ -224,8 +235,16 @@ export class StatementCache {
     const sql = this._queryBuilder.sqlFor(bindValues, connection);
     // PartialQuery inlines values into the SQL string — pass empty binds
     // to avoid findBySql trying to re-substitute them.
-    const binds = this._queryBuilder instanceof PartialQuery ? [] : bindValues;
-    return this._model.findBySql(sql, binds);
+    if (this._queryBuilder instanceof PartialQuery) {
+      return this._model.findBySql(sql);
+    }
+    // Type-cast bind objects to primitives for the adapter
+    const castedBinds = bindValues.map((b) =>
+      b !== null && typeof b === "object" && typeof (b as any).valueForDatabase === "function"
+        ? (b as { valueForDatabase(): unknown }).valueForDatabase()
+        : b,
+    );
+    return this._model.findBySql(sql, castedBinds);
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -57,18 +57,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     } finally {
       this._extractBinds = false;
     }
-    const binds = bindCollector.value.map((b) => {
-      const val = b instanceof Nodes.BindParam ? b.value : b;
-      if (
-        val &&
-        typeof val === "object" &&
-        "valueForDatabase" in val &&
-        typeof (val as Record<string, unknown>).valueForDatabase === "function"
-      ) {
-        return (val as { valueForDatabase(): unknown }).valueForDatabase();
-      }
-      return val;
-    });
+    const binds = bindCollector.value.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
     return [sqlCollector.value, binds];
   }
 


### PR DESCRIPTION
## Summary

Completes the StatementCache pipeline — `StatementCache.create(adapter, (params) => Model.where({name: params.bind()}))` → `cache.execute(["value"], adapter)` now works end-to-end.

- **cacheableQuery**: Compiles via `compileWithBinds` directly, preserving raw QueryAttribute binds for BindMap Substitute indexing. Bound to `this` via the DatabaseStatementsMixin.
- **toSqlAndBinds**: Type-casts bind objects via `valueForDatabase()` for adapter execution (matching Rails' `type_casted_binds`)
- **compileWithBinds**: Returns raw bind objects (QueryAttribute) so BindMap can detect Substitute positions
- **BindMap**: Detects QueryAttribute with Substitute `valueBeforeTypeCast`
- **StatementCache.execute**: Type-casts QueryAttribute binds to primitives before passing to `findBySql`
- **_queryBySql**: Passes separate binds directly to `adapter.execute` instead of interpolating via `sanitizeSql`
- **DatabaseStatementsMixin**: Exposes `cacheableQuery` as an instance method

Integration test: `StatementCache.create` with `params.bind()` → `execute(["Matz"])` and `execute(["DHH"])` both return correct records.

## Test plan

- [x] `pnpm run build` — clean
- [x] 9604 tests pass (0 failures)
- [x] Full `StatementCache.create → execute` round-trip test passes
- [x] CI