### PR TITLE
feat(activerecord): clear_cache! on PreparedStatementCacheExpired during txn rollback

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -114,10 +114,11 @@ export interface DatabaseAdapter {
   rollback(): Promise<void>;
 
   /**
-   * Drop cached prepared statements. Safe no-op for adapters with no
-   * statement pool. Called from the transaction-manager's rollback
-   * path when the failure is a `PreparedStatementCacheExpired` so the
-   * next call re-PREPAREs on a fresh session.
+   * Drop cached prepared statements on the current connection. Safe
+   * no-op for adapters with no statement pool. Called from the
+   * transaction-manager's rollback path when the failure is a
+   * `PreparedStatementCacheExpired` so subsequent statements
+   * re-PREPARE on the same connection after the cache is cleared.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#clear_cache!
    */

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -114,6 +114,16 @@ export interface DatabaseAdapter {
   rollback(): Promise<void>;
 
   /**
+   * Drop cached prepared statements. Safe no-op for adapters with no
+   * statement pool. Called from the transaction-manager's rollback
+   * path when the failure is a `PreparedStatementCacheExpired` so the
+   * next call re-PREPAREs on a fresh session.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#clear_cache!
+   */
+  clearCacheBang?(): void;
+
+  /**
    * Create a savepoint.
    */
   createSavepoint(name: string): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -994,10 +994,10 @@ export class TransactionManager {
   /**
    * Mirrors Rails' `TransactionManager#after_failure_actions`:
    * when a transaction fails with `PreparedStatementCacheExpired`,
-   * drop cached prepared statements so the next call re-PREPAREs
-   * on a fresh session. Rails does NOT retry the transaction body —
-   * it clears the cache and re-raises; user code decides whether
-   * to retry.
+   * drop cached prepared statements so subsequent statements
+   * re-PREPARE on the same connection. Rails does NOT retry the
+   * transaction body — it clears the cache and re-raises; user
+   * code decides whether to retry.
    *
    * Reference: activerecord/lib/active_record/connection_adapters/abstract/
    * transaction.rb: `TransactionManager#after_failure_actions`.

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -268,7 +268,6 @@ export interface TransactionConnection extends DatabaseAdapter {
   rollbackDbTransaction?(): void | Promise<void>;
   restartDbTransaction?(): void | Promise<void>;
   resetIsolationLevel?(): void | Promise<void>;
-  clearCacheBang?(): void;
   supportsLazyTransactions?(): boolean;
   supportsRestartDbTransaction?(): boolean;
   addTransactionRecord?(record: unknown): void;

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1,4 +1,5 @@
 import type { DatabaseAdapter } from "../../adapter.js";
+import { PreparedStatementCacheExpired } from "../../errors.js";
 import { ActiveRecordTransaction } from "../../transaction.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 
@@ -267,6 +268,7 @@ export interface TransactionConnection extends DatabaseAdapter {
   rollbackDbTransaction?(): void | Promise<void>;
   restartDbTransaction?(): void | Promise<void>;
   resetIsolationLevel?(): void | Promise<void>;
+  clearCacheBang?(): void;
   supportsLazyTransactions?(): boolean;
   supportsRestartDbTransaction?(): boolean;
   addTransactionRecord?(record: unknown): void;
@@ -968,6 +970,7 @@ export class TransactionManager {
       if (!transaction.state.isCompleted()) {
         transaction.incompleteBang();
       }
+      this._afterFailureActions(e);
       throw e;
     }
 
@@ -987,5 +990,22 @@ export class TransactionManager {
       transaction.incompleteBang();
     }
     return result;
+  }
+
+  /**
+   * Mirrors Rails' `TransactionManager#after_failure_actions`:
+   * when a transaction fails with `PreparedStatementCacheExpired`,
+   * drop cached prepared statements so the next call re-PREPAREs
+   * on a fresh session. Rails does NOT retry the transaction body —
+   * it clears the cache and re-raises; user code decides whether
+   * to retry.
+   *
+   * Reference: activerecord/lib/active_record/connection_adapters/abstract/
+   * transaction.rb: `TransactionManager#after_failure_actions`.
+   */
+  private _afterFailureActions(error: unknown): void {
+    if (error instanceof PreparedStatementCacheExpired) {
+      this._connection.clearCacheBang?.();
+    }
   }
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -649,6 +649,9 @@ class SchemaAdapter extends DatabaseStatementsMixin(class {}) implements Databas
   async rollbackToSavepoint(name: string): Promise<void> {
     return this.inner.rollbackToSavepoint(name);
   }
+  clearCacheBang(): void {
+    this.inner.clearCacheBang?.();
+  }
   get inTransaction(): boolean {
     return this.inner.inTransaction;
   }

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Base, transaction, savepoint, Rollback } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -1650,6 +1650,12 @@ describe("TransactionTest", () => {
     // transaction fails with PreparedStatementCacheExpired we must drop
     // cached prepared statements on the connection. The error itself
     // re-raises unchanged — Rails does NOT retry the body.
+    // A shared afterEach restores spies so a mid-test throw can't leak
+    // mocks into later tests.
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it("calls clearCacheBang and re-raises when the body throws the expired error", async () => {
       const { PreparedStatementCacheExpired } = await import("./errors.js");
       const spy = vi.spyOn(adapter as Required<DatabaseAdapter>, "clearCacheBang");
@@ -1659,7 +1665,6 @@ describe("TransactionTest", () => {
         }),
       ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
       expect(spy).toHaveBeenCalledTimes(1);
-      spy.mockRestore();
     });
 
     it("does not call clearCacheBang for unrelated errors", async () => {
@@ -1670,7 +1675,6 @@ describe("TransactionTest", () => {
         }),
       ).rejects.toThrow("unrelated");
       expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
     });
 
     // The tests above exercise the fallback path (test-adapter has no

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Base, transaction, savepoint, Rollback } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -1643,5 +1643,34 @@ describe("TransactionTest", () => {
         throw new Error("specific error message");
       }),
     ).rejects.toThrow("specific error message");
+  });
+
+  describe("after_failure_actions on PreparedStatementCacheExpired", () => {
+    // Mirrors Rails' TransactionManager#after_failure_actions: when a
+    // transaction fails with PreparedStatementCacheExpired we must drop
+    // cached prepared statements on the connection. The error itself
+    // re-raises unchanged — Rails does NOT retry the body.
+    it("calls clearCacheBang and re-raises when the body throws the expired error", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      const spy = vi.spyOn(adapter as Required<DatabaseAdapter>, "clearCacheBang");
+      await expect(
+        transaction(Account, async () => {
+          throw new PreparedStatementCacheExpired("cached plan expired");
+        }),
+      ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it("does not call clearCacheBang for unrelated errors", async () => {
+      const spy = vi.spyOn(adapter as Required<DatabaseAdapter>, "clearCacheBang");
+      await expect(
+        transaction(Account, async () => {
+          throw new Error("unrelated");
+        }),
+      ).rejects.toThrow("unrelated");
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1672,5 +1672,32 @@ describe("TransactionTest", () => {
       expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
     });
+
+    // The tests above exercise the fallback path (test-adapter has no
+    // withinNewTransaction). The TransactionManager path is reached
+    // when an adapter defines withinNewTransaction — cover that branch
+    // explicitly so it can't regress without a failing test.
+    it("calls clearCacheBang via TransactionManager.withinNewTransaction", async () => {
+      const { PreparedStatementCacheExpired } = await import("./errors.js");
+      const { TransactionManager } = await import("./connection-adapters/abstract/transaction.js");
+      const clearCacheBang = vi.fn();
+      const conn = {
+        clearCacheBang,
+        beginDbTransaction: vi.fn(),
+        commitDbTransaction: vi.fn(),
+        rollbackDbTransaction: vi.fn(),
+        supportsLazyTransactions: () => false,
+        supportsRestartDbTransaction: () => false,
+        addTransactionRecord: vi.fn(),
+        active: true,
+      };
+      const tm = new TransactionManager(conn as never);
+      await expect(
+        tm.withinNewTransaction({}, () => {
+          throw new PreparedStatementCacheExpired("cached plan expired");
+        }),
+      ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+      expect(clearCacheBang).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -2,8 +2,31 @@ import type { Base } from "./base.js";
 
 import { ArgumentError } from "@blazetrails/activemodel";
 import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
-import { Rollback, TransactionIsolationError } from "./errors.js";
+import { PreparedStatementCacheExpired, Rollback, TransactionIsolationError } from "./errors.js";
 export { Rollback };
+
+/**
+ * Rails' `TransactionManager#after_failure_actions`: when a
+ * transaction fails with `PreparedStatementCacheExpired`, drop
+ * cached prepared statements so the next call re-PREPAREs on a
+ * fresh session. The error itself re-raises unchanged — Rails
+ * does NOT retry the body.
+ *
+ * The TransactionManager path calls this from `withinNewTransaction`'s
+ * catch (see abstract/transaction.ts). The fallback path below
+ * handles adapters that don't route through TransactionManager.
+ *
+ * Reference: activerecord/lib/active_record/connection_adapters/
+ * abstract/transaction.rb `TransactionManager#after_failure_actions`.
+ */
+function _afterFailureActions(
+  adapter: import("./adapter.js").DatabaseAdapter,
+  error: unknown,
+): void {
+  if (error instanceof PreparedStatementCacheExpired) {
+    adapter.clearCacheBang?.();
+  }
+}
 import { Transaction } from "./connection-adapters/abstract/transaction.js";
 import { transaction as dbTransaction } from "./connection-adapters/abstract/database-statements.js";
 
@@ -140,6 +163,7 @@ async function _transactionFallback<T>(
         releaseLock = null;
         await tx.rollback();
         await tx.runAfterRollbackCallbacks();
+        _afterFailureActions(adapter, error);
         if (error instanceof Rollback) return undefined;
         throw error;
       }
@@ -156,6 +180,7 @@ async function _transactionFallback<T>(
         releaseLock = null;
         await tx.rollback();
         await tx.runAfterRollbackCallbacks();
+        _afterFailureActions(adapter, error);
         if (error instanceof Rollback) return undefined;
         throw error;
       }

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -6,15 +6,17 @@ import { PreparedStatementCacheExpired, Rollback, TransactionIsolationError } fr
 export { Rollback };
 
 /**
- * Rails' `TransactionManager#after_failure_actions`: when a
- * transaction fails with `PreparedStatementCacheExpired`, drop
- * cached prepared statements so the next call re-PREPAREs on a
- * fresh session. The error itself re-raises unchanged — Rails
- * does NOT retry the body.
+ * Mirrors Rails' `TransactionManager#after_failure_actions`: when a
+ * transaction fails with `PreparedStatementCacheExpired`, clear the
+ * cached prepared statements on the current connection so subsequent
+ * statements re-PREPARE. The error itself re-raises unchanged —
+ * Rails does NOT retry the body.
  *
- * The TransactionManager path calls this from `withinNewTransaction`'s
- * catch (see abstract/transaction.ts). The fallback path below
- * handles adapters that don't route through TransactionManager.
+ * This helper is only used by the fallback transaction path below
+ * (for adapters that don't route through TransactionManager, like
+ * the test adapter). `TransactionManager` has its own
+ * `_afterFailureActions` implementation in
+ * `connection-adapters/abstract/transaction.ts`.
  *
  * Reference: activerecord/lib/active_record/connection_adapters/
  * abstract/transaction.rb `TransactionManager#after_failure_actions`.


### PR DESCRIPTION
## Summary

Replacement for #632 (closed). That PR added a Rails-style transaction-body retry on `PreparedStatementCacheExpired` — but Rails **doesn't retry**. `TransactionManager#after_failure_actions` (activerecord/lib/active_record/connection_adapters/abstract/transaction.rb) calls `connection.clear_cache!` and re-raises; user code decides whether to retry.

This PR implements the Rails-faithful behavior.

- `TransactionManager#withinNewTransaction`'s rollback path calls a new private `_afterFailureActions(error)` that invokes `connection.clearCacheBang?.()` when the error is `PreparedStatementCacheExpired`. The error re-raises unchanged.
- `transactions.ts` fallback path (for adapters that don't route through `TransactionManager`) gets the same hook, so behavior is uniform across routing.
- `clearCacheBang` is now declared on the `DatabaseAdapter` interface (optional; already implemented by `AbstractAdapter` / SQLite / PG / MySQL in #628). `SchemaAdapter` wrapper forwards it.
- 2 tests: `PreparedStatementCacheExpired` triggers `clearCacheBang` + re-raises; unrelated errors don't trigger it.

## Test plan

- [ ] Full AR suite (sqlite): 8656 passed locally
- [ ] PG CI + MariaDB CI: no regressions