### PR TITLE
feat(activerecord): cacheableQuery uses PartialQueryCollector for unprepared path

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -182,6 +182,18 @@ export function cacheableQuery(
     return [klass.query(sql), binds as unknown[]];
   }
 
+  // Unprepared path: compile through PartialQueryCollector to produce
+  // parts with Substitute slots, matching Rails' cacheable_query when
+  // prepared_statements is false.
+  if (klass.partialQueryCollector && klass.partialQuery && visitor && node instanceof Nodes.Node) {
+    const collector = klass.partialQueryCollector() as {
+      value: [unknown[], unknown[]];
+    };
+    visitor.compileWithCollector(node, collector);
+    const [parts, collectedBinds] = collector.value;
+    return [klass.partialQuery(parts), collectedBinds];
+  }
+
   if (klass.partialQuery) {
     return [klass.partialQuery(typeof sql === "string" ? [sql] : sql), binds as unknown[]];
   }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -155,12 +155,7 @@ export function cacheableQuery(
   arel: unknown,
 ): [unknown, unknown[]] {
   const host = this as DatabaseStatementsHost;
-  // Use compileWithBinds directly to get raw binds (QueryAttribute
-  // objects with Substitute values) that BindMap needs for indexing.
-  // toSqlAndBinds would type-cast them to primitives, losing Substitute.
   const visitor = (host as any)?.arelVisitor as Visitors.ToSql | undefined;
-  let sql: string;
-  let binds: unknown[];
 
   // Unwrap TreeManager → Node
   let node = arel;
@@ -168,18 +163,10 @@ export function cacheableQuery(
     node = (node as any).ast;
   }
 
-  if (visitor && node instanceof Nodes.Node) {
-    [sql, binds] = visitor.compileWithBinds(node);
-  } else if (typeof arel === "string") {
-    sql = arel;
-    binds = [];
-  } else {
-    sql = (node as any).toSql?.() ?? String(node);
-    binds = [];
-  }
-
-  if (host?.preparedStatements && klass.query) {
-    return [klass.query(sql), binds as unknown[]];
+  // Prepared path: compile with bind extraction, return Query + raw binds
+  if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
+    const [sql, binds] = visitor.compileWithBinds(node);
+    return [klass.query(sql), binds];
   }
 
   // Unprepared path: compile through PartialQueryCollector to produce
@@ -194,13 +181,21 @@ export function cacheableQuery(
     return [klass.partialQuery(parts), collectedBinds];
   }
 
-  if (klass.partialQuery) {
-    return [klass.partialQuery(typeof sql === "string" ? [sql] : sql), binds as unknown[]];
+  // Fallback: compile to SQL string
+  let sql: string;
+  if (typeof arel === "string") {
+    sql = arel;
+  } else if (visitor && node instanceof Nodes.Node) {
+    sql = visitor.compile(node);
+  } else {
+    sql = (node as any).toSql?.() ?? String(node);
   }
 
-  // Fallback: use query if available, otherwise raw SQL
+  if (klass.partialQuery) {
+    return [klass.partialQuery([sql]), []];
+  }
   const queryObj = klass.query ? klass.query(sql) : sql;
-  return [queryObj, binds as unknown[]];
+  return [queryObj, []];
 }
 
 // --- Query execution ---

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -193,4 +193,41 @@ describe("StatementCacheTest", () => {
     expect(sql).toContain("alice");
     expect(sql).not.toContain("?");
   });
+
+  it("StatementCache.create unprepared path uses PartialQuery with Substitute slots", async () => {
+    await import("./relation.js");
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    const { Base } = await import("./base.js");
+
+    const adapter = new SQLite3Adapter(":memory:");
+    try {
+      await adapter.executeMutation(
+        'CREATE TABLE "books" ("id" INTEGER PRIMARY KEY, "title" TEXT)',
+      );
+      await adapter.executeMutation('INSERT INTO "books" ("title") VALUES (?)', ["Ruby"]);
+      await adapter.executeMutation('INSERT INTO "books" ("title") VALUES (?)', ["TypeScript"]);
+
+      class Book extends Base {
+        static {
+          this.tableName = "books";
+          this.adapter = adapter;
+        }
+      }
+
+      // preparedStatements defaults to false — uses PartialQuery path
+      const cache = StatementCache.create(adapter, (params) => {
+        return Book.where({ title: params.bind() }) as any;
+      });
+
+      const r1 = await cache.execute(["Ruby"], adapter);
+      expect(r1).toHaveLength(1);
+      expect(r1[0].readAttribute("title")).toBe("Ruby");
+
+      const r2 = await cache.execute(["TypeScript"], adapter);
+      expect(r2).toHaveLength(1);
+      expect(r2[0].readAttribute("title")).toBe("TypeScript");
+    } finally {
+      adapter.disconnectBang();
+    }
+  });
 });

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -63,6 +63,12 @@ export class PartialQuery extends Query {
       let value = bindsCopy.shift();
       if (value instanceof Attribute) {
         value = value.valueForDatabase;
+      } else if (
+        value !== null &&
+        typeof value === "object" &&
+        typeof (value as Record<string, unknown>).valueForDatabase === "function"
+      ) {
+        value = (value as { valueForDatabase(): unknown }).valueForDatabase();
       }
       const conn = connection as { quote?(v: unknown): string };
       val[i] = conn.quote ? conn.quote(value) : quoteValue(value);


### PR DESCRIPTION
## Summary

Final PR of both prepared statement epics. When `preparedStatements` is false, `cacheableQuery` now compiles through `PartialQueryCollector` to produce `PartialQuery(parts)` with real Substitute slots — matching Rails' `cacheable_query` unprepared path.

Both `StatementCache.create → execute` paths now work end-to-end:
- **Prepared** (`preparedStatements=true`): `Query` with `?` placeholders + bind array
- **Unprepared** (`preparedStatements=false`): `PartialQuery` with Substitute slots → values quoted and interpolated at execution time

**Changes:**
- `cacheableQuery`: compiles via `compileWithCollector` with `PartialQueryCollector` when unprepared
- `PartialQuery.sqlFor`: handles `QueryAttribute.valueForDatabase()` for type-casting before quoting
- Integration test: unprepared round-trip with different bind values

## Test plan

- [x] `pnpm run build` — clean
- [x] 9623 tests pass (0 failures)
- [x] Both prepared and unprepared `StatementCache.create → execute` round-trips pass
- [x] CI