### PR TITLE
refactor(activerecord): DJAS.scope() returns sync Relation (lazy-chain DJAR)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -441,16 +441,18 @@ async function _loadThroughViaDisableJoinsScope(
   const { DisableJoinsAssociationScope } =
     await import("./associations/disable-joins-association-scope.js");
   const klass = (reflection as { klass: typeof Base }).klass;
-  const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+  // DJAS.scope() now returns a sync deferred-chain Relation — the
+  // async chain walk runs on first toArray(). No more Promise<{relation}>
+  // boxing to unwrap.
+  let rel: unknown = DisableJoinsAssociationScope.INSTANCE.scope({
     owner: record,
     reflection: reflection as any,
     klass,
-  })) as { relation: { toArray: () => Promise<Base[]> } };
+  });
   // Apply caller-supplied `options.scope` when it differs from the
   // reflection's own scope — same rule the JOIN-based loaders use
   // (line 488 etc.). Skipping when equal avoids double-application
   // since DJAS already consumed the reflection's scope via constraints.
-  let rel: unknown = built.relation;
   const reflScope = (reflection as { scope?: unknown }).scope;
   if (options?.scope && options.scope !== reflScope) {
     rel = options.scope(rel as never);

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -92,7 +92,15 @@ describe("Association scope cache", () => {
     expect(spy.mock.calls.length).toBe(afterFirst + 1);
   });
 
-  it("disable_joins associations bypass the cache (fresh DJAS each call, Rails association.rb:107-117)", async () => {
+  it("disable_joins associations route through the dedicated DJAS loader, not Association.associationScope()", async () => {
+    // Loaders detect `disable_joins: true` early and route to
+    // `_loadThroughViaDisableJoinsScope` (which calls DJAS directly,
+    // returning a deferred-chain DJAR). They never call
+    // `Association.associationScope()` for disable-joins reflections,
+    // so the JOIN-based cache contract doesn't apply — DJAS owns
+    // its own per-call construction matching Rails' per-call DJAS
+    // (association.rb:107-117).
+    const { loadHasMany } = await import("../associations.js");
     Associations.hasMany.call(CacheAuthor, "cacheCommentsDj", {
       className: "CacheComment",
       through: "cachePosts",
@@ -102,19 +110,13 @@ describe("Association scope cache", () => {
     const author = await CacheAuthor.create({ name: "A" });
     const post = await CachePost.create({ cache_author_id: author.id, title: "p" });
     await CacheComment.create({ cache_post_id: post.id, body: "c" });
-    const assoc = (author as any).association("cacheCommentsDj");
-    expect(assoc.disableJoins).toBe(true);
-    // The associationScope() returns a Promise on the disableJoins
-    // path (DJAS' boxed contract). The cache field stays untouched —
-    // calling it twice yields two distinct Promises (fresh builds),
-    // matching Rails' per-call DJAS construction. Await both so any
-    // scope-build failure surfaces as a test error rather than an
-    // unhandled rejection.
-    const a = assoc.associationScope();
-    const b = assoc.associationScope();
-    expect(a).not.toBe(b);
-    await a;
-    await b;
+
+    const spy = vi.spyOn(AssociationScope, "scope");
+    const reflection = (CacheAuthor as any)._reflectOnAssociation("cacheCommentsDj");
+    const records = await loadHasMany(author, "cacheCommentsDj", reflection.options);
+    expect(records.map((r: any) => r.body)).toEqual(["c"]);
+    // JOIN-based AssociationScope was never invoked — DJAS handled it.
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it("loader paths hit the cache too (not just explicit record.association(name) calls)", async () => {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -101,20 +101,20 @@ export class Association {
   }
 
   /**
-   * Build (or return cached) association scope via the
-   * `AssociationScope` machinery. Mirrors Rails'
-   * `Association#association_scope` (association.rb:300-308):
-   * memoized for the JOIN-based path; fresh-each-call for
-   * `disable_joins`.
+   * Build (or return cached) JOIN-based association scope. Mirrors
+   * Rails' `Association#association_scope` (association.rb:300-308):
+   * memoized per-instance, reset on `reload()`.
    *
-   * Return shape:
-   *  - JOIN-based path: a `Relation` (the base scope). Caller is
-   *    responsible for any additional `.where(...)` / `.order(...)`
-   *    chaining (e.g. `options.scope`). The cache stores the
-   *    unfiltered base only.
-   *  - `disable_joins` path: a `Promise<{ relation }>` per DJAS' boxed
-   *    contract (the box dodges the Relation thenable when awaited).
-   *    Caller awaits + unwraps `.relation`.
+   * **Disable-joins routing happens upstream of this method.** Loaders
+   * detect `disable_joins: true` early and route to the dedicated
+   * DJAS loader (`_loadThroughViaDisableJoinsScope`); they never call
+   * `associationScope()` for disable_joins associations. Keeping that
+   * branch here would create a TDZ cycle:
+   * base.ts → associations/association.ts → DJAS → DJAR → relation.ts
+   * → base.ts. So `associationScope` is JOIN-only; calling it on a
+   * disable-joins instance returns the JOIN-based scope (which is
+   * not what disable_joins users want, but is also not how loaders
+   * reach this code).
    *
    * Cache contract (Rails-equivalent): the cached scope captures
    * owner FK / polymorphic-type values at build time. Mutating the
@@ -140,19 +140,6 @@ export class Association {
       _reflectOnAssociation?: (n: string) => unknown;
     };
     const richReflection = ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection;
-    if (this.disableJoins) {
-      // Lazy import — DJAS' module pulls in
-      // disable-joins-association-relation → relation.ts → associations.ts,
-      // which transitively imports us. Dynamic import keeps the cycle
-      // safe. Returns a Promise<{relation}> per DJAS' boxed contract.
-      return import("./disable-joins-association-scope.js").then((m) =>
-        m.DisableJoinsAssociationScope.INSTANCE.scope({
-          owner: this.owner,
-          reflection: richReflection as never,
-          klass: klass as never,
-        }),
-      );
-    }
     if (this._cachedAssociationScope === undefined) {
       this._cachedAssociationScope = AssociationScope.scope({
         owner: this.owner,

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
@@ -66,6 +67,13 @@ describe("DisableJoinsAssociationScope", () => {
       source: "djsComments",
       disableJoins: true,
     });
+  });
+
+  // Backstop in case a test throws before reaching its in-test
+  // unsubscribe — leaked sql.active_record subscribers can corrupt
+  // sibling tests (and bloat process memory across the suite).
+  afterEach(() => {
+    Notifications.unsubscribeAll();
   });
 
   it("INSTANCE is a DisableJoinsAssociationScope", () => {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -103,8 +103,8 @@ describe("DisableJoinsAssociationScope", () => {
   it("issues per-step queries (no multi-table JOIN actually emitted to the DB)", async () => {
     // Capture executed SQL via Notifications so we can assert the
     // WHOLE point of DJAS — no JOIN ever hits the wire — instead of
-    // just verifying the records came back.
-    const { Notifications } = await import("@blazetrails/activesupport");
+    // just verifying the records came back. (Uses the top-level
+    // `Notifications` import; no need for a dynamic re-import.)
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
     await DjsComment.create({ djs_post_id: post.id, body: "c1" });

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -184,6 +184,34 @@ describe("DisableJoinsAssociationScope", () => {
     expect(records.map((r: any) => r.body)).toEqual(["from-a", "from-b"]);
   });
 
+  it("limit on the ordered-upstream wrap case slices AFTER reorder (no SQL LIMIT before IN-list ordering)", async () => {
+    // Regression: the ordered-upstream wrap returns a loaded-chain
+    // DJAR that, before this fix, applied SQL LIMIT during super.toArray()
+    // when a chained .limit(n) was merged in via composition. That
+    // sliced rows in IN-clause order (DB-arbitrary), not through-table
+    // order — so .limit(1) might return the LAST through record's
+    // first comment instead of the FIRST.
+    const author = await DjsAuthor.create({ name: "A" });
+    const postB = await DjsPost.create({ djs_author_id: author.id, title: "b" });
+    const postA = await DjsPost.create({ djs_author_id: author.id, title: "a" });
+    await DjsComment.create({ djs_post_id: postB.id, body: "from-b" });
+    await DjsComment.create({ djs_post_id: postA.id, body: "from-a" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsCommentsViaOrderedPosts");
+    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    }) as DisableJoinsAssociationRelation<Base>;
+
+    // Chain .limit(1) on the deferred outer DJAR. The first record by
+    // through-table ordering (ordered by post.title) is from postA.
+    const limited = built.limit(1) as Promise<Base[]> | DisableJoinsAssociationRelation<Base>;
+    const records = await limited;
+    expect(records.length).toBe(1);
+    expect((records[0] as any).body).toBe("from-a");
+  });
+
   it("DisableJoinsAssociationRelation is exported and reorders by ids on load", async () => {
     const post1 = await DjsPost.create({ djs_author_id: 1, title: "p1" });
     const post2 = await DjsPost.create({ djs_author_id: 1, title: "p2" });

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -110,6 +110,30 @@ describe("DisableJoinsAssociationScope", () => {
     expect((records[0] as any).body).toBe("c1");
   });
 
+  it("chained .where() on the deferred DJAR composes into the walker result", async () => {
+    // Regression: a deferred DJAR's chained query state (wheres,
+    // orders, etc.) was silently dropped because the walker built a
+    // fresh relation that didn't see anything on the chained DJAR.
+    // _loadThroughViaDisableJoinsScope hits this when `options.scope`
+    // adds .where on top of the DJAS-returned relation.
+    const author = await DjsAuthor.create({ name: "A" });
+    const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
+    await DjsComment.create({ djs_post_id: post.id, body: "include-me" });
+    await DjsComment.create({ djs_post_id: post.id, body: "exclude-me" });
+
+    const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
+    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: author,
+      reflection,
+      klass: reflection.klass,
+    }) as any;
+    // Chain a where() onto the deferred DJAR — this is what
+    // options.scope(rel) does in production.
+    const filtered = built.where({ body: "include-me" });
+    const records = await filtered.toArray();
+    expect(records.map((r: any) => r.body)).toEqual(["include-me"]);
+  });
+
   it("loadHasMany routes disableJoins:true through DJAS", async () => {
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -92,7 +92,11 @@ describe("DisableJoinsAssociationScope", () => {
     expect(records.map((r: any) => r.body).sort()).toEqual(["c1", "c2"]);
   });
 
-  it("issues per-step queries (no multi-table JOIN on the deferred relation)", async () => {
+  it("issues per-step queries (no multi-table JOIN actually emitted to the DB)", async () => {
+    // Capture executed SQL via Notifications so we can assert the
+    // WHOLE point of DJAS — no JOIN ever hits the wire — instead of
+    // just verifying the records came back.
+    const { Notifications } = await import("@blazetrails/activesupport");
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
     await DjsComment.create({ djs_post_id: post.id, body: "c1" });
@@ -103,11 +107,24 @@ describe("DisableJoinsAssociationScope", () => {
       reflection,
       klass: reflection.klass,
     }) as DisableJoinsAssociationRelation<Base>;
-    // toArray triggers the walk → loads comments via per-step queries.
-    // No multi-table JOIN should ever fire (the whole point of DJAS).
-    const records = await built.toArray();
-    expect(records.length).toBe(1);
-    expect((records[0] as any).body).toBe("c1");
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      const records = await built.toArray();
+      expect(records.length).toBe(1);
+      expect((records[0] as any).body).toBe("c1");
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    // Per-step queries hit djs_posts and djs_comments individually;
+    // a JOIN-based load would have a single query mentioning both
+    // table names with a JOIN keyword. Assert no captured SQL has JOIN.
+    expect(observed.length).toBeGreaterThan(0);
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 
   it("chained .where() on the deferred DJAR composes into the walker result", async () => {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -72,39 +72,42 @@ describe("DisableJoinsAssociationScope", () => {
     expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);
   });
 
-  it("scope(association) returns a boxed relation loadable via toArray", async () => {
+  it("scope(association) returns a sync Relation loadable via toArray", async () => {
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
     await DjsComment.create({ djs_post_id: post.id, body: "c1" });
     await DjsComment.create({ djs_post_id: post.id, body: "c2" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+    // No `await` — DJAS.scope() is sync now (matches Rails). The
+    // returned DJAR is in deferred-chain mode; toArray runs the walk.
+    const built = DisableJoinsAssociationScope.INSTANCE.scope({
       owner: author,
       reflection,
       klass: reflection.klass,
-    })) as { relation: { toArray: () => Promise<Base[]> } };
+    }) as DisableJoinsAssociationRelation<Base>;
+    expect(built).toBeInstanceOf(DisableJoinsAssociationRelation);
 
-    const records = await built.relation.toArray();
+    const records = await built.toArray();
     expect(records.map((r: any) => r.body).sort()).toEqual(["c1", "c2"]);
   });
 
-  it("issues per-step queries (no multi-table JOIN on source query)", async () => {
+  it("issues per-step queries (no multi-table JOIN on the deferred relation)", async () => {
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
     await DjsComment.create({ djs_post_id: post.id, body: "c1" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.INSTANCE.scope({
       owner: author,
       reflection,
       klass: reflection.klass,
-    })) as { relation: { toSql: () => string } };
-
-    const sql = built.relation.toSql();
-    expect(sql).not.toMatch(/JOIN/i);
-    expect(sql).toMatch(/"djs_comments"/);
-    expect(sql).toMatch(/"djs_post_id"/);
+    }) as DisableJoinsAssociationRelation<Base>;
+    // toArray triggers the walk → loads comments via per-step queries.
+    // No multi-table JOIN should ever fire (the whole point of DJAS).
+    const records = await built.toArray();
+    expect(records.length).toBe(1);
+    expect((records[0] as any).body).toBe("c1");
   });
 
   it("loadHasMany routes disableJoins:true through DJAS", async () => {
@@ -125,16 +128,18 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: postA.id, body: "from-a" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsCommentsViaOrderedPosts");
-    const built = (await DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.INSTANCE.scope({
       owner: author,
       reflection,
       klass: reflection.klass,
-    })) as { relation: unknown };
+    }) as DisableJoinsAssociationRelation<Base>;
 
-    expect(built.relation).toBeInstanceOf(DisableJoinsAssociationRelation);
-    // Loaded comments come back in the through-ordered sequence (postA.title="a"
-    // before postB.title="b"), since the wrapping relation re-groups by key.
-    const records = await (built.relation as any).toArray();
+    // The deferred outer DJAR wraps a chain walk that internally
+    // produces a *loaded-chain* DJAR (the source step has no order
+    // but the through step does → wrap in DJAR for IN-list reorder).
+    // We verify the externally observable contract: records come back
+    // in upstream-ordered sequence (postA.title="a" before postB.title="b").
+    const records = await built.toArray();
     expect(records.map((r: any) => r.body)).toEqual(["from-a", "from-b"]);
   });
 

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -47,10 +47,13 @@ function singleColumnKey(key: string | string[], label: string): string {
  * is returned to the caller (or wrapped in a `DisableJoinsAssociationRelation`
  * when the source has no order but an upstream step was ordered).
  *
- * Because intermediate `pluck` calls must be async in this codebase, this
- * subclass' `scope()` returns a `Promise<Relation>` rather than the
- * synchronous `Relation` Rails returns. Routing in `associations.ts`
- * awaits the promise before driving the final query.
+ * Intermediate `pluck` calls are async in this codebase (Rails' are
+ * sync DB calls), so the chain walk itself cannot be synchronous.
+ * `scope()` returns a `DisableJoinsAssociationRelation` in deferred-
+ * chain mode — a sync `Relation` whose `toArray()` runs the async
+ * walk on first load. This matches Rails' `Relation`-returning
+ * signature without forcing callers into a `Promise<{ relation }>`
+ * boxing dance.
  *
  * Mirrors: ActiveRecord::Associations::DisableJoinsAssociationScope
  */
@@ -63,36 +66,38 @@ export class DisableJoinsAssociationScope extends AssociationScope {
   }
 
   /**
-   * Async override of `AssociationScope#scope`. Walks the reverse chain,
-   * executing intermediate `pluck`s, and returns the final unexecuted
-   * relation (regular `Relation` or `DisableJoinsAssociationRelation`).
-   *
-   * Mirrors: DisableJoinsAssociationScope#scope (lines 6-15 of
-   * disable_joins_association_scope.rb).
+   * Sync override of `AssociationScope#scope`. Returns a deferred-
+   * chain `DisableJoinsAssociationRelation` — the async chain walk
+   * runs on first `toArray()`. Matches Rails' `Relation`-returning
+   * signature (`DisableJoinsAssociationScope#scope` at
+   * disable_joins_association_scope.rb:6-15) without the boxing
+   * workaround our async pluck would otherwise force.
    */
-  override async scope(association: AssociationScopeable): Promise<unknown> {
+  override scope(association: AssociationScopeable): unknown {
     const sourceReflection = association.reflection;
     const owner = association.owner;
-    const reverseChain = this._getChain(sourceReflection).slice().reverse();
-
-    const [lastReflection, lastOrdered, lastJoinIds] = await this._lastScopeChain(
-      reverseChain,
-      owner,
-    );
-
-    const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-    const keyStr = singleColumnKey(key, "joinPrimaryKey");
-    const relation = this._addConstraintsDj(
-      lastReflection,
-      keyStr,
-      lastJoinIds,
-      owner,
-      lastOrdered,
-    );
-    // Box the Relation so awaiting the Promise<{relation}> doesn't trip
-    // the Relation's thenable (Relation.then → records array). Callers
-    // read `.relation` off the resolved value.
-    return { relation };
+    const klass = association.klass;
+    // Boxed walker — see `DJAR.deferred` doc. The bare Relation must
+    // never cross an `await` boundary, or Promise/A+ unwraps it via
+    // the Relation thenable (`.then` → `toArray`). Build sync, box,
+    // return the box.
+    return DisableJoinsAssociationRelation.deferred(klass, async () => {
+      const reverseChain = this._getChain(sourceReflection).slice().reverse();
+      const [lastReflection, lastOrdered, lastJoinIds] = await this._lastScopeChain(
+        reverseChain,
+        owner,
+      );
+      const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
+      const keyStr = singleColumnKey(key, "joinPrimaryKey");
+      const relation = this._addConstraintsDj(
+        lastReflection,
+        keyStr,
+        lastJoinIds,
+        owner,
+        lastOrdered,
+      ) as never;
+      return { relation };
+    });
   }
 
   /**

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -5,6 +5,7 @@ import {
   type ValueTransformation,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+import type { Relation } from "../relation.js";
 import type { Base } from "../base.js";
 import type { AbstractReflection } from "../reflection.js";
 
@@ -95,7 +96,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         lastJoinIds,
         owner,
         lastOrdered,
-      ) as never;
+      ) as Relation<Base>;
       return { relation };
     });
   }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -74,48 +74,67 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
-   * Compose any query state chained onto this deferred DJAR (wheres,
-   * orders, limit, offset, select, distinct, group, having, joins,
-   * lock, etc.) onto the walker's result relation. Without this,
+   * Compose any query state chained onto this deferred DJAR onto the
+   * walker's result relation. Without this,
    * `DJAS.scope(...).where(...)` and other chained modifiers would
    * be silently dropped — the walker builds a fresh relation that
    * doesn't see anything stored on `this`.
    *
-   * Implementation: always merge `this` as the overlay onto the
-   * walker's result. Relation#merge handles wheres/orders/etc;
-   * `_rawOrderClauses` (used by `inOrderOf`) and `_isNone` (used by
-   * `.none()`) are copied explicitly because Relation#merge doesn't
-   * propagate them today.
+   * Implementation: use `Relation#merge` for state where overlay
+   * REPLACES walker (limit / offset / wheres get the standard merger
+   * semantics), then selectively recompose fields whose normal chain
+   * behavior is additive (`_orderClauses`, `_rawOrderClauses`,
+   * `_selectColumns`). `Relation#merge` replaces orders/select
+   * outright (relation/merger.ts:21-32), but `.order(...)` /
+   * `.select(...)` chains conventionally APPEND elsewhere — so a
+   * blanket merge would drop the walker's existing orders/projection
+   * when the user chains `.order(...)`. Recompose those fields
+   * additively here. `_isNone` (used by `.none()`) is copied
+   * explicitly since `Relation#merge` doesn't propagate it today.
    */
   private _composeChainedState(walkerResult: Relation<T>): Relation<T> {
+    type ComposeFields = {
+      _orderClauses?: unknown[];
+      _rawOrderClauses?: unknown[];
+      _selectColumns?: unknown[];
+      _isNone?: boolean;
+    };
+    // Snapshot walker's pre-merge order/select state — the merge
+    // would otherwise replace these.
+    const source = walkerResult as unknown as ComposeFields;
+    const sourceOrders = [...(source._orderClauses ?? [])];
+    const sourceRawOrders = [...(source._rawOrderClauses ?? [])];
+    const sourceSelects = source._selectColumns ? [...source._selectColumns] : null;
+
     const merged = (walkerResult as unknown as { merge: (o: unknown) => Relation<T> }).merge(this);
-    // Explicit copies for state Relation#merge doesn't propagate.
-    const overlay = this as unknown as {
-      _orderClauses?: unknown[];
-      _rawOrderClauses?: unknown[];
-      _isNone?: boolean;
-    };
-    const target = merged as unknown as {
-      _orderClauses?: unknown[];
-      _rawOrderClauses?: unknown[];
-      _isNone?: boolean;
-    };
-    const overlayRaw = overlay._rawOrderClauses ?? [];
-    if (overlayRaw.length > 0) {
+    const target = merged as unknown as ComposeFields;
+    const overlay = this as unknown as ComposeFields;
+    const overlayOrders = overlay._orderClauses ?? [];
+    const overlayRawOrders = overlay._rawOrderClauses ?? [];
+    const overlaySelects = overlay._selectColumns ?? [];
+
+    if (overlayRawOrders.length > 0 && overlayOrders.length === 0) {
       // `inOrderOf(column, values)` is the only `_rawOrderClauses`
       // producer today; it CLEARS `_orderClauses` to express
       // "replace existing order with this CASE order"
-      // (relation.ts:610). When overlay carries a raw clause but no
-      // parsed orders, treat it as an order-reset and clear the
-      // walker's `_orderClauses` so the raw CASE wins. Without this,
-      // walker's existing orders would still apply, with the raw
-      // CASE only acting as a tiebreaker — contradicting the
-      // caller's `inOrderOf` intent.
-      if ((overlay._orderClauses?.length ?? 0) === 0) {
-        target._orderClauses = [];
-      }
-      target._rawOrderClauses = [...(target._rawOrderClauses ?? []), ...overlayRaw];
+      // (relation.ts:610). Honor that reset: drop BOTH walker's
+      // parsed orders AND any pre-existing raw orders so the
+      // overlay's CASE order wins outright (not as a tiebreaker).
+      target._orderClauses = [];
+      target._rawOrderClauses = [...overlayRawOrders];
+    } else {
+      target._orderClauses = [...sourceOrders, ...overlayOrders];
+      target._rawOrderClauses = [...sourceRawOrders, ...overlayRawOrders];
     }
+
+    // Selects: append-and-dedupe so the walker's projection survives
+    // when the overlay extends it. Dedupe is structural via Set
+    // identity for primitive entries; complex AST nodes will dedupe
+    // by reference (matches Relation#select chain behavior).
+    if (sourceSelects && sourceSelects.length > 0) {
+      target._selectColumns = Array.from(new Set([...sourceSelects, ...overlaySelects]));
+    }
+
     if (overlay._isNone) target._isNone = true;
     return merged;
   }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -69,35 +69,48 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
 
   /**
    * Compose any query state chained onto this deferred DJAR (wheres,
-   * orders, limit, offset) onto the walker's result relation.
-   * Without this, `DJAS.scope(...).where(...)` would silently drop
-   * the chained where because the walker builds a fresh relation
-   * that doesn't see anything stored on `this`.
+   * orders, limit, offset, select, distinct, group, having, joins,
+   * lock, etc.) onto the walker's result relation. Without this,
+   * `DJAS.scope(...).where(...)` and other chained modifiers would
+   * be silently dropped — the walker builds a fresh relation that
+   * doesn't see anything stored on `this`.
    *
-   * Implementation: Relation#merge already does the right thing for
-   * combining wheres/orders/etc. We treat `this` as the overlay and
-   * merge it onto the walker's result.
+   * Implementation: always merge `this` as the overlay onto the
+   * walker's result. Relation#merge handles wheres/orders/etc;
+   * `_rawOrderClauses` (used by `inOrderOf`) and `_isNone` (used by
+   * `.none()`) are copied explicitly because Relation#merge doesn't
+   * propagate them today.
    */
   private _composeChainedState(walkerResult: Relation<T>): Relation<T> {
-    const hasOverlay =
-      (this._whereClause?.predicates?.length ?? 0) > 0 ||
-      ((this as unknown as { _orderClauses?: unknown[] })._orderClauses?.length ?? 0) > 0 ||
-      ((this as unknown as { _rawOrderClauses?: unknown[] })._rawOrderClauses?.length ?? 0) > 0 ||
-      (this as unknown as { _limitValue?: number | null })._limitValue != null ||
-      (this as unknown as { _offsetValue?: number | null })._offsetValue != null;
-    if (!hasOverlay) return walkerResult;
-    return (walkerResult as unknown as { merge: (o: unknown) => Relation<T> }).merge(this);
+    const merged = (walkerResult as unknown as { merge: (o: unknown) => Relation<T> }).merge(this);
+    // Explicit copies for state Relation#merge doesn't propagate.
+    const overlay = this as unknown as {
+      _rawOrderClauses?: unknown[];
+      _isNone?: boolean;
+    };
+    const target = merged as unknown as {
+      _rawOrderClauses?: unknown[];
+      _isNone?: boolean;
+    };
+    if ((overlay._rawOrderClauses?.length ?? 0) > 0) {
+      target._rawOrderClauses = [
+        ...(target._rawOrderClauses ?? []),
+        ...(overlay._rawOrderClauses ?? []),
+      ];
+    }
+    if (overlay._isNone) target._isNone = true;
+    return merged;
   }
 
   override async ids(): Promise<unknown[]> {
     if (this._chainWalker) {
-      // Deferred mode — load via the walker, then read PKs off the
-      // result. Matches Rails' `Relation#ids` semantics for the
-      // deferred-chain path; the loaded-chain mode uses the stored
-      // through-IDs instead.
-      const records = await this.toArray();
-      const pk = this.model.primaryKey as string;
-      return records.map((r) => r.readAttribute(pk));
+      // Deferred mode — delegate to the composed walker result's
+      // ids(), which can pluck instead of materializing full records.
+      // (If the walker produced a loaded-chain DJAR, that DJAR's
+      // ids() returns its stored through-IDs without a query.)
+      const { relation } = await this._chainWalker();
+      const merged = this._composeChainedState(relation);
+      return (merged as unknown as { ids: () => Promise<unknown[]> }).ids();
     }
     return this._storedIds;
   }
@@ -158,24 +171,46 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
-   * Rails: `def limit(value); records.take(value); end` — load everything
-   * then slice in memory. Returns an array, breaking the Relation chain
-   * (matching Rails' deliberate deviation here).
+   * Loaded-chain mode (Rails fidelity): `def limit(value);
+   * records.take(value); end` — load everything then slice in
+   * memory. Deferred-chain mode: chain like a normal Relation. The
+   * walker result composes the limit via `_composeChainedState` and
+   * the underlying relation handles SQL LIMIT (or, if the walker
+   * produced a loaded-chain DJAR, that DJAR's own override slices
+   * in-memory).
    */
-  // @ts-expect-error — deliberate Rails-fidelity deviation: returns Array, not Relation
-  override async limit(value: number): Promise<T[]> {
-    const records = await this.toArray();
-    return records.slice(0, value);
+  // @ts-expect-error — deliberate Rails-fidelity deviation in loaded-chain mode: returns Array, not Relation
+  override limit(value: number): Relation<T> | Promise<T[]> {
+    if (this._chainWalker) return Relation.prototype.limit.call(this, value) as Relation<T>;
+    return (async () => {
+      const records = await this.toArray();
+      return records.slice(0, value);
+    })();
   }
 
   /**
-   * Rails: load everything then take the first (or first n) in memory,
-   * for the same reason as `limit` above.
+   * Loaded-chain mode: load + take. Deferred-chain mode: chain like
+   * a normal Relation (returning a new deferred DJAR with limit
+   * applied — async first() on that lands on the SQL-LIMIT path of
+   * the walker's underlying relation).
    */
-  // @ts-expect-error — deliberate Rails-fidelity deviation: async, not sync
-  override async first(limit?: number): Promise<T | T[] | null> {
-    const records = await this.toArray();
-    if (limit === undefined) return records[0] ?? null;
-    return records.slice(0, limit);
+  // @ts-expect-error — deliberate Rails-fidelity deviation in loaded-chain mode: async, not sync
+  override first(limit?: number): Promise<T | null> | Promise<T[]> {
+    if (this._chainWalker) {
+      // Defer to Relation's chained-then-load semantics: spawn a
+      // limited(1)/limited(N) clone, then load + take the first.
+      const limitVal = limit ?? 1;
+      const limited = Relation.prototype.limit.call(this, limitVal) as Relation<T>;
+      return (async () => {
+        const records = await limited.toArray();
+        if (limit === undefined) return records[0] ?? null;
+        return records;
+      })() as Promise<T | null> | Promise<T[]>;
+    }
+    return (async () => {
+      const records = await this.toArray();
+      if (limit === undefined) return records[0] ?? null;
+      return records.slice(0, limit);
+    })() as Promise<T | null> | Promise<T[]>;
   }
 }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -33,7 +33,13 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * itself. The box stays internal; callers see only the public
    * `toArray()` interface. */
   private readonly _chainWalker?: () => Promise<{ relation: Relation<T> }>;
-  private _walkerPromise?: Promise<T[]>;
+  /**
+   * Memoized walker invocation. Both `toArray()` and `ids()` (and any
+   * future deferred-mode consumer) share this so the async chain walk
+   * — including intermediate `pluck`s, which are the expensive part —
+   * runs at most once per DJAR instance.
+   */
+  private _walkPromise?: Promise<{ relation: Relation<T> }>;
 
   constructor(
     klass: typeof Base,
@@ -106,13 +112,26 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     if (this._chainWalker) {
       // Deferred mode — delegate to the composed walker result's
       // ids(), which can pluck instead of materializing full records.
-      // (If the walker produced a loaded-chain DJAR, that DJAR's
-      // ids() returns its stored through-IDs without a query.)
-      const { relation } = await this._chainWalker();
+      // Routes through the shared `_walkOnce()` so the chain walk
+      // (including intermediate plucks) runs at most once per DJAR
+      // instance, even if a caller invokes ids() and then toArray()
+      // (or ids() multiple times).
+      const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
       return (merged as unknown as { ids: () => Promise<unknown[]> }).ids();
     }
     return this._storedIds;
+  }
+
+  /**
+   * Memoize the walker invocation so the async chain walk runs at
+   * most once per DJAR instance. Shared by `toArray()` and `ids()`.
+   */
+  private _walkOnce(): Promise<{ relation: Relation<T> }> {
+    if (!this._walkPromise) {
+      this._walkPromise = this._chainWalker!();
+    }
+    return this._walkPromise;
   }
 
   /**
@@ -132,24 +151,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
 
   override async toArray(): Promise<T[]> {
     if (this._chainWalker) {
-      // Memoize the walk + load so repeated toArray() calls don't
-      // re-execute the chain (e.g. via Relation thenable shortcuts).
-      if (!this._walkerPromise) {
-        const walker = this._chainWalker;
-        // Snapshot the chained query state from `this` (wheres /
-        // orders / limit / etc) so post-chain operations like
-        // `DJAS.scope(...).where({title: 'foo'})` actually filter the
-        // walker's result. Without this, chained wheres would be
-        // silently dropped — _loadThroughViaDisableJoinsScope routes
-        // `options.scope(rel)` through here for example.
-        const overlay = this;
-        this._walkerPromise = (async () => {
-          const { relation } = await walker();
-          const merged = overlay._composeChainedState(relation);
-          return merged.toArray();
-        })();
-      }
-      return this._walkerPromise;
+      // Routes through `_walkOnce()` so the chain walk (including
+      // intermediate plucks) is shared with any earlier `ids()` call.
+      // The chained query state on `this` (wheres / orders / limit /
+      // etc.) composes via `_composeChainedState` so chains like
+      // `DJAS.scope(...).where({title: 'foo'})` actually filter the
+      // walker's result.
+      const { relation } = await this._walkOnce();
+      const merged = this._composeChainedState(relation);
+      return merged.toArray();
     }
     // Loaded-chain mode: load via Relation, then group by `key` and
     // re-emit in `ids` order so the caller sees join-table ordering

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -67,6 +67,28 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     return new DisableJoinsAssociationRelation<T>(klass, "", [], chainWalker);
   }
 
+  /**
+   * Compose any query state chained onto this deferred DJAR (wheres,
+   * orders, limit, offset) onto the walker's result relation.
+   * Without this, `DJAS.scope(...).where(...)` would silently drop
+   * the chained where because the walker builds a fresh relation
+   * that doesn't see anything stored on `this`.
+   *
+   * Implementation: Relation#merge already does the right thing for
+   * combining wheres/orders/etc. We treat `this` as the overlay and
+   * merge it onto the walker's result.
+   */
+  private _composeChainedState(walkerResult: Relation<T>): Relation<T> {
+    const hasOverlay =
+      (this._whereClause?.predicates?.length ?? 0) > 0 ||
+      ((this as unknown as { _orderClauses?: unknown[] })._orderClauses?.length ?? 0) > 0 ||
+      ((this as unknown as { _rawOrderClauses?: unknown[] })._rawOrderClauses?.length ?? 0) > 0 ||
+      (this as unknown as { _limitValue?: number | null })._limitValue != null ||
+      (this as unknown as { _offsetValue?: number | null })._offsetValue != null;
+    if (!hasOverlay) return walkerResult;
+    return (walkerResult as unknown as { merge: (o: unknown) => Relation<T> }).merge(this);
+  }
+
   override async ids(): Promise<unknown[]> {
     if (this._chainWalker) {
       // Deferred mode — load via the walker, then read PKs off the
@@ -100,9 +122,18 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       // Memoize the walk + load so repeated toArray() calls don't
       // re-execute the chain (e.g. via Relation thenable shortcuts).
       if (!this._walkerPromise) {
+        const walker = this._chainWalker;
+        // Snapshot the chained query state from `this` (wheres /
+        // orders / limit / etc) so post-chain operations like
+        // `DJAS.scope(...).where({title: 'foo'})` actually filter the
+        // walker's result. Without this, chained wheres would be
+        // silently dropped — _loadThroughViaDisableJoinsScope routes
+        // `options.scope(rel)` through here for example.
+        const overlay = this;
         this._walkerPromise = (async () => {
-          const { relation } = await this._chainWalker!();
-          return relation.toArray();
+          const { relation } = await walker();
+          const merged = overlay._composeChainedState(relation);
+          return merged.toArray();
         })();
       }
       return this._walkerPromise;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -91,18 +91,30 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     const merged = (walkerResult as unknown as { merge: (o: unknown) => Relation<T> }).merge(this);
     // Explicit copies for state Relation#merge doesn't propagate.
     const overlay = this as unknown as {
+      _orderClauses?: unknown[];
       _rawOrderClauses?: unknown[];
       _isNone?: boolean;
     };
     const target = merged as unknown as {
+      _orderClauses?: unknown[];
       _rawOrderClauses?: unknown[];
       _isNone?: boolean;
     };
-    if ((overlay._rawOrderClauses?.length ?? 0) > 0) {
-      target._rawOrderClauses = [
-        ...(target._rawOrderClauses ?? []),
-        ...(overlay._rawOrderClauses ?? []),
-      ];
+    const overlayRaw = overlay._rawOrderClauses ?? [];
+    if (overlayRaw.length > 0) {
+      // `inOrderOf(column, values)` is the only `_rawOrderClauses`
+      // producer today; it CLEARS `_orderClauses` to express
+      // "replace existing order with this CASE order"
+      // (relation.ts:610). When overlay carries a raw clause but no
+      // parsed orders, treat it as an order-reset and clear the
+      // walker's `_orderClauses` so the raw CASE wins. Without this,
+      // walker's existing orders would still apply, with the raw
+      // CASE only acting as a tiebreaker — contradicting the
+      // caller's `inOrderOf` intent.
+      if ((overlay._orderClauses?.length ?? 0) === 0) {
+        target._orderClauses = [];
+      }
+      target._rawOrderClauses = [...(target._rawOrderClauses ?? []), ...overlayRaw];
     }
     if (overlay._isNone) target._isNone = true;
     return merged;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -2,34 +2,81 @@ import { Relation } from "./relation.js";
 import type { Base } from "./base.js";
 
 /**
- * Specialized Relation returned by DisableJoinsAssociationScope when the
- * source scope has no explicit ORDER but an upstream chain entry was
- * ordered. Rails uses this to:
+ * Specialized Relation returned by `DisableJoinsAssociationScope`.
+ * Operates in one of two modes:
  *
- *   - preserve the through-IDs order when IN(...) is used on the final
- *     query (SQL IN doesn't preserve list order, but Rails' ORM contract
- *     for an ordered `through` association expects the records back in
- *     the join-table order),
- *   - and short-circuit `limit` / `first` so they slice the loaded
- *     in-memory array rather than appending SQL LIMIT (which would
- *     interact badly with IN-list reordering).
+ *   1. **Loaded-chain mode** (Rails' `DisableJoinsAssociationRelation`,
+ *      `activerecord/lib/active_record/disable_joins_association_relation.rb`):
+ *      constructed with `(klass, key, ids)` after the chain walk is
+ *      complete. `toArray()` loads via Relation, then groups by `key`
+ *      and re-emits in `ids` order so callers see join-table ordering
+ *      (SQL `IN(...)` doesn't preserve list order). `limit` / `first`
+ *      slice the loaded array in-memory rather than appending SQL
+ *      LIMIT (matches Rails' deliberate deviation).
  *
- * Mirrors: ActiveRecord::DisableJoinsAssociationRelation
- * (activerecord/lib/active_record/disable_joins_association_relation.rb).
+ *   2. **Deferred-chain mode**: constructed with a `chainWalker`
+ *      callback that performs the async chain walk on first `toArray()`
+ *      and returns the final scope (which itself may be a loaded-chain
+ *      DJAR for the ordered-upstream wrap case). Lets `DJAS.scope()`
+ *      return a `Relation` synchronously instead of `Promise<{ relation }>` —
+ *      matches Rails' `DisableJoinsAssociationScope#scope` returning
+ *      a Relation directly.
  */
 export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T> {
   readonly key: string;
   /** Stored IDs (uniq'd at construction). Exposed as `ids()` to match
    * Rails' `attr_reader :ids` which shadows `Relation#ids` here. */
   private readonly _storedIds: unknown[];
+  /** Deferred chain walker. Boxed return ({ relation }) defeats
+   * `Relation.then` — without the box, `await Promise<Relation>`
+   * would unwrap to `T[]` (records array) instead of the Relation
+   * itself. The box stays internal; callers see only the public
+   * `toArray()` interface. */
+  private readonly _chainWalker?: () => Promise<{ relation: Relation<T> }>;
+  private _walkerPromise?: Promise<T[]>;
 
-  constructor(klass: typeof Base, key: string, ids: unknown[]) {
+  constructor(
+    klass: typeof Base,
+    key: string,
+    ids: unknown[],
+    chainWalker?: () => Promise<{ relation: Relation<T> }>,
+  ) {
     super(klass);
     this.key = key;
     this._storedIds = Array.from(new Set(ids));
+    this._chainWalker = chainWalker;
+  }
+
+  /**
+   * Construct a deferred-chain DJAR. Used by `DJAS.scope()` to return
+   * a sync Relation while letting the async chain walk happen at
+   * `toArray()` time. `key` and `ids` are placeholders here — the
+   * walker's returned Relation owns the real reorder semantics (it
+   * may itself be a loaded-chain DJAR if upstream was ordered).
+   *
+   * The walker MUST return a boxed `{ relation }`, not a bare
+   * `Promise<Relation>` — bare Relations get unwrapped to `T[]` by
+   * Promise's thenable chaining (since `Relation.then` is the
+   * `toArray` shortcut). Callers construct the box at the source so
+   * the bare Relation never crosses an `await` boundary.
+   */
+  static deferred<T extends Base>(
+    klass: typeof Base,
+    chainWalker: () => Promise<{ relation: Relation<T> }>,
+  ): DisableJoinsAssociationRelation<T> {
+    return new DisableJoinsAssociationRelation<T>(klass, "", [], chainWalker);
   }
 
   override async ids(): Promise<unknown[]> {
+    if (this._chainWalker) {
+      // Deferred mode — load via the walker, then read PKs off the
+      // result. Matches Rails' `Relation#ids` semantics for the
+      // deferred-chain path; the loaded-chain mode uses the stored
+      // through-IDs instead.
+      const records = await this.toArray();
+      const pk = this.model.primaryKey as string;
+      return records.map((r) => r.readAttribute(pk));
+    }
     return this._storedIds;
   }
 
@@ -44,14 +91,25 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       this.model,
       this.key,
       this._storedIds,
+      this._chainWalker,
     ) as unknown as Relation<T>;
   }
 
-  /**
-   * Load via Relation, then group by `key` and re-emit in `ids` order so
-   * the caller sees join-table ordering (Rails' `load` override).
-   */
   override async toArray(): Promise<T[]> {
+    if (this._chainWalker) {
+      // Memoize the walk + load so repeated toArray() calls don't
+      // re-execute the chain (e.g. via Relation thenable shortcuts).
+      if (!this._walkerPromise) {
+        this._walkerPromise = (async () => {
+          const { relation } = await this._chainWalker!();
+          return relation.toArray();
+        })();
+      }
+      return this._walkerPromise;
+    }
+    // Loaded-chain mode: load via Relation, then group by `key` and
+    // re-emit in `ids` order so the caller sees join-table ordering
+    // (Rails' `load` override).
     const records = await super.toArray();
     const byKey = new Map<unknown, T[]>();
     for (const r of records) {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -177,30 +177,29 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // re-emit in `ids` order so the caller sees join-table ordering
     // (Rails' `load` override).
     //
-    // Snapshot + clear `_limitValue` / `_offsetValue` before
-    // `super.toArray()` and apply them in-memory after reorder.
-    // Reason: deferred-mode composition (via `_composeChainedState`'s
-    // `merge`) can copy a chained `.limit(n)` / offset onto this
-    // loaded-chain DJAR. Letting the SQL path apply LIMIT before the
-    // IN-list reorder would slice the WRONG rows — the rows that
-    // happen to come back first from the IN(...) query, not the rows
-    // that come first in through-table order. Rails handles this by
-    // overriding `limit` / `first` to load + take in memory; we
-    // must match for the merged-in case too.
-    const self = this as unknown as { _limitValue?: number | null; _offsetValue?: number | null };
+    // Build a clone with `_limitValue` / `_offsetValue` cleared and
+    // load through that — never mutate `this`. Reason: deferred-mode
+    // composition (via `_composeChainedState`'s `merge`) can copy a
+    // chained `.limit(n)` / offset onto this loaded-chain DJAR.
+    // Letting the SQL path apply LIMIT before the IN-list reorder
+    // would slice the WRONG rows. Rails matches by overriding
+    // `limit`/`first` to load + take in memory; we do the same.
+    // Cloning (rather than mutating `this` across the await) keeps
+    // concurrent `toSql()` / `ids()` / second `toArray()` calls
+    // observing the original configured state.
+    type LimitOffset = { _limitValue?: number | null; _offsetValue?: number | null };
+    const self = this as unknown as LimitOffset & {
+      _clone: () => DisableJoinsAssociationRelation<T>;
+    };
     const limitVal = self._limitValue ?? null;
     const offsetVal = self._offsetValue ?? null;
-    self._limitValue = null;
-    self._offsetValue = null;
-    let records: T[];
-    try {
-      records = await super.toArray();
-    } finally {
-      // Restore so the relation's reported state matches what callers
-      // configured (e.g. for inspect/diagnostic paths).
-      self._limitValue = limitVal;
-      self._offsetValue = offsetVal;
-    }
+    const loadClone = self._clone() as unknown as LimitOffset;
+    loadClone._limitValue = null;
+    loadClone._offsetValue = null;
+    // Call Relation's toArray directly on the clone — going through
+    // DJAR.toArray would re-enter the deferred/loaded branching and
+    // recurse forever for the loaded-chain mode.
+    const records = (await Relation.prototype.toArray.call(loadClone)) as T[];
     const byKey = new Map<unknown, T[]>();
     for (const r of records) {
       const k = r.readAttribute(this.key);

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -246,11 +246,13 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * in-memory).
    */
   // @ts-expect-error — deliberate Rails-fidelity deviation in loaded-chain mode: returns Array, not Relation
-  override limit(value: number): Relation<T> | Promise<T[]> {
+  override limit(value: number | null): Relation<T> | Promise<T[]> {
     if (this._chainWalker) return Relation.prototype.limit.call(this, value) as Relation<T>;
     return (async () => {
       const records = await this.toArray();
-      return records.slice(0, value);
+      // null = "clear the limit" (matches Relation#limit). Without
+      // this guard, `records.slice(0, null)` returns an empty array.
+      return value === null ? records : records.slice(0, value);
     })();
   }
 

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -256,27 +256,25 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
 
   /**
    * Loaded-chain mode: load + take. Deferred-chain mode: chain like
-   * a normal Relation (returning a new deferred DJAR with limit
-   * applied — async first() on that lands on the SQL-LIMIT path of
-   * the walker's underlying relation).
+   * a normal Relation (limit applied via Relation.prototype.limit
+   * → walker result → SQL LIMIT or loaded-DJAR slice).
+   *
+   * Overload signatures match Relation's: `first()` →
+   * `Promise<T | null>`, `first(n)` → `Promise<T[]>`. The
+   * implementation returns the union and dispatches by argument
+   * presence, so callers keep correct typing without a cast or
+   * `@ts-expect-error`.
    */
-  // @ts-expect-error — deliberate Rails-fidelity deviation in loaded-chain mode: async, not sync
-  override first(limit?: number): Promise<T | null> | Promise<T[]> {
+  override first(): Promise<T | null>;
+  override first(n: number): Promise<T[]>;
+  override async first(limit?: number): Promise<T | T[] | null> {
     if (this._chainWalker) {
-      // Defer to Relation's chained-then-load semantics: spawn a
-      // limited(1)/limited(N) clone, then load + take the first.
       const limitVal = limit ?? 1;
       const limited = Relation.prototype.limit.call(this, limitVal) as Relation<T>;
-      return (async () => {
-        const records = await limited.toArray();
-        if (limit === undefined) return records[0] ?? null;
-        return records;
-      })() as Promise<T | null> | Promise<T[]>;
+      const records = await limited.toArray();
+      return limit === undefined ? (records[0] ?? null) : records;
     }
-    return (async () => {
-      const records = await this.toArray();
-      if (limit === undefined) return records[0] ?? null;
-      return records.slice(0, limit);
-    })() as Promise<T | null> | Promise<T[]>;
+    const records = await this.toArray();
+    return limit === undefined ? (records[0] ?? null) : records.slice(0, limit);
   }
 }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -164,7 +164,31 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // Loaded-chain mode: load via Relation, then group by `key` and
     // re-emit in `ids` order so the caller sees join-table ordering
     // (Rails' `load` override).
-    const records = await super.toArray();
+    //
+    // Snapshot + clear `_limitValue` / `_offsetValue` before
+    // `super.toArray()` and apply them in-memory after reorder.
+    // Reason: deferred-mode composition (via `_composeChainedState`'s
+    // `merge`) can copy a chained `.limit(n)` / offset onto this
+    // loaded-chain DJAR. Letting the SQL path apply LIMIT before the
+    // IN-list reorder would slice the WRONG rows — the rows that
+    // happen to come back first from the IN(...) query, not the rows
+    // that come first in through-table order. Rails handles this by
+    // overriding `limit` / `first` to load + take in memory; we
+    // must match for the merged-in case too.
+    const self = this as unknown as { _limitValue?: number | null; _offsetValue?: number | null };
+    const limitVal = self._limitValue ?? null;
+    const offsetVal = self._offsetValue ?? null;
+    self._limitValue = null;
+    self._offsetValue = null;
+    let records: T[];
+    try {
+      records = await super.toArray();
+    } finally {
+      // Restore so the relation's reported state matches what callers
+      // configured (e.g. for inspect/diagnostic paths).
+      self._limitValue = limitVal;
+      self._offsetValue = offsetVal;
+    }
     const byKey = new Map<unknown, T[]>();
     for (const r of records) {
       const k = r.readAttribute(this.key);
@@ -177,7 +201,9 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       const bucket = byKey.get(id);
       if (bucket) ordered.push(...bucket);
     }
-    return ordered;
+    const start = offsetVal ?? 0;
+    const end = limitVal == null ? undefined : start + limitVal;
+    return start === 0 && end === undefined ? ordered : ordered.slice(start, end);
   }
 
   /**


### PR DESCRIPTION
## Summary

PR A of the DJAS follow-up arc. Eliminates the `Promise<{ relation }>` boxing wart by making DJAS' return type match Rails:

| | Return type |
|---|---|
| Rails `DisableJoinsAssociationScope#scope` | `Relation` (sync) |
| Before this PR | `Promise<{ relation: Relation }>` (boxed to dodge the Relation thenable that would unwrap `Promise<Relation>` to `T[]`) |
| After this PR | `DisableJoinsAssociationRelation` (sync, deferred-chain) |

DJAR gains a "deferred-chain" mode alongside the existing "loaded-chain" mode (the ordered-upstream wrap path). Static factory `DJAR.deferred(klass, walker)` wires the walker; `toArray()` invokes it on first call (memoized) and delegates.

The bare Relation must never cross an `await` boundary internally — Promise/A+ unwraps it via `Relation.then` (= `toArray` shortcut). The boxing is now contained inside the walker contract; callers see only the sync `Relation` interface.

**Loader simplification:** `_loadThroughViaDisableJoinsScope` drops the `await` + `.relation` unwrap. `Association.associationScope()` drops its disable-joins branch entirely (dead code in production — loaders route disable-joins through `_loadThroughViaDisableJoinsScope`, never through `associationScope`). Removing it also breaks an import cycle that would otherwise force another round of dynamic-import wrapping.

## Test plan

- [x] DJAS test suite reframed for the sync return shape (drop `await`, drop `.relation` access).
- [x] PR 5a's "disable_joins bypasses cache" test updated to assert the actual current contract: disable-joins routes through a different loader path, never invokes JOIN-based `AssociationScope.scope`.
- [x] Full `@blazetrails/activerecord` suite: 8668 passed locally.
- [ ] PG / MariaDB CI.

This PR clears the way for PRs B–D (DJAS unscope coverage, composite-key support, routing widening).