### PR TITLE
feat(activerecord): migrate simple through loaders onto AssociationScope (PR 3b)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -403,9 +403,25 @@ export async function loadHasOne(
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
-  // Handle has_one :through
+  // Handle has_one :through. Same routing rules as loadHasMany —
+  // route through AssociationScope when source is non-polymorphic
+  // belongsTo and no sourceType; otherwise fall back to the 2-step
+  // loadHasOneThrough.
   if (options.through) {
-    return loadHasOneThrough(record, assocName, options);
+    const ctorEarly = record.constructor as typeof Base;
+    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
+    const srcReflEarly = (reflEarly as any)?.sourceReflection;
+    const canRouteThrough =
+      reflEarly &&
+      srcReflEarly &&
+      !options.sourceType &&
+      typeof srcReflEarly.belongsTo === "function" &&
+      srcReflEarly.belongsTo() &&
+      !(typeof srcReflEarly.isPolymorphic === "function" && srcReflEarly.isPolymorphic());
+    if (!canRouteThrough) {
+      return loadHasOneThrough(record, assocName, options);
+    }
+    // Fall through into the AssociationScope path below.
   }
 
   const ctor = record.constructor as typeof Base;
@@ -440,15 +456,21 @@ export async function loadHasOne(
   // for hasOne, so AssociationScope.scope adds limit(1) automatically.
   const reflection = ctor._reflectOnAssociation?.(assocName);
   // Null-PK short-circuit: read the SAME columns the eventual query
-  // reads — reflection.joinForeignKey when routing through
-  // AssociationScope (= owner-side FK = activeRecordPrimaryKey for
-  // hasOne), options-derived primaryKey otherwise. Reading from a
-  // different column would silently return null while the real query
-  // would have found the row.
-  const pkCheckCols = reflection
-    ? Array.isArray((reflection as any).joinForeignKey)
-      ? ((reflection as any).joinForeignKey as string[])
-      : [(reflection as any).joinForeignKey as string]
+  // reads. For non-through, reflection.joinForeignKey is the owner-
+  // side activeRecordPrimaryKey for hasOne. For through reflections,
+  // joinForeignKey delegates to the SOURCE reflection (whose FK is on
+  // the through table, not the owner). The relevant owner-side
+  // column is on the through_reflection.
+  const reflForOwnerFk =
+    reflection && (reflection as any).throughReflection
+      ? ((reflection as any).throughReflection as { joinForeignKey: string | string[] })
+      : reflection
+        ? (reflection as { joinForeignKey: string | string[] })
+        : null;
+  const pkCheckCols = reflForOwnerFk
+    ? Array.isArray(reflForOwnerFk.joinForeignKey)
+      ? reflForOwnerFk.joinForeignKey
+      : [reflForOwnerFk.joinForeignKey]
     : Array.isArray(primaryKey)
       ? primaryKey
       : [primaryKey as string];
@@ -591,9 +613,25 @@ export async function loadHasMany(
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
-  // Handle through associations
+  // Handle through associations. PR 3b: when reflection is registered
+  // and we don't need source-type filtering or has_many-source walking,
+  // route through AssociationScope's JOIN-based path. Other shapes
+  // stay on the 2-step IN-list loader.
   if (options.through) {
-    return loadHasManyThrough(record, assocName, options);
+    const ctorEarly = record.constructor as typeof Base;
+    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
+    const srcReflEarly = (reflEarly as any)?.sourceReflection;
+    const canRouteThrough =
+      reflEarly &&
+      srcReflEarly &&
+      !options.sourceType &&
+      typeof srcReflEarly.belongsTo === "function" &&
+      srcReflEarly.belongsTo() &&
+      !(typeof srcReflEarly.isPolymorphic === "function" && srcReflEarly.isPolymorphic());
+    if (!canRouteThrough) {
+      return loadHasManyThrough(record, assocName, options);
+    }
+    // Fall through into the AssociationScope path below.
   }
 
   const ctor = record.constructor as typeof Base;
@@ -631,15 +669,22 @@ export async function loadHasMany(
   // without going through Reflection.create).
   const reflection = ctor._reflectOnAssociation?.(assocName);
   // Null-FK short-circuit: read the SAME columns the eventual query
-  // reads — reflection.joinForeignKey when routing through
-  // AssociationScope (= owner-side activeRecordPrimaryKey for hasMany),
-  // options-derived primaryKey otherwise. Reading from a different
-  // column would silently return [] while the real query would have
-  // found rows.
-  const fkCheckPks = reflection
-    ? Array.isArray((reflection as any).joinForeignKey)
-      ? ((reflection as any).joinForeignKey as string[])
-      : [(reflection as any).joinForeignKey as string]
+  // reads. For non-through, reflection.joinForeignKey is the owner-
+  // side activeRecordPrimaryKey for hasMany. For through reflections,
+  // joinForeignKey delegates to the SOURCE reflection (whose FK is on
+  // the through table, not the owner) — wrong column. The relevant
+  // owner-side column is on the through_reflection (chain.last in the
+  // chain ordering).
+  const reflForOwnerFk =
+    reflection && (reflection as any).throughReflection
+      ? ((reflection as any).throughReflection as { joinForeignKey: string | string[] })
+      : reflection
+        ? (reflection as { joinForeignKey: string | string[] })
+        : null;
+  const fkCheckPks = reflForOwnerFk
+    ? Array.isArray(reflForOwnerFk.joinForeignKey)
+      ? reflForOwnerFk.joinForeignKey
+      : [reflForOwnerFk.joinForeignKey]
     : Array.isArray(primaryKey)
       ? primaryKey
       : [primaryKey as string];

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -255,6 +255,32 @@ export function isAssociationCached(record: Base, assocName: string): boolean {
 }
 
 /**
+ * Decide whether a `:through` reflection's load can route through
+ * AssociationScope's JOIN-based path. PR 3b only handles the simplest
+ * shape: source is non-polymorphic `belongsTo`, no `sourceType`, no
+ * `disableJoins`. Other shapes (has_many/has_one source, polymorphic
+ * source, sourceType, disable-joins) need machinery this PR doesn't
+ * yet provide and stay on the existing 2-step IN-list loaders.
+ *
+ * Shared by loadHasMany and loadHasOne so the gating rules can't drift.
+ */
+function _canRouteThroughViaAssociationScope(
+  reflection: unknown,
+  options: AssociationOptions,
+): boolean {
+  if (!reflection) return false;
+  if (options.sourceType) return false;
+  if (options.disableJoins) return false;
+  const src = (reflection as { sourceReflection?: unknown }).sourceReflection as
+    | { belongsTo?: () => boolean; isPolymorphic?: () => boolean }
+    | undefined;
+  if (!src) return false;
+  if (typeof src.belongsTo !== "function" || !src.belongsTo()) return false;
+  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
+  return true;
+}
+
+/**
  * Sync loaded result to the association instance if one exists.
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
@@ -404,21 +430,12 @@ export async function loadHasOne(
   }
 
   // Handle has_one :through. Same routing rules as loadHasMany —
-  // route through AssociationScope when source is non-polymorphic
-  // belongsTo and no sourceType; otherwise fall back to the 2-step
-  // loadHasOneThrough.
+  // route through AssociationScope's JOIN-based path for the simple
+  // shape; everything else falls back to the 2-step loadHasOneThrough.
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
-    const srcReflEarly = (reflEarly as any)?.sourceReflection;
-    const canRouteThrough =
-      reflEarly &&
-      srcReflEarly &&
-      !options.sourceType &&
-      typeof srcReflEarly.belongsTo === "function" &&
-      srcReflEarly.belongsTo() &&
-      !(typeof srcReflEarly.isPolymorphic === "function" && srcReflEarly.isPolymorphic());
-    if (!canRouteThrough) {
+    if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
       return loadHasOneThrough(record, assocName, options);
     }
     // Fall through into the AssociationScope path below.
@@ -613,22 +630,14 @@ export async function loadHasMany(
     throw StrictLoadingViolationError.forAssociation(record, assocName);
   }
 
-  // Handle through associations. PR 3b: when reflection is registered
-  // and we don't need source-type filtering or has_many-source walking,
-  // route through AssociationScope's JOIN-based path. Other shapes
-  // stay on the 2-step IN-list loader.
+  // Handle through associations. Routes through AssociationScope's
+  // JOIN-based path for the simple shape (see
+  // _canRouteThroughViaAssociationScope); everything else stays on the
+  // 2-step loadHasManyThrough.
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
-    const srcReflEarly = (reflEarly as any)?.sourceReflection;
-    const canRouteThrough =
-      reflEarly &&
-      srcReflEarly &&
-      !options.sourceType &&
-      typeof srcReflEarly.belongsTo === "function" &&
-      srcReflEarly.belongsTo() &&
-      !(typeof srcReflEarly.isPolymorphic === "function" && srcReflEarly.isPolymorphic());
-    if (!canRouteThrough) {
+    if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
       return loadHasManyThrough(record, assocName, options);
     }
     // Fall through into the AssociationScope path below.

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -489,6 +489,129 @@ describe("AssociationScope", () => {
     expect(DisableJoinsAssociationScope.INSTANCE).not.toBe(AssociationScope.INSTANCE);
   });
 
+  it("through chain merges scope on the through reflection (chain.reverse_each)", () => {
+    // Rails' add_constraints walks chain.reverse_each over each
+    // reflection's constraints and merges WHERE/ORDER predicates from
+    // the scope lambda into the main relation. PR 3b adds this for
+    // non-head chain entries: a scope on the through reflection (e.g.
+    // `hasMany :memberships, scope: r => r.where(active: true)`) must
+    // emit `WHERE memberships.active = TRUE` on the JOINed-in table.
+    class CcAuthor extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CcMembership extends Base {
+      static {
+        this.attribute("cc_author_id", "integer");
+        this.attribute("cc_tag_id", "integer");
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    class CcTag extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(CcAuthor);
+    registerModel(CcMembership);
+    registerModel(CcTag);
+    Associations.hasMany.call(CcAuthor, "cc_memberships", {
+      className: "CcMembership",
+      foreignKey: "cc_author_id",
+      // Scope on the through reflection — chain.reverse_each must pick
+      // it up when AssociationScope walks the chain for cc_tags.
+      scope: (rel: any) => rel.where({ active: true }),
+    });
+    Associations.hasMany.call(CcAuthor, "cc_tags", {
+      className: "CcTag",
+      through: "cc_memberships",
+      source: "cc_tag",
+    });
+    Associations.belongsTo.call(CcMembership, "cc_tag", {
+      className: "CcTag",
+      foreignKey: "cc_tag_id",
+    });
+
+    const author = new CcAuthor({ id: 1 });
+    const reflection = (CcAuthor as any)._reflectOnAssociation("cc_tags");
+    const sql = (
+      AssociationScope.scope({
+        owner: author,
+        reflection,
+        klass: reflection.klass,
+      }) as any
+    ).toSql();
+    expect(sql).toMatch(/INNER JOIN\s+"?cc_memberships"?/i);
+    expect(sql).toMatch(/"cc_memberships"\."cc_author_id"\s*=\s*1/);
+    expect(sql).toMatch(/"cc_memberships"\."active"\s*=\s*TRUE/i);
+  });
+
+  it("loadHasMany through chain (belongsTo source, no sourceType) routes via AssociationScope", async () => {
+    // PR 3b migration: loadHasMany for has_many :through where source
+    // is non-polymorphic belongsTo (no sourceType) now routes through
+    // AssociationScope's JOIN-based path instead of the 2-step IN-list
+    // loader. End-to-end: insert records, call loadHasMany, assert the
+    // right rows return — exercises the migrated path through real DB.
+    const { loadHasMany } = await import("../associations.js");
+    class MgAuthor extends Base {
+      declare name: string;
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class MgPosting extends Base {
+      static {
+        this.attribute("mg_author_id", "integer");
+        this.attribute("mg_tag_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class MgTag extends Base {
+      declare label: string;
+      static {
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(MgAuthor);
+    registerModel(MgPosting);
+    registerModel(MgTag);
+    Associations.hasMany.call(MgAuthor, "mg_postings", {
+      className: "MgPosting",
+      foreignKey: "mg_author_id",
+    });
+    Associations.hasMany.call(MgAuthor, "mg_tags", {
+      className: "MgTag",
+      through: "mg_postings",
+      source: "mg_tag",
+    });
+    Associations.belongsTo.call(MgPosting, "mg_tag", {
+      className: "MgTag",
+      foreignKey: "mg_tag_id",
+    });
+
+    const alice = await MgAuthor.create({ name: "Alice" });
+    const bob = await MgAuthor.create({ name: "Bob" });
+    const ruby = await MgTag.create({ label: "ruby" });
+    const ts = await MgTag.create({ label: "typescript" });
+    const go = await MgTag.create({ label: "go" });
+    await MgPosting.create({ mg_author_id: alice.id, mg_tag_id: ruby.id });
+    await MgPosting.create({ mg_author_id: alice.id, mg_tag_id: ts.id });
+    await MgPosting.create({ mg_author_id: bob.id, mg_tag_id: go.id });
+
+    const tags = (await loadHasMany(alice, "mg_tags", {
+      className: "MgTag",
+      through: "mg_postings",
+      source: "mg_tag",
+    })) as MgTag[];
+    expect(tags.map((t) => t.label).sort()).toEqual(["ruby", "typescript"]);
+  });
+
   it("through chain query loads actual records end-to-end (Author -> Memberships -> Tags)", async () => {
     // Real DB roundtrip: insert records, build the through scope via
     // AssociationScope, execute it, assert the right rows come back.

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -550,6 +550,60 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/"cc_memberships"\."active"\s*=\s*TRUE/i);
   });
 
+  it("loadHasOne through chain (belongsTo source) routes via AssociationScope and returns one record", async () => {
+    // PR 3b migration covers loadHasOne too. End-to-end: insert,
+    // call loadHasOne with a through reflection, assert single result.
+    const { loadHasOne } = await import("../associations.js");
+    class HotPost extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class HotPostHook extends Base {
+      static {
+        this.attribute("hot_post_id", "integer");
+        this.attribute("hot_review_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class HotReview extends Base {
+      declare body: string;
+      static {
+        this.attribute("body", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(HotPost);
+    registerModel(HotPostHook);
+    registerModel(HotReview);
+    Associations.hasOne.call(HotPost, "hot_post_hook", {
+      className: "HotPostHook",
+      foreignKey: "hot_post_id",
+    });
+    Associations.hasOne.call(HotPost, "hot_review", {
+      className: "HotReview",
+      through: "hot_post_hook",
+      source: "hot_review",
+    });
+    Associations.belongsTo.call(HotPostHook, "hot_review", {
+      className: "HotReview",
+      foreignKey: "hot_review_id",
+    });
+
+    const post = await HotPost.create({});
+    const review = await HotReview.create({ body: "Great post" });
+    await HotPostHook.create({ hot_post_id: post.id, hot_review_id: review.id });
+
+    const loaded = (await loadHasOne(post, "hot_review", {
+      className: "HotReview",
+      through: "hot_post_hook",
+      source: "hot_review",
+    })) as HotReview | null;
+    expect(loaded).not.toBeNull();
+    expect(loaded!.body).toBe("Great post");
+  });
+
   it("loadHasMany through chain (belongsTo source, no sourceType) routes via AssociationScope", async () => {
     // PR 3b migration: loadHasMany for has_many :through where source
     // is non-polymorphic belongsTo (no sourceType) now routes through

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -500,24 +500,39 @@ export class AssociationScope {
     }
     // Rails' chain.reverse_each over reflection.constraints (Rails:
     // association_scope.rb:131-156) merges scope-chain items into the
-    // relation. For each non-head reflection in the chain, we apply
-    // its scope lambda to a fresh klass.unscoped, then push the
-    // resulting WHERE / ORDER predicates onto the main scope qualified
-    // to the reflection's table. The head reflection (chain[0]) is
-    // handled via scopeFor below — Rails' chain_head branch in
-    // add_constraints does the same effective thing.
-    for (let i = 1; i < chain.length; i++) {
+    // relation. For each non-head reflection in the chain (in REVERSE
+    // order to match Rails' chain.reverse_each), we apply its scope
+    // lambda to a fresh klass.(unscoped + STI type filter), then push
+    // only the WHERE and ORDER predicates onto the main scope —
+    // matching Rails' `where_clause +=` / `order_values |=` granular
+    // merging (NOT a full Relation#merge, which would let the chain
+    // entry's limit/select/etc override the main scope). The head
+    // reflection (chain[0]) is handled by the scope/scopeFor branch
+    // below — Rails' chain_head item in add_constraints.
+    for (let i = chain.length - 1; i >= 1; i--) {
       scope = this._mergeReflectionScopeChain(scope, chain[i], owner);
     }
     // scopeFor on the head reflection. Rails: reflection.rb:448,
     // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
     // (relation, owner) per `relation.instance_exec(owner, &scope) ||
     // relation`. Calling `reflection.scope(scope)` directly would lose
-    // the binding.
-    const scopeFor = (chain[0] as { scopeFor?: (rel: unknown, owner: unknown) => unknown })
-      .scopeFor;
-    if (typeof scopeFor === "function") {
-      scope = scopeFor.call(chain[0], scope, owner);
+    // the binding. ThroughReflection doesn't expose scopeFor (it's not
+    // a MacroReflection), so fall back to invoking .scope directly so
+    // a scope defined on the through association itself still applies.
+    const head = chain[0] as {
+      scopeFor?: (rel: unknown, owner: unknown) => unknown;
+      scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
+    };
+    if (typeof head.scopeFor === "function") {
+      scope = head.scopeFor.call(head, scope, owner);
+    } else if (typeof head.scope === "function") {
+      // Match Rails instance_exec arity: 0-arg scope → this=scope;
+      // 1+-arg → (scope, owner). Without scopeFor we mimic the same
+      // dispatch the AssociationReflection.scopeFor implementation does.
+      const fn = head.scope;
+      const result =
+        fn.length === 0 ? (fn as () => unknown).call(scope) : fn.call(scope, scope, owner);
+      if (result) scope = result;
     }
     return scope;
   }
@@ -525,15 +540,20 @@ export class AssociationScope {
   /**
    * Apply a non-head chain entry's scope lambda. Rails' add_constraints
    * does this via `eval_scope` + `scope.where_clause += item.where_clause`
-   * — the scope's WHERE / ORDER predicates are merged into the main
-   * relation, qualified to the entry's table since that's where the
-   * scope was originally written against.
+   * + `scope.order_values = item.order_values | scope.order_values` —
+   * granular per-attribute merging that pushes ONLY where and order
+   * predicates onto the main relation. A through-reflection scope's
+   * limit / select / joins / etc must NOT override the main scope.
    *
    * For non-head entries we evaluate the lambda against a fresh
-   * `entry.klass.unscoped` so its `where(...)` calls bind to the
-   * correct table, then merge that result into the main scope. Our
-   * `Relation#merge` table-tags the predicates correctly when scope
-   * tables differ (verified end-to-end by the through+scope test).
+   * `entry.klass.unscoped` (with STI type_condition re-applied for
+   * subclasses, matching the head-scope path in `scope()`) so its
+   * `where(...)` calls bind to the correct table. We then push the
+   * resulting WHERE predicates onto the main scope and union the
+   * ORDER clauses.
+   *
+   * Mirrors: ActiveRecord::Associations::AssociationScope#add_constraints
+   * (association_scope.rb:131-156).
    */
   private _mergeReflectionScopeChain(
     scope: unknown,
@@ -541,23 +561,57 @@ export class AssociationScope {
     owner: Base,
   ): unknown {
     const r = reflection as {
-      scope?: (rel: unknown, owner?: unknown) => unknown;
+      scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
       scopeFor?: (rel: unknown, owner?: unknown) => unknown;
       klass?: typeof Base;
     };
     if (typeof r.scope !== "function") return scope;
     const entryKlass = r.klass;
     if (!entryKlass) return scope;
-    const entryScope = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
+    // Build the entry-side scope with STI type_condition, matching the
+    // head-scope path so STI subclasses get the right type filter
+    // (Base.unscoped strips it; we re-add per the same compensation).
+    let entryScope: unknown = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
+    if (isStiSubclass(entryKlass)) {
+      const col = getInheritanceColumn(getStiBase(entryKlass));
+      if (col) {
+        const stiNames = [
+          entryKlass.name,
+          ...descendants(entryKlass).map((d: typeof Base) => d.name),
+        ];
+        entryScope = (entryScope as { where: (c: Record<string, unknown>) => unknown }).where({
+          [col]: stiNames.length === 1 ? stiNames[0] : stiNames,
+        });
+      }
+    }
     const evaluated =
       typeof r.scopeFor === "function"
         ? r.scopeFor.call(reflection, entryScope, owner)
         : r.scope.call(reflection, entryScope, owner);
     if (!evaluated) return scope;
-    // Rails: scope.where_clause += item.where_clause / order_values |=
-    // ... For our purposes, Relation#merge handles the per-attribute
-    // semantics (WHERE concatenation, last-wins for limit/order/etc).
-    const merger = (scope as { merge: (other: unknown) => unknown }).merge;
-    return typeof merger === "function" ? merger.call(scope, evaluated) : scope;
+    // Push ONLY the entry's WHERE predicates and ORDER clauses onto
+    // the main scope — Rails' `where_clause += ...` / `order_values |=`
+    // semantics. A full Relation#merge would let the entry's limit /
+    // select / joins / etc override the main scope, which Rails
+    // explicitly avoids (see the chain_head branch's
+    // `merge! item.except(:where, :includes, :unscope, :order)` plus
+    // explicit `where_clause += / order_values |=` afterward).
+    const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
+    const evalOrders = (evaluated as { _orderClauses?: unknown[] })._orderClauses ?? [];
+    let merged = scope as {
+      where: (n: unknown) => unknown;
+      order: (...args: unknown[]) => unknown;
+    };
+    for (const pred of evalWhere?.predicates ?? []) {
+      merged = merged.where(pred) as typeof merged;
+    }
+    if (evalOrders.length > 0) {
+      const existing = (merged as unknown as { _orderClauses?: unknown[] })._orderClauses ?? [];
+      const additions = evalOrders.filter((o) => !existing.includes(o));
+      if (additions.length > 0) {
+        merged = merged.order(...additions) as typeof merged;
+      }
+    }
+    return merged;
   }
 }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -498,20 +498,66 @@ export class AssociationScope {
     for (let i = 0; i < chain.length - 1; i++) {
       scope = this._nextChainScope(scope, chain[i], chain[i + 1]);
     }
-    // Use scopeFor (Rails: reflection.rb:448, scope_for) so 0-arity
-    // scopes get `this`=relation, and >=1-arity scopes receive
-    // (relation, owner) — matches Rails' `relation.instance_exec(owner,
-    // &scope) || relation`. Calling `reflection.scope(scope)` directly
-    // would lose the binding. The full Rails `add_constraints`
-    // chain.reverseEach merges every reflection's constraints; for
-    // chain-1 the simplified head-only path matches, and for through
-    // chains we call scopeFor on the source reflection (chain[0])
-    // matching Rails' behavior for the chain-head item.
+    // Rails' chain.reverse_each over reflection.constraints (Rails:
+    // association_scope.rb:131-156) merges scope-chain items into the
+    // relation. For each non-head reflection in the chain, we apply
+    // its scope lambda to a fresh klass.unscoped, then push the
+    // resulting WHERE / ORDER predicates onto the main scope qualified
+    // to the reflection's table. The head reflection (chain[0]) is
+    // handled via scopeFor below — Rails' chain_head branch in
+    // add_constraints does the same effective thing.
+    for (let i = 1; i < chain.length; i++) {
+      scope = this._mergeReflectionScopeChain(scope, chain[i], owner);
+    }
+    // scopeFor on the head reflection. Rails: reflection.rb:448,
+    // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
+    // (relation, owner) per `relation.instance_exec(owner, &scope) ||
+    // relation`. Calling `reflection.scope(scope)` directly would lose
+    // the binding.
     const scopeFor = (chain[0] as { scopeFor?: (rel: unknown, owner: unknown) => unknown })
       .scopeFor;
     if (typeof scopeFor === "function") {
       scope = scopeFor.call(chain[0], scope, owner);
     }
     return scope;
+  }
+
+  /**
+   * Apply a non-head chain entry's scope lambda. Rails' add_constraints
+   * does this via `eval_scope` + `scope.where_clause += item.where_clause`
+   * — the scope's WHERE / ORDER predicates are merged into the main
+   * relation, qualified to the entry's table since that's where the
+   * scope was originally written against.
+   *
+   * For non-head entries we evaluate the lambda against a fresh
+   * `entry.klass.unscoped` so its `where(...)` calls bind to the
+   * correct table, then merge that result into the main scope. Our
+   * `Relation#merge` table-tags the predicates correctly when scope
+   * tables differ (verified end-to-end by the through+scope test).
+   */
+  private _mergeReflectionScopeChain(
+    scope: unknown,
+    reflection: AbstractReflection | ReflectionProxy,
+    owner: Base,
+  ): unknown {
+    const r = reflection as {
+      scope?: (rel: unknown, owner?: unknown) => unknown;
+      scopeFor?: (rel: unknown, owner?: unknown) => unknown;
+      klass?: typeof Base;
+    };
+    if (typeof r.scope !== "function") return scope;
+    const entryKlass = r.klass;
+    if (!entryKlass) return scope;
+    const entryScope = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
+    const evaluated =
+      typeof r.scopeFor === "function"
+        ? r.scopeFor.call(reflection, entryScope, owner)
+        : r.scope.call(reflection, entryScope, owner);
+    if (!evaluated) return scope;
+    // Rails: scope.where_clause += item.where_clause / order_values |=
+    // ... For our purposes, Relation#merge handles the per-attribute
+    // semantics (WHERE concatenation, last-wins for limit/order/etc).
+    const merger = (scope as { merge: (other: unknown) => unknown }).merge;
+    return typeof merger === "function" ? merger.call(scope, evaluated) : scope;
   }
 }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -512,16 +512,14 @@ export class AssociationScope {
     for (let i = chain.length - 1; i >= 1; i--) {
       scope = this._mergeReflectionScopeChain(scope, chain[i], owner);
     }
-    // scopeFor on the head reflection. Rails: reflection.rb:448,
+    // Apply the head reflection's scope. Rails: reflection.rb:448,
     // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
     // (relation, owner) per `relation.instance_exec(owner, &scope) ||
-    // relation`. ThroughReflection inherits AbstractReflection's
-    // `scopeFor`, but its internal `_scope` field is never set — the
-    // scope on the `has_many :through` itself lives on `.scope`
-    // (delegated), so `scopeFor` returns the scope unchanged for
-    // through reflections. Detect through explicitly and invoke
-    // `.scope` directly with matching arity / `this` semantics so a
-    // scope on the through association itself still applies.
+    // relation`. For ordinary AssociationReflections we call `scopeFor`
+    // when present. ThroughReflection does NOT implement `scopeFor`;
+    // it only exposes `.scope` (delegated to the underlying source
+    // association's scope), so detect through explicitly and invoke
+    // `.scope` directly with the same arity / `this` semantics.
     const head = chain[0] as {
       scopeFor?: (rel: unknown, owner: unknown) => unknown;
       scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
@@ -606,15 +604,26 @@ export class AssociationScope {
     // select / joins / etc override the main scope, which Rails
     // explicitly avoids.
     const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
+    const evalPredicates = evalWhere?.predicates ?? [];
     const evalOrders = (evaluated as { _orderClauses?: unknown[] })._orderClauses ?? [];
     const evalRawOrders = (evaluated as { _rawOrderClauses?: string[] })._rawOrderClauses ?? [];
-    let merged = scope as {
-      where: (n: unknown) => unknown;
+    const merged = scope as {
+      _whereClause?: { predicates?: unknown[] };
       _orderClauses?: unknown[];
       _rawOrderClauses?: string[];
     };
-    for (const pred of evalWhere?.predicates ?? []) {
-      merged = merged.where(pred) as typeof merged;
+    // Rails: `scope.where_clause += item.where_clause`. Mutate the
+    // existing _whereClause's predicates array in place — appending all
+    // entry predicates in one shot — instead of looping with `.where()`
+    // which would clone the relation per-predicate. Safe because `scope`
+    // here is owned by this _addConstraints call (built fresh from
+    // klass.unscoped + per-step .where clones; not shared externally).
+    if (evalPredicates.length > 0) {
+      const existingPredicates = merged._whereClause?.predicates ?? [];
+      existingPredicates.push(...evalPredicates);
+      if (merged._whereClause) {
+        merged._whereClause.predicates = existingPredicates;
+      }
     }
     // Rails: `scope.order_values = item.order_values | scope.order_values`
     // (association_scope.rb:153). Ordering lives in both _orderClauses

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -515,20 +515,24 @@ export class AssociationScope {
     // scopeFor on the head reflection. Rails: reflection.rb:448,
     // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
     // (relation, owner) per `relation.instance_exec(owner, &scope) ||
-    // relation`. Calling `reflection.scope(scope)` directly would lose
-    // the binding. ThroughReflection doesn't expose scopeFor (it's not
-    // a MacroReflection), so fall back to invoking .scope directly so
-    // a scope defined on the through association itself still applies.
+    // relation`. ThroughReflection inherits AbstractReflection's
+    // `scopeFor`, but its internal `_scope` field is never set — the
+    // scope on the `has_many :through` itself lives on `.scope`
+    // (delegated), so `scopeFor` returns the scope unchanged for
+    // through reflections. Detect through explicitly and invoke
+    // `.scope` directly with matching arity / `this` semantics so a
+    // scope on the through association itself still applies.
     const head = chain[0] as {
       scopeFor?: (rel: unknown, owner: unknown) => unknown;
       scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
+      isThroughReflection?: () => boolean;
     };
-    if (typeof head.scopeFor === "function") {
+    const isThrough = typeof head.isThroughReflection === "function" && head.isThroughReflection();
+    if (!isThrough && typeof head.scopeFor === "function") {
       scope = head.scopeFor.call(head, scope, owner);
     } else if (typeof head.scope === "function") {
       // Match Rails instance_exec arity: 0-arg scope → this=scope;
-      // 1+-arg → (scope, owner). Without scopeFor we mimic the same
-      // dispatch the AssociationReflection.scopeFor implementation does.
+      // 1+-arg → (scope, owner).
       const fn = head.scope;
       const result =
         fn.length === 0 ? (fn as () => unknown).call(scope) : fn.call(scope, scope, owner);
@@ -584,33 +588,45 @@ export class AssociationScope {
         });
       }
     }
+    // Same arity / `this` semantics as AssociationReflection.scopeFor
+    // for the fallback path: 0-arg → `this=relation`; 1+-arg →
+    // `this=relation, args=(relation, owner)`. Without this binding,
+    // a scope written as `function () { return this.where(...) }`
+    // (the common 0-arg form) would lose the relation.
     const evaluated =
       typeof r.scopeFor === "function"
         ? r.scopeFor.call(reflection, entryScope, owner)
-        : r.scope.call(reflection, entryScope, owner);
+        : r.scope.length === 0
+          ? (r.scope as () => unknown).call(entryScope)
+          : r.scope.call(entryScope, entryScope, owner);
     if (!evaluated) return scope;
     // Push ONLY the entry's WHERE predicates and ORDER clauses onto
     // the main scope — Rails' `where_clause += ...` / `order_values |=`
     // semantics. A full Relation#merge would let the entry's limit /
     // select / joins / etc override the main scope, which Rails
-    // explicitly avoids (see the chain_head branch's
-    // `merge! item.except(:where, :includes, :unscope, :order)` plus
-    // explicit `where_clause += / order_values |=` afterward).
+    // explicitly avoids.
     const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
     const evalOrders = (evaluated as { _orderClauses?: unknown[] })._orderClauses ?? [];
     let merged = scope as {
       where: (n: unknown) => unknown;
-      order: (...args: unknown[]) => unknown;
+      _orderClauses?: unknown[];
     };
     for (const pred of evalWhere?.predicates ?? []) {
       merged = merged.where(pred) as typeof merged;
     }
     if (evalOrders.length > 0) {
-      const existing = (merged as unknown as { _orderClauses?: unknown[] })._orderClauses ?? [];
-      const additions = evalOrders.filter((o) => !existing.includes(o));
-      if (additions.length > 0) {
-        merged = merged.order(...additions) as typeof merged;
+      // Rails: `scope.order_values = item.order_values | scope.order_values`
+      // (association_scope.rb:153) — chain entry's orderings come
+      // BEFORE the main scope's, deduplicated. _orderClauses entries
+      // are `string | [string, "asc"|"desc"]` tuples; pushing tuples
+      // back through `.order(...)` doesn't round-trip, so mutate the
+      // _orderClauses array directly.
+      const existing = merged._orderClauses ?? [];
+      const next: unknown[] = [];
+      for (const o of [...evalOrders, ...existing]) {
+        if (!next.includes(o)) next.push(o);
       }
+      merged._orderClauses = next;
     }
     return merged;
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -607,27 +607,51 @@ export class AssociationScope {
     // explicitly avoids.
     const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
     const evalOrders = (evaluated as { _orderClauses?: unknown[] })._orderClauses ?? [];
+    const evalRawOrders = (evaluated as { _rawOrderClauses?: string[] })._rawOrderClauses ?? [];
     let merged = scope as {
       where: (n: unknown) => unknown;
       _orderClauses?: unknown[];
+      _rawOrderClauses?: string[];
     };
     for (const pred of evalWhere?.predicates ?? []) {
       merged = merged.where(pred) as typeof merged;
     }
+    // Rails: `scope.order_values = item.order_values | scope.order_values`
+    // (association_scope.rb:153). Ordering lives in both _orderClauses
+    // (string | [col, dir] tuples) and _rawOrderClauses (string like
+    // `inOrderOf` produces). Merge both with chain-entry-first +
+    // structural dedup so tuples compare by value, not reference.
     if (evalOrders.length > 0) {
-      // Rails: `scope.order_values = item.order_values | scope.order_values`
-      // (association_scope.rb:153) — chain entry's orderings come
-      // BEFORE the main scope's, deduplicated. _orderClauses entries
-      // are `string | [string, "asc"|"desc"]` tuples; pushing tuples
-      // back through `.order(...)` doesn't round-trip, so mutate the
-      // _orderClauses array directly.
-      const existing = merged._orderClauses ?? [];
-      const next: unknown[] = [];
-      for (const o of [...evalOrders, ...existing]) {
-        if (!next.includes(o)) next.push(o);
-      }
-      merged._orderClauses = next;
+      merged._orderClauses = unionOrderClauses(evalOrders, merged._orderClauses ?? []);
+    }
+    if (evalRawOrders.length > 0) {
+      const existingRaw = merged._rawOrderClauses ?? [];
+      merged._rawOrderClauses = Array.from(new Set([...evalRawOrders, ...existingRaw]));
     }
     return merged;
   }
+}
+
+/**
+ * Structurally dedupe `_orderClauses` entries (plain strings or
+ * `[col, "asc"|"desc"]` tuples). `Array#includes` only does reference
+ * equality, so two tuples with equal contents created separately
+ * wouldn't match. Rails' `|` operator on order_values is structural.
+ */
+function unionOrderClauses(first: unknown[], second: unknown[]): unknown[] {
+  const result: unknown[] = [];
+  const seen = new Set<string>();
+  for (const o of [...first, ...second]) {
+    const key =
+      Array.isArray(o) && o.length === 2
+        ? `T:${String(o[0])}:${String(o[1])}`
+        : typeof o === "string"
+          ? `S:${o}`
+          : `J:${JSON.stringify(o)}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(o);
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

PR 3 shipped the chain-walking machinery; PR 3b makes `loadHasMany` / `loadHasOne` actually use it for the most common through shape: `has_many :through` where the source is non-polymorphic `belongsTo`, no `sourceType`, no `disableJoins`.

## What lands

**1. Port full `add_constraints` (chain.reverse_each merging) — granular per-attribute.** Rails' `association_scope.rb:131-156` walks each non-head reflection's constraints and merges WHERE / ORDER predicates into the main relation. New `_mergeReflectionScopeChain` evaluates each non-head entry's scope on a fresh `entry.klass.unscoped` (with STI type filter re-applied for subclasses) and pushes ONLY where + order onto the main scope — NOT a full `Relation#merge`, which would let an entry's limit/select/etc override. WHERE predicates are pushed by mutating `_whereClause.predicates` once (not via per-predicate `.where()` clones). Order merging unions both `_orderClauses` (with structural dedup over `[col, dir]` tuples) and `_rawOrderClauses`, putting entry orderings BEFORE the existing per `item.order_values | scope.order_values`.

**2. Fix the null-FK short-circuit in loadHasMany/loadHasOne.** The check was reading `reflection.joinForeignKey`, but for `ThroughReflection` that delegates to the SOURCE reflection (whose FK is on the through table, not the owner). Now uses `through_reflection.joinForeignKey` (= `chain.last` in the chain ordering) so the check reads the actual owner-side column.

**3. Fix head-scope dispatch for ThroughReflection.** ThroughReflection does NOT implement `scopeFor`; it only exposes `.scope` (delegated to the underlying source association). Detect via `isThroughReflection()` and call `.scope` directly with arity-aware `this`-binding.

**4. Fix `_mergeReflectionScopeChain` arity.** Fallback path now binds `this=relation` and passes `(relation, owner)` for 1+-arity scopes, matching `AssociationReflection.scopeFor`.

## Migration gating
Shared `_canRouteThroughViaAssociationScope(reflection, options)` predicate (used by both `loadHasMany` and `loadHasOne`) requires:
- reflection registered
- source is non-polymorphic `belongsTo`
- no `sourceType`
- no `disableJoins`

Other shapes still fall back to `loadHasManyThrough` / `loadHasOneThrough`. PR 3c will widen.

## Tests
- `through chain merges scope on the through reflection (chain.reverse_each)` — SQL shape verifies the through-reflection's scope WHERE flows through.
- `loadHasMany through chain (belongsTo source, no sourceType) routes via AssociationScope` — end-to-end: 2 authors × 3 tags × 3 postings, asserts `loadHasMany` returns the right rows for one author.
- `loadHasOne through chain (belongsTo source) routes via AssociationScope and returns one record` — end-to-end mirror for `loadHasOne`.
- 1532 / 1942 in `packages/activerecord/src/associations` (+3 from PR 3's 1529).

## Out of scope (PR 3c+)
- `sourceType` filtering for polymorphic sources
- `has_many` / `has_one` source (chain inversion)
- `AliasTracker` for repeated joins (self-referential through)
- `DisableJoinsAssociationScope` real impl (PR 4)
- `eager_load!` skip-list + cache wiring (PR 5)

## Rails refs
- `activerecord/lib/active_record/associations/association_scope.rb:131-156` — `add_constraints` chain.reverse_each loop
- `activerecord/lib/active_record/associations/association_scope.rb:153` — `order_values |=` semantics