### PR TITLE
feat(activerecord): read statementLimit from adapter options hash

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -13,6 +13,21 @@ import type { Result } from "./result.js";
 export type ExplainOption = string | { format: string };
 
 /**
+ * Adapter-level options that travel alongside driver connection
+ * params in a single config hash (Rails' database.yml shape).
+ * Constructors strip these keys out before handing the rest to the
+ * driver.
+ *
+ * Mirrors: the adapter-level keys read in
+ * `ActiveRecord::ConnectionAdapters::AbstractAdapter#initialize`
+ * (`:statement_limit`, `:prepared_statements`).
+ */
+export interface TrailsAdapterOptions {
+  statementLimit?: number;
+  preparedStatements?: boolean;
+}
+
+/**
  * Stringify an arbitrary value for inclusion in an EXPLAIN validation
  * error message. `as any` callers can hand us arbitrary shapes —
  * circular objects, BigInts, Symbols, functions — and a raw

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -129,7 +129,7 @@ describeIfMysql("Mysql2Adapter", () => {
       );
     });
 
-    it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
+    it("rejects non-boolean preparedStatements at construction time and via assignment", async () => {
       // Mirror coverage to PG's statement-pool tests — without an
       // explicit guard test the runtime TypeError could regress
       // silently when adapter options are wired.
@@ -149,9 +149,15 @@ describeIfMysql("Mysql2Adapter", () => {
       ).toThrow(TypeError);
 
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      expect(() => {
-        (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
-      }).toThrow(TypeError);
+      try {
+        expect(() => {
+          (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
+        }).toThrow(TypeError);
+      } finally {
+        // mysql2 pool keeps open handles — close to avoid leaked
+        // sockets / Vitest hangs.
+        await adapter2.close();
+      }
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -104,5 +104,16 @@ describeIfMysql("Mysql2Adapter", () => {
       await adapter.close();
       expect(() => pool.clear()).not.toThrow();
     });
+
+    it("reads statementLimit from the adapter options hash", async () => {
+      const configured = new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: 7 });
+      expect(configured.statementLimit).toBe(7);
+      await configured.close();
+    });
+
+    it("rejects invalid statementLimit at construction time", () => {
+      expect(() => new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: -1 })).toThrow(RangeError);
+      expect(() => new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: 1.5 })).toThrow(RangeError);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -105,15 +105,28 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(() => pool.clear()).not.toThrow();
     });
 
-    it("reads statementLimit from the adapter options hash", async () => {
-      const configured = new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: 7 });
+    it("reads statementLimit from the config hash (database.yml shape)", async () => {
+      const configured = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 7 });
       expect(configured.statementLimit).toBe(7);
       await configured.close();
     });
 
+    it("reads preparedStatements from the config hash", async () => {
+      const configured = new Mysql2Adapter({
+        uri: MYSQL_TEST_URL,
+        preparedStatements: false,
+      });
+      expect(configured.preparedStatements).toBe(false);
+      await configured.close();
+    });
+
     it("rejects invalid statementLimit at construction time", () => {
-      expect(() => new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: -1 })).toThrow(RangeError);
-      expect(() => new Mysql2Adapter(MYSQL_TEST_URL, { statementLimit: 1.5 })).toThrow(RangeError);
+      expect(() => new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: -1 })).toThrow(
+        RangeError,
+      );
+      expect(() => new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 1.5 })).toThrow(
+        RangeError,
+      );
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -128,5 +128,30 @@ describeIfMysql("Mysql2Adapter", () => {
         RangeError,
       );
     });
+
+    it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
+      // Mirror coverage to PG's statement-pool tests — without an
+      // explicit guard test the runtime TypeError could regress
+      // silently when adapter options are wired.
+      expect(
+        () =>
+          new Mysql2Adapter({
+            uri: MYSQL_TEST_URL,
+            preparedStatements: "false" as unknown as boolean,
+          }),
+      ).toThrow(TypeError);
+      expect(
+        () =>
+          new Mysql2Adapter({
+            uri: MYSQL_TEST_URL,
+            preparedStatements: 0 as unknown as boolean,
+          }),
+      ).toThrow(TypeError);
+
+      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
+      expect(() => {
+        (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
+      }).toThrow(TypeError);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -1,6 +1,6 @@
 import mysql from "mysql2/promise";
 import { Notifications } from "@blazetrails/activesupport";
-import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import {
   AbstractMysqlAdapter,
   StatementPool as MysqlStatementPool,
@@ -144,19 +144,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // not yet probed, `true`/`false` = result.
   private _statisticsHasExpression: boolean | undefined;
 
-  constructor(config: string | mysql.PoolOptions, options: { statementLimit?: number } = {}) {
+  constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
     super();
     if (typeof config === "string") {
       this._driverPool = mysql.createPool({ uri: config });
-    } else {
-      this._driverPool = mysql.createPool(config);
+      return;
     }
-    // Rails reads `config[:statement_limit]` at adapter init; honor
-    // the same shape here. Going through the setter applies the
-    // value's validation (finite non-negative integer).
-    if (options.statementLimit !== undefined) {
-      this.statementLimit = options.statementLimit;
-    }
+    // See PostgreSQLAdapter#constructor: Rails' database.yml merges
+    // driver + adapter config, and AbstractAdapter#initialize reads
+    // `:statement_limit` / `:prepared_statements` off that single
+    // hash. Strip those before passing the rest to mysql.createPool.
+    const { statementLimit, preparedStatements, ...mysqlConfig } = config;
+    this._driverPool = mysql.createPool(mysqlConfig);
+    if (statementLimit !== undefined) this.statementLimit = statementLimit;
+    if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
   }
 
   /**

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -51,8 +51,12 @@ class Mysql2StatementPool extends MysqlStatementPool {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2Adapter
  *
- * Accepts either a connection URI (`mysql://...`) or a `mysql2` pool config
- * object. Uses a connection pool internally for concurrent access.
+ * Accepts either a connection URI (`mysql://...`) or a merged config
+ * hash — `mysql2` pool-options keys for the driver, plus Rails' adapter-
+ * level keys (`statementLimit`, `preparedStatements`) stripped into the
+ * adapter before `mysql.createPool` is called. Matches Rails' database.yml
+ * shape where driver params and adapter knobs share one hash.
+ * Uses a connection pool internally for concurrent access.
  */
 export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapter {
   override get adapterName(): string {

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -144,12 +144,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // not yet probed, `true`/`false` = result.
   private _statisticsHasExpression: boolean | undefined;
 
-  constructor(config: string | mysql.PoolOptions) {
+  constructor(config: string | mysql.PoolOptions, options: { statementLimit?: number } = {}) {
     super();
     if (typeof config === "string") {
       this._driverPool = mysql.createPool({ uri: config });
     } else {
       this._driverPool = mysql.createPool(config);
+    }
+    // Rails reads `config[:statement_limit]` at adapter init; honor
+    // the same shape here. Going through the setter applies the
+    // value's validation (finite non-negative integer).
+    if (options.statementLimit !== undefined) {
+      this.statementLimit = options.statementLimit;
     }
   }
 

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -157,11 +157,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
     // driver + adapter config, and AbstractAdapter#initialize reads
     // `:statement_limit` / `:prepared_statements` off that single
-    // hash. Strip those before passing the rest to mysql.createPool.
+    // hash. Validate & apply the adapter-level keys FIRST so an
+    // invalid value fails before `mysql.createPool` runs — otherwise
+    // a throw would leave a live pool with no cleanup path.
     const { statementLimit, preparedStatements, ...mysqlConfig } = config;
-    this._driverPool = mysql.createPool(mysqlConfig);
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
+    this._driverPool = mysql.createPool(mysqlConfig);
   }
 
   /**

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -138,15 +138,31 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(new PreparedStatementCacheExpired("test").name).toBe("PreparedStatementCacheExpired");
     });
 
-    it("reads statementLimit from the adapter options hash", () => {
-      const configured = new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: 7 });
+    it("reads statementLimit from the config hash (database.yml shape)", async () => {
+      const configured = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        statementLimit: 7,
+      });
       expect(configured.statementLimit).toBe(7);
-      return configured.close();
+      await configured.close();
+    });
+
+    it("reads preparedStatements from the config hash", async () => {
+      const configured = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        preparedStatements: false,
+      });
+      expect(configured.preparedStatements).toBe(false);
+      await configured.close();
     });
 
     it("rejects invalid statementLimit at construction time", () => {
-      expect(() => new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: -1 })).toThrow(RangeError);
-      expect(() => new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: 1.5 })).toThrow(RangeError);
+      expect(
+        () => new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: -1 }),
+      ).toThrow(RangeError);
+      expect(
+        () => new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: 1.5 }),
+      ).toThrow(RangeError);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -137,5 +137,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       const { PreparedStatementCacheExpired } = await import("../../errors.js");
       expect(new PreparedStatementCacheExpired("test").name).toBe("PreparedStatementCacheExpired");
     });
+
+    it("reads statementLimit from the adapter options hash", () => {
+      const configured = new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: 7 });
+      expect(configured.statementLimit).toBe(7);
+      return configured.close();
+    });
+
+    it("rejects invalid statementLimit at construction time", () => {
+      expect(() => new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: -1 })).toThrow(RangeError);
+      expect(() => new PostgreSQLAdapter(PG_TEST_URL, { statementLimit: 1.5 })).toThrow(RangeError);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -164,5 +164,31 @@ describeIfPg("PostgreSQLAdapter", () => {
         () => new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: 1.5 }),
       ).toThrow(RangeError);
     });
+
+    it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
+      // Construction-time validation routes preparedStatements through
+      // the setter, so a non-boolean (string, number, etc.) hits the
+      // same TypeError guard as direct assignment. Without this test
+      // the runtime guard could regress silently.
+      expect(
+        () =>
+          new PostgreSQLAdapter({
+            connectionString: PG_TEST_URL,
+            preparedStatements: "false" as unknown as boolean,
+          }),
+      ).toThrow(TypeError);
+      expect(
+        () =>
+          new PostgreSQLAdapter({
+            connectionString: PG_TEST_URL,
+            preparedStatements: 0 as unknown as boolean,
+          }),
+      ).toThrow(TypeError);
+
+      const adapter2 = new PostgreSQLAdapter(PG_TEST_URL);
+      expect(() => {
+        (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
+      }).toThrow(TypeError);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -165,7 +165,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).toThrow(RangeError);
     });
 
-    it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
+    it("rejects non-boolean preparedStatements at construction time and via assignment", async () => {
       // Construction-time validation routes preparedStatements through
       // the setter, so a non-boolean (string, number, etc.) hits the
       // same TypeError guard as direct assignment. Without this test
@@ -186,9 +186,15 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).toThrow(TypeError);
 
       const adapter2 = new PostgreSQLAdapter(PG_TEST_URL);
-      expect(() => {
-        (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
-      }).toThrow(TypeError);
+      try {
+        expect(() => {
+          (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
+        }).toThrow(TypeError);
+      } finally {
+        // pg.Pool keeps sockets/timers alive — close to avoid Vitest
+        // hangs / flakiness from leaked handles.
+        await adapter2.close();
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -253,6 +253,11 @@ export class AbstractAdapter extends AbstractAdapterBase {
   }
 
   set preparedStatements(value: boolean) {
+    if (typeof value !== "boolean") {
+      throw new TypeError(
+        `preparedStatements must be a boolean; got ${typeof value}: ${String(value)}`,
+      );
+    }
     this._preparedStatements = value;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -32,8 +32,12 @@ import { typeCastedBinds } from "./abstract/database-statements.js";
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
  *
- * Accepts either a connection string (`postgres://...`) or a `pg.PoolConfig`
- * object. Uses a connection pool internally for concurrent access.
+ * Accepts either a connection string (`postgres://...`) or a merged
+ * config hash — `pg.PoolConfig` keys for the driver, plus Rails'
+ * adapter-level keys (`statementLimit`, `preparedStatements`) stripped
+ * into the adapter before `pg.Pool` is built. Matches Rails' database.yml
+ * shape where driver params and adapter knobs share one hash.
+ * Uses a connection pool internally for concurrent access.
  */
 export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapter {
   override get adapterName(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -94,12 +94,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  constructor(config: string | pg.PoolConfig) {
+  constructor(config: string | pg.PoolConfig, options: { statementLimit?: number } = {}) {
     super();
     if (typeof config === "string") {
       this._driverPool = new pg.Pool({ connectionString: config });
     } else {
       this._driverPool = new pg.Pool(config);
+    }
+    // Rails reads `config[:statement_limit]` at adapter init; honor
+    // the same shape here. Going through the setter applies the
+    // value's validation (finite non-negative integer).
+    if (options.statementLimit !== undefined) {
+      this.statementLimit = options.statementLimit;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -107,12 +107,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Rails' database.yml merges driver connection params + adapter
     // options into one hash; AbstractAdapter#initialize reads
     // `config[:statement_limit]` / `config[:prepared_statements]`
-    // and hands the rest to the driver. Do the same here: split
-    // adapter-level keys out before constructing pg.Pool.
+    // and hands the rest to the driver. Validate & apply the
+    // adapter-level keys FIRST so an invalid value fails before
+    // `pg.Pool` is constructed — otherwise a throw here would leave
+    // a live driver pool with no cleanup path on the half-built
+    // adapter.
     const { statementLimit, preparedStatements, ...pgConfig } = config;
-    this._driverPool = new pg.Pool(pgConfig);
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
+    this._driverPool = new pg.Pool(pgConfig);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -21,7 +21,7 @@ import {
   initializeTypeMap as staticInitializeTypeMap,
 } from "./postgresql/type-map-init.js";
 import { inspectExplainOption } from "../adapter.js";
-import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import { PreparedStatementCacheExpired } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
@@ -94,19 +94,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  constructor(config: string | pg.PoolConfig, options: { statementLimit?: number } = {}) {
+  constructor(config: string | (pg.PoolConfig & TrailsAdapterOptions)) {
     super();
     if (typeof config === "string") {
       this._driverPool = new pg.Pool({ connectionString: config });
-    } else {
-      this._driverPool = new pg.Pool(config);
+      return;
     }
-    // Rails reads `config[:statement_limit]` at adapter init; honor
-    // the same shape here. Going through the setter applies the
-    // value's validation (finite non-negative integer).
-    if (options.statementLimit !== undefined) {
-      this.statementLimit = options.statementLimit;
-    }
+    // Rails' database.yml merges driver connection params + adapter
+    // options into one hash; AbstractAdapter#initialize reads
+    // `config[:statement_limit]` / `config[:prepared_statements]`
+    // and hands the rest to the driver. Do the same here: split
+    // adapter-level keys out before constructing pg.Pool.
+    const { statementLimit, preparedStatements, ...pgConfig } = config;
+    this._driverPool = new pg.Pool(pgConfig);
+    if (statementLimit !== undefined) this.statementLimit = statementLimit;
+    if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
   }
 
   /**


### PR DESCRIPTION
## Summary

PR 3 of the StatementPool plan (PR 1 = #611 PG, PR 2 = #617 MySQL). Threads `statement_limit` and `prepared_statements` from adapter config, matching Rails' `AbstractAdapter#initialize` which reads them off the merged `database.yml` hash and forwards the rest to the driver.

- New shared `TrailsAdapterOptions` type (`{ statementLimit?, preparedStatements? }`) in `adapter.ts`.
- `PostgreSQLAdapter` / `Mysql2Adapter` constructors take a single `string | (DriverConfig & TrailsAdapterOptions)` arg. Adapter-level keys are stripped before `pg.Pool` / `mysql.createPool`.
- Going through the existing setters applies validation (finite non-negative integer for `statementLimit`), so malformed config fails loudly at boot.
- Tests for both adapters: `statementLimit` round-trip, `preparedStatements` round-trip, validation (RangeError on negative/non-integer).

## Test plan

- [ ] PG CI: new `StatementPoolTest` cases pass
- [ ] MariaDB CI: new `StatementPoolTest` cases pass
- [ ] Full AR suite (sqlite): 8642 passed locally