### PR TITLE
feat(activemodel,api-compare): concrete types extend ValueType; AM inheritance 54% → 98%

### DIFF
--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -144,11 +144,3 @@ export class ModelName {
     return [scope, "models"];
   }
 }
-
-/**
- * Mirrors: ActiveModel::Name
- *
- * Inherits from ModelName — matches the Rails class name exactly.
- * ModelName remains the primary export for backwards compatibility.
- */
-export class Name extends ModelName {}

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -1,9 +1,9 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-export class BinaryType extends Type<Uint8Array> {
+export class BinaryType extends ValueType {
   readonly name = "binary";
 
   cast(value: unknown): Uint8Array | null {

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class BooleanType extends Type<boolean> {
+export class BooleanType extends ValueType {
   readonly name = "boolean";
 
   private static readonly TRUE_VALUES: ReadonlySet<unknown> = new Set([

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class DateTimeType extends Type<Date> {
+export class DateTimeType extends ValueType {
   readonly name: string = "datetime";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class DateType extends Type<Date> {
+export class DateType extends ValueType {
   readonly name: string = "date";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class DecimalType extends Type<string> {
+export class DecimalType extends ValueType {
   readonly name: string = "decimal";
 
   cast(value: unknown): string | null {

--- a/packages/activemodel/src/type/float.ts
+++ b/packages/activemodel/src/type/float.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class FloatType extends Type<number> {
+export class FloatType extends ValueType {
   readonly name = "float";
 
   cast(value: unknown): number | null {

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -1,7 +1,7 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class ImmutableStringType extends Type<string> {
-  readonly name = "immutable_string";
+export class ImmutableStringType extends ValueType {
+  readonly name: string = "immutable_string";
 
   constructor(options?: { precision?: number; scale?: number; limit?: number }) {
     super(options);
@@ -13,7 +13,7 @@ export class ImmutableStringType extends Type<string> {
     return Object.freeze(str) as string;
   }
 
-  serialize(value: unknown): string | null {
+  serialize(value: unknown): unknown {
     return this.cast(value);
   }
 

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class IntegerType extends Type<number> {
+export class IntegerType extends ValueType {
   readonly name: string = "integer";
   private readonly _range: [number, number];
 

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -1,8 +1,6 @@
-import { Type } from "./value.js";
-
 import { ImmutableStringType } from "./immutable-string.js";
 
-export class StringType extends Type<string> {
+export class StringType extends ImmutableStringType {
   readonly name: string = "string";
 
   cast(value: unknown): string | null {
@@ -10,6 +8,9 @@ export class StringType extends Type<string> {
     return String(value);
   }
 
+  // Return type stays `unknown` so subclass overrides (e.g. PG OID's
+  // Xml which wraps the cast result in a Data node) can widen the
+  // output type the way Rails' loosely-typed `serialize` does.
   serialize(value: unknown): unknown {
     return this.cast(value);
   }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,6 +1,6 @@
-import { Type } from "./value.js";
+import { ValueType } from "./value.js";
 
-export class TimeType extends Type<Date> {
+export class TimeType extends ValueType {
   readonly name = "time";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -85,7 +85,7 @@ export abstract class Type<T = unknown> {
 }
 
 export class ValueType extends Type<unknown> {
-  readonly name = "value";
+  readonly name: string = "value";
 
   cast(value: unknown): unknown {
     return value;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -141,15 +141,17 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     // pg_catalog.format_type returns "integer", "character varying(255)",
     // etc. Our type_map is keyed by typname (int4, varchar). The
     // fallback needs to map between them so the well-known types
-    // resolve when oid is missing.
-    expect(adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" })).not.toBeInstanceOf(
-      ValueType,
-    );
-    expect(
-      adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "character varying(255)" }),
-    ).not.toBeInstanceOf(ValueType);
-    expect(adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" })).not.toBeInstanceOf(
-      ValueType,
-    );
+    // resolve when oid is missing. Check for specific resolved types
+    // rather than `not ValueType` — concrete types now extend
+    // ValueType, so every typed instance is also an instanceof ValueType.
+    const integer = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" });
+    expect(integer.constructor).not.toBe(ValueType);
+    const varchar = adapter.lookupCastTypeFromColumn({
+      oid: null,
+      sqlType: "character varying(255)",
+    });
+    expect(varchar.constructor).not.toBe(ValueType);
+    const bigint = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" });
+    expect(bigint.constructor).not.toBe(ValueType);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -85,6 +85,8 @@ describe("superclassesMatch", () => {
     // still counts it as matched.
     expect(superclassesMatch("String", ["Node", "NodeExpression"], "SqlLiteral")).toBe(true);
     expect(superclassesMatch("Struct", [], "Attribute")).toBe(true);
+    // Ruby's `Module` metaprogramming primitive has no TS analog.
+    expect(superclassesMatch("Module", [], "InstanceMethodsOnActivation")).toBe(true);
   });
 
   it("accepts arel Table/Attribute extending Node when Ruby has no super", () => {
@@ -92,8 +94,15 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, ["Node"], "Attribute")).toBe(true);
   });
 
-  it("does not auto-accept other classes extending Node with null Ruby super", () => {
-    // Only Table/Attribute are on the arel-root whitelist.
+  it("accepts activemodel ValueType extending Type when Ruby Value has no super", () => {
+    // Rails' `Type::Value` has no super; TS adds an abstract `Type`
+    // intermediate so subclasses can declare `abstract cast`.
+    expect(superclassesMatch(null, ["Type"], "ValueType")).toBe(true);
+  });
+
+  it("does not auto-accept other classes extending the intermediates with null Ruby super", () => {
+    // Only Table/Attribute/ValueType are on the intermediate whitelist.
     expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
+    expect(superclassesMatch(null, ["Type"], "Something")).toBe(false);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -93,8 +93,9 @@ interface InheritanceResult {
 }
 
 // Ruby builtin types whose TS equivalent cannot meaningfully extend them
-// (e.g. `class X < String`, `class X < Struct.new(...)`). Treat the TS side's
-// choice of base class as always matching when Ruby uses one of these.
+// (e.g. `class X < String`, `class X < Struct.new(...)`, `class X < Module`
+// for Ruby metaprogramming primitives). Treat the TS side's choice of
+// base class as always matching when Ruby uses one of these.
 const RUBY_UNEXTENDABLE_BUILTINS = new Set([
   "String",
   "Struct",
@@ -106,6 +107,7 @@ const RUBY_UNEXTENDABLE_BUILTINS = new Set([
   "Set",
   "Delegator",
   "SimpleDelegator",
+  "Module",
 ]);
 
 // Ruby builtin exception classes → TS `Error` is the accepted equivalent.
@@ -126,7 +128,10 @@ const RUBY_ERROR_BUILTINS = new Set([
 
 function shortName(fqn: string | undefined | null): string | null {
   if (!fqn) return null;
-  const parts = fqn.split("::");
+  // Ruby uses `::` as the namespace separator; TS extractor stores the
+  // raw superclass expression, so `extends globalThis.Error` ends up as
+  // `globalThis.Error` — strip either separator to reach the leaf name.
+  const parts = fqn.split(/::|\./);
   return parts[parts.length - 1] || null;
 }
 
@@ -166,11 +171,31 @@ export function nameMatches(rubyName: string, tsName: string): boolean {
  * Trails' common pattern of inserting an abstract intermediate class
  * (e.g. `TableDefinition extends AbstractTableDefinition extends TableDefinition`).
  */
-// Arel's TS port treats every AST participant as a `Node` for uniform
-// traversal, even when the Ruby equivalent is a plain object (Table) or
-// uses a dynamic parent (Attribute < Struct.new(...)). Count these as
-// matched to reflect the structural choice rather than a fidelity gap.
-const AREL_ROOT_NODE_CLASSES = new Set(["Table", "Attribute"]);
+// Rails classes where the TS port adds an abstract intermediate above
+// what Rails treats as the root. Accept null-ruby-super + TS extending
+// that intermediate as a matched deviation rather than a fidelity gap.
+//
+// Keyed by ts class name → ts superclass name that should be accepted.
+// - Arel Table/Attribute: Rails has no super (plain object or
+//   `Struct.new(...)`), TS roots them at `Node` for uniform AST walking.
+// - ActiveModel ValueType: Rails' `Value` has no super, TS adds an
+//   abstract `Type` above so subclasses can declare `abstract cast`.
+const TS_ROOT_INTERMEDIATE = new Map<string, string>([
+  ["Table", "Node"],
+  ["Attribute", "Node"],
+  ["ValueType", "Type"],
+]);
+
+// Per-class TS renames that don't fit the systematic alias patterns
+// (Abstract<X>, Base<X>, ActiveModel<X>, <X>Type). Keyed by the Ruby
+// short name → the literal TS class name in the expected file.
+// - `Name` → `ModelName`: Rails `ActiveModel::Name`. `Name` alone is
+//   too generic in TS, so the flattened class keeps the `Model` prefix.
+// - `Registry` → `TypeRegistry`: same rationale for `ActiveModel::Type::Registry`.
+const TS_CLASS_RENAMES: Record<string, string> = {
+  Name: "ModelName",
+  Registry: "TypeRegistry",
+};
 
 export function superclassesMatch(
   rubySuper: string | null,
@@ -181,7 +206,8 @@ export function superclassesMatch(
   // Ruby builtins have no faithful TS superclass; accept whatever TS uses.
   if (rubySuper && RUBY_UNEXTENDABLE_BUILTINS.has(rubySuper)) return true;
   // Rails-idiomatic "plain object" classes extend Arel.Node in TS.
-  if (!rubySuper && tsChain.includes("Node") && AREL_ROOT_NODE_CLASSES.has(tsName)) return true;
+  const expectedIntermediate = TS_ROOT_INTERMEDIATE.get(tsName);
+  if (!rubySuper && expectedIntermediate && tsChain.includes(expectedIntermediate)) return true;
   if (!rubySuper || tsChain.length === 0) return false;
   return tsChain.some((ancestor) => nameMatches(rubySuper, ancestor));
 }
@@ -660,7 +686,25 @@ function main() {
         const short = shortName(fqn)!;
         const rubySuper = shortName(info.superclass);
 
-        const tsCls = tsByFileName.get(`${expectedTs}::${short}`);
+        // Look up the TS class by the Ruby short name, falling back to
+        // the same rename aliases the superclass matcher uses — TS files
+        // sometimes rename the class itself to avoid builtin collisions
+        // (e.g. Rails' Type::Integer ↔ our type/integer.ts#IntegerType).
+        let tsCls = tsByFileName.get(`${expectedTs}::${short}`);
+        if (!tsCls) {
+          for (const { transform } of TS_PARENT_ALIASES) {
+            const alias = transform(short);
+            const found = tsByFileName.get(`${expectedTs}::${alias}`);
+            if (found) {
+              tsCls = found;
+              break;
+            }
+          }
+        }
+        if (!tsCls) {
+          const rename = TS_CLASS_RENAMES[short];
+          if (rename) tsCls = tsByFileName.get(`${expectedTs}::${rename}`);
+        }
         inheritance.checked++;
 
         if (!tsCls) {
@@ -688,7 +732,10 @@ function main() {
         }
 
         const chain = ancestorChain(tsCls);
-        if (superclassesMatch(rubySuper, chain, short)) {
+        // Pass the resolved TS class name (not the Ruby short name) so
+        // the `TS_ROOT_INTERMEDIATE` whitelist keys on what the TS file
+        // actually declares (e.g. "ValueType", not Ruby's "Value").
+        if (superclassesMatch(rubySuper, chain, tsCls.name)) {
           inheritance.matched++;
         } else {
           inheritance.mismatches.push({


### PR DESCRIPTION
## Summary
Two kinds of change, each carrying its own rationale:

**Code (Rails fidelity)**

Rails' concrete attribute types — \`Type::Integer\`, \`Type::Boolean\`, \`Type::Date\`, etc. — all extend \`Type::Value\`. Our TS port had them extending the abstract \`Type\` base directly, skipping \`ValueType\` (our name for Rails' concrete \`Value\`). Every concrete type now extends \`ValueType\`:

- \`type/{binary,boolean,date,date-time,decimal,float,immutable-string,integer,time}.ts\` now \`extends ValueType\`.
- \`type/string.ts\` extends \`ImmutableStringType\` (Rails: \`String < ImmutableString\`).
- \`ValueType\` / \`ImmutableStringType\` widen their \`name\` declarations to \`string\` so subclasses can override with their own literal.
- \`StringType#serialize\` keeps the looser \`unknown\` return so PG OID's \`Xml\` can wrap the cast result in \`Data\` (matches Rails' untyped serialize).
- Deleted the backwards-compat \`class Name extends ModelName {}\` shim in \`naming.ts\` — no in-tree callers, and it muddied the inheritance check. \`ModelName\` is the only export now.
- One postgres adapter test used \`.not.toBeInstanceOf(ValueType)\` to mean "not the fallback"; since every typed instance is now an \`instanceof ValueType\`, the test now checks \`.constructor !== ValueType\`.

**Comparator (recognise Trails-specific renames)**

- \`shortName()\` splits on \`.\` as well as \`::\` so TS expressions like \`globalThis.Error\` reduce to \`Error\` (unlocks the existing error-builtins rule for \`MissingAttributeError\`, \`ForbiddenAttributesError\`, \`ValidationError\`).
- \`Module\` joins \`RUBY_UNEXTENDABLE_BUILTINS\` — Ruby's \`Module\` is a metaprogramming primitive with no TS analog (\`InstanceMethodsOnActivation\`, \`AcceptsMultiparameterTime\`).
- Renamed \`AREL_ROOT_NODE_CLASSES\` to \`TS_ROOT_INTERMEDIATE\` and generalised it: TS adds an abstract \`Type\` above Rails' \`Value\`, same pattern as Arel's \`Node\` above Rails \`Table\`/\`Attribute\`.
- \`TS_CLASS_RENAMES\` handles \`Registry → TypeRegistry\` — Trails flattens \`ActiveModel::Type::Registry\` but \`Registry\` alone is too generic in TS.
- TS class lookup now tries the rename aliases when the direct name doesn't resolve (\`Integer → IntegerType\` etc.), and \`superclassesMatch\` receives the resolved TS class name so \`TS_ROOT_INTERMEDIATE\` keys on what the TS file actually declares.

## Impact
| package | before | after |
|---------|--------|-------|
| activemodel | 22/41 (54%) | **40/41 (97.6%)** |
| overall    | 300/401 (74.8%) | 335/402 (83.3%) |

Remaining: \`Railtie extends Rails::Railtie\` in Rails but we have no trailties \`Railtie\` base yet — real unimplemented feature, not a fidelity mismatch.

## Test plan
- [x] \`pnpm vitest run packages/activemodel packages/activerecord scripts/api-compare\` — 10,050 pass
- [x] \`pnpm api:compare\` — arel still 100%, activemodel 97.6%, overall +35 matched, no regressions