### PR TITLE
feat(activerecord): AssociationScope multi-step chain (PR 3: through associations)

### DIFF
--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -489,7 +489,65 @@ describe("AssociationScope", () => {
     expect(DisableJoinsAssociationScope.INSTANCE).not.toBe(AssociationScope.INSTANCE);
   });
 
-  it("scope() raises for through chains (PR 1 limitation)", () => {
+  it("hasOne :through chain emits a JOIN with LIMIT 1", () => {
+    class HotUser extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class HotAccount extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("hot_user_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class HotSettings extends Base {
+      static {
+        this.attribute("hot_account_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(HotUser);
+    registerModel(HotAccount);
+    registerModel(HotSettings);
+    Associations.hasOne.call(HotUser, "hot_account", {
+      className: "HotAccount",
+      foreignKey: "hot_user_id",
+    });
+    Associations.hasOne.call(HotUser, "hot_settings", {
+      className: "HotSettings",
+      through: "hot_account",
+    });
+    Associations.hasOne.call(HotAccount, "hot_settings", {
+      className: "HotSettings",
+      foreignKey: "hot_account_id",
+    });
+
+    const user = new HotUser({ id: 5 });
+    const reflection = (HotUser as any)._reflectOnAssociation("hot_settings");
+    const sql = (
+      AssociationScope.scope({
+        owner: user,
+        reflection,
+        klass: reflection.klass,
+      }) as any
+    ).toSql();
+    expect(sql).toMatch(/FROM\s+"hot_settings"/);
+    expect(sql).toMatch(/INNER JOIN\s+"?hot_accounts"?/i);
+    expect(sql).toMatch(/"hot_accounts"\."hot_user_id"\s*=\s*5/);
+    expect(sql).toMatch(/LIMIT\s+1/);
+  });
+
+  it("through chain emits a JOIN-based query against the through table", () => {
+    // PR 3: chain length 2 (a has_many :through). The generated SQL
+    // selects from the source table, INNER JOINs the through table, and
+    // table-qualifies the owner-FK WHERE on the through.
+    //   SELECT through_posts.* FROM through_posts
+    //   INNER JOIN through_memberships
+    //     ON through_posts.id = through_memberships.through_post_id
+    //   WHERE through_memberships.through_author_id = 1
     class ThroughAuthor extends Base {
       static {
         this.attribute("id", "integer");
@@ -527,12 +585,16 @@ describe("AssociationScope", () => {
 
     const author = new ThroughAuthor({ id: 1 });
     const reflection = (ThroughAuthor as any)._reflectOnAssociation("through_posts");
-    expect(() =>
+    const sql = (
       AssociationScope.scope({
         owner: author,
         reflection,
         klass: reflection.klass,
-      }),
-    ).toThrow(/multi-step association chains/);
+      }) as any
+    ).toSql();
+    expect(sql).toMatch(/FROM\s+"through_posts"/);
+    expect(sql).toMatch(/INNER JOIN\s+"?through_memberships"?/i);
+    expect(sql).toMatch(/"through_posts"\."id"\s*=\s*"through_memberships"\."through_post_id"/);
+    expect(sql).toMatch(/"through_memberships"\."through_author_id"\s*=\s*1/);
   });
 });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -600,6 +600,11 @@ describe("AssociationScope", () => {
     ).toSql();
     expect(sql).toMatch(/FROM\s+"hot_settings"/);
     expect(sql).toMatch(/INNER JOIN\s+"?hot_accounts"?/i);
+    // Pin the ON condition so a regression where the join keys flip
+    // (or get dropped) doesn't slip through. PR 3 builds these via
+    // _nextChainScope using joinPrimaryKey / joinForeignKey from the
+    // chain's pair.
+    expect(sql).toMatch(/ON\s+"hot_settings"\."hot_account_id"\s*=\s*"hot_accounts"\."id"/);
     expect(sql).toMatch(/"hot_accounts"\."hot_user_id"\s*=\s*5/);
     expect(sql).toMatch(/LIMIT\s+1/);
   });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -489,6 +489,70 @@ describe("AssociationScope", () => {
     expect(DisableJoinsAssociationScope.INSTANCE).not.toBe(AssociationScope.INSTANCE);
   });
 
+  it("through chain query loads actual records end-to-end (Author -> Memberships -> Tags)", async () => {
+    // Real DB roundtrip: insert records, build the through scope via
+    // AssociationScope, execute it, assert the right rows come back.
+    // Proves the chain-walking machinery isn't just generating valid-
+    // looking SQL — it actually returns the correct records.
+    class IntAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class IntMembership extends Base {
+      static {
+        this.attribute("int_author_id", "integer");
+        this.attribute("int_tag_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class IntTag extends Base {
+      declare label: string;
+      static {
+        this.attribute("id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(IntAuthor);
+    registerModel(IntMembership);
+    registerModel(IntTag);
+    Associations.hasMany.call(IntAuthor, "int_memberships", {
+      className: "IntMembership",
+      foreignKey: "int_author_id",
+    });
+    Associations.hasMany.call(IntAuthor, "int_tags", {
+      className: "IntTag",
+      through: "int_memberships",
+      source: "int_tag",
+    });
+    Associations.belongsTo.call(IntMembership, "int_tag", {
+      className: "IntTag",
+      foreignKey: "int_tag_id",
+    });
+
+    const alice = await IntAuthor.create({ name: "Alice" });
+    const bob = await IntAuthor.create({ name: "Bob" });
+    const ruby = await IntTag.create({ label: "ruby" });
+    const ts = await IntTag.create({ label: "typescript" });
+    const go = await IntTag.create({ label: "go" });
+    await IntMembership.create({ int_author_id: alice.id, int_tag_id: ruby.id });
+    await IntMembership.create({ int_author_id: alice.id, int_tag_id: ts.id });
+    await IntMembership.create({ int_author_id: bob.id, int_tag_id: go.id });
+
+    const reflection = (IntAuthor as any)._reflectOnAssociation("int_tags");
+    const tags: IntTag[] = await (
+      AssociationScope.scope({
+        owner: alice,
+        reflection,
+        klass: reflection.klass,
+      }) as any
+    ).toArray();
+    expect(tags.map((t) => t.label).sort()).toEqual(["ruby", "typescript"]);
+  });
+
   it("hasOne :through chain emits a JOIN with LIMIT 1", () => {
     class HotUser extends Base {
       static {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -425,9 +425,14 @@ export class AssociationScope {
     const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
     if (joinPks.length !== joinFks.length) {
-      const name = (reflection as { name?: string }).name ?? "<unknown>";
-      const ownerName =
-        (reflection as { activeRecord?: { name?: string } }).activeRecord?.name ?? "<unknown>";
+      // Unwrap ReflectionProxy so activeRecord/name come from the
+      // underlying reflection rather than reading "<unknown>" off the
+      // proxy (which doesn't forward activeRecord).
+      const base =
+        (reflection as { reflection?: { name?: string; activeRecord?: { name?: string } } })
+          .reflection ?? (reflection as { name?: string; activeRecord?: { name?: string } });
+      const name = base.name ?? "<unknown>";
+      const ownerName = base.activeRecord?.name ?? "<unknown>";
       throw new CompositePrimaryKeyMismatchError(ownerName, name);
     }
     const table = r.klass?.tableName ?? "";

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,7 +1,13 @@
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
-import { isStiSubclass, getStiBase, getInheritanceColumn, descendants } from "../inheritance.js";
+import {
+  isStiSubclass,
+  getStiBase,
+  getInheritanceColumn,
+  descendants,
+  polymorphicName,
+} from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { quoteTableName, quoteColumnName, quote } from "../connection-adapters/abstract/quoting.js";
 
@@ -202,13 +208,14 @@ export class AssociationScope {
     const fks = Array.isArray(joinFk) ? joinFk : joinFk ? [joinFk] : [];
     for (const fk of fks) binds.push(owner.readAttribute(fk));
     if ((last as { type?: string | null }).type) {
-      binds.push((owner.constructor as typeof Base).name);
+      binds.push(polymorphicName(owner.constructor as typeof Base));
     }
     for (let i = 0; i < chain.length - 1; i++) {
       const refl = chain[i];
       const next = chain[i + 1];
       if ((refl as { type?: string | null }).type) {
-        binds.push((next as { klass?: { name: string } }).klass?.name ?? null);
+        const nextKlass = (next as { klass?: typeof Base }).klass;
+        binds.push(nextKlass ? polymorphicName(nextKlass) : null);
       }
     }
     return binds;
@@ -351,7 +358,9 @@ export class AssociationScope {
       scope = this._applyScope(scope, table, joinPks[i], value);
     }
     if (r.type) {
-      const polyName = this._transformValue((owner.constructor as typeof Base).name);
+      // Rails: `owner.class.polymorphic_name` (returns base_class.name
+      // for STI subclasses) routed through `transform_value`.
+      const polyName = this._transformValue(polymorphicName(owner.constructor as typeof Base));
       scope = this._applyScope(scope, table, r.type, polyName);
     }
     return scope;
@@ -448,10 +457,13 @@ export class AssociationScope {
     let onClause = conditions.join(" AND ");
     if (r.type) {
       // Polymorphic through: filter the JOIN by the next reflection's
-      // klass polymorphic name. STI base_class resolution is deferred
-      // (matches our existing polymorphic handling).
-      const nextName = (nextReflection as { klass?: { name?: string } }).klass?.name ?? "";
-      onClause += ` AND ${qTable}.${quoteColumnName(r.type)} = ${quote(nextName)}`;
+      // klass polymorphic name. Rails: `transform_value(next_reflection
+      // .klass.polymorphic_name)` (association_scope.rb:91-93). Routes
+      // through both `polymorphicName` (returns base_class.name for
+      // STI) and the value-transformation lambda.
+      const nextKlass = (nextReflection as { klass?: typeof Base }).klass;
+      const nextName = nextKlass ? polymorphicName(nextKlass) : "";
+      onClause += ` AND ${qTable}.${quoteColumnName(r.type)} = ${quote(this._transformValue(nextName))}`;
     }
     return (scope as { joins: (table: string, on: string) => unknown }).joins(
       foreignTable,

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -236,15 +236,25 @@ export class AssociationScope {
    * Rails checks `scope.table == table` and scopes the where to the
    * joined table's alias in the multi-step case. For chain length 1
    * `scope.table` is the klass table, so the where goes directly on the
-   * relation.
+   * relation. For multi-step (through), `table` is a different
+   * (joined-in) table — qualify the WHERE as `<table>.<key> = ?`.
    *
    * Mirrors: ActiveRecord::Associations::AssociationScope#apply_scope
    * (association_scope.rb:161-167).
    */
-  private _applyScope(scope: unknown, _table: unknown, key: string, value: unknown): unknown {
-    return (scope as { where: (c: Record<string, unknown>) => unknown }).where({
-      [key]: value,
-    });
+  private _applyScope(scope: unknown, table: string | null, key: string, value: unknown): unknown {
+    const w = scope as {
+      where: (c: Record<string, unknown> | string, ...binds: unknown[]) => unknown;
+      modelClassName?: string;
+      _modelClass?: { tableName?: string };
+    };
+    const scopeTable = w._modelClass?.tableName ?? null;
+    if (table && scopeTable && table !== scopeTable) {
+      // Table-qualified WHERE: `<joined_table>.<key> = ?`. Used for
+      // through chains where the FK lives on an intermediate table.
+      return w.where(`"${table}"."${key}" = ?`, value);
+    }
+    return w.where({ [key]: value });
   }
 
   /**
@@ -267,7 +277,30 @@ export class AssociationScope {
       joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
       type?: string | null;
     };
-    const table = (reflection as ReflectionProxy).aliasedTable ?? null;
+    // For multi-step chains the reflection is wrapped in ReflectionProxy
+    // with an aliasedTable set. For chain length 1 prefer the runtime
+    // klass's tableName (passed in) over reflection.klass — the latter
+    // throws for polymorphic belongsTo since the target class isn't
+    // known at definition time.
+    const aliased = (reflection as ReflectionProxy).aliasedTable as
+      | string
+      | { name?: string }
+      | null
+      | undefined;
+    let table: string | null;
+    if (typeof aliased === "string") {
+      table = aliased;
+    } else if (aliased && typeof aliased === "object" && typeof aliased.name === "string") {
+      table = aliased.name;
+    } else if (klass && typeof klass.tableName === "string") {
+      table = klass.tableName;
+    } else {
+      try {
+        table = (reflection as { klass?: { tableName?: string } }).klass?.tableName ?? null;
+      } catch {
+        table = null;
+      }
+    }
     // For polymorphic belongsTo, `joinPrimaryKey` is hard-coded to "id"
     // because the target klass isn't known at definition time. The
     // runtime klass comes from `AssociationScopeable.klass`; route
@@ -304,23 +337,94 @@ export class AssociationScope {
   }
 
   /**
-   * Build the chain of reflections to walk. Rails uses `reflection.chain`
-   * and wraps all-but-head in `ReflectionProxy` with aliased tables; for
-   * chain length 1 the source reflection stands alone.
+   * Build the chain of reflections to walk. Rails wraps all-but-head in
+   * `ReflectionProxy` with an aliased_table from `AliasTracker` so
+   * repeated joins to the same table get unique aliases.
+   *
+   * PR 3 doesn't share an AliasTracker across calls (single-query through
+   * loads typically don't collide), so each non-head reflection gets its
+   * klass.tableName as the table identifier. Sharing a tracker for
+   * repeated/eager-loaded joins is a follow-up.
    *
    * Mirrors: ActiveRecord::Associations::AssociationScope#get_chain
-   * (association_scope.rb:112-122). Multi-step wrapping comes in PR 3.
+   * (association_scope.rb:112-122).
    */
   private _getChain(
     reflection: AssociationReflection,
   ): Array<AbstractReflection | ReflectionProxy> {
-    if (reflection.chain.length > 1) {
-      throw new Error(
-        `AssociationScope: multi-step association chains are not implemented yet — ` +
-          `reflection '${reflection.name}' has ${reflection.chain.length} chain entries`,
-      );
+    const chain: Array<AbstractReflection | ReflectionProxy> = [reflection];
+    const tail = reflection.chain.slice(1);
+    for (const refl of tail) {
+      const tableName =
+        (refl as unknown as { klass?: { tableName?: string } }).klass?.tableName ?? "";
+      // ReflectionProxy expects an AssociationReflection; tail entries
+      // ARE AssociationReflection in the through case (the through-target
+      // hasMany / belongsTo on the through model). Cast for the type
+      // shape — the proxy only reads structural fields.
+      chain.push(new ReflectionProxy(refl as AssociationReflection, tableName));
     }
-    return [reflection];
+    return chain;
+  }
+
+  /**
+   * Walk a chain pair and emit an INNER JOIN constraint that joins the
+   * `next_reflection`'s table back onto the relation. The join condition
+   * is built from `reflection.joinPrimaryKey` (target-side column) and
+   * `joinForeignKey` (foreign-side column).
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#next_chain_scope
+   * (association_scope.rb:81-99).
+   */
+  private _nextChainScope(
+    scope: unknown,
+    reflection: AbstractReflection | ReflectionProxy,
+    nextReflection: AbstractReflection | ReflectionProxy,
+  ): unknown {
+    const r = reflection as {
+      joinPrimaryKey: string | string[];
+      joinForeignKey: string | string[];
+      klass?: { tableName?: string };
+      type?: string | null;
+    };
+    const nr = nextReflection as {
+      joinPrimaryKey: string | string[];
+      joinForeignKey: string | string[];
+      klass?: { tableName?: string };
+      aliasedTable?: string | { name?: string };
+    };
+    const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
+    const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
+    if (joinPks.length !== joinFks.length) {
+      const name = (reflection as { name?: string }).name ?? "<unknown>";
+      throw new CompositePrimaryKeyMismatchError(name, name);
+    }
+    const table = r.klass?.tableName ?? "";
+    // nextReflection may be a ReflectionProxy (with aliasedTable) or a
+    // raw reflection; resolve its table name the same way.
+    const aliased = nr.aliasedTable;
+    const foreignTable =
+      typeof aliased === "string"
+        ? aliased
+        : aliased && typeof aliased === "object" && typeof aliased.name === "string"
+          ? aliased.name
+          : (nr.klass?.tableName ?? "");
+    const conditions: string[] = [];
+    for (let i = 0; i < joinPks.length; i++) {
+      conditions.push(`"${table}"."${joinPks[i]}" = "${foreignTable}"."${joinFks[i]}"`);
+    }
+    let onClause = conditions.join(" AND ");
+    if (r.type) {
+      // Polymorphic through: filter the JOIN by the next reflection's
+      // klass polymorphic name. For PR 3 we use klass.name; STI base_class
+      // resolution is deferred (matches our existing polymorphic
+      // handling).
+      const nextName = (nextReflection as { klass?: { name?: string } }).klass?.name ?? "";
+      onClause += ` AND "${table}"."${r.type}" = '${nextName.replace(/'/g, "''")}'`;
+    }
+    return (scope as { joins: (table: string, on: string) => unknown }).joins(
+      foreignTable,
+      onClause,
+    );
   }
 
   /**
@@ -339,14 +443,25 @@ export class AssociationScope {
   ): unknown {
     const last = chain[chain.length - 1];
     scope = this._lastChainScope(scope, last, owner, klass);
+    // For multi-step chains, walk pairs and add INNER JOINs — Rails'
+    // `chain.each_cons(2) { |r, nr| next_chain_scope(scope, r, nr) }`
+    // (association_scope.rb:128-130).
+    for (let i = 0; i < chain.length - 1; i++) {
+      scope = this._nextChainScope(scope, chain[i], chain[i + 1]);
+    }
     // Use scopeFor (Rails: reflection.rb:448, scope_for) so 0-arity
     // scopes get `this`=relation, and >=1-arity scopes receive
     // (relation, owner) — matches Rails' `relation.instance_exec(owner,
     // &scope) || relation`. Calling `reflection.scope(scope)` directly
-    // would lose the binding.
-    const scopeFor = (last as { scopeFor?: (rel: unknown, owner: unknown) => unknown }).scopeFor;
+    // would lose the binding. The full Rails `add_constraints`
+    // chain.reverseEach merges every reflection's constraints; for
+    // chain-1 the simplified head-only path matches, and for through
+    // chains we call scopeFor on the source reflection (chain[0])
+    // matching Rails' behavior for the chain-head item.
+    const scopeFor = (chain[0] as { scopeFor?: (rel: unknown, owner: unknown) => unknown })
+      .scopeFor;
     if (typeof scopeFor === "function") {
-      scope = scopeFor.call(last, scope, owner);
+      scope = scopeFor.call(chain[0], scope, owner);
     }
     return scope;
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,7 +1,9 @@
+import { Table as ArelTable } from "@blazetrails/arel";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
 import { isStiSubclass, getStiBase, getInheritanceColumn, descendants } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
+import { quoteTableName, quoteColumnName, quote } from "../connection-adapters/abstract/quoting.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -37,10 +39,14 @@ export interface AssociationScopeable {
  * `def all_includes; nil; end`.)
  */
 export class ReflectionProxy {
-  readonly reflection: AssociationReflection;
+  // AbstractReflection rather than AssociationReflection because chain
+  // entries can be ThroughReflection / PolymorphicReflection wrappers;
+  // ReflectionProxy only reads structural fields (joinPrimaryKey/Fk,
+  // type, klass, name, scope, scopeFor) that all chain entries provide.
+  readonly reflection: AbstractReflection;
   readonly aliasedTable: unknown;
 
-  constructor(reflection: AssociationReflection, aliasedTable: unknown) {
+  constructor(reflection: AbstractReflection, aliasedTable: unknown) {
     this.reflection = reflection;
     this.aliasedTable = aliasedTable;
   }
@@ -56,9 +62,25 @@ export class ReflectionProxy {
 
   // SimpleDelegator-style forwarding of the attributes AssociationScope
   // reads. Kept explicit instead of a runtime Proxy so TypeScript sees
-  // the shape.
+  // the shape. The `_r` getter centralizes the cast — these fields are
+  // present on every chain entry shape (AssociationReflection,
+  // ThroughReflection, PolymorphicReflection) but not declared on the
+  // AbstractReflection base.
+  private get _r(): {
+    joinPrimaryKey: string | string[];
+    joinForeignKey: string | string[];
+    type?: string | null;
+    klass: typeof Base;
+    name: string;
+    scope?: ((rel: unknown) => unknown) | null;
+    joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
+    scopeFor?: (rel: unknown, owner?: unknown) => unknown;
+  } {
+    return this.reflection as unknown as ReturnType<() => ReflectionProxy["_r"]>;
+  }
+
   get joinPrimaryKey(): string | string[] {
-    return this.reflection.joinPrimaryKey;
+    return this._r.joinPrimaryKey;
   }
 
   /**
@@ -68,28 +90,25 @@ export class ReflectionProxy {
    * static `joinPrimaryKey` if the reflection doesn't expose it.
    */
   joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
-    const r = this.reflection as unknown as {
-      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
-    };
-    return typeof r.joinPrimaryKeyFor === "function"
-      ? r.joinPrimaryKeyFor(klass)
-      : this.reflection.joinPrimaryKey;
+    return typeof this._r.joinPrimaryKeyFor === "function"
+      ? this._r.joinPrimaryKeyFor(klass)
+      : this._r.joinPrimaryKey;
   }
 
   get joinForeignKey(): string | string[] {
-    return this.reflection.joinForeignKey;
+    return this._r.joinForeignKey;
   }
 
   get type(): string | null {
-    return this.reflection.type;
+    return this._r.type ?? null;
   }
 
   get klass(): typeof Base {
-    return this.reflection.klass;
+    return this._r.klass;
   }
 
   get name(): string {
-    return this.reflection.name;
+    return this._r.name;
   }
 
   get scope(): ((rel: unknown) => unknown) | undefined {
@@ -244,15 +263,17 @@ export class AssociationScope {
    */
   private _applyScope(scope: unknown, table: string | null, key: string, value: unknown): unknown {
     const w = scope as {
-      where: (c: Record<string, unknown> | string, ...binds: unknown[]) => unknown;
-      modelClassName?: string;
+      where: (c: Record<string, unknown> | unknown) => unknown;
       _modelClass?: { tableName?: string };
     };
     const scopeTable = w._modelClass?.tableName ?? null;
     if (table && scopeTable && table !== scopeTable) {
-      // Table-qualified WHERE: `<joined_table>.<key> = ?`. Used for
-      // through chains where the FK lives on an intermediate table.
-      return w.where(`"${table}"."${key}" = ?`, value);
+      // Table-qualified WHERE for through chains where the FK lives on
+      // an intermediate joined-in table. Use Arel so identifier quoting
+      // and value escaping go through the same path as the rest of the
+      // query — no manual interpolation.
+      const node = new ArelTable(table).get(key).eq(value);
+      return w.where(node);
     }
     return w.where({ [key]: value });
   }
@@ -361,7 +382,7 @@ export class AssociationScope {
       // ARE AssociationReflection in the through case (the through-target
       // hasMany / belongsTo on the through model). Cast for the type
       // shape — the proxy only reads structural fields.
-      chain.push(new ReflectionProxy(refl as AssociationReflection, tableName));
+      chain.push(new ReflectionProxy(refl, tableName));
     }
     return chain;
   }
@@ -410,18 +431,27 @@ export class AssociationScope {
         : aliased && typeof aliased === "object" && typeof aliased.name === "string"
           ? aliased.name
           : (nr.klass?.tableName ?? "");
+    // Build the ON clause with proper identifier quoting (handles
+    // schema-qualified names, embedded quotes, etc.) and Arel-style
+    // value escaping for the polymorphic-type literal. JOIN ON in our
+    // Relation is stored as a SQL string and re-wrapped in
+    // Nodes.SqlLiteral at apply time, so we still produce a string —
+    // but the identifiers/values are escape-safe.
+    const qTable = quoteTableName(table);
+    const qForeignTable = quoteTableName(foreignTable);
     const conditions: string[] = [];
     for (let i = 0; i < joinPks.length; i++) {
-      conditions.push(`"${table}"."${joinPks[i]}" = "${foreignTable}"."${joinFks[i]}"`);
+      conditions.push(
+        `${qTable}.${quoteColumnName(joinPks[i])} = ${qForeignTable}.${quoteColumnName(joinFks[i])}`,
+      );
     }
     let onClause = conditions.join(" AND ");
     if (r.type) {
       // Polymorphic through: filter the JOIN by the next reflection's
-      // klass polymorphic name. For PR 3 we use klass.name; STI base_class
-      // resolution is deferred (matches our existing polymorphic
-      // handling).
+      // klass polymorphic name. STI base_class resolution is deferred
+      // (matches our existing polymorphic handling).
       const nextName = (nextReflection as { klass?: { name?: string } }).klass?.name ?? "";
-      onClause += ` AND "${table}"."${r.type}" = '${nextName.replace(/'/g, "''")}'`;
+      onClause += ` AND ${qTable}.${quoteColumnName(r.type)} = ${quote(nextName)}`;
     }
     return (scope as { joins: (table: string, on: string) => unknown }).joins(
       foreignTable,

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -396,7 +396,9 @@ export class AssociationScope {
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
     if (joinPks.length !== joinFks.length) {
       const name = (reflection as { name?: string }).name ?? "<unknown>";
-      throw new CompositePrimaryKeyMismatchError(name, name);
+      const ownerName =
+        (reflection as { activeRecord?: { name?: string } }).activeRecord?.name ?? "<unknown>";
+      throw new CompositePrimaryKeyMismatchError(ownerName, name);
     }
     const table = r.klass?.tableName ?? "";
     // nextReflection may be a ReflectionProxy (with aliasedTable) or a


### PR DESCRIPTION
## Summary

PR 3 of 5 in the AssociationScope arc planned in #607. `AssociationScope.scope` now generates correct JOIN-based SQL **and loads actual records** for `has_many :through` and `has_one :through` chains. Verified by an end-to-end test that inserts records, executes the AssociationScope-built query, and asserts the expected rows return.

**Loaders are NOT yet migrated** — `loadHasManyThrough` / `loadHasOneThrough` keep their existing 2-step IN-list behavior. Migration attempt during self-review broke 15 tests; those depend on full `add_constraints` chain.reverse_each merging, sourceType filtering, and has_many-source walking that PR 3 doesn't yet provide. **PR 3b** will add those pieces and then migrate the loaders. Honest grade: B+ (chain machinery works end-to-end via direct invocation; not yet the production through-load path).

## What lands
- `_getChain` walks `reflection.chain`, wrapping non-head reflections in `ReflectionProxy` with `klass.tableName` as the (un-aliased) table. AliasTracker integration for shared trackers across calls is follow-up work; single-query through loads typically don't collide.
- `_nextChainScope` (Rails: `association_scope.rb:81-99`) emits `INNER JOIN <foreign_table> ON <table>.<joinPk> = <foreign_table>.<joinFk>` with a polymorphic-type `AND` clause when `reflection.type` is set. Composite `joinPk`/`joinFk` get one equality per pair; mismatched lengths throw `CompositePrimaryKeyMismatchError` with the proper `(ownerClass, name)` args (matches the `_lastChainScope` guard).
- `_addConstraints` folds `chain.eachCons(2)` over `_nextChainScope`, then applies `scopeFor` on `chain[0]` (the head) — matches Rails' chain-head item handling.
- `_lastChainScope` and `_applyScope` table-qualify the WHERE when `scope.table` differs from the reflection's table, using raw SQL (`"<table>"."<col>" = ?`). Required for through chains where the FK lives on the joined-in table.
- Polymorphic-belongsTo guard: prefer the runtime `klass` param over `reflection.klass` for table-name resolution, since `BelongsToReflection.klass` throws on polymorphic.

## Tests
- `through chain emits a JOIN-based query against the through table` — SQL shape for `has_many :through`.
- `hasOne :through chain emits a JOIN with LIMIT 1` — same plus `LIMIT 1`.
- **`through chain query loads actual records end-to-end`** — inserts 2 authors + 3 tags + 3 memberships, asserts AssociationScope-built query returns the right rows for one of them. Proves the machinery works, not just the SQL.
- 1529 / 1939 in `packages/activerecord/src/associations` (+2 from PR 2's 1527).

## Out of scope
- **PR 3b**: migrate `loadHasManyThrough` / `loadHasOneThrough` off the 2-step IN-list loaders to the JOIN-based AssociationScope path. Needs full `add_constraints` chain.reverse_each merging + sourceType + alias tracker — those features then unblock the migration.
- **PR 4**: real `DisableJoinsAssociationScope.scope` (in-memory stitching).
- **PR 5**: cache wiring + `Associations.eager_load!` skip-list.

## Rails refs
- `activerecord/lib/active_record/associations/association_scope.rb:81-99` — `next_chain_scope`
- `activerecord/lib/active_record/associations/association_scope.rb:112-122` — `get_chain`
- `activerecord/lib/active_record/associations/association_scope.rb:161-167` — `apply_scope`