### PR TITLE
feat(activerecord): real DisableJoinsAssociationScope + AssociationRelation

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -359,6 +359,24 @@ async function _loadThroughViaDisableJoinsScope(
   record: Base,
   reflection: unknown,
 ): Promise<Base[]> {
+  // Null-PK short-circuit: an unsaved owner has no through-table FK to
+  // chain off, so DJAS would build `WHERE through.<fk> IN ([null])` and
+  // either return 0 rows or (worse) match rows with null FKs. Read the
+  // owner-side column the chain seeds from — `joinForeignKey` on the
+  // through_reflection is the owner's PK column on the through table,
+  // and on the owner record itself it's the owner's PK attribute. For
+  // chain length 1 (non-through), this code isn't reached. For through,
+  // the chain reverse walk seeds with `owner.readAttribute(throughRefl
+  // .joinForeignKey)`, so checking that here matches what DJAS reads.
+  const throughRefl = (reflection as { throughReflection?: unknown }).throughReflection as
+    | { joinForeignKey?: string | string[] }
+    | undefined;
+  const fk = throughRefl?.joinForeignKey;
+  const fkCols = Array.isArray(fk) ? fk : fk ? [fk] : [];
+  for (const col of fkCols) {
+    const v = record.readAttribute(col);
+    if (v === null || v === undefined) return [];
+  }
   // Lazy-import to avoid an eager cycle: DJAS imports
   // DisableJoinsAssociationRelation → relation.ts → associations.ts.
   const { DisableJoinsAssociationScope } =

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -341,6 +341,17 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
   if (!src) return false;
   if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
   if (options.sourceType) return false;
+  // Composite-key through associations need per-column predicates (or
+  // tuple IN) at every chain step; DJAS only supports single-column keys
+  // today. Bail out if any chain entry has a composite join key so we
+  // fall back to loadHasManyThrough rather than silently truncating.
+  const chain =
+    (reflection as { chain?: Array<{ joinPrimaryKey?: unknown; joinForeignKey?: unknown }> })
+      .chain ?? [];
+  for (const entry of chain) {
+    if (Array.isArray(entry.joinPrimaryKey) && entry.joinPrimaryKey.length > 1) return false;
+    if (Array.isArray(entry.joinForeignKey) && entry.joinForeignKey.length > 1) return false;
+  }
   return true;
 }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -316,6 +316,52 @@ function _canRouteThroughViaAssociationScope(
 }
 
 /**
+ * Disable-joins routing gate. Mirrors `_canRouteThroughViaAssociationScope`
+ * but for `disable_joins: true` through associations — runs the chain
+ * via the Rails-faithful `DisableJoinsAssociationScope` (per-step pluck
+ * + IN list) rather than the legacy `loadHasManyThrough` 2-step. PR 4
+ * routes the simple non-polymorphic shape only; polymorphic / sourceType
+ * stays on the existing loader.
+ */
+function _canRouteThroughViaDisableJoinsAssociationScope(
+  reflection: unknown,
+  options: AssociationOptions,
+): boolean {
+  if (!reflection) return false;
+  if (!options.disableJoins) return false;
+  const refl = reflection as {
+    isThroughReflection?: () => boolean;
+    isNested?: () => boolean;
+  };
+  if (typeof refl.isThroughReflection !== "function" || !refl.isThroughReflection()) return false;
+  if (typeof refl.isNested === "function" && refl.isNested()) return false;
+  const src = (reflection as { sourceReflection?: unknown }).sourceReflection as
+    | { isPolymorphic?: () => boolean }
+    | undefined;
+  if (!src) return false;
+  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
+  if (options.sourceType) return false;
+  return true;
+}
+
+async function _loadThroughViaDisableJoinsScope(
+  record: Base,
+  reflection: unknown,
+): Promise<Base[]> {
+  // Lazy-import to avoid an eager cycle: DJAS imports
+  // DisableJoinsAssociationRelation → relation.ts → associations.ts.
+  const { DisableJoinsAssociationScope } =
+    await import("./associations/disable-joins-association-scope.js");
+  const klass = (reflection as { klass: typeof Base }).klass;
+  const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+    owner: record,
+    reflection: reflection as any,
+    klass,
+  })) as { relation: { toArray: () => Promise<Base[]> } };
+  return built.relation.toArray();
+}
+
+/**
  * Sync loaded result to the association instance if one exists.
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
@@ -470,6 +516,10 @@ export async function loadHasOne(
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
+    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
+      const records = await _loadThroughViaDisableJoinsScope(record, reflEarly);
+      return records[0] ?? null;
+    }
     if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
       return loadHasOneThrough(record, assocName, options);
     }
@@ -672,6 +722,9 @@ export async function loadHasMany(
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
+    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
+      return _loadThroughViaDisableJoinsScope(record, reflEarly);
+    }
     if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
       return loadHasManyThrough(record, assocName, options);
     }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -358,6 +358,7 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
 async function _loadThroughViaDisableJoinsScope(
   record: Base,
   reflection: unknown,
+  options?: AssociationOptions,
 ): Promise<Base[]> {
   // Null-PK short-circuit: an unsaved owner has no through-table FK to
   // chain off, so DJAS would build `WHERE through.<fk> IN ([null])` and
@@ -387,7 +388,16 @@ async function _loadThroughViaDisableJoinsScope(
     reflection: reflection as any,
     klass,
   })) as { relation: { toArray: () => Promise<Base[]> } };
-  return built.relation.toArray();
+  // Apply caller-supplied `options.scope` when it differs from the
+  // reflection's own scope — same rule the JOIN-based loaders use
+  // (line 488 etc.). Skipping when equal avoids double-application
+  // since DJAS already consumed the reflection's scope via constraints.
+  let rel: unknown = built.relation;
+  const reflScope = (reflection as { scope?: unknown }).scope;
+  if (options?.scope && options.scope !== reflScope) {
+    rel = options.scope(rel as never);
+  }
+  return (rel as { toArray: () => Promise<Base[]> }).toArray();
 }
 
 /**
@@ -546,7 +556,7 @@ export async function loadHasOne(
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
     if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
-      const records = await _loadThroughViaDisableJoinsScope(record, reflEarly);
+      const records = await _loadThroughViaDisableJoinsScope(record, reflEarly, options);
       return records[0] ?? null;
     }
     if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
@@ -752,7 +762,7 @@ export async function loadHasMany(
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
     if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
-      return _loadThroughViaDisableJoinsScope(record, reflEarly);
+      return _loadThroughViaDisableJoinsScope(record, reflEarly, options);
     }
     if (!_canRouteThroughViaAssociationScope(reflEarly, options)) {
       return loadHasManyThrough(record, assocName, options);

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -379,7 +379,7 @@ export class AssociationScope {
    * Mirrors: ActiveRecord::Associations::AssociationScope#get_chain
    * (association_scope.rb:112-122).
    */
