### PR TITLE
refactor(activerecord): column subclasses + NestedError inherit parents (+4 inheritance)

### DIFF
--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -1,23 +1,41 @@
-import type { Base } from "../base.js";
+import { NestedError as ActiveModelNestedError } from "@blazetrails/activemodel";
+
+interface AssociationLike {
+  owner: unknown;
+  reflection: { name: string };
+  isCollection?(): boolean;
+  target?: unknown[];
+  options?: Record<string, unknown>;
+}
+
+interface InnerErrorLike {
+  attribute: string;
+  type: string;
+  rawType?: string;
+  message: string;
+  options?: Record<string, unknown>;
+  base?: unknown;
+}
 
 /**
- * Wraps validation errors from nested associations, providing
- * the inner error and the association that caused it.
+ * Wraps validation errors from nested associations.
  *
  * Mirrors: ActiveRecord::Associations::NestedError
  */
-export class NestedError {
-  readonly attribute: string;
-  readonly innerError: Error;
-  readonly record: Base;
+export class NestedError extends ActiveModelNestedError {
+  private readonly association: AssociationLike;
 
-  constructor(record: Base, innerError: Error, attribute: string) {
-    this.record = record;
-    this.innerError = innerError;
-    this.attribute = attribute;
+  constructor(association: AssociationLike, innerError: InnerErrorLike) {
+    const attribute = NestedError.computeAttribute(association, innerError);
+    super(association.owner, innerError, { attribute });
+    this.association = association;
   }
 
-  get message(): string {
-    return this.innerError.message;
+  private static computeAttribute(
+    association: AssociationLike,
+    innerError: InnerErrorLike,
+  ): string {
+    const name = association.reflection.name;
+    return `${name}.${innerError.attribute}`;
   }
 }

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -5,7 +5,7 @@ interface AssociationLike {
   reflection: { name: string };
   isCollection?(): boolean;
   target?: unknown[];
-  options?: Record<string, unknown>;
+  options?: { indexErrors?: boolean };
 }
 
 interface InnerErrorLike {
@@ -18,12 +18,14 @@ interface InnerErrorLike {
 }
 
 /**
- * Wraps validation errors from nested associations.
+ * Wraps validation errors from nested associations, rewriting the
+ * attribute so it reads as `association.attr` (or `association[i].attr`
+ * when `index_errors` is enabled on a collection association).
  *
  * Mirrors: ActiveRecord::Associations::NestedError
  */
 export class NestedError extends ActiveModelNestedError {
-  private readonly association: AssociationLike;
+  readonly association: AssociationLike;
 
   constructor(association: AssociationLike, innerError: InnerErrorLike) {
     const attribute = NestedError.computeAttribute(association, innerError);
@@ -36,6 +38,13 @@ export class NestedError extends ActiveModelNestedError {
     innerError: InnerErrorLike,
   ): string {
     const name = association.reflection.name;
+    const isCollection = association.isCollection?.() ?? false;
+    if (isCollection && association.options?.indexErrors) {
+      const index = association.target?.findIndex((r) => r === innerError.base);
+      if (index != null && index >= 0) {
+        return `${name}[${index}].${innerError.attribute}`;
+      }
+    }
     return `${name}.${innerError.attribute}`;
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -11,9 +11,9 @@ export interface ColumnInfo {
   primaryKey?: boolean;
   null?: boolean;
   default?: unknown;
-  limit?: number;
-  precision?: number;
-  scale?: number;
+  limit?: number | null;
+  precision?: number | null;
+  scale?: number | null;
 }
 
 export interface IndexInfo {

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -4,14 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Column
  */
 
-export class Column {
-  readonly name: string;
-  readonly sqlType: string | null;
-  readonly null: boolean;
-  readonly default: unknown;
-  readonly defaultFunction: string | null;
-  readonly collation: string | null;
-  readonly primaryKey: boolean;
+import { Column as BaseColumn } from "../column.js";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
+
+export class Column extends BaseColumn {
   readonly unsigned: boolean;
   readonly autoIncrement: boolean;
   readonly virtual: boolean;
@@ -30,13 +26,15 @@ export class Column {
       virtual?: boolean;
     } = {},
   ) {
-    this.name = name;
-    this.default = defaultValue;
-    this.sqlType = sqlTypeMetadata.sqlType ?? null;
-    this.null = null_;
-    this.collation = options.collation ?? null;
-    this.defaultFunction = options.defaultFunction ?? null;
-    this.primaryKey = options.primaryKey ?? false;
+    const meta = new SqlTypeMetadata({
+      sqlType: sqlTypeMetadata.sqlType ?? undefined,
+      type: sqlTypeMetadata.type,
+    });
+    super(name, defaultValue, meta, null_, {
+      collation: options.collation,
+      defaultFunction: options.defaultFunction,
+      primaryKey: options.primaryKey,
+    });
     this.unsigned = options.unsigned ?? false;
     this.autoIncrement = options.autoIncrement ?? false;
     this.virtual = options.virtual ?? false;

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -40,10 +40,6 @@ export class Column extends BaseColumn {
     this.virtual = options.virtual ?? false;
   }
 
-  get hasDefault(): boolean {
-    return this.default != null || this.defaultFunction != null;
-  }
-
   isUnsigned(): boolean {
     return this.unsigned;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -4,14 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Column
  */
 
-export class Column {
-  readonly name: string;
-  readonly sqlType: string | null;
-  readonly null: boolean;
-  readonly default: unknown;
-  readonly defaultFunction: string | null;
-  readonly collation: string | null;
-  readonly primaryKey: boolean;
+import { Column as BaseColumn } from "../column.js";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
+
+export class Column extends BaseColumn {
   readonly serial: boolean;
   readonly oid: number | null;
   readonly fmod: number | null;
@@ -30,13 +26,15 @@ export class Column {
       array?: boolean;
     } = {},
   ) {
-    this.name = name;
-    this.default = defaultValue;
-    this.sqlType = sqlTypeMetadata.sqlType ?? null;
-    this.null = null_;
-    this.collation = options.collation ?? null;
-    this.defaultFunction = options.defaultFunction ?? null;
-    this.primaryKey = options.primaryKey ?? false;
+    const meta = new SqlTypeMetadata({
+      sqlType: sqlTypeMetadata.sqlType ?? undefined,
+      type: sqlTypeMetadata.type,
+    });
+    super(name, defaultValue, meta, null_, {
+      collation: options.collation,
+      defaultFunction: options.defaultFunction,
+      primaryKey: options.primaryKey,
+    });
     this.serial = options.serial ?? false;
     this.oid = sqlTypeMetadata.oid ?? null;
     this.fmod = sqlTypeMetadata.fmod ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -41,12 +41,8 @@ export class Column extends BaseColumn {
     this.array = options.array ?? this.sqlType?.endsWith("[]") ?? false;
   }
 
-  get type(): string {
+  override get type(): string {
     return this.sqlType ?? "";
-  }
-
-  get hasDefault(): boolean {
-    return this.default != null || this.defaultFunction != null;
   }
 
   get isSerial(): boolean {

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -4,16 +4,13 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Column
  */
 
-export class Column {
-  readonly name: string;
-  readonly sqlType: string | null;
-  readonly null: boolean;
-  readonly default: unknown;
-  readonly defaultFunction: string | null;
-  readonly collation: string | null;
-  readonly primaryKey: boolean;
+import { Column as BaseColumn } from "../column.js";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
+
+export class Column extends BaseColumn {
   readonly autoIncrement: boolean;
   readonly rowid: boolean;
+  private _generatedType: "stored" | "virtual" | null;
 
   constructor(
     name: string,
@@ -29,19 +26,19 @@ export class Column {
       generatedType?: "stored" | "virtual" | null;
     } = {},
   ) {
-    this.name = name;
-    this.default = defaultValue;
-    this.sqlType = sqlTypeMetadata.sqlType ?? null;
-    this.null = null_;
-    this.collation = options.collation ?? null;
-    this.defaultFunction = options.defaultFunction ?? null;
-    this.primaryKey = options.primaryKey ?? false;
+    const meta = new SqlTypeMetadata({
+      sqlType: sqlTypeMetadata.sqlType ?? undefined,
+      type: sqlTypeMetadata.type,
+    });
+    super(name, defaultValue, meta, null_, {
+      collation: options.collation,
+      defaultFunction: options.defaultFunction,
+      primaryKey: options.primaryKey,
+    });
     this.autoIncrement = options.autoIncrement ?? false;
     this.rowid = options.rowid ?? false;
     this._generatedType = options.generatedType ?? null;
   }
-
-  private _generatedType: "stored" | "virtual" | null;
 
   get hasDefault(): boolean {
     return this.default !== null || this.defaultFunction !== null;

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -40,10 +40,6 @@ export class Column extends BaseColumn {
     this._generatedType = options.generatedType ?? null;
   }
 
-  get hasDefault(): boolean {
-    return this.default !== null || this.defaultFunction !== null;
-  }
-
   isAutoIncrementedByDb(): boolean {
     return this.autoIncrement || this.rowid;
   }


### PR DESCRIPTION
## Summary
- PG / MySQL / SQLite3 `Column` subclasses now extend the base `Column`, delegating shared state to `super` and keeping only subclass-specific fields
- `ActiveRecord::Associations::NestedError` now extends `ActiveModel::NestedError`, matching Rails' hierarchy and taking `(association, innerError)`
- Widens `ColumnInfo.{limit,precision,scale}` to `number | null` to match the base `Column` getters now inherited by the subclasses

Lifts activerecord inheritance from **89.5% → 91.4%** (188/210 → 192/210).

## Test plan
- [x] `pnpm -F @blazetrails/activerecord exec tsc --noEmit` clean
- [x] column / postgresql-adapter / sqlite3-adapter / schema-cache test files pass
- [x] `pnpm run api:compare` reports 4 fewer inheritance mismatches