### PR TITLE
refactor(activerecord): CollectionProxy extends Relation (PR A)

### DIFF
--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -190,8 +190,11 @@ describe("declare patterns — typing runtime-attached members", () => {
     expectTypeOf(author.comments).toEqualTypeOf<AssociationProxy<Comment>>();
     // Awaitable → Comment[]
     expectTypeOf(await author.comments).toEqualTypeOf<Comment[]>();
-    // Array-shaped — sync against loaded target.
-    expectTypeOf(author.comments.length).toBeNumber();
+    // Array-shaped — sync against loaded target. `proxy.length` is now
+    // Relation's async `length()` under CP-extends-Relation; reach for
+    // `proxy.target.length` or `Array.from(proxy).length` for a sync
+    // count.
+    expectTypeOf(author.comments.target.length).toBeNumber();
     expectTypeOf(author.comments[0]).toEqualTypeOf<Comment | undefined>();
   });
 

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -97,15 +97,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Override the load path to propagate inverse_of and strict_loading onto
-   * records fetched through this relation — mirrors Rails'
-   * `AssociationRelation#exec_queries`, which calls
-   * `set_inverse_instance_from_queries` and applies `strict_loading!` when
-   * the owner or the reflection has it set. Without this, a record loaded
-   * via `blog.posts.where(...)` wouldn't cache `post.blog = blog` on the
-   * way back, so accessing the inverse would re-query.
-   */
-  /**
    * Throw `StrictLoadingViolationError` if the owning record has
    * strict-loading on and isn't inside a bypass block. Called from
    * every AR query-executing entry point (toArray, count, pluck,
@@ -125,6 +116,16 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     }
   }
 
+  /**
+   * Override the load path to enforce owner strict-loading and to
+   * propagate inverse_of / per-record strict-loading onto the fetched
+   * records — mirrors Rails' `AssociationRelation#exec_queries`, which
+   * calls `set_inverse_instance_from_queries` and applies
+   * `strict_loading!` when the owner or the reflection has it set.
+   * Without the inverse wiring, a record loaded via
+   * `blog.posts.where(...)` wouldn't cache `post.blog = blog` on the
+   * way back, so accessing the inverse would re-query.
+   */
   async toArray(): Promise<T[]> {
     this._checkStrictLoading();
     const records = await super.toArray();

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -2,6 +2,7 @@ import type { Base } from "./base.js";
 import { Relation } from "./relation.js";
 import type { CollectionProxy } from "./associations/collection-proxy.js";
 import { _setAssociationRelationCtor } from "./associations/collection-proxy.js";
+import { StrictLoadingViolationError } from "./errors.js";
 
 /**
  * A Relation produced by a collection association (e.g. `blog.posts`,
@@ -105,8 +106,20 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * way back, so accessing the inverse would re-query.
    */
   async toArray(): Promise<T[]> {
-    const records = await super.toArray();
+    // Strict-loading guard BEFORE executing the query. Previously this
+    // lived in `wrapCollectionProxy`'s `get` trap; with CP now
+    // inheriting Relation directly, chained queries (blog.posts.where
+    // (...)) become AR instances and bypass the trap — so AR has to
+    // enforce it itself.
     const owner = this._association.owner;
+    const ownerAny = owner as unknown as {
+      _strictLoading?: boolean;
+      _strictLoadingBypassCount?: number;
+    };
+    if (ownerAny._strictLoading && !ownerAny._strictLoadingBypassCount) {
+      throw StrictLoadingViolationError.forAssociation(owner, this._association.associationName);
+    }
+    const records = await super.toArray();
     const reflection = this._association.reflection;
     const inverseOf = reflection.options.inverseOf;
 
@@ -117,13 +130,12 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
       }
     }
 