-  private _getChain(
+  protected _getChain(
     reflection: AssociationReflection,
   ): Array<AbstractReflection | ReflectionProxy> {
     const chain: Array<AbstractReflection | ReflectionProxy> = [reflection];
@@ -634,7 +634,7 @@ export class AssociationScope {
    * so we re-add `where(type: stiNames)` for subclasses to keep the
    * filter on intermediate / source relation builds.
    */
-  private _buildEntryScope(entryKlass: typeof Base): unknown {
+  protected _buildEntryScope(entryKlass: typeof Base): unknown {
     let entryScope: unknown = (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
     if (isStiSubclass(entryKlass)) {
       const col = getInheritanceColumn(getStiBase(entryKlass));
@@ -658,7 +658,7 @@ export class AssociationScope {
    * select / joins / etc override the main scope, which Rails
    * explicitly avoids.
    */
-  private _pushScopeIntoRelation(scope: unknown, evaluated: unknown): unknown {
+  protected _pushScopeIntoRelation(scope: unknown, evaluated: unknown): unknown {
     if (!evaluated) return scope;
     const evalWhere = (evaluated as { _whereClause?: { predicates?: unknown[] } })._whereClause;
     const evalPredicates = evalWhere?.predicates ?? [];

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -55,6 +55,17 @@ describe("DisableJoinsAssociationScope", () => {
       source: "djsComments",
       disableJoins: true,
     });
+    Associations.hasMany.call(DjsAuthor, "djsPostsOrdered", {
+      className: "DjsPost",
+      foreignKey: "djs_author_id",
+      scope: (rel: any) => rel.order("title"),
+    });
+    Associations.hasMany.call(DjsAuthor, "djsCommentsViaOrderedPosts", {
+      className: "DjsComment",
+      through: "djsPostsOrdered",
+      source: "djsComments",
+      disableJoins: true,
+    });
   });
 
   it("INSTANCE is a DisableJoinsAssociationScope", () => {
@@ -104,6 +115,27 @@ describe("DisableJoinsAssociationScope", () => {
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
     const comments = await loadHasMany(author, "djsComments", reflection.options);
     expect(comments.map((c: any) => c.body)).toEqual(["hi"]);
+  });
+
+  it("wraps source step in DisableJoinsAssociationRelation when upstream chain is ordered", async () => {
+    const author = await DjsAuthor.create({ name: "A" });
+    const postB = await DjsPost.create({ djs_author_id: author.id, title: "b" });
+    const postA = await DjsPost.create({ djs_author_id: author.id, title: "a" });
+    await DjsComment.create({ djs_post_id: postB.id, body: "from-b" });
+    await DjsComment.create({ djs_post_id: postA.id, body: "from-a" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsCommentsViaOrderedPosts");
+    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    })) as { relation: unknown };
+
+    expect(built.relation).toBeInstanceOf(DisableJoinsAssociationRelation);
+    // Loaded comments come back in the through-ordered sequence (postA.title="a"
+    // before postB.title="b"), since the wrapping relation re-groups by key.
+    const records = await (built.relation as any).toArray();
+    expect(records.map((r: any) => r.body)).toEqual(["from-a", "from-b"]);
   });
 
   it("DisableJoinsAssociationRelation is exported and reorders by ids on load", async () => {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import { Associations, loadHasMany } from "../associations.js";
+import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
+import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+
+describe("DisableJoinsAssociationScope", () => {
+  let adapter: DatabaseAdapter;
+
+  class DjsAuthor extends Base {
+    static {
+      this._tableName = "djs_authors";
+      this.attribute("name", "string");
+    }
+  }
+  class DjsPost extends Base {
+    static {
+      this._tableName = "djs_posts";
+      this.attribute("djs_author_id", "integer");
+      this.attribute("title", "string");
+    }
+  }
+  class DjsComment extends Base {
+    static {
+      this._tableName = "djs_comments";
+      this.attribute("djs_post_id", "integer");
+      this.attribute("body", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    DjsAuthor.adapter = adapter;
+    DjsPost.adapter = adapter;
+    DjsComment.adapter = adapter;
+    registerModel("DjsAuthor", DjsAuthor);
+    registerModel("DjsPost", DjsPost);
+    registerModel("DjsComment", DjsComment);
+    (DjsAuthor as any)._associations = [];
+    (DjsPost as any)._associations = [];
+    (DjsComment as any)._associations = [];
+    Associations.hasMany.call(DjsAuthor, "djsPosts", {
+      className: "DjsPost",
+      foreignKey: "djs_author_id",
+    });
+    Associations.hasMany.call(DjsPost, "djsComments", {
+      className: "DjsComment",
+      foreignKey: "djs_post_id",
+    });
+    Associations.hasMany.call(DjsAuthor, "djsComments", {
+      className: "DjsComment",
+      through: "djsPosts",
+      source: "djsComments",
+      disableJoins: true,
+    });
+  });
+
+  it("INSTANCE is a DisableJoinsAssociationScope", () => {
+    expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);
+  });
+
+  it("scope(association) returns a boxed relation loadable via toArray", async () => {
+    const author = await DjsAuthor.create({ name: "A" });
+    const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
+    await DjsComment.create({ djs_post_id: post.id, body: "c1" });
+    await DjsComment.create({ djs_post_id: post.id, body: "c2" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
+    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    })) as { relation: { toArray: () => Promise<Base[]> } };
+
+    const records = await built.relation.toArray();
+    expect(records.map((r: any) => r.body).sort()).toEqual(["c1", "c2"]);
+  });
+
+  it("issues per-step queries (no multi-table JOIN on source query)", async () => {
+    const author = await DjsAuthor.create({ name: "A" });
+    const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
+    await DjsComment.create({ djs_post_id: post.id, body: "c1" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
+    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    })) as { relation: { toSql: () => string } };
+
+    const sql = built.relation.toSql();
+    expect(sql).not.toMatch(/JOIN/i);
+    expect(sql).toMatch(/"djs_comments"/);
+    expect(sql).toMatch(/"djs_post_id"/);
+  });
+
+  it("loadHasMany routes disableJoins:true through DJAS", async () => {
+    const author = await DjsAuthor.create({ name: "A" });
+    const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
+    await DjsComment.create({ djs_post_id: post.id, body: "hi" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
+    const comments = await loadHasMany(author, "djsComments", reflection.options);
+    expect(comments.map((c: any) => c.body)).toEqual(["hi"]);
+  });
+
+  it("DisableJoinsAssociationRelation is exported and reorders by ids on load", async () => {
+    const post1 = await DjsPost.create({ djs_author_id: 1, title: "p1" });
+    const post2 = await DjsPost.create({ djs_author_id: 1, title: "p2" });
+
+    const djar = new DisableJoinsAssociationRelation(DjsPost, "id", [post2.id, post1.id]);
+    (djar as any)._whereClause.predicates.push(
+      ...(DjsPost as any).where({ id: [post1.id, post2.id] })._whereClause.predicates,
+    );
+    const loaded = await djar.toArray();
+    expect(loaded.map((p: any) => p.title)).toEqual(["p2", "p1"]);
+  });
+});

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -130,8 +130,13 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       const recordIds = (await (records as { pluck: (col: string) => Promise<unknown[]> }).pluck(
         foreignKeyStr,
       )) as unknown[];
-      const orderValues = (records as { orderValues?: unknown[] }).orderValues ?? ([] as unknown[]);
-      const recordsOrdered = orderValues.length > 0;
+      // `orderValues` covers `_orderClauses` (the parsed form); raw-SQL
+      // orders (e.g. `inOrderOf`) live in `_rawOrderClauses` and are
+      // invisible to the public getter. Check both so chain steps with
+      // raw orders trigger the DJAR wrapping branch correctly.
+      const ord = records as { orderValues?: unknown[]; _rawOrderClauses?: unknown[] };
+      const recordsOrdered =
+        (ord.orderValues?.length ?? 0) > 0 || (ord._rawOrderClauses?.length ?? 0) > 0;
       acc = [nextReflection, recordsOrdered, recordIds];
     }
     return acc;
@@ -194,7 +199,13 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       scope = this._pushScopeIntoRelation(scope, evaluated);
     }
 
-    const finalOrders = (scope as { orderValues?: unknown[] }).orderValues ?? [];
+    // Same _rawOrderClauses guard as the chain-walk: a raw-SQL order on
+    // the source step also disables the DJAR wrap.
+    const finalOrd = scope as { orderValues?: unknown[]; _rawOrderClauses?: unknown[] };
+    const finalOrders =
+      (finalOrd.orderValues?.length ?? 0) > 0 || (finalOrd._rawOrderClauses?.length ?? 0) > 0
+        ? [1]
+        : [];
     if (finalOrders.length === 0 && ordered) {
       const split = new DisableJoinsAssociationRelation<Base>(klass, key, joinIds);
       const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -11,6 +11,30 @@ import type { AbstractReflection } from "../reflection.js";
 type ChainEntry = AbstractReflection | ReflectionProxy;
 
 /**
+ * Defense in depth: the routing gate in associations.ts already rejects
+ * composite-key through associations from this path, but per-step keys
+ * are read fresh here, so guard explicitly to fail loudly rather than
+ * silently truncating to `key[0]` and producing a broken WHERE.
+ *
+ * Composite-key support requires per-column predicates (or tuple IN)
+ * and is a follow-up.
+ */
+function singleColumnKey(key: string | string[], label: string): string {
+  if (Array.isArray(key)) {
+    if (key.length === 0) {
+      throw new Error(`DisableJoinsAssociationScope: empty ${label}`);
+    }
+    if (key.length > 1) {
+      throw new Error(
+        `DisableJoinsAssociationScope: composite ${label} not supported (got [${key.join(", ")}])`,
+      );
+    }
+    return key[0];
+  }
+  return key;
+}
+
+/**
  * Builds scopes for `:through` associations that disable joins, querying
  * each step's table separately and stitching results in memory via IN(...)
  * rather than emitting a multi-table JOIN. Used when the source and
@@ -57,7 +81,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     );
 
     const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-    const keyStr = Array.isArray(key) ? key[0] : key;
+    const keyStr = singleColumnKey(key, "joinPrimaryKey");
     const relation = this._addConstraintsDj(
       lastReflection,
       keyStr,
@@ -89,7 +113,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       throw new Error("DisableJoinsAssociationScope: empty chain");
     }
     const firstFk = (firstItem as { joinForeignKey: string | string[] }).joinForeignKey;
-    const firstFkStr = Array.isArray(firstFk) ? firstFk[0] : firstFk;
+    const firstFkStr = singleColumnKey(firstFk, "joinForeignKey");
     let acc: [ChainEntry, boolean, unknown[]] = [
       firstItem,
       false,
@@ -99,15 +123,14 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     for (const nextReflection of work) {
       const [reflection, ordered, joinIds] = acc;
       const key = (reflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-      const keyStr = Array.isArray(key) ? key[0] : key;
+      const keyStr = singleColumnKey(key, "joinPrimaryKey");
       const records = this._addConstraintsDj(reflection, keyStr, joinIds, owner, ordered);
       const foreignKey = (nextReflection as { joinForeignKey: string | string[] }).joinForeignKey;
-      const foreignKeyStr = Array.isArray(foreignKey) ? foreignKey[0] : foreignKey;
+      const foreignKeyStr = singleColumnKey(foreignKey, "joinForeignKey");
       const recordIds = (await (records as { pluck: (col: string) => Promise<unknown[]> }).pluck(
         foreignKeyStr,
       )) as unknown[];
-      const orderValues =
-        (records as { _orderClauses?: unknown[] })._orderClauses ?? ([] as unknown[]);
+      const orderValues = (records as { orderValues?: unknown[] }).orderValues ?? ([] as unknown[]);
       const recordsOrdered = orderValues.length > 0;
       acc = [nextReflection, recordsOrdered, recordIds];
     }
@@ -141,18 +164,18 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       klass as unknown as { scopeForAssociation?: () => unknown }
     ).scopeForAssociation?.();
     if (sfa) {
-      const stripped = (
-        sfa as {
-          except: (...keys: string[]) => unknown;
-        }
-      ).except(
+      // Rails: `relation.except(:select, :create_with, :includes, :preload,
+      // :eager_load, :joins, :left_outer_joins)` strips those query parts
+      // before merging. Our `Relation#except` is the SQL set-operation
+      // EXCEPT (Rails-faithful for that name); the query-part strip is
+      // `unscope(...)`. `createWith`, `preload`, `eagerLoad` aren't in
+      // our UnscopeType set yet (follow-up); the supported keys cover
+      // the practical cases (select / includes / joins / leftOuterJoins).
+      const stripped = (sfa as { unscope: (...keys: string[]) => unknown }).unscope(
         "select",
-        "create_with",
         "includes",
-        "preload",
-        "eager_load",
         "joins",
-        "left_outer_joins",
+        "leftOuterJoins",
       );
       scope = (scope as { merge: (o: unknown) => unknown }).merge(stripped);
     }
@@ -171,7 +194,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       scope = this._pushScopeIntoRelation(scope, evaluated);
     }
 
-    const finalOrders = (scope as { _orderClauses?: unknown[] })._orderClauses ?? [];
+    const finalOrders = (scope as { orderValues?: unknown[] }).orderValues ?? [];
     if (finalOrders.length === 0 && ordered) {
       const split = new DisableJoinsAssociationRelation<Base>(klass, key, joinIds);
       const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -1,31 +1,187 @@
-import { AssociationScope, type ValueTransformation } from "./association-scope.js";
+import {
+  AssociationScope,
+  ReflectionProxy,
+  type AssociationScopeable,
+  type ValueTransformation,
+} from "./association-scope.js";
+import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+import type { Base } from "../base.js";
+import type { AbstractReflection } from "../reflection.js";
+
+type ChainEntry = AbstractReflection | ReflectionProxy;
 
 /**
- * Builds scopes for associations that disable joins, querying each
- * database separately and stitching results in memory.
+ * Builds scopes for `:through` associations that disable joins, querying
+ * each step's table separately and stitching results in memory via IN(...)
+ * rather than emitting a multi-table JOIN. Used when the source and
+ * through models live in separate databases (Rails' `disable_joins: true`).
  *
- * PR 1 placeholder: `scope()` is inherited from `AssociationScope`
- * (chain length 1) and the static dispatch is polymorphic via
- * `this.INSTANCE`, so `DisableJoinsAssociationScope.scope(association)`
- * routes through this class' own INSTANCE. The real disable-joins
- * scope-building logic (`scope()` override + multi-step stitching)
- * lands in PR 4 — when it does, this subclass picks up its own
- * `scope()` override automatically.
+ * Chain walk (Rails: `disable_joins_association_scope.rb#last_scope_chain`):
+ * the chain is reversed; each non-tail step has its constraints applied,
+ * then `pluck(next_step.join_foreign_key)` collects IDs that feed the
+ * next step's `WHERE join_primary_key IN (...)`. The final step's relation
+ * is returned to the caller (or wrapped in a `DisableJoinsAssociationRelation`
+ * when the source has no order but an upstream step was ordered).
+ *
+ * Because intermediate `pluck` calls must be async in this codebase, this
+ * subclass' `scope()` returns a `Promise<Relation>` rather than the
+ * synchronous `Relation` Rails returns. Routing in `associations.ts`
+ * awaits the promise before driving the final query.
  *
  * Mirrors: ActiveRecord::Associations::DisableJoinsAssociationScope
  */
 export class DisableJoinsAssociationScope extends AssociationScope {
-  /**
-   * Subclass INSTANCE so the polymorphic `static scope` on the parent
-   * (`this.INSTANCE.scope(association)`) routes through a
-   * DisableJoinsAssociationScope rather than the base AssociationScope
-   * INSTANCE. PR 4 will override `scope()` here for real disable-joins
-   * behavior.
-   */
   static override readonly INSTANCE: DisableJoinsAssociationScope =
     DisableJoinsAssociationScope.create();
 
   constructor(valueTransformation: ValueTransformation = (v) => v) {
     super(valueTransformation);
+  }
+
+  /**
+   * Async override of `AssociationScope#scope`. Walks the reverse chain,
+   * executing intermediate `pluck`s, and returns the final unexecuted
+   * relation (regular `Relation` or `DisableJoinsAssociationRelation`).
+   *
+   * Mirrors: DisableJoinsAssociationScope#scope (lines 6-15 of
+   * disable_joins_association_scope.rb).
+   */
+  override async scope(association: AssociationScopeable): Promise<unknown> {
+    const sourceReflection = association.reflection;
+    const owner = association.owner;
+    const reverseChain = this._getChain(sourceReflection).slice().reverse();
+
+    const [lastReflection, lastOrdered, lastJoinIds] = await this._lastScopeChain(
+      reverseChain,
+      owner,
+    );
+
+    const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
+    const keyStr = Array.isArray(key) ? key[0] : key;
+    const relation = this._addConstraintsDj(
+      lastReflection,
+      keyStr,
+      lastJoinIds,
+      owner,
+      lastOrdered,
+    );
+    // Box the Relation so awaiting the Promise<{relation}> doesn't trip
+    // the Relation's thenable (Relation.then → records array). Callers
+    // read `.relation` off the resolved value.
+    return { relation };
+  }
+
+  /**
+   * Walk the reversed chain, accumulating `[reflection, ordered, joinIds]`.
+   * The first item seeds with the owner's join_foreign_key value; each
+   * subsequent step builds its scope, plucks the next step's
+   * join_foreign_key, and forwards the resulting IDs.
+   *
+   * Mirrors: DisableJoinsAssociationScope#last_scope_chain (lines 18-31).
+   */
+  private async _lastScopeChain(
+    reverseChain: ChainEntry[],
+    owner: Base,
+  ): Promise<[ChainEntry, boolean, unknown[]]> {
+    const work = reverseChain.slice();
+    const firstItem = work.shift();
+    if (!firstItem) {
+      throw new Error("DisableJoinsAssociationScope: empty chain");
+    }
+    const firstFk = (firstItem as { joinForeignKey: string | string[] }).joinForeignKey;
+    const firstFkStr = Array.isArray(firstFk) ? firstFk[0] : firstFk;
+    let acc: [ChainEntry, boolean, unknown[]] = [
+      firstItem,
+      false,
+      [owner.readAttribute(firstFkStr)],
+    ];
+
+    for (const nextReflection of work) {
+      const [reflection, ordered, joinIds] = acc;
+      const key = (reflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
+      const keyStr = Array.isArray(key) ? key[0] : key;
+      const records = this._addConstraintsDj(reflection, keyStr, joinIds, owner, ordered);
+      const foreignKey = (nextReflection as { joinForeignKey: string | string[] }).joinForeignKey;
+      const foreignKeyStr = Array.isArray(foreignKey) ? foreignKey[0] : foreignKey;
+      const recordIds = (await (records as { pluck: (col: string) => Promise<unknown[]> }).pluck(
+        foreignKeyStr,
+      )) as unknown[];
+      const orderValues =
+        (records as { _orderClauses?: unknown[] })._orderClauses ?? ([] as unknown[]);
+      const recordsOrdered = orderValues.length > 0;
+      acc = [nextReflection, recordsOrdered, recordIds];
+    }
+    return acc;
+  }
+
+  /**
+   * Build a per-step scope: `klass.unscoped.where(key IN ids)` merged with
+   * `scope_for_association` (minus the joined/eager-load options that
+   * would conflict with the disabled-joins shape) and any reflection
+   * `constraints()` (where_clause += / order_values |=).
+   *
+   * If the source step has no ORDER but an upstream step was ordered,
+   * wrap in `DisableJoinsAssociationRelation` so loaded records come
+   * back in IN-list order.
+   *
+   * Mirrors: DisableJoinsAssociationScope#add_constraints (lines 33-56).
+   */
+  private _addConstraintsDj(
+    reflection: ChainEntry,
+    key: string,
+    joinIds: unknown[],
+    owner: Base,
+    ordered: boolean,
+  ): unknown {
+    const klass = (reflection as { klass: typeof Base }).klass;
+    let scope: unknown = (klass as unknown as { unscoped: () => unknown }).unscoped();
+    scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({ [key]: joinIds });
+
+    const sfa = (
+      klass as unknown as { scopeForAssociation?: () => unknown }
+    ).scopeForAssociation?.();
+    if (sfa) {
+      const stripped = (
+        sfa as {
+          except: (...keys: string[]) => unknown;
+        }
+      ).except(
+        "select",
+        "create_with",
+        "includes",
+        "preload",
+        "eager_load",
+        "joins",
+        "left_outer_joins",
+      );
+      scope = (scope as { merge: (o: unknown) => unknown }).merge(stripped);
+    }
+
+    const constraints =
+      (
+        reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
+      ).constraints?.() ?? [];
+    for (const c of constraints) {
+      if (typeof c !== "function") continue;
+      const entryScope = this._buildEntryScope(klass);
+      const evaluated =
+        c.length === 0
+          ? (c as () => unknown).call(entryScope)
+          : c.call(entryScope, entryScope, owner);
+      scope = this._pushScopeIntoRelation(scope, evaluated);
+    }
+
+    const finalOrders = (scope as { _orderClauses?: unknown[] })._orderClauses ?? [];
+    if (finalOrders.length === 0 && ordered) {
+      const split = new DisableJoinsAssociationRelation<Base>(klass, key, joinIds);
+      const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
+      const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
+        ._whereClause;
+      if (sourceWhere?.predicates && splitWhere) {
+        splitWhere.predicates.push(...sourceWhere.predicates);
+      }
+      return split;
+    }
+    return scope;
   }
 }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -41,7 +41,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    */
   protected override _newRelation(): Relation<T> {
     return new DisableJoinsAssociationRelation<T>(
-      (this as unknown as { _modelClass: typeof Base })._modelClass,
+      this.model,
       this.key,
       this._storedIds,
     ) as unknown as Relation<T>;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -34,6 +34,20 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
+   * Preserve the subclass on `_clone()` (and any chained `where`/`order`
+   * /`merge`) so the custom `toArray` reordering and `limit`/`first`
+   * overrides survive chaining. Without this, Relation#_clone() would
+   * spawn a plain Relation and silently drop the wrapping behavior.
+   */
+  protected override _newRelation(): Relation<T> {
+    return new DisableJoinsAssociationRelation<T>(
+      (this as unknown as { _modelClass: typeof Base })._modelClass,
+      this.key,
+      this._storedIds,
+    ) as unknown as Relation<T>;
+  }
+
+  /**
    * Load via Relation, then group by `key` and re-emit in `ids` order so
    * the caller sees join-table ordering (Rails' `load` override).
    */

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -1,0 +1,78 @@
+import { Relation } from "./relation.js";
+import type { Base } from "./base.js";
+
+/**
+ * Specialized Relation returned by DisableJoinsAssociationScope when the
+ * source scope has no explicit ORDER but an upstream chain entry was
+ * ordered. Rails uses this to:
+ *
+ *   - preserve the through-IDs order when IN(...) is used on the final
+ *     query (SQL IN doesn't preserve list order, but Rails' ORM contract
+ *     for an ordered `through` association expects the records back in
+ *     the join-table order),
+ *   - and short-circuit `limit` / `first` so they slice the loaded
+ *     in-memory array rather than appending SQL LIMIT (which would
+ *     interact badly with IN-list reordering).
+ *
+ * Mirrors: ActiveRecord::DisableJoinsAssociationRelation
+ * (activerecord/lib/active_record/disable_joins_association_relation.rb).
+ */
+export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T> {
+  readonly key: string;
+  /** Stored IDs (uniq'd at construction). Exposed as `ids()` to match
+   * Rails' `attr_reader :ids` which shadows `Relation#ids` here. */
+  private readonly _storedIds: unknown[];
+
+  constructor(klass: typeof Base, key: string, ids: unknown[]) {
+    super(klass);
+    this.key = key;
+    this._storedIds = Array.from(new Set(ids));
+  }
+
+  override async ids(): Promise<unknown[]> {
+    return this._storedIds;
+  }
+
+  /**
+   * Load via Relation, then group by `key` and re-emit in `ids` order so
+   * the caller sees join-table ordering (Rails' `load` override).
+   */
+  override async toArray(): Promise<T[]> {
+    const records = await super.toArray();
+    const byKey = new Map<unknown, T[]>();
+    for (const r of records) {
+      const k = r.readAttribute(this.key);
+      const bucket = byKey.get(k);
+      if (bucket) bucket.push(r);
+      else byKey.set(k, [r]);
+    }
+    const ordered: T[] = [];
+    for (const id of this._storedIds) {
+      const bucket = byKey.get(id);
+      if (bucket) ordered.push(...bucket);
+    }
+    return ordered;
+  }
+
+  /**
+   * Rails: `def limit(value); records.take(value); end` — load everything
+   * then slice in memory. Returns an array, breaking the Relation chain
+   * (matching Rails' deliberate deviation here).
+   */
+  // @ts-expect-error — deliberate Rails-fidelity deviation: returns Array, not Relation
+  override async limit(value: number): Promise<T[]> {
+    const records = await this.toArray();
+    return records.slice(0, value);
+  }
+
+  /**
+   * Rails: load everything then take the first (or first n) in memory,
+   * for the same reason as `limit` above.
+   */
+  // @ts-expect-error — deliberate Rails-fidelity deviation: async, not sync
+  override async first(limit?: number): Promise<T | T[] | null> {
+    const records = await this.toArray();
+    if (limit === undefined) return records[0] ?? null;
+    return records.slice(0, limit);
+  }
+}


### PR DESCRIPTION
## Summary

PR 4 of the AssociationScope arc (#607). Lands the real
`DisableJoinsAssociationScope` (chain-reverse walker + per-step pluck) and
its companion `DisableJoinsAssociationRelation` (Relation subclass that
re-emits records in through-IDs order on load, plus in-memory
`limit`/`first` overrides).

- Mirrors `activerecord/lib/active_record/associations/disable_joins_association_scope.rb`.
- Routes `has_many :through` / `has_one :through` with `disableJoins: true`
  through DJAS for the simple non-polymorphic shape. Polymorphic source,
  `sourceType`, and nested-through still fall back to the existing
  `loadHasManyThrough` 2-step loader.
- `scope()` is async (returns `Promise<{ relation }>`) because
  intermediate `pluck` calls cannot be synchronous in this codebase.
  Wrapping the relation in a box avoids the Relation's `then`able from
  short-circuiting the awaited value to `records[]`.

Follows PR 3c (#627).

## Test plan

- [x] New `disable-joins-association-scope.test.ts` — direct class tests
- [x] `has-many-through-disable-joins-associations.test.ts` still green
- [x] Full `@blazetrails/activerecord` suite: 8654 passed / 3738 skipped
- [x] Lint + typecheck clean