### PR TITLE
feat(activerecord): drain orphan PG prepared statements via deferred DEALLOCATE ALL

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -248,10 +248,14 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.execute("SELECT $1::int", [1]);
       await adapter.execute("SELECT $1::text", ["a"]);
       await adapter.rollback();
+      // Capture the released client BEFORE clearCacheBang — its
+      // finally block nulls _lastReleasedTxnClient (so a post-clear
+      // _lastReleasedClientForTest() would return null and the
+      // tag check would silently fail with `WeakSet.has(null)` → false).
+      const taggedClient = adapter._lastReleasedClientForTest();
+      expect(taggedClient).not.toBeNull();
       adapter.clearCacheBang();
       // Tagged for drain on next checkout.
-      const taggedClient = adapter._lastReleasedClientForTest();
-      expect(taggedClient).toBeDefined();
       expect(adapter._needsDeallocateAllForTest(taggedClient!)).toBe(true);
 
       // Capture the next pg.PoolClient and its query() call list so we

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -1,7 +1,8 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
  */
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import type pg from "pg";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -11,6 +12,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter.preparedStatements = true;
   });
   afterEach(async () => {
+    vi.restoreAllMocks();
     await adapter.close();
   });
 
@@ -259,45 +261,45 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(adapter._needsDeallocateAllForTest(taggedClient!)).toBe(true);
 
       // Capture the next pg.PoolClient and its query() call list so we
-      // can assert DEALLOCATE ALL ran during checkout.
+      // can assert DEALLOCATE ALL ran during checkout. Use vi.spyOn
+      // (consistent with other tests in this repo, e.g.
+      // postgresql-adapter.exec-query.test.ts) so cleanup is automatic
+      // via vi.restoreAllMocks() and we don't manually reassign methods.
       const observed: string[] = [];
-      const originalConnect = adapter
-        ._driverPoolForTest()!
-        .connect.bind(adapter._driverPoolForTest()!);
-      (adapter._driverPoolForTest() as any).connect = async function (this: any, ...args: any[]) {
-        const client: any = await (originalConnect as any)(...args);
+      const pool = adapter._driverPoolForTest()!;
+      const originalConnect = pool.connect.bind(pool);
+      vi.spyOn(pool, "connect").mockImplementation((async (...args: unknown[]) => {
+        const client = (await (originalConnect as (...a: unknown[]) => Promise<pg.PoolClient>)(
+          ...args,
+        )) as unknown as { query: (...a: unknown[]) => unknown };
         const origQuery = client.query.bind(client);
-        client.query = (sql: any, ...rest: any[]) => {
+        client.query = (sql: unknown, ...rest: unknown[]) => {
           if (typeof sql === "string") observed.push(sql);
-          return origQuery(sql, ...rest);
+          return (origQuery as (...a: unknown[]) => unknown)(sql, ...rest);
         };
-        return client;
-      };
+        return client as unknown as pg.PoolClient;
+      }) as unknown as typeof pool.connect);
 
+      await adapter.beginDbTransaction();
       try {
-        await adapter.beginDbTransaction();
-        try {
-          // The DEALLOCATE ALL fires before BEGIN — but only when
-          // pg.Pool hands back the SAME physical client (the only one
-          // we tagged). With pool size > 1, a different client may be
-          // returned and the tag stays attached for its eventual reuse.
-          // Either way, the new client is no longer tagged after this
-          // checkout (drain ran or it wasn't the tagged one).
-          const newClient = adapter._currentClientForTest();
-          expect(adapter._needsDeallocateAllForTest(newClient!)).toBe(false);
-          if (newClient === taggedClient) {
-            expect(observed).toContain("DEALLOCATE ALL");
-            // DEALLOCATE ALL must run BEFORE BEGIN.
-            const deallocIdx = observed.indexOf("DEALLOCATE ALL");
-            const beginIdx = observed.indexOf("BEGIN");
-            expect(deallocIdx).toBeGreaterThanOrEqual(0);
-            expect(beginIdx).toBeGreaterThan(deallocIdx);
-          }
-        } finally {
-          await adapter.rollback();
+        // The DEALLOCATE ALL fires before BEGIN — but only when
+        // pg.Pool hands back the SAME physical client (the only one
+        // we tagged). With pool size > 1, a different client may be
+        // returned and the tag stays attached for its eventual reuse.
+        // Either way, the new client is no longer tagged after this
+        // checkout (drain ran or it wasn't the tagged one).
+        const newClient = adapter._currentClientForTest();
+        expect(adapter._needsDeallocateAllForTest(newClient!)).toBe(false);
+        if (newClient === taggedClient) {
+          expect(observed).toContain("DEALLOCATE ALL");
+          // DEALLOCATE ALL must run BEFORE BEGIN.
+          const deallocIdx = observed.indexOf("DEALLOCATE ALL");
+          const beginIdx = observed.indexOf("BEGIN");
+          expect(deallocIdx).toBeGreaterThanOrEqual(0);
+          expect(beginIdx).toBeGreaterThan(deallocIdx);
         }
       } finally {
-        (adapter._driverPoolForTest() as any).connect = originalConnect;
+        await adapter.rollback();
       }
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -239,6 +239,64 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(adapter._lastReleasedStatementPoolForTest()).toBeUndefined();
     });
 