-    const ownerAny = owner as unknown as {
-      _strictLoading?: boolean;
+    const ownerNPlus = owner as unknown as {
       isStrictLoadingNPlusOneOnly?: () => boolean;
     };
     const nPlusOneOnly =
-      typeof ownerAny.isStrictLoadingNPlusOneOnly === "function" &&
-      ownerAny.isStrictLoadingNPlusOneOnly() &&
+      typeof ownerNPlus.isStrictLoadingNPlusOneOnly === "function" &&
+      ownerNPlus.isStrictLoadingNPlusOneOnly() &&
       reflection.type === "hasMany";
     if (nPlusOneOnly || ownerAny._strictLoading || reflection.options.strictLoading) {
       for (const r of records) {

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -105,12 +105,16 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * via `blog.posts.where(...)` wouldn't cache `post.blog = blog` on the
    * way back, so accessing the inverse would re-query.
    */
-  async toArray(): Promise<T[]> {
-    // Strict-loading guard BEFORE executing the query. Previously this
-    // lived in `wrapCollectionProxy`'s `get` trap; with CP now
-    // inheriting Relation directly, chained queries (blog.posts.where
-    // (...)) become AR instances and bypass the trap — so AR has to
-    // enforce it itself.
+  /**
+   * Throw `StrictLoadingViolationError` if the owning record has
+   * strict-loading on and isn't inside a bypass block. Called from
+   * every AR query-executing entry point (toArray, count, pluck,
+   * pick, calculate, updateAll, deleteAll). Centralized here because
+   * with `CP extends Relation`, chained queries (blog.posts.where
+   * (...)) bypass the old `wrapCollectionProxy` `get` trap that used
+   * to enforce this.
+   */
+  private _checkStrictLoading(): void {
     const owner = this._association.owner;
     const ownerAny = owner as unknown as {
       _strictLoading?: boolean;
@@ -119,7 +123,12 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     if (ownerAny._strictLoading && !ownerAny._strictLoadingBypassCount) {
       throw StrictLoadingViolationError.forAssociation(owner, this._association.associationName);
     }
+  }
+
+  async toArray(): Promise<T[]> {
+    this._checkStrictLoading();
     const records = await super.toArray();
+    const owner = this._association.owner;
     const reflection = this._association.reflection;
     const inverseOf = reflection.options.inverseOf;
 
@@ -130,20 +139,70 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
       }
     }
 
-    const ownerNPlus = owner as unknown as {
+    const ownerFlags = owner as unknown as {
+      _strictLoading?: boolean;
       isStrictLoadingNPlusOneOnly?: () => boolean;
     };
     const nPlusOneOnly =
-      typeof ownerNPlus.isStrictLoadingNPlusOneOnly === "function" &&
-      ownerNPlus.isStrictLoadingNPlusOneOnly() &&
+      typeof ownerFlags.isStrictLoadingNPlusOneOnly === "function" &&
+      ownerFlags.isStrictLoadingNPlusOneOnly() &&
       reflection.type === "hasMany";
-    if (nPlusOneOnly || ownerAny._strictLoading || reflection.options.strictLoading) {
+    if (nPlusOneOnly || ownerFlags._strictLoading || reflection.options.strictLoading) {
       for (const r of records) {
         (r as unknown as { strictLoadingBang?: () => void }).strictLoadingBang?.();
       }
     }
 
     return records;
+  }
+
+  // Other SQL-executing entry points — gate on the same strict-loading
+  // check. Rails enforces strict loading uniformly across `CollectionProxy`
+  // reads; with CP now extending Relation, chained AR methods need the
+  // same gate.
+
+  // @ts-expect-error — Relation defines `count` as a property; override as
+  //   a method so we can gate strict-loading before dispatching.
+  async count(...args: unknown[]): Promise<number | Record<string, number>> {
+    this._checkStrictLoading();
+    return (
+      Relation.prototype as unknown as {
+        count: (...a: unknown[]) => Promise<number | Record<string, number>>;
+      }
+    ).count.apply(this, args);
+  }
+
+  override pluck(...columns: Parameters<Relation<T>["pluck"]>): Promise<unknown[]> {
+    this._checkStrictLoading();
+    return super.pluck(...columns);
+  }
+
+  override pick(...columns: Parameters<Relation<T>["pick"]>): Promise<unknown> {
+    this._checkStrictLoading();
+    return super.pick(...columns);
+  }
+
+  override async calculate(
+    operation: "count" | "sum" | "average" | "minimum" | "maximum",
+    column?: string,
+  ): Promise<number | Record<string, number>> {
+    this._checkStrictLoading();
+    return (
+      super.calculate as unknown as (
+        op: string,
+        col?: string,
+      ) => Promise<number | Record<string, number>>
+    ).call(this, operation, column);
+  }
+
+  override updateAll(updates: Record<string, unknown>): Promise<number> {
+    this._checkStrictLoading();
+    return super.updateAll(updates);
+  }
+
+  override deleteAll(): Promise<number> {
+    this._checkStrictLoading();
+    return super.deleteAll();
   }
 }
 

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -162,15 +162,57 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   // reads; with CP now extending Relation, chained AR methods need the
   // same gate.
 
-  // @ts-expect-error — Relation defines `count` as a property; override as
-  //   a method so we can gate strict-loading before dispatching.
-  async count(...args: unknown[]): Promise<number | Record<string, number>> {
+  // @ts-expect-error — Relation defines `count` as a property; override
+  //   as a method so we can gate strict-loading before dispatching.
+  async count(column?: string): Promise<number | Record<string, number>> {
     this._checkStrictLoading();
     return (
       Relation.prototype as unknown as {
-        count: (...a: unknown[]) => Promise<number | Record<string, number>>;
+        count: (col?: string) => Promise<number | Record<string, number>>;
       }
-    ).count.apply(this, args);
+    ).count.call(this, column);
+  }
+
+  // @ts-expect-error — sum/average/minimum/maximum are also property-
+  //   assigned on Relation (from the Calculations mixin); override as
+  //   methods to gate strict-loading before each SQL entry point.
+  async sum(column?: string): Promise<number | Record<string, number>> {
+    this._checkStrictLoading();
+    return (
+      Relation.prototype as unknown as {
+        sum: (col?: string) => Promise<number | Record<string, number>>;
+      }
+    ).sum.call(this, column);
+  }
+
+  // @ts-expect-error — see `sum`.
+  async average(column: string): Promise<number | null | Record<string, number>> {
+    this._checkStrictLoading();
+    return (
+      Relation.prototype as unknown as {
+        average: (col: string) => Promise<number | null | Record<string, number>>;
+      }
+    ).average.call(this, column);
+  }
+
+  // @ts-expect-error — see `sum`.
+  async minimum(column: string): Promise<unknown | null | Record<string, unknown>> {
+    this._checkStrictLoading();
+    return (
+      Relation.prototype as unknown as {
+        minimum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).minimum.call(this, column);
+  }
+
+  // @ts-expect-error — see `sum`.
+  async maximum(column: string): Promise<unknown | null | Record<string, unknown>> {
+    this._checkStrictLoading();
+    return (
+      Relation.prototype as unknown as {
+        maximum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).maximum.call(this, column);
   }
 
   override pluck(...columns: Parameters<Relation<T>["pluck"]>): Promise<unknown[]> {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1739,9 +1739,10 @@ export function association<T extends Base = Base>(
     throw new Error(
       "CollectionProxy not registered. Either import '@blazetrails/activerecord' " +
         "once (the package entry loads CollectionProxy eagerly), or, if you are " +
-        "using subpath imports such as '@blazetrails/activerecord/associations' / " +
-        "'/base', call `await initializeAssociations()` (exported from " +
-        "'@blazetrails/activerecord/associations') before the first `association()` call.",
+        "using subpath imports such as '@blazetrails/activerecord/associations' or " +
+        "'@blazetrails/activerecord/base', call `await initializeAssociations()` " +
+        "(exported from '@blazetrails/activerecord/associations') before the first " +
+        "`association()` call.",
     );
   }
   const proxy = new _CollectionProxyCtor(record, assocName, assocDef) as CollectionProxy<T> & {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -21,8 +21,14 @@ export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js
  * associations) that forced the late-binding in the first place.
  */
 export async function initializeAssociations(): Promise<void> {
-  if (_CollectionProxyCtor) return;
-  await import("./associations/collection-proxy.js");
+  // Load both ctor slots. `association-relation.js` imports
+  // `collection-proxy.js` for the late-bind ctor setter, so importing
+  // AR first also registers CP transitively; we still import CP
+  // explicitly as a belt-and-suspenders guarantee.
+  await Promise.all([
+    import("./associations/collection-proxy.js"),
+    import("./association-relation.js"),
+  ]);
 }
 import { StrictLoadingViolationError, ConfigurationError } from "./errors.js";
 import {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -937,32 +937,27 @@ export async function loadHasMany(
 }
 
 /**
- * Build the relation for a hasMany association without executing it.
- * Skips caching, strict loading, and inverse_of — used by countHasMany
- * so resetCounters works under strict loading.
- * Returns null if primary key values are missing.
+ * Compute the WHERE condition hash that scopes a hasMany relation to its
+ * owner. Returns null if primary key values are missing (Rails'
+ * NullRelation fallback). Pure — no Relation construction.
+ *
+ * Shared by `buildHasManyRelation` (which wraps it in `all().where(...)`)
+ * and CollectionProxy's constructor (which seeds its own where-clause
+ * via the same condition).
  */
-export function buildHasManyRelation(
+export function computeHasManyWhere(
   record: Base,
-  assocName: string,
   options: AssociationOptions,
-): any | null {
+): Record<string, unknown> | null {
   const ctor = record.constructor as typeof Base;
-  const className = options.className ?? camelize(singularize(assocName));
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
-  const targetModel = resolveModel(className);
 
   if (options.as) {
     const foreignKey = options.foreignKey ?? `${underscore(options.as)}_id`;
     const pkValue = record.readAttribute(primaryKey as string);
     if (pkValue === null || pkValue === undefined) return null;
     const typeCol = `${underscore(options.as)}_type`;
-    let rel = (targetModel as any).all().where({
-      [foreignKey as string]: pkValue,
-      [typeCol]: ctor.name,
-    });
-    if (options.scope) rel = options.scope(rel);
-    return rel;
+    return { [foreignKey as string]: pkValue, [typeCol]: ctor.name };
   }
 
   const foreignKey =
@@ -981,14 +976,30 @@ export function buildHasManyRelation(
       if (pkVal === null || pkVal === undefined) return null;
       conditions[foreignKey[i]] = pkVal;
     }
-    let rel = (targetModel as any).all().where(conditions);
-    if (options.scope) rel = options.scope(rel);
-    return rel;
+    return conditions;
   }
 
   const pkValue = record.readAttribute(primaryKey as string);
   if (pkValue === null || pkValue === undefined) return null;
-  let rel = (targetModel as any).all().where({ [foreignKey]: pkValue });
+  return { [foreignKey]: pkValue };
+}
+
+/**
+ * Build the relation for a hasMany association without executing it.
+ * Skips caching, strict loading, and inverse_of — used by countHasMany
+ * so resetCounters works under strict loading.
+ * Returns null if primary key values are missing.
+ */
+export function buildHasManyRelation(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+): any | null {
+  const conditions = computeHasManyWhere(record, options);
+  if (conditions === null) return null;
+  const className = options.className ?? camelize(singularize(assocName));
+  const targetModel = resolveModel(className);
+  let rel = (targetModel as any).all().where(conditions);
   if (options.scope) rel = options.scope(rel);
   return rel;
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1712,9 +1712,11 @@ export function association<T extends Base = Base>(
     // `associations.js` bypasses that. See the collection-proxy-slot
     // module for the load-order details.
     throw new Error(
-      "CollectionProxy not registered. Import from '@blazetrails/activerecord' " +
-        "instead of deep-importing associations.js so late-bound registration " +
-        "can run and break the associations/collection-proxy/relation/base cycle.",
+      "CollectionProxy not registered. Import '@blazetrails/activerecord' " +
+        "once before calling association() so CollectionProxy registration can run. " +
+        "If you are using a subpath import such as '@blazetrails/activerecord/associations' " +
+        "or '@blazetrails/activerecord/base', keep that import but also import " +
+        "'@blazetrails/activerecord' for initialization.",
     );
   }
   const proxy = new _CollectionProxyCtor(record, assocName, assocDef) as CollectionProxy<T> & {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -963,6 +963,7 @@ export async function loadHasMany(
  */
 export function computeHasManyWhere(
   record: Base,
+  assocName: string,
   options: AssociationOptions,
 ): Record<string, unknown> | null {
   const ctor = record.constructor as typeof Base;
@@ -970,6 +971,9 @@ export function computeHasManyWhere(
 
   if (options.as) {
     const foreignKey = options.foreignKey ?? `${underscore(options.as)}_id`;
+    if (Array.isArray(foreignKey) || Array.isArray(primaryKey)) {
+      throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+    }
     const pkValue = record.readAttribute(primaryKey as string);
     if (pkValue === null || pkValue === undefined) return null;
     const typeCol = `${underscore(options.as)}_type`;
@@ -985,16 +989,26 @@ export function computeHasManyWhere(
         : `${underscore(ctor.name)}_id`);
 
   if (Array.isArray(foreignKey)) {
-    const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+    // Composite FK requires a composite PK of matching length — otherwise
+    // we'd silently readAttribute(undefined) and produce a bogus/empty
+    // scope. Existing loaders throw CompositePrimaryKeyMismatchError; do
+    // the same here so CollectionProxy construction fails loudly.
+    if (!Array.isArray(primaryKey) || primaryKey.length !== foreignKey.length) {
+      throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+    }
     const conditions: Record<string, unknown> = {};
     for (let i = 0; i < foreignKey.length; i++) {
-      const pkVal = record.readAttribute(pkCols[i]);
+      const pkVal = record.readAttribute(primaryKey[i]);
       if (pkVal === null || pkVal === undefined) return null;
       conditions[foreignKey[i]] = pkVal;
     }
     return conditions;
   }
 
+  // Scalar FK: a composite PK here is a mismatch too.
+  if (Array.isArray(primaryKey)) {
+    throw new CompositePrimaryKeyMismatchError(ctor.name, assocName);
+  }
   const pkValue = record.readAttribute(primaryKey as string);
   if (pkValue === null || pkValue === undefined) return null;
   return { [foreignKey]: pkValue };
@@ -1011,7 +1025,7 @@ export function buildHasManyRelation(
   assocName: string,
   options: AssociationOptions,
 ): any | null {
-  const conditions = computeHasManyWhere(record, options);
+  const conditions = computeHasManyWhere(record, assocName, options);
   if (conditions === null) return null;
   const className = options.className ?? camelize(singularize(assocName));
   const targetModel = resolveModel(className);
@@ -1701,7 +1715,9 @@ export function association<T extends Base = Base>(
   }
   if (!_CollectionProxyCtor) {
     throw new Error(
-      "CollectionProxy not loaded. Import collection-proxy.js first (or access an association).",
+      "CollectionProxy not registered. Import from '@blazetrails/activerecord' " +
+        "instead of deep-importing associations.js so late-bound registration " +
+        "can run and break the associations/collection-proxy/relation/base cycle.",
     );
   }
   const proxy = new _CollectionProxyCtor<T>(record, assocName, assocDef);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,22 +1,10 @@
 import type { Base } from "./base.js";
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
-
-// Late-bound CollectionProxy constructor. We can't value-import CP at
-// module init because CP now `extends Relation`, and the cycle
-// (associations → CP → Relation → Base → associations) would read the
-// partial associations module mid-load. Registered by collection-proxy.ts
-// at the bottom of its module.
-type _CPCtor = new <T extends Base>(
-  record: Base,
-  assocName: string,
-  assocDef: AssociationDefinition,
-) => CollectionProxy<T>;
-let _CollectionProxyCtor: _CPCtor | undefined;
-/** @internal */
-export function _setCollectionProxyCtor(ctor: _CPCtor): void {
-  _CollectionProxyCtor = ctor;
-}
+import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
+// Re-export the slot's setter so the package entry and other internal
+// callers don't need to import the slot module directly.
+export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 import { StrictLoadingViolationError, ConfigurationError } from "./errors.js";
 import {
   AssociationNotFoundError,
@@ -1720,7 +1708,9 @@ export function association<T extends Base = Base>(
         "can run and break the associations/collection-proxy/relation/base cycle.",
     );
   }
-  const proxy = new _CollectionProxyCtor<T>(record, assocName, assocDef);
+  const proxy = new _CollectionProxyCtor(record, assocName, assocDef) as CollectionProxy<T> & {
+    _hydrateFromPreload: (records: T[]) => void;
+  };
 
   // Hydrate from preloaded data if available
   const preloaded = record._preloadedAssociations?.get(assocName);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -5,6 +5,25 @@ import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 // Re-export the slot's setter so the package entry and other internal
 // callers don't need to import the slot module directly.
 export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
+
+/**
+ * Explicit initialization hook for subpath consumers.
+ *
+ * The package entry (`@blazetrails/activerecord`) loads
+ * CollectionProxy eagerly so `association()` works out of the box.
+ * Consumers who deep-import `@blazetrails/activerecord/associations`
+ * without touching the entry won't trigger that registration; calling
+ * `await initializeAssociations()` once before `association()` is the
+ * supported alternative.
+ *
+ * Uses a dynamic `import()` so it doesn't participate in the static
+ * dependency cycle (associations → CP → Relation → Base →
+ * associations) that forced the late-binding in the first place.
+ */
+export async function initializeAssociations(): Promise<void> {
+  if (_CollectionProxyCtor) return;
+  await import("./associations/collection-proxy.js");
+}
 import { StrictLoadingViolationError, ConfigurationError } from "./errors.js";
 import {
   AssociationNotFoundError,
@@ -1712,11 +1731,11 @@ export function association<T extends Base = Base>(
     // `associations.js` bypasses that. See the collection-proxy-slot
     // module for the load-order details.
     throw new Error(
-      "CollectionProxy not registered. Import '@blazetrails/activerecord' " +
-        "once before calling association() so CollectionProxy registration can run. " +
-        "If you are using a subpath import such as '@blazetrails/activerecord/associations' " +
-        "or '@blazetrails/activerecord/base', keep that import but also import " +
-        "'@blazetrails/activerecord' for initialization.",
+      "CollectionProxy not registered. Either import '@blazetrails/activerecord' " +
+        "once (the package entry loads CollectionProxy eagerly), or, if you are " +
+        "using subpath imports such as '@blazetrails/activerecord/associations' / " +
+        "'/base', call `await initializeAssociations()` (exported from " +
+        "'@blazetrails/activerecord/associations') before the first `association()` call.",
     );
   }
   const proxy = new _CollectionProxyCtor(record, assocName, assocDef) as CollectionProxy<T> & {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,6 +1,22 @@
 import type { Base } from "./base.js";
 import { Table as ArelTable } from "@blazetrails/arel";
-import { CollectionProxy, type AssociationProxy } from "./associations/collection-proxy.js";
+import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
+
+// Late-bound CollectionProxy constructor. We can't value-import CP at
+// module init because CP now `extends Relation`, and the cycle
+// (associations → CP → Relation → Base → associations) would read the
+// partial associations module mid-load. Registered by collection-proxy.ts
+// at the bottom of its module.
+type _CPCtor = new <T extends Base>(
+  record: Base,
+  assocName: string,
+  assocDef: AssociationDefinition,
+) => CollectionProxy<T>;
+let _CollectionProxyCtor: _CPCtor | undefined;
+/** @internal */
+export function _setCollectionProxyCtor(ctor: _CPCtor): void {
+  _CollectionProxyCtor = ctor;
+}
 import { StrictLoadingViolationError, ConfigurationError } from "./errors.js";
 import {
   AssociationNotFoundError,
@@ -1683,7 +1699,12 @@ export function association<T extends Base = Base>(
   if (!assocDef) {
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }
-  const proxy = new CollectionProxy<T>(record, assocName, assocDef);
+  if (!_CollectionProxyCtor) {
+    throw new Error(
+      "CollectionProxy not loaded. Import collection-proxy.js first (or access an association).",
+    );
+  }
+  const proxy = new _CollectionProxyCtor<T>(record, assocName, assocDef);
 
   // Hydrate from preloaded data if available
   const preloaded = record._preloadedAssociations?.get(assocName);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1702,6 +1702,15 @@ export function association<T extends Base = Base>(
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }
   if (!_CollectionProxyCtor) {
+    // Deliberate constraint: `associations.ts`, `relation.ts`,
+    // `collection-proxy.ts`, and `base.ts` form a mandatory mutual
+    // dependency — CP `extends Relation`, Relation/Base call back
+    // into the association wiring, and attempting to value-import CP
+    // at this module's top would observe a partial module during
+    // init. The package entry (`@blazetrails/activerecord`) loads CP
+    // explicitly and triggers self-registration; deep-importing
+    // `associations.js` bypasses that. See the collection-proxy-slot
+    // module for the load-order details.
     throw new Error(
       "CollectionProxy not registered. Import from '@blazetrails/activerecord' " +
         "instead of deep-importing associations.js so late-bound registration " +

--- a/packages/activerecord/src/associations/collection-proxy-slot.ts
+++ b/packages/activerecord/src/associations/collection-proxy-slot.ts
@@ -1,0 +1,24 @@
+// Late-bound CollectionProxy constructor slot, extracted into a module
+// with ZERO imports so it cannot participate in any import cycle.
+//
+// Why this exists: CollectionProxy `extends Relation`, which transitively
+// drags in `base.ts` and `associations.ts`. Value-importing
+// CollectionProxy from `associations.ts` at module init would observe
+// a partial `associations.ts` during the cycle. This slot lets
+// `associations.ts` construct a CP via a registered ctor instead.
+//
+// The CP module sets this on load (self-registration at the bottom of
+// `collection-proxy.ts`); `associations.ts` reads it. Placing the slot
+// here — with no imports — guarantees its top-level binding runs
+// before any cycle participant touches it, so neither `let` nor TDZ
+// hazards apply.
+
+/** @internal */
+
+export let _CollectionProxyCtor: (new (...args: any[]) => any) | undefined;
+
+/** @internal */
+
+export function _setCollectionProxyCtor(ctor: new (...args: any[]) => any): void {
+  _CollectionProxyCtor = ctor;
+}

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -264,6 +264,20 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(found?.title).toBe("a");
   });
 
+  it("toArray honors direct bang-mutation of inherited Relation state", async () => {
+    // In-place bang mutations on CP (cp.whereBang/orderBang/limitBang)
+    // change the inherited Relation state. `toArray()` detects the
+    // divergence from the seed and delegates to super.toArray() so
+    // results reflect the mutations, instead of silently returning the
+    // association-cached full load. Chaining (cp.where(...).toArray())
+    // is the normal path and already goes through AR → Relation.
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts") as any;
+    proxy.whereBang({ title: "b" });
+    const results = await proxy.toArray();
+    expect(results.map((p: ApPost) => p.title)).toEqual(["b"]);
+  });
+
   // ── Phase R.2 — collection reader returns the AssociationProxy ─────
 
   it("blog.apPosts is the AssociationProxy itself (Phase R.2 reader swap)", async () => {

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -56,7 +56,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     return blog;
   }
 
-  it("exposes sync count via `Array.from(proxy).length`", async () => {
+  it("exposes `length` against the loaded target", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");
     // With CP extending Relation, `proxy.length` is now the inherited
@@ -66,7 +66,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(proxy.target.length).toBe(3);
   });
 
-  it("inherits Relation#length() — async count", async () => {
+  it("shadows Relation#length() — use proxy.count() for async count", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts") as any;
     expect(typeof proxy.length).toBe("function");

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -56,20 +56,22 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     return blog;
   }
 
-  it("exposes `length` against the loaded target", async () => {
+  it("exposes sync count via `Array.from(proxy).length`", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts");
-    expect(proxy.length).toBe(3);
+    // With CP extending Relation, `proxy.length` is now the inherited
+    // async `Relation#length()`. For a sync count over the loaded target
+    // reach for `Array.from(proxy).length` or `proxy.target.length`.
+    expect(Array.from(proxy).length).toBe(3);
+    expect(proxy.target.length).toBe(3);
   });
 
-  it("shadows Relation#length() — use proxy.count() for async count", async () => {
+  it("inherits Relation#length() — async count", async () => {
     const blog = await blogWithPosts();
     const proxy = association<ApPost>(blog, "apPosts") as any;
-    // `proxy.length` is now a sync number (mirrors Array / Rails).
-    expect(typeof proxy.length).toBe("number");
-    // For Relation's async count semantics, reach for .count() which still
-    // routes through to Relation via AssociationProxy delegation.
-    expect(typeof proxy.count).toBe("function");
+    expect(typeof proxy.length).toBe("function");
+    expect(await proxy.length()).toBe(3);
+    // `proxy.count()` still works too (association-specific path).
     expect(await proxy.count()).toBe(3);
   });
 
@@ -197,7 +199,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("await proxy hydrates `_target` so subsequent sync ops work", async () => {
     // Build a blog/post pair WITHOUT pre-loading via blogWithPosts (which
     // calls .load()). `await proxy` alone should be enough to make
-    // `proxy.length`, `proxy[0]`, iteration all work afterwards.
+    // `proxy.target`, `proxy[0]`, iteration all work afterwards.
     const blog = new ApBlog({ name: "Fresh" });
     await blog.save();
     for (const title of ["x", "y"]) {
@@ -206,7 +208,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     }
     const proxy = association<ApPost>(blog, "apPosts") as any;
     await proxy;
-    expect(proxy.length).toBe(2);
+    expect(proxy.target.length).toBe(2);
     expect(proxy[0]?.title).toBe("x");
     expect([...proxy].map((p: ApPost) => p.title)).toEqual(["x", "y"]);
   });
@@ -286,7 +288,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("blog.apPosts is array-like via R.1 surface", async () => {
     const blog = await blogWithPosts();
     const reader = (blog as any).apPosts;
-    expect(reader.length).toBe(3);
+    expect(reader.target.length).toBe(3);
     expect(reader[0]?.title).toBe("a");
     expect(reader.map((p: ApPost) => p.title)).toEqual(["a", "b", "c"]);
     const titles: string[] = [];
@@ -303,7 +305,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     (blog as any).apPosts = [replacement];
     // The proxy returned by the reader reflects the new target.
     const reader = (blog as any).apPosts;
-    expect(reader.length).toBe(1);
+    expect(reader.target.length).toBe(1);
     expect(reader[0]?.title).toBe("z");
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -410,22 +410,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (typeof original !== "function") continue;
       Object.defineProperty(this, name, {
         value: function (this: CollectionProxy<T>, ...args: unknown[]) {
-          const self = this as unknown as {
-            _cpMutated: boolean;
-            _loaded: boolean;
-            _records: unknown[];
-            _loadAsyncPromise?: Promise<unknown>;
-          };
-          self._cpMutated = true;
-          // Also invalidate the inherited Relation load cache so a
-          // subsequent super.toArray() / super.count() on the diverged
-          // path re-runs the query instead of returning stale results
-          // from a pre-bang load. The association-local target (_target)
-          // is intentionally NOT wiped — that's the owner's in-memory
-          // proxy state and survives scope mutations.
-          self._loaded = false;
-          self._records = [];
-          self._loadAsyncPromise = undefined;
+          (this as unknown as { _cpMutated: boolean })._cpMutated = true;
+          // Use Relation#reset so all inherited load-state — including
+          // `_loadToken` — is invalidated atomically. Bumping the token
+          // lets in-flight super.toArray() completions detect that
+          // they're stale and skip committing results; manually
+          // clearing a subset of fields would race on the
+          // diverged-toArray / load code paths. `_target` (the
+          // association-local in-memory state) is NOT touched —
+          // that's the owner's proxy state and survives scope
+          // mutations.
+          (
+            Relation.prototype as unknown as { reset: (this: CollectionProxy<T>) => void }
+          ).reset.call(this);
           return (original as (...a: unknown[]) => unknown).apply(this, args);
         },
         writable: true,
@@ -454,6 +451,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     //    association cache is bypassed here because it's keyed on the
     //    unmutated scope and would return stale/incorrect data.
     if (this._relationStateDiverged()) {
+      // Diverged path bypasses loadHasMany, which is where the
+      // association's strict-loading enforcement normally lives. Run
+      // the gate ourselves so owner._strictLoading still raises.
+      this._checkStrictLoading();
       const results = await super.toArray();
       const unsaved = this._target.filter((r) => r.isNewRecord());
       return unsaved.length > 0 ? [...results, ...unsaved] : results;
@@ -482,6 +483,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // would silently fall back to the full association-cache load.
     let results: T[];
     if (this._relationStateDiverged()) {
+      // Diverged path bypasses loadHasMany — enforce strict-loading
+      // explicitly, same as the toArray() diverged branch.
+      this._checkStrictLoading();
       results = await super.toArray();
     } else {
       results = (await loadHasMany(this._record, this._assocName, this._assocDef.options)) as T[];
@@ -684,6 +688,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // super.toArray().length — instantiating every row just to count
     // would be a major perf regression on large collections.
     if (this._relationStateDiverged()) {
+      // Diverged path bypasses loadHasMany — enforce strict-loading
+      // explicitly so owner._strictLoading still raises.
+      this._checkStrictLoading();
       const counted = await (
         Relation.prototype as unknown as {
           count(this: CollectionProxy<T>): Promise<number | Record<string, number>>;
@@ -1601,6 +1608,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // here: those resolve back to CollectionProxy's own methods and
     // would recurse.
     const diverged = this._relationStateDiverged();
+    // Through and diverged paths bypass scope(), which is where AR
+    // gates strict-loading. Enforce directly so deleteAll is
+    // consistent regardless of through/diverged state. The
+    // non-diverged non-through branch goes through scope() which
+    // produces an AR and enforces the same gate on its own.
+    if (this._isThrough || diverged) {
+      this._checkStrictLoading();
+    }
     if (strategy === "delete_all") {
       if (this._isThrough) {
         // For through associations, delete join rows via SQL — not the target records

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -36,10 +36,11 @@ import {
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 
-// @ts-expect-error Declaration merging with `class CollectionProxy extends
-//   Relation` propagates Relation's method types into this interface.
-//   `load()` diverges (CP returns T[], Relation returns LoadedRelation<this>)
-//   and the conflict surfaces here too. Same PR B plan as on the class.
+// Declaration merging with `class CollectionProxy extends Relation`
+// propagates Relation's method types into this interface. `load()`
+// diverges (CP returns T[], Relation returns LoadedRelation<this>)
+// and the conflict surfaces here too. Same PR B plan as on the class.
+// @ts-expect-error see block comment above — declaration-merge `load()` divergence
 export interface CollectionProxy<T extends Base = Base> {
   // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
   // which both returns the loaded records AND hydrates `_target`, so
@@ -663,6 +664,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   semantics (loaded-target fast path). PR B will delete CP's count
   //   and let Relation's win.
   async count(): Promise<number> {
+    // Same divergence gate as toArray() / load(): scope bangs on the
+    // proxy mean loadHasMany's cached count is stale.
+    if (this._relationStateDiverged()) {
+      return (await super.toArray()).length;
+    }
     const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
     return results.length;
   }
@@ -1273,6 +1279,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return records.map((r) => stringCols.map((c) => r.readAttribute(c)));
     }
     this._checkStrictLoading();
+    // Scope bangs on the proxy itself: scope() rebuilds the unmutated
+    // association relation and would drop the mutation. super.pluck
+    // uses the inherited (mutated) Relation state instead.
+    if (this._relationStateDiverged()) {
+      return super.pluck(...columns);
+    }
     return this.scope().pluck(...columns);
   }
 
@@ -1290,6 +1302,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return stringCols.map((c) => records[0].readAttribute(c));
     }
     this._checkStrictLoading();
+    // Same divergence gate as pluck().
+    if (this._relationStateDiverged()) {
+      return super.pick(...columns);
+    }
     return this.scope().pick(...columns);
   }
 
@@ -1548,12 +1564,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         );
     }
 
+    // If the proxy's inherited Relation state has been mutated in place
+    // (e.g. cp.whereBang(...)), use `this` directly instead of
+    // scope() — scope() rebuilds the unmutated association scope and
+    // would delete/nullify MORE rows than the caller constrained.
+    const rel = this._relationStateDiverged() ? (this as unknown as Relation<T>) : this.scope();
     if (strategy === "delete_all") {
       if (this._isThrough) {
         // For through associations, delete join rows via SQL — not the target records
         await this._deleteThroughAllSql();
       } else {
-        await this.scope().deleteAll();
+        await (rel as { deleteAll: () => Promise<unknown> }).deleteAll();
       }
     } else {
       // Nullify: set-based SQL update to null FKs (no per-record callbacks)
@@ -1561,7 +1582,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         await this._deleteThroughAllSql();
       } else {
         const nullUpdates = this._buildNullifyUpdates();
-        await this.scope().updateAll(nullUpdates);
+        await (rel as { updateAll: (u: Record<string, unknown>) => Promise<unknown> }).updateAll(
+          nullUpdates,
+        );
       }
     }
     this._target = [];

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1866,7 +1866,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   protected override _newRelation(): Relation<T> {
     if (!_AssociationRelationCtor) {
-      throw new Error(
+      throw new ConfigurationError(
         "CollectionProxy._newRelation: AssociationRelation constructor not set — " +
           "association-relation.ts must be loaded first",
       );

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -114,10 +114,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     offsetValue: number | null;
     selectColumns: number | null;
     isDistinct: boolean;
+    distinctOnColumns: number;
     groupColumns: number;
     joinClauses: number;
     rawJoins: number;
     isNone: boolean;
+    // SQL-shape fields added in round 5 to close divergence blind spots
+    // (fromBang / withBang / withRecursiveBang / lockBang / annotate /
+    // optimizerHints / references / eagerLoad / includes / preload).
+    lockValue: string | null;
+    ctes: number;
+    fromClause: unknown;
+    annotations: number;
+    optimizerHints: number;
+    referencesValues: number;
+    eagerLoadAssociations: number;
+    includesAssociations: number;
+    preloadAssociations: number;
+    setOperation: unknown;
   };
 
   get loaded(): boolean {
@@ -307,18 +321,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         );
       }
       resolveModel(className); // throws if the target model isn't registered
-      try {
-        const throughRel = this._buildThroughScope() as Relation<T>;
-        proxySelf._copyStateFrom(throughRel);
-      } catch {
-        // Config is valid — this path only fires for adapter/schema
-        // failures (e.g. fixture constructs a proxy before migrations
-        // run). Fail CLOSED so `cp.where(...).toArray()` returns []
-        // rather than silently querying the full target table. A
-        // later `scope()` call rebuilds and surfaces the real error
-        // if the adapter is still broken.
-        proxySelf.noneBang();
-      }
+      // No try/catch: if `_buildThroughScope()` throws, the caller
+      // sees the real error (composite-PK mismatch, join resolution
+      // failure, etc.) instead of a silently `none`-coerced proxy.
+      // Previous fail-closed catch swallowed deterministic config
+      // errors — worse than letting construction fail.
+      const throughRel = this._buildThroughScope() as Relation<T>;
+      proxySelf._copyStateFrom(throughRel);
     } else {
       // Build via `buildHasManyRelation` so CP's inherited Relation
       // state matches `scope()` / direct Relation callers: default
@@ -372,10 +381,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       _offsetValue: number | null;
       _selectColumns: unknown[] | null;
       _isDistinct: boolean;
+      _distinctOnColumns: unknown[];
       _groupColumns: unknown[];
       _joinClauses: unknown[];
       _rawJoins: unknown[];
       _isNone: boolean;
+      _lockValue: string | null;
+      _ctes: unknown[];
+      _fromClause: unknown;
+      _annotations: unknown[];
+      _optimizerHints: unknown[];
+      _referencesValues: unknown[];
+      _eagerLoadAssociations: unknown[];
+      _includesAssociations: unknown[];
+      _preloadAssociations: unknown[];
+      _setOperation: unknown;
     };
     return {
       wherePredicates: s._whereClause.predicates.length,
@@ -386,10 +406,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       offsetValue: s._offsetValue,
       selectColumns: s._selectColumns ? s._selectColumns.length : null,
       isDistinct: s._isDistinct,
+      distinctOnColumns: s._distinctOnColumns.length,
       groupColumns: s._groupColumns.length,
       joinClauses: s._joinClauses.length,
       rawJoins: s._rawJoins.length,
       isNone: s._isNone,
+      lockValue: s._lockValue,
+      ctes: s._ctes.length,
+      fromClause: s._fromClause,
+      annotations: s._annotations.length,
+      optimizerHints: s._optimizerHints.length,
+      referencesValues: s._referencesValues.length,
+      eagerLoadAssociations: s._eagerLoadAssociations.length,
+      includesAssociations: s._includesAssociations.length,
+      preloadAssociations: s._preloadAssociations.length,
+      setOperation: s._setOperation,
     };
   }
 
@@ -397,20 +428,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _relationStateDiverged(): boolean {
     const now = this._captureStateSignature();
     const seed = this._seedSignature;
-    return (
-      now.wherePredicates !== seed.wherePredicates ||
-      now.havingPredicates !== seed.havingPredicates ||
-      now.orderClauses !== seed.orderClauses ||
-      now.rawOrderClauses !== seed.rawOrderClauses ||
-      now.limitValue !== seed.limitValue ||
-      now.offsetValue !== seed.offsetValue ||
-      now.selectColumns !== seed.selectColumns ||
-      now.isDistinct !== seed.isDistinct ||
-      now.groupColumns !== seed.groupColumns ||
-      now.joinClauses !== seed.joinClauses ||
-      now.rawJoins !== seed.rawJoins ||
-      now.isNone !== seed.isNone
-    );
+    for (const key of Object.keys(seed) as (keyof typeof seed)[]) {
+      if (now[key] !== seed[key]) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -278,9 +278,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         const throughRel = this._buildThroughScope() as Relation<T>;
         proxySelf._copyStateFrom(throughRel);
       } catch {
-        // Schema/adapter not ready — leave Relation state empty; `scope()`
-        // will re-run `_buildThroughScope()` when callers invoke it and
-        // raise the real error there.
+        // `_buildThroughScope()` can fail during CP construction when
+        // the adapter/schema isn't ready yet (common in test fixtures
+        // that construct a bare proxy before migrations run). Fail
+        // CLOSED: mark the inherited Relation state as `none` so
+        // `cp.where(...).toArray()` returns [] instead of silently
+        // querying the entire target table. A later `scope()` call
+        // rebuilds the through scope and surfaces the real error if
+        // the adapter is still broken.
+        proxySelf._isNone = true;
       }
     } else {
       const conditions = computeHasManyWhere(record, assocName, assocDef.options);
@@ -1127,28 +1133,39 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     await this.replace(records);
   }
 
-  async pluck(...columns: string[]): Promise<unknown[]> {
-    if (this._isThrough || this._targetLoaded) {
+  async pluck(
+    ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
+  ): Promise<unknown[]> {
+    // Loaded-target fast path only handles bare string column names —
+    // readAttribute can't resolve Arel nodes. For any non-string arg,
+    // fall through to scope().pluck(...) so Relation's SQL path runs.
+    const allStrings = columns.every((c) => typeof c === "string");
+    if (allStrings && (this._isThrough || this._targetLoaded)) {
+      const stringCols = columns as string[];
       const records = (this._isThrough ? await this.toArray() : this._target).filter(
         (r) => !r.isNewRecord(),
       );
-      if (columns.length === 1) {
-        return records.map((r) => r.readAttribute(columns[0]));
+      if (stringCols.length === 1) {
+        return records.map((r) => r.readAttribute(stringCols[0]));
       }
-      return records.map((r) => columns.map((c) => r.readAttribute(c)));
+      return records.map((r) => stringCols.map((c) => r.readAttribute(c)));
     }
     this._checkStrictLoading();
     return this.scope().pluck(...columns);
   }
 
-  async pick(...columns: string[]): Promise<unknown> {
-    if (this._isThrough || this._targetLoaded) {
+  async pick(
+    ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
+  ): Promise<unknown> {
+    const allStrings = columns.every((c) => typeof c === "string");
+    if (allStrings && (this._isThrough || this._targetLoaded)) {
+      const stringCols = columns as string[];
       const records = (this._isThrough ? await this.toArray() : this._target).filter(
         (r) => !r.isNewRecord(),
       );
       if (records.length === 0) return null;
-      if (columns.length === 1) return records[0].readAttribute(columns[0]);
-      return columns.map((c) => records[0].readAttribute(c));
+      if (stringCols.length === 1) return records[0].readAttribute(stringCols[0]);
+      return stringCols.map((c) => records[0].readAttribute(c));
     }
     this._checkStrictLoading();
     return this.scope().pick(...columns);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -98,16 +98,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _assocDef: AssociationDefinition;
   private _target: T[] = [];
   private _targetLoaded = false;
-  // Content fingerprint of the inherited Relation state captured at
-  // end of the ctor (after FK/through seeding). `toArray()` compares
-  // the current fingerprint against this seed to detect any in-place
-  // bang-mutation — content-aware (not just array lengths), so
-  // reorderBang / regroupBang / reverseOrderBang / rewhere and other
-  // replace-in-place mutations are also caught. When state diverges,
-  // CP delegates to `super.toArray()` so the query honors the
-  // mutations instead of silently returning the association-cached
-  // load.
-  private _seedFingerprint!: string;
+  // Flag flipped by ANY post-ctor bang-style mutation on the inherited
+  // Relation state (whereBang / orderBang / reorderBang / regroupBang /
+  // reverseOrderBang / rewhereBang / limitBang / offsetBang / ... — all
+  // of them). Set by instance-level method wrappers installed at the
+  // end of the ctor (see `_installMutationTracker`). `toArray()`
+  // consults this flag to decide between the association-cache path
+  // (seed-only) and delegating to super.toArray() (mutated).
+  //
+  // Single-boolean check per toArray call — O(1) vs serializing the
+  // entire Relation state. Content-aware implicitly: any bang that
+  // touches state passes through the wrapper, regardless of whether
+  // it changes array length or only content.
+  private _cpMutated = false;
 
   get loaded(): boolean {
     return this._targetLoaded;
@@ -336,73 +339,47 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       }
     }
 
-    this._seedFingerprint = this._computeStateFingerprint();
+    this._installMutationTracker();
   }
 
   /**
-   * Serialize the SQL-shape-affecting fields of the inherited Relation
-   * state into a content-addressed fingerprint. Predicate nodes contain
-   * non-JSON-safe references (Arel attributes, etc.) so we use a
-   * defensive replacer that falls back to `String(v)` on cycles /
-   * typed instances. Fields reach through `as any` because they're
-   * `private` on Relation — scoped to CP and documented.
+   * Install instance-level wrappers for every `*Bang` method reachable
+   * via the prototype chain. Each wrapper flips `_cpMutated` and
+   * forwards to the original. Runs once per CP instance at ctor end,
+   * AFTER seeding — so `noneBang()` / `whereBang()` calls from the
+   * ctor itself don't trip the flag. The cost of a single O(N) walk
+   * over the prototype chain (N ~ 25 bang methods) is amortized over
+   * the proxy's lifetime; every subsequent `toArray()` / divergence
+   * check is a single boolean read.
    */
-  private _computeStateFingerprint(): string {
-    const s = this as unknown as Record<string, unknown>;
-    // Enumerate every private Relation field that a bang method can
-    // mutate and that affects generated SQL. Length-only sampling
-    // misses reorderBang / regroupBang / reverseOrderBang / rewrite-
-    // in-place mutations, so we serialize contents.
-    const fields = [
-      "_whereClause",
-      "_havingClause",
-      "_orderClauses",
-      "_rawOrderClauses",
-      "_limitValue",
-      "_offsetValue",
-      "_selectColumns",
-      "_isDistinct",
-      "_distinctOnColumns",
-      "_groupColumns",
-      "_joinClauses",
-      "_rawJoins",
-      "_isNone",
-      "_lockValue",
-      "_ctes",
-      "_fromClause",
-      "_annotations",
-      "_optimizerHints",
-      "_referencesValues",
-      "_eagerLoadAssociations",
-      "_includesAssociations",
-      "_preloadAssociations",
-      "_setOperation",
-    ];
-    const seen = new WeakSet<object>();
-    const replacer = (_: string, v: unknown): unknown => {
-      if (v === null || v === undefined) return v;
-      if (typeof v === "function") return "[fn]";
-      if (typeof v === "object") {
-        if (seen.has(v as object)) return "[cycle]";
-        seen.add(v as object);
+  private _installMutationTracker(): void {
+    const seen = new Set<string>();
+    for (
+      let proto = Object.getPrototypeOf(this);
+      proto && proto !== Object.prototype;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      for (const name of Object.getOwnPropertyNames(proto)) {
+        if (!name.endsWith("Bang") || seen.has(name)) continue;
+        const desc = Object.getOwnPropertyDescriptor(proto, name);
+        if (!desc || typeof desc.value !== "function") continue;
+        seen.add(name);
+        const original = desc.value as (...args: unknown[]) => unknown;
+        Object.defineProperty(this, name, {
+          value: function (this: CollectionProxy<T>, ...args: unknown[]) {
+            (this as unknown as { _cpMutated: boolean })._cpMutated = true;
+            return original.apply(this, args);
+          },
+          writable: true,
+          configurable: true,
+        });
       }
-      return v;
-    };
-    const payload: Record<string, unknown> = {};
-    for (const f of fields) payload[f] = s[f];
-    try {
-      return JSON.stringify(payload, replacer);
-    } catch {
-      // Defensive: if the payload still can't serialize, fall back to
-      // a guaranteed-diverged sentinel so toArray() takes the
-      // Relation path (safer than returning the cached result).
-      return `__unserializable__:${Math.random()}`;
     }
   }
 
-  /** Whether the inherited Relation state has diverged from the seed. */
+  /** Whether any `*Bang` mutator has run on the proxy since seeding. */
   private _relationStateDiverged(): boolean {
-    return this._computeStateFingerprint() !== this._seedFingerprint;
+    return this._cpMutated;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -459,11 +459,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   will remove CP's load in favor of Relation's.
   async load(): Promise<T[]> {
     if (this._targetLoaded) return this._target;
-    const results = (await loadHasMany(
-      this._record,
-      this._assocName,
-      this._assocDef.options,
-    )) as T[];
+    // Same divergence gate as `toArray()` — if the inherited Relation
+    // state has been mutated via scope bangs (whereBang / orderBang /
+    // ...), route through `super.toArray()` so `load()` / `await proxy`
+    // honor the mutation. Without this, `cp.whereBang({...}); await cp`
+    // would silently fall back to the full association-cache load.
+    let results: T[];
+    if (this._relationStateDiverged()) {
+      results = await super.toArray();
+    } else {
+      results = (await loadHasMany(this._record, this._assocName, this._assocDef.options)) as T[];
+    }
     // Merge: prefer existing in-memory instances (from push/build) over fresh DB records
     const existingByPk = new Map<string, T>();
     for (const r of this._target) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -250,23 +250,54 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._assocName = assocName;
     this._assocDef = assocDef;
 
-    // Seed the FK where-clause so direct Relation calls on this proxy
-    // (e.g. `cp.toSql()`, `cp.toArray()` via Relation's path) scope to
-    // the owner — matches Rails where the CollectionProxy IS a Relation
-    // already scoped by the association's foreign key. Through
-    // associations keep the subquery/join path via `scope()` — no seed
-    // here. Missing PK → set `_isNone = true` so the proxy acts like
-    // `none` (Rails' NullRelation fallback).
-    if (!assocDef.options.through) {
-      const conditions = computeHasManyWhere(record, assocDef.options);
+    // Seed the proxy's Relation state so direct Relation calls
+    // (`cp.toSql()`, `cp.where(...)`, `cp.toArray()` via Relation's path)
+    // scope to the owner — matches Rails, where CollectionProxy IS the
+    // scoped Relation. Two paths:
+    //
+    // - Non-through (hasMany / HABTM): seed the FK where-clause, then
+    //   apply any `scope:` callback. The callback returns a new relation
+    //   in our codebase, so capture it and copy state back into `this`.
+    //   Missing owner PK → `_isNone = true` (Rails' NullRelation fallback).
+    // - Through: delegate to `_buildThroughScope()`, which builds the
+    //   subquery/join relation, then copy its state onto `this` so the
+    //   inherited Relation methods see the same scope as the old
+    //   `scope()` path.
+    //
+    // Through scope-building reads adapter schema, which can fail on
+    // adapter-less test fixtures that still expect bare CP construction
+    // to succeed. Wrap in try/catch — a later `scope()` call will surface
+    // the real error.
+    const proxySelf = this as unknown as {
+      _isNone: boolean;
+      whereBang: (c: Record<string, unknown>) => unknown;
+      _copyStateFrom: (other: Relation<T>) => void;
+    };
+    if (assocDef.options.through) {
+      try {
+        const throughRel = this._buildThroughScope() as Relation<T>;
+        proxySelf._copyStateFrom(throughRel);
+      } catch {
+        // Schema/adapter not ready — leave Relation state empty; `scope()`
+        // will re-run `_buildThroughScope()` when callers invoke it and
+        // raise the real error there.
+      }
+    } else {
+      const conditions = computeHasManyWhere(record, assocName, assocDef.options);
       if (conditions === null) {
-        (this as unknown as { _isNone: boolean })._isNone = true;
+        proxySelf._isNone = true;
       } else {
-        (this as unknown as { whereBang: (c: Record<string, unknown>) => unknown }).whereBang(
-          conditions,
-        );
+        proxySelf.whereBang(conditions);
         if (assocDef.options.scope) {
-          assocDef.options.scope(this as unknown as Relation<T>);
+          const scoped = assocDef.options.scope(this as unknown as Relation<T>);
+          // Scope callbacks are written in the codebase as
+          // `(rel) => rel.where(...).order(...)` — they CLONE the input
+          // relation and return a new one. We must copy state back onto
+          // `this` so the inherited Relation methods observe the scoped
+          // where/order/limit/etc.
+          if (scoped && scoped !== (this as unknown)) {
+            proxySelf._copyStateFrom(scoped);
+          }
         }
       }
     }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -709,6 +709,76 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return results.length;
   }
 
+  // Aggregate SQL entry points inherited from Relation (via the
+  // Calculations mixin) need the same divergence + strict-loading
+  // treatment as pluck/pick/count. Without overriding, cp.sum('x') /
+  // cp.whereBang({...}); cp.average('y') would both bypass the gate
+  // and drop in-place mutations.
+  // @ts-expect-error sum is a property on Relation (Calculations mixin);
+  //   method override is intentional to gate + honor divergence.
+  async sum(column?: string): Promise<number | Record<string, number>> {
+    this._checkStrictLoading();
+    const fn = (
+      Relation.prototype as unknown as {
+        sum: (col?: string) => Promise<number | Record<string, number>>;
+      }
+    ).sum;
+    if (this._relationStateDiverged()) return fn.call(this, column);
+    const s = this.scope();
+    return (
+      s as unknown as { sum: (col?: string) => Promise<number | Record<string, number>> }
+    ).sum(column);
+  }
+
+  // @ts-expect-error see `sum`.
+  async average(column: string): Promise<number | null | Record<string, number>> {
+    this._checkStrictLoading();
+    const fn = (
+      Relation.prototype as unknown as {
+        average: (col: string) => Promise<number | null | Record<string, number>>;
+      }
+    ).average;
+    if (this._relationStateDiverged()) return fn.call(this, column);
+    const s = this.scope();
+    return (
+      s as unknown as { average: (col: string) => Promise<number | null | Record<string, number>> }
+    ).average(column);
+  }
+
+  // @ts-expect-error see `sum`.
+  async minimum(column: string): Promise<unknown | null | Record<string, unknown>> {
+    this._checkStrictLoading();
+    const fn = (
+      Relation.prototype as unknown as {
+        minimum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).minimum;
+    if (this._relationStateDiverged()) return fn.call(this, column);
+    const s = this.scope();
+    return (
+      s as unknown as {
+        minimum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).minimum(column);
+  }
+
+  // @ts-expect-error see `sum`.
+  async maximum(column: string): Promise<unknown | null | Record<string, unknown>> {
+    this._checkStrictLoading();
+    const fn = (
+      Relation.prototype as unknown as {
+        maximum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).maximum;
+    if (this._relationStateDiverged()) return fn.call(this, column);
+    const s = this.scope();
+    return (
+      s as unknown as {
+        maximum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+      }
+    ).maximum(column);
+  }
+
   /**
    * Alias for count.
    *

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,5 +1,5 @@
 import type { Base } from "../base.js";
-import type { Relation } from "../relation.js";
+import { Relation } from "../relation.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
 import { wrapWithScopeProxy } from "../relation/delegation.js";
 
@@ -32,9 +32,15 @@ import {
   resolveModel,
   fireAssocCallbacks,
   buildHasManyRelation,
+  computeHasManyWhere,
   loadHasMany,
+  _setCollectionProxyCtor,
 } from "../associations.js";
 
+// @ts-expect-error Declaration merging with `class CollectionProxy extends
+//   Relation` propagates Relation's method types into this interface.
+//   `load()` diverges (CP returns T[], Relation returns LoadedRelation<this>)
+//   and the conflict surfaces here too. Same PR B plan as on the class.
 export interface CollectionProxy<T extends Base = Base> {
   // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
   // which both returns the loaded records AND hydrates `_target`, so
@@ -87,15 +93,15 @@ export type AssociationProxy<
   };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class CollectionProxy<T extends Base = Base> {
+export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
   private _assocName: string;
   private _assocDef: AssociationDefinition;
   private _target: T[] = [];
-  private _loaded = false;
+  private _targetLoaded = false;
 
   get loaded(): boolean {
-    return this._loaded;
+    return this._targetLoaded;
   }
 
   get target(): T[] {
@@ -134,19 +140,12 @@ export class CollectionProxy<T extends Base = Base> {
   // first.
   // ──────────────────────────────────────────────────────────────────
 
-  /**
-   * Sync count of the loaded target. Mirrors `Array.prototype.length`
-   * and Rails' `posts.length` (which blocks to load in Ruby). In trails,
-   * this reads `_target` — zero if nobody loaded. Await the proxy first
-   * (or `Post.includes(...)`) if you need a fresh load.
-   *
-   * Shadows `Relation#length()` (async, `Promise<number>`). For a Relation-
-   * style async count through the proxy, use `.count()` — which still
-   * routes through to Relation via the `AssociationProxy` delegation.
-   */
-  get length(): number {
-    return this._target.length;
-  }
+  // `length` is intentionally NOT redeclared — `CollectionProxy extends
+  // Relation`, and `Relation#length()` is `async`. Previously CP shadowed
+  // it with a sync getter over `_target`; keeping that alongside
+  // inheritance would require overriding an async method with a getter,
+  // which TS rejects. Callers that need the sync count should reach for
+  // `proxy.target.length` or `Array.from(proxy).length`.
 
   [Symbol.iterator](): IterableIterator<T> {
     return this._target[Symbol.iterator]();
@@ -240,13 +239,37 @@ export class CollectionProxy<T extends Base = Base> {
     // Preserve any unsaved in-memory records (from build/push before preload ran)
     const unsaved = this._target.filter((r) => r.isNewRecord());
     this._target = unsaved.length > 0 ? [...records, ...unsaved] : records;
-    this._loaded = true;
+    this._targetLoaded = true;
   }
 
   constructor(record: Base, assocName: string, assocDef: AssociationDefinition) {
+    const className = assocDef.options.className ?? camelize(singularize(assocName));
+    const targetModel = resolveModel(className) as typeof Base;
+    super(targetModel, targetModel.arelTable);
     this._record = record;
     this._assocName = assocName;
     this._assocDef = assocDef;
+
+    // Seed the FK where-clause so direct Relation calls on this proxy
+    // (e.g. `cp.toSql()`, `cp.toArray()` via Relation's path) scope to
+    // the owner — matches Rails where the CollectionProxy IS a Relation
+    // already scoped by the association's foreign key. Through
+    // associations keep the subquery/join path via `scope()` — no seed
+    // here. Missing PK → set `_isNone = true` so the proxy acts like
+    // `none` (Rails' NullRelation fallback).
+    if (!assocDef.options.through) {
+      const conditions = computeHasManyWhere(record, assocDef.options);
+      if (conditions === null) {
+        (this as unknown as { _isNone: boolean })._isNone = true;
+      } else {
+        (this as unknown as { whereBang: (c: Record<string, unknown>) => unknown }).whereBang(
+          conditions,
+        );
+        if (assocDef.options.scope) {
+          assocDef.options.scope(this as unknown as Relation<T>);
+        }
+      }
+    }
 
     // Apply extend option — mix methods into this proxy instance
     const ext = assocDef.options.extend;
@@ -278,8 +301,11 @@ export class CollectionProxy<T extends Base = Base> {
     return results;
   }
 
+  // @ts-expect-error CP's load returns loaded records (association-hydrated
+  //   target), not a LoadedRelation<this>. Intentional divergence; PR B
+  //   will remove CP's load in favor of Relation's.
   async load(): Promise<T[]> {
-    if (this._loaded) return this._target;
+    if (this._targetLoaded) return this._target;
     const results = (await loadHasMany(
       this._record,
       this._assocName,
@@ -297,7 +323,7 @@ export class CollectionProxy<T extends Base = Base> {
     });
     const unsaved = this._target.filter((r) => r.isNewRecord());
     this._target = unsaved.length > 0 ? [...merged, ...unsaved] : merged;
-    this._loaded = true;
+    this._targetLoaded = true;
     return this._target;
   }
 
@@ -473,6 +499,10 @@ export class CollectionProxy<T extends Base = Base> {
   /**
    * Count associated records.
    */
+  // @ts-expect-error Relation defines `count` as a property (from the
+  //   calculations mixin); CP declares it as a method with association
+  //   semantics (loaded-target fast path). PR B will delete CP's count
+  //   and let Relation's win.
   async count(): Promise<number> {
     const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
     return results.length;
@@ -484,7 +514,7 @@ export class CollectionProxy<T extends Base = Base> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#size
    */
   async size(): Promise<number> {
-    if (this._loaded) return this._target.length;
+    if (this._targetLoaded) return this._target.length;
     return this.count();
   }
 
@@ -632,6 +662,9 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#delete
    */
+  // @ts-expect-error Relation#delete(id) removes by PK; CP#delete removes
+  //   loaded records via the association. Distinct API. PR B: rename or
+  //   restructure.
   async delete(...records: T[]): Promise<void> {
     this._ensureThroughWritable();
     // Through association (including HABTM): delete the join records
@@ -791,6 +824,8 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy
    */
+  // @ts-expect-error Relation#destroy(id) destroys by PK; CP#destroy
+  //   destroys loaded records. Same divergence as `delete`.
   async destroy(...records: T[]): Promise<void> {
     const destroyed: Base[] = [];
     for (const record of records) {
@@ -832,7 +867,7 @@ export class CollectionProxy<T extends Base = Base> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#include?
    */
   async isInclude(record: T): Promise<boolean> {
-    if (this._loaded) {
+    if (this._targetLoaded) {
       const targetId = this._identityFor(record);
       if (targetId != null) {
         return this._target.some((r) => this._identityFor(r) === targetId);
@@ -874,6 +909,9 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#first
    */
+  // @ts-expect-error Relation#first has overloads: () | (n: number). CP's
+  //   version only handles the zero-arg case (returns T | null). PR B
+  //   will add the n-arg overload or delete CP's version.
   async first(): Promise<T | null> {
     const records = await this.toArray();
     return records[0] ?? null;
@@ -884,6 +922,7 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#last
    */
+  // @ts-expect-error Same overload divergence as `first`.
   async last(): Promise<T | null> {
     const records = await this.toArray();
     return records[records.length - 1] ?? null;
@@ -894,6 +933,8 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#take
    */
+  // @ts-expect-error Relation#take has distinct () / (n) overloads; CP
+  //   flattens both. PR B will align overloads.
   async take(n?: number): Promise<T | T[] | null> {
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
@@ -914,6 +955,9 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#none?
    */
+  // @ts-expect-error Relation#isNone is sync (`_isNone` flag check). CP's
+  //   isNone fires a query/loaded-target empty check. PR B will rename
+  //   CP's to something like `isEmpty()` or drop it.
   async isNone(): Promise<boolean> {
     return (await this.count()) === 0;
   }
@@ -1010,6 +1054,9 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy_all
    */
+  // @ts-expect-error Relation#destroyAll returns the destroyed T[]; CP's
+  //   returns void (fires association callbacks + mutates target).
+  //   PR B: align to return T[] or drop.
   async destroyAll(): Promise<void> {
     const records = await this.toArray();
     await this.destroy(...records);
@@ -1020,6 +1067,8 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#find
    */
+  // @ts-expect-error Relation#find takes `unknown` IDs (string/number);
+  //   CP narrows to number | number[]. PR B: widen CP's param.
   async find(id: number | number[]): Promise<T | T[]> {
     const records = await this.toArray();
     const targetModel = (records[0]?.constructor ?? Object) as typeof Base;
@@ -1048,7 +1097,7 @@ export class CollectionProxy<T extends Base = Base> {
   }
 
   async pluck(...columns: string[]): Promise<unknown[]> {
-    if (this._isThrough || this._loaded) {
+    if (this._isThrough || this._targetLoaded) {
       const records = (this._isThrough ? await this.toArray() : this._target).filter(
         (r) => !r.isNewRecord(),
       );
@@ -1062,7 +1111,7 @@ export class CollectionProxy<T extends Base = Base> {
   }
 
   async pick(...columns: string[]): Promise<unknown> {
-    if (this._isThrough || this._loaded) {
+    if (this._isThrough || this._targetLoaded) {
       const records = (this._isThrough ? await this.toArray() : this._target).filter(
         (r) => !r.isNewRecord(),
       );
@@ -1075,15 +1124,16 @@ export class CollectionProxy<T extends Base = Base> {
   }
 
   async reload(): Promise<Omit<this, "then">> {
-    this._loaded = false;
+    this._targetLoaded = false;
     this._target = [];
     await this.load();
     return stripThenable(this);
   }
 
-  reset(): void {
-    this._loaded = false;
+  override reset(): this {
+    this._targetLoaded = false;
     this._target = [];
+    return this;
   }
 
   scope(): any {
@@ -1297,6 +1347,8 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#delete_all
    */
+  // @ts-expect-error Relation#deleteAll returns affected-rows count; CP's
+  //   returns void (dependent-strategy routing). PR B: align.
   async deleteAll(dependent?: string): Promise<void> {
     this._ensureThroughWritable();
     // Rails normalizes dependent: :destroy → :delete_all for deleteAll,
@@ -1337,7 +1389,7 @@ export class CollectionProxy<T extends Base = Base> {
       }
     }
     this._target = [];
-    this._loaded = true;
+    this._targetLoaded = true;
     this.resetScope();
   }
 
@@ -1346,6 +1398,8 @@ export class CollectionProxy<T extends Base = Base> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#calculate
    */
+  // @ts-expect-error Relation#calculate is strongly typed per operation.
+  //   CP's is looser (string-typed op). PR B: tighten CP's overloads.
   async calculate(operation: string, columnName?: string): Promise<unknown> {
     const op =
       operation === "avg"
@@ -1411,7 +1465,7 @@ export class CollectionProxy<T extends Base = Base> {
         return proxy._target;
       },
       get loaded() {
-        return proxy._loaded;
+        return proxy._targetLoaded;
       },
       reset: () => this.reset(),
     };
@@ -1482,6 +1536,23 @@ export class CollectionProxy<T extends Base = Base> {
       yield record;
     }
   }
+
+  /**
+   * Chains off the proxy (`blog.posts.where(...)`) return an
+   * AssociationRelation, not another CollectionProxy — matching Rails,
+   * where `blog.posts` is a CP and `blog.posts.where(...)` is an AR.
+   * AR still routes writes through `_association` (this CP) so the FK,
+   * inverse, and loaded target stay wired up.
+   */
+  protected override _newRelation(): Relation<T> {
+    if (!_AssociationRelationCtor) {
+      throw new Error(
+        "CollectionProxy._newRelation: AssociationRelation constructor not set — " +
+          "association-relation.ts must be loaded first",
+      );
+    }
+    return new _AssociationRelationCtor(this.model as typeof Base, this) as Relation<T>;
+  }
 }
 
 // Route `await proxy` through `load()` (not `toArray`) so the thenable
@@ -1492,3 +1563,9 @@ export class CollectionProxy<T extends Base = Base> {
 // through `loadHasMany`, which syncs into the record's association
 // instance cache — only this proxy's local cache is left untouched).
 applyThenable(CollectionProxy.prototype, "load");
+
+// Register the constructor so associations.ts can late-bind (it can't
+// value-import CP at module init without re-entering the cycle).
+_setCollectionProxyCtor(
+  CollectionProxy as unknown as Parameters<typeof _setCollectionProxyCtor>[0],
+);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -353,37 +353,68 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * check is a single boolean read.
    */
   private _installMutationTracker(): void {
-    // Start the scan at Relation.prototype — we only care about bangs
-    // that mutate the inherited Relation SCOPE (whereBang, orderBang,
-    // reorderBang, noneBang, …). Skipping CollectionProxy's own
-    // prototype avoids tripping on association-write APIs like
-    // `createBang` / `firstOrCreateBang` / `destroyAll`, which don't
-    // change the scope's SQL shape and shouldn't force `toArray()`
-    // to abandon the association-cache / strict-loading path.
-    // Scan Relation.prototype itself and anything mixed in above it
-    // (e.g. the QueryMethodBangs module included into Relation). Stop
-    // at Object.prototype.
-    const seen = new Set<string>();
-    for (
-      let proto: object | null = Relation.prototype;
-      proto && proto !== Object.prototype;
-      proto = Object.getPrototypeOf(proto)
-    ) {
-      for (const name of Object.getOwnPropertyNames(proto)) {
-        if (!name.endsWith("Bang") || seen.has(name)) continue;
-        const desc = Object.getOwnPropertyDescriptor(proto, name);
-        if (!desc || typeof desc.value !== "function") continue;
-        seen.add(name);
-        const original = desc.value as (...args: unknown[]) => unknown;
-        Object.defineProperty(this, name, {
-          value: function (this: CollectionProxy<T>, ...args: unknown[]) {
-            (this as unknown as { _cpMutated: boolean })._cpMutated = true;
-            return original.apply(this, args);
-          },
-          writable: true,
-          configurable: true,
-        });
-      }
+    // Explicit allowlist of SCOPE-mutator bangs — everything exported
+    // from query-methods.ts (the `*Bang` chain mutators) plus
+    // `mergeBang` from spawn-methods. Deliberately excludes finder
+    // bangs (firstBang / lastBang / takeBang / findByBang) which
+    // raise-on-missing but don't mutate scope, and save/persistence
+    // bangs (saveBang / updateBang / destroyBang). Previously we
+    // wrapped every `*Bang` name from the prototype chain, which
+    // caused finder-bang calls to flip `_cpMutated` and force
+    // toArray() to bypass the association cache.
+    const SCOPE_MUTATOR_BANGS: readonly string[] = [
+      "whereBang",
+      "rewhereBang",
+      "invertWhereBang",
+      "orderBang",
+      "reorderBang",
+      "reverseOrderBang",
+      "groupBang",
+      "regroupBang",
+      "havingBang",
+      "limitBang",
+      "offsetBang",
+      "selectBang",
+      "reselectBang",
+      "distinctBang",
+      "lockBang",
+      "readonlyBang",
+      "strictLoadingBang",
+      "noneBang",
+      "nullBang",
+      "joinsBang",
+      "leftOuterJoinsBang",
+      "includesBang",
+      "eagerLoadBang",
+      "preloadBang",
+      "referencesBang",
+      "withBang",
+      "withRecursiveBang",
+      "fromBang",
+      "createWithBang",
+      "extendingBang",
+      "optimizerHintsBang",
+      "annotateBang",
+      "uniqBang",
+      "unscopeBang",
+      "skipQueryCacheBang",
+      "skipPreloadingBang",
+      "excludingBang",
+      "andBang",
+      "orBang",
+      "mergeBang",
+    ];
+    for (const name of SCOPE_MUTATOR_BANGS) {
+      const original = (this as unknown as Record<string, unknown>)[name];
+      if (typeof original !== "function") continue;
+      Object.defineProperty(this, name, {
+        value: function (this: CollectionProxy<T>, ...args: unknown[]) {
+          (this as unknown as { _cpMutated: boolean })._cpMutated = true;
+          return (original as (...a: unknown[]) => unknown).apply(this, args);
+        },
+        writable: true,
+        configurable: true,
+      });
     }
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -18,7 +18,7 @@ import { applyThenable, stripThenable } from "../relation/thenable.js";
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Nodes } from "@blazetrails/arel";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
-import { StrictLoadingViolationError, RecordNotSaved } from "../errors.js";
+import { StrictLoadingViolationError, RecordNotSaved, ConfigurationError } from "../errors.js";
 import { RecordInvalid } from "../validations.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
@@ -294,7 +294,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         (ctor as unknown as { _associations?: AssociationDefinition[] })._associations ?? [];
       const throughAssoc = ownerAssociations.find((a) => a.name === assocDef.options.through);
       if (!throughAssoc) {
-        throw new Error(
+        throw new ConfigurationError(
           `Through association "${assocDef.options.through}" not found on ${ctor.name}`,
         );
       }
@@ -353,9 +353,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * check is a single boolean read.
    */
   private _installMutationTracker(): void {
+    // Start the scan at Relation.prototype — we only care about bangs
+    // that mutate the inherited Relation SCOPE (whereBang, orderBang,
+    // reorderBang, noneBang, …). Skipping CollectionProxy's own
+    // prototype avoids tripping on association-write APIs like
+    // `createBang` / `firstOrCreateBang` / `destroyAll`, which don't
+    // change the scope's SQL shape and shouldn't force `toArray()`
+    // to abandon the association-cache / strict-loading path.
+    // Scan Relation.prototype itself and anything mixed in above it
+    // (e.g. the QueryMethodBangs module included into Relation). Stop
+    // at Object.prototype.
     const seen = new Set<string>();
     for (
-      let proto = Object.getPrototypeOf(this);
+      let proto: object | null = Relation.prototype;
       proto && proto !== Object.prototype;
       proto = Object.getPrototypeOf(proto)
     ) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -98,6 +98,27 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _assocDef: AssociationDefinition;
   private _target: T[] = [];
   private _targetLoaded = false;
+  // Snapshot of key Relation-state sizes captured at end of the ctor
+  // (after FK/through seeding). `toArray()` compares against this to
+  // detect in-place bang-mutation of the inherited Relation state;
+  // when state has diverged from the seed, CP delegates to
+  // `super.toArray()` so the query honors the mutations instead of
+  // silently returning the association-cached load. See `toArray()`
+  // for the rationale.
+  private _seedSignature!: {
+    wherePredicates: number;
+    havingPredicates: number;
+    orderClauses: number;
+    rawOrderClauses: number;
+    limitValue: number | null;
+    offsetValue: number | null;
+    selectColumns: number | null;
+    isDistinct: boolean;
+    groupColumns: number;
+    joinClauses: number;
+    rawJoins: number;
+    isNone: boolean;
+  };
 
   get loaded(): boolean {
     return this._targetLoaded;
@@ -330,23 +351,87 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         }
       }
     }
+
+    this._seedSignature = this._captureStateSignature();
+  }
+
+  /**
+   * Snapshot the shape-influencing fields of the inherited Relation
+   * state. Used by `toArray()` to detect in-place bang-mutation of the
+   * proxy (e.g. `cp.whereBang(...)`) since seeding. The fields reach
+   * through `as any` because they're `private` on Relation — this is
+   * scoped to CP and documented.
+   */
+  private _captureStateSignature(): CollectionProxy<T>["_seedSignature"] {
+    const s = this as unknown as {
+      _whereClause: { predicates: unknown[] };
+      _havingClause: { predicates: unknown[] };
+      _orderClauses: unknown[];
+      _rawOrderClauses: unknown[];
+      _limitValue: number | null;
+      _offsetValue: number | null;
+      _selectColumns: unknown[] | null;
+      _isDistinct: boolean;
+      _groupColumns: unknown[];
+      _joinClauses: unknown[];
+      _rawJoins: unknown[];
+      _isNone: boolean;
+    };
+    return {
+      wherePredicates: s._whereClause.predicates.length,
+      havingPredicates: s._havingClause.predicates.length,
+      orderClauses: s._orderClauses.length,
+      rawOrderClauses: s._rawOrderClauses.length,
+      limitValue: s._limitValue,
+      offsetValue: s._offsetValue,
+      selectColumns: s._selectColumns ? s._selectColumns.length : null,
+      isDistinct: s._isDistinct,
+      groupColumns: s._groupColumns.length,
+      joinClauses: s._joinClauses.length,
+      rawJoins: s._rawJoins.length,
+      isNone: s._isNone,
+    };
+  }
+
+  /** Whether the inherited Relation state has diverged from the seed. */
+  private _relationStateDiverged(): boolean {
+    const now = this._captureStateSignature();
+    const seed = this._seedSignature;
+    return (
+      now.wherePredicates !== seed.wherePredicates ||
+      now.havingPredicates !== seed.havingPredicates ||
+      now.orderClauses !== seed.orderClauses ||
+      now.rawOrderClauses !== seed.rawOrderClauses ||
+      now.limitValue !== seed.limitValue ||
+      now.offsetValue !== seed.offsetValue ||
+      now.selectColumns !== seed.selectColumns ||
+      now.isDistinct !== seed.isDistinct ||
+      now.groupColumns !== seed.groupColumns ||
+      now.joinClauses !== seed.joinClauses ||
+      now.rawJoins !== seed.rawJoins ||
+      now.isNone !== seed.isNone
+    );
   }
 
   /**
    * Load and return all associated records.
    */
   async toArray(): Promise<T[]> {
-    // Known limitation (PR B): this path calls `loadHasMany` to reuse
-    // the owner's association cache + strict-loading enforcement, so
-    // in-place Relation mutations on the proxy itself (e.g.
-    // `cp.whereBang(...)`, `cp.orderBang(...)`) affect `cp.toSql()` but
-    // are NOT reflected here. Chained calls (`cp.where(...).toArray()`)
-    // return an AssociationRelation, whose `toArray` goes through
-    // Relation's query path and DOES honor the added state — that's
-    // the supported path for additional filtering. Direct CP bang-
-    // mutation is rare in practice; PR B will either reconcile this
-    // (delegate to super.toArray when state diverges from seed) or
-    // document it as-is.
+    // Two paths:
+    //
+    // 1. Seed-only state (nothing mutated post-ctor): hit `loadHasMany`
+    //    to reuse the owner's association cache + strict-loading
+    //    enforcement. This is the common case (`await blog.posts`).
+    // 2. State has diverged from the seed (e.g. `cp.whereBang(...)`
+    //    was called directly on the proxy): delegate to
+    //    `super.toArray()` so the query honors the mutations. The
+    //    association cache is bypassed here because it's keyed on the
+    //    unmutated scope and would return stale/incorrect data.
+    if (this._relationStateDiverged()) {
+      const results = await super.toArray();
+      const unsaved = this._target.filter((r) => r.isNewRecord());
+      return unsaved.length > 0 ? [...results, ...unsaved] : results;
+    }
     const results = (await loadHasMany(
       this._record,
       this._assocName,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -43,9 +43,9 @@ import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 export interface CollectionProxy<T extends Base = Base> {
   // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
   // which both returns the loaded records AND hydrates `_target`, so
-  // subsequent sync ops (`proxy.length`, `proxy[0]`, iteration) work
-  // after a single `await proxy`. Wired at the bottom of the file via
-  // `applyThenable(CollectionProxy.prototype, "load")`.
+  // subsequent sync ops (`proxy.target.length`, `proxy[0]`, iteration)
+  // work after a single `await proxy`. Wired at the bottom of the file
+  // via `applyThenable(CollectionProxy.prototype, "load")`.
   then<TResult1 = T[], TResult2 = never>(
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
@@ -268,8 +268,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // fail-closed `_isNone` path.
     const ctor = record.constructor as typeof Base;
     const proxySelf = this as unknown as {
-      _isNone: boolean;
       _copyStateFrom: (other: Relation<T>) => void;
+      noneBang: () => unknown;
     };
     if (assocDef.options.through) {
       // Config validation FIRST, outside the try — missing through
@@ -296,7 +296,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         // rather than silently querying the full target table. A
         // later `scope()` call rebuilds and surfaces the real error
         // if the adapter is still broken.
-        proxySelf._isNone = true;
+        proxySelf.noneBang();
       }
     } else {
       // Build via `buildHasManyRelation` so CP's inherited Relation
@@ -312,7 +312,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         assocDef.options,
       ) as Relation<T> | null;
       if (seedRel === null) {
-        proxySelf._isNone = true;
+        proxySelf.noneBang();
       } else {
         proxySelf._copyStateFrom(seedRel);
       }
@@ -336,6 +336,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Load and return all associated records.
    */
   async toArray(): Promise<T[]> {
+    // Known limitation (PR B): this path calls `loadHasMany` to reuse
+    // the owner's association cache + strict-loading enforcement, so
+    // in-place Relation mutations on the proxy itself (e.g.
+    // `cp.whereBang(...)`, `cp.orderBang(...)`) affect `cp.toSql()` but
+    // are NOT reflected here. Chained calls (`cp.where(...).toArray()`)
+    // return an AssociationRelation, whose `toArray` goes through
+    // Relation's query path and DOES honor the added state — that's
+    // the supported path for additional filtering. Direct CP bang-
+    // mutation is rare in practice; PR B will either reconcile this
+    // (delegate to super.toArray when state diverges from seed) or
+    // document it as-is.
     const results = (await loadHasMany(
       this._record,
       this._assocName,
@@ -1621,7 +1632,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
 // Route `await proxy` through `load()` (not `toArray`) so the thenable
 // also hydrates `_target` — matches the documented contract that
-// `await proxy; proxy[0]` / `proxy.length` work after a single await.
+// `await proxy; proxy[0]` / `proxy.target.length` work after a single await.
 // `toArray()` stays available for callers who want a fresh array
 // without hydrating this proxy's `_target` / `_loaded` (it still goes
 // through `loadHasMany`, which syncs into the record's association

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -32,10 +32,9 @@ import {
   resolveModel,
   fireAssocCallbacks,
   buildHasManyRelation,
-  computeHasManyWhere,
   loadHasMany,
-  _setCollectionProxyCtor,
 } from "../associations.js";
+import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 
 // @ts-expect-error Declaration merging with `class CollectionProxy extends
 //   Relation` propagates Relation's method types into this interface.
@@ -250,61 +249,72 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._assocName = assocName;
     this._assocDef = assocDef;
 
-    // Seed the proxy's Relation state so direct Relation calls
-    // (`cp.toSql()`, `cp.where(...)`, `cp.toArray()` via Relation's path)
-    // scope to the owner — matches Rails, where CollectionProxy IS the
-    // scoped Relation. Two paths:
+    // Seed the proxy's inherited Relation state so direct Relation calls
+    // (`cp.toSql()`, `cp.where(...)`, `cp.toArray()`) scope to the owner
+    // — matches Rails, where CollectionProxy IS the scoped Relation.
     //
-    // - Non-through (hasMany / HABTM): seed the FK where-clause, then
-    //   apply any `scope:` callback. The callback returns a new relation
-    //   in our codebase, so capture it and copy state back into `this`.
-    //   Missing owner PK → `_isNone = true` (Rails' NullRelation fallback).
-    // - Through: delegate to `_buildThroughScope()`, which builds the
-    //   subquery/join relation, then copy its state onto `this` so the
-    //   inherited Relation methods see the same scope as the old
-    //   `scope()` path.
+    // Non-through path delegates to `buildHasManyRelation()` (same
+    // helper used by `scope()`, `countHasMany()`, eager loaders) so CP
+    // gets identical semantics: the relation starts from
+    // `targetModel.all()` (default scope applied), is scope-proxied
+    // (so `options.scope` callbacks can call named scopes / generated
+    // methods on it), and composite-PK mismatches throw
+    // `CompositePrimaryKeyMismatchError`. State is then copied onto
+    // `this` so the inherited Relation methods observe the same scope.
     //
-    // Through scope-building reads adapter schema, which can fail on
-    // adapter-less test fixtures that still expect bare CP construction
-    // to succeed. Wrap in try/catch — a later `scope()` call will surface
-    // the real error.
+    // Through path copies state from `_buildThroughScope()`. Config
+    // errors (missing through assoc, unregistered target model) are
+    // validated upfront; only adapter/schema failures fall to the
+    // fail-closed `_isNone` path.
+    const ctor = record.constructor as typeof Base;
     const proxySelf = this as unknown as {
       _isNone: boolean;
-      whereBang: (c: Record<string, unknown>) => unknown;
       _copyStateFrom: (other: Relation<T>) => void;
     };
     if (assocDef.options.through) {
+      // Config validation FIRST, outside the try — missing through
+      // association or unregistered target model are deterministic
+      // bugs that must surface immediately, not silently fall to
+      // `_isNone`. The try only wraps the schema/adapter-dependent
+      // parts (join resolution, subquery build).
+      const ownerAssociations: AssociationDefinition[] =
+        (ctor as unknown as { _associations?: AssociationDefinition[] })._associations ?? [];
+      const throughAssoc = ownerAssociations.find((a) => a.name === assocDef.options.through);
+      if (!throughAssoc) {
+        throw new Error(
+          `Through association "${assocDef.options.through}" not found on ${ctor.name}`,
+        );
+      }
+      resolveModel(className); // throws if the target model isn't registered
       try {
         const throughRel = this._buildThroughScope() as Relation<T>;
         proxySelf._copyStateFrom(throughRel);
       } catch {
-        // `_buildThroughScope()` can fail during CP construction when
-        // the adapter/schema isn't ready yet (common in test fixtures
-        // that construct a bare proxy before migrations run). Fail
-        // CLOSED: mark the inherited Relation state as `none` so
-        // `cp.where(...).toArray()` returns [] instead of silently
-        // querying the entire target table. A later `scope()` call
-        // rebuilds the through scope and surfaces the real error if
-        // the adapter is still broken.
+        // Config is valid — this path only fires for adapter/schema
+        // failures (e.g. fixture constructs a proxy before migrations
+        // run). Fail CLOSED so `cp.where(...).toArray()` returns []
+        // rather than silently querying the full target table. A
+        // later `scope()` call rebuilds and surfaces the real error
+        // if the adapter is still broken.
         proxySelf._isNone = true;
       }
     } else {
-      const conditions = computeHasManyWhere(record, assocName, assocDef.options);
-      if (conditions === null) {
+      // Build via `buildHasManyRelation` so CP's inherited Relation
+      // state matches `scope()` / direct Relation callers: default
+      // scope from `targetModel.all()` is applied, the relation is
+      // scope-proxied (so `options.scope` can call named scopes /
+      // generated methods on it), and composite-PK validation runs.
+      // Then `_copyStateFrom` onto `this`. Missing owner PK →
+      // `_isNone = true` (Rails' NullRelation fallback).
+      const seedRel = buildHasManyRelation(
+        record,
+        assocName,
+        assocDef.options,
+      ) as Relation<T> | null;
+      if (seedRel === null) {
         proxySelf._isNone = true;
       } else {
-        proxySelf.whereBang(conditions);
-        if (assocDef.options.scope) {
-          const scoped = assocDef.options.scope(this as unknown as Relation<T>);
-          // Scope callbacks are written in the codebase as
-          // `(rel) => rel.where(...).order(...)` — they CLONE the input
-          // relation and return a new one. We must copy state back onto
-          // `this` so the inherited Relation methods observe the scoped
-          // where/order/limit/etc.
-          if (scoped && scoped !== (this as unknown)) {
-            proxySelf._copyStateFrom(scoped);
-          }
-        }
+        proxySelf._copyStateFrom(seedRel);
       }
     }
 
@@ -1179,6 +1189,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   override reset(): this {
+    // Call Relation.reset() so inherited query state (_records,
+    // _loaded, _loadToken, _loadAsyncPromise) is cleared alongside the
+    // association-specific target cache. Without super, callers using
+    // Relation#load() / Relation#loadAsync() patterns on the proxy
+    // would see stale results after reset.
+    super.reset();
     this._targetLoaded = false;
     this._target = [];
     return this;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -410,7 +410,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (typeof original !== "function") continue;
       Object.defineProperty(this, name, {
         value: function (this: CollectionProxy<T>, ...args: unknown[]) {
-          (this as unknown as { _cpMutated: boolean })._cpMutated = true;
+          const self = this as unknown as {
+            _cpMutated: boolean;
+            _loaded: boolean;
+            _records: unknown[];
+            _loadAsyncPromise?: Promise<unknown>;
+          };
+          self._cpMutated = true;
+          // Also invalidate the inherited Relation load cache so a
+          // subsequent super.toArray() / super.count() on the diverged
+          // path re-runs the query instead of returning stale results
+          // from a pre-bang load. The association-local target (_target)
+          // is intentionally NOT wiped — that's the owner's in-memory
+          // proxy state and survives scope mutations.
+          self._loaded = false;
+          self._records = [];
+          self._loadAsyncPromise = undefined;
           return (original as (...a: unknown[]) => unknown).apply(this, args);
         },
         writable: true,
@@ -664,10 +679,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   semantics (loaded-target fast path). PR B will delete CP's count
   //   and let Relation's win.
   async count(): Promise<number> {
-    // Same divergence gate as toArray() / load(): scope bangs on the
-    // proxy mean loadHasMany's cached count is stale.
+    // Same divergence gate as toArray() / load(). Use Relation's count
+    // (COUNT(*) query) on the diverged path rather than
+    // super.toArray().length — instantiating every row just to count
+    // would be a major perf regression on large collections.
     if (this._relationStateDiverged()) {
-      return (await super.toArray()).length;
+      const counted = await (
+        Relation.prototype as unknown as {
+          count(this: CollectionProxy<T>): Promise<number | Record<string, number>>;
+        }
+      ).count.call(this);
+      return typeof counted === "number" ? counted : Object.keys(counted).length;
     }
     const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
     return results.length;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -98,41 +98,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _assocDef: AssociationDefinition;
   private _target: T[] = [];
   private _targetLoaded = false;
-  // Snapshot of key Relation-state sizes captured at end of the ctor
-  // (after FK/through seeding). `toArray()` compares against this to
-  // detect in-place bang-mutation of the inherited Relation state;
-  // when state has diverged from the seed, CP delegates to
-  // `super.toArray()` so the query honors the mutations instead of
-  // silently returning the association-cached load. See `toArray()`
-  // for the rationale.
-  private _seedSignature!: {
-    wherePredicates: number;
-    havingPredicates: number;
-    orderClauses: number;
-    rawOrderClauses: number;
-    limitValue: number | null;
-    offsetValue: number | null;
-    selectColumns: number | null;
-    isDistinct: boolean;
-    distinctOnColumns: number;
-    groupColumns: number;
-    joinClauses: number;
-    rawJoins: number;
-    isNone: boolean;
-    // SQL-shape fields added in round 5 to close divergence blind spots
-    // (fromBang / withBang / withRecursiveBang / lockBang / annotate /
-    // optimizerHints / references / eagerLoad / includes / preload).
-    lockValue: string | null;
-    ctes: number;
-    fromClause: unknown;
-    annotations: number;
-    optimizerHints: number;
-    referencesValues: number;
-    eagerLoadAssociations: number;
-    includesAssociations: number;
-    preloadAssociations: number;
-    setOperation: unknown;
-  };
+  // Content fingerprint of the inherited Relation state captured at
+  // end of the ctor (after FK/through seeding). `toArray()` compares
+  // the current fingerprint against this seed to detect any in-place
+  // bang-mutation — content-aware (not just array lengths), so
+  // reorderBang / regroupBang / reverseOrderBang / rewhere and other
+  // replace-in-place mutations are also caught. When state diverges,
+  // CP delegates to `super.toArray()` so the query honors the
+  // mutations instead of silently returning the association-cached
+  // load.
+  private _seedFingerprint!: string;
 
   get loaded(): boolean {
     return this._targetLoaded;
@@ -361,77 +336,73 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       }
     }
 
-    this._seedSignature = this._captureStateSignature();
+    this._seedFingerprint = this._computeStateFingerprint();
   }
 
   /**
-   * Snapshot the shape-influencing fields of the inherited Relation
-   * state. Used by `toArray()` to detect in-place bang-mutation of the
-   * proxy (e.g. `cp.whereBang(...)`) since seeding. The fields reach
-   * through `as any` because they're `private` on Relation — this is
-   * scoped to CP and documented.
+   * Serialize the SQL-shape-affecting fields of the inherited Relation
+   * state into a content-addressed fingerprint. Predicate nodes contain
+   * non-JSON-safe references (Arel attributes, etc.) so we use a
+   * defensive replacer that falls back to `String(v)` on cycles /
+   * typed instances. Fields reach through `as any` because they're
+   * `private` on Relation — scoped to CP and documented.
    */
-  private _captureStateSignature(): CollectionProxy<T>["_seedSignature"] {
-    const s = this as unknown as {
-      _whereClause: { predicates: unknown[] };
-      _havingClause: { predicates: unknown[] };
-      _orderClauses: unknown[];
-      _rawOrderClauses: unknown[];
-      _limitValue: number | null;
-      _offsetValue: number | null;
-      _selectColumns: unknown[] | null;
-      _isDistinct: boolean;
-      _distinctOnColumns: unknown[];
-      _groupColumns: unknown[];
-      _joinClauses: unknown[];
-      _rawJoins: unknown[];
-      _isNone: boolean;
-      _lockValue: string | null;
-      _ctes: unknown[];
-      _fromClause: unknown;
-      _annotations: unknown[];
-      _optimizerHints: unknown[];
-      _referencesValues: unknown[];
-      _eagerLoadAssociations: unknown[];
-      _includesAssociations: unknown[];
-      _preloadAssociations: unknown[];
-      _setOperation: unknown;
+  private _computeStateFingerprint(): string {
+    const s = this as unknown as Record<string, unknown>;
+    // Enumerate every private Relation field that a bang method can
+    // mutate and that affects generated SQL. Length-only sampling
+    // misses reorderBang / regroupBang / reverseOrderBang / rewrite-
+    // in-place mutations, so we serialize contents.
+    const fields = [
+      "_whereClause",
+      "_havingClause",
+      "_orderClauses",
+      "_rawOrderClauses",
+      "_limitValue",
+      "_offsetValue",
+      "_selectColumns",
+      "_isDistinct",
+      "_distinctOnColumns",
+      "_groupColumns",
+      "_joinClauses",
+      "_rawJoins",
+      "_isNone",
+      "_lockValue",
+      "_ctes",
+      "_fromClause",
+      "_annotations",
+      "_optimizerHints",
+      "_referencesValues",
+      "_eagerLoadAssociations",
+      "_includesAssociations",
+      "_preloadAssociations",
+      "_setOperation",
+    ];
+    const seen = new WeakSet<object>();
+    const replacer = (_: string, v: unknown): unknown => {
+      if (v === null || v === undefined) return v;
+      if (typeof v === "function") return "[fn]";
+      if (typeof v === "object") {
+        if (seen.has(v as object)) return "[cycle]";
+        seen.add(v as object);
+      }
+      return v;
     };
-    return {
-      wherePredicates: s._whereClause.predicates.length,
-      havingPredicates: s._havingClause.predicates.length,
-      orderClauses: s._orderClauses.length,
-      rawOrderClauses: s._rawOrderClauses.length,
-      limitValue: s._limitValue,
-      offsetValue: s._offsetValue,
-      selectColumns: s._selectColumns ? s._selectColumns.length : null,
-      isDistinct: s._isDistinct,
-      distinctOnColumns: s._distinctOnColumns.length,
-      groupColumns: s._groupColumns.length,
-      joinClauses: s._joinClauses.length,
-      rawJoins: s._rawJoins.length,
-      isNone: s._isNone,
-      lockValue: s._lockValue,
-      ctes: s._ctes.length,
-      fromClause: s._fromClause,
-      annotations: s._annotations.length,
-      optimizerHints: s._optimizerHints.length,
-      referencesValues: s._referencesValues.length,
-      eagerLoadAssociations: s._eagerLoadAssociations.length,
-      includesAssociations: s._includesAssociations.length,
-      preloadAssociations: s._preloadAssociations.length,
-      setOperation: s._setOperation,
-    };
+    const payload: Record<string, unknown> = {};
+    for (const f of fields) payload[f] = s[f];
+    try {
+      return JSON.stringify(payload, replacer);
+    } catch {
+      // Defensive: if the payload still can't serialize, fall back to
+      // a guaranteed-diverged sentinel so toArray() takes the
+      // Relation path (safer than returning the cached result).
+      return `__unserializable__:${Math.random()}`;
+    }
   }
 
   /** Whether the inherited Relation state has diverged from the seed. */
   private _relationStateDiverged(): boolean {
-    const now = this._captureStateSignature();
-    const seed = this._seedSignature;
-    for (const key of Object.keys(seed) as (keyof typeof seed)[]) {
-      if (now[key] !== seed[key]) return true;
-    }
-    return false;
+    return this._computeStateFingerprint() !== this._seedFingerprint;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -689,7 +689,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           count(this: CollectionProxy<T>): Promise<number | Record<string, number>>;
         }
       ).count.call(this);
-      return typeof counted === "number" ? counted : Object.keys(counted).length;
+      // A grouped count (Record) would mean the caller added a
+      // `groupBang(...)` on the proxy — ambiguous for CP#count (which
+      // returns a single number). Match `countHasMany`'s contract and
+      // fail loudly instead of silently collapsing to the group count.
+      if (typeof counted !== "number") {
+        throw new Error("Grouped counts are not supported for association collection counts");
+      }
+      return counted;
     }
     const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
     return results.length;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1565,16 +1565,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
 
     // If the proxy's inherited Relation state has been mutated in place
-    // (e.g. cp.whereBang(...)), use `this` directly instead of
-    // scope() — scope() rebuilds the unmutated association scope and
-    // would delete/nullify MORE rows than the caller constrained.
-    const rel = this._relationStateDiverged() ? (this as unknown as Relation<T>) : this.scope();
+    // (e.g. cp.whereBang(...)), go through super.deleteAll() /
+    // super.updateAll() directly — scope() would rebuild the
+    // unmutated association scope and delete/nullify MORE rows than
+    // the caller constrained. NOT `this.deleteAll()` / `this.updateAll()`
+    // here: those resolve back to CollectionProxy's own methods and
+    // would recurse.
+    const diverged = this._relationStateDiverged();
     if (strategy === "delete_all") {
       if (this._isThrough) {
         // For through associations, delete join rows via SQL — not the target records
         await this._deleteThroughAllSql();
+      } else if (diverged) {
+        await super.deleteAll();
       } else {
-        await (rel as { deleteAll: () => Promise<unknown> }).deleteAll();
+        await this.scope().deleteAll();
       }
     } else {
       // Nullify: set-based SQL update to null FKs (no per-record callbacks)
@@ -1582,9 +1587,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         await this._deleteThroughAllSql();
       } else {
         const nullUpdates = this._buildNullifyUpdates();
-        await (rel as { updateAll: (u: Record<string, unknown>) => Promise<unknown> }).updateAll(
-          nullUpdates,
-        );
+        if (diverged) {
+          await super.updateAll(nullUpdates);
+        } else {
+          await this.scope().updateAll(nullUpdates);
+        }
       }
     }
     this._target = [];

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -164,8 +164,10 @@ export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
 // call before base.ts reaches this line. `let` would throw TDZ; `var
 // x = null` would hoist then RESET the value back to null; `var x;`
 // hoists as `undefined` without clobbering a later-set value.
-let _RelationCtor: (new (modelClass: typeof Base) => any) | undefined;
-let _wrapWithScopeProxy: ((rel: any) => any) | undefined;
+// eslint-disable-next-line no-var
+var _RelationCtor: (new (modelClass: typeof Base) => any) | undefined;
+// eslint-disable-next-line no-var
+var _wrapWithScopeProxy: ((rel: any) => any) | undefined;
 
 /** @internal Called by relation.ts to register itself. */
 export function _setRelationCtor(ctor: new (modelClass: typeof Base) => any): void {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -156,8 +156,16 @@ export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
 
 // Late-bound Relation constructor to break circular dependency.
 // Set by relation.ts when it loads.
-let _RelationCtor: (new (modelClass: typeof Base) => any) | null = null;
-let _wrapWithScopeProxy: ((rel: any) => any) | null = null;
+//
+// `var` (rather than `let`) with no initializer is deliberate: these are
+// assigned from other modules' top-level code (relation.ts's
+// `_setRelationCtor(Relation)` call runs during module init). With
+// `extends Relation` chains, base.ts's own imports can trigger that
+// call before base.ts reaches this line. `let` would throw TDZ; `var
+// x = null` would hoist then RESET the value back to null; `var x;`
+// hoists as `undefined` without clobbering a later-set value.
+let _RelationCtor: (new (modelClass: typeof Base) => any) | undefined;
+let _wrapWithScopeProxy: ((rel: any) => any) | undefined;
 
 /** @internal Called by relation.ts to register itself. */
 export function _setRelationCtor(ctor: new (modelClass: typeof Base) => any): void {

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -98,7 +98,7 @@ describe("virtualized patterns — trails-tsc injects declares + auto-imports", 
     const author = new Author({ name: "dean" });
     expectTypeOf(author.comments).toEqualTypeOf<AssociationProxy<Comment>>();
     expectTypeOf(await author.comments).toEqualTypeOf<Comment[]>();
-    expectTypeOf(author.comments.length).toBeNumber();
+    expectTypeOf(author.comments.target.length).toBeNumber();
     expectTypeOf(author.comments[0]).toEqualTypeOf<Comment | undefined>();
   });
 


### PR DESCRIPTION
## Summary

Baseline of a multi-PR refactor to make `CollectionProxy` a real subclass of `Relation`, matching Rails' `ActiveRecord::Associations::CollectionProxy < Relation`. This is **PR A** — the inheritance edge exists, all tests pass, duplicate methods are preserved (PR B will delete them).

- `class CollectionProxy<T> extends Relation<T>` — constructor resolves the target model from the association reflection, calls `super(targetModel, targetModel.arelTable)`, and seeds the FK where-clause via a new `computeHasManyWhere` helper extracted from `buildHasManyRelation`. Through associations keep the subquery/join path via `scope()`.
- `_newRelation()` is overridden to return an `AssociationRelation` so chains (`blog.posts.where(...)`) become AR, matching Rails' layering.
- Duplicate methods (`load`, `count`, `first`, `last`, `take`, `find`, `destroyAll`, `deleteAll`, `calculate`, `delete`, `destroy`, `isNone`) are kept with `@ts-expect-error` pointing at PR B, which will delete them and inherit from Relation.
- CP's sync `get length()` is **removed** — it can't coexist with `Relation#length()` (async) under inheritance. Callers needing a sync count use `proxy.target.length` or `Array.from(proxy).length`. Tests updated.
- Module-init cycle fixes: `base.ts` late-bind slots become `var` without initializers (avoids TDZ and avoids wiping an early-set value); `associations.ts` late-binds the `CollectionProxy` constructor the same way it late-binds `AssociationRelation`.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [x] Full activerecord vitest suite: 8673 passed / 3743 skipped / 0 failed
- [x] CollectionProxy-specific test file updated for `.length` → `.target.length` / `Array.from(...).length`

## Follow-ups (PR B)

- Delete CP methods that duplicate Relation (the `@ts-expect-error` sites)
- Consider removing `wrapCollectionProxy` once Relation's own scope-proxy chain is fully covering named scopes on the bare proxy