### PR TITLE
refactor(activerecord): extract Core instance predicates from Base to core.ts

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -101,6 +101,7 @@ import {
   isPresent as _isPresent,
   isBlank as _isBlank,
 } from "./core.js";
+import * as _Core from "./core.js";
 import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
@@ -2019,9 +2020,9 @@ export class Base extends Model {
   // -- Instance state --
 
   _newRecord = true;
-  private _destroyed = false;
-  private _readonly = false;
-  private _frozen = false;
+  _destroyed = false;
+  _readonly = false;
+  _frozen = false;
   private _previouslyNewRecord = false;
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
@@ -2062,46 +2063,13 @@ export class Base extends Model {
     return this._destroyed;
   }
 
-  /**
-   * Returns true if the record is marked readonly.
-   *
-   * Mirrors: ActiveRecord::Base#readonly?
-   */
-  isReadonly(): boolean {
-    return this._readonly;
-  }
-
-  /**
-   * Mark the record as readonly. Raises on save/update/destroy.
-   *
-   * Mirrors: ActiveRecord::Base#readonly!
-   */
-  readonlyBang(): this {
-    this._readonly = true;
-    return this;
-  }
-
-  /**
-   * Returns true if strict loading is enabled.
-   *
-   * Mirrors: ActiveRecord::Base#strict_loading?
-   */
-  isStrictLoading(): boolean {
-    return this._strictLoading;
-  }
-
-  /**
-   * Enable (or disable, with `value: false`) strict loading —
-   * lazily-loaded associations will raise. Matches Rails'
-   * `strict_loading!(value = true)` which accepts an explicit argument
-   * for symmetrical on/off.
-   *
-   * Mirrors: ActiveRecord::Base#strict_loading!
-   */
-  strictLoadingBang(value: boolean = true): this {
-    this._strictLoading = value;
-    return this;
-  }
+  // --- Core instance methods (wired via include() after class body) ---
+  declare isReadonly: typeof _Core.isReadonly;
+  declare readonlyBang: typeof _Core.readonlyBang;
+  declare isStrictLoading: typeof _Core.isStrictLoading;
+  declare strictLoadingBang: typeof _Core.strictLoadingBang;
+  declare isFrozen: typeof _Core.isFrozen;
+  declare freeze: typeof _Core.freeze;
 
   /**
    * Returns true if this record was a new record before the last save.
@@ -2110,25 +2078,6 @@ export class Base extends Model {
    */
   isPreviouslyNewRecord(): boolean {
     return this._previouslyNewRecord;
-  }
-
-  /**
-   * Returns true if the record is frozen (e.g. after destroy).
-   *
-   * Mirrors: ActiveRecord::Base#frozen?
-   */
-  isFrozen(): boolean {
-    return this._frozen;
-  }
-
-  /**
-   * Freeze the record, preventing further modifications.
-   *
-   * Mirrors: ActiveRecord::Base#freeze
-   */
-  freeze(): this {
-    this._frozen = true;
-    return this;
   }
 
   /**
@@ -3477,6 +3426,12 @@ include(Base, {
   isEqual: _isEqual,
   isPresent: _isPresent,
   isBlank: _isBlank,
+  isReadonly: _Core.isReadonly,
+  readonlyBang: _Core.readonlyBang,
+  isStrictLoading: _Core.isStrictLoading,
+  strictLoadingBang: _Core.strictLoadingBang,
+  isFrozen: _Core.isFrozen,
+  freeze: _Core.freeze,
   // Integration
   toParam: _toParam,
   cacheKey: _cacheKey,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2027,6 +2027,7 @@ export class Base extends Model {
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
   _strictLoading = false;
+  _strictLoadingMode?: _Core.StrictLoadingMode;
   _strictLoadingBypassCount = 0;
   _preloadedAssociations: Map<string, unknown> = new Map();
   _collectionProxies: Map<string, unknown> = new Map();
@@ -2068,6 +2069,9 @@ export class Base extends Model {
   declare readonlyBang: typeof _Core.readonlyBang;
   declare isStrictLoading: typeof _Core.isStrictLoading;
   declare strictLoadingBang: typeof _Core.strictLoadingBang;
+  declare strictLoadingMode: typeof _Core.strictLoadingMode;
+  declare isStrictLoadingAll: typeof _Core.isStrictLoadingAll;
+  declare isStrictLoadingNPlusOneOnly: typeof _Core.isStrictLoadingNPlusOneOnly;
   declare isFrozen: typeof _Core.isFrozen;
   declare freeze: typeof _Core.freeze;
 
@@ -3430,6 +3434,9 @@ include(Base, {
   readonlyBang: _Core.readonlyBang,
   isStrictLoading: _Core.isStrictLoading,
   strictLoadingBang: _Core.strictLoadingBang,
+  strictLoadingMode: _Core.strictLoadingMode,
+  isStrictLoadingAll: _Core.isStrictLoadingAll,
+  isStrictLoadingNPlusOneOnly: _Core.isStrictLoadingNPlusOneOnly,
   isFrozen: _Core.isFrozen,
   freeze: _Core.freeze,
   // Integration

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -131,6 +131,59 @@ export function isBlank(this: CoreRecord): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Readonly / strict-loading / freeze instance predicates and setters.
+// Mirrors the corresponding defs in activerecord/lib/active_record/core.rb.
+// ---------------------------------------------------------------------------
+
+interface ReadonlyFields {
+  _readonly: boolean;
+}
+
+interface StrictLoadingFields {
+  _strictLoading: boolean;
+}
+
+interface FrozenFields {
+  _frozen: boolean;
+}
+
+/** Mirrors: ActiveRecord::Core#readonly? */
+export function isReadonly(this: ReadonlyFields): boolean {
+  return this._readonly;
+}
+
+/** Mirrors: ActiveRecord::Core#readonly! */
+export function readonlyBang<T extends ReadonlyFields>(this: T): T {
+  this._readonly = true;
+  return this;
+}
+
+/** Mirrors: ActiveRecord::Core#strict_loading? */
+export function isStrictLoading(this: StrictLoadingFields): boolean {
+  return this._strictLoading;
+}
+
+/** Mirrors: ActiveRecord::Core#strict_loading! */
+export function strictLoadingBang<T extends StrictLoadingFields>(
+  this: T,
+  value: boolean = true,
+): T {
+  this._strictLoading = value;
+  return this;
+}
+
+/** Mirrors: ActiveRecord::Core#frozen? */
+export function isFrozen(this: FrozenFields): boolean {
+  return this._frozen;
+}
+
+/** Mirrors: ActiveRecord::Core#freeze */
+export function freeze<T extends FrozenFields>(this: T): T {
+  this._frozen = true;
+  return this;
+}
+
+// ---------------------------------------------------------------------------
 // Instance methods missing from api:compare
 // ---------------------------------------------------------------------------
 

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -7,6 +7,7 @@
 import { Notifications, ParameterFilter, getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
+import { argumentError } from "./relation/query-methods.js";
 
 /**
  * The Core module interface — methods mixed into every AR model.
@@ -22,7 +23,7 @@ export interface Core {
   isReadonly(): boolean;
   readonlyBang(): this;
   isStrictLoading(): boolean;
-  strictLoadingBang(value?: boolean): this;
+  strictLoadingBang(value?: boolean, options?: { mode?: StrictLoadingMode }): this;
   isFrozen(): boolean;
   freeze(): this;
 }
@@ -181,7 +182,8 @@ export function strictLoadingBang<T extends StrictLoadingFields>(
 ): T {
   const mode = options.mode ?? "all";
   if (mode !== "all" && mode !== "n_plus_one_only") {
-    throw new Error(
+    // Rails: `raise ArgumentError, "The :mode option must be one of ..."`
+    throw argumentError(
       `The :mode option must be one of ["all", "n_plus_one_only"] but ${JSON.stringify(mode)} was provided.`,
     );
   }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -141,7 +141,10 @@ interface ReadonlyFields {
 
 interface StrictLoadingFields {
   _strictLoading: boolean;
+  _strictLoadingMode?: StrictLoadingMode;
 }
+
+export type StrictLoadingMode = "all" | "n_plus_one_only";
 
 interface FrozenFields {
   _frozen: boolean;
@@ -163,11 +166,26 @@ export function isStrictLoading(this: StrictLoadingFields): boolean {
   return this._strictLoading;
 }
 
-/** Mirrors: ActiveRecord::Core#strict_loading! */
+/**
+ * Enable (or disable with `value: false`) strict loading on this record.
+ * An optional `mode` selects strictness: "all" (default, raises on any
+ * lazily-loaded association) or "n_plus_one_only" (only raises on
+ * associations that would lead to N+1 queries).
+ *
+ * Mirrors: ActiveRecord::Core#strict_loading!
+ */
 export function strictLoadingBang<T extends StrictLoadingFields>(
   this: T,
   value: boolean = true,
+  options: { mode?: StrictLoadingMode } = {},
 ): T {
+  const mode = options.mode ?? "all";
+  if (mode !== "all" && mode !== "n_plus_one_only") {
+    throw new Error(
+      `The :mode option must be one of ["all", "n_plus_one_only"] but ${JSON.stringify(mode)} was provided.`,
+    );
+  }
+  this._strictLoadingMode = mode;
   this._strictLoading = value;
   return this;
 }
@@ -210,18 +228,20 @@ export function initAttributes(
 }
 
 export function strictLoadingMode(
-  this: CoreRecord & { _strictLoadingMode?: string },
-): string | null {
+  this: CoreRecord & { _strictLoadingMode?: StrictLoadingMode },
+): StrictLoadingMode | null {
   return this._strictLoadingMode ?? null;
 }
 
 export function isStrictLoadingNPlusOneOnly(
-  this: CoreRecord & { _strictLoadingMode?: string },
+  this: CoreRecord & { _strictLoadingMode?: StrictLoadingMode },
 ): boolean {
   return this._strictLoadingMode === "n_plus_one_only";
 }
 
-export function isStrictLoadingAll(this: CoreRecord & { _strictLoadingMode?: string }): boolean {
+export function isStrictLoadingAll(
+  this: CoreRecord & { _strictLoadingMode?: StrictLoadingMode },
+): boolean {
   return this._strictLoadingMode === "all";
 }
 

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -24,6 +24,9 @@ export interface Core {
   readonlyBang(): this;
   isStrictLoading(): boolean;
   strictLoadingBang(value?: boolean, options?: { mode?: StrictLoadingMode }): this;
+  strictLoadingMode(): StrictLoadingMode | null;
+  isStrictLoadingAll(): boolean;
+  isStrictLoadingNPlusOneOnly(): boolean;
   isFrozen(): boolean;
   freeze(): this;
 }

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -215,6 +215,37 @@ describe("StrictLoadingTest", () => {
     }
     const author = new Author({ name: "Grace" });
     expect(author.isStrictLoading()).toBe(false);
+    author.strictLoadingBang();
+    // Rails: strict_loading! defaults `mode: :all`; strict_loading_mode returns :all.
+    expect((author as any)._strictLoadingMode).toBe("all");
+  });
+
+  it("strictLoadingBang accepts mode: n_plus_one_only", async () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const author = new Author({ name: "Ivy" });
+    author.strictLoadingBang(true, { mode: "n_plus_one_only" });
+    expect(author.isStrictLoading()).toBe(true);
+    expect((author as any)._strictLoadingMode).toBe("n_plus_one_only");
+  });
+
+  it("strictLoadingBang rejects an invalid mode", async () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const author = new Author({ name: "Jack" });
+    expect(() =>
+      (author.strictLoadingBang as (v: boolean, o: { mode: string }) => unknown)(true, {
+        mode: "bogus",
+      }),
+    ).toThrow(/The :mode option must be one of/);
   });
 
   // Rails: test_strict_loading

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -241,11 +241,17 @@ describe("StrictLoadingTest", () => {
       }
     }
     const author = new Author({ name: "Jack" });
