### PR TITLE
feat(api-compare): accept Trails rename patterns in inheritance check

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { nameMatches, superclassesMatch } from "./compare.js";
+
+describe("nameMatches", () => {
+  it("matches identical names", () => {
+    expect(nameMatches("Binary", "Binary")).toBe(true);
+  });
+
+  it("matches Ruby error builtins against JS Error", () => {
+    expect(nameMatches("StandardError", "Error")).toBe(true);
+    expect(nameMatches("ArgumentError", "Error")).toBe(true);
+    expect(nameMatches("RangeError", "Error")).toBe(true);
+  });
+
+  it("does not match a Ruby non-builtin error name against JS Error", () => {
+    expect(nameMatches("ConfigurationError", "Error")).toBe(false);
+    expect(nameMatches("ActiveRecordError", "Error")).toBe(false);
+  });
+
+  describe("Trails rename conventions", () => {
+    it("accepts Abstract<X> (import alias for shadowed parents)", () => {
+      // `TableDefinition as AbstractTableDefinition` when a subclass
+      // shadows the parent's name.
+      expect(nameMatches("TableDefinition", "AbstractTableDefinition")).toBe(true);
+      expect(nameMatches("SchemaCreation", "AbstractSchemaCreation")).toBe(true);
+    });
+
+    it("accepts Base<X> (intermediate base layer)", () => {
+      // Rails has a single class; Trails splits it (BaseLogSubscriber +
+      // LogSubscriber, BaseAbsenceValidator + AbsenceValidator, ...).
+      expect(nameMatches("LogSubscriber", "BaseLogSubscriber")).toBe(true);
+      expect(nameMatches("AbsenceValidator", "BaseAbsenceValidator")).toBe(true);
+    });
+
+    it("accepts ActiveModel<X> (aliased to avoid JS builtin collision)", () => {
+      // Our Date type extends ActiveModel's Date, aliased on import
+      // because the identifier `Date` in the TS file refers to this class.
+      expect(nameMatches("Date", "ActiveModelDate")).toBe(true);
+      expect(nameMatches("DateTime", "ActiveModelDateTime")).toBe(true);
+      expect(nameMatches("Time", "ActiveModelTime")).toBe(true);
+    });
+
+    it("accepts <X>Type (suffix to distinguish value vs cast type)", () => {
+      // Rails's `Type::Json` value type; our TS class is `JsonType` so
+      // the file can still export `Json` as the value constructor.
+      expect(nameMatches("Json", "JsonType")).toBe(true);
+      expect(nameMatches("Integer", "IntegerType")).toBe(true);
+      expect(nameMatches("Binary", "BinaryType")).toBe(true);
+    });
+
+    it("rejects unrelated names that happen to share a prefix/suffix", () => {
+      // "FooBar" isn't "Abstract" / "Base" / "ActiveModel" + rubyName,
+      // nor rubyName + "Type".
+      expect(nameMatches("Foo", "FooBar")).toBe(false);
+      expect(nameMatches("Foo", "BarFoo")).toBe(false);
+    });
+  });
+});
+
+describe("superclassesMatch", () => {
+  it("treats empty ruby super + empty ts chain as matched", () => {
+    expect(superclassesMatch(null, [], "Anything")).toBe(true);
+  });
+
+  it("flags ruby super with empty ts chain", () => {
+    expect(superclassesMatch("Foo", [], "Anything")).toBe(false);
+  });
+
+  it("matches when ruby super appears anywhere in the ts chain", () => {
+    expect(superclassesMatch("Binary", ["Binary"], "Cte")).toBe(true);
+    // Trails adds an abstract intermediate; the Ruby parent still
+    // shows up in the ts chain.
+    expect(
+      superclassesMatch("TableDefinition", ["AbstractTableDefinition"], "TableDefinition"),
+    ).toBe(true);
+  });
+
+  it("matches when ts chain contains a deeper ancestor equal to ruby super", () => {
+    // Binary extends NodeExpression extends Node; Rails parent is Binary.
+    expect(superclassesMatch("Binary", ["Binary", "NodeExpression", "Node"], "Cte")).toBe(true);
+  });
+
+  it("accepts Ruby unextendable builtins regardless of ts chain", () => {
+    // Rails SqlLiteral < String — TS can't extend String, but the check
+    // still counts it as matched.
+    expect(superclassesMatch("String", ["Node", "NodeExpression"], "SqlLiteral")).toBe(true);
+    expect(superclassesMatch("Struct", [], "Attribute")).toBe(true);
+  });
+
+  it("accepts arel Table/Attribute extending Node when Ruby has no super", () => {
+    expect(superclassesMatch(null, ["Node"], "Table")).toBe(true);
+    expect(superclassesMatch(null, ["Node"], "Attribute")).toBe(true);
+  });
+
+  it("does not auto-accept other classes extending Node with null Ruby super", () => {
+    // Only Table/Attribute are on the arel-root whitelist.
+    expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
+  });
+});

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -151,7 +151,7 @@ const TS_PARENT_ALIASES: { transform: (ruby: string) => string }[] = [
   { transform: (r) => `${r}Type` },
 ];
 
