### PR TITLE
feat(activerecord,activemodel): Rails-faithful freeze/frozen? via AttributeSet

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -10,9 +10,32 @@ const LAZY_ATTR = Symbol("lazyAttr");
  */
 export class AttributeSet {
   private attributes: Map<string, Attribute>;
+  private _frozen = false;
 
   constructor(attributes: Map<string, Attribute> = new Map()) {
     this.attributes = attributes;
+  }
+
+  /**
+   * Freeze this set in place so subsequent mutations throw.
+   * Matches Ruby's `Hash#freeze` semantic used by `ActiveRecord::Core#freeze`.
+   */
+  freeze(): this {
+    this._frozen = true;
+    return this;
+  }
+
+  /** Whether this set has been frozen via {@link freeze}. */
+  isFrozen(): boolean {
+    return this._frozen;
+  }
+
+  private assertNotFrozen(): void {
+    if (this._frozen) {
+      const err = new Error("can't modify frozen AttributeSet");
+      err.name = "FrozenError";
+      throw err;
+    }
   }
 
   /**
@@ -32,6 +55,7 @@ export class AttributeSet {
   }
 
   set(name: string, attrOrValue: Attribute | unknown): void {
+    this.assertNotFrozen();
     if (attrOrValue instanceof Attribute) {
       this.attributes.set(name, attrOrValue);
     } else {
@@ -59,6 +83,7 @@ export class AttributeSet {
   }
 
   writeFromUser(name: string, value: unknown): unknown {
+    this.assertNotFrozen();
     const existing = this.attributes.get(name);
     if (existing) {
       this.attributes.set(name, existing.withValueFromUser(value));
@@ -70,6 +95,7 @@ export class AttributeSet {
   }
 
   writeFromDatabase(name: string, value: unknown): void {
+    this.assertNotFrozen();
     const existing = this.attributes.get(name);
     if (existing) {
       this.attributes.set(name, existing.withValueFromDatabase(value));
@@ -79,6 +105,7 @@ export class AttributeSet {
   }
 
   writeCastValue(name: string, value: unknown): void {
+    this.assertNotFrozen();
     const attr = this.attributes.get(name);
     if (attr) {
       attr.overrideCastValue(value);
@@ -149,6 +176,7 @@ export class AttributeSet {
   }
 
   delete(name: string): boolean {
+    this.assertNotFrozen();
     return this.attributes.delete(name);
   }
 

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -269,6 +269,7 @@ export class AttributeSet {
   }
 
   reverseMergeBang(target: AttributeSet): this {
+    this.assertNotFrozen();
     const cache = new Map<Attribute, Attribute>();
     target.forEach((attr, name) => {
       if (!this.isKey(name)) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2667,17 +2667,16 @@ export class Base extends Model {
   async delete(): Promise<this> {
     const ctor = this.constructor as typeof Base;
     const table = ctor.arelTable;
-    const pk = this.id;
 
     // Rails' `delete` issues a DELETE only when `persisted?`, then
     // unconditionally marks the record destroyed + frozen.
-    if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
-      const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
+    if (this.isPersisted()) {
+      const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(this.id));
       await ctor.adapter.execDelete(dm.toSql(), "Delete");
     }
 
     this._destroyed = true;
-    (this as any)._previouslyNewRecord = false;
+    this._previouslyNewRecord = false;
     this.freeze();
     return this;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2022,7 +2022,6 @@ export class Base extends Model {
   _newRecord = true;
   _destroyed = false;
   _readonly = false;
-  _frozen = false;
   private _previouslyNewRecord = false;
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
@@ -2107,7 +2106,7 @@ export class Base extends Model {
   declare cacheVersion: () => string | null;
 
   writeAttribute(name: string, value: unknown): void {
-    if (this._frozen) {
+    if (this._attributes.isFrozen()) {
       throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
     }
     super.writeAttribute(name, value);
@@ -2625,7 +2624,9 @@ export class Base extends Model {
       }
 
       this._destroyed = true;
-      this._frozen = true;
+      // Rails' destroy ends with a `freeze` call. Delegate to it so we
+      // pick up the clone-and-freeze semantics on `_attributes`.
+      this.freeze();
       this._collectionProxies.clear();
       this._preloadedAssociations.clear();
       this._associationInstances.clear();
@@ -2678,7 +2679,7 @@ export class Base extends Model {
     await ctor.adapter.execDelete(dm.toSql(), "Delete");
 
     this._destroyed = true;
-    this._frozen = true;
+    this.freeze();
     return this;
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2669,16 +2669,15 @@ export class Base extends Model {
     const table = ctor.arelTable;
     const pk = this.id;
 
-    if (Array.isArray(pk) ? pk.every((v) => v == null) : pk == null) {
-      // New (unpersisted) record — nothing to delete
-      this._destroyed = true;
-      return this;
+    // Rails' `delete` issues a DELETE only when `persisted?`, then
+    // unconditionally marks the record destroyed + frozen.
+    if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {
+      const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
+      await ctor.adapter.execDelete(dm.toSql(), "Delete");
     }
 
-    const dm = new DeleteManager().from(table).where(ctor._buildPkWhereNode(pk));
-    await ctor.adapter.execDelete(dm.toSql(), "Delete");
-
     this._destroyed = true;
+    (this as any)._previouslyNewRecord = false;
     this.freeze();
     return this;
   }

--- a/packages/activerecord/src/core.test.ts
+++ b/packages/activerecord/src/core.test.ts
@@ -270,6 +270,29 @@ describe("frozen / isFrozen", () => {
     expect(user.isFrozen()).toBe(true);
     expect(() => (user.name = "Bob")).toThrow("Cannot modify a frozen");
   });
+
+  // Rails: ActiveRecord::Core#freeze aliases @attributes = @attributes.clone.freeze.
+  // Verifies our implementation backs isFrozen() by freezing the AttributeSet,
+  // and that the pre-freeze reference is left untouched so records sharing
+  // an attribute map (e.g. via clone/becomes) aren't frozen together.
+  it("freeze clones the attribute set so prior references stay mutable", async () => {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static _tableName = "users";
+    }
+    User.attribute("id", "integer");
+    User.attribute("name", "string");
+    User.adapter = adapter;
+
+    const user = await User.create({ name: "Alice" });
+    const preFreezeAttrs = (user as any)._attributes;
+    user.freeze();
+    expect(user.isFrozen()).toBe(true);
+    expect((user as any)._attributes).not.toBe(preFreezeAttrs);
+    expect(preFreezeAttrs.isFrozen()).toBe(false);
+    // The frozen clone is what the record now exposes.
+    expect((user as any)._attributes.isFrozen()).toBe(true);
+  });
 });
 
 describe("Base#isEqual", () => {

--- a/packages/activerecord/src/core.test.ts
+++ b/packages/activerecord/src/core.test.ts
@@ -271,6 +271,23 @@ describe("frozen / isFrozen", () => {
     expect(() => (user.name = "Bob")).toThrow("Cannot modify a frozen");
   });
 
+  it("deleting an unpersisted record still marks it destroyed and frozen", async () => {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static _tableName = "users";
+    }
+    User.attribute("id", "integer");
+    User.attribute("name", "string");
+    User.adapter = adapter;
+
+    // Matches Rails' `delete` which only issues the DELETE when persisted?
+    // is true, but always ends with `@destroyed = true; freeze`.
+    const user = new User({ name: "Alice" });
+    await user.delete();
+    expect(user.isDestroyed()).toBe(true);
+    expect(user.isFrozen()).toBe(true);
+  });
+
   // Rails: ActiveRecord::Core#freeze aliases @attributes = @attributes.clone.freeze.
   // Verifies our implementation backs isFrozen() by freezing the AttributeSet,
   // and that the pre-freeze reference is left untouched so records sharing

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -150,8 +150,8 @@ interface StrictLoadingFields {
 
 export type StrictLoadingMode = "all" | "n_plus_one_only";
 
-interface FrozenFields {
-  _frozen: boolean;
+interface FrozenRecord {
+  _attributes: import("@blazetrails/activemodel").AttributeSet;
 }
 
 /** Mirrors: ActiveRecord::Core#readonly? */
@@ -195,14 +195,26 @@ export function strictLoadingBang<T extends StrictLoadingFields>(
   return this;
 }
 
-/** Mirrors: ActiveRecord::Core#frozen? */
-export function isFrozen(this: FrozenFields): boolean {
-  return this._frozen;
+/**
+ * Returns true if this record's attribute set has been frozen.
+ *
+ * Mirrors: ActiveRecord::Core#frozen? — `@attributes.frozen?` in Rails.
+ */
+export function isFrozen(this: FrozenRecord): boolean {
+  return this._attributes.isFrozen();
 }
 
-/** Mirrors: ActiveRecord::Core#freeze */
-export function freeze<T extends FrozenFields>(this: T): T {
-  this._frozen = true;
+/**
+ * Clone and freeze the attribute set. Subsequent writes to `_attributes`
+ * (e.g. `writeAttribute`, `writeFromUser`) raise. Associations remain
+ * accessible since they aren't stored in the attribute set. The clone
+ * step ensures records sharing an attribute reference (e.g. via
+ * `clone()` / `becomes`) aren't accidentally frozen together.
+ *
+ * Mirrors: ActiveRecord::Core#freeze — `@attributes = @attributes.clone.freeze; self` in Rails.
+ */
+export function freeze<T extends FrozenRecord>(this: T): T {
+  this._attributes = this._attributes.deepDup().freeze();
   return this;
 }
 

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -403,20 +403,23 @@ function restoreTransactionRecordState(record: Base, snapshot: TransactionRecord
   r._destroyed = snapshot.destroyed;
   r._previouslyNewRecord = snapshot.previouslyNewRecord;
 
-  // Reconcile frozen state with the snapshot. If the record was frozen
-  // during the transaction (e.g. destroy) but rollback unwinds that,
-  // replace _attributes with an unfrozen deep clone so subsequent writes
-  // (including the PK restore below) succeed. Rails takes the mirror
-  // path in `restore_transaction_record_state` by reassigning
-  // `@attributes`.
-  if (r._attributes.isFrozen() !== snapshot.frozen) {
-    r._attributes = snapshot.frozen ? r._attributes.deepDup().freeze() : r._attributes.deepDup();
+  // Unfreeze the attribute set while internal fields are restored so the
+  // PK write below always succeeds — even when the snapshot itself was
+  // frozen. Mirrors Rails' `restore_transaction_record_state`, which
+  // unconditionally reassigns `@attributes` to a fresh mapped set.
+  if (r._attributes.isFrozen()) {
+    r._attributes = r._attributes.deepDup();
   }
 
   // Restore the primary key if it was auto-assigned during insert
   if (snapshot.newRecord && !Array.isArray(record.id)) {
     const ctor = record.constructor as typeof Base;
     r._attributes.set(ctor.primaryKey as string, snapshot.id);
+  }
+
+  // Re-apply the snapshot's frozen state *after* any internal restores.
+  if (snapshot.frozen && !r._attributes.isFrozen()) {
+    r._attributes.freeze();
   }
 }
 

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -384,7 +384,7 @@ function rememberTransactionRecordState(record: Base): TransactionRecordSnapshot
   return {
     newRecord: r._newRecord,
     destroyed: r._destroyed,
-    frozen: r._frozen,
+    frozen: r._attributes.isFrozen(),
     id: record.id,
     previouslyNewRecord: r._previouslyNewRecord,
   };
@@ -401,8 +401,17 @@ function restoreTransactionRecordState(record: Base, snapshot: TransactionRecord
   const r = record as any;
   r._newRecord = snapshot.newRecord;
   r._destroyed = snapshot.destroyed;
-  r._frozen = snapshot.frozen;
   r._previouslyNewRecord = snapshot.previouslyNewRecord;
+
+  // Reconcile frozen state with the snapshot. If the record was frozen
+  // during the transaction (e.g. destroy) but rollback unwinds that,
+  // replace _attributes with an unfrozen deep clone so subsequent writes
+  // (including the PK restore below) succeed. Rails takes the mirror
+  // path in `restore_transaction_record_state` by reassigning
+  // `@attributes`.
+  if (r._attributes.isFrozen() !== snapshot.frozen) {
+    r._attributes = snapshot.frozen ? r._attributes.deepDup().freeze() : r._attributes.deepDup();
+  }
 
   // Restore the primary key if it was auto-assigned during insert
   if (snapshot.newRecord && !Array.isArray(record.id)) {


### PR DESCRIPTION
## Summary
Replaces `Base._frozen: boolean` with real attribute-set freezing, matching [Rails' `ActiveRecord::Core#freeze`](scripts/api-compare/.rails-source/activerecord/lib/active_record/core.rb):

```ruby
def freeze
  @attributes = @attributes.clone.freeze
  self
end

def frozen?
  @attributes.frozen?
end
```

### activemodel (AttributeSet)
- adds `freeze()` / `isFrozen()` and an internal `assertNotFrozen()` guard invoked from every mutator: `set`, `writeFromUser`, `writeFromDatabase`, `writeCastValue`, `delete` (and transitively `reset`)
- violations raise a JS `Error` with `name = "FrozenError"`, matching Ruby's `FrozenError` and the codebase's pattern of branding errors via `err.name`
- `deepDup()` still returns a fresh unfrozen AttributeSet, so `deepDup().freeze()` is the clone-and-freeze pair Rails uses

### activerecord (Core / Base / Transactions)
- `core.freeze()` now does `this._attributes = this._attributes.deepDup().freeze(); return this`
- `core.isFrozen()` reads `this._attributes.isFrozen()`
- drops the `_frozen` instance field from `Base`
- `writeAttribute` guards via `this._attributes.isFrozen()` — the existing `Cannot modify a frozen X` user-facing error is unchanged
- `destroy` / `delete` end with `this.freeze()` instead of setting a boolean, matching Rails' `@destroyed = true; freeze`
- transaction rollback reconciles frozen state by replacing `_attributes` with a deep clone (frozen or not per snapshot), so subsequent writes (incl. the PK restore) can proceed — mirroring Rails' `@attributes = restore_state[:attributes].map{...}`

## Test plan
- [x] `tsc --noEmit` clean across affected packages
- [x] Full `pnpm vitest run` passes (17759 tests, +1 new)
- [x] `pnpm run api:compare` steady (2498/2819, inheritance 91.4%)
- [x] New core.test case proves (1) freeze clones the attribute set, (2) pre-freeze references stay mutable, (3) the new `_attributes` is the frozen clone