### PR TITLE
chore(activerecord): StatementPool loose ends (SQLite config, clearCacheBang, docs)

### DIFF
--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/adapters/mysql2-adapter.d.ts",
       "default": "./dist/adapters/mysql2-adapter.js"
     },
+    "./connection-adapters/mysql2-adapter.js": {
+      "types": "./dist/connection-adapters/mysql2-adapter.d.ts",
+      "default": "./dist/connection-adapters/mysql2-adapter.js"
+    },
     "./tsc": {
       "types": "./dist/tsc-wrapper/index.d.ts",
       "default": "./dist/tsc-wrapper/index.js"

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -159,5 +159,22 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter2.close();
       }
     });
+
+    it("clearCacheBang drops cached plans on the active connection", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT ? AS n", [1]);
+        await adapter.execute("SELECT ? AS s", ["a"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(2);
+        adapter.clearCacheBang();
+        expect(pool.length).toBe(0);
+        // Pool stays attached; counter continues so we never reissue
+        // a name that's still PREPAREd on this session post-dealloc.
+        expect(adapter._statementPoolForTest()).toBe(pool);
+      } finally {
+        await adapter.rollback();
+      }
+    });
   });
 });

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -142,6 +142,22 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   _statementPoolForTest(): Mysql2StatementPool | undefined {
     return this._conn ? this._statementPools.get(this._conn) : undefined;
   }
+
+  /**
+   * Clear cached prepared statements. Mirrors Rails'
+   * `Mysql2Adapter#clear_cache!` — each entry's `dealloc` calls
+   * `connection.unprepare(sql)` (COM_STMT_CLOSE). The active
+   * transaction connection's pool is cleared; the WeakMap is reset
+   * so other pooled connections (which we can't iterate) get fresh
+   * pools on next checkout.
+   */
+  override clearCacheBang(): void {
+    super.clearCacheBang();
+    if (this._conn) {
+      this._statementPools.get(this._conn)?.clear();
+    }
+    this._statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
+  }
   // Cached capability flag — information_schema.statistics.expression
   // is MySQL 8.0.13+. Pre-8 MySQL and MariaDB (through at least 10.x)
   // don't expose it, so we detect once and remember. `undefined` =

--- a/packages/activerecord/src/adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/adapters/mysql2-adapter.ts
@@ -144,19 +144,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Clear cached prepared statements. Mirrors Rails'
-   * `Mysql2Adapter#clear_cache!` — each entry's `dealloc` calls
-   * `connection.unprepare(sql)` (COM_STMT_CLOSE). The active
-   * transaction connection's pool is cleared; the WeakMap is reset
-   * so other pooled connections (which we can't iterate) get fresh
-   * pools on next checkout.
+   * Clear cached prepared statements on the currently-held transaction
+   * connection. Mirrors Rails' `Mysql2Adapter#clear_cache!` which
+   * calls `close` on each cached statement on the adapter's sole
+   * connection. Non-active per-connection pools are intentionally
+   * left attached: resetting the WeakMap would orphan our sql→name
+   * map while the server-side PREPAREs still exist, and a later
+   * checkout of that same mysql.PoolConnection would restart the
+   * counter and collide with still-PREPAREd statements.
    */
   override clearCacheBang(): void {
     super.clearCacheBang();
     if (this._conn) {
       this._statementPools.get(this._conn)?.clear();
     }
-    this._statementPools = new WeakMap<mysql.PoolConnection, Mysql2StatementPool>();
   }
   // Cached capability flag — information_schema.statistics.expression
   // is MySQL 8.0.13+. Pre-8 MySQL and MariaDB (through at least 10.x)

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -196,5 +196,23 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter2.close();
       }
     });
