### PR TITLE
refactor(activerecord): extract Persistence instance predicates from Base

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -102,6 +102,7 @@ import {
   isBlank as _isBlank,
 } from "./core.js";
 import * as _Core from "./core.js";
+import * as _Persistence from "./persistence.js";
 import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
@@ -2022,7 +2023,7 @@ export class Base extends Model {
   _newRecord = true;
   _destroyed = false;
   _readonly = false;
-  private _previouslyNewRecord = false;
+  _previouslyNewRecord = false;
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
   _strictLoading = false;
@@ -2036,32 +2037,12 @@ export class Base extends Model {
     super(attrs);
   }
 
-  /**
-   * Returns true if the record has not been saved yet.
-   *
-   * Mirrors: ActiveRecord::Base#new_record?
-   */
-  isNewRecord(): boolean {
-    return this._newRecord;
-  }
-
-  /**
-   * Returns true if the record has been saved and not destroyed.
-   *
-   * Mirrors: ActiveRecord::Base#persisted?
-   */
-  isPersisted(): boolean {
-    return !this._newRecord && !this._destroyed;
-  }
-
-  /**
-   * Returns true if the record has been destroyed.
-   *
-   * Mirrors: ActiveRecord::Base#destroyed?
-   */
-  isDestroyed(): boolean {
-    return this._destroyed;
-  }
+  // --- Persistence instance predicates (wired via include() after class body) ---
+  declare isNewRecord: typeof _Persistence.isNewRecord;
+  declare isPersisted: typeof _Persistence.isPersisted;
+  declare isDestroyed: typeof _Persistence.isDestroyed;
+  declare isPreviouslyNewRecord: typeof _Persistence.isPreviouslyNewRecord;
+  declare isPreviouslyPersisted: typeof _Persistence.isPreviouslyPersisted;
 
   // --- Core instance methods (wired via include() after class body) ---
   declare isReadonly: typeof _Core.isReadonly;
@@ -2073,15 +2054,6 @@ export class Base extends Model {
   declare isStrictLoadingNPlusOneOnly: typeof _Core.isStrictLoadingNPlusOneOnly;
   declare isFrozen: typeof _Core.isFrozen;
   declare freeze: typeof _Core.freeze;
-
-  /**
-   * Returns true if this record was a new record before the last save.
-   *
-   * Mirrors: ActiveRecord::Base#previously_new_record?
-   */
-  isPreviouslyNewRecord(): boolean {
-    return this._previouslyNewRecord;
-  }
 
   /**
    * Get the association that triggered the destruction of this record (if any).
@@ -3056,15 +3028,6 @@ export class Base extends Model {
   }
 
   /**
-   * Returns true if the record was previously persisted but is now destroyed.
-   *
-   * Mirrors: ActiveRecord::Base#previously_persisted?
-   */
-  isPreviouslyPersisted(): boolean {
-    return !this._newRecord && this._destroyed;
-  }
-
-  /**
    * Re-instantiate as the given class, raising on failure.
    *
    * Mirrors: ActiveRecord::Base#becomes!
@@ -3423,6 +3386,12 @@ extend(Base, NamedScoping.ClassMethods);
 extend(Base, ModelSchema.ClassMethods);
 
 include(Base, {
+  // Persistence
+  isNewRecord: _Persistence.isNewRecord,
+  isPersisted: _Persistence.isPersisted,
+  isDestroyed: _Persistence.isDestroyed,
+  isPreviouslyNewRecord: _Persistence.isPreviouslyNewRecord,
+  isPreviouslyPersisted: _Persistence.isPreviouslyPersisted,
   // Core
   inspect: _inspect,
   attributeForInspect: _attributeForInspect,

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -4376,4 +4376,38 @@ describe("PersistenceTest", () => {
       expect(true).toBe(true);
     });
   }); // QueryConstraintsTest
+
+  // Rails' `previously_persisted?` is defined as `!new_record? && destroyed?`
+  // — dispatched through `self`, so subclass overrides of either predicate
+  // change the result. Locks in the dispatch-through-this implementation.
+  describe("previously_persisted? dispatches through new_record? / destroyed?", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+    }
+
+    it("returns true when record is not new and is destroyed", () => {
+      const p = new Post();
+      p._newRecord = false;
+      p._destroyed = true;
+      expect(p.isPreviouslyPersisted()).toBe(true);
+    });
+
+    it("honors an instance override of isDestroyed", () => {
+      const p = new Post();
+      p._newRecord = false;
+      // underlying _destroyed is false, but the instance override says true
+      p.isDestroyed = () => true;
+      expect(p._destroyed).toBe(false);
+      expect(p.isPreviouslyPersisted()).toBe(true);
+    });
+
+    it("honors an instance override of isNewRecord", () => {
+      const p = new Post();
+      p._newRecord = false; // raw field says not new
+      p._destroyed = true;
+      // override makes isNewRecord() report true, which gates isPreviouslyPersisted
+      p.isNewRecord = () => true;
+      expect(p.isPreviouslyPersisted()).toBe(false);
+    });
+  });
 });

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -199,3 +199,42 @@ export async function _deleteRecord(
   const sql = adapter.toSql ? adapter.toSql(dm) : dm.toSql();
   return adapter.executeMutation(sql);
 }
+
+// ---------------------------------------------------------------------------
+// Instance predicates — Rails' ActiveRecord::Persistence module
+// (persistence.rb lines 338, 345, 355, 361). These live alongside
+// `destroy` / `save` in Rails; here they're module-level functions mixed
+// into Base via include() so the implementation file matches Rails'
+// source location.
+// ---------------------------------------------------------------------------
+
+interface PersistenceRecord {
+  _newRecord: boolean;
+  _destroyed: boolean;
+  _previouslyNewRecord: boolean;
+}
+
+/** Mirrors: ActiveRecord::Persistence#new_record? */
+export function isNewRecord(this: PersistenceRecord): boolean {
+  return this._newRecord;
+}
+
+/** Mirrors: ActiveRecord::Persistence#persisted? */
+export function isPersisted(this: PersistenceRecord): boolean {
+  return !this._newRecord && !this._destroyed;
+}
+
+/** Mirrors: ActiveRecord::Persistence#destroyed? */
+export function isDestroyed(this: PersistenceRecord): boolean {
+  return this._destroyed;
+}
+
+/** Mirrors: ActiveRecord::Persistence#previously_new_record? */
+export function isPreviouslyNewRecord(this: PersistenceRecord): boolean {
+  return this._previouslyNewRecord;
+}
+
+/** Mirrors: ActiveRecord::Persistence#previously_persisted? */
+export function isPreviouslyPersisted(this: PersistenceRecord): boolean {
+  return !this._newRecord && this._destroyed;
+}

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -201,11 +201,10 @@ export async function _deleteRecord(
 }
 
 // ---------------------------------------------------------------------------
-// Instance predicates — Rails' ActiveRecord::Persistence module
-// (persistence.rb lines 338, 345, 355, 361). These live alongside
-// `destroy` / `save` in Rails; here they're module-level functions mixed
-// into Base via include() so the implementation file matches Rails'
-// source location.
+// Instance predicates — Rails' ActiveRecord::Persistence module.
+// These live alongside `destroy` / `save` in Rails' persistence.rb; here
+// they're module-level functions mixed into Base via include() so the
+// implementation file matches Rails' source location.
 // ---------------------------------------------------------------------------
 
 interface PersistenceRecordFields {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -208,33 +208,46 @@ export async function _deleteRecord(
 // source location.
 // ---------------------------------------------------------------------------
 
-interface PersistenceRecord {
+interface PersistenceRecordFields {
   _newRecord: boolean;
   _destroyed: boolean;
   _previouslyNewRecord: boolean;
 }
 
-/** Mirrors: ActiveRecord::Persistence#new_record? */
-export function isNewRecord(this: PersistenceRecord): boolean {
+interface PersistenceRecordDispatch {
+  isNewRecord(): boolean;
+  isDestroyed(): boolean;
+}
+
+/** Mirrors: ActiveRecord::Persistence#new_record? — `@new_record` */
+export function isNewRecord(this: PersistenceRecordFields): boolean {
   return this._newRecord;
 }
 
-/** Mirrors: ActiveRecord::Persistence#persisted? */
-export function isPersisted(this: PersistenceRecord): boolean {
+/**
+ * Mirrors: ActiveRecord::Persistence#persisted? — `!(@new_record || @destroyed)`.
+ * Rails reads the ivars directly, so subclasses overriding `new_record?` /
+ * `destroyed?` don't change `persisted?`.
+ */
+export function isPersisted(this: PersistenceRecordFields): boolean {
   return !this._newRecord && !this._destroyed;
 }
 
-/** Mirrors: ActiveRecord::Persistence#destroyed? */
-export function isDestroyed(this: PersistenceRecord): boolean {
+/** Mirrors: ActiveRecord::Persistence#destroyed? — `@destroyed` */
+export function isDestroyed(this: PersistenceRecordFields): boolean {
   return this._destroyed;
 }
 
-/** Mirrors: ActiveRecord::Persistence#previously_new_record? */
-export function isPreviouslyNewRecord(this: PersistenceRecord): boolean {
+/** Mirrors: ActiveRecord::Persistence#previously_new_record? — `@previously_new_record` */
+export function isPreviouslyNewRecord(this: PersistenceRecordFields): boolean {
   return this._previouslyNewRecord;
 }
 
-/** Mirrors: ActiveRecord::Persistence#previously_persisted? */
-export function isPreviouslyPersisted(this: PersistenceRecord): boolean {
-  return !this._newRecord && this._destroyed;
+/**
+ * Mirrors: ActiveRecord::Persistence#previously_persisted? — `!new_record? && destroyed?`.
+ * Rails dispatches through `self` here, so subclass overrides of
+ * `new_record?` / `destroyed?` do affect this predicate.
+ */
+export function isPreviouslyPersisted(this: PersistenceRecordDispatch): boolean {
+  return !this.isNewRecord() && this.isDestroyed();
 }


### PR DESCRIPTION
## Summary
PR 3b of the Base → Rails-module extraction plan. Moves five `ActiveRecord::Persistence` instance predicates out of `base.ts` into `persistence.ts` as `this`-typed functions, wired onto `Base` via the existing `include()` call:

- `isNewRecord` — mirrors [`persistence.rb#new_record?`](scripts/api-compare/.rails-source/activerecord/lib/active_record/persistence.rb) (line 338)
- `isPersisted` — mirrors `#persisted?` (line 361)
- `isDestroyed` — mirrors `#destroyed?` (line 355)
- `isPreviouslyNewRecord` — mirrors `#previously_new_record?` (line 345)
- `isPreviouslyPersisted` — mirrors `#previously_persisted?` (line 350)

Widens `_previouslyNewRecord` on `Base` from `private` to public to match the other `_`-prefixed state fields (`_destroyed`, `_readonly`, `_strictLoading`) and let the extracted `this`-typed functions reference it structurally.

### Behavior change (intentional): `isPreviouslyPersisted` dispatches through `this`
Rails defines `previously_persisted?` as `!new_record? && destroyed?` — dispatched through `self`, so subclass/instance overrides of either predicate change the result. Our prior `Base` method read the raw `_newRecord`/`_destroyed` fields directly; the extracted version now matches Rails' `self` dispatch. Tests cover override semantics on both predicates.

`persisted?` / `new_record?` / `destroyed?` keep reading the fields directly — Rails defines them that way (`!(@new_record || @destroyed)` reads ivars, not `self.new_record?`), so no dispatch change there.

## api:compare impact
| | before | after |
|-|--------|-------|
| matched | 2498/2819 (88.6%) | **2513/2819 (89.1%)** |
| moves | 215 | **210** |
| inheritance | 192/210 (91.4%) | **194/210 (92.4%)** |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17773 tests, +3 new)
- [x] `pnpm run api:compare` confirms all 5 targets no longer flagged as moves
- [x] New tests lock in dispatch-through-`this` semantics on `isPreviouslyPersisted`