### PR TITLE
feat(activerecord): PG OID + AR types extend ValueType (+17 inheritance matches)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -5,7 +5,7 @@
  * (Rails: `class Array < Type::Value; include Helpers::Mutable`).
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 function stableStringify(value: unknown): string {
   try {
@@ -24,7 +24,7 @@ export interface ArraySubtype {
   map?(value: unknown, block?: (value: unknown) => unknown): unknown;
 }
 
-export class Array extends Type<unknown> {
+export class Array extends ValueType<unknown> {
   readonly name: string = "array";
   readonly subtype: ArraySubtype;
   readonly delimiter: string;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/bit.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/bit.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 export class Data {
   readonly value: string;
@@ -47,7 +47,7 @@ export class Data {
   }
 }
 
-export class Bit extends Type<string> {
+export class Bit extends ValueType<string> {
   readonly name: string = "bit";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -9,9 +9,9 @@
  * the consumer.
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
-export class Cidr extends Type<string> {
+export class Cidr extends ValueType<string> {
   readonly name: string = "cidr";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -6,9 +6,9 @@
  * def cast_value(value); value.to_s; end`.
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
-export class Enum extends Type<string> {
+export class Enum extends ValueType<string> {
   readonly name: string = "enum";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -9,13 +9,13 @@
  * dirty.
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 import { StringKeyedHashAccessor } from "../../../store.js";
 
 const HSTORE_ERROR = "Invalid Hstore document: %s";
 
-export class Hstore extends Type<Record<string, string | null>> {
+export class Hstore extends ValueType<Record<string, string | null>> {
   readonly name: string = "hstore";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -7,10 +7,10 @@
  * inspects the serialized form.
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 import { Duration } from "@blazetrails/activesupport";
 
-export class Interval extends Type<Duration> {
+export class Interval extends ValueType<Duration> {
   readonly name: string = "interval";
 
   constructor(options?: { precision?: number }) {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -4,8 +4,12 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::LegacyPoint
  */
 
-export class LegacyPoint {
-  get type(): string {
+import { ValueType } from "@blazetrails/activemodel";
+
+export class LegacyPoint extends ValueType<[number, number]> {
+  override readonly name: string = "point";
+
+  override type(): string {
     return "point";
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -10,7 +10,7 @@ export class LegacyPoint extends ValueType<[number, number]> {
   override readonly name: string = "point";
 
   override type(): string {
-    return "point";
+    return this.name;
   }
 
   cast(value: unknown): [number, number] | null {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/oid.ts
@@ -2,16 +2,14 @@
  * PostgreSQL OID type — object identifier.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Oid.
- * Rails: `class Oid < Type::UnsignedInteger`. We don't yet have an
- * UnsignedIntegerType in activemodel, so extend IntegerType and add a
- * signed-range rejection in cast to approximate unsigned semantics.
+ * Rails: `class Oid < Type::UnsignedInteger`.
  */
 
-import { IntegerType } from "@blazetrails/activemodel";
+import { UnsignedInteger } from "../../../type/unsigned-integer.js";
 
 const PG_OID_MAX = 0xffffffff;
 
-export class Oid extends IntegerType {
+export class Oid extends UnsignedInteger {
   override readonly name: string = "oid";
 
   constructor(options?: { limit?: number }) {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -8,7 +8,7 @@
  * struct) and the `Point` Type::Value (the OID class).
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 /**
  * Mirrors Rails' `ActiveRecord::Point = Struct.new(:x, :y)`.
@@ -23,7 +23,7 @@ export class PointValue {
   }
 }
 
-export class Point extends Type<PointValue> {
+export class Point extends ValueType<PointValue> {
   readonly name: string = "point";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -17,7 +17,7 @@
  *     the subtype and emits `Range` instances from `castValue`/`serialize`.
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 export class Range {
   readonly begin: unknown;
@@ -41,7 +41,7 @@ export interface RangeSubtype {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.
  */
-export class RangeType extends Type<Range> {
+export class RangeType extends ValueType<Range> {
   readonly name: string;
   readonly subtype: RangeSubtype;
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
 // Rails uses /\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z/ — a conditional
 // pattern that enforces balanced braces. JS regex has no conditional, so
@@ -21,7 +21,7 @@ export const CANONICAL_UUID = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/;
 export const ACCEPTABLE_UUID_REGEX =
   /^\{?[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\}?$/i;
 
-export class Uuid extends Type<string> {
+export class Uuid extends ValueType<string> {
   readonly name = "uuid";
 
   override type(): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/vector.ts
@@ -7,9 +7,9 @@
  * subtype.cast, but current Rails behavior is the raw passthrough).
  */
 
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 
-export class Vector extends Type<unknown> {
+export class Vector extends ValueType<unknown> {
   readonly name: string = "vector";
   readonly delim: string;
   readonly subtype: unknown;

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -1,4 +1,4 @@
-import { Type, StringType } from "@blazetrails/activemodel";
+import { Type, ValueType, StringType } from "@blazetrails/activemodel";
 import type { Scheme } from "./scheme.js";
 import type { Encryptor } from "./encryptor.js";
 import type { WrappedType } from "./wrapped-type.js";
@@ -13,7 +13,7 @@ import { Encryption as EncryptionError } from "./errors.js";
  *
  * Mirrors: ActiveRecord::Encryption::EncryptedAttributeType
  */
-export class EncryptedAttributeType extends Type implements WrappedType {
+export class EncryptedAttributeType extends ValueType implements WrappedType {
   readonly name = "encrypted";
   readonly scheme: Scheme;
   readonly castType: Type;

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -80,7 +80,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.encrypt(toEncrypt);
   }
 
-  changedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const oldValue = rawOldValue === null ? null : this.deserialize(rawOldValue);
     return oldValue !== newValue;
   }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -171,6 +171,14 @@ export class EnumType extends ValueType<string> {
     this.subtype = subtype;
   }
 
+  // Rails' EnumType does `delegate :type, to: :subtype` — callers that
+  // ask what an enum column's storage type is want the underlying
+  // column type (e.g. "integer"), not the enum's attribute name. Our
+  // subtype is already the type string, so return it directly.
+  override type(): string {
+    return this.subtype;
+  }
+
   cast(value: unknown): string | null {
     if (typeof value === "string" && this._mapping.has(value)) {
       return value;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
 import { camelize } from "@blazetrails/activesupport";
+import { ValueType } from "@blazetrails/activemodel";
 
 /**
  * Enum definition — maps symbolic names to integer values.
@@ -145,8 +146,8 @@ export function defineEnum(
  *
  * Mirrors: ActiveRecord::Enum::EnumType
  */
-export class EnumType {
-  private _name: string;
+export class EnumType extends ValueType<string> {
+  override readonly name: string;
   private _mapping: ReadonlyMap<string, number | string>;
   private _reverseMapping: ReadonlyMap<number | string, string>;
   private _raiseOnInvalidValues: boolean;
@@ -158,7 +159,8 @@ export class EnumType {
     subtype: string,
     raiseOnInvalidValues = true,
   ) {
-    this._name = name;
+    super();
+    this.name = name;
     this._mapping = mapping;
     const reverse = new Map<number | string, string>();
     for (const [k, v] of mapping) {
@@ -231,7 +233,7 @@ export class EnumType {
       const num = Number(value);
       if (!Number.isNaN(num) && this._reverseMapping.has(num)) return;
     }
-    throw new Error(`'${value}' is not a valid ${this._name}`);
+    throw new Error(`'${value}' is not a valid ${this.name}`);
   }
 }
 

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -1,5 +1,5 @@
 import type { Base } from "../base.js";
-import { Type } from "@blazetrails/activemodel";
+import { Type, ValueType } from "@blazetrails/activemodel";
 
 /**
  * Optimistic locking support for ActiveRecord models.
@@ -40,16 +40,14 @@ export function lockingEnabled(modelClass: typeof Base): boolean {
  *
  * Mirrors: ActiveRecord::Locking::LockingType
  */
-export class LockingType extends Type {
+export class LockingType extends ValueType<number> {
   private _subtype: Type;
+  override readonly name: string;
 
   constructor(subtype: Type) {
     super();
     this._subtype = subtype;
-  }
-
-  get name(): string {
-    return this._subtype.name;
+    this.name = subtype.name;
   }
 
   cast(value: unknown): number {

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -35,7 +35,7 @@ export class Json extends ValueType<unknown> {
     return ActiveSupportJSON.encode(value);
   }
 
-  changedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
+  override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     return this.serialize(this.deserialize(rawOldValue)) !== this.serialize(newValue);
   }
 }

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -1,10 +1,10 @@
 /**
  * Mirrors: ActiveRecord::Type::Json
  */
-import { Type } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 import { ActiveSupportJSON } from "@blazetrails/activesupport";
 
-export class Json extends Type<unknown> {
+export class Json extends ValueType<unknown> {
   readonly name = "json";
 
   cast(value: unknown): unknown {

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -1,4 +1,4 @@
-import { Type } from "@blazetrails/activemodel";
+import { Type, ValueType } from "@blazetrails/activemodel";
 
 export interface Coder {
   dump(value: unknown): string | null;
@@ -14,7 +14,7 @@ export interface Coder {
  *
  * Mirrors: ActiveRecord::Type::Serialized
  */
-export class Serialized extends Type {
+export class Serialized extends ValueType {
   readonly name = "serialized";
   readonly subtype: Type;
   readonly coder: Coder;

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -60,7 +60,7 @@ export class Serialized extends ValueType {
     return dumped;
   }
 
-  changedInPlace(rawOldValue: unknown, value: unknown): boolean {
+  override isChangedInPlace(rawOldValue: unknown, value: unknown): boolean {
     const oldSerialized = this.serialize(this.deserialize(rawOldValue));
     const newSerialized = this.serialize(value);
     return oldSerialized !== newSerialized;
@@ -72,11 +72,11 @@ export class Serialized extends ValueType {
     }
   }
 
-  forceEquality(value: unknown): boolean {
+  override isForceEquality(value: unknown): boolean {
     return this.coder.objectClass !== undefined && value instanceof this.coder.objectClass;
   }
 
-  get serialized(): boolean {
+  override isSerialized(): boolean {
     return true;
   }
 

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -1,5 +1,28 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { UnsignedInteger } from "./unsigned-integer.js";
 
 describe("UnsignedIntegerTest", () => {
   it.skip("serialize_cast_value enforces range", () => {});
+
+  it("cast rejects negative values (returns null)", () => {
+    // Rails' UnsignedInteger raises ActiveModel::RangeError when a
+    // negative value hits `ensure_in_range`; TS mirrors that as null so
+    // callers don't silently see a clamped zero.
+    const t = new UnsignedInteger();
+    expect(t.cast(-1)).toBeNull();
+    expect(t.cast("-7")).toBeNull();
+  });
+
+  it("cast preserves non-negative integers unchanged", () => {
+    const t = new UnsignedInteger();
+    expect(t.cast(0)).toBe(0);
+    expect(t.cast(42)).toBe(42);
+    expect(t.cast("17")).toBe(17);
+  });
+
+  it("cast propagates null/undefined", () => {
+    const t = new UnsignedInteger();
+    expect(t.cast(null)).toBeNull();
+    expect(t.cast(undefined)).toBeNull();
+  });
 });

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -25,4 +25,18 @@ describe("UnsignedIntegerTest", () => {
     expect(t.cast(null)).toBeNull();
     expect(t.cast(undefined)).toBeNull();
   });
+
+  it("isSerializable rejects negatives to stay in sync with cast", () => {
+    const t = new UnsignedInteger();
+    expect(t.isSerializable(-1)).toBe(false);
+    expect(t.isSerializable("-7")).toBe(false);
+  });
+
+  it("isSerializable accepts null and non-negative values", () => {
+    const t = new UnsignedInteger();
+    expect(t.isSerializable(null)).toBe(true);
+    expect(t.isSerializable(0)).toBe(true);
+    expect(t.isSerializable(42)).toBe(true);
+    expect(t.isSerializable("17")).toBe(true);
+  });
 });

--- a/packages/activerecord/src/type/unsigned-integer.test.ts
+++ b/packages/activerecord/src/type/unsigned-integer.test.ts
@@ -35,6 +35,7 @@ describe("UnsignedIntegerTest", () => {
   it("isSerializable accepts null and non-negative values", () => {
     const t = new UnsignedInteger();
     expect(t.isSerializable(null)).toBe(true);
+    expect(t.isSerializable(undefined)).toBe(true);
     expect(t.isSerializable(0)).toBe(true);
     expect(t.isSerializable(42)).toBe(true);
     expect(t.isSerializable("17")).toBe(true);

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -2,14 +2,19 @@ import { IntegerType } from "@blazetrails/activemodel";
 
 /**
  * Integer type that only allows unsigned (non-negative) values.
- * Values below 0 are clamped to 0.
  *
- * Mirrors: ActiveRecord::Type::UnsignedInteger
+ * Mirrors: ActiveRecord::Type::UnsignedInteger. Rails overrides
+ * `min_value` to `0` and lets `Integer#ensure_in_range` raise
+ * `ActiveModel::RangeError` when a negative slips through. In TS we
+ * return `null` for the same outcome — values < 0 cannot round-trip as
+ * unsigned, so cast rejects them outright (subclasses like PG's Oid
+ * layer their own range check on top without worrying that the parent
+ * silently clamps).
  */
 export class UnsignedInteger extends IntegerType {
   override cast(value: unknown): number | null {
     const result = super.cast(value);
     if (result === null) return null;
-    return result < 0 ? 0 : result;
+    return result < 0 ? null : result;
   }
 }

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -17,4 +17,11 @@ export class UnsignedInteger extends IntegerType {
     if (result === null) return null;
     return result < 0 ? null : result;
   }
+
+  // Keep serializability in sync with cast — negatives drop to null, so
+  // they aren't serializable. Inherited IntegerType.isSerializable only
+  // checks the signed range and would return true for small negatives.
+  override isSerializable(value: unknown): boolean {
+    return value === null || this.cast(value) !== null;
+  }
 }

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -22,6 +22,6 @@ export class UnsignedInteger extends IntegerType {
   // they aren't serializable. Inherited IntegerType.isSerializable only
   // checks the signed range and would return true for small negatives.
   override isSerializable(value: unknown): boolean {
-    return value === null || this.cast(value) !== null;
+    return value == null || this.cast(value) !== null;
   }
 }

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { nameMatches, superclassesMatch } from "./compare.js";
+import { nameMatches, superclassesMatch, resolveTsClassForRuby } from "./compare.js";
+import type { ClassInfo } from "./types.js";
+
+function cls(file: string, name: string, superclass?: string): ClassInfo {
+  return {
+    file,
+    name,
+    superclass,
+    includes: [],
+    extends: [],
+    instanceMethods: [],
+    classMethods: [],
+  };
+}
 
 describe("nameMatches", () => {
   it("matches identical names", () => {
@@ -104,5 +117,53 @@ describe("superclassesMatch", () => {
     // Only Table/Attribute/ValueType are on the intermediate whitelist.
     expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Type"], "Something")).toBe(false);
+  });
+});
+
+describe("resolveTsClassForRuby", () => {
+  const file = "type/integer.ts";
+
+  it("returns the direct-name match when it has a superclass", () => {
+    const direct = cls(file, "Integer", "Value");
+    const map = new Map([[`${file}::Integer`, direct]]);
+    expect(resolveTsClassForRuby("Integer", file, map)).toBe(direct);
+  });
+
+  it("falls back to an alias match when the direct name is absent", () => {
+    const aliased = cls(file, "IntegerType", "ValueType");
+    const map = new Map([[`${file}::IntegerType`, aliased]]);
+    expect(resolveTsClassForRuby("Integer", file, map)).toBe(aliased);
+  });
+
+  it("prefers an alias match with a super over a direct match without one", () => {
+    // Mirrors oid/range.ts: `Range` is a bare bounds helper (no super);
+    // `RangeType extends ValueType<Range>` is the real OID cast type.
+    const direct = cls("oid/range.ts", "Range"); // no super
+    const alias = cls("oid/range.ts", "RangeType", "ValueType");
+    const map = new Map([
+      ["oid/range.ts::Range", direct],
+      ["oid/range.ts::RangeType", alias],
+    ]);
+    expect(resolveTsClassForRuby("Range", "oid/range.ts", map)).toBe(alias);
+  });
+
+  it("keeps the direct match when it has a super, even if an alias also exists", () => {
+    const direct = cls(file, "Integer", "Value");
+    const alias = cls(file, "IntegerType", "ValueType");
+    const map = new Map([
+      [`${file}::Integer`, direct],
+      [`${file}::IntegerType`, alias],
+    ]);
+    expect(resolveTsClassForRuby("Integer", file, map)).toBe(direct);
+  });
+
+  it("honors TS_CLASS_RENAMES when neither direct nor alias match (e.g. Registry → TypeRegistry)", () => {
+    const renamed = cls("type/registry.ts", "TypeRegistry");
+    const map = new Map([["type/registry.ts::TypeRegistry", renamed]]);
+    expect(resolveTsClassForRuby("Registry", "type/registry.ts", map)).toBe(renamed);
+  });
+
+  it("returns undefined when nothing resolves", () => {
+    expect(resolveTsClassForRuby("Nothing", "nowhere.ts", new Map())).toBeUndefined();
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -180,10 +180,15 @@ export function nameMatches(rubyName: string, tsName: string): boolean {
 //   `Struct.new(...)`), TS roots them at `Node` for uniform AST walking.
 // - ActiveModel ValueType: Rails' `Value` has no super, TS adds an
 //   abstract `Type` above so subclasses can declare `abstract cast`.
+// - AR LockingType / Serialized: Rails uses `DelegateClass(Type::Value)`
+//   — a dynamic parent our extractor can't resolve (comes through as
+//   null). TS extends `ValueType` directly, which matches the intent.
 const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   ["Table", "Node"],
   ["Attribute", "Node"],
   ["ValueType", "Type"],
+  ["LockingType", "ValueType"],
+  ["Serialized", "ValueType"],
 ]);
 
 // Per-class TS renames that don't fit the systematic alias patterns
@@ -690,16 +695,22 @@ function main() {
         // the same rename aliases the superclass matcher uses — TS files
         // sometimes rename the class itself to avoid builtin collisions
         // (e.g. Rails' Type::Integer ↔ our type/integer.ts#IntegerType).
+        //
+        // If both a direct-name match and an alias match exist, prefer
+        // whichever has an actual superclass. This handles files that
+        // keep a query-value helper under the plain name while the true
+        // Rails-shape class lives under the alias (e.g. oid/range.ts
+        // with `class Range` for bounds + `class RangeType extends
+        // ValueType<Range>` for the OID type).
         let tsCls = tsByFileName.get(`${expectedTs}::${short}`);
+        const aliasMatches = TS_PARENT_ALIASES.map(({ transform }) =>
+          tsByFileName.get(`${expectedTs}::${transform(short)}`),
+        ).filter((c): c is ClassInfo => Boolean(c));
         if (!tsCls) {
-          for (const { transform } of TS_PARENT_ALIASES) {
-            const alias = transform(short);
-            const found = tsByFileName.get(`${expectedTs}::${alias}`);
-            if (found) {
-              tsCls = found;
-              break;
-            }
-          }
+          tsCls = aliasMatches[0];
+        } else if (!tsCls.superclass) {
+          const withSuper = aliasMatches.find((c) => Boolean(c.superclass));
+          if (withSuper) tsCls = withSuper;
         }
         if (!tsCls) {
           const rename = TS_CLASS_RENAMES[short];

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -202,6 +202,44 @@ const TS_CLASS_RENAMES: Record<string, string> = {
   Registry: "TypeRegistry",
 };
 
+/**
+ * Resolve the TS class that corresponds to a Ruby class. Tries, in order:
+ *
+ *   1. The direct short-name match in the expected file.
+ *   2. The Trails rename aliases (`Abstract<X>`, `Base<X>`,
+ *      `ActiveModel<X>`, `<X>Type`) in the same file.
+ *   3. Explicit per-class renames (TS_CLASS_RENAMES).
+ *
+ * When both (1) and (2) hit, prefer whichever declares a superclass —
+ * TS files sometimes keep a query-value helper under the plain Ruby
+ * name while the real Rails-shape class lives under the alias
+ * (`oid/range.ts`: the bounds helper `Range` + the OID cast type
+ * `RangeType extends ValueType<Range>`).
+ */
+export function resolveTsClassForRuby(
+  short: string,
+  expectedFile: string,
+  tsByFileName: Map<string, ClassInfo>,
+): ClassInfo | undefined {
+  const direct = tsByFileName.get(`${expectedFile}::${short}`);
+  const aliasMatches = TS_PARENT_ALIASES.map(({ transform }) =>
+    tsByFileName.get(`${expectedFile}::${transform(short)}`),
+  ).filter((c): c is ClassInfo => Boolean(c));
+
+  let resolved = direct;
+  if (!resolved) {
+    resolved = aliasMatches[0];
+  } else if (!resolved.superclass) {
+    const withSuper = aliasMatches.find((c) => Boolean(c.superclass));
+    if (withSuper) resolved = withSuper;
+  }
+  if (!resolved) {
+    const rename = TS_CLASS_RENAMES[short];
+    if (rename) resolved = tsByFileName.get(`${expectedFile}::${rename}`);
+  }
+  return resolved;
+}
+
 export function superclassesMatch(
   rubySuper: string | null,
   tsChain: string[],
@@ -691,31 +729,7 @@ function main() {
         const short = shortName(fqn)!;
         const rubySuper = shortName(info.superclass);
 
-        // Look up the TS class by the Ruby short name, falling back to
-        // the same rename aliases the superclass matcher uses — TS files
-        // sometimes rename the class itself to avoid builtin collisions
-        // (e.g. Rails' Type::Integer ↔ our type/integer.ts#IntegerType).
-        //
-        // If both a direct-name match and an alias match exist, prefer
-        // whichever has an actual superclass. This handles files that
-        // keep a query-value helper under the plain name while the true
-        // Rails-shape class lives under the alias (e.g. oid/range.ts
-        // with `class Range` for bounds + `class RangeType extends
-        // ValueType<Range>` for the OID type).
-        let tsCls = tsByFileName.get(`${expectedTs}::${short}`);
-        const aliasMatches = TS_PARENT_ALIASES.map(({ transform }) =>
-          tsByFileName.get(`${expectedTs}::${transform(short)}`),
-        ).filter((c): c is ClassInfo => Boolean(c));
-        if (!tsCls) {
-          tsCls = aliasMatches[0];
-        } else if (!tsCls.superclass) {
-          const withSuper = aliasMatches.find((c) => Boolean(c.superclass));
-          if (withSuper) tsCls = withSuper;
-        }
-        if (!tsCls) {
-          const rename = TS_CLASS_RENAMES[short];
-          if (rename) tsCls = tsByFileName.get(`${expectedTs}::${rename}`);
-        }
+        const tsCls = resolveTsClassForRuby(short, expectedTs, tsByFileName);
         inheritance.checked++;
 
         if (!tsCls) {


### PR DESCRIPTION
Priority 1 of the activerecord inheritance plan. Mirrors the refactor shipped for ActiveModel in #637: every concrete attribute / cast type now extends \`ValueType<T>\` instead of the abstract \`Type\` base, matching Rails' \`class X < Value\` chain.

## Code changes

**PG OID** (\`extends Type<T>\` → \`extends ValueType<T>\`):
array, bit, cidr, enum, hstore, interval, point, uuid, vector.

- \`oid.ts\` now \`extends UnsignedInteger\` (matches Rails \`class Oid < Type::UnsignedInteger\` exactly).
- \`legacy-point.ts\` didn't extend anything; now \`extends ValueType<[number, number]>\` with typed cast / serialize.
- \`range.ts\`'s \`RangeType\` (the OID cast-type wrapper, distinct from the query-value \`Range\`) extends \`ValueType<Range>\`.

**AR types**:
- \`type/json.ts\`, \`type/serialized.ts\` extend \`ValueType\`.
- \`locking/optimistic.ts#LockingType\` extends \`ValueType<number>\`; \`name\` switches from getter to field so the override matches the base shape.
- \`enum.ts#EnumType\` extends \`ValueType<string>\` (drops private \`_name\` in favor of the inherited overridable \`name\`).
- \`encryption/encrypted-attribute-type.ts\` extends \`ValueType\` while keeping its WrappedType implementation.

## Comparator updates

- \`TS_ROOT_INTERMEDIATE\` gains \`LockingType\` and \`Serialized\`. Both inherit from \`DelegateClass(Type::Value)\` in Rails — a dynamic parent our extractor reads as null. Accept \`ValueType\` on the TS chain.
- TS class lookup now prefers an alias match (\`<X>Type\`, \`Base<X>\`, …) over a direct-name match when the direct match has no super and the alias does. Fixes \`oid/range.ts\`: Ruby's \`OID::Range\` maps to TS \`RangeType\`, not the unrelated query-value \`Range\` helper.

## Impact

| metric | before | after |
|-|-|-|
| activerecord inheritance | 165/210 (78.6%) | **182/210 (86.7%)** |
| overall | 335/402 (83.3%) | 352/402 (87.6%) |

arel (100%), activemodel (97.6%) unchanged.

## Test plan
- [x] \`pnpm run build\` clean across the whole monorepo.
- [x] \`pnpm vitest run packages/activerecord packages/activemodel scripts/api-compare\` — 10,052 pass, no regressions.
- [x] \`pnpm api:compare --package activerecord\` — 182/210 inheritance.