### PR TITLE
feat(activemodel): ValueType<T> restores subclass types; DecimalType preserves precision

### DIFF
--- a/packages/activemodel/src/misc.test.ts
+++ b/packages/activemodel/src/misc.test.ts
@@ -929,7 +929,12 @@ describe("ActiveModel", () => {
       });
 
       it("type cast decimal from invalid string", () => {
-        expect(type.cast("not-a-number")).toBe(null);
+        // Mirrors Rails decimal_test.rb — "" nils out; leading-numeric
+        // prefix is kept; no-numeric-prefix returns BigDecimal(0).
+        expect(type.cast("")).toBe(null);
+        expect(type.cast("1ignore")).toBe("1");
+        expect(type.cast("bad1")).toBe("0");
+        expect(type.cast("bad")).toBe("0");
       });
     });
 

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -3,7 +3,7 @@ import { ValueType } from "./value.js";
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-export class BinaryType extends ValueType {
+export class BinaryType extends ValueType<Uint8Array> {
   readonly name = "binary";
 
   cast(value: unknown): Uint8Array | null {

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class BooleanType extends ValueType {
+export class BooleanType extends ValueType<boolean> {
   readonly name = "boolean";
 
   private static readonly TRUE_VALUES: ReadonlySet<unknown> = new Set([

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class DateTimeType extends ValueType {
+export class DateTimeType extends ValueType<Date> {
   readonly name: string = "datetime";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class DateType extends ValueType {
+export class DateType extends ValueType<Date> {
   readonly name: string = "date";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -39,8 +39,14 @@ describe("DecimalTest", () => {
   });
 
   it("type cast decimal from invalid string", () => {
+    // Mirrors Rails' decimal_test.rb#test_type_cast_decimal_from_invalid_string:
+    // empty string -> nil, leading-numeric prefix keeps the prefix,
+    // non-numeric leading chars return BigDecimal(0).
     const type = new Types.DecimalType();
-    expect(type.cast("not-a-number")).toBe(null);
+    expect(type.cast("")).toBe(null);
+    expect(type.cast("1ignore")).toBe("1");
+    expect(type.cast("bad1")).toBe("0");
+    expect(type.cast("bad")).toBe("0");
   });
 
   it("changed?", () => {

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -3,10 +3,33 @@ import { ValueType } from "./value.js";
 export class DecimalType extends ValueType<string> {
   readonly name: string = "decimal";
 
+  // JS has no BigDecimal, so we represent decimals as strings to avoid
+  // losing precision through IEEE-754 floats. Rails' `cast_value`:
+  //   - Numeric  -> BigDecimal(value)
+  //   - String   -> value.to_d  (returns BigDecimal(0) on invalid)
+  //   - nil      -> nil
+  // We mirror the same shape, returning the string form rather than a
+  // BigDecimal wrapper.
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;
-    const n = Number(value);
-    return isNaN(n) ? null : n.toString();
+    if (typeof value === "bigint") return value.toString();
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) return null;
+      // `String(0.1)` -> "0.1" — as precise as JS can represent the
+      // input. Callers who need full precision should pass a string.
+      return String(value);
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") return null;
+      // Rails' `String#to_d` parses a leading numeric prefix and
+      // silently drops everything after, returning `BigDecimal(0)` if
+      // no leading number is present. Tests assert, e.g.,
+      // `"1ignore" -> BigDecimal("1")`, `"bad" -> BigDecimal("0")`.
+      const match = trimmed.match(/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?/);
+      return match ? match[0] : "0";
+    }
+    return null;
   }
 
   type(): string {

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class DecimalType extends ValueType {
+export class DecimalType extends ValueType<string> {
   readonly name: string = "decimal";
 
   cast(value: unknown): string | null {

--- a/packages/activemodel/src/type/float.ts
+++ b/packages/activemodel/src/type/float.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class FloatType extends ValueType {
+export class FloatType extends ValueType<number> {
   readonly name = "float";
 
   cast(value: unknown): number | null {

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class ImmutableStringType extends ValueType {
+export class ImmutableStringType extends ValueType<string> {
   readonly name: string = "immutable_string";
 
   constructor(options?: { precision?: number; scale?: number; limit?: number }) {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class IntegerType extends ValueType {
+export class IntegerType extends ValueType<number> {
   readonly name: string = "integer";
   private readonly _range: [number, number];
 

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,6 +1,6 @@
 import { ValueType } from "./value.js";
 
-export class TimeType extends ValueType {
+export class TimeType extends ValueType<Date> {
   readonly name = "time";
 
   cast(value: unknown): Date | null {

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -84,11 +84,13 @@ export abstract class Type<T = unknown> {
   }
 }
 
-export class ValueType extends Type<unknown> {
+export class ValueType<T = unknown> extends Type<T> {
   readonly name: string = "value";
 
-  cast(value: unknown): unknown {
-    return value;
+  cast(value: unknown): T | null {
+    // No-op default: pass the value through. Subclasses narrow by
+    // overriding `cast` with a concrete return type.
+    return value as T | null;
   }
 
   equals(other: Type): boolean {

--- a/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
+++ b/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
@@ -1,0 +1,56 @@
+import { describe, it, expectTypeOf } from "vitest";
+import {
+  ValueType,
+  IntegerType,
+  BooleanType,
+  DateType,
+  FloatType,
+  ImmutableStringType,
+  StringType,
+  BinaryType,
+} from "@blazetrails/activemodel";
+
+// Regression guard for the ValueType<T> refactor — inherited methods on
+// concrete subclasses must return the concrete narrowed type, not
+// `unknown`. Before `ValueType<T = unknown>` was introduced, extending
+// `ValueType` without a type parameter silently leaked `unknown` back
+// into every subclass's cast / deserialize / serialize surface.
+
+describe("ValueType<T> type parameter flows into concrete subclasses", () => {
+  it("IntegerType#cast narrows to number | null", () => {
+    const t = new IntegerType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<number | null>();
+  });
+
+  it("BooleanType#cast narrows to boolean | null", () => {
+    const t = new BooleanType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<boolean | null>();
+  });
+
+  it("DateType#cast narrows to Date | null", () => {
+    const t = new DateType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<Date | null>();
+  });
+
+  it("FloatType#cast narrows to number | null", () => {
+    const t = new FloatType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<number | null>();
+  });
+
+  it("BinaryType#cast narrows to Uint8Array | null", () => {
+    const t = new BinaryType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<Uint8Array | null>();
+  });
+
+  it("ImmutableStringType and StringType narrow to string | null", () => {
+    const a = new ImmutableStringType();
+    const b = new StringType();
+    expectTypeOf(a.cast(0)).toEqualTypeOf<string | null>();
+    expectTypeOf(b.cast(0)).toEqualTypeOf<string | null>();
+  });
+
+  it("bare ValueType defaults to unknown | null", () => {
+    const t = new ValueType();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<unknown>();
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #637's Copilot review + a DecimalType precision fix caught during review.

### 1. \`ValueType<T = unknown>\`

#637 landed the Rails-faithful \`concrete type extends ValueType\` shape, but silently regressed the TS surface: before, \`IntegerType extends Type<number>\` meant inherited methods like \`deserialize()\` returned \`number | null\`; after, \`IntegerType extends ValueType\` collapsed that to \`unknown | null\` via \`ValueType extends Type<unknown>\`.

Parameterise \`ValueType<T = unknown>\` and pipe the cast target through from each concrete subclass. Rails shape preserved (still \`extends ValueType\`, matching \`class Integer < Value\`), TS types restored:

- BinaryType<Uint8Array>
- BooleanType<boolean>
- DateType<Date>, DateTimeType<Date>, TimeType<Date>
- FloatType<number>, IntegerType<number>
- ImmutableStringType<string> (StringType inherits)
- DecimalType<string>

Added a 7-assertion \`.test-d.ts\` regression guard so this can't silently come back.

### 2. DecimalType precision

Existing \`cast\` body routed everything through \`Number(value)\` then \`.toString()\` — so the declared \`string\` return type was a lossy float in string clothing. Anything outside IEEE-754 range (16+ significant digits, large exponents) got silently truncated.

Match Rails' \`Type::Decimal#cast_value\`:

- \`nil\` → \`nil\`
- \`bigint\` → \`String(value)\`
- finite \`number\` → \`String(value)\` (precise to whatever JS can represent)
- \`string\` → trim; parse leading numeric prefix (what Ruby's \`String#to_d\` does); return prefix verbatim, or \`"0"\` when no leading digits
- other → \`null\`

Tests updated to mirror Rails' \`decimal_test.rb#test_type_cast_decimal_from_invalid_string\` (\`"" → nil\`, \`"1ignore" → "1"\`, \`"bad1" → "0"\`, \`"bad" → "0"\`).

## Test plan
- [x] \`pnpm run build\` clean across the whole monorepo.
- [x] \`pnpm vitest run packages/activemodel packages/activerecord\` — 10,036 pass, no regressions.
- [x] \`pnpm test:types\` — 70 pass, including the 7 new DX assertions.
- [x] \`pnpm api:compare --package activemodel\` — 40/41 (97.6%) inheritance, unchanged.