### PR TITLE
feat(activerecord): memoize Association#associationScope (Rails @association_scope)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -3,6 +3,7 @@ import { Table as ArelTable } from "@blazetrails/arel";
 import { CollectionProxy, type AssociationProxy } from "./associations/collection-proxy.js";
 import { StrictLoadingViolationError, ConfigurationError } from "./errors.js";
 import {
+  AssociationNotFoundError,
   DeleteRestrictionError,
   InverseOfAssociationNotFoundError,
   HasOneThroughNestedAssociationsAreReadonly,
@@ -389,11 +390,17 @@ function _builtAssociationScope(
   if (typeof assocFn === "function") {
     try {
       instance = assocFn.call(record, assocName) as typeof instance;
-    } catch {
-      // Association registry mismatch (e.g. low-level test fixtures
-      // that bypass `Associations.hasMany.call`); fall through to the
-      // fresh-build path so callers still work.
-      instance = undefined;
+    } catch (e) {
+      // Only swallow the "association not registered" case (low-level
+      // test fixtures that bypass `Associations.hasMany.call`). Real
+      // bugs in instance construction must surface — otherwise the
+      // fresh-build fallback would silently mask them and callers
+      // would see mysterious behavior changes.
+      if (e instanceof AssociationNotFoundError) {
+        instance = undefined;
+      } else {
+        throw e;
+      }
     }
   }
   if (instance && !instance.disableJoins && typeof instance.associationScope === "function") {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -377,11 +377,25 @@ function _builtAssociationScope(
   reflection: unknown,
   targetModel: typeof Base,
 ): unknown {
-  const instance = (
-    record as { _associationInstances?: Map<string, unknown> }
-  )._associationInstances?.get(assocName) as
-    | { disableJoins?: boolean; associationScope?: () => unknown }
-    | undefined;
+  // Materialize the Association instance if missing — proxy paths
+  // (CollectionProxy, AssociationProxy) call loaders directly without
+  // first going through `record.association(name)`, so an instance-
+  // only cache wouldn't hit in the common case. Rails caches on the
+  // Association instance too, but Rails' proxy IS the Association so
+  // the instance always exists. Calling `record.association(name)`
+  // here bridges that gap.
+  let instance: { disableJoins?: boolean; associationScope?: () => unknown } | undefined;
+  const assocFn = (record as { association?: (n: string) => unknown }).association;
+  if (typeof assocFn === "function") {
+    try {
+      instance = assocFn.call(record, assocName) as typeof instance;
+    } catch {
+      // Association registry mismatch (e.g. low-level test fixtures
+      // that bypass `Associations.hasMany.call`); fall through to the
+      // fresh-build path so callers still work.
+      instance = undefined;
+    }
+  }
   if (instance && !instance.disableJoins && typeof instance.associationScope === "function") {
     return instance.associationScope();
   }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -355,6 +355,43 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
   return true;
 }
 
+/**
+ * Build (or return cached) base AssociationScope. When the owner has
+ * a registered `Association` instance for this name, route through
+ * its `associationScope()` so calls hit Rails' `@association_scope`-
+ * style memoization (cleared on `reload()`). Without an instance,
+ * fall back to a fresh `AssociationScope.scope(...)` build — matches
+ * test paths that exercise loaders without going through
+ * `record.association(name)`.
+ *
+ * Disable-joins associations bypass the cache (Rails' `Association#scope`
+ * creates a fresh `DisableJoinsAssociationScope` per call,
+ * association.rb:107-117). The disableJoins routing is already
+ * handled above this call site, so falling through to the fresh
+ * `AssociationScope.scope(...)` here only matters if a future caller
+ * stretches the contract.
+ */
+function _builtAssociationScope(
+  record: Base,
+  assocName: string,
+  reflection: unknown,
+  targetModel: typeof Base,
+): unknown {
+  const instance = (
+    record as { _associationInstances?: Map<string, unknown> }
+  )._associationInstances?.get(assocName) as
+    | { disableJoins?: boolean; associationScope?: () => unknown }
+    | undefined;
+  if (instance && !instance.disableJoins && typeof instance.associationScope === "function") {
+    return instance.associationScope();
+  }
+  return AssociationScope.scope({
+    owner: record,
+    reflection: reflection as never,
+    klass: targetModel,
+  });
+}
+
 async function _loadThroughViaDisableJoinsScope(
   record: Base,
   reflection: unknown,
@@ -488,11 +525,7 @@ export async function loadBelongsTo(
 
   let result: Base | null;
   if (reflection) {
-    const built = AssociationScope.scope({
-      owner: record,
-      reflection,
-      klass: targetModel,
-    }) as any;
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel) as any;
     const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
     let rel = baseRelation.merge(built);
     if (options.scope && options.scope !== (reflection as any).scope) {
@@ -622,11 +655,7 @@ export async function loadHasOne(
 
   let result: Base | null;
   if (reflection) {
-    const built = AssociationScope.scope({
-      owner: record,
-      reflection,
-      klass: targetModel,
-    }) as any;
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel) as any;
     const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
     let rel = baseRelation.merge(built);
     if (options.scope && options.scope !== (reflection as any).scope) {
@@ -841,11 +870,7 @@ export async function loadHasMany(
     // function. Callers like `loadHasManyThrough` synthesize a NEW
     // `options.scope` (wrapping with `sourceType` filtering) — those
     // must still run.
-    const built = AssociationScope.scope({
-      owner: record,
-      reflection,
-      klass: targetModel,
-    }) as any;
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel) as any;
     const baseRelation = (targetModel as any).scopeForAssociation?.() ?? (targetModel as any).all();
     rel = baseRelation.merge(built);
     if (options.scope && options.scope !== (reflection as any).scope) {

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -31,18 +31,31 @@ describe("Association scope cache", () => {
       this.attribute("title", "string");
     }
   }
+  class CacheComment extends Base {
+    static {
+      this.attribute("cache_post_id", "integer");
+      this.attribute("body", "string");
+    }
+  }
 
   beforeEach(() => {
     adapter = createTestAdapter();
     CacheAuthor.adapter = adapter;
     CachePost.adapter = adapter;
+    CacheComment.adapter = adapter;
     registerModel("CacheAuthor", CacheAuthor);
     registerModel("CachePost", CachePost);
+    registerModel("CacheComment", CacheComment);
     (CacheAuthor as any)._associations = [];
     (CachePost as any)._associations = [];
+    (CacheComment as any)._associations = [];
     Associations.hasMany.call(CacheAuthor, "cachePosts", {
       className: "CachePost",
       foreignKey: "cache_author_id",
+    });
+    Associations.hasMany.call(CachePost, "cacheComments", {
+      className: "CacheComment",
+      foreignKey: "cache_post_id",
     });
   });
 
@@ -80,22 +93,28 @@ describe("Association scope cache", () => {
   });
 
   it("disable_joins associations bypass the cache (fresh DJAS each call, Rails association.rb:107-117)", async () => {
-    Associations.hasMany.call(CacheAuthor, "cachePostsDj", {
-      className: "CachePost",
+    Associations.hasMany.call(CacheAuthor, "cacheCommentsDj", {
+      className: "CacheComment",
       through: "cachePosts",
-      source: "self",
+      source: "cacheComments",
       disableJoins: true,
     });
     const author = await CacheAuthor.create({ name: "A" });
-    const assoc = (author as any).association("cachePostsDj");
+    const post = await CachePost.create({ cache_author_id: author.id, title: "p" });
+    await CacheComment.create({ cache_post_id: post.id, body: "c" });
+    const assoc = (author as any).association("cacheCommentsDj");
     expect(assoc.disableJoins).toBe(true);
     // The associationScope() returns a Promise on the disableJoins
     // path (DJAS' boxed contract). The cache field stays untouched —
-    // verify that calling it twice yields two distinct Promises (fresh
-    // builds), matching Rails' per-call DJAS construction.
+    // calling it twice yields two distinct Promises (fresh builds),
+    // matching Rails' per-call DJAS construction. Await both so any
+    // scope-build failure surfaces as a test error rather than an
+    // unhandled rejection.
     const a = assoc.associationScope();
     const b = assoc.associationScope();
     expect(a).not.toBe(b);
+    await a;
+    await b;
   });
 
   it("loader paths hit the cache too (not just explicit record.association(name) calls)", async () => {

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Mirrors Rails' Association#association_scope memoization
+ * (activerecord/lib/active_record/associations/association.rb:300-308):
+ *
+ *     def association_scope
+ *       if klass
+ *         @association_scope ||= ...AssociationScope.scope(self)...
+ *       end
+ *     end
+ *
+ * Reset on init and on `reload()` via `reset_scope`.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations } from "../associations.js";
+import { AssociationScope } from "./association-scope.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("Association scope cache", () => {
+  let adapter: DatabaseAdapter;
+
+  class CacheAuthor extends Base {
+    static {
+      this.attribute("name", "string");
+    }
+  }
+  class CachePost extends Base {
+    static {
+      this.attribute("cache_author_id", "integer");
+      this.attribute("title", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    CacheAuthor.adapter = adapter;
+    CachePost.adapter = adapter;
+    registerModel("CacheAuthor", CacheAuthor);
+    registerModel("CachePost", CachePost);
+    (CacheAuthor as any)._associations = [];
+    (CachePost as any)._associations = [];
+    Associations.hasMany.call(CacheAuthor, "cachePosts", {
+      className: "CachePost",
+      foreignKey: "cache_author_id",
+    });
+  });
+
+  it("AssociationScope.scope is called once across repeated loads (memoized)", async () => {
+    const author = await CacheAuthor.create({ name: "A" });
+    await CachePost.create({ cache_author_id: author.id, title: "p1" });
+    await CachePost.create({ cache_author_id: author.id, title: "p2" });
+
+    const spy = vi.spyOn(AssociationScope, "scope");
+
+    // Materialize the Association instance so the cache path is taken.
+    const assoc = (author as any).association("cachePosts");
+    expect(assoc).toBeDefined();
+
+    await assoc.loadTarget();
+    const callsAfterFirst = spy.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    // Re-load via the same proxy; cached scope should serve.
+    await assoc.reload(); // resets cache + reloads
+    const callsAfterReload = spy.mock.calls.length;
+    expect(callsAfterReload).toBeGreaterThan(callsAfterFirst);
+
+    // Now do a load that should hit the cache (no reload between).
+    await assoc.loadTarget();
+    expect(spy.mock.calls.length).toBe(callsAfterReload);
+
+    spy.mockRestore();
+  });
+
+  it("disable_joins associations bypass the cache (fresh DJAS each call, Rails association.rb:107-117)", async () => {
+    Associations.hasMany.call(CacheAuthor, "cachePostsDj", {
+      className: "CachePost",
+      through: "cachePosts",
+      source: "self",
+      disableJoins: true,
+    });
+    const author = await CacheAuthor.create({ name: "A" });
+    const assoc = (author as any).association("cachePostsDj");
+    expect(assoc.disableJoins).toBe(true);
+    // The associationScope() returns a Promise on the disableJoins
+    // path (DJAS' boxed contract). The cache field stays untouched —
+    // verify that calling it twice yields two distinct Promises (fresh
+    // builds), matching Rails' per-call DJAS construction.
+    const a = assoc.associationScope();
+    const b = assoc.associationScope();
+    expect(a).not.toBe(b);
+  });
+
+  it("different owners get independent caches", async () => {
+    const a1 = await CacheAuthor.create({ name: "A1" });
+    const a2 = await CacheAuthor.create({ name: "A2" });
+    const assoc1 = (a1 as any).association("cachePosts");
+    const assoc2 = (a2 as any).association("cachePosts");
+    await assoc1.loadTarget();
+    await assoc2.loadTarget();
+    // Cache fields are per-instance; loading one doesn't pollute the other.
+    expect((assoc1 as any)._cachedAssociationScope).toBeDefined();
+    expect((assoc2 as any)._cachedAssociationScope).toBeDefined();
+    expect((assoc1 as any)._cachedAssociationScope).not.toBe(
+      (assoc2 as any)._cachedAssociationScope,
+    );
+  });
+});

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -10,7 +10,7 @@
  *
  * Reset on init and on `reload()` via `reset_scope`.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
@@ -46,6 +46,12 @@ describe("Association scope cache", () => {
     });
   });
 
+  // Restore spies even if a test throws — leaked spies on
+  // AssociationScope.scope can corrupt sibling tests in this file.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("AssociationScope.scope is called once across repeated scope builds (memoized)", async () => {
     // Test the scope cache directly: assert that calling
     // associationScope() twice on the same instance only invokes
@@ -71,8 +77,6 @@ describe("Association scope cache", () => {
     assoc.resetScope();
     assoc.associationScope();
     expect(spy.mock.calls.length).toBe(afterFirst + 1);
-
-    spy.mockRestore();
   });
 
   it("disable_joins associations bypass the cache (fresh DJAS each call, Rails association.rb:107-117)", async () => {
@@ -121,8 +125,6 @@ describe("Association scope cache", () => {
     // With our cache, AssociationScope.scope count is unchanged.
     await loadHasMany(author, "cachePosts", opts);
     expect(spy.mock.calls.length).toBe(afterFirst);
-
-    spy.mockRestore();
   });
 
   it("different owners get independent caches", async () => {

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -46,29 +46,31 @@ describe("Association scope cache", () => {
     });
   });
 
-  it("AssociationScope.scope is called once across repeated loads (memoized)", async () => {
+  it("AssociationScope.scope is called once across repeated scope builds (memoized)", async () => {
+    // Test the scope cache directly: assert that calling
+    // associationScope() twice on the same instance only invokes
+    // AssociationScope.scope once, and that resetScope() forces a
+    // rebuild. (Going through loadTarget/reload would be ambiguous —
+    // a second loadTarget short-circuits on the already-loaded target
+    // and never builds a scope, so the cache wouldn't be exercised.)
     const author = await CacheAuthor.create({ name: "A" });
     await CachePost.create({ cache_author_id: author.id, title: "p1" });
-    await CachePost.create({ cache_author_id: author.id, title: "p2" });
 
     const spy = vi.spyOn(AssociationScope, "scope");
-
-    // Materialize the Association instance so the cache path is taken.
     const assoc = (author as any).association("cachePosts");
-    expect(assoc).toBeDefined();
 
-    await assoc.loadTarget();
-    const callsAfterFirst = spy.mock.calls.length;
-    expect(callsAfterFirst).toBeGreaterThan(0);
+    assoc.associationScope();
+    const afterFirst = spy.mock.calls.length;
+    expect(afterFirst).toBe(1);
 
-    // Re-load via the same proxy; cached scope should serve.
-    await assoc.reload(); // resets cache + reloads
-    const callsAfterReload = spy.mock.calls.length;
-    expect(callsAfterReload).toBeGreaterThan(callsAfterFirst);
+    // Second call hits the cache — no new AssociationScope.scope call.
+    assoc.associationScope();
+    expect(spy.mock.calls.length).toBe(afterFirst);
 
-    // Now do a load that should hit the cache (no reload between).
-    await assoc.loadTarget();
-    expect(spy.mock.calls.length).toBe(callsAfterReload);
+    // resetScope() (called by reload()) clears the cache; next call rebuilds.
+    assoc.resetScope();
+    assoc.associationScope();
+    expect(spy.mock.calls.length).toBe(afterFirst + 1);
 
     spy.mockRestore();
   });

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -92,6 +92,37 @@ describe("Association scope cache", () => {
     expect(a).not.toBe(b);
   });
 
+  it("loader paths hit the cache too (not just explicit record.association(name) calls)", async () => {
+    // CollectionProxy / AssociationProxy call loadHasMany / loadHasOne
+    // directly without first calling `record.association(name)`. The
+    // cache must still apply — otherwise the common proxy path
+    // (e.g. `await blog.posts`) would rebuild the scope every time.
+    // `_builtAssociationScope` lazily materializes the Association
+    // instance to cover this case.
+    const { loadHasMany } = await import("../associations.js");
+    const author = await CacheAuthor.create({ name: "A" });
+    await CachePost.create({ cache_author_id: author.id, title: "p1" });
+    await CachePost.create({ cache_author_id: author.id, title: "p2" });
+
+    const spy = vi.spyOn(AssociationScope, "scope");
+    const opts = {
+      className: "CachePost",
+      foreignKey: "cache_author_id",
+    };
+
+    // First loader call populates the Association-instance cache.
+    await loadHasMany(author, "cachePosts", opts);
+    const afterFirst = spy.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Second loader call — different caches would rebuild the scope.
+    // With our cache, AssociationScope.scope count is unchanged.
+    await loadHasMany(author, "cachePosts", opts);
+    expect(spy.mock.calls.length).toBe(afterFirst);
+
+    spy.mockRestore();
+  });
+
   it("different owners get independent caches", async () => {
     const a1 = await CacheAuthor.create({ name: "A1" });
     const a2 = await CacheAuthor.create({ name: "A2" });

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -105,12 +105,23 @@ export class Association {
    * `AssociationScope` machinery. Mirrors Rails'
    * `Association#association_scope` (association.rb:300-308):
    * memoized for the JOIN-based path; fresh-each-call for
-   * `disable_joins` (the cache would mask owner FK snapshot
-   * dependencies on the chain walk).
+   * `disable_joins`.
    *
-   * Returns the **base** scope — caller is responsible for any
-   * additional `.where(...)` / `.order(...)` chaining (e.g.
-   * `options.scope`). The cache stores the unfiltered base only.
+   * Return shape:
+   *  - JOIN-based path: a `Relation` (the base scope). Caller is
+   *    responsible for any additional `.where(...)` / `.order(...)`
+   *    chaining (e.g. `options.scope`). The cache stores the
+   *    unfiltered base only.
+   *  - `disable_joins` path: a `Promise<{ relation }>` per DJAS' boxed
+   *    contract (the box dodges the Relation thenable when awaited).
+   *    Caller awaits + unwraps `.relation`.
+   *
+   * Cache contract (Rails-equivalent): the cached scope captures
+   * owner FK / polymorphic-type values at build time. Mutating the
+   * owner's FK after a first load does NOT invalidate the cache —
+   * Rails behaves the same (`@association_scope` only resets via
+   * `reset_scope`, called on init and `reload()`). Callers that
+   * mutate FKs and want a fresh query must `reload()`.
    */
   associationScope(): unknown {
     // `this.reflection` here is the lightweight AssociationDefinition

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -1,6 +1,7 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
 import { resolveModel, buildHasManyRelation } from "../associations.js";
+import { AssociationScope } from "./association-scope.js";
 import { camelize, singularize } from "@blazetrails/activesupport";
 
 /**
@@ -21,6 +22,16 @@ export class Association {
   target: Base | Base[] | null;
 
   private _staleState: unknown = undefined;
+  /**
+   * Memoized result of `associationScope()` — Rails' `@association_scope`
+   * (association.rb:300-308). Built lazily on first access; reset by
+   * `resetScope()` (called from `reload()` and on init). Skipped for
+   * `disable_joins` paths — Rails creates a fresh
+   * `DisableJoinsAssociationScope` per call (association.rb:107-117)
+   * because the scope's chain walk depends on owner FK snapshots that
+   * a long-lived cache would mask.
+   */
+  private _cachedAssociationScope: unknown = undefined;
 
   constructor(owner: Base, reflection: AssociationDefinition) {
     this.owner = owner;
@@ -86,7 +97,53 @@ export class Association {
   }
 
   resetScope(): void {
-    // Subclasses may cache the scope; reset any cached value.
+    this._cachedAssociationScope = undefined;
+  }
+
+  /**
+   * Build (or return cached) association scope via the
+   * `AssociationScope` machinery. Mirrors Rails'
+   * `Association#association_scope` (association.rb:300-308):
+   * memoized for the JOIN-based path; fresh-each-call for
+   * `disable_joins` (the cache would mask owner FK snapshot
+   * dependencies on the chain walk).
+   *
+   * Returns the **base** scope — caller is responsible for any
+   * additional `.where(...)` / `.order(...)` chaining (e.g.
+   * `options.scope`). The cache stores the unfiltered base only.
+   */
+  associationScope(): unknown {
+    // `this.reflection` here is the lightweight AssociationDefinition
+    // attached at macro time. AssociationScope needs the rich
+    // Reflection (with `chain`, `joinPrimaryKey`, etc.) that lives on
+    // the model class via `_reflectOnAssociation(name)`. Resolve once
+    // per call — the result is small and the cache stores the BUILT
+    // scope, not the reflection.
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => unknown;
+    };
+    const richReflection = ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection;
+    if (this.disableJoins) {
+      // Lazy import — DJAS' module pulls in
+      // disable-joins-association-relation → relation.ts → associations.ts,
+      // which transitively imports us. Dynamic import keeps the cycle
+      // safe. Returns a Promise<{relation}> per DJAS' boxed contract.
+      return import("./disable-joins-association-scope.js").then((m) =>
+        m.DisableJoinsAssociationScope.INSTANCE.scope({
+          owner: this.owner,
+          reflection: richReflection as never,
+          klass: this.klass as never,
+        }),
+      );
+    }
+    if (this._cachedAssociationScope === undefined) {
+      this._cachedAssociationScope = AssociationScope.scope({
+        owner: this.owner,
+        reflection: richReflection as never,
+        klass: this.klass as never,
+      });
+    }
+    return this._cachedAssociationScope;
   }
 
   /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -124,6 +124,12 @@ export class Association {
    * mutate FKs and want a fresh query must `reload()`.
    */
   associationScope(): unknown {
+    // Mirror Rails' `if klass` guard (association.rb:301): polymorphic
+    // belongs_to with a blank type column has no resolvable target
+    // class. Return undefined and skip caching so the next access
+    // (after the type column is set) builds a fresh scope.
+    const klass = this.klass as typeof Base | undefined;
+    if (!klass) return undefined;
     // `this.reflection` here is the lightweight AssociationDefinition
     // attached at macro time. AssociationScope needs the rich
     // Reflection (with `chain`, `joinPrimaryKey`, etc.) that lives on
@@ -143,7 +149,7 @@ export class Association {
         m.DisableJoinsAssociationScope.INSTANCE.scope({
           owner: this.owner,
           reflection: richReflection as never,
-          klass: this.klass as never,
+          klass: klass as never,
         }),
       );
     }
@@ -151,7 +157,7 @@ export class Association {
       this._cachedAssociationScope = AssociationScope.scope({
         owner: this.owner,
         reflection: richReflection as never,
-        klass: this.klass as never,
+        klass: klass as never,
       });
     }
     return this._cachedAssociationScope;


### PR DESCRIPTION
## Summary

PR 5a of the AssociationScope arc. Mirrors Rails' `Association#association_scope` memoization (`activerecord/lib/active_record/associations/association.rb:300-308`):

\`\`\`ruby
def association_scope
  if klass
    @association_scope ||= if disable_joins
      DisableJoinsAssociationScope.scope(self)
    else
      AssociationScope.scope(self)
    end
  end
end
\`\`\`

- New `_cachedAssociationScope` field on `Association` + `associationScope()` method that builds-and-caches the JOIN-based scope on first call.
- **Disable-joins is intentionally NOT cached** (Rails `association.rb:107-117` creates fresh DJAS per call — chain walk depends on owner FK snapshots).
- `resetScope()` (called from `reload()`) clears the cache.
- Loaders consult the Association instance via new `_builtAssociationScope` helper. Without an instance, fall back to fresh `AssociationScope.scope(...)` — keeps existing test fixtures working.
- All 3 loader call sites (loadBelongsTo / loadHasOne / loadHasMany) route through the helper.

## Test plan

- [x] 3 new tests in `association-scope-cache.test.ts` — repeated loads memoize, reload() resets, DJAS bypasses, per-owner caches independent.
- [x] Full `@blazetrails/activerecord` suite: 8667 passed locally.
- [ ] PG / MariaDB CI.