+    it("tags the released client and runs DEALLOCATE ALL on its next checkout", async () => {
+      // Released-client `reset()` path can't fire DEALLOCATE on a
+      // session it doesn't own, so server-side PREPAREs leak. The
+      // deferred half: tag the client; on next checkout, drain via
+      // `DEALLOCATE ALL` before user code.
+      await adapter.beginDbTransaction();
+      await adapter.execute("SELECT $1::int", [1]);
+      await adapter.execute("SELECT $1::text", ["a"]);
+      await adapter.rollback();
+      adapter.clearCacheBang();
+      // Tagged for drain on next checkout.
+      const taggedClient = adapter._lastReleasedClientForTest();
+      expect(taggedClient).toBeDefined();
+      expect(adapter._needsDeallocateAllForTest(taggedClient!)).toBe(true);
+
+      // Capture the next pg.PoolClient and its query() call list so we
+      // can assert DEALLOCATE ALL ran during checkout.
+      const observed: string[] = [];
+      const originalConnect = adapter
+        ._driverPoolForTest()!
+        .connect.bind(adapter._driverPoolForTest()!);
+      (adapter._driverPoolForTest() as any).connect = async function (this: any, ...args: any[]) {
+        const client: any = await (originalConnect as any)(...args);
+        const origQuery = client.query.bind(client);
+        client.query = (sql: any, ...rest: any[]) => {
+          if (typeof sql === "string") observed.push(sql);
+          return origQuery(sql, ...rest);
+        };
+        return client;
+      };
+
+      try {
+        await adapter.beginDbTransaction();
+        try {
+          // The DEALLOCATE ALL fires before BEGIN — but only when
+          // pg.Pool hands back the SAME physical client (the only one
+          // we tagged). With pool size > 1, a different client may be
+          // returned and the tag stays attached for its eventual reuse.
+          // Either way, the new client is no longer tagged after this
+          // checkout (drain ran or it wasn't the tagged one).
+          const newClient = adapter._currentClientForTest();
+          expect(adapter._needsDeallocateAllForTest(newClient!)).toBe(false);
+          if (newClient === taggedClient) {
+            expect(observed).toContain("DEALLOCATE ALL");
+            // DEALLOCATE ALL must run BEFORE BEGIN.
+            const deallocIdx = observed.indexOf("DEALLOCATE ALL");
+            const beginIdx = observed.indexOf("BEGIN");
+            expect(deallocIdx).toBeGreaterThanOrEqual(0);
+            expect(beginIdx).toBeGreaterThan(deallocIdx);
+          }
+        } finally {
+          await adapter.rollback();
+        }
+      } finally {
+        (adapter._driverPoolForTest() as any).connect = originalConnect;
+      }
+    });
+
     it("clearCacheBang resets the released-client pool even when a new txn is in progress", async () => {
       // Repro for the after_rollback-callback-opens-new-txn race: if
       // an after_rollback callback begins a new transaction before

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -246,60 +246,63 @@ describeIfPg("PostgreSQLAdapter", () => {
       // session it doesn't own, so server-side PREPAREs leak. The
       // deferred half: tag the client; on next checkout, drain via
       // `DEALLOCATE ALL` before user code.
-      await adapter.beginDbTransaction();
-      await adapter.execute("SELECT $1::int", [1]);
-      await adapter.execute("SELECT $1::text", ["a"]);
-      await adapter.rollback();
-      // Capture the released client BEFORE clearCacheBang — its
-      // finally block nulls _lastReleasedTxnClient (so a post-clear
-      // _lastReleasedClientForTest() would return null and the
-      // tag check would silently fail with `WeakSet.has(null)` → false).
-      const taggedClient = adapter._lastReleasedClientForTest();
-      expect(taggedClient).not.toBeNull();
-      adapter.clearCacheBang();
-      // Tagged for drain on next checkout.
-      expect(adapter._needsDeallocateAllForTest(taggedClient!)).toBe(true);
-
-      // Capture the next pg.PoolClient and its query() call list so we
-      // can assert DEALLOCATE ALL ran during checkout. Use vi.spyOn
-      // (consistent with other tests in this repo, e.g.
-      // postgresql-adapter.exec-query.test.ts) so cleanup is automatic
-      // via vi.restoreAllMocks() and we don't manually reassign methods.
-      const observed: string[] = [];
-      const pool = adapter._driverPoolForTest()!;
-      const originalConnect = pool.connect.bind(pool);
-      vi.spyOn(pool, "connect").mockImplementation((async (...args: unknown[]) => {
-        const client = (await (originalConnect as (...a: unknown[]) => Promise<pg.PoolClient>)(
-          ...args,
-        )) as unknown as { query: (...a: unknown[]) => unknown };
-        const origQuery = client.query.bind(client);
-        client.query = (sql: unknown, ...rest: unknown[]) => {
-          if (typeof sql === "string") observed.push(sql);
-          return (origQuery as (...a: unknown[]) => unknown)(sql, ...rest);
-        };
-        return client as unknown as pg.PoolClient;
-      }) as unknown as typeof pool.connect);
-
-      await adapter.beginDbTransaction();
+      //
+      // Use a dedicated pool-size-1 adapter so pg.Pool always hands
+      // back the same physical client on re-checkout — makes the
+      // DEALLOCATE-before-BEGIN assertion deterministic. The shared
+      // `adapter` from beforeEach uses pg.Pool's default max (10) and
+      // could hand back a different client, weakening the assertion.
+      const max1 = new PostgreSQLAdapter({ connectionString: PG_TEST_URL, max: 1 });
+      max1.preparedStatements = true;
       try {
-        // The DEALLOCATE ALL fires before BEGIN — but only when
-        // pg.Pool hands back the SAME physical client (the only one
-        // we tagged). With pool size > 1, a different client may be
-        // returned and the tag stays attached for its eventual reuse.
-        // Either way, the new client is no longer tagged after this
-        // checkout (drain ran or it wasn't the tagged one).
-        const newClient = adapter._currentClientForTest();
-        expect(adapter._needsDeallocateAllForTest(newClient!)).toBe(false);
-        if (newClient === taggedClient) {
+        await max1.beginDbTransaction();
+        await max1.execute("SELECT $1::int", [1]);
+        await max1.execute("SELECT $1::text", ["a"]);
+        await max1.rollback();
+        // Capture the released client BEFORE clearCacheBang — its
+        // finally block nulls _lastReleasedTxnClient (so a post-clear
+        // _lastReleasedClientForTest() would return null and the
+        // tag check would silently fail with `WeakSet.has(null)` → false).
+        const taggedClient = max1._lastReleasedClientForTest();
+        expect(taggedClient).not.toBeNull();
+        max1.clearCacheBang();
+        expect(max1._needsDeallocateAllForTest(taggedClient!)).toBe(true);
+
+        // vi.spyOn both pool.connect AND the returned client's query
+        // so vi.restoreAllMocks() handles cleanup for both.
+        const observed: string[] = [];
+        const pool = max1._driverPoolForTest()!;
+        const originalConnect = pool.connect.bind(pool);
+        vi.spyOn(pool, "connect").mockImplementation((async (...args: unknown[]) => {
+          const client = await (originalConnect as (...a: unknown[]) => Promise<pg.PoolClient>)(
+            ...args,
+          );
+          const origQuery = client.query.bind(client);
+          vi.spyOn(client, "query").mockImplementation(((sql: unknown, ...rest: unknown[]) => {
+            if (typeof sql === "string") observed.push(sql);
+            return (origQuery as (...a: unknown[]) => unknown)(sql, ...rest);
+          }) as typeof client.query);
+          return client;
+        }) as unknown as typeof pool.connect);
+
+        await max1.beginDbTransaction();
+        try {
+          // max:1 guarantees pg.Pool returned the same physical client.
+          const newClient = max1._currentClientForTest();
+          expect(newClient).toBe(taggedClient);
+          // Drain ran → no longer tagged.
+          expect(max1._needsDeallocateAllForTest(newClient!)).toBe(false);
+          // DEALLOCATE ALL fired BEFORE BEGIN.
           expect(observed).toContain("DEALLOCATE ALL");
-          // DEALLOCATE ALL must run BEFORE BEGIN.
           const deallocIdx = observed.indexOf("DEALLOCATE ALL");
           const beginIdx = observed.indexOf("BEGIN");
           expect(deallocIdx).toBeGreaterThanOrEqual(0);
           expect(beginIdx).toBeGreaterThan(deallocIdx);
+        } finally {
+          await max1.rollback();
         }
       } finally {
-        await adapter.rollback();
+        await max1.close();
       }
     });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -84,6 +84,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private set _lastReleasedTxnClient(client: pg.PoolClient | null) {
     this._lastReleasedTxnClientRef = client == null ? null : new WeakRef(client);
   }
+  // Clients tagged for `DEALLOCATE ALL` on next checkout. Set by the
+  // released-client `reset()` branch of `clearCacheBang` — that path
+  // drops the local sql→name map but can't fire DEALLOCATE on a
+  // released session, so server-side PREPAREs leak. When pg.Pool
+  // hands the same physical client back later, `beginTransaction`
+  // checks this set and runs `DEALLOCATE ALL` before user code, draining
+  // those orphans. WeakSet so pg.Pool reaping the client GCs the entry.
+  private _clientsNeedingDeallocateAll = new WeakSet<pg.PoolClient>();
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
   private _statementLimit = 1000;
@@ -745,6 +753,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     this._client = await this._driverPool.connect();
     try {
+      // Drain any server-side prepared statements that a prior PSCE
+      // event left orphaned on this physical session. The released-
+      // client `reset()` path in `clearCacheBang` couldn't fire
+      // DEALLOCATE because the client was checked back into the pool;
+      // tag-on-reset + drain-on-checkout is the deferred half. If
+      // `DEALLOCATE ALL` itself fails, propagate to the BEGIN catch
+      // below so the (broken) client is discarded with the error.
+      if (this._clientsNeedingDeallocateAll.has(this._client)) {
+        this._clientsNeedingDeallocateAll.delete(this._client);
+        await this._client.query("DEALLOCATE ALL");
+      }
       await this._client.query("BEGIN");
       this._inTransaction = true;
       // Note: do NOT null `_lastReleasedTxnClient` here. After-rollback
@@ -1047,6 +1066,26 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return client ? this._statementPools.get(client) : undefined;
   }
 
+  /** @internal — the most recently released txn client (deref'd once). */
+  _lastReleasedClientForTest(): pg.PoolClient | null {
+    return this._lastReleasedTxnClient;
+  }
+
+  /** @internal — the currently-held txn client. */
+  _currentClientForTest(): pg.PoolClient | null {
+    return this._client;
+  }
+
+  /** @internal — whether a client is tagged for DEALLOCATE ALL on next checkout. */
+  _needsDeallocateAllForTest(client: pg.PoolClient): boolean {
+    return this._clientsNeedingDeallocateAll.has(client);
+  }
+
+  /** @internal — underlying pg.Pool, for test instrumentation. */
+  _driverPoolForTest(): pg.Pool | null {
+    return this._driverPool;
+  }
+
   /**
    * Clear cached prepared statements on the currently-held transaction
    * client. Mirrors Rails' `PostgreSQLAdapter#clear_cache!` which
@@ -1089,8 +1128,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // in the pool and call `exec_prepared(staleName)`, hitting
           // the same PSCE error again. `reset()` forces re-PREPARE
           // with a fresh name (counter never resets, so no collision
-          // with the orphaned server-side statement).
+          // with the orphaned server-side statement). Tag the client
+          // so the next checkout (in `beginTransaction`) runs
+          // `DEALLOCATE ALL` to drain the orphaned server-side
+          // statements left behind by the local-only reset.
           this._statementPools.get(lastReleased)?.reset();
+          this._clientsNeedingDeallocateAll.add(lastReleased);
         }
       } finally {
         this._lastReleasedTxnClient = null;
@@ -1102,19 +1145,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // (via StatementPool's pg-specific dealloc override).
       this._statementPools.get(currentClient)?.clear();
     }
-    // Trade-off (follow-up) for the released-client `reset()` path
-    // above: we can't fire DEALLOCATE on a released client, so
-    // server-side PREPAREs persist until the connection is recycled.
-    // Repeated PSCE on the same physical client could accumulate
-    // orphaned server statements beyond what statement_limit / LRU
-    // would normally evict (we discarded the local entries that drive
-    // eviction). Our per-pool counter never resets, so name collisions
-    // are impossible — but memory on the server session grows. The
-    // proper fix is to tag the released client (per-client WeakMap
-    // flag) and have the next checkout run `DEALLOCATE ALL` (or
-    // `DISCARD ALL`) before user code; that requires a pool-checkout
-    // interception not wired here. Tracked as a follow-up; this PR's
-    // scope is the `after_failure_actions` hook itself.
+    // Server-side accumulation note: the released-client `reset()`
+    // path above only drops the local sql→name map. Server-side
+    // PREPAREs are drained by `_clientsNeedingDeallocateAll` +
+    // `DEALLOCATE ALL` on next checkout (see beginTransaction). Until
+    // that checkout happens, the orphans live on the idle pg.PoolClient.
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -430,15 +430,26 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async getClient(): Promise<pg.PoolClient> {
     if (this._client) return this._client;
+    return this._acquireFreshClient();
+  }
+
+  /**
+   * Acquire a fresh client from the pool and drain any orphaned
+   * server-side prepared statements left by a prior PSCE event. All
+   * direct pool checkouts MUST go through this helper so the drain
+   * guarantee holds for every code path (getClient, beginTransaction,
+   * getAdvisoryLock, etc.).
+   *
+   * On drain failure, the client is released with the error so node-
+   * postgres discards it, then the error propagates — callers don't
+   * have a client to release on this path.
+   */
+  private async _acquireFreshClient(): Promise<pg.PoolClient> {
     if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
     const client = await this._driverPool.connect();
     try {
       await this._maybeDrainOrphanedPreparedStatements(client);
     } catch (error) {
-      // The drain failed before we returned the client to the caller,
-      // so the caller has no chance to release it. Discard via
-      // release(err) so node-postgres doesn't put a broken socket back
-      // in the idle pool, then propagate.
       client.release(error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
@@ -449,8 +460,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * If `client` was tagged for `DEALLOCATE ALL` (by the released-client
    * `reset()` branch in `clearCacheBang`), drain its server-side
    * prepared statements before handing it to user code. Centralized
-   * here so EVERY checkout path benefits — `getClient` (non-txn via
-   * `withClient`) and `beginTransaction` both go through this.
+   * here so EVERY checkout path benefits, by routing all direct
+   * `pool.connect()` callers through `_acquireFreshClient` (which
+   * calls this).
    *
    * Failure of `DEALLOCATE ALL` propagates: the caller's existing
    * error path will release the (broken) client with the error so
@@ -778,15 +790,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
-    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
-    this._client = await this._driverPool.connect();
+    // Routes through `_acquireFreshClient` so the drain runs on every
+    // checkout (a tagged client returned here gets `DEALLOCATE ALL`'d
+    // before BEGIN). Drain failures are released-with-error inside
+    // the helper, so a thrown drain doesn't leak `_client`.
+    this._client = await this._acquireFreshClient();
     try {
-      // Drain any server-side prepared statements that a prior PSCE
-      // event left orphaned on this physical session (released-client
-      // `reset()` path in `clearCacheBang` tagged it). Failure
-      // propagates to the BEGIN catch below — the broken client is
-      // discarded via `release(err)`.
-      await this._maybeDrainOrphanedPreparedStatements(this._client);
       await this._client.query("BEGIN");
       this._inTransaction = true;
       // Note: do NOT null `_lastReleasedTxnClient` here. After-rollback
@@ -1171,8 +1180,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Server-side accumulation note: the released-client `reset()`
     // path above only drops the local sql→name map. Server-side
     // PREPAREs are drained by `_clientsNeedingDeallocateAll` +
-    // `DEALLOCATE ALL` on next checkout (see beginTransaction). Until
-    // that checkout happens, the orphans live on the idle pg.PoolClient.
+    // `DEALLOCATE ALL` on next checkout (any path that goes through
+    // `_acquireFreshClient` — getClient / beginTransaction /
+    // getAdvisoryLock / etc.). Until that checkout happens, the
+    // orphans live on the idle pg.PoolClient.
   }
 
   /**
@@ -1345,8 +1356,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _advisoryLockClient: pg.PoolClient | null = null;
 
   async getAdvisoryLock(lockId: number | string): Promise<boolean> {
-    if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
-    const client = await this._driverPool.connect();
+    const client = await this._acquireFreshClient();
     try {
       const isNumeric = typeof lockId === "number";
       const sql = `SELECT pg_try_advisory_lock(${isNumeric ? "$1" : "hashtext($1)"}) AS locked`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -84,13 +84,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private set _lastReleasedTxnClient(client: pg.PoolClient | null) {
     this._lastReleasedTxnClientRef = client == null ? null : new WeakRef(client);
   }
-  // Clients tagged for `DEALLOCATE ALL` on next checkout. Set by the
-  // released-client `reset()` branch of `clearCacheBang` — that path
-  // drops the local sql→name map but can't fire DEALLOCATE on a
-  // released session, so server-side PREPAREs leak. When pg.Pool
-  // hands the same physical client back later, `beginTransaction`
-  // checks this set and runs `DEALLOCATE ALL` before user code, draining
-  // those orphans. WeakSet so pg.Pool reaping the client GCs the entry.
+  // Clients tagged for `DEALLOCATE ALL` on the next fresh checkout.
+  // Set by the released-client `reset()` branch of `clearCacheBang` —
+  // that path drops the local sql→name map but can't fire DEALLOCATE
+  // on a released session, so server-side PREPAREs leak. When pg.Pool
+  // hands the same physical client back later, `_acquireFreshClient`
+  // checks this set and runs `DEALLOCATE ALL` before user code, so
+  // any fresh checkout path (e.g. `getClient`, `getAdvisoryLock`,
+  // `beginTransaction`) drains those orphans. WeakSet so pg.Pool
+  // reaping the client GCs the entry.
   private _clientsNeedingDeallocateAll = new WeakSet<pg.PoolClient>();
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
@@ -1161,7 +1163,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // the same PSCE error again. `reset()` forces re-PREPARE
           // with a fresh name (counter never resets, so no collision
           // with the orphaned server-side statement). Tag the client
-          // so the next checkout (in `beginTransaction`) runs
+          // so the next checkout through `_acquireFreshClient` runs
           // `DEALLOCATE ALL` to drain the orphaned server-side
           // statements left behind by the local-only reset.
           this._statementPools.get(lastReleased)?.reset();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -431,7 +431,35 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private async getClient(): Promise<pg.PoolClient> {
     if (this._client) return this._client;
     if (!this._driverPool) throw new Error("PostgreSQLAdapter: connection is closed");
-    return this._driverPool.connect();
+    const client = await this._driverPool.connect();
+    try {
+      await this._maybeDrainOrphanedPreparedStatements(client);
+    } catch (error) {
+      // The drain failed before we returned the client to the caller,
+      // so the caller has no chance to release it. Discard via
+      // release(err) so node-postgres doesn't put a broken socket back
+      // in the idle pool, then propagate.
+      client.release(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+    return client;
+  }
+
+  /**
+   * If `client` was tagged for `DEALLOCATE ALL` (by the released-client
+   * `reset()` branch in `clearCacheBang`), drain its server-side
+   * prepared statements before handing it to user code. Centralized
+   * here so EVERY checkout path benefits — `getClient` (non-txn via
+   * `withClient`) and `beginTransaction` both go through this.
+   *
+   * Failure of `DEALLOCATE ALL` propagates: the caller's existing
+   * error path will release the (broken) client with the error so
+   * node-postgres discards it.
+   */
+  private async _maybeDrainOrphanedPreparedStatements(client: pg.PoolClient): Promise<void> {
+    if (!this._clientsNeedingDeallocateAll.has(client)) return;
+    this._clientsNeedingDeallocateAll.delete(client);
+    await client.query("DEALLOCATE ALL");
   }
 
   /**
@@ -754,16 +782,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._client = await this._driverPool.connect();
     try {
       // Drain any server-side prepared statements that a prior PSCE
-      // event left orphaned on this physical session. The released-
-      // client `reset()` path in `clearCacheBang` couldn't fire
-      // DEALLOCATE because the client was checked back into the pool;
-      // tag-on-reset + drain-on-checkout is the deferred half. If
-      // `DEALLOCATE ALL` itself fails, propagate to the BEGIN catch
-      // below so the (broken) client is discarded with the error.
-      if (this._clientsNeedingDeallocateAll.has(this._client)) {
-        this._clientsNeedingDeallocateAll.delete(this._client);
-        await this._client.query("DEALLOCATE ALL");
-      }
+      // event left orphaned on this physical session (released-client
+      // `reset()` path in `clearCacheBang` tagged it). Failure
+      // propagates to the BEGIN catch below — the broken client is
+      // discarded via `release(err)`.
+      await this._maybeDrainOrphanedPreparedStatements(this._client);
       await this._client.query("BEGIN");
       this._inTransaction = true;
       // Note: do NOT null `_lastReleasedTxnClient` here. After-rollback


### PR DESCRIPTION
## Summary

Closes the follow-up gap from #633. The released-client `reset()` branch in `clearCacheBang` drops the local sql→name map but can't fire DEALLOCATE on a session it doesn't own — server-side PREPAREs leak on the idle pg.PoolClient until the connection is recycled.

This PR adds tag-on-reset + drain-on-checkout:

- New `_clientsNeedingDeallocateAll: WeakSet<pg.PoolClient>` (WeakSet so pg.Pool can still GC reaped clients).
- The released-client `reset()` branch in `clearCacheBang` now adds the client to the set.
- `beginTransaction`, after `pool.connect()`, checks the returned client. If tagged: delete from set, run `DEALLOCATE ALL`, then proceed to BEGIN. Failure of `DEALLOCATE ALL` propagates to the existing BEGIN catch — the (broken) client is released with the error so node-postgres discards it.

Net effect: server-side PREPAREs no longer accumulate across repeated PSCE events on the same physical client. The drain is bounded to one `DEALLOCATE ALL` per affected client per checkout cycle.

## Test plan

- [x] Full activerecord suite: 8664 passed locally
- [ ] PG CI runs the new regression test (skips without PG_TEST_URL): asserts the client is tagged after rollback+clearCacheBang, untagged on next checkout, and — when pg.Pool re-checks-out the same physical client — that DEALLOCATE ALL ran before BEGIN.