### PR TITLE
feat(activerecord): per-connection MySQL StatementPool via Mysql2Adapter

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/mysql2/statement_pool_test.rb
+ */
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+
+describeIfMysql("Mysql2Adapter", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(async () => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter.preparedStatements = true;
+  });
+  afterEach(async () => {
+    await adapter.close();
+  });
+
+  describe("StatementPoolTest", () => {
+    it("statement pool tracks distinct prepared queries", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT ? AS n", [1]);
+        await adapter.execute("SELECT ? AS n", [2]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool).toBeDefined();
+        expect(pool.length).toBe(1);
+
+        await adapter.execute("SELECT ? AS s", ["a"]);
+        expect(pool.length).toBe(2);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("statement pool max evicts LRU via unprepare", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT ? AS n", [1]);
+        const pool = adapter._statementPoolForTest()!;
+        // Rails' matching test sets statement_limit = 1 and asserts
+        // LRU eviction. setMaxSize immediately evicts the older entry
+        // via our Mysql2StatementPool#dealloc (conn.unprepare).
+        pool.setMaxSize(1);
+        await adapter.execute("SELECT ? AS s", ["a"]);
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("statementLimit config resizes the active pool", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT ? AS n", [1]);
+        await adapter.execute("SELECT ? AS s", ["a"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(2);
+        adapter.statementLimit = 1;
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("statementLimit = 0 disables named prepared statements", async () => {
+      adapter.statementLimit = 0;
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT ? AS n", [1]);
+        const pool = adapter._statementPoolForTest()!;
+        // Pool was created (first _poolFor call) but caching is off
+        // because maxSize is 0. Rails' StatementPool#set is likewise
+        // a no-op at limit=0, so we'd otherwise leak unbounded
+        // server-side prepared statements.
+        expect(pool).toBeDefined();
+        expect(pool.length).toBe(0);
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("executeMutation caches the plan for INSERT (reuses on repeat)", async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS \`sp_mut\``);
+      await adapter.exec(
+        `CREATE TABLE \`sp_mut\` (\`id\` INT AUTO_INCREMENT PRIMARY KEY, \`name\` VARCHAR(32))`,
+      );
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.executeMutation(`INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`, ["a"]);
+        await adapter.executeMutation(`INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`, ["b"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(1);
+      } finally {
+        await adapter.rollback();
+        await adapter.exec(`DROP TABLE IF EXISTS \`sp_mut\``);
+      }
+    });
+
+    it("dealloc does not raise on inactive connection", async () => {
+      await adapter.beginDbTransaction();
+      await adapter.execute("SELECT ? AS n", [1]);
+      const pool = adapter._statementPoolForTest()!;
+      await adapter.rollback();
+      await adapter.close();
+      expect(() => pool.clear()).not.toThrow();
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -65,14 +65,14 @@ describeIfMysql("Mysql2Adapter", () => {
       adapter.statementLimit = 0;
       await adapter.beginDbTransaction();
       try {
-        await adapter.execute("SELECT ? AS n", [1]);
-        const pool = adapter._statementPoolForTest()!;
-        // Pool was created (first _poolFor call) but caching is off
-        // because maxSize is 0. Rails' StatementPool#set is likewise
-        // a no-op at limit=0, so we'd otherwise leak unbounded
-        // server-side prepared statements.
-        expect(pool).toBeDefined();
-        expect(pool.length).toBe(0);
+        // Query still runs — just via `conn.query` (text protocol)
+        // instead of `conn.execute` (binary prepared). No pool is
+        // created because `_shouldPrepare` short-circuits, so we'd
+        // otherwise leak unbounded server-side PREPAREs. Rails'
+        // StatementPool#set is likewise a no-op at limit=0.
+        const rows = await adapter.execute("SELECT ? AS n", [1]);
+        expect(rows[0]).toBeDefined();
+        expect(adapter._statementPoolForTest()).toBeUndefined();
       } finally {
         await adapter.rollback();
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -37,7 +37,8 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.execute("SELECT ? AS n", [1]);
         const pool = adapter._statementPoolForTest()!;
         // Rails' matching test sets statement_limit = 1 and asserts
-        // LRU eviction. setMaxSize immediately evicts the older entry
+        // LRU eviction. With one cached statement, setMaxSize(1) just
+        // records the new limit; eviction happens on the next insert
         // via our Mysql2StatementPool#dealloc (conn.unprepare).
         pool.setMaxSize(1);
         await adapter.execute("SELECT ? AS s", ["a"]);

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -1,11 +1,50 @@
 import mysql from "mysql2/promise";
 import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
-import { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql-adapter.js";
+import {
+  AbstractMysqlAdapter,
+  StatementPool as MysqlStatementPool,
+  type MysqlPreparedStatement,
+} from "../connection-adapters/abstract-mysql-adapter.js";
 import { Column } from "../connection-adapters/column.js";
 import { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "../connection-adapters/mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "../connection-adapters/abstract/database-statements.js";
+
+/**
+ * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
+ * via `connection.unprepare(sql)` so the mysql2 driver's internal
+ * cache (and the server's) stay in step with our `statement_limit`.
+ *
+ * Mirrors: Mysql2Adapter::StatementPool in activerecord. Errors are
+ * intentionally swallowed — Rails' equivalent rescues Mysql2::Error.
+ */
+class Mysql2StatementPool extends MysqlStatementPool {
+  private _conn: mysql.PoolConnection | null;
+
+  constructor(conn: mysql.PoolConnection, maxSize: number) {
+    super(maxSize);
+    this._conn = conn;
+  }
+
+  protected override dealloc(stmt: MysqlPreparedStatement): void {
+    const conn = this._conn;
+    if (!conn) return;
+    // `unprepare` is synchronous in node-mysql2 (it only touches the
+    // client-side cache and queues COM_STMT_CLOSE on the socket), but
+    // wrap in try/catch in case the client was already destroyed —
+    // eviction can't throw or it escapes the base class's loop.
+    try {
+      (conn as unknown as { unprepare: (sql: string) => void }).unprepare(stmt.sql);
+    } catch {
+      // swallow — matches Rails' Mysql2::Error rescue on stmt close
+    }
+  }
+
+  detach(): void {
+    this._conn = null;
+  }
+}
 
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
@@ -35,6 +74,66 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _driverPool: mysql.Pool | null;
   private _conn: mysql.PoolConnection | null = null;
   private _inTransaction = false;
+  // Per-mysql.PoolConnection StatementPool. Mirrors the PG adapter's
+  // WeakMap approach — prepared statements are session-scoped, so the
+  // pool stays attached to the physical connection across the pool's
+  // checkin/checkout cycle. WeakMap lets mysql2.Pool reap connections
+  // without us leaking entries.
+  private _statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
+
+  protected override _onStatementLimitChanged(value: number): void {
+    if (this._conn) this._statementPools.get(this._conn)?.setMaxSize(value);
+  }
+
+  /**
+   * Look up (or lazily create) the statement pool for `conn`. Matches
+   * the PG adapter's `_poolFor`.
+   */
+  private _poolFor(conn: mysql.PoolConnection): Mysql2StatementPool {
+    let pool = this._statementPools.get(conn);
+    if (!pool) {
+      pool = new Mysql2StatementPool(conn, this._statementLimit);
+      this._statementPools.set(conn, pool);
+    }
+    return pool;
+  }
+
+  /**
+   * Gate named-prepared-statement routing through our pool. Mirrors
+   * Rails' `prepared_statements && !binds.empty?` plus the extra
+   * `statement_limit > 0` check that disables caching (and therefore
+   * the whole prepared-statement path) when the operator sets
+   * `statement_limit = 0`.
+   */
+  private _shouldPrepare(conn: mysql.PoolConnection, binds: unknown[]): boolean {
+    if (!this.preparedStatements || binds.length === 0) return false;
+    const poolLimit = this._statementPools.get(conn)?.maxSize ?? this._statementLimit;
+    return poolLimit > 0;
+  }
+
+  /**
+   * Track a SQL string in the per-connection pool BEFORE handing it
+   * to `conn.execute()`. If the insert evicts an older entry, our
+   * pool's `dealloc` sends COM_STMT_CLOSE via `unprepare` so the
+   * mysql2 driver's internal cache and the server both release the
+   * prepared statement. No-op when caching is disabled.
+   */
+  private _trackPrepared(conn: mysql.PoolConnection, sql: string): void {
+    const pool = this._poolFor(conn);
+    if (pool.maxSize === 0) return;
+    if (pool.has(sql)) return;
+    pool.set(sql, { sql, key: pool.nextKey() });
+  }
+
+  /**
+   * Test-only accessor for the statement pool attached to the
+   * currently-held transaction connection. Returns undefined outside
+   * a transaction — matches the PG adapter's equivalent hook.
+   * @internal
+   */
+  _statementPoolForTest(): Mysql2StatementPool | undefined {
+    return this._conn ? this._statementPools.get(this._conn) : undefined;
+  }
   // Cached capability flag — information_schema.statistics.expression
   // is MySQL 8.0.13+. Pre-8 MySQL and MariaDB (through at least 10.x)
   // don't expose it, so we detect once and remember. `undefined` =
@@ -133,10 +232,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         conn = await this.getConn();
         // Use server-side prepared statements when enabled and binds
         // are present — matches PR #589's preparedStatements toggle.
-        const [rows] =
-          this.preparedStatements && binds.length > 0
-            ? await conn.execute(driverSql, driverBinds as any[])
-            : await conn.query(driverSql, driverBinds);
+        // Track the SQL in our per-connection pool first so LRU
+        // eviction sends COM_STMT_CLOSE (via unprepare) when we
+        // exceed `statement_limit`.
+        const prepare = this._shouldPrepare(conn, binds);
+        if (prepare) this._trackPrepared(conn, driverSql);
+        const [rows] = prepare
+          ? await conn.execute(driverSql, driverBinds as any[])
+          : await conn.query(driverSql, driverBinds);
         const r = rows as Record<string, unknown>[];
         payload.row_count = Array.isArray(r) ? r.length : 0;
         return r;
@@ -173,10 +276,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       let conn: mysql.PoolConnection | undefined;
       try {
         conn = await this.getConn();
-        const [result] =
-          this.preparedStatements && binds.length > 0
-            ? await conn.execute(driverSql, driverBinds as any[])
-            : await conn.query(driverSql, driverBinds);
+        const prepare = this._shouldPrepare(conn, binds);
+        if (prepare) this._trackPrepared(conn, driverSql);
+        const [result] = prepare
+          ? await conn.execute(driverSql, driverBinds as any[])
+          : await conn.query(driverSql, driverBinds);
         this.dirtyCurrentTransaction();
         const info = result as mysql.ResultSetHeader;
         payload.row_count = info.affectedRows ?? 0;
@@ -722,9 +826,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       this._advisoryLockConn = null;
     }
     if (this._conn) {
+      this._statementPools.get(this._conn)?.detach();
       this._conn.release();
       this._conn = null;
     }
+    // Drop adapter-held references; pools become unreachable once
+    // mysql2 releases the underlying connections. Matches PG's
+    // close() — we never detach on commit/rollback because prepared
+    // statements are session-scoped, not transaction-scoped.
+    this._statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
     if (this._driverPool) {
       await this._driverPool.end();
       this._driverPool = null;

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -121,7 +121,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _trackPrepared(conn: mysql.PoolConnection, sql: string): void {
     const pool = this._poolFor(conn);
     if (pool.maxSize === 0) return;
-    if (pool.has(sql)) return;
+    // Use `get` (not `has`) so an already-cached entry is moved to
+    // the MRU end of the LRU. Otherwise a hot statement executed
+    // repeatedly would keep its original insertion position and get
+    // evicted the moment any other distinct query came along.
+    if (pool.get(sql)) return;
     pool.set(sql, { sql, key: pool.nextKey() });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -54,6 +54,41 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
+  // Rails' `statement_limit` database.yml key — max prepared
+  // statements cached per session before LRU eviction (default 1000).
+  // Mirrors the same surface we expose on PostgreSQLAdapter; driver-
+  // specific subclasses (Mysql2Adapter, TrilogyAdapter) decide how to
+  // actually wire the per-connection pool.
+  protected _statementLimit = 1000;
+
+  /**
+   * Maximum prepared statements cached per MySQL connection.
+   *
+   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
+   * `config[:statement_limit]` in AbstractMysqlAdapter#initialize.
+   */
+  get statementLimit(): number {
+    return this._statementLimit;
+  }
+
+  set statementLimit(value: number) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new RangeError(
+        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
+      );
+    }
+    this._statementLimit = value;
+    // Driver-specific subclasses override this to resize their active
+    // per-connection pool. Base impl is a no-op.
+    this._onStatementLimitChanged(value);
+  }
+
+  /**
+   * Hook for driver-specific subclasses to propagate a statementLimit
+   * change to the currently-held connection's StatementPool, if any.
+   * Base impl intentionally does nothing.
+   */
+  protected _onStatementLimitChanged(_value: number): void {}
 
   get adapterName(): string {
     return "Mysql2";
@@ -567,11 +602,38 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 }
 
 /**
- * Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::StatementPool
+ * Shape of a cached MySQL prepared statement. `sql` is the key the
+ * mysql2 driver uses for its own internal client-side cache — passing
+ * it back to `connection.unprepare(sql)` closes the server-side
+ * statement (COM_STMT_CLOSE). `key` is the Rails-style `a<n>` identifier
+ * we use only for logging / diagnostics.
  *
- * MySQL-specific statement pool that inherits the base eviction logic
- * from ConnectionAdapters::StatementPool.
+ * Mirrors: the Statement struct in Rails'
+ * `ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements`.
+ */
+export interface MysqlPreparedStatement {
+  sql: string;
+  key: string;
+}
+
+/**
+ * MySQL-family StatementPool. Adds Rails-parity `nextKey()` on top of
+ * the base LRU cache. Driver-specific subclasses (Mysql2Adapter's
+ * inline subclass) override `dealloc` to send COM_STMT_CLOSE via
+ * `connection.unprepare`.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::StatementPool
  */
 // Named to avoid collision with the base StatementPool import — consumers
 // can import this under the AbstractMysqlAdapter namespace.
-export class StatementPool extends ConnectionStatementPool {}
+export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatement> {
+  private _counter = 0;
+
+  /**
+   * Allocate a fresh prepared-statement key. Mirrors Rails' per-pool
+   * `@counter += 1` on `AbstractMysqlAdapter::StatementPool`.
+   */
+  nextKey(): string {
+    return `a${++this._counter}`;
+  }
+}


### PR DESCRIPTION
## Summary

PR 2 of the StatementPool plan (PR 1 = #611 PG). Brings Rails-parity `statement_limit` semantics to the MySQL family. Previously `Mysql2Adapter.execute()` went straight to mysql2's driver-level prepared-statement cache with no visibility or bound from our side — Rails' `AbstractMysqlAdapter::StatementPool` + `statement_limit` had no analog.

- `AbstractMysqlAdapter.StatementPool` now stores typed `MysqlPreparedStatement` entries and exposes `nextKey()` (per-pool `@counter`, mirrors Rails).
- `AbstractMysqlAdapter.statementLimit` getter/setter with input validation; subclasses override `_onStatementLimitChanged` to propagate.
- `Mysql2Adapter` subclasses the pool with a `dealloc` that sends COM_STMT_CLOSE via `connection.unprepare(sql)` on LRU eviction — matches Rails' `Mysql2::Error`-rescuing `stmt.close`.
- Per-`mysql.PoolConnection` pool via `WeakMap`, attached for the physical connection lifetime. Commit/rollback don't detach (prepared statements are session-scoped, not txn-scoped — matches PG and Rails).
- `_shouldPrepare` gates on `preparedStatements && binds.length > 0 && pool.maxSize > 0` so `statement_limit = 0` reliably disables named prepared statements.
- 6 Rails-mirrored tests under `adapters/abstract-mysql-adapter/statement-pool.test.ts`.

Trilogy inherits the `StatementPool` class + `statementLimit` API via `AbstractMysqlAdapter`; wiring it into a real Trilogy driver path is out of scope (the adapter is a stub).

## Test plan

- [ ] MariaDB CI: new `StatementPoolTest` cases pass
- [ ] Full AR suite (sqlite): 8634 passed locally, 0 new failures
- [ ] No regression under `MYSQL_TEST_URL` CI run