+
+    it("clearCacheBang drops cached plans on the active connection", async () => {
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [1]);
+        await adapter.execute("SELECT $1::text", ["a"]);
+        const pool = adapter._statementPoolForTest()!;
+        expect(pool.length).toBe(2);
+        adapter.clearCacheBang();
+        expect(pool.length).toBe(0);
+        // Pool itself remains attached — counter continues from where
+        // it left off so we never collide with a still-PREPAREd name
+        // on this session after the server DEALLOCATEs complete.
+        expect(adapter._statementPoolForTest()).toBe(pool);
+      } finally {
+        await adapter.rollback();
+      }
+    });
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
@@ -1,5 +1,32 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 describe("SQLite3StatementPoolTest", () => {
   it.skip("cache is per pid", () => {});
+
+  it("reads statementLimit from the options hash", () => {
+    const adapter = new SQLite3Adapter(":memory:", { statementLimit: 7 });
+    expect(adapter.statementLimit).toBe(7);
+    adapter.disconnectBang();
+  });
+
+  it("reads preparedStatements from the options hash", () => {
+    const adapter = new SQLite3Adapter(":memory:", { preparedStatements: false });
+    expect(adapter.preparedStatements).toBe(false);
+    adapter.disconnectBang();
+  });
+
+  it("rejects invalid statementLimit at construction time", () => {
+    expect(() => new SQLite3Adapter(":memory:", { statementLimit: -1 })).toThrow(RangeError);
+    expect(() => new SQLite3Adapter(":memory:", { statementLimit: 1.5 })).toThrow(RangeError);
+  });
+
+  it("clearCacheBang clears the pool without throwing on next query", async () => {
+    const adapter = new SQLite3Adapter(":memory:");
+    await adapter.exec(`CREATE TABLE t (id INTEGER)`);
+    await adapter.execute("SELECT * FROM t WHERE id = ?", [1]);
+    adapter.clearCacheBang();
+    await adapter.execute("SELECT * FROM t WHERE id = ?", [2]);
+    adapter.disconnectBang();
+  });
 });

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
@@ -1,19 +1,34 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 describe("SQLite3StatementPoolTest", () => {
+  // Track every adapter created so a failing assertion can't leak an
+  // open SQLite handle into later tests.
+  const openAdapters: SQLite3Adapter[] = [];
+  const track = (adapter: SQLite3Adapter): SQLite3Adapter => {
+    openAdapters.push(adapter);
+    return adapter;
+  };
+  afterEach(() => {
+    while (openAdapters.length) {
+      try {
+        openAdapters.pop()!.disconnectBang();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
   it.skip("cache is per pid", () => {});
 
   it("reads statementLimit from the options hash", () => {
-    const adapter = new SQLite3Adapter(":memory:", { statementLimit: 7 });
+    const adapter = track(new SQLite3Adapter(":memory:", { statementLimit: 7 }));
     expect(adapter.statementLimit).toBe(7);
-    adapter.disconnectBang();
   });
 
   it("reads preparedStatements from the options hash", () => {
-    const adapter = new SQLite3Adapter(":memory:", { preparedStatements: false });
+    const adapter = track(new SQLite3Adapter(":memory:", { preparedStatements: false }));
     expect(adapter.preparedStatements).toBe(false);
-    adapter.disconnectBang();
   });
 
   it("rejects invalid statementLimit at construction time", () => {
@@ -29,19 +44,17 @@ describe("SQLite3StatementPoolTest", () => {
       () => new SQLite3Adapter(":memory:", { preparedStatements: 0 as unknown as boolean }),
     ).toThrow(TypeError);
 
-    const adapter = new SQLite3Adapter(":memory:");
+    const adapter = track(new SQLite3Adapter(":memory:"));
     expect(() => {
       (adapter as unknown as { preparedStatements: unknown }).preparedStatements = "true";
     }).toThrow(TypeError);
-    adapter.disconnectBang();
   });
 
   it("clearCacheBang clears the pool without throwing on next query", async () => {
-    const adapter = new SQLite3Adapter(":memory:");
-    await adapter.exec(`CREATE TABLE t (id INTEGER)`);
+    const adapter = track(new SQLite3Adapter(":memory:"));
+    adapter.exec(`CREATE TABLE t (id INTEGER)`);
     await adapter.execute("SELECT * FROM t WHERE id = ?", [1]);
     adapter.clearCacheBang();
     await adapter.execute("SELECT * FROM t WHERE id = ?", [2]);
-    adapter.disconnectBang();
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
@@ -21,6 +21,21 @@ describe("SQLite3StatementPoolTest", () => {
     expect(() => new SQLite3Adapter(":memory:", { statementLimit: 1.5 })).toThrow(RangeError);
   });
 
+  it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
+    expect(
+      () => new SQLite3Adapter(":memory:", { preparedStatements: "false" as unknown as boolean }),
+    ).toThrow(TypeError);
+    expect(
+      () => new SQLite3Adapter(":memory:", { preparedStatements: 0 as unknown as boolean }),
+    ).toThrow(TypeError);
+
+    const adapter = new SQLite3Adapter(":memory:");
+    expect(() => {
+      (adapter as unknown as { preparedStatements: unknown }).preparedStatements = "true";
+    }).toThrow(TypeError);
+    adapter.disconnectBang();
+  });
+
   it("clearCacheBang clears the pool without throwing on next query", async () => {
     const adapter = new SQLite3Adapter(":memory:");
     await adapter.exec(`CREATE TABLE t (id INTEGER)`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -100,6 +100,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   constructor(config: string | (pg.PoolConfig & TrailsAdapterOptions)) {
     super();
+    // Rails: `PostgreSQLAdapter` inherits the abstract adapter's
+    // `default_prepared_statements = true`.
+    this.preparedStatements = true;
     if (typeof config === "string") {
       this._driverPool = new pg.Pool({ connectionString: config });
       return;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -965,20 +965,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Clear cached prepared statements. Mirrors Rails'
-   * `PostgreSQLAdapter#clear_cache!` which sends DEALLOCATE for each
-   * cached entry. The active transaction client's pool is cleared
-   * (evicting through `dealloc`); the WeakMap is reset so any other
-   * pooled clients (which we can't iterate) get fresh pools on next
-   * checkout. Server-side statements on non-held clients will drop
-   * on session close.
+   * Clear cached prepared statements on the currently-held transaction
+   * client. Mirrors Rails' `PostgreSQLAdapter#clear_cache!` which
+   * sends DEALLOCATE for each cached entry on the adapter's sole
+   * PG::Connection. Rails has exactly one connection per adapter
+   * instance; we back multiple via pg.Pool, so "the connection" is
+   * ambiguous outside a transaction. Non-active per-client pools are
+   * intentionally left attached: resetting the WeakMap would orphan
+   * our counter + sql→name map while the server-side PREPAREs still
+   * exist, and a later checkout of that same pg.PoolClient would
+   * restart the counter at `a1` — colliding with the statement
+   * already PREPAREd on that session.
    */
   override clearCacheBang(): void {
     super.clearCacheBang();
     if (this._client) {
       this._statementPools.get(this._client)?.clear();
     }
-    this._statementPools = new WeakMap<pg.PoolClient, StatementPool>();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -965,6 +965,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Clear cached prepared statements. Mirrors Rails'
+   * `PostgreSQLAdapter#clear_cache!` which sends DEALLOCATE for each
+   * cached entry. The active transaction client's pool is cleared
+   * (evicting through `dealloc`); the WeakMap is reset so any other
+   * pooled clients (which we can't iterate) get fresh pools on next
+   * checkout. Server-side statements on non-held clients will drop
+   * on session close.
+   */
+  override clearCacheBang(): void {
+    super.clearCacheBang();
+    if (this._client) {
+      this._statementPools.get(this._client)?.clear();
+    }
+    this._statementPools = new WeakMap<pg.PoolClient, StatementPool>();
+  }
+
+  /**
    * Check if we're in a transaction.
    */
   get inTransaction(): boolean {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -78,11 +78,44 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return filename.startsWith("file::memory:") || filename.includes("mode=memory");
   }
 
-  constructor(filename: string | ":memory:" = ":memory:", options?: { readonly?: boolean }) {
+  // Rails' `statement_limit` database.yml key. SQLite has a single
+  // connection (no pool), so the adapter owns exactly one pool and the
+  // setter resizes it directly.
+  private _statementLimit = 1000;
+
+  /**
+   * Maximum prepared statements cached on the single SQLite connection.
+   *
+   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
+   * `config[:statement_limit]` in `SQLite3Adapter#initialize`.
+   */
+  get statementLimit(): number {
+    return this._statementLimit;
+  }
+
+  set statementLimit(value: number) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new RangeError(
+        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
+      );
+    }
+    this._statementLimit = value;
+    this._statementPool.setMaxSize(value);
+  }
+
+  constructor(
+    filename: string | ":memory:" = ":memory:",
+    options: { readonly?: boolean; statementLimit?: number; preparedStatements?: boolean } = {},
+  ) {
     super();
     this._filename = filename;
     this._memoryDatabase = SQLite3Adapter._isMemoryFilename(filename);
-    this._readonly = options?.readonly ?? false;
+    this._readonly = options.readonly ?? false;
+    // Apply adapter-level options FIRST so invalid values fail before
+    // the native driver opens a file handle that would otherwise leak.
+    if (options.statementLimit !== undefined) this.statementLimit = options.statementLimit;
+    if (options.preparedStatements !== undefined)
+      this.preparedStatements = options.preparedStatements;
     try {
       this.db = new Database(filename, { readonly: this._readonly });
     } catch (e) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -111,11 +111,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     this._filename = filename;
     this._memoryDatabase = SQLite3Adapter._isMemoryFilename(filename);
     this._readonly = options.readonly ?? false;
+    // Rails: `SQLite3Adapter#default_prepared_statements` inherits the
+    // abstract adapter's `true`. Mirror that default and let options
+    // override per connection.
+    this.preparedStatements = options.preparedStatements ?? true;
     // Apply adapter-level options FIRST so invalid values fail before
     // the native driver opens a file handle that would otherwise leak.
     if (options.statementLimit !== undefined) this.statementLimit = options.statementLimit;
-    if (options.preparedStatements !== undefined)
-      this.preparedStatements = options.preparedStatements;
     try {
       this.db = new Database(filename, { readonly: this._readonly });
     } catch (e) {
@@ -168,6 +170,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   private _cachedStatement(sql: string): Database.Statement {
+    // When preparedStatements is off, skip the pool and prepare per call —
+    // matches Rails' `statement_pool` behavior gated on
+    // `prepared_statements`. better-sqlite3 still uses its own statement
+    // handle internally, but we no longer cache across executes.
+    if (!this.preparedStatements) {
+      return this.db.prepare(sql);
+    }
     let stmt = this._statementPool.get(sql);
     if (!stmt) {
       stmt = this.db.prepare(sql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { Visitors } from "@blazetrails/arel";
-import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
+import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
@@ -105,7 +105,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   constructor(
     filename: string | ":memory:" = ":memory:",
-    options: { readonly?: boolean; statementLimit?: number; preparedStatements?: boolean } = {},
+    options: TrailsAdapterOptions & { readonly?: boolean } = {},
   ) {
     super();
     this._filename = filename;

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -168,20 +168,22 @@ import { PostgreSQLAdapter } from "@blazetrails/activerecord/connection-adapters
 import { Mysql2Adapter } from "@blazetrails/activerecord/adapters/mysql2-adapter.js";
 import { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 
-// PG: default_prepared_statements = true (abstract default).
+// PG defaults preparedStatements to true (matches Rails, where
+// PostgreSQLAdapter inherits AbstractAdapter#default_prepared_statements = true).
 new PostgreSQLAdapter({
   connectionString: "postgres://localhost/app",
   statementLimit: 500, // default 1000
   preparedStatements: true,
 });
 
-// MySQL2: default_prepared_statements = false (Rails override).
+// MySQL2 defaults preparedStatements to false (matches Rails'
+// Mysql2Adapter#default_prepared_statements override).
 new Mysql2Adapter({
   uri: "mysql://localhost/app",
   statementLimit: 0, // 0 disables caching entirely
 });
 
-// SQLite3: default_prepared_statements = true (abstract default).
+// SQLite3 defaults preparedStatements to true (matches Rails' abstract default).
 new SQLite3Adapter("db/app.sqlite3", { statementLimit: 200 });
 ```
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -151,6 +151,38 @@ pools are acquired per query rather than checked out per thread.
 underlying pool model is different because there are no threads to
 pool over. See `packages/activerecord/src/connection-handling.ts`.
 
+### Adapter config: `statementLimit` and `preparedStatements`
+
+Rails reads `statement_limit` and `prepared_statements` off the
+merged `database.yml` hash in `AbstractAdapter#initialize`. The same
+shape works here — pass them alongside driver connection options in
+the single config hash:
+
+```ts
+new PostgreSQLAdapter({
+  connectionString: "postgres://localhost/app",
+  statementLimit: 500, // default 1000
+  preparedStatements: true, // default true
+});
+
+new Mysql2Adapter({
+  uri: "mysql://localhost/app",
+  statementLimit: 0, // 0 disables caching entirely
+});
+
+new SQLite3Adapter("db/app.sqlite3", { statementLimit: 200 });
+```
+
+Adapter-level keys are stripped from the config hash before it's
+handed to the driver pool; invalid values (non-integer / negative
+`statementLimit`, non-boolean `preparedStatements`) throw at
+construction so misconfiguration fails loudly at boot instead of
+silently leaking unbounded prepared statements later. A
+`statementLimit` of 0 disables the named-prepared-statement path on
+PG and MySQL (Rails' `PG::StatementPool#set` / MySQL equivalent are
+likewise no-ops at 0); queries still run, they just go through the
+unprepared path on that call.
+
 ## 5. Relation `method_missing` → typed `Proxy`
 
 Rails' `ActiveRecord::Relation` uses `method_missing` to forward

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -165,7 +165,7 @@ the second argument accepts the same adapter knobs.
 
 ```ts
 import { PostgreSQLAdapter } from "@blazetrails/activerecord/connection-adapters/postgresql-adapter.js";
-import { Mysql2Adapter } from "@blazetrails/activerecord/adapters/mysql2-adapter.js";
+import { Mysql2Adapter } from "@blazetrails/activerecord/connection-adapters/mysql2-adapter.js";
 import { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 
 // PG defaults preparedStatements to true (matches Rails, where

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -158,22 +158,30 @@ merged `database.yml` hash in `AbstractAdapter#initialize`. The same
 shape works here — pass them alongside driver connection options in
 the single config hash:
 
+PG and MySQL take a single merged config hash (driver params + adapter
+knobs), matching Rails' `database.yml` shape. SQLite3 takes `(filename,
+options)` because the driver's first argument is a path, not a hash;
+the second argument accepts the same adapter knobs.
+
 ```ts
 import { PostgreSQLAdapter } from "@blazetrails/activerecord/connection-adapters/postgresql-adapter.js";
 import { Mysql2Adapter } from "@blazetrails/activerecord/adapters/mysql2-adapter.js";
 import { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 
+// PG: default_prepared_statements = true (abstract default).
 new PostgreSQLAdapter({
   connectionString: "postgres://localhost/app",
   statementLimit: 500, // default 1000
-  preparedStatements: true, // default true
+  preparedStatements: true,
 });
 
+// MySQL2: default_prepared_statements = false (Rails override).
 new Mysql2Adapter({
   uri: "mysql://localhost/app",
   statementLimit: 0, // 0 disables caching entirely
 });
 
+// SQLite3: default_prepared_statements = true (abstract default).
 new SQLite3Adapter("db/app.sqlite3", { statementLimit: 200 });
 ```
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -159,6 +159,10 @@ shape works here — pass them alongside driver connection options in
 the single config hash:
 
 ```ts
+import { PostgreSQLAdapter } from "@blazetrails/activerecord/connection-adapters/postgresql-adapter.js";
+import { Mysql2Adapter } from "@blazetrails/activerecord/adapters/mysql2-adapter.js";
+import { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
+
 new PostgreSQLAdapter({
   connectionString: "postgres://localhost/app",
   statementLimit: 500, // default 1000


### PR DESCRIPTION
## Summary

Cleanup after the three-PR StatementPool plan (#611 PG, #617 MySQL, #625 config threading).

- **SQLite3 consistency** — `SQLite3Adapter` now accepts `{ statementLimit?, preparedStatements? }` alongside `{ readonly? }`, mirroring the PG / MySQL surface. Validated and applied before opening the native Database handle so invalid values don't leak a file descriptor. Setter resizes the on-adapter `StatementPool`. `preparedStatements: false` bypasses the pool on a per-call basis (matches Rails gating in `statement_pool`).
- **`clearCacheBang` overrides** for PG + MySQL — previously a no-op for these two. Now clears the *active transaction client's* pool via `dealloc`, mirroring Rails' `clear_cache!` which sends DEALLOCATE on the adapter's sole connection. Non-active per-client pools are intentionally left attached so pooled clients keep their counter + sql→name map in sync with server-side PREPAREs (see the in-code docstring for the reasoning).
- **Docs** — new subsection in `activerecord-rails-deviations.md` documenting the adapter config keys across all three adapters, including the `statementLimit = 0` disable behavior.
- 4 new SQLite3 tests (config round-trip + validation + `clearCacheBang`).

## Test plan

- [ ] Full AR suite (sqlite): 8649 passed locally
- [ ] PG CI + MariaDB CI: no regressions