### PR TITLE
feat(arel,activerecord): compileWithCollector accepts external collector

### DIFF
--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -171,4 +171,26 @@ describe("StatementCacheTest", () => {
       adapter.disconnectBang();
     }
   });
+
+  it("PartialQueryCollector produces Substitute slots via compileWithCollector", async () => {
+    const { Table, Visitors, star } = await import("@blazetrails/arel");
+    const v = new Visitors.ToSql();
+    const table = new Table("users");
+    const mgr = table.project(star).where(table.get("name").eq("alice"));
+
+    const collector = new PartialQueryCollector();
+    v.compileWithCollector(mgr.ast, collector);
+    const [parts, binds] = collector.value;
+
+    const hasSubstitute = parts.some((p: unknown) => p instanceof Substitute);
+    expect(hasSubstitute).toBe(true);
+    expect(binds.length).toBeGreaterThan(0);
+
+    // PartialQuery can interpolate values at these Substitute positions
+    const pq = new PartialQuery(parts);
+    const sql = pq.sqlFor(binds, { quote: (v: unknown) => `'${v}'` });
+    expect(sql).toContain('"users"."name"');
+    expect(sql).toContain("alice");
+    expect(sql).not.toContain("?");
+  });
 });

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -94,7 +94,7 @@ export class PartialQueryCollector {
 
   addBinds(
     binds: unknown[],
-    procForBinds?: (v: unknown) => unknown,
+    procForBinds?: ((v: unknown) => unknown) | null,
     _block?: (index: number) => string,
   ): this {
     const mapped = procForBinds ? binds.map(procForBinds) : binds;

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -86,13 +86,17 @@ export class PartialQueryCollector {
     return this;
   }
 
-  addBind(obj: unknown): this {
+  addBind(obj: unknown, _block?: (index: number) => string): this {
     this._binds.push(obj);
     this._parts.push(new Substitute());
     return this;
   }
 
-  addBinds(binds: unknown[], procForBinds?: (v: unknown) => unknown): this {
+  addBinds(
+    binds: unknown[],
+    procForBinds?: (v: unknown) => unknown,
+    _block?: (index: number) => string,
+  ): this {
     const mapped = procForBinds ? binds.map(procForBinds) : binds;
     this._binds.push(...mapped);
     for (let i = 0; i < binds.length; i++) {

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -69,9 +69,9 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compile(node);
   }
 
-  override compileWithCollector(node: Node): SQLString {
+  override compileWithCollector(node: Node, externalCollector?: unknown): SQLString {
     this.bindIndex = 0;
-    return super.compileWithCollector(node);
+    return super.compileWithCollector(node, externalCollector);
   }
 
   override compileWithBinds(node: Node): [string, unknown[]] {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -902,6 +902,38 @@ describe("the to_sql visitor", () => {
     expect(binds).toHaveLength(1);
   });
 
+  it("compileWithCollector accepts external collector", () => {
+    const v = new Visitors.ToSql();
+    const table = new Table("users");
+    const mgr = table.project(star).where(table.get("name").eq("alice"));
+
+    // Use a custom collector that tracks parts and binds
+    const parts: unknown[] = [];
+    const binds: unknown[] = [];
+    const collector = {
+      preparable: false,
+      retryable: true,
+      append(str: string) {
+        parts.push(str);
+        return collector;
+      },
+      addBind(value: unknown) {
+        binds.push(value);
+        parts.push("?");
+        return collector;
+      },
+      get value() {
+        return [parts, binds];
+      },
+    };
+
+    v.compileWithCollector(mgr.ast, collector);
+    // The collector received addBind calls for Casted values
+    expect(binds.length).toBeGreaterThan(0);
+    // SQL parts are accumulated
+    expect(parts.some((p) => typeof p === "string" && p.includes("users"))).toBe(true);
+  });
+
   it("works with lists", () => {
     const node = new Nodes.ValuesList([[new Nodes.Quoted(1)], [new Nodes.Quoted(2)]]);
     const sql = new Visitors.ToSql().compile(node);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -35,7 +35,17 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector.value;
   }
 
-  compileWithCollector(node: Node): SQLString {
+  compileWithCollector(node: Node, externalCollector?: unknown): SQLString {
+    if (externalCollector) {
+      this.collector = externalCollector as SQLString;
+      this._extractBinds = true;
+      try {
+        this.visit(node);
+      } finally {
+        this._extractBinds = false;
+      }
+      return this.collector;
+    }
     this.collector = new SQLString();
     this.visit(node);
     return this.collector;


### PR DESCRIPTION
## Summary

PR 1 of the cacheableQuery PartialCollector epic. Enables Arel visitors to compile AST nodes into an external collector (like PartialQueryCollector) instead of always creating a new SQLString.

- **compileWithCollector(node, externalCollector?)**: When an external collector is provided, sets `_extractBinds=true` so `visitCasted`/`visitBindParam` route values through `collector.addBind()` instead of inlining
- **PartialQueryCollector**: `addBind`/`addBinds` accept optional `block` param for PG `$N` formatting compatibility
- Tests verify external collector receives addBind calls, and PartialQueryCollector produces Substitute slots that PartialQuery can interpolate

## Test plan

- [x] `pnpm run build` — clean
- [x] 9606 tests pass (0 failures)
- [x] CI