### PR TITLE
refactor(activerecord): extract sanitization statics from Base to Sanitization

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -200,6 +200,11 @@ export class Base extends Model {
   declare static sanitizeSql: typeof Sanitization.sanitizeSql;
   declare static sanitizeSqlArray: typeof Sanitization.sanitizeSqlArray;
   declare static sanitizeSqlLike: typeof Sanitization.sanitizeSqlLike;
+  declare static sanitizeSqlForConditions: typeof Sanitization.sanitizeSqlForConditions;
+  declare static sanitizeSqlForAssignment: typeof Sanitization.sanitizeSqlForAssignment;
+  declare static sanitizeSqlForOrder: typeof Sanitization.sanitizeSqlForOrder;
+  declare static sanitizeSqlHashForAssignment: typeof Sanitization.sanitizeSqlHashForAssignment;
+  declare static disallowRawSqlBang: typeof Sanitization.disallowRawSqlBang;
 
   // --- Associations (wired below after class body) ---
   declare static belongsTo: typeof _Associations.belongsTo;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -197,10 +197,10 @@ export class Base extends Model {
   declare static lookupAncestors: typeof Translation.lookupAncestors;
 
   // --- Sanitization mixin (wired via extend() after class) ---
-  declare static sanitizeSql: typeof Sanitization.sanitizeSql;
+  declare static sanitizeSql: typeof Sanitization.ClassMethods.sanitizeSql;
   declare static sanitizeSqlArray: typeof Sanitization.sanitizeSqlArray;
   declare static sanitizeSqlLike: typeof Sanitization.sanitizeSqlLike;
-  declare static sanitizeSqlForConditions: typeof Sanitization.sanitizeSqlForConditions;
+  declare static sanitizeSqlForConditions: typeof Sanitization.ClassMethods.sanitizeSqlForConditions;
   declare static sanitizeSqlForAssignment: typeof Sanitization.sanitizeSqlForAssignment;
   declare static sanitizeSqlForOrder: typeof Sanitization.sanitizeSqlForOrder;
   declare static sanitizeSqlHashForAssignment: typeof Sanitization.sanitizeSqlHashForAssignment;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -73,7 +73,7 @@ const loadSignedId = async () => {
 import * as LockingOptimistic from "./locking/optimistic.js";
 import * as LockingPessimistic from "./locking/pessimistic.js";
 import * as Translation from "./translation.js";
-import { sanitizeSqlArray, sanitizeSqlLike } from "./sanitization.js";
+import * as Sanitization from "./sanitization.js";
 import * as Querying from "./querying.js";
 import { include, extend, type Included } from "@blazetrails/activesupport";
 import {
@@ -195,6 +195,11 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
 export class Base extends Model {
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
+
+  // --- Sanitization mixin (wired via extend() after class) ---
+  declare static sanitizeSql: typeof Sanitization.sanitizeSql;
+  declare static sanitizeSqlArray: typeof Sanitization.sanitizeSqlArray;
+  declare static sanitizeSqlLike: typeof Sanitization.sanitizeSqlLike;
 
   // --- Associations (wired below after class body) ---
   declare static belongsTo: typeof _Associations.belongsTo;
@@ -3093,20 +3098,6 @@ export class Base extends Model {
     return this.toParam();
   }
 
-  static sanitizeSqlArray(template: string, ...binds: unknown[]): string {
-    return sanitizeSqlArray(template, ...binds);
-  }
-
-  static sanitizeSql(input: string | [string, ...unknown[]]): string {
-    if (typeof input === "string") return input;
-    const [template, ...binds] = input;
-    return this.sanitizeSqlArray(template, ...binds);
-  }
-
-  static sanitizeSqlLike(value: string, escapeChar: string = "\\"): string {
-    return sanitizeSqlLike(value, escapeChar);
-  }
-
   /**
    * Returns true if the record was previously persisted but is now destroyed.
    *
@@ -3467,6 +3458,7 @@ extend(Base, {
   hasAndBelongsToMany: _Associations.hasAndBelongsToMany,
 });
 extend(Base, Translation.ClassMethods);
+extend(Base, Sanitization.ClassMethods);
 extend(Base, ReadonlyAttributes.ClassMethods);
 extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -201,8 +201,8 @@ export class Base extends Model {
   declare static sanitizeSqlArray: typeof Sanitization.sanitizeSqlArray;
   declare static sanitizeSqlLike: typeof Sanitization.sanitizeSqlLike;
   declare static sanitizeSqlForConditions: typeof Sanitization.ClassMethods.sanitizeSqlForConditions;
-  declare static sanitizeSqlForAssignment: typeof Sanitization.sanitizeSqlForAssignment;
-  declare static sanitizeSqlForOrder: typeof Sanitization.sanitizeSqlForOrder;
+  declare static sanitizeSqlForAssignment: typeof Sanitization.ClassMethods.sanitizeSqlForAssignment;
+  declare static sanitizeSqlForOrder: typeof Sanitization.ClassMethods.sanitizeSqlForOrder;
   declare static sanitizeSqlHashForAssignment: typeof Sanitization.sanitizeSqlHashForAssignment;
   declare static disallowRawSqlBang: typeof Sanitization.disallowRawSqlBang;
 

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -142,3 +142,13 @@ export function sanitizeSqlLike(value: string, escapeChar: string = "\\"): strin
     .replace(/%/g, () => escapeChar + "%")
     .replace(/_/g, () => escapeChar + "_");
 }
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveRecord::Sanitization::ClassMethods`.
+ */
+export const ClassMethods = {
+  sanitizeSql,
+  sanitizeSqlArray,
+  sanitizeSqlLike,
+};

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -144,14 +144,42 @@ export function sanitizeSqlLike(value: string, escapeChar: string = "\\"): strin
 }
 
 /**
+ * Class-method variant of `sanitizeSql` that dispatches through
+ * `this.sanitizeSqlArray`, so subclass overrides of `sanitizeSqlArray`
+ * take effect — matching Rails' `Sanitization::ClassMethods#sanitize_sql`
+ * which calls `sanitize_sql_array` via `self`.
+ */
+function sanitizeSqlClassMethod(
+  this: { sanitizeSqlArray(template: string, ...binds: unknown[]): string },
+  input: string | [string, ...unknown[]],
+): string {
+  if (typeof input === "string") return input;
+  const [template, ...binds] = input;
+  return this.sanitizeSqlArray(template, ...binds);
+}
+
+/**
+ * Class-method variant of `sanitizeSqlForConditions` that dispatches
+ * through `this.sanitizeSql` (and therefore `this.sanitizeSqlArray`),
+ * matching Rails' Ruby `self` dispatch through `ClassMethods`.
+ */
+function sanitizeSqlForConditionsClassMethod(
+  this: { sanitizeSql(input: string | [string, ...unknown[]]): string },
+  condition: string | [string, ...unknown[]] | null | undefined,
+): string | null {
+  if (!condition || (typeof condition === "string" && condition.trim() === "")) return null;
+  return this.sanitizeSql(condition);
+}
+
+/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveRecord::Sanitization::ClassMethods`.
  */
 export const ClassMethods = {
-  sanitizeSql,
+  sanitizeSql: sanitizeSqlClassMethod,
   sanitizeSqlArray,
   sanitizeSqlLike,
-  sanitizeSqlForConditions,
+  sanitizeSqlForConditions: sanitizeSqlForConditionsClassMethod,
   sanitizeSqlForAssignment,
   sanitizeSqlForOrder,
   sanitizeSqlHashForAssignment,

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -151,4 +151,9 @@ export const ClassMethods = {
   sanitizeSql,
   sanitizeSqlArray,
   sanitizeSqlLike,
+  sanitizeSqlForConditions,
+  sanitizeSqlForAssignment,
+  sanitizeSqlForOrder,
+  sanitizeSqlHashForAssignment,
+  disallowRawSqlBang,
 };

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -172,6 +172,42 @@ function sanitizeSqlForConditionsClassMethod(
 }
 
 /**
+ * Class-method variant of `sanitizeSqlForAssignment` that dispatches
+ * `Array` case through `this.sanitizeSql` — matching Rails' self dispatch
+ * from `sanitize_sql_for_assignment` → `sanitize_sql_array`.
+ */
+function sanitizeSqlForAssignmentClassMethod(
+  this: { sanitizeSql(input: string | [string, ...unknown[]]): string },
+  assignments: string | [string, ...unknown[]] | Record<string, unknown>,
+  defaultTableName?: string,
+): string {
+  if (typeof assignments === "string") return assignments;
+  if (Array.isArray(assignments)) return this.sanitizeSql(assignments);
+  return sanitizeSqlHashForAssignment(assignments, defaultTableName ?? "");
+}
+
+/**
+ * Class-method variant of `sanitizeSqlForOrder` that dispatches
+ * `disallowRawSqlBang` and `sanitizeSqlArray` through `this` — matching
+ * Rails' self dispatch.
+ */
+function sanitizeSqlForOrderClassMethod(
+  this: {
+    disallowRawSqlBang(args: (string | symbol | Nodes.Node)[], permit?: RegExp): void;
+    sanitizeSqlArray(template: string, ...binds: unknown[]): string;
+  },
+  condition: string | [string, ...unknown[]] | Nodes.Node,
+): string | Nodes.Node {
+  if (condition instanceof Nodes.Node) return condition;
+  if (Array.isArray(condition) && condition[0]?.toString().includes("?")) {
+    const sanitized = this.sanitizeSqlArray(condition[0], ...condition.slice(1));
+    this.disallowRawSqlBang([sanitized]);
+    return arelSql(sanitized);
+  }
+  return typeof condition === "string" ? condition : condition[0];
+}
+
+/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveRecord::Sanitization::ClassMethods`.
  */
@@ -180,8 +216,8 @@ export const ClassMethods = {
   sanitizeSqlArray,
   sanitizeSqlLike,
   sanitizeSqlForConditions: sanitizeSqlForConditionsClassMethod,
-  sanitizeSqlForAssignment,
-  sanitizeSqlForOrder,
+  sanitizeSqlForAssignment: sanitizeSqlForAssignmentClassMethod,
+  sanitizeSqlForOrder: sanitizeSqlForOrderClassMethod,
   sanitizeSqlHashForAssignment,
   disallowRawSqlBang,
 };

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -330,6 +330,34 @@ describe("sanitizeSql", () => {
     expect(Post.sanitizeSqlForConditions("")).toBeNull();
   });
 
+  it("sanitizeSqlForAssignment dispatches array-form through this.sanitizeSql", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+      static override sanitizeSql(_input: string | [string, ...unknown[]]): string {
+        return "VIA_SANITIZE_SQL";
+      }
+    }
+    expect(Post.sanitizeSqlForAssignment(["a = ?", 1])).toBe("VIA_SANITIZE_SQL");
+  });
+
+  it("sanitizeSqlForOrder dispatches through this.sanitizeSqlArray and this.disallowRawSqlBang", () => {
+    let disallowCalled = false;
+    class Post extends Base {
+      static _tableName = "posts";
+      static override sanitizeSqlArray(_template: string, ..._binds: unknown[]): string {
+        return "id, 1, 2";
+      }
+      static override disallowRawSqlBang(_args: unknown[]): void {
+        disallowCalled = true;
+      }
+    }
+    const result = Post.sanitizeSqlForOrder(["field(id, ?)", [1, 2]]);
+    // sanitizeSqlForOrder wraps the sanitized string in Arel.sql() (a Node).
+    // Assert the override output was threaded through by inspecting it.
+    expect(result).not.toBeNull();
+    expect(disallowCalled).toBe(true);
+  });
+
   it("Base exposes the full Rails Sanitization::ClassMethods surface", () => {
     class Post extends Base {
       static _tableName = "posts";

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -307,4 +307,40 @@ describe("sanitizeSql", () => {
       /wrong number of bind variables \(1 for 2\)/,
     );
   });
+
+  it("sanitizeSql dispatches through this.sanitizeSqlArray (subclass override)", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+      static override sanitizeSqlArray(_template: string, ..._binds: unknown[]): string {
+        return "OVERRIDDEN";
+      }
+    }
+    expect(Post.sanitizeSql(["title = ?", "x"])).toBe("OVERRIDDEN");
+  });
+
+  it("sanitizeSqlForConditions dispatches through this.sanitizeSql", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+      static override sanitizeSql(_input: string | [string, ...unknown[]]): string {
+        return "VIA_SANITIZE_SQL";
+      }
+    }
+    expect(Post.sanitizeSqlForConditions(["a = ?", 1])).toBe("VIA_SANITIZE_SQL");
+    expect(Post.sanitizeSqlForConditions(null)).toBeNull();
+    expect(Post.sanitizeSqlForConditions("")).toBeNull();
+  });
+
+  it("Base exposes the full Rails Sanitization::ClassMethods surface", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+    // sanitize_sql_like
+    expect(Post.sanitizeSqlLike("50%_off")).toBe("50\\%\\_off");
+    // sanitize_sql_for_order passes raw Arel/strings through
+    expect(Post.sanitizeSqlForOrder("id asc")).toBe("id asc");
+    // sanitize_sql_for_assignment hash form
+    expect(Post.sanitizeSqlForAssignment({ title: "hi" }, "posts")).toContain("= 'hi'");
+    // disallow_raw_sql! rejects non-column-ish input
+    expect(() => Post.disallowRawSqlBang(["DROP TABLE users"])).toThrow(/Dangerous query method/);
+  });
 });

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -352,9 +352,10 @@ describe("sanitizeSql", () => {
       }
     }
     const result = Post.sanitizeSqlForOrder(["field(id, ?)", [1, 2]]);
