### PR TITLE
refactor(activerecord): CP.first/last/take/find align with Relation overloads (PR B)

### DIFF
--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -85,8 +85,13 @@ describe("associations DX", () => {
   it("CollectionProxy is generic in its element type", () => {
     const proxy = {} as CollectionProxy<Post>;
     expectTypeOf(proxy.toArray).returns.resolves.toEqualTypeOf<Post[]>();
-    expectTypeOf(proxy.first).returns.resolves.toEqualTypeOf<Post | null>();
-    expectTypeOf(proxy.last).returns.resolves.toEqualTypeOf<Post | null>();
+    // first / last are overloaded: () → T | null, (n) → T[]. Call the
+    // zero-arg form explicitly so the assertion picks the intended
+    // overload.
+    expectTypeOf(proxy.first()).resolves.toEqualTypeOf<Post | null>();
+    expectTypeOf(proxy.first(2)).resolves.toEqualTypeOf<Post[]>();
+    expectTypeOf(proxy.last()).resolves.toEqualTypeOf<Post | null>();
+    expectTypeOf(proxy.last(2)).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.build).returns.toEqualTypeOf<Post>();
     expectTypeOf(proxy.create).returns.resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -85,13 +85,19 @@ describe("associations DX", () => {
   it("CollectionProxy is generic in its element type", () => {
     const proxy = {} as CollectionProxy<Post>;
     expectTypeOf(proxy.toArray).returns.resolves.toEqualTypeOf<Post[]>();
-    // first / last are overloaded: () → T | null, (n) → T[]. Call the
-    // zero-arg form explicitly so the assertion picks the intended
-    // overload.
+    // first / last / take are overloaded: () → T | null, (n) → T[].
+    // Call the zero-arg form explicitly so the assertion picks the
+    // intended overload.
     expectTypeOf(proxy.first()).resolves.toEqualTypeOf<Post | null>();
     expectTypeOf(proxy.first(2)).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.last()).resolves.toEqualTypeOf<Post | null>();
     expectTypeOf(proxy.last(2)).resolves.toEqualTypeOf<Post[]>();
+    expectTypeOf(proxy.take()).resolves.toEqualTypeOf<Post | null>();
+    expectTypeOf(proxy.take(2)).resolves.toEqualTypeOf<Post[]>();
+    // find is overloaded: (id) → T, ([ids]) → T[], (...ids) → T | T[].
+    expectTypeOf(proxy.find(1)).resolves.toEqualTypeOf<Post>();
+    expectTypeOf(proxy.find([1, 2])).resolves.toEqualTypeOf<Post[]>();
+    expectTypeOf(proxy.find(1, 2)).resolves.toMatchTypeOf<Post | Post[]>();
     expectTypeOf(proxy.build).returns.toEqualTypeOf<Post>();
     expectTypeOf(proxy.create).returns.resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1201,6 +1201,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override last(): Promise<T | null>;
   override last(n: number): Promise<T[]>;
   override async last(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) {
+      // Relation.last(n) routes through limit(n) → limitBang which
+      // validates. Match that contract here so cp.last(-1) / cp.last(1.5)
+      // raise the same 'Invalid limit value' error.
+      if (!Number.isSafeInteger(Number(n)) || Number(n) < 0) {
+        throw new Error(`Invalid limit value: ${String(n)}`);
+      }
+    }
     const records = await this.toArray();
     if (n === undefined) return records[records.length - 1] ?? null;
     return records.slice(Math.max(0, records.length - n));
@@ -1440,9 +1448,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       for (const id of ids) {
         if (!Array.isArray(id) || id.length !== pkArity) {
           throw new RecordNotFound(
-            `Couldn't find ${targetModel.name} with an invalid composite primary key id: ${
-              Array.isArray(id) ? JSON.stringify(id) : String(id)
-            } (expected an array with ${pkArity} elements)`,
+            `${targetModel.name}: composite primary key requires a ${pkArity}-element array, got ${String(id)}`,
             targetModel.name,
             String(pk),
             id,
@@ -1513,7 +1519,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           ids,
         );
       }
-      return castedIds.map((c) => byPk.get(keyForCastedId(c)) as T);
+      // Return in DB/load order (the order records appear in
+      // this.toArray()), matching Relation.performFind which returns
+      // the WHERE-IN result set without reordering by input ids.
+      const wantedKeys = new Set(castedIds.map(keyForCastedId));
+      return records.filter((r) => wantedKeys.has(keyForRecord(r)));
     }
 
     const id = ids[0];

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1351,26 +1351,62 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override async find(...args: unknown[]): Promise<T | T[]> {
     const targetModel = this.model as typeof Base;
     const pk = targetModel.primaryKey ?? "id";
+    const composite = Array.isArray(pk);
 
     // No-args contract matches Relation.find / Rails: raise a clear
     // not-found instead of normalizing to [undefined] and producing a
     // misleading message.
     if (args.length === 0) {
-      throw new RecordNotFound(`Couldn't find ${targetModel.name} without an ID`, targetModel.name);
+      throw new RecordNotFound(
+        `Couldn't find ${targetModel.name} without an ID`,
+        targetModel.name,
+        String(pk),
+      );
     }
 
-    // Normalize the overload set: `find(a, b, c)` and `find([a, b, c])`
-    // both return arrays; `find(a)` returns a single record.
+    // Normalize the overload set into (ids, wantArray). Rules:
+    //
+    // - Variadic (`find(a, b, c)`) → each arg is a full id (scalar for
+    //   simple PKs, tuple for composite). Returns T[].
+    // - Single array arg + composite PK: ambiguous. Follow Rails:
+    //     * flat array of scalars whose length matches PK arity →
+    //       ONE composite-tuple id (find([k1, k2]) on [id1, id2]).
+    //     * array of arrays → each inner array is a composite-tuple id.
+    // - Single array arg + scalar PK → list of ids.
+    // - Single scalar / single tuple → that's the only id.
     const [first, ...rest] = args;
-    const wantArray = Array.isArray(first) || rest.length > 0;
-    const ids: unknown[] = Array.isArray(first) ? first : [first, ...rest];
+    let ids: unknown[];
+    let wantArray: boolean;
+    if (rest.length > 0) {
+      ids = args;
+      wantArray = true;
+    } else if (Array.isArray(first)) {
+      if (composite) {
+        const pkArity = (pk as string[]).length;
+        const looksLikeSingleTuple =
+          first.length === pkArity && first.every((x) => !Array.isArray(x));
+        if (looksLikeSingleTuple) {
+          ids = [first];
+          wantArray = false;
+        } else {
+          // Array of tuples (or mixed / wrong arity — fall through so
+          // each element is treated as an id and keyForId normalizes).
+          ids = first;
+          wantArray = true;
+        }
+      } else {
+        ids = first;
+        wantArray = true;
+      }
+    } else {
+      ids = [first];
+      wantArray = false;
+    }
 
     const records = await this.toArray();
 
-    // Index records by PK once: O(records + ids) instead of
-    // O(records × ids) for large collections. Composite keys are
-    // stringified as a JSON tuple so the comparison is stable.
-    const composite = Array.isArray(pk);
+    // Index records by PK once — O(records + ids) instead of
+    // O(records × ids). Composite keys stringify as a JSON tuple.
     const keyForRecord = (r: Base): string => {
       if (composite) {
         const cols = pk as string[];
@@ -1395,6 +1431,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             Array.isArray(id) ? JSON.stringify(id) : String(id)
           }`,
           targetModel.name,
+          String(pk),
+          id as string | number,
         );
       }
       return match;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -97,20 +97,6 @@ export type AssociationProxy<
     readonly [index: number]: T | undefined;
   };
 
-/**
- * Validate a numeric limit using the same rule as
- * `Relation#limitBang` — safe non-negative integer. Keeps
- * `first(n)` / `last(n)` / `take(n)` consistent with Relation's
- * limit semantics and rejects surprises like -1 or 1.5 that
- * `Array.prototype.slice` would silently accept.
- */
-function assertValidLimit(n: number): void {
-  const num = Number(n);
-  if (!Number.isSafeInteger(num) || num < 0) {
-    throw new Error(`Invalid limit value: ${String(n)}`);
-  }
-}
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
@@ -1202,7 +1188,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override first(): Promise<T | null>;
   override first(n: number): Promise<T[]>;
   override async first(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);
@@ -1216,7 +1201,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override last(): Promise<T | null>;
   override last(n: number): Promise<T[]>;
   override async last(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[records.length - 1] ?? null;
     return records.slice(Math.max(0, records.length - n));
@@ -1230,7 +1214,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override take(): Promise<T | null>;
   override take(limit: number): Promise<T[]>;
   override async take(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);
@@ -1511,9 +1494,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // RecordNotFound with the full id list instead of one per
     // missing id.
     if (wantArray || ids.length > 1) {
+      // Match Relation.performFind exactly: the SQL path does a single
+      // WHERE-IN query and compares result count to the requested
+      // count. Duplicate ids or missing ids both yield a count
+      // mismatch and raise the aggregate "couldn't find all" error.
+      // Mirror that here by comparing the distinct found-key count to
+      // the requested ids count — `find([1, 1])` fails the same way
+      // `Base.find([1, 1])` does.
       const castedIds = ids.map(castId);
-      const missing = ids.filter((_, i) => !byPk.has(keyForCastedId(castedIds[i])));
-      if (missing.length > 0) {
+      const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
+      if (uniqueFoundKeys.size !== ids.length) {
         throw new RecordNotFound(
           `Couldn't find all ${targetModel.name} with '${String(pk)}': (${ids
             .map((id) => formatId(id))

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -97,6 +97,21 @@ export type AssociationProxy<
     readonly [index: number]: T | undefined;
   };
 
+/**
+ * Validate a numeric limit (safe non-negative integer) and raise the
+ * same error shape as Relation#limitBang. Rails' `first(n)` / `last(n)`
+ * / `take(n)` all route through `limit(limit)` which validates; our
+ * TS finder methods bypass validation for first/take via
+ * `_limitValue = n` (a TS-internal shortcut that diverges from Rails).
+ * For Rails fidelity at the CollectionProxy layer we validate all
+ * three.
+ */
+function assertValidLimit(n: number): void {
+  if (!Number.isSafeInteger(Number(n)) || Number(n) < 0) {
+    throw new Error(`Invalid limit value: ${String(n)}`);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
@@ -1188,6 +1203,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override first(): Promise<T | null>;
   override first(n: number): Promise<T[]>;
   override async first(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);
@@ -1201,14 +1217,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override last(): Promise<T | null>;
   override last(n: number): Promise<T[]>;
   override async last(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) {
-      // Relation.last(n) routes through limit(n) → limitBang which
-      // validates. Match that contract here so cp.last(-1) / cp.last(1.5)
-      // raise the same 'Invalid limit value' error.
-      if (!Number.isSafeInteger(Number(n)) || Number(n) < 0) {
-        throw new Error(`Invalid limit value: ${String(n)}`);
-      }
-    }
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[records.length - 1] ?? null;
     return records.slice(Math.max(0, records.length - n));
@@ -1222,6 +1231,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override take(): Promise<T | null>;
   override take(limit: number): Promise<T[]>;
   override async take(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1379,7 +1379,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         `Couldn't find ${targetModel.name} with an empty list of ids`,
         targetModel.name,
         String(pk),
-        [] as unknown as string | number,
+        [],
       );
     }
 
@@ -1397,8 +1397,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     let ids: unknown[];
     let wantArray: boolean;
     if (rest.length > 0) {
-      ids = args;
-      wantArray = true;
+      // Composite PK variadic scalars — `find(1, 42)` on PK
+      // [id1, id2] is ONE tuple, matching Relation.performFind.
+      // Only collapses when the arg count exactly equals the PK
+      // arity AND no arg is itself an array (arrays signal
+      // "tuples-of-tuples" for multi-lookup).
+      if (
+        composite &&
+        args.length === (pk as string[]).length &&
+        args.every((x) => !Array.isArray(x))
+      ) {
+        ids = [args];
+        wantArray = false;
+      } else {
+        ids = args;
+        wantArray = true;
+      }
     } else if (Array.isArray(first)) {
       if (composite) {
         const pkArity = (pk as string[]).length;
@@ -1431,7 +1445,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         `Couldn't find ${targetModel.name} with an empty list of ids`,
         targetModel.name,
         String(pk),
-        [] as unknown as string | number,
+        [],
       );
     }
 
@@ -1448,7 +1462,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             } (expected an array with ${pkArity} elements)`,
             targetModel.name,
             String(pk),
-            id as string | number,
+            id,
           );
         }
       }
@@ -1506,7 +1520,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             .join(", ")})`,
           targetModel.name,
           String(pk),
-          ids as unknown as string | number,
+          ids,
         );
       }
       return castedIds.map((c) => byPk.get(keyForCastedId(c)) as T);
@@ -1519,7 +1533,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         `Couldn't find ${targetModel.name} with '${String(pk)}'=${formatId(id)}`,
         targetModel.name,
         String(pk),
-        id as string | number,
+        id,
       );
     }
     return match;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1484,59 +1484,70 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     };
 
     // Index records by PK once — O(records + ids) instead of
-    // O(records × ids). Composite keys stringify as a JSON tuple.
+    // O(records × ids). Composite keys join with a NUL separator
+    // (unambiguous + bigint-safe; JSON.stringify throws on bigint
+    // and this codebase's big_integer type casts to bigint).
+    const TUPLE_SEP = "\u0000";
+    const keyForTuple = (tuple: unknown[]): string => tuple.map((x) => String(x)).join(TUPLE_SEP);
     const keyForRecord = (r: Base): string => {
       if (composite) {
         const cols = pk as string[];
-        return JSON.stringify(cols.map((c) => r.readAttribute(c)));
+        return keyForTuple(cols.map((c) => r.readAttribute(c)));
       }
       return String(r.readAttribute(pk as string));
     };
     const keyForCastedId = (castedId: unknown): string => {
-      if (composite) return JSON.stringify(castedId);
+      if (composite) return keyForTuple(castedId as unknown[]);
       return String(castedId);
     };
     const byPk = new Map<string, T>();
     for (const r of records) byPk.set(keyForRecord(r), r);
 
-    const formatId = (id: unknown): string => (Array.isArray(id) ? JSON.stringify(id) : String(id));
+    // For composite PKs, collapse the caller-provided ids into the
+    // `tuples` shape performFind uses, so error messages and the
+    // `id` payload match exactly: tuples is always `unknown[][]`;
+    // `String(tuples)` yields "1,2,3,4" for [[1,2],[3,4]]. For
+    // simple PKs, stay with the scalar form.
+    const tuples: unknown[][] | null = composite ? (ids as unknown[][]) : null;
 
     // Aggregate "couldn't find all" error when looking up multiple
-    // ids — matches Relation.performFind so callers see a single
-    // RecordNotFound with the full id list instead of one per
-    // missing id.
-    if (wantArray || ids.length > 1) {
-      // Match Relation.performFind exactly: the SQL path does a single
-      // WHERE-IN query and compares result count to the requested
-      // count. Duplicate ids or missing ids both yield a count
-      // mismatch and raise the aggregate "couldn't find all" error.
-      // Mirror that here by comparing the distinct found-key count to
-      // the requested ids count — `find([1, 1])` fails the same way
-      // `Base.find([1, 1])` does.
+    // ids or composite-tuple lookups — matches Relation.performFind:
+    //   * ALWAYS uses the "Couldn't find all X with 'pk': (ids)" shape
+    //     when at least one requested id is missing, even for a
+    //     single-tuple lookup under composite PKs (relation/
+    //     finder-methods.ts:129-137).
+    //   * Simple-PK single-id lookup uses the "with 'pk'=id" shape.
+    if (composite || wantArray || ids.length > 1) {
+      // Duplicate-id handling matches Relation.performFind: the SQL
+      // path compares result count to requested count; duplicates
+      // collapse to one row and raise. Mirror by comparing distinct
+      // found-key count to ids.length.
       const castedIds = ids.map(castId);
       const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
       if (uniqueFoundKeys.size !== ids.length) {
+        const idPayload = tuples ?? ids;
         throw new RecordNotFound(
-          `Couldn't find all ${targetModel.name} with '${String(pk)}': (${ids
-            .map((id) => formatId(id))
-            .join(", ")})`,
+          `Couldn't find all ${targetModel.name} with '${String(pk)}': (${String(idPayload)})`,
           targetModel.name,
           String(pk),
-          ids,
+          idPayload,
         );
       }
-      // Return in DB/load order (the order records appear in
-      // this.toArray()), matching Relation.performFind which returns
-      // the WHERE-IN result set without reordering by input ids.
+      // Return in DB/load order, matching Relation.performFind.
       const wantedKeys = new Set(castedIds.map(keyForCastedId));
-      return records.filter((r) => wantedKeys.has(keyForRecord(r)));
+      const found = records.filter((r) => wantedKeys.has(keyForRecord(r)));
+      // Composite single-tuple lookup (`find([k1, k2])`) returns one
+      // record, matching performFind's `isArrayOfTuples ? records :
+      // records[0]` branch.
+      return wantArray ? found : found[0];
     }
 
+    // Simple PK, single scalar id.
     const id = ids[0];
     const match = byPk.get(keyForCastedId(castId(id)));
     if (!match) {
       throw new RecordNotFound(
-        `Couldn't find ${targetModel.name} with '${String(pk)}'=${formatId(id)}`,
+        `Couldn't find ${targetModel.name} with '${String(pk)}'=${String(id)}`,
         targetModel.name,
         String(pk),
         id,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1349,21 +1349,51 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override find(id: unknown): Promise<T>;
   override find(...ids: unknown[]): Promise<T | T[]>;
   override async find(...args: unknown[]): Promise<T | T[]> {
-    // Normalize the overload set to a single `ids: unknown[]` + `wantArray` pair,
-    // matching Relation#find's shape. `find(a, b, c)` and `find([a, b, c])`
+    const targetModel = this.model as typeof Base;
+    const pk = targetModel.primaryKey ?? "id";
+
+    // No-args contract matches Relation.find / Rails: raise a clear
+    // not-found instead of normalizing to [undefined] and producing a
+    // misleading message.
+    if (args.length === 0) {
+      throw new RecordNotFound(`Couldn't find ${targetModel.name} without an ID`, targetModel.name);
+    }
+
+    // Normalize the overload set: `find(a, b, c)` and `find([a, b, c])`
     // both return arrays; `find(a)` returns a single record.
     const [first, ...rest] = args;
     const wantArray = Array.isArray(first) || rest.length > 0;
     const ids: unknown[] = Array.isArray(first) ? first : [first, ...rest];
 
     const records = await this.toArray();
-    const targetModel = (records[0]?.constructor ?? Object) as typeof Base;
-    const pk = targetModel.primaryKey ?? "id";
+
+    // Index records by PK once: O(records + ids) instead of
+    // O(records × ids) for large collections. Composite keys are
+    // stringified as a JSON tuple so the comparison is stable.
+    const composite = Array.isArray(pk);
+    const keyForRecord = (r: Base): string => {
+      if (composite) {
+        const cols = pk as string[];
+        return JSON.stringify(cols.map((c) => r.readAttribute(c)));
+      }
+      return String(r.readAttribute(pk as string));
+    };
+    const keyForId = (id: unknown): string => {
+      if (composite) {
+        return JSON.stringify(Array.isArray(id) ? id : [id]);
+      }
+      return String(id);
+    };
+    const byPk = new Map<string, T>();
+    for (const r of records) byPk.set(keyForRecord(r), r);
+
     const matches = ids.map((id) => {
-      const match = records.find((r) => r.readAttribute(pk as string) === id);
+      const match = byPk.get(keyForId(id));
       if (!match) {
         throw new RecordNotFound(
-          `Couldn't find ${targetModel.name} with '${String(pk)}'=${String(id)}`,
+          `Couldn't find ${targetModel.name} with '${String(pk)}'=${
+            Array.isArray(id) ? JSON.stringify(id) : String(id)
+          }`,
           targetModel.name,
         );
       }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -18,7 +18,12 @@ import { applyThenable, stripThenable } from "../relation/thenable.js";
 import { Table as ArelTable } from "@blazetrails/arel";
 import type { Nodes } from "@blazetrails/arel";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
-import { StrictLoadingViolationError, RecordNotSaved, ConfigurationError } from "../errors.js";
+import {
+  StrictLoadingViolationError,
+  RecordNotSaved,
+  RecordNotFound,
+  ConfigurationError,
+} from "../errors.js";
 import { RecordInvalid } from "../validations.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
@@ -1356,7 +1361,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const pk = targetModel.primaryKey ?? "id";
     const matches = ids.map((id) => {
       const match = records.find((r) => r.readAttribute(pk as string) === id);
-      if (!match) throw new Error(`Couldn't find record with id=${String(id)}`);
+      if (!match) {
+        throw new RecordNotFound(
+          `Couldn't find ${targetModel.name} with '${String(pk)}'=${String(id)}`,
+          targetModel.name,
+        );
+      }
       return match;
     });
     return wantArray ? matches : matches[0];

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1403,6 +1403,37 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       wantArray = false;
     }
 
+    // Empty-id-list contract: Relation.find / performFind raises for
+    // an empty list so callers can distinguish "no ids" from "found
+    // nothing". Mirror that here — `find([])` and the composite
+    // fallthrough that produces zero ids both raise.
+    if (ids.length === 0) {
+      throw new RecordNotFound(
+        `Couldn't find ${targetModel.name} with an empty list of ids`,
+        targetModel.name,
+        String(pk),
+      );
+    }
+
+    // Composite PKs require a tuple id of matching arity. Fail fast
+    // with a clear message instead of computing a lookup key that
+    // can never match (scalar id → [scalar] → no match).
+    if (composite) {
+      const pkArity = (pk as string[]).length;
+      for (const id of ids) {
+        if (!Array.isArray(id) || id.length !== pkArity) {
+          throw new RecordNotFound(
+            `Couldn't find ${targetModel.name} with an invalid composite primary key id: ${
+              Array.isArray(id) ? JSON.stringify(id) : String(id)
+            } (expected an array with ${pkArity} elements)`,
+            targetModel.name,
+            String(pk),
+            id as string | number,
+          );
+        }
+      }
+    }
+
     const records = await this.toArray();
 
     // Index records by PK once — O(records + ids) instead of
@@ -1415,9 +1446,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return String(r.readAttribute(pk as string));
     };
     const keyForId = (id: unknown): string => {
-      if (composite) {
-        return JSON.stringify(Array.isArray(id) ? id : [id]);
-      }
+      // Composite ids are pre-validated above as arrays of the right
+      // arity, so the JSON form matches keyForRecord's tuple exactly.
+      if (composite) return JSON.stringify(id);
       return String(id);
     };
     const byPk = new Map<string, T>();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -97,6 +97,20 @@ export type AssociationProxy<
     readonly [index: number]: T | undefined;
   };
 
+/**
+ * Validate a numeric limit using the same rule as
+ * `Relation#limitBang` — safe non-negative integer. Keeps
+ * `first(n)` / `last(n)` / `take(n)` consistent with Relation's
+ * limit semantics and rejects surprises like -1 or 1.5 that
+ * `Array.prototype.slice` would silently accept.
+ */
+function assertValidLimit(n: number): void {
+  const num = Number(n);
+  if (!Number.isSafeInteger(num) || num < 0) {
+    throw new Error(`Invalid limit value: ${String(n)}`);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
@@ -1188,6 +1202,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override first(): Promise<T | null>;
   override first(n: number): Promise<T[]>;
   override async first(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);
@@ -1201,6 +1216,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override last(): Promise<T | null>;
   override last(n: number): Promise<T[]>;
   override async last(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[records.length - 1] ?? null;
     return records.slice(Math.max(0, records.length - n));
@@ -1214,6 +1230,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override take(): Promise<T | null>;
   override take(limit: number): Promise<T[]>;
   override async take(n?: number): Promise<T | T[] | null> {
+    if (n !== undefined) assertValidLimit(n);
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1398,16 +1398,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     let ids: unknown[];
     let wantArray: boolean;
     if (rest.length > 0) {
-      // Composite PK variadic scalars — `find(1, 42)` on PK
-      // [id1, id2] is ONE tuple, matching Relation.performFind.
-      // Only collapses when the arg count exactly equals the PK
-      // arity AND no arg is itself an array (arrays signal
-      // "tuples-of-tuples" for multi-lookup).
-      if (
-        composite &&
-        args.length === (pk as string[]).length &&
-        args.every((x) => !Array.isArray(x))
-      ) {
+      // Composite PK variadic: treat the whole arg list as ONE
+      // composite-tuple id when every arg is a scalar. If the arity
+      // doesn't match, the downstream validator reports the whole
+      // tuple (e.g. "got 1,2,3"), matching Relation.performFind. An
+      // array arg signals tuples-of-tuples — list-of-ids form.
+      if (composite && args.every((x) => !Array.isArray(x))) {
         ids = [args];
         wantArray = false;
       } else {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1425,7 +1425,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           wantArray = true;
         }
       } else {
-        ids = first;
+        // Simple PK: Relation.performFind flattens nested arrays
+        // (finder-methods.ts:78 `ids.flat()`), so `find([[1, 2]])`
+        // behaves like `find([1, 2])`. Mirror that here.
+        ids = (first as unknown[]).flat(Infinity);
         wantArray = true;
       }
     } else {
@@ -1525,9 +1528,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       const castedIds = ids.map(castId);
       const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
       if (uniqueFoundKeys.size !== ids.length) {
+        // Simple PK: performFind uses `flatIds.join(", ")` and stores
+        // flatIds on the exception (finder-methods.ts:78-95).
+        // Composite: performFind uses `String(tuples)` (comma-join,
+        // no space) and stores tuples (finder-methods.ts:129-137).
         const idPayload = tuples ?? ids;
+        const messageIds = tuples ? String(tuples) : (ids as unknown[]).join(", ");
         throw new RecordNotFound(
-          `Couldn't find all ${targetModel.name} with '${String(pk)}': (${String(idPayload)})`,
+          `Couldn't find all ${targetModel.name} with '${String(pk)}': (${messageIds})`,
           targetModel.name,
           String(pk),
           idPayload,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1370,14 +1370,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const pk = targetModel.primaryKey ?? "id";
     const composite = Array.isArray(pk);
 
-    // No-args contract matches Relation.find / Rails: raise a clear
-    // not-found instead of normalizing to [undefined] and producing a
-    // misleading message.
+    // No-args / empty-list contract matches Relation.find (same
+    // message shape, same `id: []` on the exception) so callers
+    // writing `catch (e) { e.id; e.primaryKey }` see consistent
+    // fields across both finders.
     if (args.length === 0) {
       throw new RecordNotFound(
-        `Couldn't find ${targetModel.name} without an ID`,
+        `Couldn't find ${targetModel.name} with an empty list of ids`,
         targetModel.name,
         String(pk),
+        [] as unknown as string | number,
       );
     }
 
@@ -1429,6 +1431,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         `Couldn't find ${targetModel.name} with an empty list of ids`,
         targetModel.name,
         String(pk),
+        [] as unknown as string | number,
       );
     }
 
@@ -1453,6 +1456,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     const records = await this.toArray();
 
+    // Cast incoming ids through the target model's attribute types so
+    // in-memory find matches Relation.find's WHERE-condition casting
+    // (e.g. proxy.find("1") on an integer PK). For composite keys,
+    // cast each tuple element by its PK column.
+    const castFn = (
+      targetModel as typeof Base & {
+        _castAttributeValue?: (attributeName: string, value: unknown) => unknown;
+      }
+    )._castAttributeValue;
+    const castId = (id: unknown): unknown => {
+      if (composite) {
+        const cols = pk as string[];
+        const values = id as unknown[];
+        return castFn ? cols.map((c, i) => castFn.call(targetModel, c, values[i])) : values;
+      }
+      return castFn ? castFn.call(targetModel, pk as string, id) : id;
+    };
+
     // Index records by PK once — O(records + ids) instead of
     // O(records × ids). Composite keys stringify as a JSON tuple.
     const keyForRecord = (r: Base): string => {
@@ -1462,30 +1483,46 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       }
       return String(r.readAttribute(pk as string));
     };
-    const keyForId = (id: unknown): string => {
-      // Composite ids are pre-validated above as arrays of the right
-      // arity, so the JSON form matches keyForRecord's tuple exactly.
-      if (composite) return JSON.stringify(id);
-      return String(id);
+    const keyForCastedId = (castedId: unknown): string => {
+      if (composite) return JSON.stringify(castedId);
+      return String(castedId);
     };
     const byPk = new Map<string, T>();
     for (const r of records) byPk.set(keyForRecord(r), r);
 
-    const matches = ids.map((id) => {
-      const match = byPk.get(keyForId(id));
-      if (!match) {
+    const formatId = (id: unknown): string => (Array.isArray(id) ? JSON.stringify(id) : String(id));
+
+    // Aggregate "couldn't find all" error when looking up multiple
+    // ids — matches Relation.performFind so callers see a single
+    // RecordNotFound with the full id list instead of one per
+    // missing id.
+    if (wantArray || ids.length > 1) {
+      const castedIds = ids.map(castId);
+      const missing = ids.filter((_, i) => !byPk.has(keyForCastedId(castedIds[i])));
+      if (missing.length > 0) {
         throw new RecordNotFound(
-          `Couldn't find ${targetModel.name} with '${String(pk)}'=${
-            Array.isArray(id) ? JSON.stringify(id) : String(id)
-          }`,
+          `Couldn't find all ${targetModel.name} with '${String(pk)}': (${ids
+            .map((id) => formatId(id))
+            .join(", ")})`,
           targetModel.name,
           String(pk),
-          id as string | number,
+          ids as unknown as string | number,
         );
       }
-      return match;
-    });
-    return wantArray ? matches : matches[0];
+      return castedIds.map((c) => byPk.get(keyForCastedId(c)) as T);
+    }
+
+    const id = ids[0];
+    const match = byPk.get(keyForCastedId(castId(id)));
+    if (!match) {
+      throw new RecordNotFound(
+        `Couldn't find ${targetModel.name} with '${String(pk)}'=${formatId(id)}`,
+        targetModel.name,
+        String(pk),
+        id as string | number,
+      );
+    }
+    return match;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1180,12 +1180,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#first
    */
-  // @ts-expect-error Relation#first has overloads: () | (n: number). CP's
-  //   version only handles the zero-arg case (returns T | null). PR B
-  //   will add the n-arg overload or delete CP's version.
-  async first(): Promise<T | null> {
+  override first(): Promise<T | null>;
+  override first(n: number): Promise<T[]>;
+  override async first(n?: number): Promise<T | T[] | null> {
     const records = await this.toArray();
-    return records[0] ?? null;
+    if (n === undefined) return records[0] ?? null;
+    return records.slice(0, n);
   }
 
   /**
@@ -1193,10 +1193,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#last
    */
-  // @ts-expect-error Same overload divergence as `first`.
-  async last(): Promise<T | null> {
+  override last(): Promise<T | null>;
+  override last(n: number): Promise<T[]>;
+  override async last(n?: number): Promise<T | T[] | null> {
     const records = await this.toArray();
-    return records[records.length - 1] ?? null;
+    if (n === undefined) return records[records.length - 1] ?? null;
+    return records.slice(Math.max(0, records.length - n));
   }
 
   /**
@@ -1204,9 +1206,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#take
    */
-  // @ts-expect-error Relation#take has distinct () / (n) overloads; CP
-  //   flattens both. PR B will align overloads.
-  async take(n?: number): Promise<T | T[] | null> {
+  override take(): Promise<T | null>;
+  override take(limit: number): Promise<T[]>;
+  override async take(n?: number): Promise<T | T[] | null> {
     const records = await this.toArray();
     if (n === undefined) return records[0] ?? null;
     return records.slice(0, n);
@@ -1338,20 +1340,26 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#find
    */
-  // @ts-expect-error Relation#find takes `unknown` IDs (string/number);
-  //   CP narrows to number | number[]. PR B: widen CP's param.
-  async find(id: number | number[]): Promise<T | T[]> {
+  override find(ids: unknown[]): Promise<T[]>;
+  override find(id: unknown): Promise<T>;
+  override find(...ids: unknown[]): Promise<T | T[]>;
+  override async find(...args: unknown[]): Promise<T | T[]> {
+    // Normalize the overload set to a single `ids: unknown[]` + `wantArray` pair,
+    // matching Relation#find's shape. `find(a, b, c)` and `find([a, b, c])`
+    // both return arrays; `find(a)` returns a single record.
+    const [first, ...rest] = args;
+    const wantArray = Array.isArray(first) || rest.length > 0;
+    const ids: unknown[] = Array.isArray(first) ? first : [first, ...rest];
+
     const records = await this.toArray();
     const targetModel = (records[0]?.constructor ?? Object) as typeof Base;
     const pk = targetModel.primaryKey ?? "id";
-    if (Array.isArray(id)) {
-      const found = records.filter((r) => id.includes(r.readAttribute(pk as string) as number));
-      if (found.length !== id.length) throw new Error(`Couldn't find all records with ids: ${id}`);
-      return found;
-    }
-    const found = records.find((r) => r.readAttribute(pk as string) === id);
-    if (!found) throw new Error(`Couldn't find record with id=${id}`);
-    return found;
+    const matches = ids.map((id) => {
+      const match = records.find((r) => r.readAttribute(pk as string) === id);
+      if (!match) throw new Error(`Couldn't find record with id=${String(id)}`);
+      return match;
+    });
+    return wantArray ? matches : matches[0];
   }
 
   /**

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -499,9 +499,7 @@ describe("InverseHasManyTests", () => {
     const { Man } = makeModels();
     const m = await Man.create({ name: "Gordon" });
     const proxy = association(m, "interests");
-    // Empty array returns empty array (no error) in current impl; test that it returns empty
-    const result = await proxy.find([] as any);
-    expect(Array.isArray(result) ? result.length : -1).toBe(0);
+    await expect(proxy.find([] as any)).rejects.toThrow(/empty list of ids/);
   });
 
   it("trying to use inverses that dont exist should raise an error", async () => {

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -499,7 +499,11 @@ describe("InverseHasManyTests", () => {
     const { Man } = makeModels();
     const m = await Man.create({ name: "Gordon" });
     const proxy = association(m, "interests");
+    // Both shapes raise the same "empty list of ids" contract:
+    //   find([])   — explicit empty array
+    //   find()     — zero args (Relation.find normalizes to id=[])
     await expect(proxy.find([] as any)).rejects.toThrow(/empty list of ids/);
+    await expect((proxy as any).find()).rejects.toThrow(/empty list of ids/);
   });
 
   it("trying to use inverses that dont exist should raise an error", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #643 (CollectionProxy extends Relation). The four `@ts-expect-error` markers on `first` / `last` / `take` / `find` flagged signature divergence — Relation has overloaded or unknown-typed versions, CP had flattened/narrowed ones. Resolve by adding the missing overloads; the association-cache behavior via `this.toArray()` is preserved unchanged.

- `first()` now also accepts `n` → `Promise<T[]>`.
- `last()` same — n-arg returns the tail slice.
- `take()` overload-split into `()` → `T | null` and `(n)` → `T[]`.
- `find()` widened to Relation's `(ids[])` / `(id)` / `(...ids)` signature; single-id returns `T`, array-form returns `T[]`.

**Not** included in this PR: the other 13 `@ts-expect-error` markers (`load`, `count`, `pluck`, `pick`, `delete`, `destroy`, `isNone`, `destroyAll`, `deleteAll`, `calculate`, `sum`/`avg`/`min`/`max`, interface declaration-merge). Each of those guards real association semantics — association cache integration, target mutation, strict-loading gate, through/nullify delete strategies — that can't be dropped without regressing behavior. The markers on those are the correct signal that CP intentionally diverges.

## Test plan

- [x] `pnpm build` / `pnpm typecheck` clean
- [x] `pnpm exec vitest run packages/activerecord` — 8700 passed, 0 failed

Marker count: 17 → 13.