### PR TITLE
refactor(activerecord): extract thin query delegators from Base to Querying

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1377,19 +1377,6 @@ export class Base extends Model {
   }
 
   /**
-   * Shorthand for all().from(source).
-   *
-   * Mirrors: ActiveRecord::Base.from
-   */
-  static from<T extends typeof Base>(
-    this: T,
-    source: string | Relation<any>,
-    subqueryName?: string,
-  ): Relation<InstanceType<T>> {
-    return this.all().from(source, subqueryName);
-  }
-
-  /**
    * Shorthand for all().where(conditions).
    *
    * Mirrors: ActiveRecord::Base.where
@@ -1834,108 +1821,6 @@ export class Base extends Model {
   }
 
   /**
-   * Scope: SELECT specific columns.
-   *
-   * Mirrors: ActiveRecord::Base.select
-   */
-  static select(...columns: string[]) {
-    return this.all().select(...columns);
-  }
-
-  /**
-   * Scope: ORDER BY.
-   *
-   * Mirrors: ActiveRecord::Base.order
-   */
-  static order(...args: Array<string | Record<string, "asc" | "desc">>) {
-    return this.all().order(...args);
-  }
-
-  /**
-   * Scope: GROUP BY.
-   *
-   * Mirrors: ActiveRecord::Base.group
-   */
-  static group(...columns: string[]) {
-    return this.all().group(...columns);
-  }
-
-  /**
-   * Scope: LIMIT.
-   *
-   * Mirrors: ActiveRecord::Base.limit
-   */
-  static limit(value: number | null) {
-    return this.all().limit(value);
-  }
-
-  /**
-   * Scope: OFFSET.
-   *
-   * Mirrors: ActiveRecord::Base.offset
-   */
-  static offset(value: number) {
-    return this.all().offset(value);
-  }
-
-  /**
-   * Scope: DISTINCT.
-   *
-   * Mirrors: ActiveRecord::Base.distinct
-   */
-  static distinct<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
-    return this.all().distinct();
-  }
-
-  /**
-   * Scope: JOIN.
-   *
-   * Mirrors: ActiveRecord::Base.joins
-   */
-  static joins<T extends typeof Base>(
-    this: T,
-    tableOrSql?: string,
-    on?: string,
-  ): Relation<InstanceType<T>> {
-    return this.all().joins(tableOrSql, on);
-  }
-
-  /**
-   * Scope: LEFT OUTER JOIN.
-   *
-   * Mirrors: ActiveRecord::Base.left_joins
-   */
-  static leftJoins<T extends typeof Base>(
-    this: T,
-    table: string,
-    on?: string,
-  ): Relation<InstanceType<T>> {
-    return this.all().leftJoins(table, on);
-  }
-
-  /**
-   * Scope: add a LEFT OUTER JOIN.
-   *
-   * Mirrors: ActiveRecord::Base.left_outer_joins
-   */
-  static leftOuterJoins<T extends typeof Base>(
-    this: T,
-    table?: string,
-    on?: string,
-  ): Relation<InstanceType<T>> {
-    return this.all().leftOuterJoins(table, on);
-  }
-
-  /**
-   * Scope: return an empty relation.
-   *
-   * Mirrors: ActiveRecord::Base.none
-   */
-  static none<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
-    return this.all().none();
-  }
-
-  /**
    * Find the first record matching conditions, or create one.
    *
    * Mirrors: ActiveRecord::Base.find_or_create_by
@@ -2057,6 +1942,17 @@ export class Base extends Model {
   declare static asyncFindBySql: typeof Querying.asyncFindBySql;
   declare static countBySql: typeof Querying.countBySql;
   declare static asyncCountBySql: typeof Querying.asyncCountBySql;
+  declare static from: typeof Querying.from;
+  declare static select: typeof Querying.select;
+  declare static order: typeof Querying.order;
+  declare static group: typeof Querying.group;
+  declare static limit: typeof Querying.limit;
+  declare static offset: typeof Querying.offset;
+  declare static distinct: typeof Querying.distinct;
+  declare static joins: typeof Querying.joins;
+  declare static leftJoins: typeof Querying.leftJoins;
+  declare static leftOuterJoins: typeof Querying.leftOuterJoins;
+  declare static none: typeof Querying.none;
 
   /**
    * Increment counter columns for a record by primary key.

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -7,6 +7,7 @@
 
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
+import type { Relation } from "./relation.js";
 import { sanitizeSql } from "./sanitization.js";
 
 /**
@@ -107,4 +108,82 @@ export function _loadFromSql<T extends typeof Base>(
   );
   if (block) records.forEach(block);
   return records;
+}
+
+// ---------------------------------------------------------------------------
+// Thin static delegators to `all()` — Rails' `Querying::QUERYING_METHODS`
+// list. Each forwards to the default relation, matching Rails' `delegate(...,
+// to: :all)`.
+// ---------------------------------------------------------------------------
+
+export function from<T extends typeof Base>(
+  this: T,
+  source: string | Relation<any>,
+  subqueryName?: string,
+): Relation<InstanceType<T>> {
+  return this.all().from(source, subqueryName);
+}
+
+export function select<T extends typeof Base>(
+  this: T,
+  ...columns: string[]
+): Relation<InstanceType<T>> {
+  return this.all().select(...columns);
+}
+
+export function order<T extends typeof Base>(
+  this: T,
+  ...args: Array<string | Record<string, "asc" | "desc">>
+): Relation<InstanceType<T>> {
+  return this.all().order(...args);
+}
+
+export function group<T extends typeof Base>(
+  this: T,
+  ...columns: string[]
+): Relation<InstanceType<T>> {
+  return this.all().group(...columns);
+}
+
+export function limit<T extends typeof Base>(
+  this: T,
+  value: number | null,
+): Relation<InstanceType<T>> {
+  return this.all().limit(value);
+}
+
+export function offset<T extends typeof Base>(this: T, value: number): Relation<InstanceType<T>> {
+  return this.all().offset(value);
+}
+
+export function distinct<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
+  return this.all().distinct();
+}
+
+export function joins<T extends typeof Base>(
+  this: T,
+  tableOrSql?: string,
+  on?: string,
+): Relation<InstanceType<T>> {
+  return this.all().joins(tableOrSql, on);
+}
+
+export function leftJoins<T extends typeof Base>(
+  this: T,
+  table: string,
+  on?: string,
+): Relation<InstanceType<T>> {
+  return this.all().leftJoins(table, on);
+}
+
+export function leftOuterJoins<T extends typeof Base>(
+  this: T,
+  table?: string,
+  on?: string,
+): Relation<InstanceType<T>> {
+  return this.all().leftOuterJoins(table, on);
+}
+
+export function none<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
+  return this.all().none();
 }

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -112,10 +112,12 @@ export function _loadFromSql<T extends typeof Base>(
 
 // ---------------------------------------------------------------------------
 // Thin static delegators to `all()` — Rails' `Querying::QUERYING_METHODS`
-// list. Each forwards to the default relation, matching Rails' `delegate(...,
-// to: :all)`.
+// list, delegated via `delegate(*QUERYING_METHODS, to: :all)`. Each forwards
+// to the default relation, so calling `Model.where(...)` is equivalent to
+// `Model.all.where(...)`.
 // ---------------------------------------------------------------------------
 
+/** Mirrors: ActiveRecord::Querying#from */
 export function from<T extends typeof Base>(
   this: T,
   source: string | Relation<any>,
@@ -124,6 +126,7 @@ export function from<T extends typeof Base>(
   return this.all().from(source, subqueryName);
 }
 
+/** Mirrors: ActiveRecord::Querying#select */
 export function select<T extends typeof Base>(
   this: T,
   ...columns: string[]
@@ -131,6 +134,7 @@ export function select<T extends typeof Base>(
   return this.all().select(...columns);
 }
 
+/** Mirrors: ActiveRecord::Querying#order */
 export function order<T extends typeof Base>(
   this: T,
   ...args: Array<string | Record<string, "asc" | "desc">>
@@ -138,6 +142,7 @@ export function order<T extends typeof Base>(
   return this.all().order(...args);
 }
 
+/** Mirrors: ActiveRecord::Querying#group */
 export function group<T extends typeof Base>(
   this: T,
   ...columns: string[]
@@ -145,6 +150,7 @@ export function group<T extends typeof Base>(
   return this.all().group(...columns);
 }
 
+/** Mirrors: ActiveRecord::Querying#limit */
 export function limit<T extends typeof Base>(
   this: T,
   value: number | null,
@@ -152,14 +158,17 @@ export function limit<T extends typeof Base>(
   return this.all().limit(value);
 }
 
+/** Mirrors: ActiveRecord::Querying#offset */
 export function offset<T extends typeof Base>(this: T, value: number): Relation<InstanceType<T>> {
   return this.all().offset(value);
 }
 
+/** Mirrors: ActiveRecord::Querying#distinct */
 export function distinct<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
   return this.all().distinct();
 }
 
+/** Mirrors: ActiveRecord::Querying#joins */
 export function joins<T extends typeof Base>(
   this: T,
   tableOrSql?: string,
@@ -168,6 +177,7 @@ export function joins<T extends typeof Base>(
   return this.all().joins(tableOrSql, on);
 }
 
+/** Mirrors: ActiveRecord::Querying#left_joins */
 export function leftJoins<T extends typeof Base>(
   this: T,
   table: string,
@@ -176,6 +186,7 @@ export function leftJoins<T extends typeof Base>(
   return this.all().leftJoins(table, on);
 }
 
+/** Mirrors: ActiveRecord::Querying#left_outer_joins */
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
   table?: string,
@@ -184,6 +195,7 @@ export function leftOuterJoins<T extends typeof Base>(
   return this.all().leftOuterJoins(table, on);
 }
 
+/** Mirrors: ActiveRecord::Querying#none */
 export function none<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
   return this.all().none();
 }


### PR DESCRIPTION
## Summary
First step of the Base → Rails-module extraction plan. Moves 11 thin static chain delegators (`from`, `select`, `order`, `group`, `limit`, `offset`, `distinct`, `joins`, `leftJoins`, `leftOuterJoins`, `none`) out of `base.ts` and into `querying.ts` as `this`-typed functions. Each is now declared on `Base` via `declare static` + wired through the existing `extend(Base, Querying)` call — mirroring Rails' `Querying#QUERYING_METHODS` delegating to `:all`.

Pure delegation. No behavior change, no signature change (types preserved via `typeof Querying.foo`).

`where` / `whereNot` stay inlined in `base.ts` for now — they carry abstract-class and composite-key guards that deserve their own PR.

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17729 tests)
- [x] `base.ts` shrinks by ~120 lines