### PR TITLE
refactor(activerecord): resolve 3 'class missing' inheritance misses (+3)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1,5 +1,5 @@
 import type { DatabaseAdapter } from "../../adapter.js";
-import { ActiveRecordTransaction } from "../../transaction.js";
+import { Transaction as UserTransaction } from "../../transaction.js";
 import { ActiveRecordError, PreparedStatementCacheExpired } from "../../errors.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 
@@ -222,8 +222,8 @@ export class NullTransaction {
 
   afterRollback(_fn?: () => void | Promise<void>): void {}
 
-  get userTransaction(): ActiveRecordTransaction {
-    return ActiveRecordTransaction.NULL_TRANSACTION;
+  get userTransaction(): UserTransaction {
+    return UserTransaction.NULL_TRANSACTION;
   }
 }
 
@@ -290,7 +290,7 @@ export class Transaction {
   private _runCommitCallbacks: boolean;
   private _dirty = false;
   written = false;
-  readonly userTransaction: ActiveRecordTransaction;
+  readonly userTransaction: UserTransaction;
   protected _instrumenter: TransactionInstrumenter;
 
   static readonly Callback = TransactionCallback;
@@ -308,8 +308,8 @@ export class Transaction {
     this.isolationLevel = options.isolation ?? null;
     this._runCommitCallbacks = options.runCommitCallbacks ?? false;
     this.userTransaction = this._joinable
-      ? new ActiveRecordTransaction(this)
-      : ActiveRecordTransaction.NULL_TRANSACTION;
+      ? new UserTransaction(this)
+      : UserTransaction.NULL_TRANSACTION;
     this._instrumenter = new TransactionInstrumenter({
       connection,
       transaction: this.userTransaction,
@@ -978,7 +978,7 @@ export class TransactionManager {
 
   async withinNewTransaction<T>(
     options: { isolation?: string | null; joinable?: boolean },
-    fn: (tx: ActiveRecordTransaction) => Promise<T> | T,
+    fn: (tx: UserTransaction) => Promise<T> | T,
   ): Promise<T> {
     const transaction = await this.beginTransaction({
       isolation: options.isolation,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -56,8 +56,12 @@ export { CollectionProxy } from "./associations/collection-proxy.js";
 export type { AssociationProxy } from "./associations/collection-proxy.js";
 export { AssociationRelation } from "./association-relation.js";
 export type { AssociationOptions } from "./associations.js";
-export { Transaction } from "./connection-adapters/abstract/transaction.js";
-export { ActiveRecordTransaction } from "./transaction.js";
+// Public Rails-facing Transaction wrapper. The internal transaction
+// class lives at connection-adapters/abstract/transaction.ts and is
+// intentionally NOT re-exported at the top level — Rails doesn't
+// expose ConnectionAdapters::Transaction as part of the
+// ActiveRecord:: surface either.
+export { Transaction } from "./transaction.js";
 export {
   LogSubscriber,
   getVerboseQueryLogs,

--- a/packages/activerecord/src/query-logs-formatter.ts
+++ b/packages/activerecord/src/query-logs-formatter.ts
@@ -16,31 +16,37 @@ export interface QueryLogsFormatter {
  * Legacy Rails format: key:value pairs separated by commas.
  * Example: application:MyApp,controller:users
  *
- * Mirrors: ActiveRecord::QueryLogs::LegacyFormatter
+ * Mirrors: ActiveRecord::QueryLogs::LegacyFormatter — Rails exposes
+ * this as a singleton class (`class << self`). In TS we model it as
+ * a class with static methods so consumers call
+ * `LegacyFormatter.format(k, v)` the same way they'd call
+ * `LegacyFormatter.format` in Ruby.
  */
-export const LegacyFormatter: QueryLogsFormatter = {
-  format(key: string, value: TagValue): string {
+export class LegacyFormatter {
+  static format(key: string, value: TagValue): string {
     return `${key}:${value}`;
-  },
-  join(pairs: string[]): string {
+  }
+  static join(pairs: string[]): string {
     return pairs.join(",");
-  },
-};
+  }
+}
 
 /**
  * SQLCommenter format (OpenTelemetry standard).
  * Example: application='MyApp',controller='users'
  *
- * Mirrors: ActiveRecord::QueryLogs::SQLCommenter
+ * Mirrors: ActiveRecord::QueryLogs::SQLCommenter (Rails singleton
+ * class). Static-method class keeps the `SQLCommenter.format(...)` /
+ * `.join(...)` call shape users write in Ruby.
  */
-export const SQLCommenter: QueryLogsFormatter = {
-  format(key: string, value: TagValue): string {
+export class SQLCommenter {
+  static format(key: string, value: TagValue): string {
     return `${sqlCommenterEncode(key)}='${sqlCommenterEncode(String(value))}'`;
-  },
-  join(pairs: string[]): string {
+  }
+  static join(pairs: string[]): string {
     return pairs.join(",");
-  },
-};
+  }
+}
 
 function sqlCommenterEncode(value: string): string {
   return encodeURIComponent(value).replace(/'/g, "%27");

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -199,6 +199,17 @@ describe("GetKeyHandler", () => {
     logs.updateContext({ controller: "UsersController" });
     expect(logs.tagContent()).toBe("controller:UsersController");
   });
+
+  it("lazy-creates a handler if a tag is pushed without going through tags=", () => {
+    // tagContent must survive callers that mutate the live tags
+    // array directly — the handler cache is populated lazily on
+    // first access so we can't crash on a missing map entry.
+    const logs = new QueryLogs();
+    logs.tags = ["controller"];
+    logs.tags.push("action");
+    logs.updateContext({ controller: "Users", action: "index" });
+    expect(logs.tagContent()).toBe("controller:Users,action:index");
+  });
 });
 
 describe("LegacyFormatter", () => {

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -211,6 +211,29 @@ describe("LegacyFormatter", () => {
   });
 });
 
+describe("QueryLogs.formatter =", () => {
+  it("accepts a static-method class (LegacyFormatter / SQLCommenter) directly", () => {
+    const logs = new QueryLogs();
+    // Class value — typeof === "function". Must not throw.
+    expect(() => (logs.formatter = SQLCommenter)).not.toThrow();
+    expect(() => (logs.formatter = LegacyFormatter)).not.toThrow();
+  });
+
+  it("still accepts instance-shaped formatters", () => {
+    const logs = new QueryLogs();
+    const custom = {
+      format: (k: string, v: unknown) => `${k}=${v}`,
+      join: (pairs: string[]) => pairs.join(";"),
+    };
+    expect(() => (logs.formatter = custom)).not.toThrow();
+  });
+
+  it("rejects values missing format/join methods", () => {
+    const logs = new QueryLogs();
+    expect(() => (logs.formatter = { foo: 1 } as any)).toThrow(/unsupported/i);
+  });
+});
+
 describe("SQLCommenter", () => {
   it("formats as OpenTelemetry key='value' with URL-encoding", () => {
     expect(SQLCommenter.format("app", "My App")).toBe("app='My%20App'");

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { QueryLogs, escapeComment } from "./query-logs.js";
+import { QueryLogs, escapeComment, GetKeyHandler } from "./query-logs.js";
+import { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
 
 describe("QueryLogsTest", () => {
   let logs: QueryLogs;
@@ -179,5 +180,47 @@ describe("QueryLogsTest", () => {
     ];
     logs.call("SELECT 1");
     expect(called).toBe(true);
+  });
+});
+
+describe("GetKeyHandler", () => {
+  it("looks up a named key in the context hash", () => {
+    const handler = new GetKeyHandler("controller");
+    expect(handler.call({ controller: "UsersController" })).toBe("UsersController");
+  });
+
+  it("returns undefined when the key is absent", () => {
+    expect(new GetKeyHandler("missing").call({})).toBeUndefined();
+  });
+
+  it("is used by QueryLogs string-tag resolution", () => {
+    const logs = new QueryLogs();
+    logs.tags = ["controller"];
+    logs.updateContext({ controller: "UsersController" });
+    expect(logs.tagContent()).toBe("controller:UsersController");
+  });
+});
+
+describe("LegacyFormatter", () => {
+  it("formats as 'key:value'", () => {
+    expect(LegacyFormatter.format("app", "MyApp")).toBe("app:MyApp");
+  });
+
+  it("joins with ','", () => {
+    expect(LegacyFormatter.join(["a:1", "b:2"])).toBe("a:1,b:2");
+  });
+});
+
+describe("SQLCommenter", () => {
+  it("formats as OpenTelemetry key='value' with URL-encoding", () => {
+    expect(SQLCommenter.format("app", "My App")).toBe("app='My%20App'");
+  });
+
+  it("encodes single quotes as %27", () => {
+    expect(SQLCommenter.format("k", "v'x")).toBe("k='v%27x'");
+  });
+
+  it("joins with ','", () => {
+    expect(SQLCommenter.join(["a='1'", "b='2'"])).toBe("a='1',b='2'");
   });
 });

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -175,7 +175,16 @@ export class QueryLogs {
         // Dispatch via the pre-built GetKeyHandler (rebuilt in `tags=`),
         // matching Rails' build_handler caching. The handler is
         // guaranteed present because `tags=` populated it.
-        const handler = this._keyHandlers.get(tag)!;
+        // Prefer the pre-built handler (warm path — populated by
+        // tags= setter). Fall back to a fresh one if callers mutated
+        // the live _tags array without going through the setter —
+        // better to pay the allocation than crash on a non-null
+        // assertion.
+        let handler = this._keyHandlers.get(tag);
+        if (!handler) {
+          handler = new GetKeyHandler(tag);
+          this._keyHandlers.set(tag, handler);
+        }
         const value = handler.call(this._context);
         if (value != null) {
           pairs.push(this._formatter.format(tag, value));

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -111,6 +111,7 @@ export class QueryLogs {
       // constructor name and type for a useful diagnostic.
       const describe = (v: unknown): string => {
         if (v === null) return "null";
+        if (v === undefined) return "undefined";
         if (typeof v === "function") return `class/function ${v.name || "<anonymous>"}`;
         if (typeof v === "object") {
           const name = (v as { constructor?: { name?: string } })?.constructor?.name;

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -43,6 +43,11 @@ export class QueryLogs {
   private _cacheEnabled = false;
   private _cachedComment: string | null | undefined = undefined;
   private _context: Record<string, TagValue> = {};
+  // One GetKeyHandler per string tag, built when tags= is set so we
+  // don't allocate one per query inside `tagContent()`. Matches
+  // Rails' build_handler path (query_logs.rb:180) which builds the
+  // handler list once during configuration.
+  private _keyHandlers: Map<string, GetKeyHandler> = new Map();
 
   get tags(): TagDefinition[] {
     return this._tags;
@@ -50,6 +55,12 @@ export class QueryLogs {
 
   set tags(tags: TagDefinition[]) {
     this._tags = tags;
+    this._keyHandlers = new Map();
+    for (const tag of tags) {
+      if (typeof tag === "string") {
+        this._keyHandlers.set(tag, new GetKeyHandler(tag));
+      }
+    }
     this._cachedComment = undefined;
   }
 
@@ -83,8 +94,17 @@ export class QueryLogs {
       this._formatter = LegacyFormatter;
     } else if (format === "sqlcommenter") {
       this._formatter = SQLCommenter;
-    } else if (typeof format === "object" && format !== null) {
-      this._formatter = format;
+    } else if (
+      format !== null &&
+      (typeof format === "object" || typeof format === "function") &&
+      typeof (format as QueryLogsFormatter).format === "function" &&
+      typeof (format as QueryLogsFormatter).join === "function"
+    ) {
+      // Accept anything with the right call shape — an instance, a
+      // const object, or a class / function with static `format` /
+      // `join` (matches how Rails' singleton-class formatters are
+      // invoked: `MyFormatter.format(k, v)`).
+      this._formatter = format as QueryLogsFormatter;
     } else {
       throw new ConfigurationError(`Formatter is unsupported: ${format}`);
     }
@@ -152,10 +172,11 @@ export class QueryLogs {
     const pairs: string[] = [];
     for (const tag of this._tags) {
       if (typeof tag === "string") {
-        // Route through GetKeyHandler — same structure as Rails'
-        // build_handler path, which wraps every string tag in a
-        // GetKeyHandler for uniform dispatch.
-        const value = new GetKeyHandler(tag).call(this._context);
+        // Dispatch via the pre-built GetKeyHandler (rebuilt in `tags=`),
+        // matching Rails' build_handler caching. The handler is
+        // guaranteed present because `tags=` populated it.
+        const handler = this._keyHandlers.get(tag)!;
+        const value = handler.call(this._context);
         if (value != null) {
           pairs.push(this._formatter.format(tag, value));
         }

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -18,6 +18,22 @@ export type TagHandler = (context?: Record<string, TagValue>) => TagValue;
 export type TagDefinition = string | TagHandler | Record<string, TagValue | TagHandler>;
 
 /**
+ * Handler that resolves a tag value by looking up a named key in the
+ * QueryLogs context hash.
+ *
+ * Mirrors: ActiveRecord::QueryLogs::GetKeyHandler — Rails builds one
+ * of these per string tag (`build_handler` in query_logs.rb) so
+ * `[name, handler]` pairs can be uniformly dispatched via `.call`.
+ */
+export class GetKeyHandler {
+  constructor(private readonly name: string) {}
+
+  call(context: Record<string, TagValue>): TagValue {
+    return context[this.name];
+  }
+}
+
+/**
  * QueryLogs configuration and SQL comment generation.
  */
 export class QueryLogs {
@@ -136,7 +152,10 @@ export class QueryLogs {
     const pairs: string[] = [];
     for (const tag of this._tags) {
       if (typeof tag === "string") {
-        const value = this._context[tag];
+        // Route through GetKeyHandler — same structure as Rails'
+        // build_handler path, which wraps every string tag in a
+        // GetKeyHandler for uniform dispatch.
+        const value = new GetKeyHandler(tag).call(this._context);
         if (value != null) {
           pairs.push(this._formatter.format(tag, value));
         }

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -55,7 +55,7 @@ export class QueryLogs {
 
   set tags(tags: TagDefinition[]) {
     this._tags = tags;
-    this._keyHandlers = new Map();
+    this._keyHandlers = new Map<string, GetKeyHandler>();
     for (const tag of tags) {
       if (typeof tag === "string") {
         this._keyHandlers.set(tag, new GetKeyHandler(tag));
@@ -106,7 +106,21 @@ export class QueryLogs {
       // invoked: `MyFormatter.format(k, v)`).
       this._formatter = format as QueryLogsFormatter;
     } else {
-      throw new ConfigurationError(`Formatter is unsupported: ${format}`);
+      // Describe the bad value without dumping a full function body
+      // (classes stringify to their whole source) — prefer the
+      // constructor name and type for a useful diagnostic.
+      const describe = (v: unknown): string => {
+        if (v === null) return "null";
+        if (typeof v === "function") return `class/function ${v.name || "<anonymous>"}`;
+        if (typeof v === "object") {
+          const name = (v as { constructor?: { name?: string } })?.constructor?.name;
+          return `${typeof v}${name ? ` (${name})` : ""}`;
+        }
+        return `${typeof v} ${String(v)}`;
+      };
+      throw new ConfigurationError(
+        `Formatter is unsupported: ${describe(format)} — expected "legacy", "sqlcommenter", or an object/class with callable \`format\` and \`join\``,
+      );
     }
     this._cachedComment = undefined;
   }

--- a/packages/activerecord/src/transaction.test.ts
+++ b/packages/activerecord/src/transaction.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the public ActiveRecord::Transaction wrapper.
+ * The behavior-in-transaction test suites (transaction-callbacks,
+ * transaction-instrumentation, transaction-isolation, transactions)
+ * exercise the wrapper indirectly; these pin the direct API shape.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Transaction } from "./transaction.js";
+
+describe("Transaction (public wrapper, Rails ActiveRecord::Transaction)", () => {
+  it("NULL_TRANSACTION is closed + blank + has no uuid", () => {
+    const t = Transaction.NULL_TRANSACTION;
+    expect(t.isOpen()).toBe(false);
+    expect(t.isClosed()).toBe(true);
+    expect(t.isBlank()).toBe(true);
+    expect(t.uuid()).toBeNull();
+  });
+
+  it("afterCommit on a null transaction runs the block immediately", () => {
+    const t = Transaction.NULL_TRANSACTION;
+    let ran = false;
+    t.afterCommit(() => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("afterRollback on a null transaction is a no-op", () => {
+    const t = Transaction.NULL_TRANSACTION;
+    let ran = false;
+    t.afterRollback(() => {
+      ran = true;
+    });
+    expect(ran).toBe(false);
+  });
+
+  it("NULL_TRANSACTION is a shared singleton (matches Rails' frozen constant)", () => {
+    expect(Transaction.NULL_TRANSACTION).toBe(Transaction.NULL_TRANSACTION);
+  });
+});

--- a/packages/activerecord/src/transaction.ts
+++ b/packages/activerecord/src/transaction.ts
@@ -9,7 +9,7 @@ import { Transaction as InternalTransaction } from "./connection-adapters/abstra
  *
  * Mirrors: ActiveRecord::Transaction
  */
-export class ActiveRecordTransaction {
+export class Transaction {
   private _internalTransaction: InternalTransaction | null;
   private _uuid: string | null = null;
 
@@ -83,5 +83,5 @@ export class ActiveRecordTransaction {
     return this._uuid;
   }
 
-  static readonly NULL_TRANSACTION = new ActiveRecordTransaction(null);
+  static readonly NULL_TRANSACTION = new Transaction(null);
 }


### PR DESCRIPTION
## Summary

Three classes showed `ts<class missing>` in `api:compare --inheritance` because the behavior existed but the surface shape didn't match Rails. Pre-launch, fix the names / shapes to match Rails directly.

1. **`transaction.ts:Transaction`** — the public-facing `ActiveRecord::Transaction` wrapper lived in `transaction.ts` as `ActiveRecordTransaction`. Rename to `Transaction`. Disambiguate the internal `ConnectionAdapters::Abstract::Transaction` with an import alias (`Transaction as UserTransaction`) where both are in scope. Drop the duplicate top-level `Transaction` export of the internal class — Rails doesn't expose `ConnectionAdapters::Transaction` at the `ActiveRecord::` surface either.

2. **`query-logs-formatter.ts:SQLCommenter`** (and sibling `LegacyFormatter`) — Rails defines these as singleton classes (`class << self`); we had them as const objects implementing a `QueryLogsFormatter` interface. Convert both to TS classes with static methods. Call shape (`LegacyFormatter.format(k, v)`, `.join(pairs)`) is identical.

3. **`query-logs.ts:GetKeyHandler`** — Rails wraps every string tag in a `GetKeyHandler` (`query_logs.rb:75`) so `[name, handler]` pairs dispatch uniformly via `.call`. We were inlining `context[tag]` directly inside `tagContent()`. Add the class and route the string-tag path through it.

## Test plan

- [x] `pnpm build` / `pnpm typecheck` clean
- [x] `pnpm exec vitest run packages/activerecord` — 8736 passed, 0 failed
- [x] `pnpm api:compare --package activerecord --inheritance` — **195/210 → 198/210 (92.9% → 94.3%)**