### PR TITLE
feat(activerecord): unscope coverage for createWith / preload / eagerLoad

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -179,12 +179,13 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // :eager_load, :joins, :left_outer_joins)` strips those query parts
       // before merging. Our `Relation#except` is the SQL set-operation
       // EXCEPT (Rails-faithful for that name); the query-part strip is
-      // `unscope(...)`. `createWith`, `preload`, `eagerLoad` aren't in
-      // our UnscopeType set yet (follow-up); the supported keys cover
-      // the practical cases (select / includes / joins / leftOuterJoins).
+      // `unscope(...)`. The full Rails set is now supported.
       const stripped = (sfa as { unscope: (...keys: string[]) => unknown }).unscope(
         "select",
+        "createWith",
         "includes",
+        "preload",
+        "eagerLoad",
         "joins",
         "leftOuterJoins",
       );

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -6,6 +6,7 @@ import {
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import type { Relation } from "../relation.js";
+import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
 import type { AbstractReflection } from "../reflection.js";
 
@@ -180,7 +181,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // before merging. Our `Relation#except` is the SQL set-operation
       // EXCEPT (Rails-faithful for that name); the query-part strip is
       // `unscope(...)`. The full Rails set is now supported.
-      const stripped = (sfa as { unscope: (...keys: string[]) => unknown }).unscope(
+      const stripped = (sfa as { unscope: (...keys: UnscopeType[]) => unknown }).unscope(
         "select",
         "createWith",
         "includes",

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -252,11 +252,14 @@ export type UnscopeType =
   | "joins"
   | "leftOuterJoins"
   | "includes"
+  | "preload"
+  | "eagerLoad"
   | "from"
   | "readonly"
   | "having"
   | "optimizerHints"
-  | "annotate";
+  | "annotate"
+  | "createWith";
 
 export const VALID_UNSCOPING_VALUES: ReadonlySet<UnscopeType> = new Set<UnscopeType>([
   "where",
@@ -269,11 +272,14 @@ export const VALID_UNSCOPING_VALUES: ReadonlySet<UnscopeType> = new Set<UnscopeT
   "joins",
   "leftOuterJoins",
   "includes",
+  "preload",
+  "eagerLoad",
   "from",
   "readonly",
   "having",
   "optimizerHints",
   "annotate",
+  "createWith",
 ]);
 
 function unscopeBang(
@@ -326,9 +332,20 @@ function unscopeBang(
           this._joinClauses = this._joinClauses.filter((j) => j.type !== "left");
           break;
         case "includes":
+          // Rails: `unscope(:includes)` clears includes only — preload
+          // and eager_load are independent and have their own keys
+          // below (matches Rails `query_methods.rb` switch on
+          // :includes / :preload / :eager_load).
           this._includesAssociations = [];
-          this._eagerLoadAssociations = [];
+          break;
+        case "preload":
           this._preloadAssociations = [];
+          break;
+        case "eagerLoad":
+          this._eagerLoadAssociations = [];
+          break;
+        case "createWith":
+          this._createWithAttrs = {};
           break;
         case "optimizerHints":
           this._optimizerHints = [];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -236,10 +236,16 @@ function reorderBang(
 
 /**
  * Valid argument values for `unscope`. The TS API is camelCase only —
- * no Rails snake_case aliases. Mirrors Rails' VALID_UNSCOPING_VALUES set
- * (where, select, group, order, lock, limit, offset, joins,
- *  left_outer_joins, includes, from, readonly, having, optimizer_hints,
- *  annotate) translated to TS naming.
+ * no Rails snake_case aliases. Mirrors Rails' VALID_UNSCOPING_VALUES
+ * set (relation/query_methods.rb), camelCased:
+ *
+ *   where, select, group, order, lock, limit, offset, joins,
+ *   left_outer_joins, includes, preload, eager_load, from, readonly,
+ *   having, optimizer_hints, annotate, create_with
+ *
+ * → camelCase: where, select, group, order, lock, limit, offset,
+ *   joins, leftOuterJoins, includes, preload, eagerLoad, from,
+ *   readonly, having, optimizerHints, annotate, createWith.
  */
 export type UnscopeType =
   | "where"

--- a/packages/activerecord/src/relation/unscope-coverage.test.ts
+++ b/packages/activerecord/src/relation/unscope-coverage.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unscope coverage for keys that were missing from UnscopeType:
+ * `:create_with`, `:preload`, `:eager_load`. Mirrors Rails'
+ * `Relation::QueryMethods#unscope` switch (relation/query_methods.rb).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("Relation#unscope — full Rails key coverage", () => {
+  let adapter: DatabaseAdapter;
+
+  class UscAuthor extends Base {
+    static {
+      this.attribute("name", "string");
+    }
+  }
+  class UscPost extends Base {
+    static {
+      this.attribute("usc_author_id", "integer");
+      this.attribute("title", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    UscAuthor.adapter = adapter;
+    UscPost.adapter = adapter;
+    registerModel("UscAuthor", UscAuthor);
+    registerModel("UscPost", UscPost);
+    (UscAuthor as any)._associations = [];
+    (UscPost as any)._associations = [];
+    Associations.hasMany.call(UscAuthor, "uscPosts", {
+      className: "UscPost",
+      foreignKey: "usc_author_id",
+    });
+  });
+
+  it("unscope('createWith') clears _createWithAttrs", () => {
+    const rel = (UscAuthor as any).all().createWith({ name: "default" });
+    expect((rel as any)._createWithAttrs).toEqual({ name: "default" });
+    const cleared = rel.unscope("createWith");
+    expect((cleared as any)._createWithAttrs).toEqual({});
+  });
+
+  it("unscope('preload') clears preload only — leaves includes / eagerLoad alone", () => {
+    const rel = (UscAuthor as any)
+      .all()
+      .preload("uscPosts")
+      .includes("uscPosts")
+      .eagerLoad("uscPosts");
+    expect((rel as any)._preloadAssociations).toEqual(["uscPosts"]);
+    const cleared = rel.unscope("preload");
+    expect((cleared as any)._preloadAssociations).toEqual([]);
+    expect((cleared as any)._includesAssociations).toEqual(["uscPosts"]);
+    expect((cleared as any)._eagerLoadAssociations).toEqual(["uscPosts"]);
+  });
+
+  it("unscope('eagerLoad') clears eagerLoad only — leaves includes / preload alone", () => {
+    const rel = (UscAuthor as any)
+      .all()
+      .preload("uscPosts")
+      .includes("uscPosts")
+      .eagerLoad("uscPosts");
+    const cleared = rel.unscope("eagerLoad");
+    expect((cleared as any)._eagerLoadAssociations).toEqual([]);
+    expect((cleared as any)._includesAssociations).toEqual(["uscPosts"]);
+    expect((cleared as any)._preloadAssociations).toEqual(["uscPosts"]);
+  });
+
+  it("unscope('includes') clears includes only — leaves preload / eagerLoad alone (Rails-faithful)", () => {
+    // Pre-PR-B behavior: unscope('includes') ALSO cleared preload and
+    // eagerLoad. Rails' query_methods.rb scopes each key independently.
+    const rel = (UscAuthor as any)
+      .all()
+      .preload("uscPosts")
+      .includes("uscPosts")
+      .eagerLoad("uscPosts");
+    const cleared = rel.unscope("includes");
+    expect((cleared as any)._includesAssociations).toEqual([]);
+    expect((cleared as any)._preloadAssociations).toEqual(["uscPosts"]);
+    expect((cleared as any)._eagerLoadAssociations).toEqual(["uscPosts"]);
+  });
+});


### PR DESCRIPTION
## Summary

PR B of the DJAS follow-up arc. Closes the unscope coverage gap that PR 4 (#631) left behind.

DJAS' replacement of Rails' \`except(:select, :create_with, :includes, :preload, :eager_load, :joins, :left_outer_joins)\` was limited to the keys our \`UnscopeType\` supported (select / includes / joins / leftOuterJoins). This PR wires the missing three:

- Add \`createWith\` / \`preload\` / \`eagerLoad\` to \`UnscopeType\` + \`VALID_UNSCOPING_VALUES\` + \`unscopeBang\` switch. Each clears its own field independently (matches Rails' \`query_methods.rb\` switch on \`:create_with\` / \`:preload\` / \`:eager_load\`).
- Fix the existing \`case "includes"\` to clear includes ONLY — it was also clearing preload + eagerLoad, which was a pre-existing Rails-fidelity bug.
- Update DJAS' \`scope_for_association\` strip to use the full Rails key set.

## Test plan

- [x] 4 new tests in \`unscope-coverage.test.ts\` assert each new key clears only its own field; regression test for the includes-only behavior.
- [x] Full \`@blazetrails/activerecord\` suite: 8679 passed locally.
- [ ] PG / MariaDB CI.