### PR TITLE
refactor(activerecord): extract writeAttribute from Base to ReadonlyAttributes

### DIFF
--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1778,6 +1778,10 @@ describe("AttributeMethodsTest", () => {
 
   describe("readonly attributes", () => {
     it("readonly attributes are not updated after create", async () => {
+      // Rails raises ReadonlyAttributeError on a persisted-record write to an
+      // attr_readonly column (readonly_attributes.rb line 49). The test name's
+      // "are not updated" wording pre-dates Rails adding the raise; the
+      // attribute isn't updated because the write itself is rejected.
       class Item extends Base {
         static {
           this.attribute("code", "string");
@@ -1787,11 +1791,12 @@ describe("AttributeMethodsTest", () => {
         }
       }
       const item = await Item.create({ code: "ABC", name: "Widget" });
-      item.code = "XYZ";
+      expect(() => {
+        item.code = "XYZ";
+      }).toThrow(/code/);
       item.name = "Updated";
       await item.save();
       const found = await Item.find(item.id);
-      // code should remain unchanged because it's readonly
       expect(found.code).toBe("ABC");
       expect(found.name).toBe("Updated");
     });

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -3,7 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base } from "./index.js";
+import { Base, ReadonlyAttributeError } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1793,7 +1793,7 @@ describe("AttributeMethodsTest", () => {
       const item = await Item.create({ code: "ABC", name: "Widget" });
       expect(() => {
         item.code = "XYZ";
-      }).toThrow(/code/);
+      }).toThrow(ReadonlyAttributeError);
       item.name = "Updated";
       await item.save();
       const found = await Item.find(item.id);

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1791,21 +1791,10 @@ describe("BasicsTest", () => {
     }
     expect(ConcreteModel.readonlyAttributes).toContain("code");
   });
-  it("readonly attributes when configured to not raise", async () => {
-    const adp = freshAdapter();
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("body", "string");
-        this.attrReadonly("title");
-        this.adapter = adp;
-      }
-    }
-    const p = await Post.create({ title: "Original", body: "Content" });
-    p.title = "Changed";
-    await p.save();
-    const reloaded = await Post.find(p.id);
-    expect(reloaded.title).toBe("Original");
+  it.skip("readonly attributes when configured to not raise", async () => {
+    /* Needs ActiveRecord config `raise_on_assign_to_attr_readonly` (Rails 7.1+).
+     * We don't expose that knob yet — the default behavior (raise) is covered
+     * by the `attrReadonly prevents updating readonly attributes` test. */
   });
   it.skip("readonly attributes on belongs to association", () => {});
   it.skip("respect internal encoding", () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2453,11 +2453,10 @@ export class Base extends Model {
       this.writeAttribute("updated_at", new Date());
     }
 
-    // Filter out readonly attributes from changes (they can only be set on create)
+    // Rails raises ReadonlyAttributeError at write time (HasReadonlyAttributes),
+    // so by the time we reach save the change set can never contain a readonly
+    // column on a persisted record. No silent-filter needed.
     const changedAttrs = { ...this.changes };
-    for (const readonlyAttr of ctor._readonlyAttributes) {
-      delete changedAttrs[readonlyAttr];
-    }
 
     if (Object.keys(changedAttrs).length === 0) return;
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2077,12 +2077,7 @@ export class Base extends Model {
   declare cacheKeyWithVersion: () => string;
   declare cacheVersion: () => string | null;
 
-  writeAttribute(name: string, value: unknown): void {
-    if (this._attributes.isFrozen()) {
-      throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
-    }
-    super.writeAttribute(name, value);
-  }
+  declare writeAttribute: typeof ReadonlyAttributes.writeAttribute;
 
   /**
    * The primary key value. When the concrete PK type is known, narrow it at
@@ -3386,6 +3381,8 @@ extend(Base, NamedScoping.ClassMethods);
 extend(Base, ModelSchema.ClassMethods);
 
 include(Base, {
+  // ReadonlyAttributes
+  writeAttribute: ReadonlyAttributes.writeAttribute,
   // Persistence
   isNewRecord: _Persistence.isNewRecord,
   isPersisted: _Persistence.isPersisted,

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -14,6 +14,7 @@ import {
   registerModel,
 } from "./index.js";
 import { Associations, loadBelongsTo } from "./associations.js";
+import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -5088,7 +5089,11 @@ describe("CalculationsTest", () => {
     }
 
     const product = await Product.create({ sku: "ABC-123", name: "Widget" });
-    product.sku = "CHANGED";
+    // Rails: writing a readonly attribute on a persisted record raises.
+    expect(() => {
+      product.sku = "CHANGED";
+    }).toThrow(ReadonlyAttributeError);
+
     product.name = "Better Widget";
     await product.save();
     await product.reload();

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -204,6 +204,7 @@ export {
   TransactionIsolationError,
   IrreversibleOrderError,
 } from "./errors.js";
+export { ReadonlyAttributeError } from "./readonly-attributes.js";
 export { RecordInvalid } from "./validations.js";
 export {
   AssociationNotFoundError,

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,4 +1,5 @@
 import type { Base } from "./base.js";
+import { Model } from "@blazetrails/activemodel";
 
 /**
  * Track and enforce readonly attributes on ActiveRecord models.
@@ -42,6 +43,27 @@ export function readonlyAttributes(this: typeof Base): string[] {
  */
 export function readonlyAttributeQ(this: typeof Base, attribute: string): boolean {
   return ((this as any)._readonlyAttributes as Set<string> | undefined)?.has(attribute) ?? false;
+}
+
+/**
+ * AR's `write_attribute` override. In Rails this lives in the
+ * `HasReadonlyAttributes` mixin inside readonly_attributes.rb. Our version
+ * carries only the frozen-record guard today; the Rails-faithful
+ * "raise ReadonlyAttributeError on a persisted-record readonly-column write"
+ * is a behavioral change and lands in a follow-up PR (existing tests
+ * encode silent-ignore-on-save, which predates Rails' raise).
+ *
+ * `Base.prototype.writeAttribute` installed via include() in base.ts.
+ *
+ * Mirrors: ActiveRecord::HasReadonlyAttributes#write_attribute
+ */
+export function writeAttribute(this: Base, name: string, value: unknown): void {
+  if (this._attributes.isFrozen()) {
+    throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
+  }
+  // `super` — route through Model's writeAttribute (the next ancestor with
+  // a writeAttribute impl, matching Rails' `super` in HasReadonlyAttributes).
+  Model.prototype.writeAttribute.call(this, name, value);
 }
 
 /**

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,5 +1,22 @@
 import type { Base } from "./base.js";
 import { Model } from "@blazetrails/activemodel";
+import { ActiveRecordError } from "./errors.js";
+
+/**
+ * Raised when a persisted record attempts to write to a column declared
+ * via `attr_readonly`.
+ *
+ * Mirrors: ActiveRecord::ReadonlyAttributeError (defined alongside
+ * HasReadonlyAttributes in Rails' readonly_attributes.rb).
+ */
+export class ReadonlyAttributeError extends ActiveRecordError {
+  readonly attribute: string;
+  constructor(attribute: string) {
+    super(attribute);
+    this.name = "ReadonlyAttributeError";
+    this.attribute = attribute;
+  }
+}
 
 /**
  * Track and enforce readonly attributes on ActiveRecord models.
@@ -46,12 +63,20 @@ export function readonlyAttributeQ(this: typeof Base, attribute: string): boolea
 }
 
 /**
- * AR's `write_attribute` override. In Rails this lives in the
- * `HasReadonlyAttributes` mixin inside readonly_attributes.rb. Our version
- * carries only the frozen-record guard today; the Rails-faithful
- * "raise ReadonlyAttributeError on a persisted-record readonly-column write"
- * is a behavioral change and lands in a follow-up PR (existing tests
- * encode silent-ignore-on-save, which predates Rails' raise).
+ * AR's `write_attribute` override — Rails' `HasReadonlyAttributes` mixin in
+ * readonly_attributes.rb (line 49). Adds two guards before delegating to the
+ * base Model implementation:
+ *
+ *   - frozen record: raises `Cannot modify a frozen X` (matching the
+ *     pre-extraction message and test coverage).
+ *   - readonly column on a persisted record: raises ReadonlyAttributeError,
+ *     matching Rails' HasReadonlyAttributes#write_attribute.
+ *
+ * During construction the `_newRecord` field initializer on `Base` hasn't
+ * run yet when `Model`'s constructor invokes `writeAttribute` — gate the
+ * readonly check on the definitively-persisted state (`_newRecord === false`)
+ * rather than `!isNewRecord()` so initial assignments during `new X(...)`
+ * aren't mistakenly blocked.
  *
  * `Base.prototype.writeAttribute` installed via include() in base.ts.
  *
@@ -60,6 +85,10 @@ export function readonlyAttributeQ(this: typeof Base, attribute: string): boolea
 export function writeAttribute(this: Base, name: string, value: unknown): void {
   if (this._attributes.isFrozen()) {
     throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
+  }
+  const ctor = this.constructor as typeof Base;
+  if (this._newRecord === false && ctor.readonlyAttributeQ(String(name))) {
+    throw new ReadonlyAttributeError(String(name));
   }
   // `super` — route through Model's writeAttribute (the next ancestor with
   // a writeAttribute impl, matching Rails' `super` in HasReadonlyAttributes).

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -6,6 +6,11 @@ import { ActiveRecordError } from "./errors.js";
  * Raised when a persisted record attempts to write to a column declared
  * via `attr_readonly`.
  *
+ * The message is just the attribute name — matching Rails, which defines
+ * `class ReadonlyAttributeError < ActiveRecordError; end` with no custom
+ * initializer and raises via `ReadonlyAttributeError.new(attr_name)`. The
+ * `.attribute` property gives programmatic access to the same value.
+ *
  * Mirrors: ActiveRecord::ReadonlyAttributeError (defined alongside
  * HasReadonlyAttributes in Rails' readonly_attributes.rb).
  */

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, ReadOnlyRecord } from "./index.js";
+import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -255,6 +256,10 @@ describe("ReadonlyTest", () => {
   });
 
   it("ignores readonly attribute changes on update", async () => {
+    // Rails' HasReadonlyAttributes#write_attribute raises ReadonlyAttributeError
+    // on a persisted-record write to an attr_readonly column (readonly_attributes.rb
+    // line 49). The Rails test by this name in newer Rails asserts that
+    // behavior — the "ignores" wording pre-dates the raise being added.
     const adapter = freshAdapter();
     class Product extends Base {
       static _tableName = "products";
@@ -266,11 +271,13 @@ describe("ReadonlyTest", () => {
     Product.attrReadonly("sku");
 
     const product = await Product.create({ sku: "ABC-123", name: "Widget" });
-    product.sku = "CHANGED";
+    expect(() => {
+      product.sku = "CHANGED";
+    }).toThrow(ReadonlyAttributeError);
+
+    // Non-readonly columns still update normally.
     product.name = "Updated Widget";
     await product.save();
-
-    // The in-memory value changes, but the SQL should not include sku
     await product.reload();
     expect(product.sku).toBe("ABC-123");
     expect(product.name).toBe("Updated Widget");


### PR DESCRIPTION
## Summary
PR 3c of the Base → Rails-module extraction plan. Moves `Base.prototype.writeAttribute` into `readonly-attributes.ts` where [Rails' `HasReadonlyAttributes` mixin](scripts/api-compare/.rails-source/activerecord/lib/active_record/readonly_attributes.rb) keeps it (line 49), and implements the full Rails-fidelity guard set:

1. **Frozen record** → `Cannot modify a frozen X` (pre-existing message preserved)
2. **Readonly column on a persisted record** → `ReadonlyAttributeError` (matches Rails' default behavior; previously our codebase silently dropped the change at save time)

`super` dispatches explicitly through `Model.prototype.writeAttribute` — the next ancestor with a `writeAttribute` impl — matching Rails' `super` in `HasReadonlyAttributes#write_attribute`.

Adds the `ReadonlyAttributeError` class in its Rails-canonical file, closing the inheritance `ts-class-missing` flag for that type.

Drops the silent-filter at the save path — by the time `save` runs, the change set can no longer contain a readonly column on a persisted record.

### Construction-time guard
During construction the `_newRecord` field initializer on `Base` hasn't run yet when `Model`'s constructor invokes `writeAttribute` — `_newRecord` is `undefined` at that point. Gating the readonly check on `this._newRecord === false` (rather than `!isNewRecord()`) keeps initial assignments during `new X(...)` working.

### Tests
- `"attrReadonly prevents updating readonly attributes"` now asserts the raise (calculations.test.ts)
- `"ignores readonly attribute changes on update"` now asserts the raise — "ignores" wording pre-dates Rails adding the raise (readonly.test.ts)
- `"readonly attributes are not updated after create"` same (attribute-methods.test.ts)
- `"readonly attributes when configured to not raise"` **skipped** — needs Rails 7.1+ config `raise_on_assign_to_attr_readonly` which we don't expose yet

## api:compare impact
| | before | after |
|-|--------|-------|
| moves | 210 | **209** |
| inheritance | 194/210 (92.4%) | **195/210 (92.9%)** |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17773 tests + 1 newly-skipped, 601 test files)
- [x] `pnpm run api:compare` confirms `write_attribute` no longer flagged as a move