### PR TITLE
feat(activerecord): DJAS routes polymorphic-source + sourceType through-associations

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -349,9 +349,17 @@ function _canRouteThroughViaAssociationScope(
  * Disable-joins routing gate. Mirrors `_canRouteThroughViaAssociationScope`
  * but for `disable_joins: true` through associations — runs the chain
  * via the Rails-faithful `DisableJoinsAssociationScope` (per-step pluck
- * + IN list) rather than the legacy `loadHasManyThrough` 2-step. PR 4
- * routes the simple non-polymorphic shape only; polymorphic / sourceType
- * stays on the existing loader.
+ * + IN list) rather than the legacy `loadHasManyThrough` 2-step.
+ *
+ * Currently routes: single-column and composite-key through
+ * associations (from PR #645) and polymorphic-source + `sourceType`
+ * through-associations (from PR #661 — Rails' DJAS has no such gate
+ * and evaluates the per-reflection `constraints()` chain, including
+ * `ThroughReflection#_sourceTypeScope()` which applies
+ * `where(source_type: ...)` on the through step).
+ *
+ * Remaining bail-out: nested-through (`isNested()`). Follow-up
+ * widening covers that case.
  */
 function _canRouteThroughViaDisableJoinsAssociationScope(
   reflection: unknown,

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -369,8 +369,6 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
     | { isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
-  if (typeof src.isPolymorphic === "function" && src.isPolymorphic()) return false;
-  if (options.sourceType) return false;
   // Composite-key through associations are now supported by DJAS'
   // `_addConstraintsDj`, which builds an Arel `OR`-of-`AND` predicate
   // (`(c1=v1a AND c2=v1b) OR ...`) for the chain walk — same shape

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -354,9 +354,11 @@ function _canRouteThroughViaAssociationScope(
  * Currently routes: single-column and composite-key through
  * associations (from PR #645) and polymorphic-source + `sourceType`
  * through-associations (from PR #661 — Rails' DJAS has no such gate
- * and evaluates the per-reflection `constraints()` chain, including
- * `ThroughReflection#_sourceTypeScope()` which applies
- * `where(source_type: ...)` on the through step).
+ * and evaluates the per-reflection `constraints()` chain. When the
+ * source is polymorphic, the through chain includes a
+ * `PolymorphicReflection` wrapper whose `constraints()` contributes
+ * `_sourceTypeScope()` (reflection.ts) — the `where(source_type:
+ * ...)` closure that lands on the through step).
  *
  * Remaining bail-out: nested-through (`isNested()`). Follow-up
  * widening covers that case.

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -379,6 +379,22 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
     | { isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
+  // `sourceType` is only meaningful with a polymorphic source — it's
+  // the tag Rails uses to disambiguate which polymorphic target to
+  // select. With a non-polymorphic source, the through chain still
+  // inserts a `PolymorphicReflection` (reflection.ts#_collectJoinReflections
+  // triggers on `options.sourceType`), but its `foreignType` resolves
+  // to `null` (reflection.ts:544), and `_sourceTypeScope()` would
+  // emit `where({[null]: sourceType})` — invalid SQL. Rails doesn't
+  // explicitly guard this misconfiguration either, but we can reject
+  // the DJAS fast-path so the 2-step `loadHasManyThrough` handles it
+  // predictably.
+  if (
+    options.sourceType != null &&
+    (typeof src.isPolymorphic !== "function" || !src.isPolymorphic())
+  ) {
+    return false;
+  }
   // Composite-key through associations are now supported by DJAS'
   // `_addConstraintsDj`, which builds an Arel `OR`-of-`AND` predicate
   // (`(c1=v1a AND c2=v1b) OR ...`) for the chain walk — same shape

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -379,22 +379,20 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
     | { isPolymorphic?: () => boolean }
     | undefined;
   if (!src) return false;
-  // `sourceType` is only meaningful with a polymorphic source — it's
-  // the tag Rails uses to disambiguate which polymorphic target to
-  // select. With a non-polymorphic source, the through chain still
-  // inserts a `PolymorphicReflection` (reflection.ts#_collectJoinReflections
-  // triggers on `options.sourceType`), but its `foreignType` resolves
-  // to `null` (reflection.ts:544), and `_sourceTypeScope()` would
-  // emit `where({[null]: sourceType})` — invalid SQL. Rails doesn't
-  // explicitly guard this misconfiguration either, but we can reject
-  // the DJAS fast-path so the 2-step `loadHasManyThrough` handles it
-  // predictably.
-  if (
-    options.sourceType != null &&
-    (typeof src.isPolymorphic !== "function" || !src.isPolymorphic())
-  ) {
-    return false;
-  }
+  // `sourceType` must pair with a polymorphic source. Rails' own
+  // reflection validation rejects `has_many :through` with a
+  // polymorphic source and no `source_type`
+  // (`HasManyThroughAssociationPolymorphicSourceError`), and `source_type`
+  // with a non-polymorphic source injects a useless
+  // `PolymorphicReflection` whose `foreignType` is null
+  // (reflection.ts:544) — `_sourceTypeScope()` would emit
+  // `where({[null]: sourceType})` (invalid SQL). Reject both
+  // mismatches so the fallback loader handles them predictably:
+  // - polymorphic source without sourceType → missing type filter,
+  //   through-step pluck could mix ids across polymorphic targets.
+  // - sourceType without polymorphic source → no valid type column.
+  const srcIsPolymorphic = typeof src.isPolymorphic === "function" && src.isPolymorphic();
+  if (srcIsPolymorphic !== (options.sourceType != null)) return false;
   // Composite-key through associations are now supported by DJAS'
   // `_addConstraintsDj`, which builds an Arel `OR`-of-`AND` predicate
   // (`(c1=v1a AND c2=v1b) OR ...`) for the chain walk — same shape

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -8,11 +8,11 @@
  *
  * Rails has no such restriction: `DisableJoinsAssociationScope` walks
  * the reverseChain and evaluates `reflection.constraints()` at each
- * step. The source-type filter is already returned from
- * `ThroughReflection#constraints()` via `_sourceTypeScope()`
- * (reflection.ts#_sourceTypeScope), so the walk naturally applies
- * `WHERE source_type = 'Target'` on the through step once the gate is
- * lifted.
+ * step. When the source is polymorphic, the through chain wraps the
+ * relevant step in a `PolymorphicReflection` whose `constraints()`
+ * contributes `_sourceTypeScope()` (reflection.ts#_sourceTypeScope),
+ * so the walk naturally applies `WHERE source_type = 'Target'` on
+ * the through step once the gate is lifted.
  *
  * These tests pin the resulting SQL shape (no JOIN) so a regression
  * that re-introduces the gate — or any future change that silently
@@ -151,9 +151,9 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     // Hard assert: no JOIN in any query — would be present if the
     // loader regressed back to AssociationScope's join-based path.
     expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
-    // And the source_type filter actually lands somewhere. Rails
-    // applies it on the through step (rw_comments) via
-    // ThroughReflection#_sourceTypeScope.
+    // And the source_type filter actually lands somewhere —
+    // contributed by PolymorphicReflection#_sourceTypeScope via
+    // constraints() during the DJAS chain walk.
     expect(observed.some((s) => /origin_type/i.test(s))).toBe(true);
   });
 

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -1,0 +1,138 @@
+/**
+ * DJAS routing gate widening (task #12).
+ *
+ * `_canRouteThroughViaDisableJoinsAssociationScope` in associations.ts
+ * used to bail out on `options.sourceType` and on
+ * `sourceReflection.isPolymorphic()` — those shapes fell back to the
+ * JOIN-based AssociationScope path, defeating `disable_joins: true`.
+ *
+ * Rails has no such restriction: `DisableJoinsAssociationScope` walks
+ * the reverseChain and evaluates `reflection.constraints()` at each
+ * step. The source-type filter is already returned from
+ * `ThroughReflection#constraints()` via `_sourceTypeScope()`
+ * (reflection.ts#_sourceTypeScope), so the walk naturally applies
+ * `WHERE source_type = 'Target'` on the through step once the gate is
+ * lifted.
+ *
+ * These tests pin the resulting SQL shape (no JOIN) so a regression
+ * that re-introduces the gate — or any future change that silently
+ * falls back to AssociationScope — is caught.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import { Base, registerModel } from "../index.js";
+import { Associations, loadHasMany } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("DJAS routing widening — sourceType + polymorphic source", () => {
+  let adapter: DatabaseAdapter;
+
+  class RwAuthor extends Base {
+    static {
+      this._tableName = "rw_authors";
+      this.attribute("name", "string");
+    }
+  }
+  class RwComment extends Base {
+    static {
+      this._tableName = "rw_comments";
+      this.attribute("rw_author_id", "integer");
+      this.attribute("origin_id", "integer");
+      this.attribute("origin_type", "string");
+    }
+  }
+  class RwMember extends Base {
+    static {
+      this._tableName = "rw_members";
+      this.attribute("name", "string");
+    }
+  }
+  class RwOtherOrigin extends Base {
+    static {
+      this._tableName = "rw_other_origins";
+      this.attribute("label", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    RwAuthor.adapter = adapter;
+    RwComment.adapter = adapter;
+    RwMember.adapter = adapter;
+    RwOtherOrigin.adapter = adapter;
+    registerModel("RwAuthor", RwAuthor);
+    registerModel("RwComment", RwComment);
+    registerModel("RwMember", RwMember);
+    registerModel("RwOtherOrigin", RwOtherOrigin);
+    (RwAuthor as any)._associations = [];
+    (RwComment as any)._associations = [];
+
+    Associations.hasMany.call(RwAuthor, "rwComments", {
+      className: "RwComment",
+      foreignKey: "rw_author_id",
+    });
+    Associations.belongsTo.call(RwComment, "origin", {
+      className: "RwMember",
+      foreignKey: "origin_id",
+      polymorphic: true,
+    });
+    // has_many :no_joins_rw_members, through: :rw_comments,
+    //   source: :origin, source_type: "RwMember", disable_joins: true
+    // Direct (non-nested) through: RwAuthor → rwComments (through) →
+    // origin (polymorphic belongsTo, sourceType disambiguates).
+    Associations.hasMany.call(RwAuthor, "noJoinsRwMembers", {
+      className: "RwMember",
+      through: "rwComments",
+      source: "origin",
+      sourceType: "RwMember",
+      disableJoins: true,
+    });
+  });
+
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
+
+  it("routes through DJAS (no JOIN emitted) and filters by source_type", async () => {
+    const author = await RwAuthor.create({ name: "a" });
+    const member = (await RwMember.create({ name: "m" })) as any;
+    const other = (await RwOtherOrigin.create({ label: "o" })) as any;
+    // A comment whose origin is an RwMember (matches sourceType).
+    await RwComment.create({
+      rw_author_id: author.id,
+      origin_id: member.id,
+      origin_type: "RwMember",
+    });
+    // A comment whose origin is RwOtherOrigin (should NOT match — the
+    // source_type filter is what distinguishes the polymorphic
+    // targets).
+    await RwComment.create({
+      rw_author_id: author.id,
+      origin_id: other.id,
+      origin_type: "RwOtherOrigin",
+    });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      const reflection = (RwAuthor as any)._reflectOnAssociation("noJoinsRwMembers");
+      const members = await loadHasMany(author, "noJoinsRwMembers", reflection.options);
+      // Only the RwMember-originated row resolves to a real RwMember.
+      expect(members.map((m: any) => m.id)).toEqual([member.id]);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(observed.length).toBeGreaterThan(0);
+    // Hard assert: no JOIN in any query — would be present if the
+    // loader regressed back to AssociationScope's join-based path.
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
+    // And the source_type filter actually lands somewhere. Rails
+    // applies it on the through step (rw_comments) via
+    // ThroughReflection#_sourceTypeScope.
+    expect(observed.some((s) => /origin_type/i.test(s))).toBe(true);
+  });
+});

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -21,7 +21,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations, association, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -96,17 +96,25 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
 
   it("routes through DJAS (no JOIN emitted) and filters by source_type", async () => {
     const author = await RwAuthor.create({ name: "a" });
-    const member = (await RwMember.create({ name: "m" })) as any;
+    const m1 = (await RwMember.create({ name: "m1" })) as any;
+    const m2 = (await RwMember.create({ name: "m2" })) as any;
+    // Insert an RwOtherOrigin FIRST so the id-sequences overlap —
+    // ensures the source_type filter is the thing doing the
+    // disambiguation, not a lucky id mismatch.
     const other = (await RwOtherOrigin.create({ label: "o" })) as any;
-    // A comment whose origin is an RwMember (matches sourceType).
+    expect(other.id).toBe(m1.id); // id collision across polymorphic targets
+    // Comments pointing at both RwMembers (match sourceType) and the
+    // RwOtherOrigin (must be filtered out by source_type, not by id).
     await RwComment.create({
       rw_author_id: author.id,
-      origin_id: member.id,
+      origin_id: m1.id,
       origin_type: "RwMember",
     });
-    // A comment whose origin is RwOtherOrigin (should NOT match — the
-    // source_type filter is what distinguishes the polymorphic
-    // targets).
+    await RwComment.create({
+      rw_author_id: author.id,
+      origin_id: m2.id,
+      origin_type: "RwMember",
+    });
     await RwComment.create({
       rw_author_id: author.id,
       origin_id: other.id,
@@ -121,8 +129,11 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     try {
       const reflection = (RwAuthor as any)._reflectOnAssociation("noJoinsRwMembers");
       const members = await loadHasMany(author, "noJoinsRwMembers", reflection.options);
-      // Only the RwMember-originated row resolves to a real RwMember.
-      expect(members.map((m: any) => m.id)).toEqual([member.id]);
+      expect(members.map((m: any) => m.id).sort()).toEqual([m1.id, m2.id].sort());
+      // `count()` should hit the same routing gate and also avoid the
+      // JOIN path. Covers the pluck branch of DJAR alongside toArray.
+      const count = await association(author, "noJoinsRwMembers").count();
+      expect(count).toBe(2);
     } finally {
       Notifications.unsubscribe(sub);
     }
@@ -134,5 +145,45 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     // applies it on the through step (rw_comments) via
     // ThroughReflection#_sourceTypeScope.
     expect(observed.some((s) => /origin_type/i.test(s))).toBe(true);
+  });
+
+  it("has_one :through polymorphic+sourceType routes through DJAS (no JOIN)", async () => {
+    // The routing gate is shared by loadHasMany and loadHasOne
+    // (associations.ts), so the same widening needs to hold for
+    // has_one :through.
+    Associations.hasOne.call(RwAuthor, "noJoinsOneRwMember", {
+      className: "RwMember",
+      through: "rwComments",
+      source: "origin",
+      sourceType: "RwMember",
+      disableJoins: true,
+    });
+    const author = await RwAuthor.create({ name: "a" });
+    const member = (await RwMember.create({ name: "m" })) as any;
+    const other = (await RwOtherOrigin.create({ label: "o" })) as any;
+    await RwComment.create({
+      rw_author_id: author.id,
+      origin_id: other.id,
+      origin_type: "RwOtherOrigin",
+    });
+    await RwComment.create({
+      rw_author_id: author.id,
+      origin_id: member.id,
+      origin_type: "RwMember",
+    });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    let loaded: any;
+    try {
+      loaded = await (author as any).loadHasOne("noJoinsOneRwMember");
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(loaded?.id).toBe(member.id);
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 });

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -98,9 +98,9 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     const author = await RwAuthor.create({ name: "a" });
     const m1 = (await RwMember.create({ name: "m1" })) as any;
     const m2 = (await RwMember.create({ name: "m2" })) as any;
-    // Insert an RwOtherOrigin FIRST so the id-sequences overlap —
-    // ensures the source_type filter is the thing doing the
-    // disambiguation, not a lucky id mismatch.
+    // ids overlap across polymorphic target tables (separate
+    // per-table sequences), so the source_type filter is the only
+    // thing that could discriminate — not a lucky id mismatch.
     const other = (await RwOtherOrigin.create({ label: "o" })) as any;
     expect(other.id).toBe(m1.id); // id collision across polymorphic targets
     // Comments pointing at both RwMembers (match sourceType) and the

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -88,6 +88,13 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
       sourceType: "RwMember",
       disableJoins: true,
     });
+    Associations.hasOne.call(RwAuthor, "noJoinsOneRwMember", {
+      className: "RwMember",
+      through: "rwComments",
+      source: "origin",
+      sourceType: "RwMember",
+      disableJoins: true,
+    });
   });
 
   afterEach(() => {
@@ -130,8 +137,11 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
       const reflection = (RwAuthor as any)._reflectOnAssociation("noJoinsRwMembers");
       const members = await loadHasMany(author, "noJoinsRwMembers", reflection.options);
       expect(members.map((m: any) => m.id).sort()).toEqual([m1.id, m2.id].sort());
-      // `count()` should hit the same routing gate and also avoid the
-      // JOIN path. Covers the pluck branch of DJAR alongside toArray.
+      // `count()` should hit the same routing gate and also avoid
+      // the JOIN path. CollectionProxy#count currently loads
+      // records and returns `.length` rather than issuing a
+      // distinct COUNT — we only assert the cardinality and the
+      // no-JOIN shape, not the query form.
       const count = await association(author, "noJoinsRwMembers").count();
       expect(count).toBe(2);
     } finally {
@@ -150,14 +160,9 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
   it("has_one :through polymorphic+sourceType routes through DJAS (no JOIN)", async () => {
     // The routing gate is shared by loadHasMany and loadHasOne
     // (associations.ts), so the same widening needs to hold for
-    // has_one :through.
-    Associations.hasOne.call(RwAuthor, "noJoinsOneRwMember", {
-      className: "RwMember",
-      through: "rwComments",
-      source: "origin",
-      sourceType: "RwMember",
-      disableJoins: true,
-    });
+    // has_one :through. `noJoinsOneRwMember` is defined in
+    // beforeEach above so we don't mutate RwAuthor's association list
+    // across tests.
     const author = await RwAuthor.create({ name: "a" });
     const member = (await RwMember.create({ name: "m" })) as any;
     const other = (await RwOtherOrigin.create({ label: "o" })) as any;


### PR DESCRIPTION
## Summary

PR-A of task #12 (DJAS routing widening). Closes two of the three bail-out gates in `_canRouteThroughViaDisableJoinsAssociationScope` (associations.ts): `options.sourceType` and `sourceReflection.isPolymorphic()`. These shapes were forced onto the JOIN-based `AssociationScope` path, defeating `disable_joins: true`.

Rails has no such restriction. `DisableJoinsAssociationScope` walks the chain and evaluates `reflection.constraints()` at each step, and `ThroughReflection#_sourceTypeScope()` (reflection.ts) already returns a constraint closure that applies `where(source_type: ...)` on the through step. Drop the gates, and the existing chain-walk + constraints machinery picks it up automatically.

Nested-through (`isNested()`) is the remaining gate — separate PR since it's less tangled with these two (sourceType is almost always paired with polymorphic source).

## Test plan

- [x] New `disable-joins-routing-widening.test.ts` pins the shape with Notifications SQL capture: asserts no JOIN in any emitted query and that the `origin_type` filter lands on the through step.
- [x] `has-many-through-disable-joins-associations.test.ts`: 13/13 pass (including the pre-existing `"polymophic disable joins through counting"` case, which now genuinely exercises DJAS instead of silently falling back to AS).
- [x] Full `@blazetrails/activerecord` suite: 8737 passed locally.
- [ ] PG / MariaDB CI.