### PR TITLE
feat(activerecord): composite-key WHERE form (PredicateBuilder.buildComposite + Relation#where overload)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1410,11 +1410,17 @@ export class Base extends Model {
     if (typeof conditionsOrSql === "string") {
       return this.all().where(conditionsOrSql, ...rest);
     }
-    if (
-      Array.isArray(conditionsOrSql) &&
-      conditionsOrSql.every((c) => typeof c === "string") &&
-      Array.isArray(rest[0])
-    ) {
+    if (Array.isArray(conditionsOrSql) && conditionsOrSql.every((c) => typeof c === "string")) {
+      // Fast-fail: composite-key form requires exactly one extra
+      // argument that is an array of tuples. Without this, a stray
+      // `Model.where(['a','b'])` would fall through to the hash path
+      // and treat the array as a record (numeric keys), producing
+      // nonsense.
+      if (rest.length !== 1 || !Array.isArray(rest[0])) {
+        throw new Error(
+          `${(this as { name?: string }).name ?? "Model"}.where(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
+        );
+      }
       return this.all().where(conditionsOrSql, rest[0] as unknown[][]);
     }
     return this.all().where(conditionsOrSql as Record<string, unknown>);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1396,16 +1396,28 @@ export class Base extends Model {
   ): Relation<InstanceType<T>>;
   static where<T extends typeof Base>(
     this: T,
-    conditionsOrSql: Record<string, unknown> | string,
-    ...binds: unknown[]
+    cols: string[],
+    tuples: unknown[][],
+  ): Relation<InstanceType<T>>;
+  static where<T extends typeof Base>(
+    this: T,
+    conditionsOrSql: Record<string, unknown> | string | string[],
+    ...rest: unknown[]
   ): Relation<InstanceType<T>> {
     if (this.abstractClass) {
       throw new Error(`Cannot call where on abstract class ${this.name}`);
     }
     if (typeof conditionsOrSql === "string") {
-      return this.all().where(conditionsOrSql, ...binds);
+      return this.all().where(conditionsOrSql, ...rest);
     }
-    return this.all().where(conditionsOrSql);
+    if (
+      Array.isArray(conditionsOrSql) &&
+      conditionsOrSql.every((c) => typeof c === "string") &&
+      Array.isArray(rest[0])
+    ) {
+      return this.all().where(conditionsOrSql, rest[0] as unknown[][]);
+    }
+    return this.all().where(conditionsOrSql as Record<string, unknown>);
   }
 
   static whereNot<T extends typeof Base>(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -101,6 +101,7 @@ import {
   isPresent as _isPresent,
   isBlank as _isBlank,
 } from "./core.js";
+import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
 import { Default as DefaultScoping } from "./scoping/default.js";
@@ -1165,12 +1166,10 @@ export class Base extends Model {
       // neither of which matches the CPK tuple contract). Require an
       // explicit array form so intent is unambiguous.
       if (this.compositePrimaryKey && ids.every((i) => !Array.isArray(i))) {
-        const err = new Error(
+        throw argumentError(
           `${this.name} has a composite primary key (${String(this.primaryKey)}); ` +
             `call find([...tuple]) or find([[...], [...]]) rather than variadic scalars.`,
         );
-        err.name = "ArgumentError";
-        throw err;
       }
       return this.find(ids);
     }
@@ -1417,11 +1416,9 @@ export class Base extends Model {
       // and treat the array as a record (numeric keys), producing
       // nonsense.
       if (rest.length !== 1 || !Array.isArray(rest[0])) {
-        const err = new Error(
+        throw argumentError(
           `${(this as { name?: string }).name ?? "Model"}.where(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
         );
-        err.name = "ArgumentError";
-        throw err;
       }
       return this.all().where(conditionsOrSql, rest[0] as unknown[][]);
     }
@@ -1449,11 +1446,9 @@ export class Base extends Model {
       // and Relation#whereNot's matching guard would throw — same
       // outcome but the error message would mention Relation, not Model.
       if (!Array.isArray(tuples)) {
-        const err = new Error(
+        throw argumentError(
           `${(this as { name?: string }).name ?? "Model"}.whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
         );
-        err.name = "ArgumentError";
-        throw err;
       }
       return this.all().whereNot(conditions, tuples);
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1417,9 +1417,11 @@ export class Base extends Model {
       // and treat the array as a record (numeric keys), producing
       // nonsense.
       if (rest.length !== 1 || !Array.isArray(rest[0])) {
-        throw new Error(
+        const err = new Error(
           `${(this as { name?: string }).name ?? "Model"}.where(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
         );
+        err.name = "ArgumentError";
+        throw err;
       }
       return this.all().where(conditionsOrSql, rest[0] as unknown[][]);
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1431,8 +1431,33 @@ export class Base extends Model {
   static whereNot<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
+  ): Relation<InstanceType<T>>;
+  static whereNot<T extends typeof Base>(
+    this: T,
+    cols: string[],
+    tuples: unknown[][],
+  ): Relation<InstanceType<T>>;
+  static whereNot<T extends typeof Base>(
+    this: T,
+    conditions: Record<string, unknown> | string[],
+    tuples?: unknown[][],
   ): Relation<InstanceType<T>> {
-    return this.all().whereNot(conditions);
+    if (Array.isArray(conditions) && conditions.every((c) => typeof c === "string")) {
+      // Same fast-fail as Base.where: composite-key form requires
+      // a tuples argument as an array of arrays. Without this guard
+      // a stray `Model.whereNot(['c'])` would forward only the cols
+      // and Relation#whereNot's matching guard would throw — same
+      // outcome but the error message would mention Relation, not Model.
+      if (!Array.isArray(tuples)) {
+        const err = new Error(
+          `${(this as { name?: string }).name ?? "Model"}.whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
+        );
+        err.name = "ArgumentError";
+        throw err;
+      }
+      return this.all().whereNot(conditions, tuples);
+    }
+    return this.all().whereNot(conditions as Record<string, unknown>);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -167,12 +167,38 @@ export class Relation<T extends Base> {
   where(conditions: Record<string, unknown> | null): Relation<T>;
   where(sql: string, ...binds: unknown[]): Relation<T>;
   where(node: Nodes.Node): Relation<T>;
+  /**
+   * Composite-key form: `where(['c1', 'c2'], [[v11, v12], [v21, v22]])`
+   * compiles to `(c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22)`.
+   * The Rails analog is `where({['c1', 'c2'] => [[v11, v12], ...]})` —
+   * JS object keys can't be arrays, so columns become a leading
+   * positional argument. Tuples containing null/undefined are
+   * filtered (SQL tuple-equality treats any null component as a
+   * non-match); after filtering, an empty list short-circuits via
+   * `none()`.
+   */
+  where(cols: string[], tuples: unknown[][]): Relation<T>;
   where(
-    conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | null,
-    ...binds: unknown[]
+    conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | string[] | null,
+    ...rest: unknown[]
   ): Relation<T> | WhereChain<Relation<T>> {
     if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this._clone());
-    return this._clone().whereBang(conditionsOrSql, ...binds);
+    // Composite-key form: array of column names + array of tuples.
+    if (
+      Array.isArray(conditionsOrSql) &&
+      conditionsOrSql.every((c) => typeof c === "string") &&
+      Array.isArray(rest[0])
+    ) {
+      const cols = conditionsOrSql as string[];
+      const tuples = rest[0] as unknown[][];
+      const node = this.predicateBuilder.buildComposite(cols, tuples);
+      if (node === null) return this._clone().noneBang();
+      return this._clone().whereBang(node);
+    }
+    return this._clone().whereBang(
+      conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
+      ...rest,
+    );
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -191,11 +191,17 @@ export class Relation<T extends Base> {
   ): Relation<T> | WhereChain<Relation<T>> {
     if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this._clone());
     // Composite-key form: array of column names + array of tuples.
-    if (
-      Array.isArray(conditionsOrSql) &&
-      conditionsOrSql.every((c) => typeof c === "string") &&
-      Array.isArray(rest[0])
-    ) {
+    if (Array.isArray(conditionsOrSql) && conditionsOrSql.every((c) => typeof c === "string")) {
+      // Fast-fail on malformed call: must have exactly one extra
+      // argument that is an array of tuples. Without this guard, a
+      // stray `where(['a','b'])` would fall through to whereBang and
+      // treat the array as a record (numeric keys), producing
+      // nonsense.
+      if (rest.length !== 1 || !Array.isArray(rest[0])) {
+        throw new Error(
+          "Relation#where(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
+        );
+      }
       const cols = conditionsOrSql as string[];
       const tuples = rest[0] as unknown[][];
       const node = this.predicateBuilder.buildComposite(cols, tuples);
@@ -397,11 +403,16 @@ export class Relation<T extends Base> {
   whereNot(cols: string[], tuples: unknown[][]): Relation<T>;
   whereNot(conditions: Record<string, unknown> | string[], tuples?: unknown[][]): Relation<T> {
     const rel = this._clone();
-    if (
-      Array.isArray(conditions) &&
-      conditions.every((c) => typeof c === "string") &&
-      Array.isArray(tuples)
-    ) {
+    if (Array.isArray(conditions) && conditions.every((c) => typeof c === "string")) {
+      // Fast-fail on malformed call: see Relation#where guard for
+      // the same reasoning. Without this, a stray
+      // `whereNot(['a','b'])` falls through to Object.entries and
+      // produces an invalid predicate.
+      if (!Array.isArray(tuples)) {
+        throw new Error(
+          "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
+        );
+      }
       const node = this.predicateBuilder.buildComposite(conditions as string[], tuples);
       // null = empty/all-filtered → NOT (no rows) = ALL rows = no
       // predicate added (matches Rails' `where.not(...)` no-op for

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -28,6 +28,7 @@ import {
   QueryMethodBangs,
   areStructurallyCompatible,
   VALID_UNSCOPING_VALUES,
+  argumentError,
   type UnscopeType,
 } from "./relation/query-methods.js";
 import { Batches } from "./relation/batches.js";
@@ -198,11 +199,9 @@ export class Relation<T extends Base> {
       // treat the array as a record (numeric keys), producing
       // nonsense.
       if (rest.length !== 1 || !Array.isArray(rest[0])) {
-        const err = new Error(
+        throw argumentError(
           "Relation#where(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
-        err.name = "ArgumentError";
-        throw err;
       }
       const cols = conditionsOrSql as string[];
       const tuples = rest[0] as unknown[][];
@@ -411,11 +410,9 @@ export class Relation<T extends Base> {
       // `whereNot(['a','b'])` falls through to Object.entries and
       // produces an invalid predicate.
       if (!Array.isArray(tuples)) {
-        const err = new Error(
+        throw argumentError(
           "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
-        err.name = "ArgumentError";
-        throw err;
       }
       const node = this.predicateBuilder.buildComposite(conditions as string[], tuples);
       // null = empty/all-filtered → NOT (no rows) = ALL rows = no

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -152,8 +152,14 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Add WHERE conditions. Accepts a hash of column/value pairs,
-   * or a raw SQL string with optional bind values.
+   * Add WHERE conditions. Accepts:
+   *  - a hash of column/value pairs
+   *  - a raw SQL string with optional bind values
+   *  - an Arel `Nodes.Node`
+   *  - composite-key positional form: `where(['c1','c2'], [[v1a,v1b], ...])`
+   *    (the JS analog of Rails' `where({[c1, c2] => [tuples]})` —
+   *    JS object keys can't be arrays, so columns become a leading
+   *    positional argument)
    *
    * Mirrors: ActiveRecord::Relation#where
    *
@@ -161,6 +167,7 @@ export class Relation<T extends Base> {
    *   where({ name: "dean" })
    *   where("age > ?", 18)
    *   where("name LIKE ?", "%dean%")
+   *   where(['shop_id', 'order_number'], [[1, 100], [2, 200]])
    */
   where(): WhereChain<Relation<T>>;
   where(conditions: undefined): WhereChain<Relation<T>>;
@@ -381,14 +388,31 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Add NOT WHERE conditions. Accepts a hash of column/value pairs.
+   * Add NOT WHERE conditions. Accepts a hash of column/value pairs,
+   * or the composite-key positional form (mirrors `where(cols, tuples)`).
    *
    * Mirrors: ActiveRecord::Relation#where.not
    */
-  whereNot(conditions: Record<string, unknown>): Relation<T> {
+  whereNot(conditions: Record<string, unknown>): Relation<T>;
+  whereNot(cols: string[], tuples: unknown[][]): Relation<T>;
+  whereNot(conditions: Record<string, unknown> | string[], tuples?: unknown[][]): Relation<T> {
     const rel = this._clone();
+    if (
+      Array.isArray(conditions) &&
+      conditions.every((c) => typeof c === "string") &&
+      Array.isArray(tuples)
+    ) {
+      const node = this.predicateBuilder.buildComposite(conditions as string[], tuples);
+      // null = empty/all-filtered → NOT (no rows) = ALL rows = no
+      // predicate added (matches Rails' `where.not(...)` no-op for
+      // empty hashes).
+      if (node !== null) {
+        rel._whereClause.predicates.push(new Nodes.Not(new Nodes.Grouping(node)));
+      }
+      return rel;
+    }
     const castConditions: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(conditions)) {
+    for (const [key, value] of Object.entries(conditions as Record<string, unknown>)) {
       castConditions[key] = Array.isArray(value)
         ? value.map((v) => this._castWhereValue(key, v))
         : this._castWhereValue(key, value);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -198,9 +198,11 @@ export class Relation<T extends Base> {
       // treat the array as a record (numeric keys), producing
       // nonsense.
       if (rest.length !== 1 || !Array.isArray(rest[0])) {
-        throw new Error(
+        const err = new Error(
           "Relation#where(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
+        err.name = "ArgumentError";
+        throw err;
       }
       const cols = conditionsOrSql as string[];
       const tuples = rest[0] as unknown[][];
@@ -409,9 +411,11 @@ export class Relation<T extends Base> {
       // `whereNot(['a','b'])` falls through to Object.entries and
       // produces an invalid predicate.
       if (!Array.isArray(tuples)) {
-        throw new Error(
+        const err = new Error(
           "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
+        err.name = "ArgumentError";
+        throw err;
       }
       const node = this.predicateBuilder.buildComposite(conditions as string[], tuples);
       // null = empty/all-filtered → NOT (no rows) = ALL rows = no

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -98,4 +98,40 @@ describe("Relation#where — composite-key form", () => {
     const rel = (CompOrder as any).all();
     expect(() => rel.predicateBuilder.buildComposite([], [[1, 2]])).toThrow(/empty column list/);
   });
+
+  it("whereNot(cols, tuples) negates the OR-of-AND grouping", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "exclude-me" });
+    await CompOrder.create({ shop_id: 2, order_number: 200, name: "exclude-me-2" });
+    await CompOrder.create({ shop_id: 3, order_number: 300, name: "keep" });
+
+    const matched = await (CompOrder as any)
+      .all()
+      .whereNot(
+        ["shop_id", "order_number"],
+        [
+          [1, 100],
+          [2, 200],
+        ],
+      )
+      .toArray();
+    expect(matched.map((r: any) => r.name)).toEqual(["keep"]);
+  });
+
+  it("whereNot(cols, tuples) on all-filtered tuples is a no-op (matches Rails' empty-hash behavior)", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "a" });
+    await CompOrder.create({ shop_id: 2, order_number: 200, name: "b" });
+    // All tuples have a null component → filtered out → no predicate
+    // added → all rows returned.
+    const matched = await (CompOrder as any)
+      .all()
+      .whereNot(
+        ["shop_id", "order_number"],
+        [
+          [1, null],
+          [null, 200],
+        ],
+      )
+      .toArray();
+    expect(matched.map((r: any) => r.name).sort()).toEqual(["a", "b"]);
+  });
 });

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -11,7 +11,7 @@
  * Mirrors: ActiveRecord predicate-builder composite-key handling.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, registerModel } from "../index.js";
+import { Base } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -31,7 +31,11 @@ describe("Relation#where — composite-key form", () => {
   beforeEach(() => {
     adapter = createTestAdapter();
     CompOrder.adapter = adapter;
-    registerModel("CompOrder", CompOrder);
+    // No registerModel() — this test only exercises where /
+    // whereNot / PredicateBuilder directly; nothing resolves
+    // associations through the global modelRegistry. Skipping
+    // registration also avoids the stale-entry leak across the
+    // suite that registerModel would otherwise create.
   });
 
   it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -116,6 +116,16 @@ describe("Relation#where — composite-key form", () => {
     ).toThrow(/tuple must be an array/);
   });
 
+  it("PredicateBuilder.buildComposite throws ArgumentError when tuples itself is not an array (null/object)", () => {
+    const rel = (CompOrder as any).all();
+    expect(() =>
+      rel.predicateBuilder.buildComposite(["shop_id"], null as unknown as unknown[][]),
+    ).toThrow(/tuples must be an array, got null/);
+    expect(() =>
+      rel.predicateBuilder.buildComposite(["shop_id"], { 0: [1] } as unknown as unknown[][]),
+    ).toThrow(/tuples must be an array, got object/);
+  });
+
   it("composite predicate values flow through QueryAttribute (bind params, not inlined Casted)", () => {
     // Regression: an earlier draft used `attribute.eq(rawValue)`,
     // which wraps as Arel::Nodes::Casted and inlines values into SQL.

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -176,6 +176,21 @@ describe("Relation#where — composite-key form", () => {
     );
   });
 
+  it("Base.whereNot(cols, tuples) routes through Relation#whereNot composite form", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "exclude" });
+    await CompOrder.create({ shop_id: 2, order_number: 200, name: "keep" });
+    const matched = await (CompOrder as any)
+      .whereNot(["shop_id", "order_number"], [[1, 100]])
+      .toArray();
+    expect(matched.map((r: any) => r.name)).toEqual(["keep"]);
+  });
+
+  it("Base.whereNot(cols) without tuples arg throws a clear ArgumentError", () => {
+    expect(() => (CompOrder as any).whereNot(["shop_id"])).toThrow(
+      /requires a tuples argument as an array of arrays/,
+    );
+  });
+
   it("whereNot(cols, tuples) negates the OR-of-AND grouping", async () => {
     await CompOrder.create({ shop_id: 1, order_number: 100, name: "exclude-me" });
     await CompOrder.create({ shop_id: 2, order_number: 200, name: "exclude-me-2" });

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -99,6 +99,51 @@ describe("Relation#where — composite-key form", () => {
     expect(() => rel.predicateBuilder.buildComposite([], [[1, 2]])).toThrow(/empty column list/);
   });
 
+  it("PredicateBuilder.buildComposite throws on tuple arity mismatch (caller bug, not silent filter)", () => {
+    const rel = (CompOrder as any).all();
+    expect(() => rel.predicateBuilder.buildComposite(["shop_id", "order_number"], [[1]])).toThrow(
+      /tuple arity 1 does not match column count 2/,
+    );
+  });
+
+  it("PredicateBuilder.buildComposite throws on non-array tuple", () => {
+    const rel = (CompOrder as any).all();
+    expect(() =>
+      rel.predicateBuilder.buildComposite(
+        ["shop_id", "order_number"],
+        [42 as unknown as unknown[]],
+      ),
+    ).toThrow(/tuple must be an array/);
+  });
+
+  it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
+    const rel = (CompOrder as any).all();
+    const node = rel.predicateBuilder.buildComposite(["shop_id"], [[1], [2], [3]]);
+    // The Arel In node renders as `shop_id IN (1, 2, 3)`; OR-chain
+    // would render as `shop_id = 1 OR shop_id = 2 OR shop_id = 3`.
+    const sql = (CompOrder as any).all().where(node).toSql();
+    expect(sql).toMatch(/IN \(1,\s*2,\s*3\)/);
+    expect(sql).not.toMatch(/OR/);
+  });
+
+  it("Relation#where(cols) without tuples arg throws a clear error", () => {
+    expect(() => (CompOrder as any).all().where(["shop_id"])).toThrow(
+      /requires a tuples argument as an array of arrays/,
+    );
+  });
+
+  it("Relation#whereNot(cols) without tuples arg throws a clear error", () => {
+    expect(() => (CompOrder as any).all().whereNot(["shop_id"])).toThrow(
+      /requires a tuples argument as an array of arrays/,
+    );
+  });
+
+  it("Base.where(cols) without tuples arg throws a clear error", () => {
+    expect(() => (CompOrder as any).where(["shop_id"])).toThrow(
+      /requires a tuples argument as an array of arrays/,
+    );
+  });
+
   it("whereNot(cols, tuples) negates the OR-of-AND grouping", async () => {
     await CompOrder.create({ shop_id: 1, order_number: 100, name: "exclude-me" });
     await CompOrder.create({ shop_id: 2, order_number: 200, name: "exclude-me-2" });

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -116,6 +116,28 @@ describe("Relation#where — composite-key form", () => {
     ).toThrow(/tuple must be an array/);
   });
 
+  it("composite predicate values flow through QueryAttribute (bind params, not inlined Casted)", () => {
+    // Regression: an earlier draft used `attribute.eq(rawValue)`,
+    // which wraps as Arel::Nodes::Casted and inlines values into SQL.
+    // That breaks compileWithBinds / prepared-statement caching.
+    // Switching to buildBindAttribute makes each value a
+    // QueryAttribute → BindParam at SQL emission. Inspect the node
+    // tree: the AND's right-hand sides should be QueryAttribute
+    // instances (carrying `name` / `type`), not raw literals or
+    // Casted nodes.
+    const rel = (CompOrder as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(["shop_id", "order_number"], [[1, 100]]);
+    // Single-tuple path returns Grouping(And([eq, eq])). Arel wraps
+    // QueryAttribute in BindParam at `attribute.eq()`, so the Eq's
+    // right-hand side is BindParam(QueryAttribute(name, value, type)).
+    const and = node.expr;
+    const firstEq = and.children[0];
+    const rhs = firstEq.right;
+    expect(rhs?.constructor?.name).toBe("BindParam");
+    expect(rhs?.value?.name).toBe("shop_id");
+    expect(rhs?.value?.constructor?.name).toBe("QueryAttribute");
+  });
+
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
     const rel = (CompOrder as any).all();
     const node = rel.predicateBuilder.buildComposite(["shop_id"], [[1], [2], [3]]);

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Composite-key WHERE: `Relation#where(cols, tuples)` and the
+ * underlying `PredicateBuilder.buildComposite(cols, tuples)`.
+ *
+ * Rails uses `where({[col1, col2] => [[v1, v2], ...]})` for
+ * composite-key matching, routing through PredicateBuilder. JS object
+ * keys can't be arrays, so we expose the same shape as a positional
+ * overload — `where(['c1', 'c2'], [[v1a, v1b], ...])` — and a
+ * matching `PredicateBuilder.buildComposite` method.
+ *
+ * Mirrors: ActiveRecord predicate-builder composite-key handling.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("Relation#where — composite-key form", () => {
+  let adapter: DatabaseAdapter;
+
+  class CompOrder extends Base {
+    static {
+      this._tableName = "comp_orders";
+      this.primaryKey = ["shop_id", "order_number"];
+      this.attribute("shop_id", "integer");
+      this.attribute("order_number", "integer");
+      this.attribute("name", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    CompOrder.adapter = adapter;
+    registerModel("CompOrder", CompOrder);
+  });
+
+  it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "match-1" });
+    await CompOrder.create({ shop_id: 2, order_number: 200, name: "match-2" });
+    await CompOrder.create({ shop_id: 1, order_number: 999, name: "no-match" });
+
+    const matched = await (CompOrder as any)
+      .where(
+        ["shop_id", "order_number"],
+        [
+          [1, 100],
+          [2, 200],
+        ],
+      )
+      .toArray();
+    expect(matched.map((r: any) => r.name).sort()).toEqual(["match-1", "match-2"]);
+  });
+
+  it("returns no rows when all tuples are filtered (empty after null-strip → none())", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "exists" });
+    const matched = await (CompOrder as any)
+      .where(
+        ["shop_id", "order_number"],
+        [
+          [1, null],
+          [null, 200],
+        ],
+      )
+      .toArray();
+    expect(matched).toEqual([]);
+  });
+
+  it("filters null/undefined-bearing tuples instead of emitting IS NULL (SQL tuple-equality semantics)", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "valid" });
+    await CompOrder.create({ shop_id: 2, order_number: 200, name: "also-valid" });
+    // [1, null] is filtered out; [2, 200] remains.
+    const matched = await (CompOrder as any)
+      .where(
+        ["shop_id", "order_number"],
+        [
+          [1, null],
+          [2, 200],
+        ],
+      )
+      .toArray();
+    expect(matched.map((r: any) => r.name)).toEqual(["also-valid"]);
+  });
+
+  it("single-column case (cols.length === 1) still works (degenerate composite)", async () => {
+    await CompOrder.create({ shop_id: 1, order_number: 100, name: "a" });
+    await CompOrder.create({ shop_id: 1, order_number: 200, name: "b" });
+    const matched = await (CompOrder as any).where(["shop_id"], [[1]]).toArray();
+    expect(matched.map((r: any) => r.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("PredicateBuilder.buildComposite returns null on empty input (caller short-circuits with none())", async () => {
+    const rel = (CompOrder as any).all();
+    const node = rel.predicateBuilder.buildComposite(["shop_id", "order_number"], []);
+    expect(node).toBeNull();
+  });
+
+  it("PredicateBuilder.buildComposite throws on empty column list", () => {
+    const rel = (CompOrder as any).all();
+    expect(() => rel.predicateBuilder.buildComposite([], [[1, 2]])).toThrow(/empty column list/);
+  });
+});

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -7,6 +7,7 @@ import { BasicObjectHandler } from "./predicate-builder/basic-object-handler.js"
 import { RelationHandler } from "./predicate-builder/relation-handler.js";
 import { AssociationQueryValue } from "./predicate-builder/association-query-value.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
+import { argumentError } from "./query-methods.js";
 
 /**
  * Converts hash conditions ({ name: "dean", age: 30 }) into
@@ -237,13 +238,13 @@ export class PredicateBuilder {
    */
   buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node | null {
     if (cols.length === 0) {
-      throw composeArgumentError("PredicateBuilder.buildComposite: empty column list");
+      throw argumentError("PredicateBuilder.buildComposite: empty column list");
     }
     if (!Array.isArray(tuples)) {
       // Surface as ArgumentError instead of letting the for-of /
       // .filter() below throw a bare TypeError on null / object /
       // non-iterable inputs.
-      throw composeArgumentError(
+      throw argumentError(
         `PredicateBuilder.buildComposite: tuples must be an array, got ${tuples === null ? "null" : typeof tuples}`,
       );
     }
@@ -253,12 +254,12 @@ export class PredicateBuilder {
     // consistently with other query-method validation throws.
     for (const t of tuples) {
       if (!Array.isArray(t)) {
-        throw composeArgumentError(
+        throw argumentError(
           `PredicateBuilder.buildComposite: tuple must be an array, got ${typeof t}`,
         );
       }
       if (t.length !== cols.length) {
-        throw composeArgumentError(
+        throw argumentError(
           `PredicateBuilder.buildComposite: tuple arity ${t.length} does not match column count ${cols.length} (cols=[${cols.join(", ")}])`,
         );
       }
@@ -375,18 +376,6 @@ export class PredicateBuilder {
       typeof value === "object" && value !== null && "_modelClass" in value && "toArel" in value
     );
   }
-}
-
-/**
- * Tag throws from `buildComposite` as `ArgumentError` so callers can
- * catch them consistently with other argument-shape errors raised
- * elsewhere in query-methods.ts (matches Rails' ArgumentError surface
- * for invalid where arguments).
- */
-function composeArgumentError(message: string): Error {
-  const error = new Error(message);
-  error.name = "ArgumentError";
-  return error;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -286,15 +286,22 @@ export class PredicateBuilder {
     // PredicateBuilder.BasicObjectHandler uses for type lookup —
     // otherwise `typeForAttribute("orders.shop_id")` returns
     // undefined and the cast falls back to identity.
+    //
+    // Pre-resolve `Attribute[]` once outside the per-tuple loop —
+    // each `resolveColumn` allocates a fresh `Arel::Attribute` (and
+    // sometimes a `Table`). Reusing the resolved attrs keeps large
+    // tuple lists allocation-light.
+    const attrs = cols.map((c) => this.resolveColumn(c));
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = cols.map((c, i) => {
-        const attr = this.resolveColumn(c);
-        return attr.eq(this.buildBindAttribute(attr.name, tuple[i]));
-      });
+      const eqs = attrs.map((attr, i) => attr.eq(this.buildBindAttribute(attr.name, tuple[i])));
       return new Nodes.Grouping(new Nodes.And(eqs));
     });
     if (groupings.length === 1) return groupings[0];
-    return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));
+    // Use n-ary `Or(children[])` (Arel `Nodes::Or` extends `Nary`)
+    // for a flat AST instead of the deeply-nested binary chain
+    // `reduce` would produce. Keeps depth O(1) instead of O(n) for
+    // large tuple lists.
+    return new Nodes.Grouping(new Nodes.Or(groupings));
   }
 
   resolveColumn(key: string): Nodes.Attribute {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -207,9 +207,13 @@ export class PredicateBuilder {
   }
 
   /**
-   * Build an OR-of-AND composite-key predicate:
+   * Build a composite-key predicate. For `cols.length > 1`:
    *
    *   (c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22) OR ...
+   *
+   * For `cols.length === 1` (degenerate composite): a single
+   * `c IN (v1, v2, ...)` predicate via `Attribute#in` — more compact
+   * and often planner-friendlier than an OR chain.
    *
    * The Rails analog is `where({[col1, col2] => [[v1, v2], ...]})`,
    * which Rails routes through `Arel::Nodes::HomogeneousIn` and the
@@ -223,6 +227,10 @@ export class PredicateBuilder {
    * different). After filtering, an empty tuple list returns `null`
    * — caller short-circuits via `Relation#none()`.
    *
+   * Throws on caller bugs: empty `cols`, non-array tuple, or tuple
+   * arity mismatch (silent filtering would mask real issues by
+   * collapsing them into `null` → `none()`).
+   *
    * Mirrors: ActiveRecord predicate-builder composite-key handling
    * (relation/predicate_builder/array_handler.rb's homogeneous-in
    * path for tuple values).
@@ -231,16 +239,33 @@ export class PredicateBuilder {
     if (cols.length === 0) {
       throw new Error("PredicateBuilder.buildComposite: empty column list");
     }
-    const validTuples = tuples.filter(
-      (t) =>
-        Array.isArray(t) &&
-        t.length === cols.length &&
-        t.every((v) => v !== null && v !== undefined),
-    );
+    // Validate shape/arity loudly — silently dropping malformed
+    // tuples would turn caller bugs into `null` (→ `none()`), which
+    // is hard to debug.
+    for (const t of tuples) {
+      if (!Array.isArray(t)) {
+        throw new Error(`PredicateBuilder.buildComposite: tuple must be an array, got ${typeof t}`);
+      }
+      if (t.length !== cols.length) {
+        throw new Error(
+          `PredicateBuilder.buildComposite: tuple arity ${t.length} does not match column count ${cols.length} (cols=[${cols.join(", ")}])`,
+        );
+      }
+    }
+    // Filter null/undefined-bearing tuples (SQL tuple-equality
+    // semantics — see method docstring).
+    const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
+    // Single-column degenerate case: a single `IN (...)` predicate is
+    // more compact than `c=v1 OR c=v2 OR ...` and typically optimizes
+    // identically (or better) on indexed columns.
+    if (cols.length === 1) {
+      const values = validTuples.map((t) => t[0]);
+      return this.resolveColumn(cols[0]).in(values);
+    }
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
       const eqs = cols.map((c, i) => this.resolveColumn(c).eq(tuple[i]));
-      return new Nodes.Grouping(eqs.length === 1 ? eqs[0] : new Nodes.And(eqs));
+      return new Nodes.Grouping(new Nodes.And(eqs));
     });
     if (groupings.length === 1) return groupings[0];
     return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -239,6 +239,14 @@ export class PredicateBuilder {
     if (cols.length === 0) {
       throw composeArgumentError("PredicateBuilder.buildComposite: empty column list");
     }
+    if (!Array.isArray(tuples)) {
+      // Surface as ArgumentError instead of letting the for-of /
+      // .filter() below throw a bare TypeError on null / object /
+      // non-iterable inputs.
+      throw composeArgumentError(
+        `PredicateBuilder.buildComposite: tuples must be an array, got ${tuples === null ? "null" : typeof tuples}`,
+      );
+    }
     // Validate shape/arity loudly — silently dropping malformed
     // tuples would turn caller bugs into `null` (→ `none()`), which
     // is hard to debug. Tagged as ArgumentError so callers can catch

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -206,6 +206,46 @@ export class PredicateBuilder {
     return this.rangeHandler.call(attribute, range);
   }
 
+  /**
+   * Build an OR-of-AND composite-key predicate:
+   *
+   *   (c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22) OR ...
+   *
+   * The Rails analog is `where({[col1, col2] => [[v1, v2], ...]})`,
+   * which Rails routes through `Arel::Nodes::HomogeneousIn` and the
+   * predicate builder. JS object keys can't be arrays, so we expose
+   * the composite shape as a separate method (and a matching
+   * `Relation#where(cols, tuples)` overload).
+   *
+   * Tuples containing `null` / `undefined` are filtered out: SQL
+   * tuple-equality semantics treat any null component as a non-match
+   * (Arel's `Attribute#eq(null)` would emit `IS NULL`, which is
+   * different). After filtering, an empty tuple list returns `null`
+   * — caller short-circuits via `Relation#none()`.
+   *
+   * Mirrors: ActiveRecord predicate-builder composite-key handling
+   * (relation/predicate_builder/array_handler.rb's homogeneous-in
+   * path for tuple values).
+   */
+  buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node | null {
+    if (cols.length === 0) {
+      throw new Error("PredicateBuilder.buildComposite: empty column list");
+    }
+    const validTuples = tuples.filter(
+      (t) =>
+        Array.isArray(t) &&
+        t.length === cols.length &&
+        t.every((v) => v !== null && v !== undefined),
+    );
+    if (validTuples.length === 0) return null;
+    const groupings: Nodes.Node[] = validTuples.map((tuple) => {
+      const eqs = cols.map((c, i) => this.resolveColumn(c).eq(tuple[i]));
+      return new Nodes.Grouping(eqs.length === 1 ? eqs[0] : new Nodes.And(eqs));
+    });
+    if (groupings.length === 1) return groupings[0];
+    return new Nodes.Grouping(groupings.reduce((left, right) => new Nodes.Or(left, right)));
+  }
+
   resolveColumn(key: string): Nodes.Attribute {
     return PredicateBuilder.resolveColumn(this.table, key);
   }

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -263,8 +263,17 @@ export class PredicateBuilder {
       const values = validTuples.map((t) => t[0]);
       return this.resolveColumn(cols[0]).in(values);
     }
+    // Build equalities through `buildBindAttribute` so each value
+    // becomes a `QueryAttribute` (= bind param) rather than an
+    // `Arel::Nodes::Casted` (= inlined SQL literal). Inlined values
+    // bypass `compileWithBinds` / prepared-statement caching and
+    // mishandle `StatementCache::Substitute` placeholders. Matches
+    // how the normal hash-WHERE handler builds per-attribute bind
+    // values.
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = cols.map((c, i) => this.resolveColumn(c).eq(tuple[i]));
+      const eqs = cols.map((c, i) =>
+        this.resolveColumn(c).eq(this.buildBindAttribute(c, tuple[i])),
+      );
       return new Nodes.Grouping(new Nodes.And(eqs));
     });
     if (groupings.length === 1) return groupings[0];

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -237,17 +237,20 @@ export class PredicateBuilder {
    */
   buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node | null {
     if (cols.length === 0) {
-      throw new Error("PredicateBuilder.buildComposite: empty column list");
+      throw composeArgumentError("PredicateBuilder.buildComposite: empty column list");
     }
     // Validate shape/arity loudly — silently dropping malformed
     // tuples would turn caller bugs into `null` (→ `none()`), which
-    // is hard to debug.
+    // is hard to debug. Tagged as ArgumentError so callers can catch
+    // consistently with other query-method validation throws.
     for (const t of tuples) {
       if (!Array.isArray(t)) {
-        throw new Error(`PredicateBuilder.buildComposite: tuple must be an array, got ${typeof t}`);
+        throw composeArgumentError(
+          `PredicateBuilder.buildComposite: tuple must be an array, got ${typeof t}`,
+        );
       }
       if (t.length !== cols.length) {
-        throw new Error(
+        throw composeArgumentError(
           `PredicateBuilder.buildComposite: tuple arity ${t.length} does not match column count ${cols.length} (cols=[${cols.join(", ")}])`,
         );
       }
@@ -267,13 +270,19 @@ export class PredicateBuilder {
     // becomes a `QueryAttribute` (= bind param) rather than an
     // `Arel::Nodes::Casted` (= inlined SQL literal). Inlined values
     // bypass `compileWithBinds` / prepared-statement caching and
-    // mishandle `StatementCache::Substitute` placeholders. Matches
-    // how the normal hash-WHERE handler builds per-attribute bind
-    // values.
+    // mishandle `StatementCache::Substitute` placeholders.
+    //
+    // Use the resolved attribute's `.name` (not the raw `c`) when
+    // constructing the bind so qualified column keys
+    // (e.g. `"orders.shop_id"`) resolve to the same column-name
+    // PredicateBuilder.BasicObjectHandler uses for type lookup —
+    // otherwise `typeForAttribute("orders.shop_id")` returns
+    // undefined and the cast falls back to identity.
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = cols.map((c, i) =>
-        this.resolveColumn(c).eq(this.buildBindAttribute(c, tuple[i])),
-      );
+      const eqs = cols.map((c, i) => {
+        const attr = this.resolveColumn(c);
+        return attr.eq(this.buildBindAttribute(attr.name, tuple[i]));
+      });
       return new Nodes.Grouping(new Nodes.And(eqs));
     });
     if (groupings.length === 1) return groupings[0];
@@ -351,6 +360,18 @@ export class PredicateBuilder {
       typeof value === "object" && value !== null && "_modelClass" in value && "toArel" in value
     );
   }
+}
+
+/**
+ * Tag throws from `buildComposite` as `ArgumentError` so callers can
+ * catch them consistently with other argument-shape errors raised
+ * elsewhere in query-methods.ts (matches Rails' ArgumentError surface
+ * for invalid where arguments).
+ */
+function composeArgumentError(message: string): Error {
+  const error = new Error(message);
+  error.name = "ArgumentError";
+  return error;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -481,7 +481,14 @@ function invertWhereBang(this: QueryMethodsHost): any {
  * Constructs an Error tagged with name "ArgumentError" so callers can
  * catch it the same way they would catch Rails' ArgumentError.
  */
-function argumentError(message: string): Error {
+/**
+ * Build an ArgumentError-tagged Error. Exported so other modules
+ * (PredicateBuilder, Relation public methods, Base.where, etc.) can
+ * raise the same shape without redeclaring the helper. Matches
+ * Rails' ArgumentError convention so callers can `catch err if
+ * err.name === 'ArgumentError'` consistently.
+ */
+export function argumentError(message: string): Error {
   const err = new Error(message);
   err.name = "ArgumentError";
   return err;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -478,15 +478,12 @@ function invertWhereBang(this: QueryMethodsHost): any {
 }
 
 /**
- * Constructs an Error tagged with name "ArgumentError" so callers can
- * catch it the same way they would catch Rails' ArgumentError.
- */
-/**
- * Build an ArgumentError-tagged Error. Exported so other modules
- * (PredicateBuilder, Relation public methods, Base.where, etc.) can
- * raise the same shape without redeclaring the helper. Matches
- * Rails' ArgumentError convention so callers can `catch err if
- * err.name === 'ArgumentError'` consistently.
+ * Build an Error tagged with `name = "ArgumentError"` so callers can
+ * catch it the same way they would catch Rails' ArgumentError
+ * (`catch err if err.name === 'ArgumentError'`). Exported so other
+ * modules (PredicateBuilder, Relation public methods, Base.where /
+ * Base.whereNot, etc.) can raise the same shape without
+ * re-declaring the helper.
  */
 export function argumentError(message: string): Error {
   const err = new Error(message);


### PR DESCRIPTION
## Summary

Adds Rails-equivalent composite-key matching to the where-machinery — at the right layer (PredicateBuilder), not inline in callers.

Rails: \`where({[col1, col2] => [[v1, v2], ...]})\` routes through PredicateBuilder and emits a tuple-form \`HomogeneousIn\`. JS object keys can't be arrays, so we expose the same shape as positional args:

\`\`\`ts
Model.where(['shop_id', 'order_number'], [[1, 100], [2, 200]])
rel.where(['shop_id', 'order_number'], [[1, 100], [2, 200]])
\`\`\`

Compiles to: \`(shop_id=1 AND order_number=100) OR (shop_id=2 AND order_number=200)\` — same shape as \`counter-cache.ts#buildPkPredicate\`. PG / MySQL / SQLite all optimize OR-of-AND on indexed columns to the same plan as tuple-IN; adapter-portable without raw SQL.

Three-layer wiring:
- \`PredicateBuilder.buildComposite(cols, tuples) → Node | null\` — filters null/undefined-bearing tuples (SQL tuple-equality treats any null component as a non-match), throws on empty cols, returns null on empty input (caller short-circuits via \`none()\`).
- \`Relation#where(cols, tuples)\` overload — dispatches to \`noneBang()\` on null or \`whereBang(node)\` otherwise.
- \`Base.where\` overload — thin wrapper that routes to \`all().where\`.

**Unblocks PR #645** (DJAS composite-key support, currently parked): once this lands, DJAS reverts its inline \`tuplePredicate\` to plain \`where({key: ids})\` (single col) / \`where(cols, tuples)\` (composite), matching Rails' \`disable_joins_association_scope.rb:34\` in mechanism not just behavior.

## Test plan

- [x] 6 new tests in \`composite-where.test.ts\`: OR-of-AND emission, empty-after-null-filter → \`none()\`, null-component filtering vs buggy Arel \`IS NULL\` default, single-column degenerate case, null-return + empty-cols guard contracts.
- [x] Full \`@blazetrails/activerecord\` suite: 8687 passed locally.
- [ ] PG / MariaDB CI.