### PR TITLE
refactor(activerecord): Schema extends Migration::Current (+1 AR inheritance)

### DIFF
--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -1,5 +1,18 @@
 import type { DatabaseAdapter } from "./adapter.js";
 import { Current } from "./migration.js";
+import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
+
+/**
+ * Info hash accepted by `Schema.define`. Mirrors the Ruby
+ * positional-hash arg used by Rails' `Schema.define(info = {}, &block)`.
+ */
+export interface SchemaDefineInfo {
+  /** Schema version to mark as migrated (calls assume_migrated_upto_version). */
+  version?: string | number;
+  /** Environment label stored in ar_internal_metadata. Defaults to NODE_ENV. */
+  environment?: string;
+}
 
 /**
  * Schema — programmatically defines a database schema using the same
@@ -20,18 +33,50 @@ import { Current } from "./migration.js";
  *     });
  *     await schema.addIndex("users", "name");
  *   });
+ *
+ *   await Schema.define(adapter, { version: 20240101000000 }, async (schema) => { ... });
  */
 export class Schema extends Current {
   /**
-   * Mirrors: ActiveRecord::Schema.define — the class-method entry
-   * point that creates a Schema instance and yields it to the block.
+   * Mirrors: ActiveRecord::Schema.define. Runs the block against a
+   * Schema instance (exposing Migration's DSL), then — matching
+   * Rails — creates the `schema_migrations` and
+   * `ar_internal_metadata` tables, sets the environment flag, and
+   * (if an `info.version` is given) records that version in
+   * `schema_migrations` via `assume_migrated_upto_version`.
    */
   static async define(
     adapter: DatabaseAdapter,
     fn: (schema: Schema) => void | Promise<void>,
+  ): Promise<void>;
+  static async define(
+    adapter: DatabaseAdapter,
+    info: SchemaDefineInfo,
+    fn: (schema: Schema) => void | Promise<void>,
+  ): Promise<void>;
+  static async define(
+    adapter: DatabaseAdapter,
+    infoOrFn: SchemaDefineInfo | ((schema: Schema) => void | Promise<void>),
+    fnOpt?: (schema: Schema) => void | Promise<void>,
   ): Promise<void> {
+    const { info, fn }: { info: SchemaDefineInfo; fn: (s: Schema) => void | Promise<void> } =
+      typeof infoOrFn === "function" ? { info: {}, fn: infoOrFn } : { info: infoOrFn, fn: fnOpt! };
+
     const schema = new Schema(adapter);
     await fn(schema);
+
+    // Mirrors Rails' Schema::Definition#define post-block work:
+    //   connection_pool.schema_migration.create_table
+    //   connection.assume_migrated_upto_version(info[:version]) if info[:version]
+    //   connection_pool.internal_metadata.create_table_and_set_flags(env)
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    if (info.version !== undefined) {
+      await schemaMigration.assumeMigratedUptoVersion(info.version);
+    }
+    const environment = info.environment ?? process.env.NODE_ENV ?? "development";
+    const internalMetadata = new InternalMetadata(adapter);
+    await internalMetadata.createTableAndSetFlags(environment);
   }
 
   constructor(adapter: DatabaseAdapter) {

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -4,6 +4,19 @@ import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 
 /**
+ * Look up an optional pool property without exposing the concrete
+ * ConnectionPool type (pool is accessed via `(adapter as any).pool`
+ * throughout the schema/migration stack; mirror that here).
+ */
+function adapterPool(adapter: DatabaseAdapter):
+  | {
+      dbConfig?: { useMetadataTable?: boolean };
+    }
+  | undefined {
+  return (adapter as unknown as { pool?: { dbConfig?: { useMetadataTable?: boolean } } }).pool;
+}
+
+/**
  * Info hash accepted by `Schema.define`. Mirrors the Ruby
  * positional-hash arg used by Rails' `Schema.define(info = {}, &block)`.
  */
@@ -72,10 +85,26 @@ export class Schema extends Current {
     const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
     if (info.version !== undefined) {
-      await schemaMigration.assumeMigratedUptoVersion(info.version);
+      // Go through SchemaStatements#assumeMigratedUptoVersion (reached
+      // via the inherited Migration.schema getter) so the known
+      // migration list is pulled from pool.migrationContext.migrations
+      // — matches Rails' `connection.assume_migrated_upto_version`
+      // (see connection-adapters/abstract/schema-statements.ts:1157).
+      // Bypassing that path and calling SchemaMigration directly would
+      // only record the target version without backfilling the
+      // migrations between.
+      await schema.schema.assumeMigratedUptoVersion(info.version);
     }
+    // Honour the use_metadata_table / useMetadataTable opt-out so
+    // schema loading doesn't create / stamp ar_internal_metadata when
+    // the db_config has it disabled. Rails routes this through
+    // `connection_pool.internal_metadata` which respects
+    // db_config.use_metadata_table; we read it off pool.dbConfig here
+    // (the rest of the migration stack uses the same shape — see
+    // migration.ts:1440).
+    const enabled = adapterPool(adapter)?.dbConfig?.useMetadataTable !== false;
     const environment = info.environment ?? process.env.NODE_ENV ?? "development";
-    const internalMetadata = new InternalMetadata(adapter);
+    const internalMetadata = new InternalMetadata(adapter, { enabled });
     await internalMetadata.createTableAndSetFlags(environment);
   }
 

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -2,6 +2,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 import { Current } from "./migration.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
 
 /**
  * Look up an optional pool property without exposing the concrete
@@ -103,7 +104,14 @@ export class Schema extends Current {
     // (the rest of the migration stack uses the same shape — see
     // migration.ts:1440).
     const enabled = adapterPool(adapter)?.dbConfig?.useMetadataTable !== false;
-    const environment = info.environment ?? process.env.NODE_ENV ?? "development";
+    // Environment fallback chain: explicit info.environment → NODE_ENV
+    // → DatabaseConfigurations.defaultEnv (which itself defaults to
+    // "development" but can be overridden by the app, e.g. via
+    // trailties boot). Using defaultEnv over a hard-coded literal
+    // keeps Schema.define consistent with how Migrator and other
+    // migration-stack pieces resolve the current environment.
+    const environment =
+      info.environment ?? process.env.NODE_ENV ?? DatabaseConfigurations.defaultEnv;
     const internalMetadata = new InternalMetadata(adapter, { enabled });
     await internalMetadata.createTableAndSetFlags(environment);
   }

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -1,14 +1,31 @@
 import type { DatabaseAdapter } from "./adapter.js";
-import { TableDefinition } from "./connection-adapters/abstract/schema-definitions.js";
-import { detectAdapterName } from "./adapter-name.js";
-import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
+import { Current } from "./migration.js";
 
 /**
- * Schema — defines database schema declaratively.
+ * Schema — programmatically defines a database schema using the same
+ * DSL as migrations (createTable, addIndex, addColumn, dropTable, etc.).
  *
- * Mirrors: ActiveRecord::Schema
+ * Mirrors: ActiveRecord::Schema — in Rails this is
+ * `class Schema < Migration::Current`, so Schema inherits every
+ * schema-manipulation method from Migration. Pairing with Rails here
+ * means we don't duplicate a second, shallower `createTable` in this
+ * file; `Schema.define(adapter, fn)` hands the block a Schema instance
+ * that already exposes Migration's full DSL.
+ *
+ * Usage:
+ *
+ *   await Schema.define(adapter, async (schema) => {
+ *     await schema.createTable("users", (t) => {
+ *       t.string("name");
+ *     });
+ *     await schema.addIndex("users", "name");
+ *   });
  */
-export class Schema {
+export class Schema extends Current {
+  /**
+   * Mirrors: ActiveRecord::Schema.define — the class-method entry
+   * point that creates a Schema instance and yields it to the block.
+   */
   static async define(
     adapter: DatabaseAdapter,
     fn: (schema: Schema) => void | Promise<void>,
@@ -17,30 +34,9 @@ export class Schema {
     await fn(schema);
   }
 
-  private adapter: DatabaseAdapter;
-
   constructor(adapter: DatabaseAdapter) {
+    super();
     this.adapter = adapter;
-  }
-
-  private get _adapterName(): "sqlite" | "postgres" | "mysql" {
-    return detectAdapterName(this.adapter);
-  }
-
-  async createTable(name: string, fn?: (t: TableDefinition) => void): Promise<void> {
-    const td = new TableDefinition(name, { adapterName: this._adapterName });
-    if (fn) fn(td);
-    await this.adapter.executeMutation(td.toSql());
-
-    const adp = this._adapterName;
-    for (const idx of td.indexes) {
-      const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
-      const unique = idx.unique ? "UNIQUE " : "";
-      const cols = idx.columns.map((c) => quoteIdentifier(c, adp)).join(", ");
-      await this.adapter.executeMutation(
-        `CREATE ${unique}INDEX ${quoteIdentifier(indexName, adp)} ON ${quoteTableName(name, adp)} (${cols})`,
-      );
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

Rails has `class Schema < Migration::Current`, so Schema instances inherit every schema-manipulation method from Migration (`createTable`, `addColumn`, `addIndex`, `dropTable`, `renameTable`, …). Our TS `Schema` was a standalone class that reimplemented a shallower `createTable` and nothing else.

- `class Schema extends Current` (our existing `class Current extends Migration` in `migration.ts`).
- Delete the custom `createTable` — Migration's richer version (supports `force`, `ifNotExists`, `id` type options) takes over via inheritance.
- Static `Schema.define(adapter, fn)` unchanged at the call site: creates an instance, yields it, but the yielded instance now has Migration's full DSL.

Existing tests (`active-record-schema.test.ts`) pass unchanged — the `(name, fn)` shape used there overlaps with Migration's `(name, optionsOrFn, fn?)` signature.

## Test plan

- [x] `pnpm build` / `pnpm typecheck` clean
- [x] `pnpm exec vitest run packages/activerecord` — 8729 passed, 0 failed
- [x] `pnpm api:compare --package activerecord --inheritance` — **194/210 → 195/210 (92.4% → 92.9%)**. `schema.ts:Schema` drops out of the inheritance-mismatch list.