-function nameMatches(rubyName: string, tsName: string): boolean {
+export function nameMatches(rubyName: string, tsName: string): boolean {
   if (rubyName === tsName) return true;
   if (RUBY_ERROR_BUILTINS.has(rubyName) && tsName === "Error") return true;
   for (const { transform } of TS_PARENT_ALIASES) {
@@ -172,7 +172,11 @@ function nameMatches(rubyName: string, tsName: string): boolean {
 // matched to reflect the structural choice rather than a fidelity gap.
 const AREL_ROOT_NODE_CLASSES = new Set(["Table", "Attribute"]);
 
-function superclassesMatch(rubySuper: string | null, tsChain: string[], tsName: string): boolean {
+export function superclassesMatch(
+  rubySuper: string | null,
+  tsChain: string[],
+  tsName: string,
+): boolean {
   if (!rubySuper && tsChain.length === 0) return true;
   // Ruby builtins have no faithful TS superclass; accept whatever TS uses.
   if (rubySuper && RUBY_UNEXTENDABLE_BUILTINS.has(rubySuper)) return true;
@@ -839,4 +843,11 @@ function printReport(
   console.log(`${"=".repeat(100)}\n`);
 }
 
-main();
+// Only run the CLI when invoked as a script. `import`s (e.g. from tests)
+// should be able to pull in exported helpers without triggering main().
+const invokedAsScript =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  typeof process.argv[1] === "string" &&
+  process.argv[1].endsWith("compare.ts");
+if (invokedAsScript) main();

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -130,13 +130,33 @@ function shortName(fqn: string | undefined | null): string | null {
   return parts[parts.length - 1] || null;
 }
 
+// Trails rename prefixes/suffixes used to disambiguate when a Rails class
+// name would collide with a built-in, a TS keyword, or another identifier
+// already in scope. Each entry lets `<ruby>` match `<prefix><ruby>` /
+// `<ruby><suffix>` on the TS side so the inheritance check sees through the
+// alias.
+// - `Abstract<X>`: parent import-aliased so an adapter can shadow its name
+//   (e.g. PG's `TableDefinition extends TableDefinition`).
+// - `Base<X>`: TS-added intermediate base class (`BaseLogSubscriber`,
+//   `BaseAbsenceValidator`) — Rails has a single class Trails splits in two.
+// - `ActiveModel<X>`: ActiveRecord's `Type::Date` collides with the JS
+//   `Date` constructor, so we import the ActiveModel type aliased.
+// - `<X>Type` suffix: Trails suffixes attribute-type classes to avoid
+//   clashing with the value they represent (e.g. `Json` value vs
+//   `JsonType` the cast type).
+const TS_PARENT_ALIASES: { transform: (ruby: string) => string }[] = [
+  { transform: (r) => `Abstract${r}` },
+  { transform: (r) => `Base${r}` },
+  { transform: (r) => `ActiveModel${r}` },
+  { transform: (r) => `${r}Type` },
+];
+
 function nameMatches(rubyName: string, tsName: string): boolean {
   if (rubyName === tsName) return true;
   if (RUBY_ERROR_BUILTINS.has(rubyName) && tsName === "Error") return true;
-  // Trails convention: when a subclass in one adapter shadows its parent's
-  // name (e.g. PG's `TableDefinition extends TableDefinition`), the parent is
-  // import-aliased as `Abstract<Name>`. Treat the alias as the same class.
-  if (tsName === `Abstract${rubyName}`) return true;
+  for (const { transform } of TS_PARENT_ALIASES) {
+    if (tsName === transform(rubyName)) return true;
+  }
   return false;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,11 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ["packages/*/src/**/*.test.ts", "scripts/guides-typecheck/*.test.ts"],
+    include: [
+      "packages/*/src/**/*.test.ts",
+      "scripts/guides-typecheck/*.test.ts",
+      "scripts/api-compare/*.test.ts",
+    ],
     exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**", "packages/*/dx-tests/**"],
     setupFiles: process.env.MYSQL_TEST_URL
       ? ["./packages/activerecord/src/test-setup-mysql.ts"]


### PR DESCRIPTION
## Summary
Extend the inheritance comparator's \`nameMatches\` so three more Trails rename patterns count as matched, without any code churn in the packages:

- **\`Base<X>\`** — Trails inserts an intermediate class (\`BaseLogSubscriber\`, \`BaseAbsenceValidator\`, \`BaseLengthValidator\`, ...) where Rails has a single class. Generalises the existing \`Abstract<X>\` rule.
- **\`ActiveModel<X>\`** — \`ActiveRecord::Type::{Date, DateTime, Time}\` collide with the JS \`Date\`/\`DateTime\`/\`Time\` constructors, so the TS port imports them aliased (\`class Date extends ActiveModelDate\`).
- **\`<X>Type\`** — type classes suffix \`Type\` to avoid clashing with the value they represent (\`JsonType\`, \`IntegerType\`, \`BinaryType\`, ...).

## Impact
| package       | before         | after         |
|---------------|----------------|---------------|
| activerecord  | 148/209 (70.8%)| 163/209 (78%) |
| activemodel   | 20/41 (48.8%)  | 21/41 (51.2%) |
| others        | unchanged      | unchanged     |

## Test plan
- [x] \`pnpm tsx scripts/api-compare/compare.ts\` per-package scores — arel/activesupport/actiondispatch/actioncontroller/actionview all unchanged; activemodel +1, activerecord +15.