### PR TITLE
feat(activerecord): retry transaction body on PreparedStatementCacheExpired

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1644,4 +1644,72 @@ describe("TransactionTest", () => {
       }),
     ).rejects.toThrow("specific error message");
   });
+
+  describe("PreparedStatementCacheExpired retry", () => {
+    it("retries the transaction body once on PreparedStatementCacheExpired", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
+      }
+      let attempts = 0;
+      const result = await transaction(Topic, async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new PreparedStatementCacheExpired("cached plan expired");
+        }
+        return attempts;
+      });
+      expect(attempts).toBe(2);
+      expect(result).toBe(2);
+    });
+
+    it("raises after exhausting a single retry", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
+      }
+      let attempts = 0;
+      await expect(
+        transaction(Topic, async () => {
+          attempts += 1;
+          throw new PreparedStatementCacheExpired("still expired");
+        }),
+      ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+      // Rails' MAX_ATTEMPTS = 1 retry — initial + one retry = 2 total.
+      expect(attempts).toBe(2);
+    });
+
+    it("does not retry when nested — bubbles up for outer to handle", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.adapter = adapter;
+        }
+      }
+      let outerAttempts = 0;
+      let innerAttempts = 0;
+      const result = await transaction(Topic, async () => {
+        outerAttempts += 1;
+        await transaction(Topic, async () => {
+          innerAttempts += 1;
+          if (outerAttempts === 1) {
+            throw new PreparedStatementCacheExpired("cached plan expired");
+          }
+        });
+        return outerAttempts;
+      });
+      // Inner didn't retry — error bubbled; outer retried the whole
+      // thing, which re-ran both inner and outer bodies.
+      expect(outerAttempts).toBe(2);
+      expect(innerAttempts).toBe(2);
+      expect(result).toBe(2);
+    });
+  });
 });

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -2,8 +2,15 @@ import type { Base } from "./base.js";
 
 import { ArgumentError } from "@blazetrails/activemodel";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
-import { Rollback, TransactionIsolationError } from "./errors.js";
+import { PreparedStatementCacheExpired, Rollback, TransactionIsolationError } from "./errors.js";
 export { Rollback };
+
+/**
+ * Rails-style max retries for `PreparedStatementCacheExpired`. Rails'
+ * `ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction`
+ * retries the block once on this error; a second failure raises.
+ */
+const PREPARED_STATEMENT_CACHE_EXPIRED_RETRIES = 1;
 import { Transaction } from "./connection-adapters/abstract/transaction.js";
 import { transaction as dbTransaction } from "./connection-adapters/abstract/database-statements.js";
 
@@ -62,6 +69,39 @@ export function currentTransaction(): Transaction | null {
  * lifecycle. Falls back to direct adapter calls for simple adapters.
  */
 export async function transaction<T>(
+  modelClass: typeof Base,
+  fn: (tx: Transaction) => Promise<T>,
+  options?: { isolation?: string; requiresNew?: boolean; joinable?: boolean },
+): Promise<T | undefined> {
+  // Rails retries the whole transaction once on
+  // `PreparedStatementCacheExpired` — a mid-txn cached-plan
+  // invalidation (DDL on a referenced object) can't be transparently
+  // retried in place because PG aborts the txn on any error, so the
+  // adapter raises and the transaction machinery re-runs the block.
+  // Only retry at the outermost frame: if we're already nested, bubble
+  // up so the outer transaction handles it.
+  const nested = currentTransaction() !== null;
+  if (nested) return _transactionAttempt(modelClass, fn, options);
+
+  let attempts = 0;
+
+  while (true) {
+    try {
+      return await _transactionAttempt(modelClass, fn, options);
+    } catch (e) {
+      if (
+        e instanceof PreparedStatementCacheExpired &&
+        attempts < PREPARED_STATEMENT_CACHE_EXPIRED_RETRIES
+      ) {
+        attempts += 1;
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
+async function _transactionAttempt<T>(
   modelClass: typeof Base,
   fn: (tx: Transaction) => Promise<T>,
   options?: { isolation?: string; requiresNew?: boolean; joinable?: boolean },


### PR DESCRIPTION
## Summary

Residual from the StatementPool series. We already raise `PreparedStatementCacheExpired` from the PG adapter's `_runQuery` when a cached plan is invalidated mid-txn (can't transparently retry in place because PG aborts the txn on any error). Rails' `ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction` closes the loop by catching that error and retrying the whole block once; our transaction wrapper was missing that half.

- Module-level `transaction()` now wraps the attempt in a retry-once loop on `PreparedStatementCacheExpired`.
- Only retries at the outermost frame — nested `transaction()` calls re-raise so the outer handles it. Prevents inner retry from fighting an already-aborted enclosing PG txn.
- `MAX_ATTEMPTS = 1` matches Rails (`activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb`).
- 3 tests: happy-path retry, exhausted-retry re-raises, nested transactions defer to the outer.

Note: #2 (SQLite `preparedStatements: false`) and #4 (PG `bind_types`) from the loose-ends list turned out not to need work. SQLite already bypasses the pool when `preparedStatements` is false (already landed). And Rails' PG StatementPool actually stores just `name` — not `bind_types` — so there's no gap; the 0A000 "invalid cached plan" retry already covers bind-type drift.

## Test plan

- [ ] Full AR suite (sqlite): 8657 passed locally
- [ ] PG CI + MariaDB CI: no regressions