### PR TITLE
feat(activerecord): DJAR composite-key tuple grouping + IN-list reorder

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -269,6 +269,12 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         ? [1]
         : [];
     if (finalOrders.length === 0 && ordered) {
+      // If PredicateBuilder.buildComposite short-circuited to
+      // `Relation#none()` (empty tuples / all-null components), the
+      // scope is already a never-match. Skip the wrap: the fresh DJAR
+      // would only copy `_whereClause.predicates` and lose `_isNone`,
+      // causing a full-table SELECT instead of an empty result.
+      if ((scope as { _isNone?: boolean })._isNone) return scope;
       // Loaded-chain wrap: DJAR loads via SQL, then re-groups by the
       // join key and re-emits in `ids` order so callers see the
       // through-table ordering (SQL `IN(...)` / composite OR-of-AND

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -269,28 +269,21 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         ? [1]
         : [];
     if (finalOrders.length === 0 && ordered) {
-      // DJAR's loaded-chain wrap groups records by `key` (single
-      // string) and re-emits in `ids` order. For composite keys this
-      // would need tuple grouping (out of scope for this PR — see
-      // task #10). Skip the wrap for composite; records still load
-      // correctly via the composite-key `where` constraint built
-      // above (an Arel OR-of-AND from PredicateBuilder.buildComposite),
-      // just without the through-table-order reorder. Single-column
-      // case keeps the wrap.
-      if (keyCols.length === 1) {
-        const split = new DisableJoinsAssociationRelation<Base>(
-          klass,
-          keyCols[0],
-          joinIds as unknown[],
-        );
-        const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
-        const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
-          ._whereClause;
-        if (sourceWhere?.predicates && splitWhere) {
-          splitWhere.predicates.push(...sourceWhere.predicates);
-        }
-        return split;
+      // Loaded-chain wrap: DJAR loads via SQL, then re-groups by the
+      // join key and re-emits in `ids` order so callers see the
+      // through-table ordering (SQL `IN(...)` / composite OR-of-AND
+      // don't preserve list order). Both single-column and composite
+      // keys are supported — DJAR serializes tuples for Map identity
+      // so `[1, 100]` buckets collide as expected.
+      const splitKey: string | string[] = keyCols.length === 1 ? keyCols[0] : keyCols;
+      const split = new DisableJoinsAssociationRelation<Base>(klass, splitKey, joinIds);
+      const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
+      const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
+        ._whereClause;
+      if (sourceWhere?.predicates && splitWhere) {
+        splitWhere.predicates.push(...sourceWhere.predicates);
       }
+      return split;
     }
     return scope;
   }

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -274,7 +274,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // scope is already a never-match. Skip the wrap: the fresh DJAR
       // would only copy `_whereClause.predicates` and lose `_isNone`,
       // causing a full-table SELECT instead of an empty result.
-      if ((scope as { _isNone?: boolean })._isNone) return scope;
+      if ((scope as { isNone: () => boolean }).isNone()) return scope;
       // Loaded-chain wrap: DJAR loads via SQL, then re-groups by the
       // join key and re-emits in `ids` order so callers see the
       // through-table ordering (SQL `IN(...)` / composite OR-of-AND

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -281,8 +281,13 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // don't preserve list order). Both single-column and composite
       // keys are supported — DJAR serializes tuples for Map identity
       // so `[1, 100]` buckets collide as expected.
-      const splitKey: string | string[] = keyCols.length === 1 ? keyCols[0] : keyCols;
-      const split = new DisableJoinsAssociationRelation<Base>(klass, splitKey, joinIds);
+      // Branch over key arity so we hit DJAR's correlated overloads.
+      // At this point `joinIds` is already shape-matched to `keyCols`
+      // by the single-vs-composite branches in `_addConstraintsDj`.
+      const split =
+        keyCols.length === 1
+          ? new DisableJoinsAssociationRelation<Base>(klass, keyCols[0], joinIds as unknown[])
+          : new DisableJoinsAssociationRelation<Base>(klass, keyCols, joinIds as unknown[][]);
       const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
       const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
         ._whereClause;

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -271,9 +271,67 @@ describe("DJAS — composite key support", () => {
       ],
     );
     expect(await djar.ids()).toEqual([[1n, 100n]]);
-    // Records set is empty (no DB hit needed) — what we're pinning is
-    // that construction + ids() don't throw on bigint components.
+    // The empty result matters less than the fact that bigint tuple
+    // components don't make construction, ids(), or toArray() throw.
     await expect(djar.toArray()).resolves.toEqual([]);
+  });
+
+  it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {
+    // Fail-fast on caller bugs. Without the guard, a flat scalar list
+    // would silently dedupe to "one bucket per scalar" and reorder to
+    // nothing.
+    expect(
+      () =>
+        new DisableJoinsAssociationRelation(CkLineItem, ["ck_order_shop_id", "ck_order_number"], [
+          1, 2, 3,
+        ] as any),
+    ).toThrow(/must be an array/);
+    expect(
+      () =>
+        new DisableJoinsAssociationRelation(CkLineItem, ["ck_order_shop_id", "ck_order_number"], [
+          [1, 2, 3],
+        ] as any),
+    ).toThrow(/arity/);
+  });
+
+  it("composite-key + ordered upstream + empty through: preserves none() instead of full table scan", async () => {
+    // Regression: when PredicateBuilder.buildComposite short-circuits
+    // to `Relation#none()` (empty tuples / all-null), the DJAR wrap
+    // would previously copy `_whereClause.predicates` but drop
+    // `_isNone`, producing a full-table SELECT. The scope itself is
+    // already a never-match, so DJAS now returns it directly.
+    Associations.hasMany.call(CkShop, "ckOrdersOrdered2", {
+      className: "CkOrder",
+      foreignKey: "shop_id",
+      scope: (rel: any) => rel.order("name"),
+    });
+    Associations.hasMany.call(CkShop, "ckLineItemsEmpty", {
+      className: "CkLineItem",
+      through: "ckOrdersOrdered2",
+      source: "ckLineItems",
+      disableJoins: true,
+    });
+    const shop = await CkShop.create({ name: "S" });
+    // No orders — through step plucks nothing, final step gets
+    // composite `where([...], [])` which PredicateBuilder resolves to
+    // none().
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string" && /\bFROM\b\s+["`]?ck_line_items\b/i.test(sql)) {
+        observed.push(sql);
+      }
+    });
+    try {
+      const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsEmpty");
+      const items = await loadHasMany(shop, "ckLineItemsEmpty", reflection.options);
+      expect(items).toEqual([]);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    // The none() short-circuit means no SELECT against ck_line_items
+    // at all. A full-table scan (regression) would show at least one.
+    expect(observed).toEqual([]);
   });
 
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -231,23 +231,22 @@ describe("DJAS — composite key support", () => {
     // ordering. Without tuple dedupe + grouping, the duplicate would
     // double-count or the Map would bucket by reference and miss
     // both records.
-    const djar = new DisableJoinsAssociationRelation(
-      CkLineItem,
-      ["ck_order_shop_id", "ck_order_number"],
-      [
-        [shop.id, 200],
-        [shop.id, 100],
-        [shop.id, 200],
-      ],
-    );
-    (djar as any)._whereClause.predicates.push(
-      ...(CkLineItem as any).where(
+    const djar = (
+      new DisableJoinsAssociationRelation(
+        CkLineItem,
         ["ck_order_shop_id", "ck_order_number"],
         [
+          [shop.id, 200],
           [shop.id, 100],
           [shop.id, 200],
         ],
-      )._whereClause.predicates,
+      ) as any
+    ).where(
+      ["ck_order_shop_id", "ck_order_number"],
+      [
+        [shop.id, 100],
+        [shop.id, 200],
+      ],
     );
     const loaded = await djar.toArray();
     expect(loaded.map((r: any) => r.sku)).toEqual(["lb", "la"]);

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -309,6 +309,16 @@ describe("DJAS — composite key support", () => {
     expect(() => new DisableJoinsAssociationRelation(CkLineItem, "sku", [[1], [2]] as any)).toThrow(
       /must not be an array/,
     );
+
+    // Non-array `ids` via dynamic erasure — without the early guard
+    // `.map` / `.length` below would throw a generic TypeError or
+    // silently store zero ids.
+    expect(
+      () => new DisableJoinsAssociationRelation(CkLineItem, "sku", new Set(["a"]) as any),
+    ).toThrow(/ids must be an array/);
+    expect(() => new DisableJoinsAssociationRelation(CkLineItem, "sku", null as any)).toThrow(
+      /ids must be an array/,
+    );
   });
 
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -291,6 +291,17 @@ describe("DJAS — composite key support", () => {
     const djarTuples = new DisableJoinsAssociationRelation(CkLineItem, ["sku"], [["a"], ["b"]]);
     expect(djarTuples.key).toBe("sku");
     expect(await djarTuples.ids()).toEqual(["a", "b"]);
+
+    // A non-singleton tuple under a length-1 key is a caller bug —
+    // without the guard it would silently route through the scalar
+    // path with an array id that can never match scalar record
+    // attributes, dropping all loaded records. Fail fast.
+    expect(
+      () =>
+        new DisableJoinsAssociationRelation(CkLineItem, ["sku"], [
+          [1, 2],
+        ] as unknown as unknown[][]),
+    ).toThrow(/single-element array/);
   });
 
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -284,6 +284,13 @@ describe("DJAS — composite key support", () => {
     expect(() => new DisableJoinsAssociationRelation(CkLineItem, [] as any, [])).toThrow(
       /at least one column/,
     );
+    // Empty-string key in loaded-chain mode would make
+    // readAttribute("") return null and silently empty the reorder.
+    // `deferred()` uses "" as a placeholder so the guard only fires
+    // when no chainWalker is present.
+    expect(() => new DisableJoinsAssociationRelation(CkLineItem, "", [1])).toThrow(
+      /key must not be empty/,
+    );
     // length 1 is equivalent to the string form; normalize so
     // `this.key` / `_composite` stay consistent with the scalar path.
     // The correlated overloads pair `string[]` with `unknown[][]`, so

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -257,6 +257,25 @@ describe("DJAS — composite key support", () => {
     ]);
   });
 
+  it("DisableJoinsAssociationRelation composite-key load: bigint tuple components don't crash serialization", async () => {
+    // Regression: `big_integer`-cast PKs produce bigints, and
+    // JSON.stringify throws on bigint. The serializer must normalize
+    // them before hashing so composite-key dedupe/group-by can't
+    // crash when a tuple component is a bigint.
+    const djar = new DisableJoinsAssociationRelation(
+      CkLineItem,
+      ["ck_order_shop_id", "ck_order_number"],
+      [
+        [1n, 100n],
+        [1n, 100n],
+      ],
+    );
+    expect(await djar.ids()).toEqual([[1n, 100n]]);
+    // Records set is empty (no DB hit needed) — what we're pinning is
+    // that construction + ids() don't throw on bigint components.
+    await expect(djar.toArray()).resolves.toEqual([]);
+  });
+
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
     const shop = await CkShop.create({ name: "Lonely" });
     // No orders for this shop → through-records pluck yields [] →

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -124,12 +124,15 @@ describe("DJAS — composite key support", () => {
     expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 
-  it("composite-key + ordered upstream: DJAR wrap reorders records by through-table tuple order", async () => {
-    // DJAR's loaded-chain wrap now supports composite keys via
-    // serialized tuple grouping. When the through-step is ordered
-    // (upstream `.order("name")` yields orderA before orderB), the
-    // source step's records re-emit in that tuple order regardless
-    // of the DB's own insertion / default order.
+  it("composite-key + ordered upstream: skips DJAR wrap (records load via composite-key WHERE, no in-list reorder)", async () => {
+    // NOTE: the test name is preserved from PR #645 (test names are
+    // an identifier in this repo — `test:compare` uses them to match
+    // against Rails). The body now asserts the *new* behavior: the
+    // loaded-chain DJAR wrap supports composite keys via serialized
+    // tuple grouping, so when the through-step is ordered (upstream
+    // `.order("name")` yields orderA before orderB) the source
+    // step's records re-emit in that tuple order regardless of the
+    // DB's own insertion / default order.
     Associations.hasMany.call(CkShop, "ckOrdersOrdered", {
       className: "CkOrder",
       foreignKey: "shop_id",
@@ -319,6 +322,21 @@ describe("DJAS — composite key support", () => {
     expect(() => new DisableJoinsAssociationRelation(CkLineItem, "sku", null as any)).toThrow(
       /ids must be an array/,
     );
+
+    // ids() returns a defensive copy — caller mutation of the
+    // returned list or its tuples must not desync the internal
+    // `_storedKeyStrings` cache (which the load-time reorder uses).
+    const djar = new DisableJoinsAssociationRelation(
+      CkLineItem,
+      ["ck_order_shop_id", "ck_order_number"],
+      [[1, 100]],
+    );
+    const returned = (await djar.ids()) as unknown[][];
+    returned.push([999, 999]);
+    (returned[0] as unknown[])[1] = 42;
+    // Second call sees the original — mutation didn't leak into
+    // the DJAR's internal state.
+    expect(await djar.ids()).toEqual([[1, 100]]);
   });
 
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -276,6 +276,19 @@ describe("DJAS — composite key support", () => {
     await expect(djar.toArray()).resolves.toEqual([]);
   });
 
+  it("DisableJoinsAssociationRelation key normalization: empty array throws, single-element array collapses to string", async () => {
+    // length 0 is always a bug — the load/reorder path would call
+    // readAttribute(undefined) and misbehave.
+    expect(() => new DisableJoinsAssociationRelation(CkLineItem, [] as any, [])).toThrow(
+      /at least one column/,
+    );
+    // length 1 is equivalent to the string form; normalize so
+    // `this.key` / `_composite` stay consistent with the scalar path.
+    const djar = new DisableJoinsAssociationRelation(CkLineItem, ["sku"], ["a", "b"]);
+    expect(djar.key).toBe("sku");
+    expect(await djar.ids()).toEqual(["a", "b"]);
+  });
+
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {
     // Fail-fast on caller bugs. Without the guard, a flat scalar list
     // would silently dedupe to "one bucket per scalar" and reorder to

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -301,6 +301,14 @@ describe("DJAS — composite key support", () => {
           [1, 2],
         ] as unknown as unknown[][]),
     ).toThrow(/single-element array/);
+
+    // Scalar-key + tuple-ids via dynamic `any` erasure: Set dedup
+    // would keep arrays by reference and the Map lookup on load
+    // would never match a scalar record attribute, silently
+    // yielding an empty ordering. Guard fails fast instead.
+    expect(() => new DisableJoinsAssociationRelation(CkLineItem, "sku", [[1], [2]] as any)).toThrow(
+      /must not be an array/,
+    );
   });
 
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -123,13 +123,12 @@ describe("DJAS — composite key support", () => {
     expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 
-  it("composite-key + ordered upstream: skips DJAR wrap (records load via composite-key WHERE, no in-list reorder)", async () => {
-    // Document the trade-off: composite-key chains skip the loaded-
-    // chain DJAR wrap because DJAR's per-key group-by would need
-    // tuple grouping (out of scope for this PR). Records still load
-    // correctly via the composite-key WHERE; they just aren't re-ordered
-    // by through-table sequence. Future work could extend DJAR to
-    // group by tuple keys.
+  it("composite-key + ordered upstream: DJAR wrap reorders records by through-table tuple order", async () => {
+    // DJAR's loaded-chain wrap now supports composite keys via
+    // serialized tuple grouping. When the through-step is ordered
+    // (upstream `.order("name")` yields orderA before orderB), the
+    // source step's records re-emit in that tuple order regardless
+    // of the DB's own insertion / default order.
     Associations.hasMany.call(CkShop, "ckOrdersOrdered", {
       className: "CkOrder",
       foreignKey: "shop_id",
@@ -165,9 +164,9 @@ describe("DJAS — composite key support", () => {
 
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsOrdered");
     const items = await loadHasMany(shop, "ckLineItemsOrdered", reflection.options);
-    // Both records load. Order is DB-arbitrary (no reorder applied
-    // for composite + ordered-upstream); just assert presence.
-    expect(items.map((i: any) => i.sku).sort()).toEqual(["from-a", "from-b"]);
+    // orderA sorts before orderB by `name`, so the wrap yields
+    // `from-a` before `from-b` even though `from-b` was inserted first.
+    expect(items.map((i: any) => i.sku)).toEqual(["from-a", "from-b"]);
   });
 
   it("skips tuples containing null/undefined (matches SQL tuple-equality semantics, not Arel IS NULL)", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
+import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -201,6 +202,59 @@ describe("DJAS — composite key support", () => {
     // ck_order_number=NULL doesn't match the (shop_id=1, order_number=100)
     // tuple even though shop_id matches.
     expect(items.map((i: any) => i.sku)).toEqual(["valid"]);
+  });
+
+  it("DisableJoinsAssociationRelation composite-key load: dedupes tuples and reorders by ids on load", async () => {
+    const shop = await CkShop.create({ name: "S" });
+    const orderA = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 100,
+      name: "a",
+    })) as any;
+    const orderB = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 200,
+      name: "b",
+    })) as any;
+    await CkLineItem.create({
+      ck_order_shop_id: orderA.shop_id,
+      ck_order_number: orderA.order_number,
+      sku: "la",
+    });
+    await CkLineItem.create({
+      ck_order_shop_id: orderB.shop_id,
+      ck_order_number: orderB.order_number,
+      sku: "lb",
+    });
+
+    // Two independently-read `[shop.id, 200]` tuples + B-before-A
+    // ordering. Without tuple dedupe + grouping, the duplicate would
+    // double-count or the Map would bucket by reference and miss
+    // both records.
+    const djar = new DisableJoinsAssociationRelation(
+      CkLineItem,
+      ["ck_order_shop_id", "ck_order_number"],
+      [
+        [shop.id, 200],
+        [shop.id, 100],
+        [shop.id, 200],
+      ],
+    );
+    (djar as any)._whereClause.predicates.push(
+      ...(CkLineItem as any).where(
+        ["ck_order_shop_id", "ck_order_number"],
+        [
+          [shop.id, 100],
+          [shop.id, 200],
+        ],
+      )._whereClause.predicates,
+    );
+    const loaded = await djar.toArray();
+    expect(loaded.map((r: any) => r.sku)).toEqual(["lb", "la"]);
+    expect(await djar.ids()).toEqual([
+      [shop.id, 200],
+      [shop.id, 100],
+    ]);
   });
 
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -284,9 +284,13 @@ describe("DJAS — composite key support", () => {
     );
     // length 1 is equivalent to the string form; normalize so
     // `this.key` / `_composite` stay consistent with the scalar path.
-    const djar = new DisableJoinsAssociationRelation(CkLineItem, ["sku"], ["a", "b"]);
-    expect(djar.key).toBe("sku");
-    expect(await djar.ids()).toEqual(["a", "b"]);
+    // The correlated overloads pair `string[]` with `unknown[][]`, so
+    // the length-1 case is exercised through the tuple-ids route and
+    // the constructor's singleton-tuple flattening (`[[1], [2]]` →
+    // `[1, 2]`).
+    const djarTuples = new DisableJoinsAssociationRelation(CkLineItem, ["sku"], [["a"], ["b"]]);
+    expect(djarTuples.key).toBe("sku");
+    expect(await djarTuples.ids()).toEqual(["a", "b"]);
   });
 
   it("DisableJoinsAssociationRelation composite-key load: throws ArgumentError on shape/arity mismatch", async () => {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -91,9 +91,10 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   // Typed overloads keep `key`/`ids` correlated at the call site so
   // `new DJAR(..., "id", [[1, 2]])` (string key + tuple ids) or
   // `new DJAR(..., ["a", "b"], [1, 2])` (tuple key + scalar ids) are
-  // rejected at compile time. The implementation signature accepts
-  // the union, and the runtime guards below still cover dynamic
-  // callers that erase through `unknown`/`any`.
+  // rejected at compile time. Only the two correlated overloads are
+  // public — the broad `DjarKey`/`DjarIds` union stays on the
+  // implementation signature alone. Runtime guards in the body still
+  // cover dynamic callers that erase through `unknown` / `any`.
   constructor(
     klass: typeof Base,
     key: string,
@@ -111,24 +112,28 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     key: DjarKey,
     ids: DjarIds,
     chainWalker?: () => Promise<{ relation: Relation<T> }>,
-  );
-  constructor(
-    klass: typeof Base,
-    key: DjarKey,
-    ids: DjarIds,
-    chainWalker?: () => Promise<{ relation: Relation<T> }>,
   ) {
     super(klass);
     // Normalize array-key shapes: length 0 is always a bug; length 1
     // collapses to the string form so `this.key` / `_composite`
     // stay consistent with the scalar path (and `readAttribute`
-    // never gets `undefined`).
+    // never gets `undefined`). When we collapse a length-1 key, we
+    // also flatten singleton-tuple ids (`[[1], [2]]` → `[1, 2]`) so
+    // the caller's shape isn't silently incompatible with the scalar
+    // path they now route through — a tuple-typed overload call like
+    // `new DJAR(..., ["col"], [[1], [2]])` keeps working.
     let normalizedKey: DjarKey = key;
+    let normalizedIds: DjarIds = ids;
     if (Array.isArray(key)) {
       if (key.length === 0) {
         throw argumentError("DisableJoinsAssociationRelation: key must have at least one column");
       }
-      if (key.length === 1) normalizedKey = key[0];
+      if (key.length === 1) {
+        normalizedKey = key[0];
+        normalizedIds = (ids as unknown[]).map((id) =>
+          Array.isArray(id) && id.length === 1 ? id[0] : id,
+        );
+      }
     }
     this.key = normalizedKey;
     this._composite = Array.isArray(normalizedKey);
@@ -143,8 +148,8 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       const seen = new Set<string>();
       const out: unknown[][] = [];
       const keyStrings: string[] = [];
-      for (let i = 0; i < (ids as unknown[]).length; i++) {
-        const t = (ids as unknown[])[i];
+      for (let i = 0; i < (normalizedIds as unknown[]).length; i++) {
+        const t = (normalizedIds as unknown[])[i];
         // Fail fast on shape/arity mismatch. Without this, a flat
         // `unknown[]` slipping through as composite `ids` would
         // silently dedupe to "one bucket per scalar" and reorder to
@@ -169,7 +174,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       this._storedIds = out;
       this._storedKeyStrings = keyStrings;
     } else {
-      this._storedIds = Array.from(new Set(ids as unknown[]));
+      this._storedIds = Array.from(new Set(normalizedIds as unknown[]));
       this._storedKeyStrings = null;
     }
     this._chainWalker = chainWalker;
@@ -294,12 +299,23 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * spawn a plain Relation and silently drop the wrapping behavior.
    */
   protected override _newRelation(): Relation<T> {
-    return new DisableJoinsAssociationRelation<T>(
-      this.model,
-      this.key,
-      this._storedIds,
-      this._chainWalker,
-    ) as unknown as Relation<T>;
+    // Branch to route through the correlated overloads; `this.key` is
+    // already normalized in the constructor so the two shapes line up
+    // with `this._storedIds`.
+    const clone = this._composite
+      ? new DisableJoinsAssociationRelation<T>(
+          this.model,
+          this.key as string[],
+          this._storedIds as unknown[][],
+          this._chainWalker,
+        )
+      : new DisableJoinsAssociationRelation<T>(
+          this.model,
+          this.key as string,
+          this._storedIds as unknown[],
+          this._chainWalker,
+        );
+    return clone as unknown as Relation<T>;
   }
 
   override async toArray(): Promise<T[]> {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -34,14 +34,24 @@ export type DjarIds = unknown[] | unknown[][];
 /**
  * Stable Map key for both scalar and tuple join keys. Scalars are used
  * as-is (Map identity already works); tuples are serialized so
- * `[1, 100]` from two independent reads collides in the bucket. JSON
- * covers the primitive shapes pluck returns (number/string/null/bool).
- * A leading `\u0000T` marker makes tuple keys non-collidable with any
- * plausible scalar.
+ * `[1, 100]` from two independent reads collides in the bucket.
+ *
+ * JSON covers the primitive shapes pluck returns (number/string/
+ * null/bool), but `bigint` throws in `JSON.stringify` — the `big_integer`
+ * cast type produces bigints, and composite PKs on large tables are
+ * the exact case that hits them. Normalize bigints via a replacer
+ * (`"bigint:<decimal>"`) so a `123n` never collides with the string
+ * `"123"`. A leading `\u0000T` marker makes tuple keys
+ * non-collidable with any plausible scalar passed through this helper.
  */
 function serializeKey(v: unknown, composite: boolean): unknown {
   if (!composite) return v;
-  return "\u0000T" + JSON.stringify(v);
+  return (
+    "\u0000T" +
+    JSON.stringify(v, (_k, value) =>
+      typeof value === "bigint" ? `\u0000B${value.toString()}` : value,
+    )
+  );
 }
 
 export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T> {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -65,6 +65,12 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * by serialized tuple so two independently-read `[1, 100]`s
    * collapse. */
   private readonly _storedIds: DjarIds;
+  /** Serialized form of `_storedIds` for the composite path — computed
+   * once during constructor dedup so the load-time reorder loop can
+   * reuse it instead of re-running `JSON.stringify` on every tuple
+   * per `toArray()`. `null` for single-column keys (Map identity works
+   * directly on scalars). */
+  private readonly _storedKeyStrings: string[] | null;
   /** Whether `key` is composite (string[] with arity > 1). Derived at
    * construction; controls tuple-vs-scalar behavior in read/dedup/group. */
   private readonly _composite: boolean;
@@ -82,6 +88,30 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    */
   private _walkPromise?: Promise<{ relation: Relation<T> }>;
 
+  // Typed overloads keep `key`/`ids` correlated at the call site so
+  // `new DJAR(..., "id", [[1, 2]])` (string key + tuple ids) or
+  // `new DJAR(..., ["a", "b"], [1, 2])` (tuple key + scalar ids) are
+  // rejected at compile time. The implementation signature accepts
+  // the union, and the runtime guards below still cover dynamic
+  // callers that erase through `unknown`/`any`.
+  constructor(
+    klass: typeof Base,
+    key: string,
+    ids: unknown[],
+    chainWalker?: () => Promise<{ relation: Relation<T> }>,
+  );
+  constructor(
+    klass: typeof Base,
+    key: string[],
+    ids: unknown[][],
+    chainWalker?: () => Promise<{ relation: Relation<T> }>,
+  );
+  constructor(
+    klass: typeof Base,
+    key: DjarKey,
+    ids: DjarIds,
+    chainWalker?: () => Promise<{ relation: Relation<T> }>,
+  );
   constructor(
     klass: typeof Base,
     key: DjarKey,
@@ -89,16 +119,30 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     chainWalker?: () => Promise<{ relation: Relation<T> }>,
   ) {
     super(klass);
-    this.key = key;
-    this._composite = Array.isArray(key) && key.length > 1;
+    // Normalize array-key shapes: length 0 is always a bug; length 1
+    // collapses to the string form so `this.key` / `_composite`
+    // stay consistent with the scalar path (and `readAttribute`
+    // never gets `undefined`).
+    let normalizedKey: DjarKey = key;
+    if (Array.isArray(key)) {
+      if (key.length === 0) {
+        throw argumentError("DisableJoinsAssociationRelation: key must have at least one column");
+      }
+      if (key.length === 1) normalizedKey = key[0];
+    }
+    this.key = normalizedKey;
+    this._composite = Array.isArray(normalizedKey);
     // Scalar case: Set identity dedup matches Rails' `ids.uniq`.
     // Composite case: dedupe by serialized tuple so `[1, 100]` from
     // two owner rows collapses to one entry (Set-of-arrays would keep
-    // both by reference).
+    // both by reference). Cache the serialized forms so the load-time
+    // reorder doesn't re-run JSON.stringify.
     if (this._composite) {
-      const arity = (key as string[]).length;
+      const cols = normalizedKey as string[];
+      const arity = cols.length;
       const seen = new Set<string>();
       const out: unknown[][] = [];
+      const keyStrings: string[] = [];
       for (let i = 0; i < (ids as unknown[]).length; i++) {
         const t = (ids as unknown[])[i];
         // Fail fast on shape/arity mismatch. Without this, a flat
@@ -112,18 +156,21 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
         }
         if (t.length !== arity) {
           throw argumentError(
-            `DisableJoinsAssociationRelation: composite ids[${i}] arity ${t.length} does not match key [${(key as string[]).join(", ")}] (arity ${arity})`,
+            `DisableJoinsAssociationRelation: composite ids[${i}] arity ${t.length} does not match key [${cols.join(", ")}] (arity ${arity})`,
           );
         }
         const k = serializeKey(t, true) as string;
         if (!seen.has(k)) {
           seen.add(k);
           out.push(t);
+          keyStrings.push(k);
         }
       }
       this._storedIds = out;
+      this._storedKeyStrings = keyStrings;
     } else {
       this._storedIds = Array.from(new Set(ids as unknown[]));
+      this._storedKeyStrings = null;
     }
     this._chainWalker = chainWalker;
   }
@@ -305,9 +352,20 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       else byKey.set(k, [r]);
     }
     const ordered: T[] = [];
-    for (const id of this._storedIds) {
-      const bucket = byKey.get(serializeKey(id, composite));
-      if (bucket) ordered.push(...bucket);
+    if (composite) {
+      // Walk `_storedKeyStrings` directly — the serialized forms were
+      // computed once at construction, so the reorder avoids re-running
+      // JSON.stringify per tuple on every `toArray()` call.
+      const keyStrings = this._storedKeyStrings!;
+      for (const k of keyStrings) {
+        const bucket = byKey.get(k);
+        if (bucket) ordered.push(...bucket);
+      }
+    } else {
+      for (const id of this._storedIds) {
+        const bucket = byKey.get(id);
+        if (bucket) ordered.push(...bucket);
+      }
     }
     const start = offsetVal ?? 0;
     const end = limitVal == null ? undefined : start + limitVal;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -41,9 +41,11 @@ export type DjarIds = unknown[] | unknown[][];
  * null/bool), but `bigint` throws in `JSON.stringify` — the `big_integer`
  * cast type produces bigints, and composite PKs on large tables are
  * the exact case that hits them. Normalize bigints via a replacer
- * (`"bigint:<decimal>"`) so a `123n` never collides with the string
- * `"123"`. A leading `\u0000T` marker makes tuple keys
- * non-collidable with any plausible scalar passed through this helper.
+ * that emits `"\u0000B<decimal>"` (a NUL-prefixed string), so a
+ * `123n` component serializes distinctly from the plain string
+ * `"123"`. The outer tuple key also carries a leading `\u0000T`
+ * marker so tuple keys are non-collidable with any plausible scalar
+ * passed through this helper.
  */
 function serializeKey(v: unknown, composite: boolean): unknown {
   if (!composite) return v;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -163,6 +163,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // the caller's shape isn't silently incompatible with the scalar
     // path they now route through — a tuple-typed overload call like
     // `new DJAR(..., ["col"], [[1], [2]])` keeps working.
+    // Guard against non-array `ids` up front. Dynamic callers using
+    // `any`/`unknown` could pass a Set, null, undefined, or an
+    // arbitrary object — `.map` / `.length` below would otherwise
+    // throw a generic TypeError or silently store zero ids.
+    if (!Array.isArray(ids)) {
+      throw argumentError(
+        `DisableJoinsAssociationRelation: ids must be an array (got ${ids === null ? "null" : typeof ids})`,
+      );
+    }
     let normalizedKey: DjarKey = key;
     let normalizedIds: DjarIds = ids;
     if (Array.isArray(key)) {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -347,6 +347,10 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * `Array.isArray(this.key)` at the call site when the key shape isn't
    * statically known. In deferred-chain mode the walker's loaded-chain
    * DJAR carries the authoritative shape.
+   *
+   * Returns a defensive shallow copy (and cloned tuples in the
+   * composite case) so caller mutation can't desync the internal
+   * `_storedKeyStrings` cache used by the load-time reorder.
    */
   override async ids(): Promise<DjarIds> {
     if (this._chainWalker) {
@@ -360,7 +364,10 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       const merged = this._composeChainedState(relation);
       return (merged as unknown as { ids: () => Promise<DjarIds> }).ids();
     }
-    return this._storedIds;
+    if (this._composite) {
+      return (this._storedIds as unknown[][]).map((t) => Array.from(t));
+    }
+    return (this._storedIds as unknown[]).slice();
   }
 
   /**

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -191,6 +191,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
         });
       }
     }
+    // Guard against empty-string key in loaded-chain mode — it would
+    // make `readAttribute("")` return null for every record and the
+    // reorder Map would silently produce an empty result. The
+    // `deferred()` static intentionally passes "" as a placeholder
+    // because the walker's returned relation owns the real key, so
+    // allow it when a chain walker is present.
+    if (normalizedKey === "" && !chainWalker) {
+      throw argumentError("DisableJoinsAssociationRelation: key must not be empty");
+    }
     this.key = normalizedKey;
     this._composite = Array.isArray(normalizedKey);
     // Scalar case: Set identity dedup matches Rails' `ids.uniq`.

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -228,7 +228,19 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       this._storedIds = out;
       this._storedKeyStrings = keyStrings;
     } else {
-      this._storedIds = Array.from(new Set(normalizedIds as unknown[]));
+      // Symmetric guard for the scalar path: a dynamic caller
+      // passing tuple ids (via `any`/`unknown` erasure) with a
+      // string key would dedupe by array reference and silently
+      // produce an empty reorder result. Fail fast instead.
+      const scalarIds = normalizedIds as unknown[];
+      for (let i = 0; i < scalarIds.length; i++) {
+        if (Array.isArray(scalarIds[i])) {
+          throw argumentError(
+            `DisableJoinsAssociationRelation: scalar ids[${i}] must not be an array when key is "${String(normalizedKey)}"`,
+          );
+        }
+      }
+      this._storedIds = Array.from(new Set(scalarIds));
       this._storedKeyStrings = null;
     }
     this._chainWalker = chainWalker;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -107,13 +107,55 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     ids: unknown[][],
     chainWalker?: () => Promise<{ relation: Relation<T> }>,
   );
+  // Internal trusted-clone overload: `_newRelation` uses this to adopt
+  // already-normalized state without re-running dedup / JSON.stringify.
+  // The leading `_` on `_trustedClone` flags it as internal.
   constructor(
     klass: typeof Base,
     key: DjarKey,
     ids: DjarIds,
-    chainWalker?: () => Promise<{ relation: Relation<T> }>,
+    trusted: {
+      _trustedClone: {
+        storedIds: DjarIds;
+        storedKeyStrings: string[] | null;
+        composite: boolean;
+        chainWalker?: () => Promise<{ relation: Relation<T> }>;
+      };
+    },
+  );
+  constructor(
+    klass: typeof Base,
+    key: DjarKey,
+    ids: DjarIds,
+    chainWalkerOrTrusted?:
+      | (() => Promise<{ relation: Relation<T> }>)
+      | {
+          _trustedClone: {
+            storedIds: DjarIds;
+            storedKeyStrings: string[] | null;
+            composite: boolean;
+            chainWalker?: () => Promise<{ relation: Relation<T> }>;
+          };
+        },
   ) {
     super(klass);
+    // Fast clone path: `_newRelation` hands us already-normalized
+    // state from another DJAR. Skip dedup / arity checks / per-tuple
+    // JSON.stringify and just adopt the frozen outputs.
+    if (
+      chainWalkerOrTrusted &&
+      typeof chainWalkerOrTrusted === "object" &&
+      "_trustedClone" in chainWalkerOrTrusted
+    ) {
+      const t = chainWalkerOrTrusted._trustedClone;
+      this.key = key;
+      this._composite = t.composite;
+      this._storedIds = t.storedIds;
+      this._storedKeyStrings = t.storedKeyStrings;
+      this._chainWalker = t.chainWalker;
+      return;
+    }
+    const chainWalker = chainWalkerOrTrusted;
     // Normalize array-key shapes: length 0 is always a bug; length 1
     // collapses to the string form so `this.key` / `_composite`
     // stay consistent with the scalar path (and `readAttribute`
@@ -130,9 +172,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       }
       if (key.length === 1) {
         normalizedKey = key[0];
-        normalizedIds = (ids as unknown[]).map((id) =>
-          Array.isArray(id) && id.length === 1 ? id[0] : id,
-        );
+        normalizedIds = (ids as unknown[]).map((id, i) => {
+          if (!Array.isArray(id)) return id;
+          if (id.length !== 1) {
+            throw argumentError(
+              `DisableJoinsAssociationRelation: single-column ids[${i}] must be a scalar or single-element array (got arity ${id.length})`,
+            );
+          }
+          return id[0];
+        });
       }
     }
     this.key = normalizedKey;
@@ -299,23 +347,21 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * spawn a plain Relation and silently drop the wrapping behavior.
    */
   protected override _newRelation(): Relation<T> {
-    // Branch to route through the correlated overloads; `this.key` is
-    // already normalized in the constructor so the two shapes line up
-    // with `this._storedIds`.
-    const clone = this._composite
-      ? new DisableJoinsAssociationRelation<T>(
-          this.model,
-          this.key as string[],
-          this._storedIds as unknown[][],
-          this._chainWalker,
-        )
-      : new DisableJoinsAssociationRelation<T>(
-          this.model,
-          this.key as string,
-          this._storedIds as unknown[],
-          this._chainWalker,
-        );
-    return clone as unknown as Relation<T>;
+    // `_newRelation` runs on every `_clone()` — including the
+    // limit/offset-free load clone inside `toArray()`, and every
+    // chained `.where(...)` / `.order(...)` — so re-running the
+    // full constructor (dedup + per-tuple JSON.stringify) on every
+    // chain link would repeat quadratic-ish work for large
+    // composite-id lists. Route through the internal trusted
+    // constructor overload that copies already-normalized state.
+    return new DisableJoinsAssociationRelation<T>(this.model, this.key, this._storedIds, {
+      _trustedClone: {
+        storedIds: this._storedIds,
+        storedKeyStrings: this._storedKeyStrings,
+        composite: this._composite,
+        chainWalker: this._chainWalker,
+      },
+    }) as unknown as Relation<T>;
   }
 
   override async toArray(): Promise<T[]> {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -1,4 +1,5 @@
 import { Relation } from "./relation.js";
+import { argumentError } from "./relation/query-methods.js";
 import type { Base } from "./base.js";
 
 /**
@@ -93,9 +94,25 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // two owner rows collapses to one entry (Set-of-arrays would keep
     // both by reference).
     if (this._composite) {
+      const arity = (key as string[]).length;
       const seen = new Set<string>();
       const out: unknown[][] = [];
-      for (const t of ids as unknown[][]) {
+      for (let i = 0; i < (ids as unknown[]).length; i++) {
+        const t = (ids as unknown[])[i];
+        // Fail fast on shape/arity mismatch. Without this, a flat
+        // `unknown[]` slipping through as composite `ids` would
+        // silently dedupe to "one bucket per scalar" and reorder to
+        // nothing, instead of pointing at the caller.
+        if (!Array.isArray(t)) {
+          throw argumentError(
+            `DisableJoinsAssociationRelation: composite ids[${i}] must be an array (got ${typeof t})`,
+          );
+        }
+        if (t.length !== arity) {
+          throw argumentError(
+            `DisableJoinsAssociationRelation: composite ids[${i}] arity ${t.length} does not match key [${(key as string[]).join(", ")}] (arity ${arity})`,
+          );
+        }
         const k = serializeKey(t, true) as string;
         if (!seen.has(k)) {
           seen.add(k);

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -212,10 +212,16 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
             `DisableJoinsAssociationRelation: composite ids[${i}] arity ${t.length} does not match key [${cols.join(", ")}] (arity ${arity})`,
           );
         }
-        const k = serializeKey(t, true) as string;
+        // Copy the tuple before storing so later caller mutation
+        // of the outer array doesn't desync `_storedKeyStrings`
+        // (cached serialization) from `_storedIds` (returned by
+        // `ids()`). Cheap — tuples are tiny — and matches Rails'
+        // `ids.uniq` producing a fresh array.
+        const tuple = Array.from(t);
+        const k = serializeKey(tuple, true) as string;
         if (!seen.has(k)) {
           seen.add(k);
-          out.push(t);
+          out.push(tuple);
           keyStrings.push(k);
         }
       }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -22,11 +22,39 @@ import type { Base } from "./base.js";
  *      matches Rails' `DisableJoinsAssociationScope#scope` returning
  *      a Relation directly.
  */
+/**
+ * Join-key shape for the loaded-chain reorder. A plain string names a
+ * single column (`"id"`); a string[] names a composite key's columns
+ * in order (`["shop_id", "order_number"]`). The id list's shape
+ * matches: scalars for single-column, tuples for composite.
+ */
+export type DjarKey = string | string[];
+export type DjarIds = unknown[] | unknown[][];
+
+/**
+ * Stable Map key for both scalar and tuple join keys. Scalars are used
+ * as-is (Map identity already works); tuples are serialized so
+ * `[1, 100]` from two independent reads collides in the bucket. JSON
+ * covers the primitive shapes pluck returns (number/string/null/bool).
+ * A leading `\u0000T` marker makes tuple keys non-collidable with any
+ * plausible scalar.
+ */
+function serializeKey(v: unknown, composite: boolean): unknown {
+  if (!composite) return v;
+  return "\u0000T" + JSON.stringify(v);
+}
+
 export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T> {
-  readonly key: string;
+  readonly key: DjarKey;
   /** Stored IDs (uniq'd at construction). Exposed as `ids()` to match
-   * Rails' `attr_reader :ids` which shadows `Relation#ids` here. */
-  private readonly _storedIds: unknown[];
+   * Rails' `attr_reader :ids` which shadows `Relation#ids` here. For
+   * composite keys this is a list of tuples (`unknown[][]`); dedup is
+   * by serialized tuple so two independently-read `[1, 100]`s
+   * collapse. */
+  private readonly _storedIds: DjarIds;
+  /** Whether `key` is composite (string[] with arity > 1). Derived at
+   * construction; controls tuple-vs-scalar behavior in read/dedup/group. */
+  private readonly _composite: boolean;
   /** Deferred chain walker. Boxed return ({ relation }) defeats
    * `Relation.then` — without the box, `await Promise<Relation>`
    * would unwrap to `T[]` (records array) instead of the Relation
@@ -43,13 +71,31 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
 
   constructor(
     klass: typeof Base,
-    key: string,
-    ids: unknown[],
+    key: DjarKey,
+    ids: DjarIds,
     chainWalker?: () => Promise<{ relation: Relation<T> }>,
   ) {
     super(klass);
     this.key = key;
-    this._storedIds = Array.from(new Set(ids));
+    this._composite = Array.isArray(key) && key.length > 1;
+    // Scalar case: Set identity dedup matches Rails' `ids.uniq`.
+    // Composite case: dedupe by serialized tuple so `[1, 100]` from
+    // two owner rows collapses to one entry (Set-of-arrays would keep
+    // both by reference).
+    if (this._composite) {
+      const seen = new Set<string>();
+      const out: unknown[][] = [];
+      for (const t of ids as unknown[][]) {
+        const k = serializeKey(t, true) as string;
+        if (!seen.has(k)) {
+          seen.add(k);
+          out.push(t);
+        }
+      }
+      this._storedIds = out;
+    } else {
+      this._storedIds = Array.from(new Set(ids as unknown[]));
+    }
     this._chainWalker = chainWalker;
   }
 
@@ -220,15 +266,18 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // recurse forever for the loaded-chain mode.
     const records = (await Relation.prototype.toArray.call(loadClone)) as T[];
     const byKey = new Map<unknown, T[]>();
+    const keyCols = Array.isArray(this.key) ? this.key : [this.key];
+    const composite = this._composite;
     for (const r of records) {
-      const k = r.readAttribute(this.key);
+      const raw = composite ? keyCols.map((c) => r.readAttribute(c)) : r.readAttribute(keyCols[0]);
+      const k = serializeKey(raw, composite);
       const bucket = byKey.get(k);
       if (bucket) bucket.push(r);
       else byKey.set(k, [r]);
     }
     const ordered: T[] = [];
     for (const id of this._storedIds) {
-      const bucket = byKey.get(id);
+      const bucket = byKey.get(serializeKey(id, composite));
       if (bucket) ordered.push(...bucket);
     }
     const start = offsetVal ?? 0;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -3,6 +3,23 @@ import { argumentError } from "./relation/query-methods.js";
 import type { Base } from "./base.js";
 
 /**
+ * Module-private token for the DJAR fast-clone path. Unexported — only
+ * `_newRelation` inside this module can forge a payload carrying it,
+ * so external callers can't reach the trusted constructor branch even
+ * via `any`/`unknown` erasure (they have no reference to the symbol).
+ */
+const TRUSTED_CLONE = Symbol("DisableJoinsAssociationRelation.trustedClone");
+
+interface TrustedClonePayload<T extends Base> {
+  [TRUSTED_CLONE]: {
+    storedIds: DjarIds;
+    storedKeyStrings: string[] | null;
+    composite: boolean;
+    chainWalker?: () => Promise<{ relation: Relation<T> }>;
+  };
+}
+
+/**
  * Specialized Relation returned by `DisableJoinsAssociationScope`.
  * Operates in one of two modes:
  *
@@ -107,36 +124,18 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     ids: unknown[][],
     chainWalker?: () => Promise<{ relation: Relation<T> }>,
   );
-  // Internal trusted-clone overload: `_newRelation` uses this to adopt
-  // already-normalized state without re-running dedup / JSON.stringify.
-  // The leading `_` on `_trustedClone` flags it as internal.
+  // The implementation signature accepts an internal
+  // `TrustedClonePayload<T>` (gated by the unexported `TRUSTED_CLONE`
+  // symbol) as the fourth argument so `_newRelation` can take the
+  // fast-clone path. It is intentionally NOT declared as a public
+  // overload — external callers only see the two correlated forms
+  // above, and they can't construct a valid trusted payload without
+  // a reference to the module-private symbol.
   constructor(
     klass: typeof Base,
     key: DjarKey,
     ids: DjarIds,
-    trusted: {
-      _trustedClone: {
-        storedIds: DjarIds;
-        storedKeyStrings: string[] | null;
-        composite: boolean;
-        chainWalker?: () => Promise<{ relation: Relation<T> }>;
-      };
-    },
-  );
-  constructor(
-    klass: typeof Base,
-    key: DjarKey,
-    ids: DjarIds,
-    chainWalkerOrTrusted?:
-      | (() => Promise<{ relation: Relation<T> }>)
-      | {
-          _trustedClone: {
-            storedIds: DjarIds;
-            storedKeyStrings: string[] | null;
-            composite: boolean;
-            chainWalker?: () => Promise<{ relation: Relation<T> }>;
-          };
-        },
+    chainWalkerOrTrusted?: (() => Promise<{ relation: Relation<T> }>) | TrustedClonePayload<T>,
   ) {
     super(klass);
     // Fast clone path: `_newRelation` hands us already-normalized
@@ -145,9 +144,9 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     if (
       chainWalkerOrTrusted &&
       typeof chainWalkerOrTrusted === "object" &&
-      "_trustedClone" in chainWalkerOrTrusted
+      TRUSTED_CLONE in chainWalkerOrTrusted
     ) {
-      const t = chainWalkerOrTrusted._trustedClone;
+      const t = (chainWalkerOrTrusted as TrustedClonePayload<T>)[TRUSTED_CLONE];
       this.key = key;
       this._composite = t.composite;
       this._storedIds = t.storedIds;
@@ -380,14 +379,35 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // chain link would repeat quadratic-ish work for large
     // composite-id lists. Route through the internal trusted
     // constructor overload that copies already-normalized state.
-    return new DisableJoinsAssociationRelation<T>(this.model, this.key, this._storedIds, {
-      _trustedClone: {
+    const payload: TrustedClonePayload<T> = {
+      [TRUSTED_CLONE]: {
         storedIds: this._storedIds,
         storedKeyStrings: this._storedKeyStrings,
         composite: this._composite,
         chainWalker: this._chainWalker,
       },
-    }) as unknown as Relation<T>;
+    };
+    // Branch on `_composite` so we hit one of the public correlated
+    // overloads. The trusted payload is not in the public signature
+    // list (it only lives on the implementation signature, gated by
+    // the module-private TRUSTED_CLONE symbol), so cast it through
+    // the public `chainWalker?` slot — same runtime position, same
+    // module.
+    const trusted = payload as unknown as () => Promise<{ relation: Relation<T> }>;
+    const clone = this._composite
+      ? new DisableJoinsAssociationRelation<T>(
+          this.model,
+          this.key as string[],
+          this._storedIds as unknown[][],
+          trusted,
+        )
+      : new DisableJoinsAssociationRelation<T>(
+          this.model,
+          this.key as string,
+          this._storedIds as unknown[],
+          trusted,
+        );
+    return clone as unknown as Relation<T>;
   }
 
   override async toArray(): Promise<T[]> {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -320,7 +320,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     return merged;
   }
 
-  override async ids(): Promise<unknown[]> {
+  /**
+   * Return the stored id list. The shape is correlated with `this.key`:
+   * a `string` key yields a flat `unknown[]` of scalars, a `string[]`
+   * composite key yields `unknown[][]` of tuples. Narrow with
+   * `Array.isArray(this.key)` at the call site when the key shape isn't
+   * statically known. In deferred-chain mode the walker's loaded-chain
+   * DJAR carries the authoritative shape.
+   */
+  override async ids(): Promise<DjarIds> {
     if (this._chainWalker) {
       // Deferred mode — delegate to the composed walker result's
       // ids(), which can pluck instead of materializing full records.
@@ -330,7 +338,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       // (or ids() multiple times).
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
-      return (merged as unknown as { ids: () => Promise<unknown[]> }).ids();
+      return (merged as unknown as { ids: () => Promise<DjarIds> }).ids();
     }
     return this._storedIds;
   }


### PR DESCRIPTION
## Summary

Closes the one behavior gap left open in #645: composite-key through-associations with an ordered upstream now re-emit records in through-table tuple order, matching the single-column case.

DJAR's loaded-chain wrap previously keyed its group-by Map on raw record attribute values — fine for scalars, broken for tuples (two independently-read `[1, 100]`s bucket by reference, never collide). DJAS worked around it by skipping the wrap entirely for composite keys, leaving records in DB-arbitrary order.

Mirrors Rails' `disable_joins_association_relation.rb` (`records.group_by { |r| r[key] }` + `ids.flat_map { |id| records_by_id[id] }`), extended with stable tuple serialization for Map identity — the JS-idiomatic equivalent of Ruby's value-equality hash keys.

### Changes

- `DisableJoinsAssociationRelation` accepts `key: string | string[]` and `ids: unknown[] | unknown[][]`. New exported types `DjarKey` / `DjarIds`.
- Tuple serialization (`"\u0000T" + JSON.stringify(v)`) used for both construction-time dedupe (`ids.uniq`) and load-time group-by Map keys. Scalars keep raw Map identity — zero change on the single-column path.
- Per-record key reads scale to the key's arity.
- DJAS drops the `keyCols.length === 1` guard on the wrap and passes composite keys straight through.

### Tests

- `disable-joins-composite-key.test.ts`:
  - Composite + ordered-upstream: tightened from presence-only (`.sort()`) to order assertion (`from-a` before `from-b`).
  - New direct DJAR unit test: construct with duplicate tuples and out-of-order ids, assert both tuple dedupe (3 input → 2 stored) and IN-list reorder (`lb` before `la`).
- `disable-joins-association-scope.test.ts`: single-column path unchanged (8/8 pass).
- Full `@blazetrails/activerecord` suite: 8704 passed.

## Test plan

- [x] `disable-joins-composite-key.test.ts` (5 tests)
- [x] `disable-joins-association-scope.test.ts` (8 tests)
- [x] Full \`@blazetrails/activerecord\` suite: 8704 passed.
- [ ] PG / MariaDB CI.