-    expect(() =>
+    let caught: Error | null = null;
+    try {
       (author.strictLoadingBang as (v: boolean, o: { mode: string }) => unknown)(true, {
         mode: "bogus",
-      }),
-    ).toThrow(/The :mode option must be one of/);
+      });
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.name).toBe("ArgumentError");
+    expect(caught!.message).toMatch(/The :mode option must be one of/);
   });
 
   // Rails: test_strict_loading

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -217,7 +217,9 @@ describe("StrictLoadingTest", () => {
     expect(author.isStrictLoading()).toBe(false);
     author.strictLoadingBang();
     // Rails: strict_loading! defaults `mode: :all`; strict_loading_mode returns :all.
-    expect((author as any)._strictLoadingMode).toBe("all");
+    expect(author.strictLoadingMode()).toBe("all");
+    expect(author.isStrictLoadingAll()).toBe(true);
+    expect(author.isStrictLoadingNPlusOneOnly()).toBe(false);
   });
 
   it("strictLoadingBang accepts mode: n_plus_one_only", async () => {
@@ -230,7 +232,9 @@ describe("StrictLoadingTest", () => {
     const author = new Author({ name: "Ivy" });
     author.strictLoadingBang(true, { mode: "n_plus_one_only" });
     expect(author.isStrictLoading()).toBe(true);
-    expect((author as any)._strictLoadingMode).toBe("n_plus_one_only");
+    expect(author.strictLoadingMode()).toBe("n_plus_one_only");
+    expect(author.isStrictLoadingNPlusOneOnly()).toBe(true);
+    expect(author.isStrictLoadingAll()).toBe(false);
   });
 
   it("strictLoadingBang rejects an invalid mode", async () => {


### PR DESCRIPTION
## Summary
Third step of the Base → Rails-module extraction plan. Moves six `ActiveRecord::Core` instance methods (`isReadonly`, `readonlyBang`, `isStrictLoading`, `strictLoadingBang`, `isFrozen`, `freeze`) out of `base.ts` into `core.ts` as `this`-typed functions, wired via the existing `include()` call. Each now lives where [Rails' `core.rb`](scripts/api-compare/.rails-source/activerecord/lib/active_record/core.rb) (lines 654-764) keeps it.

Widens `_readonly` / `_destroyed` / `_frozen` from `private` to public on `Base` — matching the already-public `_strictLoading` and the codebase convention of `_`-prefix for internal fields.

### Rails-fidelity fix included: `strictLoadingBang(value, { mode })`
Rails' `strict_loading!(value = true, mode: :all)` sets both `@strict_loading` and `@strict_loading_mode`. Our version was only setting the flag, so `strictLoadingMode()` always returned null despite being exported. This PR adds the `mode` kwarg with `"all"` (default) / `"n_plus_one_only"`, mirrors Rails' validation (throws on any other value), and threads the resulting `_strictLoadingMode` through the existing `strictLoadingMode()` / `isStrictLoadingAll()` / `isStrictLoadingNPlusOneOnly()` getters. New type `StrictLoadingMode` shared by setter and getters.

### Known gap (pre-existing, not in scope)
Rails' `freeze` / `frozen?` operate on the attributes hash (`@attributes = @attributes.clone.freeze` / `@attributes.frozen?`), whereas our implementation toggles a boolean on the record. Preserving the existing (simpler) semantics here; aligning attribute-level freezing is a separate behavioral fix.

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17758 tests)
- [x] New tests cover: default mode = "all", `mode: "n_plus_one_only"`, invalid-mode rejection
- [x] `pnpm run api:compare` steady (2498/2819, inheritance 91.4%)