### PR TITLE
feat(activerecord): DJAS composite-key support via composite OR-of-AND WHERE

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -342,10 +342,12 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
   if (!src) return false;
   if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
   if (options.sourceType) return false;
-  // Composite-key through associations are now supported via tuple-IN
-  // WHERE clauses (see DJAS `_addConstraintsDj`). The previous gate
-  // that bailed on multi-column joinPrimaryKey / joinForeignKey is
-  // gone — the chain walk handles both single and composite shapes.
+  // Composite-key through associations are now supported by DJAS'
+  // `_addConstraintsDj`, which builds an Arel `OR`-of-`AND` predicate
+  // (`(c1=v1a AND c2=v1b) OR ...`) for the chain walk — same shape
+  // counter-cache.ts#buildPkPredicate uses. The previous gate that
+  // bailed on multi-column joinPrimaryKey / joinForeignKey is gone —
+  // the chain walk handles both single and composite shapes.
   return true;
 }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -342,17 +342,10 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
   if (!src) return false;
   if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
   if (options.sourceType) return false;
-  // Composite-key through associations need per-column predicates (or
-  // tuple IN) at every chain step; DJAS only supports single-column keys
-  // today. Bail out if any chain entry has a composite join key so we
-  // fall back to loadHasManyThrough rather than silently truncating.
-  const chain =
-    (reflection as { chain?: Array<{ joinPrimaryKey?: unknown; joinForeignKey?: unknown }> })
-      .chain ?? [];
-  for (const entry of chain) {
-    if (Array.isArray(entry.joinPrimaryKey) && entry.joinPrimaryKey.length > 1) return false;
-    if (Array.isArray(entry.joinForeignKey) && entry.joinForeignKey.length > 1) return false;
-  }
+  // Composite-key through associations are now supported via tuple-IN
+  // WHERE clauses (see DJAS `_addConstraintsDj`). The previous gate
+  // that bailed on multi-column joinPrimaryKey / joinForeignKey is
+  // gone — the chain walk handles both single and composite shapes.
   return true;
 }
 

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -178,8 +178,12 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     const klass = (reflection as { klass: typeof Base }).klass;
     let scope: unknown = (klass as unknown as { unscoped: () => unknown }).unscoped();
     if (keyCols.length === 1) {
-      // Single-column key: hash WHERE compiles to `key IN (?, ?, ...)`.
-      // Matches Rails' `disable_joins_association_scope.rb:34`:
+      // Single-column key: hash WHERE typically compiles to
+      // `key IN (?, ?, ...)`. The PredicateBuilder array handler
+      // splits null entries into a separate `OR key IS NULL` branch,
+      // so the exact emitted shape depends on whether `joinIds`
+      // contains nulls (rare in the chain-walk's pluck output, but
+      // possible). Matches Rails' `disable_joins_association_scope.rb:34`:
       // `reflection.build_scope(...).where(key => join_ids)`.
       scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
         [keyCols[0]]: joinIds,

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -5,7 +5,6 @@ import {
   type ValueTransformation,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
-import { Nodes } from "@blazetrails/arel";
 import type { Relation } from "../relation.js";
 import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
@@ -15,11 +14,11 @@ type ChainEntry = AbstractReflection | ReflectionProxy;
 
 /**
  * Normalize a `joinPrimaryKey` / `joinForeignKey` to an array of column
- * names. Both single-column (`"id"`) and composite (`["a", "b"]`)
- * shapes are supported; downstream code branches on `cols.length === 1`
- * vs `> 1` to decide between hash-WHERE (`{ key: ids }`) and the
- * composite-key predicate built by `tuplePredicate`
- * (`(c1=v11 AND c2=v12) OR (c1=v21 AND c2=v22) OR ...`).
+ * names. Single-column (`"id"`) and composite (`["a", "b"]`) shapes
+ * are both supported; the per-step WHERE goes through `where({key:
+ * ids})` for single-column or `where(cols, tuples)` for composite —
+ * both paths land in `PredicateBuilder` (the latter via
+ * `buildComposite`).
  */
 function keyColumns(key: string | string[], label: string): string[] {
   if (Array.isArray(key)) {
@@ -38,31 +37,6 @@ function keyColumns(key: string | string[], label: string): string[] {
  */
 function readTuple(owner: Base, cols: string[]): unknown[] {
   return cols.map((c) => owner.readAttribute(c));
-}
-
-/**
- * Build a composite-key predicate as `(c1=v11 AND c2=v12) OR
- * (c1=v21 AND c2=v22) OR ...`. Semantically equivalent to tuple-IN
- * but built with Arel nodes — keeps adapter-specific identifier
- * quoting centralized in Arel (no manual `quoteColumnName` /
- * `detectAdapterName` plumbing) and matches the existing pattern in
- * `counter-cache.ts#buildPkPredicate`.
- *
- * Caller must guarantee `tuples.length > 0` — empty input is handled
- * by the caller via `Relation#none()`.
- */
-function tuplePredicate(
-  klass: typeof Base,
-  cols: string[],
-  tuples: unknown[][],
-): InstanceType<typeof Nodes.Node> {
-  const table = klass.arelTable;
-  const groupings: InstanceType<typeof Nodes.Node>[] = tuples.map((tuple) => {
-    const eqs = cols.map((c, i) => table.get(c).eq(tuple[i]));
-    return new Nodes.Grouping(new Nodes.And(eqs));
-  });
-  if (groupings.length === 1) return groupings[0];
-  return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));
 }
 
 /**
@@ -205,31 +179,22 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     let scope: unknown = (klass as unknown as { unscoped: () => unknown }).unscoped();
     if (keyCols.length === 1) {
       // Single-column key: hash WHERE compiles to `key IN (?, ?, ...)`.
+      // Matches Rails' `disable_joins_association_scope.rb:34`:
+      // `reflection.build_scope(...).where(key => join_ids)`.
       scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
         [keyCols[0]]: joinIds,
       });
     } else {
-      // Composite key: tuples of values. Filter out tuples
-      // containing null/undefined — Arel's `Attribute#eq(null)` would
-      // emit `IS NULL`, but tuple-equality semantics (and SQL tuple-
-      // IN) treat any null component as a non-match, never a true
-      // equality. Mirrors `buildPkPredicate` in counter-cache.ts:93.
-      // After filtering, an empty tuple list ⇒ no possible match;
-      // use `Relation#none()` (idiomatic, skips the DB hit at
-      // toArray time, matches Rails' `.none` contract).
-      const allTuples = joinIds as unknown[][];
-      const tuples = allTuples.filter(
-        (t) =>
-          Array.isArray(t) &&
-          t.length === keyCols.length &&
-          t.every((v) => v !== null && v !== undefined),
+      // Composite key: route through `Relation#where(cols, tuples)`,
+      // which delegates to `PredicateBuilder.buildComposite`. That
+      // helper handles null-component filtering (SQL tuple-equality
+      // semantics), arity validation, single-column degeneracy → IN,
+      // and bind-param emission via QueryAttribute. Empty/all-filtered
+      // tuples become `Relation#none()`. No DJAS-local scaffolding.
+      scope = (scope as { where: (c: string[], t: unknown[][]) => unknown }).where(
+        keyCols,
+        joinIds as unknown[][],
       );
-      if (tuples.length === 0) {
-        scope = (scope as { none: () => unknown }).none();
-      } else {
-        const node = tuplePredicate(klass, keyCols, tuples);
-        scope = (scope as { where: (n: InstanceType<typeof Nodes.Node>) => unknown }).where(node);
-      }
     }
 
     const sfa = (

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -5,6 +5,7 @@ import {
   type ValueTransformation,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+import { quoteColumnName } from "../connection-adapters/abstract/quoting.js";
 import type { Relation } from "../relation.js";
 import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
@@ -40,15 +41,17 @@ function readTuple(owner: Base, cols: string[]): unknown[] {
 
 /**
  * Build a tuple-IN WHERE clause as raw SQL: `(c1, c2) IN ((?, ?), ...)`.
- * Returns null when `tuples` is empty (caller should short-circuit
- * with no records). PG / MySQL / SQLite all support tuple IN; Arel's
- * AST doesn't expose a direct constructor for it, so raw SQL is the
- * portable path.
+ * Caller must guarantee `tuples.length > 0` — empty input is handled
+ * by the caller via `Relation#none()`. PG / MySQL / SQLite all support
+ * tuple IN; Arel's AST doesn't expose a direct constructor for it, so
+ * raw SQL is the portable path. Identifiers go through
+ * `quoteColumnName` (handles embedded quotes / schema-qualified
+ * names per Rails' adapter quoting).
  */
 function tupleInClause(cols: string[], tuples: unknown[][]): { sql: string; binds: unknown[] } {
   const placeholderRow = "(" + cols.map(() => "?").join(", ") + ")";
   const allRows = tuples.map(() => placeholderRow).join(", ");
-  const colList = cols.map((c) => `"${c.replace(/"/g, '""')}"`).join(", ");
+  const colList = cols.map((c) => quoteColumnName(c)).join(", ");
   const flat: unknown[] = [];
   for (const t of tuples) flat.push(...t);
   return { sql: `(${colList}) IN (${allRows})`, binds: flat };
@@ -198,21 +201,13 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         [keyCols[0]]: joinIds,
       });
     } else {
-      // Composite key: tuples of values. Empty tuple list ⇒ empty
-      // result; short-circuit by emitting a never-true WHERE so the
-      // load returns 0 rows without a malformed `() IN ()` SQL.
+      // Composite key: tuples of values. Empty tuple list ⇒ no
+      // possible match; use Relation#none() for an idiomatic "no
+      // rows" short-circuit (skips the DB hit entirely at toArray
+      // time, matches Rails' `relation.none` contract).
       const tuples = joinIds as unknown[][];
       if (tuples.length === 0) {
-        scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
-          [keyCols[0]]: null as unknown,
-        });
-        // The where above doesn't strictly produce zero rows for a
-        // nullable column; follow with `.none()` semantics by chaining
-        // a literal-false predicate. Fall through to scope_for_assoc /
-        // constraints below for parity, then the `none` short-circuit
-        // ensures no DB hit at toArray time. Use raw-SQL safety: a
-        // `1=0` clause is the universal "no rows" predicate.
-        scope = (scope as { where: (sql: string) => unknown }).where("1=0");
+        scope = (scope as { none: () => unknown }).none();
       } else {
         const { sql, binds } = tupleInClause(keyCols, tuples);
         scope = (scope as { where: (sql: string, ...binds: unknown[]) => unknown }).where(

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -9,8 +9,17 @@ import type { Relation } from "../relation.js";
 import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
 import type { AbstractReflection } from "../reflection.js";
+import { argumentError } from "../relation/query-methods.js";
 
 type ChainEntry = AbstractReflection | ReflectionProxy;
+
+/**
+ * Join-id accumulator shape across the chain walk. Single-column keys
+ * carry a flat list of scalars (`unknown[]`); composite keys carry a
+ * list of tuples (`unknown[][]`). The shape per iteration is decided
+ * by the step's key arity in `_addConstraintsDj` / `_lastScopeChain`.
+ */
+type JoinIds = unknown[] | unknown[][];
 
 /**
  * Normalize a `joinPrimaryKey` / `joinForeignKey` to an array of column
@@ -116,7 +125,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
   private async _lastScopeChain(
     reverseChain: ChainEntry[],
     owner: Base,
-  ): Promise<[ChainEntry, boolean, unknown[]]> {
+  ): Promise<[ChainEntry, boolean, JoinIds]> {
     const work = reverseChain.slice();
     const firstItem = work.shift();
     if (!firstItem) {
@@ -129,8 +138,8 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     // tuple per join candidate). The owner contributes exactly one
     // tuple as the chain seed.
     const seedTuple = readTuple(owner, firstFkCols);
-    const initialIds = firstFkCols.length === 1 ? [seedTuple[0]] : [seedTuple];
-    let acc: [ChainEntry, boolean, unknown[]] = [firstItem, false, initialIds];
+    const initialIds: JoinIds = firstFkCols.length === 1 ? [seedTuple[0]] : [seedTuple];
+    let acc: [ChainEntry, boolean, JoinIds] = [firstItem, false, initialIds];
 
     for (const nextReflection of work) {
       const [reflection, ordered, joinIds] = acc;
@@ -143,7 +152,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // `[[v1a, v1b], ...]`. Forward as-is into the next iteration.
       const recordIds = (await (
         records as { pluck: (...cols: string[]) => Promise<unknown[]> }
-      ).pluck(...foreignKeyCols)) as unknown[];
+      ).pluck(...foreignKeyCols)) as JoinIds;
       // `orderValues` covers `_orderClauses` (the parsed form); raw-SQL
       // orders (e.g. `inOrderOf`) live in `_rawOrderClauses` and are
       // invisible to the public getter. Check both so chain steps with
@@ -171,7 +180,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
   private _addConstraintsDj(
     reflection: ChainEntry,
     keyCols: string[],
-    joinIds: unknown[],
+    joinIds: JoinIds,
     owner: Base,
     ordered: boolean,
   ): unknown {
@@ -195,10 +204,26 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // semantics), arity validation, single-column degeneracy → IN,
       // and bind-param emission via QueryAttribute. Empty/all-filtered
       // tuples become `Relation#none()`. No DJAS-local scaffolding.
-      scope = (scope as { where: (c: string[], t: unknown[][]) => unknown }).where(
-        keyCols,
-        joinIds as unknown[][],
-      );
+      // Defense in depth: the chain walk constructs `joinIds` from
+      // `pluck(...cols)` with `cols.length > 1`, which yields an
+      // array of tuples. A bug upstream that hands us a flat list
+      // (or mismatched arity) would otherwise surface deep inside
+      // PredicateBuilder with a less actionable trace.
+      const arity = keyCols.length;
+      const tuples = joinIds.map((t, i) => {
+        if (!Array.isArray(t)) {
+          throw argumentError(
+            `DisableJoinsAssociationScope: composite joinIds[${i}] must be an array (got ${typeof t})`,
+          );
+        }
+        if (t.length !== arity) {
+          throw argumentError(
+            `DisableJoinsAssociationScope: composite joinIds[${i}] arity ${t.length} does not match key columns [${keyCols.join(", ")}] (arity ${arity})`,
+          );
+        }
+        return t;
+      }) as unknown[][];
+      scope = (scope as { where: (c: string[], t: unknown[][]) => unknown }).where(keyCols, tuples);
     }
 
     const sfa = (
@@ -253,7 +278,11 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // just without the through-table-order reorder. Single-column
       // case keeps the wrap.
       if (keyCols.length === 1) {
-        const split = new DisableJoinsAssociationRelation<Base>(klass, keyCols[0], joinIds);
+        const split = new DisableJoinsAssociationRelation<Base>(
+          klass,
+          keyCols[0],
+          joinIds as unknown[],
+        );
         const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
         const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
           ._whereClause;

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -6,6 +6,7 @@ import {
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { quoteColumnName } from "../connection-adapters/abstract/quoting.js";
+import { detectAdapterName } from "../adapter-name.js";
 import type { Relation } from "../relation.js";
 import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
@@ -51,10 +52,20 @@ function readTuple(owner: Base, cols: string[]): unknown[] {
  * `quoteTableName`'s responsibility, and column names here come
  * from reflection metadata which is always bare).
  */
-function tupleInClause(cols: string[], tuples: unknown[][]): { sql: string; binds: unknown[] } {
+function tupleInClause(
+  klass: typeof Base,
+  cols: string[],
+  tuples: unknown[][],
+): { sql: string; binds: unknown[] } {
+  // Resolve the adapter flavor from the target class so identifier
+  // quoting picks the right delimiter — double-quotes for PG/SQLite,
+  // backticks for MySQL/MariaDB. Without this, the default
+  // double-quote style would emit invalid SQL on MySQL unless the
+  // server was in ANSI_QUOTES mode.
+  const flavor = detectAdapterName(klass.adapter);
   const placeholderRow = "(" + cols.map(() => "?").join(", ") + ")";
   const allRows = tuples.map(() => placeholderRow).join(", ");
-  const colList = cols.map((c) => quoteColumnName(c)).join(", ");
+  const colList = cols.map((c) => quoteColumnName(c, flavor)).join(", ");
   const flat: unknown[] = [];
   for (const t of tuples) flat.push(...t);
   return { sql: `(${colList}) IN (${allRows})`, binds: flat };
@@ -212,7 +223,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       if (tuples.length === 0) {
         scope = (scope as { none: () => unknown }).none();
       } else {
-        const { sql, binds } = tupleInClause(keyCols, tuples);
+        const { sql, binds } = tupleInClause(klass, keyCols, tuples);
         scope = (scope as { where: (sql: string, ...binds: unknown[]) => unknown }).where(
           sql,
           ...binds,

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -13,27 +13,45 @@ import type { AbstractReflection } from "../reflection.js";
 type ChainEntry = AbstractReflection | ReflectionProxy;
 
 /**
- * Defense in depth: the routing gate in associations.ts already rejects
- * composite-key through associations from this path, but per-step keys
- * are read fresh here, so guard explicitly to fail loudly rather than
- * silently truncating to `key[0]` and producing a broken WHERE.
- *
- * Composite-key support requires per-column predicates (or tuple IN)
- * and is a follow-up.
+ * Normalize a `joinPrimaryKey` / `joinForeignKey` to an array of column
+ * names. Both single-column (`"id"`) and composite (`["a", "b"]`)
+ * shapes are supported; downstream code branches on `cols.length === 1`
+ * vs `> 1` to decide between hash-WHERE (`{key: ids}`) and tuple-IN
+ * raw SQL (`(c1, c2) IN ((?, ?), ...)`).
  */
-function singleColumnKey(key: string | string[], label: string): string {
+function keyColumns(key: string | string[], label: string): string[] {
   if (Array.isArray(key)) {
     if (key.length === 0) {
       throw new Error(`DisableJoinsAssociationScope: empty ${label}`);
     }
-    if (key.length > 1) {
-      throw new Error(
-        `DisableJoinsAssociationScope: composite ${label} not supported (got [${key.join(", ")}])`,
-      );
-    }
-    return key[0];
+    return key;
   }
-  return key;
+  return [key];
+}
+
+/**
+ * Read multiple owner attributes as a tuple. Single-column case
+ * returns `[v]`; composite returns `[v1, v2, ...]` matching the
+ * column order. Used to seed the chain-walk's first join-IDs entry.
+ */
+function readTuple(owner: Base, cols: string[]): unknown[] {
+  return cols.map((c) => owner.readAttribute(c));
+}
+
+/**
+ * Build a tuple-IN WHERE clause as raw SQL: `(c1, c2) IN ((?, ?), ...)`.
+ * Returns null when `tuples` is empty (caller should short-circuit
+ * with no records). PG / MySQL / SQLite all support tuple IN; Arel's
+ * AST doesn't expose a direct constructor for it, so raw SQL is the
+ * portable path.
+ */
+function tupleInClause(cols: string[], tuples: unknown[][]): { sql: string; binds: unknown[] } {
+  const placeholderRow = "(" + cols.map(() => "?").join(", ") + ")";
+  const allRows = tuples.map(() => placeholderRow).join(", ");
+  const colList = cols.map((c) => `"${c.replace(/"/g, '""')}"`).join(", ");
+  const flat: unknown[] = [];
+  for (const t of tuples) flat.push(...t);
+  return { sql: `(${colList}) IN (${allRows})`, binds: flat };
 }
 
 /**
@@ -90,10 +108,10 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         owner,
       );
       const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-      const keyStr = singleColumnKey(key, "joinPrimaryKey");
+      const keyCols = keyColumns(key, "joinPrimaryKey");
       const relation = this._addConstraintsDj(
         lastReflection,
-        keyStr,
+        keyCols,
         lastJoinIds,
         owner,
         lastOrdered,
@@ -120,23 +138,27 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       throw new Error("DisableJoinsAssociationScope: empty chain");
     }
     const firstFk = (firstItem as { joinForeignKey: string | string[] }).joinForeignKey;
-    const firstFkStr = singleColumnKey(firstFk, "joinForeignKey");
-    let acc: [ChainEntry, boolean, unknown[]] = [
-      firstItem,
-      false,
-      [owner.readAttribute(firstFkStr)],
-    ];
+    const firstFkCols = keyColumns(firstFk, "joinForeignKey");
+    // Single-column shape stays `[v1, v2, ...]` (one value per join
+    // candidate). Composite shape becomes `[[v1a, v1b], ...]` (one
+    // tuple per join candidate). The owner contributes exactly one
+    // tuple as the chain seed.
+    const seedTuple = readTuple(owner, firstFkCols);
+    const initialIds = firstFkCols.length === 1 ? [seedTuple[0]] : [seedTuple];
+    let acc: [ChainEntry, boolean, unknown[]] = [firstItem, false, initialIds];
 
     for (const nextReflection of work) {
       const [reflection, ordered, joinIds] = acc;
       const key = (reflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-      const keyStr = singleColumnKey(key, "joinPrimaryKey");
-      const records = this._addConstraintsDj(reflection, keyStr, joinIds, owner, ordered);
+      const keyCols = keyColumns(key, "joinPrimaryKey");
+      const records = this._addConstraintsDj(reflection, keyCols, joinIds, owner, ordered);
       const foreignKey = (nextReflection as { joinForeignKey: string | string[] }).joinForeignKey;
-      const foreignKeyStr = singleColumnKey(foreignKey, "joinForeignKey");
-      const recordIds = (await (records as { pluck: (col: string) => Promise<unknown[]> }).pluck(
-        foreignKeyStr,
-      )) as unknown[];
+      const foreignKeyCols = keyColumns(foreignKey, "joinForeignKey");
+      // Pluck single column → `[v, v, ...]`; pluck multiple →
+      // `[[v1a, v1b], ...]`. Forward as-is into the next iteration.
+      const recordIds = (await (
+        records as { pluck: (...cols: string[]) => Promise<unknown[]> }
+      ).pluck(...foreignKeyCols)) as unknown[];
       // `orderValues` covers `_orderClauses` (the parsed form); raw-SQL
       // orders (e.g. `inOrderOf`) live in `_rawOrderClauses` and are
       // invisible to the public getter. Check both so chain steps with
@@ -163,14 +185,42 @@ export class DisableJoinsAssociationScope extends AssociationScope {
    */
   private _addConstraintsDj(
     reflection: ChainEntry,
-    key: string,
+    keyCols: string[],
     joinIds: unknown[],
     owner: Base,
     ordered: boolean,
   ): unknown {
     const klass = (reflection as { klass: typeof Base }).klass;
     let scope: unknown = (klass as unknown as { unscoped: () => unknown }).unscoped();
-    scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({ [key]: joinIds });
+    if (keyCols.length === 1) {
+      // Single-column key: hash WHERE compiles to `key IN (?, ?, ...)`.
+      scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
+        [keyCols[0]]: joinIds,
+      });
+    } else {
+      // Composite key: tuples of values. Empty tuple list ⇒ empty
+      // result; short-circuit by emitting a never-true WHERE so the
+      // load returns 0 rows without a malformed `() IN ()` SQL.
+      const tuples = joinIds as unknown[][];
+      if (tuples.length === 0) {
+        scope = (scope as { where: (c: Record<string, unknown>) => unknown }).where({
+          [keyCols[0]]: null as unknown,
+        });
+        // The where above doesn't strictly produce zero rows for a
+        // nullable column; follow with `.none()` semantics by chaining
+        // a literal-false predicate. Fall through to scope_for_assoc /
+        // constraints below for parity, then the `none` short-circuit
+        // ensures no DB hit at toArray time. Use raw-SQL safety: a
+        // `1=0` clause is the universal "no rows" predicate.
+        scope = (scope as { where: (sql: string) => unknown }).where("1=0");
+      } else {
+        const { sql, binds } = tupleInClause(keyCols, tuples);
+        scope = (scope as { where: (sql: string, ...binds: unknown[]) => unknown }).where(
+          sql,
+          ...binds,
+        );
+      }
+    }
 
     const sfa = (
       klass as unknown as { scopeForAssociation?: () => unknown }
@@ -215,14 +265,23 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         ? [1]
         : [];
     if (finalOrders.length === 0 && ordered) {
-      const split = new DisableJoinsAssociationRelation<Base>(klass, key, joinIds);
-      const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
-      const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
-        ._whereClause;
-      if (sourceWhere?.predicates && splitWhere) {
-        splitWhere.predicates.push(...sourceWhere.predicates);
+      // DJAR's loaded-chain wrap groups records by `key` (single
+      // string) and re-emits in `ids` order. For composite keys this
+      // would need tuple grouping (out of scope for this PR — see
+      // task #10). Skip the wrap for composite; records still load
+      // correctly via the tuple-IN WHERE above, just without the
+      // through-table-order reorder. Single-column case keeps the
+      // wrap.
+      if (keyCols.length === 1) {
+        const split = new DisableJoinsAssociationRelation<Base>(klass, keyCols[0], joinIds);
+        const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
+        const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
+          ._whereClause;
+        if (sourceWhere?.predicates && splitWhere) {
+          splitWhere.predicates.push(...sourceWhere.predicates);
+        }
+        return split;
       }
-      return split;
     }
     return scope;
   }

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -17,8 +17,9 @@ type ChainEntry = AbstractReflection | ReflectionProxy;
  * Normalize a `joinPrimaryKey` / `joinForeignKey` to an array of column
  * names. Both single-column (`"id"`) and composite (`["a", "b"]`)
  * shapes are supported; downstream code branches on `cols.length === 1`
- * vs `> 1` to decide between hash-WHERE (`{key: ids}`) and tuple-IN
- * raw SQL (`(c1, c2) IN ((?, ?), ...)`).
+ * vs `> 1` to decide between hash-WHERE (`{ key: ids }`) and the
+ * composite-key predicate built by `tuplePredicate`
+ * (`(c1=v11 AND c2=v12) OR (c1=v21 AND c2=v22) OR ...`).
  */
 function keyColumns(key: string | string[], label: string): string[] {
   if (Array.isArray(key)) {
@@ -208,11 +209,21 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         [keyCols[0]]: joinIds,
       });
     } else {
-      // Composite key: tuples of values. Empty tuple list ⇒ no
-      // possible match; use Relation#none() for an idiomatic "no
-      // rows" short-circuit (skips the DB hit entirely at toArray
-      // time, matches Rails' `relation.none` contract).
-      const tuples = joinIds as unknown[][];
+      // Composite key: tuples of values. Filter out tuples
+      // containing null/undefined — Arel's `Attribute#eq(null)` would
+      // emit `IS NULL`, but tuple-equality semantics (and SQL tuple-
+      // IN) treat any null component as a non-match, never a true
+      // equality. Mirrors `buildPkPredicate` in counter-cache.ts:93.
+      // After filtering, an empty tuple list ⇒ no possible match;
+      // use `Relation#none()` (idiomatic, skips the DB hit at
+      // toArray time, matches Rails' `.none` contract).
+      const allTuples = joinIds as unknown[][];
+      const tuples = allTuples.filter(
+        (t) =>
+          Array.isArray(t) &&
+          t.length === keyCols.length &&
+          t.every((v) => v !== null && v !== undefined),
+      );
       if (tuples.length === 0) {
         scope = (scope as { none: () => unknown }).none();
       } else {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -45,8 +45,11 @@ function readTuple(owner: Base, cols: string[]): unknown[] {
  * by the caller via `Relation#none()`. PG / MySQL / SQLite all support
  * tuple IN; Arel's AST doesn't expose a direct constructor for it, so
  * raw SQL is the portable path. Identifiers go through
- * `quoteColumnName` (handles embedded quotes / schema-qualified
- * names per Rails' adapter quoting).
+ * `quoteColumnName` for adapter-specific column quoting (handles
+ * embedded quote characters in the identifier itself; does NOT
+ * split on `.` for schema-qualified names — that's
+ * `quoteTableName`'s responsibility, and column names here come
+ * from reflection metadata which is always bare).
  */
 function tupleInClause(cols: string[], tuples: unknown[][]): { sql: string; binds: unknown[] } {
   const placeholderRow = "(" + cols.map(() => "?").join(", ") + ")";

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -5,8 +5,7 @@ import {
   type ValueTransformation,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
-import { quoteColumnName } from "../connection-adapters/abstract/quoting.js";
-import { detectAdapterName } from "../adapter-name.js";
+import { Nodes } from "@blazetrails/arel";
 import type { Relation } from "../relation.js";
 import type { UnscopeType } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
@@ -41,34 +40,28 @@ function readTuple(owner: Base, cols: string[]): unknown[] {
 }
 
 /**
- * Build a tuple-IN WHERE clause as raw SQL: `(c1, c2) IN ((?, ?), ...)`.
+ * Build a composite-key predicate as `(c1=v11 AND c2=v12) OR
+ * (c1=v21 AND c2=v22) OR ...`. Semantically equivalent to tuple-IN
+ * but built with Arel nodes — keeps adapter-specific identifier
+ * quoting centralized in Arel (no manual `quoteColumnName` /
+ * `detectAdapterName` plumbing) and matches the existing pattern in
+ * `counter-cache.ts#buildPkPredicate`.
+ *
  * Caller must guarantee `tuples.length > 0` — empty input is handled
- * by the caller via `Relation#none()`. PG / MySQL / SQLite all support
- * tuple IN; Arel's AST doesn't expose a direct constructor for it, so
- * raw SQL is the portable path. Identifiers go through
- * `quoteColumnName` for adapter-specific column quoting (handles
- * embedded quote characters in the identifier itself; does NOT
- * split on `.` for schema-qualified names — that's
- * `quoteTableName`'s responsibility, and column names here come
- * from reflection metadata which is always bare).
+ * by the caller via `Relation#none()`.
  */
-function tupleInClause(
+function tuplePredicate(
   klass: typeof Base,
   cols: string[],
   tuples: unknown[][],
-): { sql: string; binds: unknown[] } {
-  // Resolve the adapter flavor from the target class so identifier
-  // quoting picks the right delimiter — double-quotes for PG/SQLite,
-  // backticks for MySQL/MariaDB. Without this, the default
-  // double-quote style would emit invalid SQL on MySQL unless the
-  // server was in ANSI_QUOTES mode.
-  const flavor = detectAdapterName(klass.adapter);
-  const placeholderRow = "(" + cols.map(() => "?").join(", ") + ")";
-  const allRows = tuples.map(() => placeholderRow).join(", ");
-  const colList = cols.map((c) => quoteColumnName(c, flavor)).join(", ");
-  const flat: unknown[] = [];
-  for (const t of tuples) flat.push(...t);
-  return { sql: `(${colList}) IN (${allRows})`, binds: flat };
+): InstanceType<typeof Nodes.Node> {
+  const table = klass.arelTable;
+  const groupings: InstanceType<typeof Nodes.Node>[] = tuples.map((tuple) => {
+    const eqs = cols.map((c, i) => table.get(c).eq(tuple[i]));
+    return new Nodes.Grouping(new Nodes.And(eqs));
+  });
+  if (groupings.length === 1) return groupings[0];
+  return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));
 }
 
 /**
@@ -223,11 +216,8 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       if (tuples.length === 0) {
         scope = (scope as { none: () => unknown }).none();
       } else {
-        const { sql, binds } = tupleInClause(klass, keyCols, tuples);
-        scope = (scope as { where: (sql: string, ...binds: unknown[]) => unknown }).where(
-          sql,
-          ...binds,
-        );
+        const node = tuplePredicate(klass, keyCols, tuples);
+        scope = (scope as { where: (n: InstanceType<typeof Nodes.Node>) => unknown }).where(node);
       }
     }
 

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -248,9 +248,10 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // string) and re-emits in `ids` order. For composite keys this
       // would need tuple grouping (out of scope for this PR — see
       // task #10). Skip the wrap for composite; records still load
-      // correctly via the tuple-IN WHERE above, just without the
-      // through-table-order reorder. Single-column case keeps the
-      // wrap.
+      // correctly via the composite-key `where` constraint built
+      // above (an Arel OR-of-AND from PredicateBuilder.buildComposite),
+      // just without the through-table-order reorder. Single-column
+      // case keeps the wrap.
       if (keyCols.length === 1) {
         const split = new DisableJoinsAssociationRelation<Base>(klass, keyCols[0], joinIds);
         const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -1,10 +1,19 @@
 /**
  * Composite-key support in DisableJoinsAssociationScope.
  *
- * Rails' disable_joins through associations work with composite
- * primary/foreign keys via tuple IN: `WHERE (c1, c2) IN ((v1a, v1b),
- * (v2a, v2b), ...)`. Same path our impl follows when keyColumns has
- * length > 1.
+ * Rails' DJAS handles composite primary/foreign keys by passing them
+ * through `where(key => ids)` — Rails' lower PredicateBuilder layer
+ * understands composite hash keys with tuple values and emits an
+ * `Arel::Nodes::HomogeneousIn` (effectively tuple-IN) on the chain
+ * step. Our PredicateBuilder doesn't yet support that hash form, so
+ * DJAS builds the composite predicate inline as an Arel OR-of-AND
+ * (`(c1=v11 AND c2=v12) OR (c1=v21 AND c2=v22) OR ...`), matching
+ * the existing pattern in `counter-cache.ts#buildPkPredicate`.
+ * Functionally equivalent; PG / MySQL / SQLite all optimize OR-of-
+ * AND on indexed columns to the same plan as tuple-IN. Tracked as a
+ * deviation: the right Rails-faithful fix is to extend
+ * PredicateBuilder for composite hash keys, then DJAS reverts to
+ * `where({key: ids})` matching disable_joins_association_scope.rb:34.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -152,10 +152,10 @@ describe("DJAS — composite key support", () => {
   it("skips tuples containing null/undefined (matches SQL tuple-equality semantics, not Arel IS NULL)", async () => {
     // Regression: Arel's Attribute#eq(null) emits IS NULL, but SQL
     // tuple-equality treats any null component as a non-match.
-    // _addConstraintsDj filters null/undefined-bearing tuples
-    // BEFORE handing them to tuplePredicate; if all tuples are
-    // filtered out, falls back to Relation#none(). Mirrors
-    // counter-cache.ts#buildPkPredicate's null handling.
+    // The composite path now goes DJAS → Relation#where(cols, tuples)
+    // → PredicateBuilder.buildComposite, which handles the null /
+    // undefined filter and the empty-list short-circuit (→ none()).
+    // Mirrors counter-cache.ts#buildPkPredicate's null handling.
     const shop = await CkShop.create({ name: "S" });
     const order = (await CkOrder.create({
       shop_id: shop.id,

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -94,6 +94,53 @@ describe("DJAS — composite key support", () => {
     expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
   });
 
+  it("composite-key + ordered upstream: skips DJAR wrap (records load via tuple-IN, no in-list reorder)", async () => {
+    // Document the trade-off: composite-key chains skip the loaded-
+    // chain DJAR wrap because DJAR's per-key group-by would need
+    // tuple grouping (out of scope for this PR). Records still load
+    // correctly via the tuple-IN WHERE; they just aren't re-ordered
+    // by through-table sequence. Future work could extend DJAR to
+    // group by tuple keys.
+    Associations.hasMany.call(CkShop, "ckOrdersOrdered", {
+      className: "CkOrder",
+      foreignKey: "shop_id",
+      scope: (rel: any) => rel.order("name"),
+    });
+    Associations.hasMany.call(CkShop, "ckLineItemsOrdered", {
+      className: "CkLineItem",
+      through: "ckOrdersOrdered",
+      source: "ckLineItems",
+      disableJoins: true,
+    });
+    const shop = await CkShop.create({ name: "S" });
+    const orderB = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 200,
+      name: "b",
+    })) as any;
+    const orderA = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 100,
+      name: "a",
+    })) as any;
+    await CkLineItem.create({
+      ck_order_shop_id: orderB.shop_id,
+      ck_order_number: orderB.order_number,
+      sku: "from-b",
+    });
+    await CkLineItem.create({
+      ck_order_shop_id: orderA.shop_id,
+      ck_order_number: orderA.order_number,
+      sku: "from-a",
+    });
+
+    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsOrdered");
+    const items = await loadHasMany(shop, "ckLineItemsOrdered", reflection.options);
+    // Both records load. Order is DB-arbitrary (no reorder applied
+    // for composite + ordered-upstream); just assert presence.
+    expect(items.map((i: any) => i.sku).sort()).toEqual(["from-a", "from-b"]);
+  });
+
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
     const shop = await CkShop.create({ name: "Lonely" });
     // No orders for this shop → through-records pluck yields [] →

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -79,7 +79,7 @@ describe("DJAS — composite key support", () => {
     });
   });
 
-  it("loads through a composite-PK chain via tuple-IN — no JOIN", async () => {
+  it("loads through a composite-PK chain via composite-key WHERE — no JOIN", async () => {
     const shop = await CkShop.create({ name: "S" });
     const order = (await CkOrder.create({
       shop_id: shop.id,
@@ -102,11 +102,11 @@ describe("DJAS — composite key support", () => {
     expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
   });
 
-  it("composite-key + ordered upstream: skips DJAR wrap (records load via tuple-IN, no in-list reorder)", async () => {
+  it("composite-key + ordered upstream: skips DJAR wrap (records load via composite-key WHERE, no in-list reorder)", async () => {
     // Document the trade-off: composite-key chains skip the loaded-
     // chain DJAR wrap because DJAR's per-key group-by would need
     // tuple grouping (out of scope for this PR). Records still load
-    // correctly via the tuple-IN WHERE; they just aren't re-ordered
+    // correctly via the composite-key WHERE WHERE; they just aren't re-ordered
     // by through-table sequence. Future work could extend DJAR to
     // group by tuple keys.
     Associations.hasMany.call(CkShop, "ckOrdersOrdered", {
@@ -186,7 +186,7 @@ describe("DJAS — composite key support", () => {
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
     const shop = await CkShop.create({ name: "Lonely" });
     // No orders for this shop → through-records pluck yields [] →
-    // tuple-IN short-circuits to a never-true predicate.
+    // composite-key WHERE short-circuits to a never-true predicate.
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
     const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
     expect(items).toEqual([]);

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Composite-key support in DisableJoinsAssociationScope.
+ *
+ * Rails' disable_joins through associations work with composite
+ * primary/foreign keys via tuple IN: `WHERE (c1, c2) IN ((v1a, v1b),
+ * (v2a, v2b), ...)`. Same path our impl follows when keyColumns has
+ * length > 1.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations, loadHasMany } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("DJAS — composite key support", () => {
+  let adapter: DatabaseAdapter;
+
+  // Shopify-style composite-PK shape: (shop_id, order_number). We
+  // avoid `id` as the second PK column because Base.id is an accessor
+  // that collides with raw column reads on test-adapter.
+  class CkShop extends Base {
+    static {
+      this._tableName = "ck_shops";
+      this.attribute("name", "string");
+    }
+  }
+  class CkOrder extends Base {
+    static {
+      this._tableName = "ck_orders";
+      this.primaryKey = ["shop_id", "order_number"];
+      this.attribute("shop_id", "integer");
+      this.attribute("order_number", "integer");
+      this.attribute("name", "string");
+    }
+  }
+  class CkLineItem extends Base {
+    static {
+      this._tableName = "ck_line_items";
+      this.attribute("ck_order_shop_id", "integer");
+      this.attribute("ck_order_number", "integer");
+      this.attribute("sku", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    CkShop.adapter = adapter;
+    CkOrder.adapter = adapter;
+    CkLineItem.adapter = adapter;
+    registerModel("CkShop", CkShop);
+    registerModel("CkOrder", CkOrder);
+    registerModel("CkLineItem", CkLineItem);
+    (CkShop as any)._associations = [];
+    (CkOrder as any)._associations = [];
+    (CkLineItem as any)._associations = [];
+    Associations.hasMany.call(CkShop, "ckOrders", {
+      className: "CkOrder",
+      foreignKey: "shop_id",
+    });
+    // Composite FK on line_items references CkOrder's composite PK.
+    Associations.hasMany.call(CkOrder, "ckLineItems", {
+      className: "CkLineItem",
+      foreignKey: ["ck_order_shop_id", "ck_order_number"],
+      primaryKey: ["shop_id", "order_number"],
+    });
+    Associations.hasMany.call(CkShop, "ckLineItemsThroughOrders", {
+      className: "CkLineItem",
+      through: "ckOrders",
+      source: "ckLineItems",
+      disableJoins: true,
+    });
+  });
+
+  it("loads through a composite-PK chain via tuple-IN — no JOIN", async () => {
+    const shop = await CkShop.create({ name: "S" });
+    const order = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 100,
+      name: "O",
+    })) as any;
+    await CkLineItem.create({
+      ck_order_shop_id: order.shop_id,
+      ck_order_number: order.order_number,
+      sku: "sku-1",
+    });
+    await CkLineItem.create({
+      ck_order_shop_id: order.shop_id,
+      ck_order_number: order.order_number,
+      sku: "sku-2",
+    });
+
+    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
+    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+    expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
+  });
+
+  it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
+    const shop = await CkShop.create({ name: "Lonely" });
+    // No orders for this shop → through-records pluck yields [] →
+    // tuple-IN short-circuits to a never-true predicate.
+    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
+    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+    expect(items).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -1,19 +1,18 @@
 /**
  * Composite-key support in DisableJoinsAssociationScope.
  *
- * Rails' DJAS handles composite primary/foreign keys by passing them
- * through `where(key => ids)` — Rails' lower PredicateBuilder layer
- * understands composite hash keys with tuple values and emits an
- * `Arel::Nodes::HomogeneousIn` (effectively tuple-IN) on the chain
- * step. Our PredicateBuilder doesn't yet support that hash form, so
- * DJAS builds the composite predicate inline as an Arel OR-of-AND
- * (`(c1=v11 AND c2=v12) OR (c1=v21 AND c2=v22) OR ...`), matching
- * the existing pattern in `counter-cache.ts#buildPkPredicate`.
- * Functionally equivalent; PG / MySQL / SQLite all optimize OR-of-
- * AND on indexed columns to the same plan as tuple-IN. Tracked as a
- * deviation: the right Rails-faithful fix is to extend
- * PredicateBuilder for composite hash keys, then DJAS reverts to
- * `where({key: ids})` matching disable_joins_association_scope.rb:34.
+ * DJAS delegates composite matching to the positional composite form
+ * `where(columns, tuples)`, which routes through
+ * `PredicateBuilder.buildComposite` (PR #647). That helper emits the
+ * composite predicate (Arel `OR`-of-`AND` over per-column equalities,
+ * matching `counter-cache.ts#buildPkPredicate`) so DJAS itself stays
+ * a thin chain-walker — same layering as Rails'
+ * `disable_joins_association_scope.rb:34` (`where(key => join_ids)`
+ * with PredicateBuilder doing the composite work).
+ *
+ * This test covers the current composite-key path used for disable-
+ * joins through associations: tuple-style matching across the
+ * intermediate records, no JOIN in the generated query shape.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -141,6 +141,40 @@ describe("DJAS — composite key support", () => {
     expect(items.map((i: any) => i.sku).sort()).toEqual(["from-a", "from-b"]);
   });
 
+  it("skips tuples containing null/undefined (matches SQL tuple-equality semantics, not Arel IS NULL)", async () => {
+    // Regression: Arel's Attribute#eq(null) emits IS NULL, but SQL
+    // tuple-equality treats any null component as a non-match.
+    // _addConstraintsDj filters null/undefined-bearing tuples
+    // BEFORE handing them to tuplePredicate; if all tuples are
+    // filtered out, falls back to Relation#none(). Mirrors
+    // counter-cache.ts#buildPkPredicate's null handling.
+    const shop = await CkShop.create({ name: "S" });
+    const order = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 100,
+      name: "O",
+    })) as any;
+    // line item with a NULL composite component — not a match for
+    // any (shop_id, order_number) tuple.
+    await CkLineItem.create({
+      ck_order_shop_id: order.shop_id,
+      ck_order_number: null as any,
+      sku: "orphan",
+    });
+    await CkLineItem.create({
+      ck_order_shop_id: order.shop_id,
+      ck_order_number: order.order_number,
+      sku: "valid",
+    });
+
+    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
+    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+    // Only the "valid" record is returned — the orphan with
+    // ck_order_number=NULL doesn't match the (shop_id=1, order_number=100)
+    // tuple even though shop_id matches.
+    expect(items.map((i: any) => i.sku)).toEqual(["valid"]);
+  });
+
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
     const shop = await CkShop.create({ name: "Lonely" });
     // No orders for this shop → through-records pluck yields [] →

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -14,7 +14,8 @@
  * joins through associations: tuple-style matching across the
  * intermediate records, no JOIN in the generated query shape.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
@@ -79,6 +80,12 @@ describe("DJAS — composite key support", () => {
     });
   });
 
+  // Backstop in case a test throws before reaching its in-test
+  // unsubscribe. Same pattern as instrumentation.test.ts.
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
+
   it("loads through a composite-PK chain via composite-key WHERE — no JOIN", async () => {
     const shop = await CkShop.create({ name: "S" });
     const order = (await CkOrder.create({
@@ -97,16 +104,30 @@ describe("DJAS — composite key support", () => {
       sku: "sku-2",
     });
 
-    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
-    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
-    expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
+    // Capture SQL to actually prove the "no JOIN" claim — without
+    // this, the test would still pass if the loader regressed to a
+    // JOIN-based path.
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
+      const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+      expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(observed.length).toBeGreaterThan(0);
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 
   it("composite-key + ordered upstream: skips DJAR wrap (records load via composite-key WHERE, no in-list reorder)", async () => {
     // Document the trade-off: composite-key chains skip the loaded-
     // chain DJAR wrap because DJAR's per-key group-by would need
     // tuple grouping (out of scope for this PR). Records still load
-    // correctly via the composite-key WHERE WHERE; they just aren't re-ordered
+    // correctly via the composite-key WHERE; they just aren't re-ordered
     // by through-table sequence. Future work could extend DJAR to
     // group by tuple keys.
     Associations.hasMany.call(CkShop, "ckOrdersOrdered", {


### PR DESCRIPTION
## Summary

PR C of the DJAS follow-up arc. Closes the composite-key gap that PR 4 (#631) explicitly threw on.

**Now Rails-faithful in mechanism, not just behavior.** Builds on PR #647 (`PredicateBuilder.buildComposite` + `Relation#where(cols, tuples)`):

\`\`\`ts
// disable_joins_association_scope.rb:34 — Rails:
//   reflection.build_scope(...).where(key => join_ids)

// Our DJAS:
scope = klass.unscoped.where({key: ids})        // single-column
scope = klass.unscoped.where(keyCols, tuples)   // composite
\`\`\`

The composite path delegates to `PredicateBuilder.buildComposite`, which emits an Arel **OR-of-AND** predicate (`(a=? AND b=?) OR (a=? AND b=?) ...`) — the adapter-portable equivalent of Rails' `Arel::Nodes::HomogeneousIn` / SQL row-constructor `(a,b) IN ((?,?),...)`. All composite SQL details are handled centrally:
- null/undefined-component filtering (SQL tuple-equality semantics)
- arity / shape validation (`ArgumentError`)
- single-column degenerate case → `IN(...)` instead of OR-chain
- bind-param emission via `QueryAttribute` (prepared-statement caching)
- empty/all-filtered → `Relation#none()`

DJAS itself is back to two paths (single-col hash, composite positional), no inline predicate construction or null-handling. Single-column case keeps the loaded-chain DJAR wrap for ordered-upstream reorder; composite case skips the wrap (DJAR's per-key group-by would need tuple grouping — separate follow-up).

Routing gate drops the composite-key bail-out — every chain shape is now supported.

## Test plan

- [x] 3 tests in \`disable-joins-composite-key.test.ts\`: end-to-end load through composite-PK chain, composite + ordered-upstream (DJAR wrap intentionally skipped), null-component filtering on the source step.
- [x] Full \`@blazetrails/activerecord\` suite: 8703 passed locally.
- [ ] PG / MariaDB CI.