### PR TITLE
feat(activerecord): widen through migration to has_many source + sourceType (PR 3c)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -293,15 +293,23 @@ function _canRouteThroughViaAssociationScope(
     | { belongsTo?: () => boolean; isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
-  // Polymorphic source (any kind): _nextChainScope reads
-  // reflection.joinPrimaryKey, but BelongsToReflection.joinPrimaryKey
-  // hard-codes "id" for polymorphic — and ThroughReflection.joinPrimaryKey
-  // delegates to its source. If the resolved sourceType class uses a
-  // non-"id" PK, the JOIN emits `target."id" = through."<fk>"` against
-  // a column that doesn't exist. Until per-klass JOIN routing honors
-  // joinPrimaryKeyFor consistently in the chain walker, fall back to
-  // the existing 2-step loaders for ALL polymorphic source reflections.
-  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) {
+  // Polymorphic has_many / has_one source (rare): the chain walker
+  // would need inversion machinery not present in PR 3c. Polymorphic
+  // belongsTo source WITH sourceType is routed — AssociationScope's
+  // _nextChainScope now uses ThroughReflection#joinPrimaryKeyFor(klass)
+  // so the resolved sourceType class's PK drives the JOIN.
+  if (
+    typeof src.isPolymorphic === "function" &&
+    src.isPolymorphic() &&
+    (typeof src.belongsTo !== "function" || !src.belongsTo())
+  ) {
+    return false;
+  }
+  // Polymorphic belongsTo source requires sourceType to resolve the
+  // target class. Without sourceType the JOIN can't pick a single
+  // target table — fall back to the 2-step loader which handles that
+  // by grouping through records by type.
+  if (typeof src.isPolymorphic === "function" && src.isPolymorphic() && !options.sourceType) {
     return false;
   }
   return true;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -269,14 +269,43 @@ function _canRouteThroughViaAssociationScope(
   options: AssociationOptions,
 ): boolean {
   if (!reflection) return false;
-  if (options.sourceType) return false;
   if (options.disableJoins) return false;
+  // Only ThroughReflection has a real distinct sourceReflection.
+  // AssociationReflection.sourceReflection returns `this` (line 793 in
+  // reflection.ts), which means HABTM and other non-through reflections
+  // would falsely match. Gate explicitly on isThroughReflection so HABTM's
+  // anonymous-join-model machinery (with its own load path) keeps using
+  // the existing 2-step loaders.
+  const refl = reflection as {
+    isThroughReflection?: () => boolean;
+    chain?: unknown[];
+    throughReflection?: { options?: { through?: string } };
+  };
+  if (typeof refl.isThroughReflection !== "function" || !refl.isThroughReflection()) {
+    return false;
+  }
+  // Through-a-through (chain length 3+): the through reflection itself
+  // points at another through reflection (e.g. Author has_many :ratings
+  // through :comments where :comments is itself through :posts). Chain
+  // walking would need to recurse on the inner through; PR 3c sticks
+  // with chain-length-2 and falls back to the 2-step loader otherwise.
+  if (refl.throughReflection?.options?.through) return false;
   const src = (reflection as { sourceReflection?: unknown }).sourceReflection as
     | { belongsTo?: () => boolean; isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
-  if (typeof src.belongsTo !== "function" || !src.belongsTo()) return false;
-  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
+  // Polymorphic has_many / has_one source is unusual and needs
+  // chain-inversion machinery this PR doesn't yet provide. Polymorphic
+  // belongsTo source is fine — _lastChainScope's reflection.type branch
+  // handles the type filter.
+  if (
+    typeof src.isPolymorphic === "function" &&
+    src.isPolymorphic() &&
+    typeof src.belongsTo === "function" &&
+    !src.belongsTo()
+  ) {
+    return false;
+  }
   return true;
 }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -293,16 +293,15 @@ function _canRouteThroughViaAssociationScope(
     | { belongsTo?: () => boolean; isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
-  // Polymorphic has_many / has_one source is unusual and needs
-  // chain-inversion machinery this PR doesn't yet provide. Polymorphic
-  // belongsTo source is fine — _lastChainScope's reflection.type branch
-  // handles the type filter.
-  if (
-    typeof src.isPolymorphic === "function" &&
-    src.isPolymorphic() &&
-    typeof src.belongsTo === "function" &&
-    !src.belongsTo()
-  ) {
+  // Polymorphic source (any kind): _nextChainScope reads
+  // reflection.joinPrimaryKey, but BelongsToReflection.joinPrimaryKey
+  // hard-codes "id" for polymorphic — and ThroughReflection.joinPrimaryKey
+  // delegates to its source. If the resolved sourceType class uses a
+  // non-"id" PK, the JOIN emits `target."id" = through."<fk>"` against
+  // a column that doesn't exist. Until per-klass JOIN routing honors
+  // joinPrimaryKeyFor consistently in the chain walker, fall back to
+  // the existing 2-step loaders for ALL polymorphic source reflections.
+  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) {
     return false;
   }
   return true;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -278,18 +278,17 @@ function _canRouteThroughViaAssociationScope(
   // the existing 2-step loaders.
   const refl = reflection as {
     isThroughReflection?: () => boolean;
-    chain?: unknown[];
-    throughReflection?: { options?: { through?: string } };
+    isNested?: () => boolean;
   };
   if (typeof refl.isThroughReflection !== "function" || !refl.isThroughReflection()) {
     return false;
   }
-  // Through-a-through (chain length 3+): the through reflection itself
-  // points at another through reflection (e.g. Author has_many :ratings
-  // through :comments where :comments is itself through :posts). Chain
-  // walking would need to recurse on the inner through; PR 3c sticks
-  // with chain-length-2 and falls back to the 2-step loader otherwise.
-  if (refl.throughReflection?.options?.through) return false;
+  // Through-a-through (nested) cases — either the throughReflection
+  // OR the sourceReflection is itself a ThroughReflection. Rails
+  // exposes both via ThroughReflection#isNested (reflection.ts:1187);
+  // PR 3c sticks with chain-length-2, so any nested shape falls back
+  // to the 2-step loader.
+  if (typeof refl.isNested === "function" && refl.isNested()) return false;
   const src = (reflection as { sourceReflection?: unknown }).sourceReflection as
     | { belongsTo?: () => boolean; isPolymorphic?: () => boolean }
     | undefined;

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -550,6 +550,149 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/"cc_memberships"\."active"\s*=\s*TRUE/i);
   });
 
+  it("loadHasMany through with sourceType filters by polymorphic source type (PR 3c)", async () => {
+    // Gallery has_many :imageables polymorphic; PolymorphicReflection
+    // wraps the chain entry and adds a type constraint
+    // `where(imageable_type: sourceType)`. PR 3c's
+    // _mergeReflectionScopeChain detects PolymorphicReflection and
+    // applies its constraints() — including the source_type_scope —
+    // to the chain JOIN so only the right polymorphic rows match.
+    const { loadHasMany } = await import("../associations.js");
+    class StAuthor extends Base {
+      declare name: string;
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class StGallery extends Base {
+      static {
+        this.attribute("st_author_id", "integer");
+        this.attribute("imageable_id", "integer");
+        this.attribute("imageable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    class StPhoto extends Base {
+      declare title: string;
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    class StVideo extends Base {
+      declare title: string;
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(StAuthor);
+    registerModel(StGallery);
+    registerModel(StPhoto);
+    registerModel(StVideo);
+    Associations.hasMany.call(StAuthor, "st_galleries", {
+      className: "StGallery",
+      foreignKey: "st_author_id",
+    });
+    Associations.belongsTo.call(StGallery, "imageable", { polymorphic: true });
+    // Through with sourceType — only StPhoto galleries should match.
+    Associations.hasMany.call(StAuthor, "st_photos", {
+      className: "StPhoto",
+      through: "st_galleries",
+      source: "imageable",
+      sourceType: "StPhoto",
+    });
+
+    const author = await StAuthor.create({ name: "Alice" });
+    const photo = await StPhoto.create({ title: "p1" });
+    const video = await StVideo.create({ title: "v1" });
+    await StGallery.create({
+      st_author_id: author.id,
+      imageable_id: photo.id,
+      imageable_type: "StPhoto",
+    });
+    await StGallery.create({
+      st_author_id: author.id,
+      imageable_id: video.id,
+      imageable_type: "StVideo",
+    });
+
+    const photos = (await loadHasMany(author, "st_photos", {
+      className: "StPhoto",
+      through: "st_galleries",
+      source: "imageable",
+      sourceType: "StPhoto",
+    })) as StPhoto[];
+    // Without sourceType filtering, the through join would return BOTH
+    // gallery rows; we'd then JOIN to the wrong rows in st_photos.
+    // With the filter, only the StPhoto-typed gallery participates.
+    expect(photos.map((p) => p.title)).toEqual(["p1"]);
+  });
+
+  it("loadHasMany through with has_many source routes via AssociationScope (PR 3c widening)", async () => {
+    // Author has_many :posts; Post has_many :comments; Author has_many
+    // :comments, through: :posts (source: :comments → has_many on Post,
+    // NOT belongsTo). PR 3b only routed belongsTo-source shapes; PR 3c
+    // widens to has_many source — the chain machinery already handles
+    // the join direction via reflection.joinPrimaryKey/joinForeignKey
+    // delegation, the gate just needed dropping.
+    const { loadHasMany } = await import("../associations.js");
+    class HsAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class HsPost extends Base {
+      static {
+        this.attribute("hs_author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class HsComment extends Base {
+      declare body: string;
+      static {
+        this.attribute("hs_post_id", "integer");
+        this.attribute("body", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(HsAuthor);
+    registerModel(HsPost);
+    registerModel(HsComment);
+    Associations.hasMany.call(HsAuthor, "hs_posts", {
+      className: "HsPost",
+      foreignKey: "hs_author_id",
+    });
+    Associations.hasMany.call(HsPost, "hs_comments", {
+      className: "HsComment",
+      foreignKey: "hs_post_id",
+    });
+    Associations.hasMany.call(HsAuthor, "hs_comments", {
+      className: "HsComment",
+      through: "hs_posts",
+      source: "hs_comments",
+    });
+
+    const author = await HsAuthor.create({ name: "Alice" });
+    const p1 = await HsPost.create({ hs_author_id: author.id });
+    const p2 = await HsPost.create({ hs_author_id: author.id });
+    await HsComment.create({ hs_post_id: p1.id, body: "first" });
+    await HsComment.create({ hs_post_id: p2.id, body: "second" });
+    // Another author's comment shouldn't show up
+    const other = await HsAuthor.create({ name: "Bob" });
+    const op = await HsPost.create({ hs_author_id: other.id });
+    await HsComment.create({ hs_post_id: op.id, body: "other" });
+
+    const comments = (await loadHasMany(author, "hs_comments", {
+      className: "HsComment",
+      through: "hs_posts",
+      source: "hs_comments",
+    })) as HsComment[];
+    expect(comments.map((c) => c.body).sort()).toEqual(["first", "second"]);
+  });
+
   it("loadHasOne through chain (belongsTo source) routes via AssociationScope and returns one record", async () => {
     // PR 3b migration covers loadHasOne too. End-to-end: insert,
     // call loadHasOne with a through reflection, assert single result.

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -551,8 +551,10 @@ describe("AssociationScope", () => {
   });
 
   it("loadHasMany through with sourceType filters by polymorphic source type (PR 3c)", async () => {
-    // Gallery has_many :imageables polymorphic; PolymorphicReflection
-    // wraps the chain entry and adds a type constraint
+    // Gallery belongsTo :imageable, polymorphic: true (the Gallery
+    // model holds the polymorphic FK + type pair). When we hop through
+    // galleries with a sourceType filter, PolymorphicReflection wraps
+    // the chain entry and adds a type constraint
     // `where(imageable_type: sourceType)`. PR 3c's
     // _mergeReflectionScopeChain detects PolymorphicReflection and
     // applies its constraints() — including the source_type_scope —

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -632,6 +632,129 @@ describe("AssociationScope", () => {
     expect(photos.map((p) => p.title)).toEqual(["p1"]);
   });
 
+  it("loadHasMany through with sourceType + non-id target PK uses correct join column", async () => {
+    // Regression: BelongsToReflection.joinPrimaryKey hard-codes "id"
+    // for polymorphic sources, but the sourceType target may use a
+    // different PK. Without per-klass JOIN routing, we'd emit
+    // target."id" = through."<fk>" instead of target."<custom_pk>".
+    const { loadHasMany } = await import("../associations.js");
+    class NpAuthor extends Base {
+      declare name: string;
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class NpGallery extends Base {
+      static {
+        this.attribute("np_author_id", "integer");
+        this.attribute("imageable_uuid", "string");
+        this.attribute("imageable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    class NpPhoto extends Base {
+      declare title: string;
+      static {
+        this.attribute("uuid", "string");
+        this.attribute("title", "string");
+        this.primaryKey = "uuid";
+        this.adapter = adapter;
+      }
+    }
+    registerModel(NpAuthor);
+    registerModel(NpGallery);
+    registerModel(NpPhoto);
+    Associations.hasMany.call(NpAuthor, "np_galleries", {
+      className: "NpGallery",
+      foreignKey: "np_author_id",
+    });
+    Associations.belongsTo.call(NpGallery, "imageable", {
+      polymorphic: true,
+      foreignKey: "imageable_uuid",
+    });
+    Associations.hasMany.call(NpAuthor, "np_photos", {
+      className: "NpPhoto",
+      through: "np_galleries",
+      source: "imageable",
+      sourceType: "NpPhoto",
+    });
+
+    const author = await NpAuthor.create({ name: "Alice" });
+    const photo = await NpPhoto.create({ uuid: "u1", title: "p1" });
+    await NpGallery.create({
+      np_author_id: author.id,
+      imageable_uuid: "u1",
+      imageable_type: "NpPhoto",
+    });
+
+    const photos = (await loadHasMany(author, "np_photos", {
+      className: "NpPhoto",
+      through: "np_galleries",
+      source: "imageable",
+      sourceType: "NpPhoto",
+    })) as NpPhoto[];
+    expect(photos.map((p) => p.title)).toEqual(["p1"]);
+  });
+
+  it("loadHasOne through with hasOne source routes via AssociationScope and returns one record", async () => {
+    // PR 3c also covers hasOne source on the through model. e.g.,
+    // User has_one :account; Account has_one :preferences;
+    // User has_one :preferences through :account (source is hasOne,
+    // not belongsTo). Verifies the join direction differs from
+    // belongsTo-source — target's FK back to through, not the other
+    // way — and that loadHasOne returns exactly one record.
+    const { loadHasOne } = await import("../associations.js");
+    class Ho1User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Ho1Account extends Base {
+      static {
+        this.attribute("ho1_user_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Ho1Pref extends Base {
+      declare theme: string;
+      static {
+        this.attribute("ho1_account_id", "integer");
+        this.attribute("theme", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(Ho1User);
+    registerModel(Ho1Account);
+    registerModel(Ho1Pref);
+    Associations.hasOne.call(Ho1User, "ho1_account", {
+      className: "Ho1Account",
+      foreignKey: "ho1_user_id",
+    });
+    Associations.hasOne.call(Ho1Account, "ho1_pref", {
+      className: "Ho1Pref",
+      foreignKey: "ho1_account_id",
+    });
+    Associations.hasOne.call(Ho1User, "ho1_pref", {
+      className: "Ho1Pref",
+      through: "ho1_account",
+      source: "ho1_pref",
+    });
+
+    const user = await Ho1User.create({ name: "Alice" });
+    const account = await Ho1Account.create({ ho1_user_id: user.id });
+    await Ho1Pref.create({ ho1_account_id: account.id, theme: "dark" });
+
+    const pref = (await loadHasOne(user, "ho1_pref", {
+      className: "Ho1Pref",
+      through: "ho1_account",
+      source: "ho1_pref",
+    })) as Ho1Pref | null;
+    expect(pref).not.toBeNull();
+    expect(pref!.theme).toBe("dark");
+  });
+
   it("loadHasMany through with has_many source routes via AssociationScope (PR 3c widening)", async () => {
     // Author has_many :posts; Post has_many :comments; Author has_many
     // :comments, through: :posts (source: :comments → has_many on Post,

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,6 +1,7 @@
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
+import { PolymorphicReflection } from "../reflection.js";
 import {
   isStiSubclass,
   getStiBase,
@@ -567,9 +568,37 @@ export class AssociationScope {
       scopeFor?: (rel: unknown, owner?: unknown) => unknown;
       klass?: typeof Base;
     };
-    if (typeof r.scope !== "function") return scope;
     const entryKlass = r.klass;
     if (!entryKlass) return scope;
+    // PolymorphicReflection wraps a chain entry whose previousReflection
+    // had `sourceType: 'X'` set. Its `constraints()` returns
+    // `[innerConstraints..., typeConstraint]` where the type constraint
+    // is `(rel) => rel.where(foreignType: sourceType)`. Apply it
+    // explicitly so a sourceType-filtered through chain emits the WHERE
+    // even when the underlying reflection itself has no scope (the
+    // common case).
+    // _getChain wraps non-head reflections in ReflectionProxy; unwrap
+    // before the instanceof check so PolymorphicReflection through
+    // proxies are detected.
+    const inner =
+      (reflection as { reflection?: AbstractReflection }).reflection ??
+      (reflection as AbstractReflection);
+    if (inner instanceof PolymorphicReflection) {
+      const constraints = (
+        inner as { constraints?: () => Array<(rel: unknown) => unknown> }
+      ).constraints?.();
+      if (constraints) {
+        let merged = scope;
+        for (const c of constraints) {
+          if (typeof c !== "function") continue;
+          const entryScope = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
+          const evaluated = c(entryScope);
+          merged = this._pushScopeIntoRelation(merged, evaluated);
+        }
+        return merged;
+      }
+    }
+    if (typeof r.scope !== "function") return scope;
     // Build the entry-side scope with STI type_condition, matching the
     // head-scope path so STI subclasses get the right type filter
     // (Base.unscoped strips it; we re-add per the same compensation).
@@ -597,12 +626,18 @@ export class AssociationScope {
         : r.scope.length === 0
           ? (r.scope as () => unknown).call(entryScope)
           : r.scope.call(entryScope, entryScope, owner);
+    return this._pushScopeIntoRelation(scope, evaluated);
+  }
+
+  /**
+   * Push ONLY the entry's WHERE predicates and ORDER clauses onto
+   * the main scope — Rails' `where_clause += ...` / `order_values |=`
+   * semantics. A full Relation#merge would let the entry's limit /
+   * select / joins / etc override the main scope, which Rails
+   * explicitly avoids.
+   */
+  private _pushScopeIntoRelation(scope: unknown, evaluated: unknown): unknown {
     if (!evaluated) return scope;
-    // Push ONLY the entry's WHERE predicates and ORDER clauses onto
-    // the main scope — Rails' `where_clause += ...` / `order_values |=`
-    // semantics. A full Relation#merge would let the entry's limit /
-    // select / joins / etc override the main scope, which Rails
-    // explicitly avoids.
     const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
     const evalPredicates = evalWhere?.predicates ?? [];
     const evalOrders = (evaluated as { _orderClauses?: unknown[] })._orderClauses ?? [];
@@ -612,12 +647,12 @@ export class AssociationScope {
       _orderClauses?: unknown[];
       _rawOrderClauses?: string[];
     };
-    // Rails: `scope.where_clause += item.where_clause`. Mutate the
-    // existing _whereClause's predicates array in place — appending all
-    // entry predicates in one shot — instead of looping with `.where()`
-    // which would clone the relation per-predicate. Safe because `scope`
-    // here is owned by this _addConstraints call (built fresh from
-    // klass.unscoped + per-step .where clones; not shared externally).
+    // Mutate the existing _whereClause's predicates array in place —
+    // appending all entry predicates in one shot — instead of looping
+    // with `.where()` which would clone the relation per-predicate.
+    // Safe because `scope` here is owned by this _addConstraints call
+    // (built fresh from klass.unscoped + per-step .where clones; not
+    // shared externally).
     if (evalPredicates.length > 0) {
       const existingPredicates = merged._whereClause?.predicates ?? [];
       existingPredicates.push(...evalPredicates);
@@ -626,10 +661,7 @@ export class AssociationScope {
       }
     }
     // Rails: `scope.order_values = item.order_values | scope.order_values`
-    // (association_scope.rb:153). Ordering lives in both _orderClauses
-    // (string | [col, dir] tuples) and _rawOrderClauses (string like
-    // `inOrderOf` produces). Merge both with chain-entry-first +
-    // structural dedup so tuples compare by value, not reference.
+    // (association_scope.rb:153). Chain-entry-first + structural dedup.
     if (evalOrders.length > 0) {
       merged._orderClauses = unionOrderClauses(evalOrders, merged._orderClauses ?? []);
     }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -591,17 +591,37 @@ export class AssociationScope {
         let merged = scope;
         for (const c of constraints) {
           if (typeof c !== "function") continue;
-          const entryScope = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
-          const evaluated = c(entryScope);
+          const evaluated = c(this._buildEntryScope(entryKlass));
           merged = this._pushScopeIntoRelation(merged, evaluated);
         }
         return merged;
       }
     }
     if (typeof r.scope !== "function") return scope;
-    // Build the entry-side scope with STI type_condition, matching the
-    // head-scope path so STI subclasses get the right type filter
-    // (Base.unscoped strips it; we re-add per the same compensation).
+    const entryScope = this._buildEntryScope(entryKlass);
+    // Same arity / `this` semantics as AssociationReflection.scopeFor
+    // for the fallback path: 0-arg → `this=relation`; 1+-arg →
+    // `this=relation, args=(relation, owner)`. Without this binding,
+    // a scope written as `function () { return this.where(...) }`
+    // (the common 0-arg form) would lose the relation.
+    const evaluated =
+      typeof r.scopeFor === "function"
+        ? r.scopeFor.call(reflection, entryScope, owner)
+        : r.scope.length === 0
+          ? (r.scope as () => unknown).call(entryScope)
+          : r.scope.call(entryScope, entryScope, owner);
+    return this._pushScopeIntoRelation(scope, evaluated);
+  }
+
+  /**
+   * Build a fresh scope for evaluating a chain entry's lambda. Mirrors
+   * `entryKlass.unscoped` plus the same STI type_condition compensation
+   * the head-scope path applies — Rails' `unscoped` retains the STI
+   * type filter via `relation()` (core.rb:431-435); ours strips it,
+   * so we re-add `where(type: stiNames)` for subclasses to keep the
+   * filter on intermediate / source relation builds.
+   */
+  private _buildEntryScope(entryKlass: typeof Base): unknown {
     let entryScope: unknown = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
     if (isStiSubclass(entryKlass)) {
       const col = getInheritanceColumn(getStiBase(entryKlass));
@@ -615,18 +635,7 @@ export class AssociationScope {
         });
       }
     }
-    // Same arity / `this` semantics as AssociationReflection.scopeFor
-    // for the fallback path: 0-arg → `this=relation`; 1+-arg →
-    // `this=relation, args=(relation, owner)`. Without this binding,
-    // a scope written as `function () { return this.where(...) }`
-    // (the common 0-arg form) would lose the relation.
-    const evaluated =
-      typeof r.scopeFor === "function"
-        ? r.scopeFor.call(reflection, entryScope, owner)
-        : r.scope.length === 0
-          ? (r.scope as () => unknown).call(entryScope)
-          : r.scope.call(entryScope, entryScope, owner);
-    return this._pushScopeIntoRelation(scope, evaluated);
+    return entryScope;
   }
 
   /**

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -409,10 +409,12 @@ export class AssociationScope {
     scope: unknown,
     reflection: AbstractReflection | ReflectionProxy,
     nextReflection: AbstractReflection | ReflectionProxy,
+    klass?: typeof Base,
   ): unknown {
     const r = reflection as {
       joinPrimaryKey: string | string[];
       joinForeignKey: string | string[];
+      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
       klass?: { tableName?: string };
       type?: string | null;
     };
@@ -422,7 +424,16 @@ export class AssociationScope {
       klass?: { tableName?: string };
       aliasedTable?: string | { name?: string };
     };
-    const joinPks = Array.isArray(r.joinPrimaryKey) ? r.joinPrimaryKey : [r.joinPrimaryKey];
+    // For polymorphic belongsTo sources, reflection.joinPrimaryKey is
+    // hard-coded to "id" — but the resolved sourceType class may use a
+    // different PK. Route through joinPrimaryKeyFor(klass) when the
+    // reflection exposes it (ThroughReflection / BelongsToReflection
+    // both do) so the JOIN uses the right target PK column.
+    const rawJoinPk =
+      typeof r.joinPrimaryKeyFor === "function"
+        ? r.joinPrimaryKeyFor(klass ?? (r.klass as typeof Base | undefined))
+        : r.joinPrimaryKey;
+    const joinPks = Array.isArray(rawJoinPk) ? rawJoinPk : [rawJoinPk];
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
     if (joinPks.length !== joinFks.length) {
       // Unwrap ReflectionProxy so activeRecord/name come from the
@@ -435,7 +446,19 @@ export class AssociationScope {
       const ownerName = base.activeRecord?.name ?? "<unknown>";
       throw new CompositePrimaryKeyMismatchError(ownerName, name);
     }
-    const table = r.klass?.tableName ?? "";
+    // For polymorphic belongsTo-through with sourceType, r.klass may
+    // throw (polymorphic) or resolve to the wrong class; prefer the
+    // explicit runtime klass passed in when available.
+    let table: string;
+    if (klass && typeof klass.tableName === "string") {
+      table = klass.tableName;
+    } else {
+      try {
+        table = r.klass?.tableName ?? "";
+      } catch {
+        table = "";
+      }
+    }
     // nextReflection may be a ReflectionProxy (with aliasedTable) or a
     // raw reflection; resolve its table name the same way.
     const aliased = nr.aliasedTable;
@@ -496,7 +519,7 @@ export class AssociationScope {
     // `chain.each_cons(2) { |r, nr| next_chain_scope(scope, r, nr) }`
     // (association_scope.rb:128-130).
     for (let i = 0; i < chain.length - 1; i++) {
-      scope = this._nextChainScope(scope, chain[i], chain[i + 1]);
+      scope = this._nextChainScope(scope, chain[i], chain[i + 1], klass);
     }
     // Rails' chain.reverse_each over reflection.constraints (Rails:
     // association_scope.rb:131-156) merges scope-chain items into the

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -585,13 +585,23 @@ export class AssociationScope {
       (reflection as AbstractReflection);
     if (inner instanceof PolymorphicReflection) {
       const constraints = (
-        inner as { constraints?: () => Array<(rel: unknown) => unknown> }
+        inner as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.();
       if (constraints) {
         let merged = scope;
         for (const c of constraints) {
           if (typeof c !== "function") continue;
-          const evaluated = c(this._buildEntryScope(entryKlass));
+          // Same arity / `this` semantics as AssociationReflection.scopeFor:
+          // 0-arg → call(relation); 1+-arg → call(relation, relation, owner).
+          // Without this binding, a constraint written as
+          // `function () { return this.where(...) }` (the common 0-arg
+          // form Rails uses for scope_for_association) loses the
+          // relation.
+          const entryScope = this._buildEntryScope(entryKlass);
+          const evaluated =
+            c.length === 0
+              ? (c as () => unknown).call(entryScope)
+              : c.call(entryScope, entryScope, owner);
           merged = this._pushScopeIntoRelation(merged, evaluated);
         }
         return merged;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,7 +1,6 @@
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
-import { PolymorphicReflection } from "../reflection.js";
 import {
   isStiSubclass,
   getStiBase,
@@ -570,57 +569,38 @@ export class AssociationScope {
     };
     const entryKlass = r.klass;
     if (!entryKlass) return scope;
-    // PolymorphicReflection wraps a chain entry whose previousReflection
-    // had `sourceType: 'X'` set. Its `constraints()` returns
-    // `[innerConstraints..., typeConstraint]` where the type constraint
-    // is `(rel) => rel.where(foreignType: sourceType)`. Apply it
-    // explicitly so a sourceType-filtered through chain emits the WHERE
-    // even when the underlying reflection itself has no scope (the
-    // common case).
-    // _getChain wraps non-head reflections in ReflectionProxy; unwrap
-    // before the instanceof check so PolymorphicReflection through
-    // proxies are detected.
-    const inner =
-      (reflection as { reflection?: AbstractReflection }).reflection ??
-      (reflection as AbstractReflection);
-    if (inner instanceof PolymorphicReflection) {
-      const constraints = (
-        inner as { constraints?: () => Array<(...args: unknown[]) => unknown> }
-      ).constraints?.();
-      if (constraints) {
-        let merged = scope;
-        for (const c of constraints) {
-          if (typeof c !== "function") continue;
-          // Same arity / `this` semantics as AssociationReflection.scopeFor:
-          // 0-arg → call(relation); 1+-arg → call(relation, relation, owner).
-          // Without this binding, a constraint written as
-          // `function () { return this.where(...) }` (the common 0-arg
-          // form Rails uses for scope_for_association) loses the
-          // relation.
-          const entryScope = this._buildEntryScope(entryKlass);
-          const evaluated =
-            c.length === 0
-              ? (c as () => unknown).call(entryScope)
-              : c.call(entryScope, entryScope, owner);
-          merged = this._pushScopeIntoRelation(merged, evaluated);
-        }
-        return merged;
-      }
+    // Iterate `reflection.constraints()` rather than special-casing
+    // PolymorphicReflection via instanceof. For ordinary
+    // AssociationReflection / ReflectionProxy entries `constraints()`
+    // returns `chain.flatMap(scopes)` — for non-through chain entries
+    // that's just `[self.scope].compact`. For PolymorphicReflection
+    // (sourceType wrapper) `constraints()` ALSO returns the
+    // `source_type_scope` lambda
+    // (`where(foreign_type: source_type)`). Iterating handles both
+    // cases without an instanceof check, avoiding a value-import cycle
+    // (reflection → associations → association-scope → reflection).
+    const constraints =
+      (
+        reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
+      ).constraints?.() ?? [];
+    if (constraints.length === 0) return scope;
+    let merged = scope;
+    for (const c of constraints) {
+      if (typeof c !== "function") continue;
+      // Same arity / `this` semantics as AssociationReflection.scopeFor:
+      // 0-arg → call(relation); 1+-arg → call(relation, relation, owner).
+      // Without this binding, a scope written as
+      // `function () { return this.where(...) }` (the common 0-arg
+      // form Rails uses for scope_for_association / source_type_scope)
+      // loses the relation.
+      const entryScope = this._buildEntryScope(entryKlass);
+      const evaluated =
+        c.length === 0
+          ? (c as () => unknown).call(entryScope)
+          : c.call(entryScope, entryScope, owner);
+      merged = this._pushScopeIntoRelation(merged, evaluated);
     }
-    if (typeof r.scope !== "function") return scope;
-    const entryScope = this._buildEntryScope(entryKlass);
-    // Same arity / `this` semantics as AssociationReflection.scopeFor
-    // for the fallback path: 0-arg → `this=relation`; 1+-arg →
-    // `this=relation, args=(relation, owner)`. Without this binding,
-    // a scope written as `function () { return this.where(...) }`
-    // (the common 0-arg form) would lose the relation.
-    const evaluated =
-      typeof r.scopeFor === "function"
-        ? r.scopeFor.call(reflection, entryScope, owner)
-        : r.scope.length === 0
-          ? (r.scope as () => unknown).call(entryScope)
-          : r.scope.call(entryScope, entryScope, owner);
-    return this._pushScopeIntoRelation(scope, evaluated);
+    return merged;
   }
 
   /**

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1150,6 +1150,24 @@ export class ThroughReflection extends AbstractReflection {
     return this.sourceReflection?.joinPrimaryKey ?? this._delegate.joinPrimaryKey;
   }
 
+  /**
+   * Resolve the join primary key against a runtime klass, mirroring
+   * BelongsToReflection#joinPrimaryKeyFor. Needed when the source is
+   * a polymorphic belongsTo with sourceType: the static joinPrimaryKey
+   * hardcodes "id", but the resolved sourceType class may use a
+   * different PK column (e.g. `uuid`).
+   */
+  joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
+    const src = this.sourceReflection as unknown as {
+      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
+      joinPrimaryKey?: string | string[];
+    } | null;
+    if (src && typeof src.joinPrimaryKeyFor === "function") {
+      return src.joinPrimaryKeyFor(klass);
+    }
+    return src?.joinPrimaryKey ?? this._delegate.joinPrimaryKey;
+  }
+
   get joinForeignKey(): string | string[] {
     return this.sourceReflection?.joinForeignKey ?? this._delegate.joinForeignKey;
   }


### PR DESCRIPTION
## Summary

PR 3b only routed `has_many :through` where source was non-polymorphic `belongsTo`. PR 3c widens to:

- **has_many / has_one source** — chain machinery already handled this via `ThroughReflection.joinPrimaryKey/joinForeignKey` delegation; the gate just needed dropping.
- **Polymorphic `belongsTo` source with `sourceType`** — `_nextChainScope` now routes through `ThroughReflection#joinPrimaryKeyFor(klass)` (new method delegating to `BelongsToReflection#joinPrimaryKeyFor`) and falls back to the runtime `klass.tableName` when `reflection.klass` throws (polymorphic). The resolved `sourceType` class's PK drives the JOIN, so `where sourceType target uses a non-"id" PK` (e.g. `primaryKey = "uuid"`) still emits the right column.
- **PolymorphicReflection constraint application** — `_mergeReflectionScopeChain` now iterates `reflection.constraints()` (no instanceof check → no runtime import cycle) so a `PolymorphicReflection` wrapper's `source_type_scope` lambda (`where(foreign_type: source_type)`) flows through the same arity / `this` dispatch.
- **HABTM gate** — `AssociationReflection.sourceReflection` returns `this` as a fallback; HABTM was falsely matching. Now requires `isThroughReflection() === true`.
- **Through-a-through gated out** via `ThroughReflection.isNested()` (checks BOTH `sourceReflection` and `throughReflection`).

## Routing predicate (`_canRouteThroughViaAssociationScope`)
- reflection registered
- `!options.disableJoins`
- `reflection.isThroughReflection() === true`
- `!reflection.isNested()` (no through-a-through on either side)
- `sourceReflection` exists
- polymorphic source only when `belongsTo` AND `sourceType` is set (so the sourceType class resolves to a single target table)

## Tests
- `loadHasMany through with has_many source routes via AssociationScope (PR 3c widening)` — Author hm posts → Post hm comments.
- `loadHasOne through with hasOne source routes via AssociationScope and returns one record` — User ho account → Account ho pref.
- **`loadHasMany through with sourceType + non-id target PK uses correct join column`** — `NpPhoto.primaryKey = "uuid"`; polymorphic belongsTo source with sourceType now routes via AssociationScope and the JOIN uses `np_photos."uuid" = np_galleries."imageable_uuid"`.
- `loadHasMany through with sourceType filters by polymorphic source type (PR 3c)` — existing sourceType SQL test.
- 1536 / 1946 in `packages/activerecord/src/associations` (+2 from PR 3b's 1532).

## Out of scope (follow-ups)
- Polymorphic `has_many` / `has_one` source (chain inversion needed)
- Through-a-through chain inversion
- AliasTracker for repeated joins (eager loading)
- `DisableJoinsAssociationScope` real impl (PR 4)
- `eager_load!` skip-list + cache wiring (PR 5)

## Rails refs
- `activerecord/lib/active_record/associations/association_scope.rb:131-156` — `add_constraints` chain.reverse_each
- `activerecord/lib/active_record/reflection.rb:1370+` — `PolymorphicReflection`
- `activerecord/lib/active_record/reflection.rb:1251-1255` — `source_type_scope`
- `activerecord/lib/active_record/reflection.rb:973-982` — `BelongsToReflection#join_primary_key_for`