### PR TITLE
feat(activerecord): AssociationScope polymorphic + :as (PR 2: single-chain)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -6,6 +6,7 @@ import {
   DeleteRestrictionError,
   InverseOfAssociationNotFoundError,
   HasOneThroughNestedAssociationsAreReadonly,
+  CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
 import { ForeignAssociation } from "./associations/foreign-association.js";
 import { AssociationScope } from "./associations/association-scope.js";
@@ -345,6 +346,9 @@ export async function loadBelongsTo(
     // Inline fallback: no reflection registered.
     if (Array.isArray(foreignKey)) {
       const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      if (pkCols.length !== foreignKey.length) {
+        throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+      }
       const conditions: Record<string, unknown> = {};
       for (let i = 0; i < foreignKey.length; i++) {
         conditions[pkCols[i]] = record.readAttribute(foreignKey[i]);
@@ -414,12 +418,14 @@ export async function loadHasOne(
           ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
           : `${underscore(ctor.name)}_id`));
 
+  // Polymorphic `:as` doesn't model composite owner-PK or composite
+  // FK in Rails. Reject explicitly so the caller gets a clear error
+  // rather than `readAttribute(undefined)` building a broken WHERE.
+  if (options.as && (Array.isArray(primaryKey) || Array.isArray(foreignKey))) {
+    throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+  }
   // Null-PK short-circuit: avoid a query when the owner's PK is missing.
-  const pkCheckCols = options.as
-    ? [primaryKey as string]
-    : Array.isArray(primaryKey)
-      ? primaryKey
-      : [primaryKey as string];
+  const pkCheckCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
   for (const pk of pkCheckCols) {
     const v = record.readAttribute(pk);
     if (v === null || v === undefined) return null;
@@ -446,6 +452,9 @@ export async function loadHasOne(
     // Inline fallback: no reflection registered.
     if (Array.isArray(foreignKey)) {
       const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      if (pkCols.length !== foreignKey.length) {
+        throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+      }
       const conditions: Record<string, unknown> = {};
       for (let i = 0; i < foreignKey.length; i++) {
         conditions[foreignKey[i]] = record.readAttribute(pkCols[i]);
@@ -586,14 +595,16 @@ export async function loadHasMany(
           ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
           : `${underscore(ctor.name)}_id`));
 
+  // Polymorphic `:as` doesn't model composite owner-PK or composite
+  // FK in Rails. Reject explicitly so the caller gets a clear error
+  // rather than `readAttribute(undefined)` building a broken WHERE.
+  if (options.as && (Array.isArray(primaryKey) || Array.isArray(foreignKey))) {
+    throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+  }
   // Null-FK short-circuit: avoid a query when the owner's PK value is
   // missing (unsaved record). Rails would WHERE on null and return [];
   // we skip the roundtrip.
-  const fkCheckPks = options.as
-    ? [primaryKey as string]
-    : Array.isArray(primaryKey)
-      ? primaryKey
-      : [primaryKey as string];
+  const fkCheckPks = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
   for (const pk of fkCheckPks) {
     const v = record.readAttribute(pk);
     if (v === null || v === undefined) return [];
@@ -632,6 +643,9 @@ export async function loadHasMany(
     // Inline fallback: no reflection (lower-level test helpers).
     if (Array.isArray(foreignKey)) {
       const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      if (pkCols.length !== foreignKey.length) {
+        throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+      }
       const conditions: Record<string, unknown> = {};
       for (let i = 0; i < foreignKey.length; i++) {
         conditions[foreignKey[i]] = record.readAttribute(pkCols[i]);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -315,13 +315,6 @@ export async function loadBelongsTo(
         : defaultFk);
   const primaryKey = options.primaryKey ?? targetModel.primaryKey;
 
-  // Null-FK short-circuit: avoid a query when owner's FK column is null.
-  const fkCols = Array.isArray(foreignKey) ? foreignKey : [foreignKey as string];
-  for (const fk of fkCols) {
-    const v = record.readAttribute(fk);
-    if (v === null || v === undefined) return null;
-  }
-
   // Route through AssociationScope when reflection is registered.
   // For polymorphic belongsTo, AssociationScope receives the
   // runtime-resolved klass; the reflection's own joinPrimaryKey
@@ -329,6 +322,24 @@ export async function loadBelongsTo(
   // returns the owner-side FK, so the WHERE shape is identical to
   // the non-polymorphic case.
   const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Null-FK short-circuit: avoid a query when owner's FK column is null.
+  // The check must read the SAME columns the eventual query uses —
+  // reflection.joinForeignKey when routing through AssociationScope,
+  // options-derived foreignKey otherwise. Reading from a different
+  // column would silently return null while a real query would have
+  // found the row (or vice versa).
+  const fkColsForCheck = reflection
+    ? Array.isArray((reflection as any).joinForeignKey)
+      ? ((reflection as any).joinForeignKey as string[])
+      : [(reflection as any).joinForeignKey as string]
+    : Array.isArray(foreignKey)
+      ? foreignKey
+      : [foreignKey as string];
+  for (const fk of fkColsForCheck) {
+    const v = record.readAttribute(fk);
+    if (v === null || v === undefined) return null;
+  }
+
   let result: Base | null;
   if (reflection) {
     const built = AssociationScope.scope({
@@ -424,17 +435,28 @@ export async function loadHasOne(
   if (options.as && (Array.isArray(primaryKey) || Array.isArray(foreignKey))) {
     throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
   }
-  // Null-PK short-circuit: avoid a query when the owner's PK is missing.
-  const pkCheckCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
+  // Route through AssociationScope (handles scalar, composite, :as, STI
+  // in a single Rails-faithful path). reflection.isCollection() === false
+  // for hasOne, so AssociationScope.scope adds limit(1) automatically.
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Null-PK short-circuit: read the SAME columns the eventual query
+  // reads — reflection.joinForeignKey when routing through
+  // AssociationScope (= owner-side FK = activeRecordPrimaryKey for
+  // hasOne), options-derived primaryKey otherwise. Reading from a
+  // different column would silently return null while the real query
+  // would have found the row.
+  const pkCheckCols = reflection
+    ? Array.isArray((reflection as any).joinForeignKey)
+      ? ((reflection as any).joinForeignKey as string[])
+      : [(reflection as any).joinForeignKey as string]
+    : Array.isArray(primaryKey)
+      ? primaryKey
+      : [primaryKey as string];
   for (const pk of pkCheckCols) {
     const v = record.readAttribute(pk);
     if (v === null || v === undefined) return null;
   }
 
-  // Route through AssociationScope (handles scalar, composite, :as, STI
-  // in a single Rails-faithful path). reflection.isCollection() === false
-  // for hasOne, so AssociationScope.scope adds limit(1) automatically.
-  const reflection = ctor._reflectOnAssociation?.(assocName);
   let result: Base | null;
   if (reflection) {
     const built = AssociationScope.scope({
@@ -601,15 +623,6 @@ export async function loadHasMany(
   if (options.as && (Array.isArray(primaryKey) || Array.isArray(foreignKey))) {
     throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
   }
-  // Null-FK short-circuit: avoid a query when the owner's PK value is
-  // missing (unsaved record). Rails would WHERE on null and return [];
-  // we skip the roundtrip.
-  const fkCheckPks = Array.isArray(primaryKey) ? primaryKey : [primaryKey as string];
-  for (const pk of fkCheckPks) {
-    const v = record.readAttribute(pk);
-    if (v === null || v === undefined) return [];
-  }
-
   // Route through AssociationScope when we have a reflection registered.
   // AssociationScope handles scalar, composite, polymorphic `:as`, and
   // STI in a single path matching Rails' `AssociationScope.scope`.
@@ -617,6 +630,24 @@ export async function loadHasMany(
   // (happens in tests that define associations via the lower-level API
   // without going through Reflection.create).
   const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Null-FK short-circuit: read the SAME columns the eventual query
+  // reads — reflection.joinForeignKey when routing through
+  // AssociationScope (= owner-side activeRecordPrimaryKey for hasMany),
+  // options-derived primaryKey otherwise. Reading from a different
+  // column would silently return [] while the real query would have
+  // found rows.
+  const fkCheckPks = reflection
+    ? Array.isArray((reflection as any).joinForeignKey)
+      ? ((reflection as any).joinForeignKey as string[])
+      : [(reflection as any).joinForeignKey as string]
+    : Array.isArray(primaryKey)
+      ? primaryKey
+      : [primaryKey as string];
+  for (const pk of fkCheckPks) {
+    const v = record.readAttribute(pk);
+    if (v === null || v === undefined) return [];
+  }
+
   let rel: any;
   if (reflection) {
     // Rails' `Association#scope` is

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -284,6 +284,7 @@ export async function loadBelongsTo(
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
+  const ctor = record.constructor as typeof Base;
   const defaultFk = `${underscore(assocName)}_id`;
 
   // Polymorphic: use the _type column to determine the target model
@@ -303,7 +304,7 @@ export async function loadBelongsTo(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Resolve foreign key and primary key (may be arrays for CPK)
+  // Resolve foreign key and primary key (may be arrays for CPK).
   const foreignKey =
     options.foreignKey ??
     (options.queryConstraints
@@ -313,28 +314,48 @@ export async function loadBelongsTo(
         : defaultFk);
   const primaryKey = options.primaryKey ?? targetModel.primaryKey;
 
-  // Composite FK/PK: build multi-column where
-  if (Array.isArray(foreignKey)) {
-    const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-    const conditions: Record<string, unknown> = {};
-    for (let i = 0; i < foreignKey.length; i++) {
-      const fkVal = record.readAttribute(foreignKey[i]);
-      if (fkVal === null || fkVal === undefined) return null;
-      conditions[pkCols[i]] = fkVal;
-    }
-    const result = await targetModel.findBy(conditions);
-    if (result && options.inverseOf) {
-      (result as any)._cachedAssociations = (result as any)._cachedAssociations ?? new Map();
-      (result as any)._cachedAssociations.set(options.inverseOf, record);
-    }
-    syncToAssociationInstance(record, assocName, result);
-    return result;
+  // Null-FK short-circuit: avoid a query when owner's FK column is null.
+  const fkCols = Array.isArray(foreignKey) ? foreignKey : [foreignKey as string];
+  for (const fk of fkCols) {
+    const v = record.readAttribute(fk);
+    if (v === null || v === undefined) return null;
   }
 
-  const fkValue = record.readAttribute(foreignKey as string);
-  if (fkValue === null || fkValue === undefined) return null;
-
-  const result = await targetModel.findBy({ [primaryKey as string]: fkValue });
+  // Route through AssociationScope when reflection is registered.
+  // For polymorphic belongsTo, AssociationScope receives the
+  // runtime-resolved klass; the reflection's own joinPrimaryKey
+  // returns associationPrimaryKey (target's PK) and joinForeignKey
+  // returns the owner-side FK, so the WHERE shape is identical to
+  // the non-polymorphic case.
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  let result: Base | null;
+  if (reflection) {
+    const built = AssociationScope.scope({
+      owner: record,
+      reflection,
+      klass: targetModel,
+    }) as any;
+    const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
+    let rel = baseRelation.merge(built);
+    if (options.scope && options.scope !== (reflection as any).scope) {
+      rel = options.scope(rel);
+    }
+    result = await rel.first();
+  } else {
+    // Inline fallback: no reflection registered.
+    if (Array.isArray(foreignKey)) {
+      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < foreignKey.length; i++) {
+        conditions[pkCols[i]] = record.readAttribute(foreignKey[i]);
+      }
+      result = await targetModel.findBy(conditions);
+    } else {
+      result = await targetModel.findBy({
+        [primaryKey as string]: record.readAttribute(foreignKey as string),
+      });
+    }
+  }
 
   // Set inverse_of: store reference back to the owner
   if (result && options.inverseOf) {
@@ -382,55 +403,71 @@ export async function loadHasOne(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Polymorphic "as" option: has_one :image, as: :imageable
-  if (options.as) {
-    const foreignKey = options.foreignKey ?? `${underscore(options.as)}_id`;
-    const pkValue = record.readAttribute(primaryKey as string);
-    if (pkValue === null || pkValue === undefined) return null;
-    const typeCol = `${underscore(options.as)}_type`;
-    return targetModel.findBy({
-      [foreignKey as string]: pkValue,
-      [typeCol]: ctor.name,
-    });
+  // Resolve FK columns (may be array for CPK; `:as` swaps to the
+  // polymorphic FK column).
+  const foreignKey = options.as
+    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
+    : (options.foreignKey ??
+      (options.queryConstraints
+        ? options.queryConstraints
+        : Array.isArray(primaryKey)
+          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
+          : `${underscore(ctor.name)}_id`));
+
+  // Null-PK short-circuit: avoid a query when the owner's PK is missing.
+  const pkCheckCols = options.as
+    ? [primaryKey as string]
+    : Array.isArray(primaryKey)
+      ? primaryKey
+      : [primaryKey as string];
+  for (const pk of pkCheckCols) {
+    const v = record.readAttribute(pk);
+    if (v === null || v === undefined) return null;
   }
 
-  // Resolve FK columns (may be array for CPK)
-  const foreignKey =
-    options.foreignKey ??
-    (options.queryConstraints
-      ? options.queryConstraints
-      : Array.isArray(primaryKey)
-        ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-        : `${underscore(ctor.name)}_id`);
-
-  // Composite FK/PK: build multi-column where
-  if (Array.isArray(foreignKey)) {
-    const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-    const conditions: Record<string, unknown> = {};
-    for (let i = 0; i < foreignKey.length; i++) {
-      const pkVal = record.readAttribute(pkCols[i]);
-      if (pkVal === null || pkVal === undefined) return null;
-      conditions[foreignKey[i]] = pkVal;
-    }
-    const result = await targetModel.findBy(conditions);
-    if (result && options.inverseOf) {
-      (result as any)._cachedAssociations = (result as any)._cachedAssociations ?? new Map();
-      (result as any)._cachedAssociations.set(options.inverseOf, record);
-    }
-    syncToAssociationInstance(record, assocName, result);
-    return result;
-  }
-
-  const pkValue = record.readAttribute(primaryKey as string);
-  if (pkValue === null || pkValue === undefined) return null;
-
+  // Route through AssociationScope (handles scalar, composite, :as, STI
+  // in a single Rails-faithful path). reflection.isCollection() === false
+  // for hasOne, so AssociationScope.scope adds limit(1) automatically.
+  const reflection = ctor._reflectOnAssociation?.(assocName);
   let result: Base | null;
-  if (options.scope) {
-    let rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
-    rel = options.scope(rel);
+  if (reflection) {
+    const built = AssociationScope.scope({
+      owner: record,
+      reflection,
+      klass: targetModel,
+    }) as any;
+    const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
+    let rel = baseRelation.merge(built);
+    if (options.scope && options.scope !== (reflection as any).scope) {
+      rel = options.scope(rel);
+    }
     result = await rel.first();
   } else {
-    result = await targetModel.findBy({ [foreignKey]: pkValue });
+    // Inline fallback: no reflection registered.
+    if (Array.isArray(foreignKey)) {
+      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < foreignKey.length; i++) {
+        conditions[foreignKey[i]] = record.readAttribute(pkCols[i]);
+      }
+      result = await targetModel.findBy(conditions);
+    } else if (options.as) {
+      const typeCol = `${underscore(options.as)}_type`;
+      result = await targetModel.findBy({
+        [foreignKey as string]: record.readAttribute(primaryKey as string),
+        [typeCol]: ctor.name,
+      });
+    } else if (options.scope) {
+      let rel = (targetModel as any)
+        .all()
+        .where({ [foreignKey as string]: record.readAttribute(primaryKey as string) });
+      rel = options.scope(rel);
+      result = await rel.first();
+    } else {
+      result = await targetModel.findBy({
+        [foreignKey as string]: record.readAttribute(primaryKey as string),
+      });
+    }
   }
 
   // Set inverse_of: store reference back to the owner
@@ -538,76 +575,49 @@ export async function loadHasMany(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Polymorphic "as" option: has_many :comments, as: :commentable
-  if (options.as) {
-    const foreignKey = options.foreignKey ?? `${underscore(options.as)}_id`;
-    const pkValue = record.readAttribute(primaryKey as string);
-    if (pkValue === null || pkValue === undefined) return [];
-    const typeCol = `${underscore(options.as)}_type`;
-    const rel = (targetModel as any).all().where({
-      [foreignKey as string]: pkValue,
-      [typeCol]: ctor.name,
-    });
-    return rel.toArray();
+  // Resolve FK columns (may be array for CPK; `:as` swaps to the
+  // polymorphic FK column).
+  const foreignKey = options.as
+    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
+    : (options.foreignKey ??
+      (options.queryConstraints
+        ? options.queryConstraints
+        : Array.isArray(primaryKey)
+          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
+          : `${underscore(ctor.name)}_id`));
+
+  // Null-FK short-circuit: avoid a query when the owner's PK value is
+  // missing (unsaved record). Rails would WHERE on null and return [];
+  // we skip the roundtrip.
+  const fkCheckPks = options.as
+    ? [primaryKey as string]
+    : Array.isArray(primaryKey)
+      ? primaryKey
+      : [primaryKey as string];
+  for (const pk of fkCheckPks) {
+    const v = record.readAttribute(pk);
+    if (v === null || v === undefined) return [];
   }
 
-  // Resolve FK columns (may be array for CPK)
-  const foreignKey =
-    options.foreignKey ??
-    (options.queryConstraints
-      ? options.queryConstraints
-      : Array.isArray(primaryKey)
-        ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-        : `${underscore(ctor.name)}_id`);
-
-  // Composite FK/PK: build multi-column where
-  if (Array.isArray(foreignKey)) {
-    const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-    const conditions: Record<string, unknown> = {};
-    for (let i = 0; i < foreignKey.length; i++) {
-      const pkVal = record.readAttribute(pkCols[i]);
-      if (pkVal === null || pkVal === undefined) return [];
-      conditions[foreignKey[i]] = pkVal;
-    }
-    let rel = (targetModel as any).all().where(conditions);
-    if (options.scope) rel = options.scope(rel);
-    const results: Base[] = await rel.toArray();
-    if (options.inverseOf) {
-      for (const child of results) {
-        (child as any)._cachedAssociations = (child as any)._cachedAssociations ?? new Map();
-        (child as any)._cachedAssociations.set(options.inverseOf, record);
-      }
-    }
-    syncToAssociationInstance(record, assocName, results);
-    return results;
-  }
-
-  const pkValue = record.readAttribute(primaryKey as string);
-  if (pkValue === null || pkValue === undefined) return [];
-
-  // Route through AssociationScope when we have a reflection registered
-  // for this association — single code path with the explicit loaders in
-  // `load*` sharing WHERE/FK construction. Falls back to the inline
-  // builder when the reflection hasn't been registered (happens in
-  // tests that define associations via the lower-level API without
-  // going through the full Reflection.create path).
+  // Route through AssociationScope when we have a reflection registered.
+  // AssociationScope handles scalar, composite, polymorphic `:as`, and
+  // STI in a single path matching Rails' `AssociationScope.scope`.
+  // Inline fallback only when the reflection hasn't been registered
+  // (happens in tests that define associations via the lower-level API
+  // without going through Reflection.create).
   const reflection = ctor._reflectOnAssociation?.(assocName);
   let rel: any;
-  // `options.through` is handled by the early-return above, so we don't
-  // need to re-check it here.
-  if (reflection && !options.as) {
+  if (reflection) {
     // Rails' `Association#scope` is
     //   AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
-    // (association.rb:313), so the unscoped+constraints relation built
-    // by AssociationScope.scope MUST be merged with the target's
-    // scope_for_association — otherwise the target model's default_scope
-    // / scope extensions would silently disappear on the reflection-
-    // backed path. AssociationScope.scope already merges
-    // `reflection.scope` (the macro-time user lambda) via scopeFor, so
-    // skip re-applying it ONLY when `options.scope` is that exact same
+    // (association.rb:313), so the unscoped+constraints relation MUST
+    // be merged with `klass.scope_for_association` — otherwise default_scope
+    // / scope extensions silently disappear. AssociationScope.scope
+    // already merges `reflection.scope` (macro-time lambda) via scopeFor;
+    // skip re-applying `options.scope` ONLY when it's that exact same
     // function. Callers like `loadHasManyThrough` synthesize a NEW
-    // `options.scope` (e.g. wrapping with `sourceType` filtering) —
-    // those must still run.
+    // `options.scope` (wrapping with `sourceType` filtering) — those
+    // must still run.
     const built = AssociationScope.scope({
       owner: record,
       reflection,
@@ -619,10 +629,26 @@ export async function loadHasMany(
       rel = options.scope(rel);
     }
   } else {
-    rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
-    if (options.scope) {
-      rel = options.scope(rel);
+    // Inline fallback: no reflection (lower-level test helpers).
+    if (Array.isArray(foreignKey)) {
+      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < foreignKey.length; i++) {
+        conditions[foreignKey[i]] = record.readAttribute(pkCols[i]);
+      }
+      rel = (targetModel as any).all().where(conditions);
+    } else if (options.as) {
+      const typeCol = `${underscore(options.as)}_type`;
+      rel = (targetModel as any).all().where({
+        [foreignKey as string]: record.readAttribute(primaryKey as string),
+        [typeCol]: ctor.name,
+      });
+    } else {
+      rel = (targetModel as any)
+        .all()
+        .where({ [foreignKey as string]: record.readAttribute(primaryKey as string) });
     }
+    if (options.scope) rel = options.scope(rel);
   }
   const results: Base[] = await rel.toArray();
 

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -413,6 +413,38 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/LIMIT\s+1/);
   });
 
+  it("loadHasMany rejects composite primary key with :as polymorphic", async () => {
+    // Rails doesn't support polymorphic :as combined with composite
+    // owner PK / composite FK — the polymorphic FK column is a single
+    // <as>_id by convention. Loaders must throw fast rather than
+    // silently building a broken WHERE via readAttribute(undefined).
+    const { loadHasMany, CompositePrimaryKeyMismatchError } = await import("../index.js");
+    class CpkAsOwner extends Base {
+      static {
+        this.attribute("a", "integer");
+        this.attribute("b", "integer");
+        this.primaryKey = ["a", "b"];
+        this.adapter = adapter;
+      }
+    }
+    class CpkAsTarget extends Base {
+      static {
+        this.attribute("commentable_id", "integer");
+        this.attribute("commentable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(CpkAsOwner);
+    registerModel(CpkAsTarget);
+    const owner = new CpkAsOwner({ a: 1, b: 2 });
+    await expect(
+      loadHasMany(owner, "comments", {
+        className: "CpkAsTarget",
+        as: "commentable",
+      }),
+    ).rejects.toThrow(CompositePrimaryKeyMismatchError);
+  });
+
   it("polymorphic belongsTo uses runtime klass's primary key (non-id PK)", () => {
     // BelongsToReflection#joinPrimaryKey hard-codes "id" for polymorphic
     // associations because the target klass isn't known at definition

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -413,6 +413,42 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/LIMIT\s+1/);
   });
 
+  it("polymorphic belongsTo uses runtime klass's primary key (non-id PK)", () => {
+    // BelongsToReflection#joinPrimaryKey hard-codes "id" for polymorphic
+    // associations because the target klass isn't known at definition
+    // time. AssociationScope must route through joinPrimaryKeyFor(klass)
+    // so a target with a non-default PK (e.g. "uuid") gets the right
+    // WHERE column. Regression for Copilot review on PR #618.
+    class UuidTarget extends Base {
+      static {
+        this.attribute("uuid", "string");
+        this.primaryKey = "uuid";
+        this.adapter = adapter;
+      }
+    }
+    class UuidComment extends Base {
+      static {
+        this.attribute("commentable_id", "string");
+        this.attribute("commentable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(UuidTarget);
+    registerModel(UuidComment);
+    Associations.belongsTo.call(UuidComment, "commentable", { polymorphic: true });
+    const comment = new UuidComment({
+      commentable_id: "abc-123",
+      commentable_type: "UuidTarget",
+    });
+    const reflection = (UuidComment as any)._reflectOnAssociation("commentable");
+    const sql = (
+      AssociationScope.scope({ owner: comment, reflection, klass: UuidTarget }) as any
+    ).toSql();
+    // Must WHERE on uuid (the target's actual PK), NOT id.
+    expect(sql).toMatch(/"uuid"\s*=\s*'abc-123'/);
+    expect(sql).not.toMatch(/"id"\s*=/);
+  });
+
   it("static scope() routes through this.INSTANCE (subclass dispatch)", async () => {
     const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
     expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -317,6 +317,102 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/"active"\s*=\s*TRUE/i);
   });
 
+  it("hasMany :as adds the polymorphic type WHERE on the target table", () => {
+    // For `hasMany :comments, as: :commentable`, Rails' AssociationScope
+    // builds `WHERE comments.commentable_id = owner.id AND
+    // comments.commentable_type = OwnerClass.name`. The type filter
+    // comes from reflection.type === foreignType (`commentable_type`).
+    class AsOwner extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class AsComment extends Base {
+      static {
+        this.attribute("commentable_id", "integer");
+        this.attribute("commentable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(AsOwner);
+    registerModel(AsComment);
+    Associations.hasMany.call(AsOwner, "as_comments", {
+      className: "AsComment",
+      as: "commentable",
+    });
+    const owner = new AsOwner({ id: 7 });
+    const reflection = (AsOwner as any)._reflectOnAssociation("as_comments");
+    const sql = (
+      AssociationScope.scope({ owner, reflection, klass: reflection.klass }) as any
+    ).toSql();
+    expect(sql).toMatch(/"commentable_id"\s*=\s*7/);
+    expect(sql).toMatch(/"commentable_type"\s*=\s*'AsOwner'/);
+  });
+
+  it("hasOne :as adds the polymorphic type WHERE plus LIMIT 1", () => {
+    class AsOneOwner extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class AsOneImage extends Base {
+      static {
+        this.attribute("imageable_id", "integer");
+        this.attribute("imageable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(AsOneOwner);
+    registerModel(AsOneImage);
+    Associations.hasOne.call(AsOneOwner, "as_one_image", {
+      className: "AsOneImage",
+      as: "imageable",
+    });
+    const owner = new AsOneOwner({ id: 3 });
+    const reflection = (AsOneOwner as any)._reflectOnAssociation("as_one_image");
+    const sql = (
+      AssociationScope.scope({ owner, reflection, klass: reflection.klass }) as any
+    ).toSql();
+    expect(sql).toMatch(/"imageable_id"\s*=\s*3/);
+    expect(sql).toMatch(/"imageable_type"\s*=\s*'AsOneOwner'/);
+    expect(sql).toMatch(/LIMIT\s+1/);
+  });
+
+  it("polymorphic belongsTo accepts a runtime-resolved klass via AssociationScopeable", () => {
+    // Polymorphic belongsTo: target klass is resolved at runtime from
+    // owner's <assoc>_type column. Callers (loadBelongsTo) pass the
+    // resolved klass via the AssociationScopeable.klass field; the
+    // reflection's joinPrimaryKey returns the target's PK and
+    // joinForeignKey returns the owner-side FK column.
+    class PolyTarget extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class PolyComment extends Base {
+      static {
+        this.attribute("commentable_id", "integer");
+        this.attribute("commentable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(PolyTarget);
+    registerModel(PolyComment);
+    Associations.belongsTo.call(PolyComment, "commentable", { polymorphic: true });
+    const comment = new PolyComment({ commentable_id: 99, commentable_type: "PolyTarget" });
+    const reflection = (PolyComment as any)._reflectOnAssociation("commentable");
+    const sql = (
+      AssociationScope.scope({ owner: comment, reflection, klass: PolyTarget }) as any
+    ).toSql();
+    // Target side: WHERE poly_targets.id = 99 (the FK value), LIMIT 1.
+    expect(sql).toMatch(/"poly_targets"/);
+    expect(sql).toMatch(/"id"\s*=\s*99/);
+    expect(sql).toMatch(/LIMIT\s+1/);
+  });
+
   it("static scope() routes through this.INSTANCE (subclass dispatch)", async () => {
     const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
     expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -61,6 +61,21 @@ export class ReflectionProxy {
     return this.reflection.joinPrimaryKey;
   }
 
+  /**
+   * Forwarding `joinPrimaryKeyFor(klass)` so AssociationScope's
+   * runtime-klass path (polymorphic belongsTo) finds the correct
+   * primary key column on the resolved target. Falls back to the
+   * static `joinPrimaryKey` if the reflection doesn't expose it.
+   */
+  joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
+    const r = this.reflection as unknown as {
+      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
+    };
+    return typeof r.joinPrimaryKeyFor === "function"
+      ? r.joinPrimaryKeyFor(klass)
+      : this.reflection.joinPrimaryKey;
+  }
+
   get joinForeignKey(): string | string[] {
     return this.reflection.joinForeignKey;
   }
@@ -206,7 +221,7 @@ export class AssociationScope {
       }
     }
     const chain = this._getChain(reflection);
-    scope = this._addConstraints(scope, owner, chain);
+    scope = this._addConstraints(scope, owner, chain, klass);
     if (!reflection.isCollection()) {
       scope = (scope as { limit: (n: number) => unknown }).limit(1);
     }
@@ -244,14 +259,25 @@ export class AssociationScope {
     scope: unknown,
     reflection: AbstractReflection | ReflectionProxy,
     owner: Base,
+    klass?: typeof Base,
   ): unknown {
     const r = reflection as {
       joinPrimaryKey: string | string[];
       joinForeignKey: string | string[];
+      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
       type?: string | null;
     };
     const table = (reflection as ReflectionProxy).aliasedTable ?? null;
-    const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
+    // For polymorphic belongsTo, `joinPrimaryKey` is hard-coded to "id"
+    // because the target klass isn't known at definition time. The
+    // runtime klass comes from `AssociationScopeable.klass`; route
+    // through `joinPrimaryKeyFor(klass)` so the correct PK column (incl.
+    // composite / non-"id") is used. Mirrors Rails'
+    // `BelongsToReflection#join_primary_key_for(klass)`
+    // (reflection.rb:968 in our codebase).
+    const joinPk =
+      typeof r.joinPrimaryKeyFor === "function" ? r.joinPrimaryKeyFor(klass) : r.joinPrimaryKey;
+    const joinPks = Array.isArray(joinPk) ? joinPk : [joinPk];
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
     // Same guard `AbstractReflection#joinScope` uses — mismatched
     // composite join-key lengths would silently read
@@ -309,9 +335,10 @@ export class AssociationScope {
     scope: unknown,
     owner: Base,
     chain: Array<AbstractReflection | ReflectionProxy>,
+    klass?: typeof Base,
   ): unknown {
     const last = chain[chain.length - 1];
-    scope = this._lastChainScope(scope, last, owner);
+    scope = this._lastChainScope(scope, last, owner, klass);
     // Use scopeFor (Rails: reflection.rb:448, scope_for) so 0-arity
     // scopes get `this`=relation, and >=1-arity scopes receive
     // (relation, owner) — matches Rails' `relation.instance_exec(owner,


### PR DESCRIPTION
## Summary

PR 2 of 5 in the AssociationScope arc planned in #607. Migrates polymorphic and `:as` branches of the three loaders onto `AssociationScope`. Chain length stays at 1 — through chains land in PR 3.

**What's now routed through `AssociationScope`:**
- `loadHasMany`: scalar, composite-FK, AND polymorphic `:as`. Previously composite + `:as` were inline branches; now all three call `AssociationScope.scope` which handles them via `reflection.joinPrimaryKey`/`joinForeignKey` (composite arrays) plus `reflection.type` (= `foreignType`, e.g. `commentable_type`) for the type WHERE.
- `loadHasOne`: same shape. `AssociationScope` adds `limit(1)` automatically via `reflection.isCollection() === false`.
- `loadBelongsTo`: scalar + composite + polymorphic. For polymorphic `belongsTo` the target klass is resolved at runtime from the owner's `<assoc>_type` column and passed via `AssociationScopeable.klass`; reflection's `joinPrimaryKey` returns `associationPrimaryKey` (target PK) and `joinForeignKey` returns the owner-side FK column.

The reflection's polymorphic type WHERE was already in `_lastChainScope`'s `if (r.type)` branch from PR 1 — it just wasn't exercised since loaders short-circuited `:as`/polymorphic before reaching it. No new logic in `AssociationScope` itself.

Inline fallback path retained for tests that bypass `Reflection.create`.

## Tests
- `hasMany :as adds the polymorphic type WHERE on the target table`
- `hasOne :as adds the polymorphic type WHERE plus LIMIT 1`
- `polymorphic belongsTo accepts a runtime-resolved klass via AssociationScopeable`
- 1525 / 1935 in `packages/activerecord/src/associations` (+3 from PR 1's 1522)

## Rails refs
- `activerecord/lib/active_record/associations/association_scope.rb:58-75` — `last_chain_scope` polymorphic branch
- `activerecord/lib/active_record/reflection.rb:544-549` — `foreignType` for belongsTo polymorphic / hasMany `:as`

## Out of scope (deferred to later PRs)
- PR 3: multi-step chains for through associations (`next_chain_scope`, full `get_chain`); also brings the full `add_constraints` constraint-chain merging (`reflection.constraints` across `reverse_each` + per-attribute merge). For chain-1 the simplified `scopeFor` path produces equivalent SQL.
- PR 4: real `DisableJoinsAssociationScope.scope`
- PR 5: cache wiring + `Associations.eager_load!` skip-list