### PR TITLE
refactor(activerecord): extract defaultScope/unscoped from Base to scoping/default

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -110,8 +110,11 @@ import * as _Persistence from "./persistence.js";
 import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
-import { Default as DefaultScoping } from "./scoping/default.js";
-import * as _DefaultScoping from "./scoping/default.js";
+import {
+  Default as DefaultScoping,
+  defaultScope as _defaultScope,
+  unscoped as _unscoped,
+} from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
 import { AssociationNotFoundError } from "./associations/errors.js";
 import { Associations as _Associations, loadBelongsTo, loadHasOne } from "./associations.js";
@@ -1045,8 +1048,8 @@ export class Base extends Model {
   static _defaultScope: ((rel: any) => any) | null = null;
 
   // --- Default scope (wired via extend() after class body) ---
-  declare static defaultScope: typeof _DefaultScoping.defaultScope;
-  declare static unscoped: typeof _DefaultScoping.unscoped;
+  declare static defaultScope: typeof _defaultScope;
+  declare static unscoped: typeof _unscoped;
 
   /** @internal Like all() but skips currentScope — used by the preloader. */
   static _allForPreload(): any {
@@ -3368,8 +3371,8 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, {
-  defaultScope: _DefaultScoping.defaultScope,
-  unscoped: _DefaultScoping.unscoped,
+  defaultScope: _defaultScope,
+  unscoped: _unscoped,
 });
 extend(Base, ModelSchema.ClassMethods);
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -111,6 +111,7 @@ import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
 import { Default as DefaultScoping } from "./scoping/default.js";
+import * as _DefaultScoping from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
 import { AssociationNotFoundError } from "./associations/errors.js";
 import { Associations as _Associations, loadBelongsTo, loadHasOne } from "./associations.js";
@@ -1043,36 +1044,23 @@ export class Base extends Model {
   static _scopes: Map<string, (rel: any, ...args: any[]) => any> = new Map();
   static _defaultScope: ((rel: any) => any) | null = null;
 
-  /**
-   * Define a default scope applied to all queries.
-   *
-   * Mirrors: ActiveRecord::Base.default_scope
-   */
-  static defaultScope<T extends typeof Base>(
-    this: T,
-    fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
-  ): void {
-    this._defaultScope = fn as (rel: any) => any;
-  }
-
-  /**
-   * Return a relation that bypasses the default scope.
-   *
-   * Mirrors: ActiveRecord::Base.unscoped
-   */
-  static unscoped<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
-    return DefaultScoping.unscoped(this, () => {
-      if (!_RelationCtor) {
-        throw new Error("Relation not loaded. Import relation.ts first.");
-      }
-      const rel = new _RelationCtor(this);
-      return _wrapWithScopeProxy ? _wrapWithScopeProxy(rel) : rel;
-    });
-  }
+  // --- Default scope (wired via extend() after class body) ---
+  declare static defaultScope: typeof _DefaultScoping.defaultScope;
+  declare static unscoped: typeof _DefaultScoping.unscoped;
 
   /** @internal Like all() but skips currentScope — used by the preloader. */
   static _allForPreload(): any {
     return this._buildDefaultRelation();
+  }
+
+  /** @internal Build a scope-proxy-wrapped Relation with no default scope
+   *  applied. Used by `unscoped()` in scoping/default.ts. */
+  static _buildUnscopedRelation(): any {
+    if (!_RelationCtor) {
+      throw new Error("Relation not loaded. Import relation.ts first.");
+    }
+    const rel = new _RelationCtor(this);
+    return _wrapWithScopeProxy ? _wrapWithScopeProxy(rel) : rel;
   }
 
   private static _buildDefaultRelation(): any {
@@ -3379,6 +3367,10 @@ extend(Base, ReadonlyAttributes.ClassMethods);
 extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
+extend(Base, {
+  defaultScope: _DefaultScoping.defaultScope,
+  unscoped: _DefaultScoping.unscoped,
+});
 extend(Base, ModelSchema.ClassMethods);
 
 include(Base, {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -52,6 +52,28 @@ describe("DefaultScopingTest", () => {
     expect(result.length).toBe(2);
   });
 
+  // Rails: unscoped(&block) runs the block with the unscoped relation
+  // as the current scope, so any queries inside bypass default scopes.
+  it("unscoped with a block runs queries without the default scope", async () => {
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("published", "boolean");
+        this.adapter = adapter;
+        this.defaultScope((rel: any) => rel.where({ published: true }));
+      }
+    }
+    await Post.create({ title: "a", published: true });
+    await Post.create({ title: "b", published: false });
+
+    const insideBlock = await Post.unscoped(async () => await Post.all().toArray());
+    expect(insideBlock.length).toBe(2);
+
+    // Outside the block, default scope is back in effect.
+    const outsideBlock = await Post.all().toArray();
+    expect(outsideBlock.length).toBe(1);
+  });
+
   it("named scope creates a chainable query", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -1,3 +1,6 @@
+import type { Base } from "../base.js";
+import type { Relation } from "../relation.js";
+
 /**
  * Default scope handling — applies default_scope to all queries
  * and provides unscoped to bypass it.
@@ -36,6 +39,29 @@ export class DefaultScope {
   get scope(): ((rel: any) => any) | null {
     return this.modelClass._defaultScope ?? null;
   }
+}
+
+/**
+ * Define a default scope applied to all queries for this model.
+ *
+ * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#default_scope
+ */
+export function defaultScope<T extends typeof Base>(
+  this: T,
+  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+): void {
+  (this as unknown as { _defaultScope: ((rel: any) => any) | null })._defaultScope = fn as (
+    rel: any,
+  ) => any;
+}
+
+/**
+ * Return a relation that bypasses the default scope.
+ *
+ * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#unscoped
+ */
+export function unscoped<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
+  return Default.unscoped(this, () => (this as unknown as typeof Base)._buildUnscopedRelation());
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -56,12 +56,30 @@ export function defaultScope<T extends typeof Base>(
 }
 
 /**
- * Return a relation that bypasses the default scope.
+ * Return a relation that bypasses the default scope. With a block, runs
+ * the block with the unscoped relation installed as the current scope so
+ * any queries inside also bypass default scopes — matching Rails'
+ * `unscoped { ... }` / `unscoped(&block)` form.
  *
- * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#unscoped
+ * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#unscoped —
+ * `block_given? ? relation.scoping(&block) : relation`
  */
-export function unscoped<T extends typeof Base>(this: T): Relation<InstanceType<T>> {
-  return Default.unscoped(this, () => (this as unknown as typeof Base)._buildUnscopedRelation());
+export function unscoped<T extends typeof Base>(this: T): Relation<InstanceType<T>>;
+export function unscoped<T extends typeof Base, R>(
+  this: T,
+  block: () => R | Promise<R>,
+): Promise<R>;
+export function unscoped<T extends typeof Base, R>(
+  this: T,
+  block?: () => R | Promise<R>,
+): Relation<InstanceType<T>> | Promise<R> {
+  const rel = Default.unscoped(this, () =>
+    (this as unknown as typeof Base)._buildUnscopedRelation(),
+  ) as Relation<InstanceType<T>>;
+  if (block) {
+    return rel.scoping(block);
+  }
+  return rel;
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -50,9 +50,7 @@ export function defaultScope<T extends typeof Base>(
   this: T,
   fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
 ): void {
-  (this as unknown as { _defaultScope: ((rel: any) => any) | null })._defaultScope = fn as (
-    rel: any,
-  ) => any;
+  this._defaultScope = fn as (rel: any) => any;
 }
 
 /**
@@ -73,9 +71,9 @@ export function unscoped<T extends typeof Base, R>(
   this: T,
   block?: () => R | Promise<R>,
 ): Relation<InstanceType<T>> | Promise<R> {
-  const rel = Default.unscoped(this, () =>
-    (this as unknown as typeof Base)._buildUnscopedRelation(),
-  ) as Relation<InstanceType<T>>;
+  const rel = Default.unscoped(this, () => this._buildUnscopedRelation()) as Relation<
+    InstanceType<T>
+  >;
   if (block) {
     return rel.scoping(block);
   }


### PR DESCRIPTION
## Summary
PR 4 of the Base → Rails-module extraction plan. Moves `Base.defaultScope` and `Base.unscoped` into `scoping/default.ts` as `this`-typed functions, wired onto `Base` via `extend()`. Each now lives where [Rails' `scoping/default.rb`](scripts/api-compare/.rails-source/activerecord/lib/active_record/scoping/default.rb) keeps it (ClassMethods#default_scope, ClassMethods#unscoped).

`unscoped` needs a scope-proxy-wrapped raw `Relation` (no default scope applied). Adds a `_buildUnscopedRelation()` helper on `Base` that captures the existing bypass-default-scope builder, and has the extracted `unscoped()` call through to it — matching the prior behavior exactly (no STI filter, no default scope).

## Rails-fidelity fix: `unscoped(&block)`
Rails' `unscoped` accepts a block and routes it through `relation.scoping(&block)` so queries inside the block also bypass default scopes. Our version now supports the same block form via overloads:

```ts
unscoped(): Relation<T>
unscoped(block): Promise<R>
```

Test coverage: queries inside the block bypass default scope; queries outside continue to honor it.

## api:compare impact
| | before | after |
|-|--------|-------|
| matched | 2513/2819 (89.1%) | **2514/2819 (89.2%)** |
| inheritance | 195/210 (92.9%) | **199/210 (94.8%)** |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17792 tests, +1 new)
- [x] `pnpm run api:compare` confirms the extractions