-    // sanitizeSqlForOrder wraps the sanitized string in Arel.sql() (a Node).
-    // Assert the override output was threaded through by inspecting it.
-    expect(result).not.toBeNull();
+    // sanitizeSqlForOrder wraps the sanitized string in Arel.sql() (a SqlLiteral
+    // node). Read `.value` to confirm the subclass's sanitizeSqlArray override
+    // produced the sanitized text.
+    expect((result as { value?: string }).value).toBe("id, 1, 2");
     expect(disallowCalled).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
Second step of the Base → Rails-module extraction plan. Moves the sanitization statics out of `base.ts` and exposes the **full Rails `ActiveRecord::Sanitization::ClassMethods` surface** on `Base` via `extend(Base, Sanitization.ClassMethods)`.

Class methods now wired onto `Base`:
- `sanitizeSql`, `sanitizeSqlArray`, `sanitizeSqlLike` (previously inlined in base.ts)
- `sanitizeSqlForConditions`, `sanitizeSqlForAssignment`, `sanitizeSqlForOrder`, `sanitizeSqlHashForAssignment`, `disallowRawSqlBang` (newly reachable from `Base`, matching Rails)

`sanitizeSql` and `sanitizeSqlForConditions` dispatch through `this` when called as class methods (matching Rails' Ruby `self` dispatch), so subclass overrides of `sanitizeSqlArray` / `sanitizeSql` take effect. Module-level variants (`sanitization.ts` exports) still work standalone for internal callers that don't have a class context (e.g., `querying.ts`).

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes
- [x] New tests cover: subclass-override dispatch on `sanitizeSql` and `sanitizeSqlForConditions`, full Base surface reachability for every newly-exposed ClassMethod
- [x] `pnpm run api:compare` steady (2498/2819, inheritance 91.4%)