### PR TITLE
fix(activerecord): clear prepared-statement cache after RealTransaction PSCE failure

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -214,5 +214,68 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.rollback();
       }
     });
+
+    it("clearCacheBang clears the just-released txn pool when called post-rollback", async () => {
+      // TransactionManager calls `clearCacheBang` AFTER `rollback()`
+      // (Rails' after_failure_actions ordering, abstract/transaction.rb
+      // :627-631). Our PG `rollback()` releases `_client`, so the hook
+      // needs to reach the pool of the just-released client. Exercises
+      // the `_lastReleasedTxnClient` fallback path in `clearCacheBang`.
+      await adapter.beginDbTransaction();
+      await adapter.execute("SELECT $1::int", [1]);
+      await adapter.execute("SELECT $1::text", ["a"]);
+      const pool = adapter._statementPoolForTest()!;
+      expect(pool.length).toBe(2);
+      await adapter.rollback();
+      // After rollback, _client is null but the released-client pool
+      // is still reachable.
+      const releasedPool = adapter._lastReleasedStatementPoolForTest()!;
+      expect(releasedPool).toBe(pool);
+      // clearCacheBang falls back to the released pool and `reset()`s
+      // it (local-only — can't fire DEALLOCATE on a released client),
+      // then drops the WeakRef so we don't pin longer than needed.
+      adapter.clearCacheBang();
+      expect(pool.length).toBe(0);
+      expect(adapter._lastReleasedStatementPoolForTest()).toBeUndefined();
+    });
+
+    it("clearCacheBang resets the released-client pool even when a new txn is in progress", async () => {
+      // Repro for the after_rollback-callback-opens-new-txn race: if
+      // an after_rollback callback begins a new transaction before
+      // TransactionManager calls clearCacheBang, _client points at the
+      // NEW client while _lastReleasedTxnClient still points at the
+      // failed one. The hook must reset the failed pool AND clear the
+      // new-txn pool (both branches fire in clearCacheBang).
+      //
+      // pg.Pool can either re-checkout the same physical client
+      // (pool size 1, no concurrency) or hand back a different one;
+      // the test has to work with both. When same-client, `failedPool`
+      // and `newTxnPool` are the same pool object; when different,
+      // they are distinct. Both paths still have to end with all
+      // relevant pools empty after clearCacheBang.
+      await adapter.beginDbTransaction();
+      await adapter.execute("SELECT $1::int", [1]);
+      const failedPool = adapter._statementPoolForTest()!;
+      expect(failedPool.length).toBe(1);
+      await adapter.rollback();
+      await adapter.beginDbTransaction();
+      try {
+        await adapter.execute("SELECT $1::int", [2]);
+        const newTxnPool = adapter._statementPoolForTest()!;
+        // Precondition: at least one entry exists to be cleared.
+        expect(newTxnPool.length).toBeGreaterThan(0);
+        adapter.clearCacheBang();
+        // Hook behavior: the failed pool (via _lastReleasedTxnClient)
+        // gets reset(), and the current txn pool (via _client) gets
+        // clear()'d. Whether the pools are the same object or not, both
+        // end up empty.
+        expect(failedPool.length).toBe(0);
+        expect(newTxnPool.length).toBe(0);
+        // Released-client ref dropped regardless.
+        expect(adapter._lastReleasedStatementPoolForTest()).toBeUndefined();
+      } finally {
+        await adapter.rollback();
+      }
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1,6 +1,6 @@
 import type { DatabaseAdapter } from "../../adapter.js";
-import { PreparedStatementCacheExpired } from "../../errors.js";
 import { ActiveRecordTransaction } from "../../transaction.js";
+import { PreparedStatementCacheExpired } from "../../errors.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 
 /**
@@ -953,6 +953,29 @@ export class TransactionManager {
     await txn.rollbackRecords();
   }
 
+  /**
+   * Clear the connection's prepared-statement cache after a failed
+   * (now rolled-back) transaction. The exact effect is adapter-defined
+   * (PG fires DEALLOCATE per entry on a held client; on a released
+   * client it drops the local map only — see `clearCacheBang` docs).
+   * Runs only when the rolled-back frame is a `RealTransaction` and
+   * the error is `PreparedStatementCacheExpired` — Savepoint frames
+   * don't drop the underlying connection's cached plans, and other
+   * errors aren't related to plan invalidation.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::TransactionManager
+   *   #after_failure_actions (abstract/transaction.rb:669-673):
+   *
+   *     return unless transaction.is_a?(RealTransaction)
+   *     return unless error.is_a?(ActiveRecord::PreparedStatementCacheExpired)
+   *     @connection.clear_cache!
+   */
+  private _afterFailureActions(transaction: unknown, error: unknown): void {
+    if (!(transaction instanceof RealTransaction)) return;
+    if (!(error instanceof PreparedStatementCacheExpired)) return;
+    this._connection.clearCacheBang?.();
+  }
+
   async withinNewTransaction<T>(
     options: { isolation?: string | null; joinable?: boolean },
     fn: (tx: ActiveRecordTransaction) => Promise<T> | T,
@@ -966,10 +989,18 @@ export class TransactionManager {
       result = await fn(transaction.userTransaction);
     } catch (e) {
       await this.rollbackTransaction();
+      // Rails' ordering (abstract/transaction.rb:627-631):
+      // `after_failure_actions` runs AFTER `rollback_transaction` so
+      // the ROLLBACK isn't delayed behind DEALLOCATE traffic on the
+      // same client (PG StatementPool fires DEALLOCATE per entry via
+      // `.clear()`), and so the server is in a non-aborted state when
+      // cache-clear work runs. PG's adapter retains a WeakRef to the
+      // just-released txn client so the post-rollback `clearCacheBang`
+      // can still reach the StatementPool (see `_lastReleasedTxnClient`).
+      this._afterFailureActions(transaction, e);
       if (!transaction.state.isCompleted()) {
         transaction.incompleteBang();
       }
-      this._afterFailureActions(e);
       throw e;
     }
 
@@ -989,22 +1020,5 @@ export class TransactionManager {
       transaction.incompleteBang();
     }
     return result;
-  }
-
-  /**
-   * Mirrors Rails' `TransactionManager#after_failure_actions`:
-   * when a transaction fails with `PreparedStatementCacheExpired`,
-   * drop cached prepared statements so subsequent statements
-   * re-PREPARE on the same connection. Rails does NOT retry the
-   * transaction body — it clears the cache and re-raises; user
-   * code decides whether to retry.
-   *
-   * Reference: activerecord/lib/active_record/connection_adapters/abstract/
-   * transaction.rb: `TransactionManager#after_failure_actions`.
-   */
-  private _afterFailureActions(error: unknown): void {
-    if (error instanceof PreparedStatementCacheExpired) {
-      this._connection.clearCacheBang?.();
-    }
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -65,6 +65,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // its own counter (matching Rails' `PostgreSQL::StatementPool`).
   // The WeakMap lets pg.Pool reap clients without us leaking entries.
   private _statementPools = new WeakMap<pg.PoolClient, StatementPool>();
+  // The most recently released txn client. Held via WeakRef so that
+  // pg.Pool reaping an idle client can still GC it — strong-holding
+  // would defeat the WeakMap design above. Used by `clearCacheBang`
+  // to reach the released client's StatementPool when the
+  // TransactionManager's `after_failure_actions` hook fires AFTER
+  // `rollback()` has nulled `_client`. Lifecycle: set on every
+  // `rollback()` (overwriting the previous WeakRef); cleared inside
+  // `clearCacheBang` after `reset()` runs. NOT cleared on
+  // `beginTransaction` — after-rollback callbacks can open a new
+  // transaction before `after_failure_actions` reaches the hook, and
+  // nulling the ref there would lose the pointer to the failed client.
+  private _lastReleasedTxnClientRef: WeakRef<pg.PoolClient> | null = null;
+
+  private get _lastReleasedTxnClient(): pg.PoolClient | null {
+    return this._lastReleasedTxnClientRef?.deref() ?? null;
+  }
+  private set _lastReleasedTxnClient(client: pg.PoolClient | null) {
+    this._lastReleasedTxnClientRef = client == null ? null : new WeakRef(client);
+  }
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
   private _statementLimit = 1000;
@@ -725,8 +744,30 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async beginTransaction(): Promise<void> {
     if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     this._client = await this._driverPool.connect();
-    await this._client.query("BEGIN");
-    this._inTransaction = true;
+    try {
+      await this._client.query("BEGIN");
+      this._inTransaction = true;
+      // Note: do NOT null `_lastReleasedTxnClient` here. After-rollback
+      // callbacks (rollback_records) run BEFORE TransactionManager's
+      // `after_failure_actions` hook fires; if such a callback opens a
+      // new transaction (this beginTransaction call), nulling the ref
+      // would lose the pointer to the just-failed client and the hook
+      // would clear the wrong pool. The ref is dropped instead inside
+      // `clearCacheBang` after `reset()` — bounded to the failure-hook
+      // window, while still WeakRef-held so pg.Pool can reap idles.
+    } catch (error) {
+      // If BEGIN fails (e.g. network blip after connect), release the
+      // acquired client so it returns to the pool. Leaving `_client`
+      // set would leak a pool slot and eventually deadlock acquires.
+      // Pass the error to release() so node-postgres discards the
+      // (potentially damaged) client instead of returning a bad
+      // socket to the idle set.
+      const client = this._client;
+      this._client = null;
+      this._inTransaction = false;
+      client?.release(error instanceof Error ? error : undefined);
+      throw error;
+    }
   }
 
   async beginDbTransaction(): Promise<void> {
@@ -764,13 +805,43 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   async rollback(): Promise<void> {
     if (!this._client) throw new Error("No active transaction");
-    await this._client.query("ROLLBACK");
-    // See commit() — ROLLBACK doesn't drop server-side prepared
-    // statements, so we keep the pool attached to the pg.PoolClient
-    // for the duration of the connection's life.
-    this._client.release();
-    this._client = null;
-    this._inTransaction = false;
+    const releasedClient = this._client;
+    let rollbackError: unknown;
+    try {
+      await this._client.query("ROLLBACK");
+    } catch (e) {
+      // If ROLLBACK itself throws (e.g. network drop mid-txn), we still
+      // have to release the client or the pool leaks. Rethrow after
+      // cleanup. Pass the error to release() so pg.Pool discards the
+      // client rather than returning it to the idle set.
+      rollbackError = e;
+    } finally {
+      // See commit() — ROLLBACK doesn't drop server-side prepared
+      // statements, so we keep the pool attached to the pg.PoolClient
+      // for the duration of the connection's life.
+      this._client = null;
+      this._inTransaction = false;
+      // Normalize to Error before passing to release() — node-postgres
+      // expects an Error to discard the client, and downstream code
+      // (and our own rethrow path) may read `.message`. Matches the
+      // pattern in beginTransaction's catch.
+      releasedClient.release(
+        rollbackError === undefined
+          ? undefined
+          : rollbackError instanceof Error
+            ? rollbackError
+            : new Error(String(rollbackError)),
+      );
+      // Retain a reference to the just-released client so a
+      // post-rollback `clearCacheBang` (Rails' `after_failure_actions`)
+      // can still reach the StatementPool. This reference is dropped
+      // by `clearCacheBang` after the cache reset runs; it's NOT
+      // cleared by `beginDbTransaction` (after-rollback callbacks can
+      // open a new txn before the failure hook fires, and nulling
+      // the ref there would lose the pointer to the failed client).
+      this._lastReleasedTxnClient = releasedClient;
+    }
+    if (rollbackError !== undefined) throw rollbackError;
   }
 
   async rollbackDbTransaction(): Promise<void> {
@@ -967,6 +1038,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this._client ? this._statementPools.get(this._client) : undefined;
   }
 
+  /** @internal — pool for the most recently released txn client. */
+  _lastReleasedStatementPoolForTest(): StatementPool | undefined {
+    // Deref once: the WeakRef behind `_lastReleasedTxnClient` can flip
+    // to null between two getter calls if the GC runs between them,
+    // and `WeakMap.get(null)` throws (keys must be objects).
+    const client = this._lastReleasedTxnClient;
+    return client ? this._statementPools.get(client) : undefined;
+  }
+
   /**
    * Clear cached prepared statements on the currently-held transaction
    * client. Mirrors Rails' `PostgreSQLAdapter#clear_cache!` which
@@ -982,9 +1062,59 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override clearCacheBang(): void {
     super.clearCacheBang();
-    if (this._client) {
-      this._statementPools.get(this._client)?.clear();
+    // Always handle the just-released txn client first when set —
+    // this is the failure-hook target. After-rollback callbacks may
+    // have opened a new transaction (so `_client` is non-null) before
+    // `after_failure_actions` reached us; without this branch we'd
+    // clear the WRONG pool (the new txn's) and leave the failed
+    // session's stale entries behind. Bounded to the failure-hook
+    // window: we drop the ref immediately after.
+    const lastReleased = this._lastReleasedTxnClient;
+    const currentClient = this._client;
+    if (lastReleased) {
+      try {
+        if (lastReleased === currentClient) {
+          // pg.Pool handed back the same physical client to the new
+          // txn — we own the session again, so prefer full `clear()`
+          // which fires DEALLOCATE per entry (cleans up the orphaned
+          // server-side PREPAREs that `reset()` would have left).
+          this._statementPools.get(lastReleased)?.clear();
+        } else {
+          // Released client (different from any current txn): we
+          // can't fire DEALLOCATE on a session we don't own. We also
+          // can't SKIP the reset: the WeakMap-stored pool persists
+          // across pg.Pool checkouts of the same physical client. If
+          // we left the stale entries in place, a future checkout of
+          // this same pg.PoolClient would find the invalidated name
+          // in the pool and call `exec_prepared(staleName)`, hitting
+          // the same PSCE error again. `reset()` forces re-PREPARE
+          // with a fresh name (counter never resets, so no collision
+          // with the orphaned server-side statement).
+          this._statementPools.get(lastReleased)?.reset();
+        }
+      } finally {
+        this._lastReleasedTxnClient = null;
+      }
     }
+    if (currentClient && currentClient !== lastReleased) {
+      // Live txn client (distinct from the failed one we already
+      // handled above): full clear() — fires DEALLOCATE per entry
+      // (via StatementPool's pg-specific dealloc override).
+      this._statementPools.get(currentClient)?.clear();
+    }
+    // Trade-off (follow-up) for the released-client `reset()` path
+    // above: we can't fire DEALLOCATE on a released client, so
+    // server-side PREPAREs persist until the connection is recycled.
+    // Repeated PSCE on the same physical client could accumulate
+    // orphaned server statements beyond what statement_limit / LRU
+    // would normally evict (we discarded the local entries that drive
+    // eviction). Our per-pool counter never resets, so name collisions
+    // are impossible — but memory on the server session grows. The
+    // proper fix is to tag the released client (per-client WeakMap
+    // flag) and have the next checkout run `DEALLOCATE ALL` (or
+    // `DISCARD ALL`) before user code; that requires a pool-checkout
+    // interception not wired here. Tracked as a follow-up; this PR's
+    // scope is the `after_failure_actions` hook itself.
   }
 
   /**

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1703,5 +1703,45 @@ describe("TransactionTest", () => {
       ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
       expect(clearCacheBang).toHaveBeenCalledTimes(1);
     });
+
+    // Rails-fidelity guard: TransactionManager#after_failure_actions only
+    // fires for RealTransaction frames (abstract/transaction.rb:670 —
+    // `return unless transaction.is_a?(RealTransaction)`). Savepoints
+    // don't drop the underlying connection's cached plans, so clearing
+    // them on a savepoint failure would be wasted work (and on PG would
+    // pointlessly DEALLOCATE the outer-txn cache).
+    it("does not call clearCacheBang for SavepointTransaction failures (RealTransaction-only guard)", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      const { TransactionManager } = await import("./connection-adapters/abstract/transaction.js");
+      const clearCacheBang = vi.fn();
+      const conn = {
+        clearCacheBang,
+        beginDbTransaction: vi.fn(),
+        commitDbTransaction: vi.fn(),
+        rollbackDbTransaction: vi.fn(),
+        rollbackToSavepoint: vi.fn(),
+        releaseSavepoint: vi.fn(),
+        createSavepoint: vi.fn(),
+        supportsLazyTransactions: () => false,
+        supportsRestartDbTransaction: () => false,
+        addTransactionRecord: vi.fn(),
+        active: true,
+      };
+      const tm = new TransactionManager(conn as never);
+      // Force inner frame to SavepointTransaction (not
+      // RestartParentTransaction): outer must be non-restartable, which
+      // requires `joinable: false`.
+      await expect(
+        tm.withinNewTransaction({ joinable: false }, async () => {
+          await tm.withinNewTransaction({}, () => {
+            throw new PreparedStatementCacheExpired("inner savepoint plan miss");
+          });
+        }),
+      ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+      // Inner savepoint frame raised — guard skipped clear. Outer
+      // frame also raised (PSCE bubbled), is a RealTransaction, so
+      // clear fires exactly once for the outer.
+      expect(clearCacheBang).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the closed #632. Verified against `scripts/api-compare/.rails-source/`: Rails does **not** auto-retry the transaction body on `PreparedStatementCacheExpired`. It clears the connection's prepared-statement cache and re-raises, leaving retry up to the caller.

What Rails does (`activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:669-673`):

\`\`\`ruby
def after_failure_actions(transaction, error)
  return unless transaction.is_a?(RealTransaction)
  return unless error.is_a?(ActiveRecord::PreparedStatementCacheExpired)
  @connection.clear_cache!
end
\`\`\`

This PR adds the equivalent hook to our `TransactionManager#withinNewTransaction`'s rescue path. After rollback, if the rolled-back frame is a `RealTransaction` and the error is `PreparedStatementCacheExpired`, call `clearCacheBang()` (our existing `clear_cache!` equivalent on the abstract/PG adapters). Savepoint frames are left alone — they don't drop the underlying connection's cached plans.

The PG adapter already raises `PreparedStatementCacheExpired` from `_runQuery` on a `0A000` cached-plan failure inside a transaction (landed in #611); this PR closes the loop by clearing the now-invalid cache before the error propagates.

## Test plan

- [x] 3 new unit tests on `TransactionManager.withinNewTransaction`:
  - PSCE in RealTransaction → `clearCacheBang` called once
  - Non-PSCE error in RealTransaction → not called
  - PSCE in nested SavepointTransaction → only the outer (RealTransaction) hook fires
- [x] Existing transaction suite: 181 passed / 93 skipped, no regressions
- [ ] PG CI cached-plan paths