### PR TITLE
refactor(activerecord): extract _reflectOnAssociation; drop redundant previouslyNewRecord alias

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1267,6 +1267,26 @@ describe("AssociationReflection", () => {
     expect(all).toHaveLength(3);
   });
 
+  // Rails exposes reflect_on_association / reflect_on_all_associations on
+  // every model class (ActiveRecord::Reflection::ClassMethods). Exercises the
+  // Base-wired variants so `Model.reflectOnAssociation("name")` works
+  // idiomatically.
+  it("test_class_method_reflection_api_is_callable_on_base", () => {
+    class Author extends Base {
+      static {
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Author, "books", {});
+    Associations.belongsTo.call(Author, "publisher", {});
+
+    expect(Author.reflectOnAssociation("books")?.name).toBe("books");
+    expect(Author.reflectOnAssociation("publisher")?.name).toBe("publisher");
+    expect(Author.reflectOnAssociation("unknown")).toBeNull();
+    expect(Author.reflectOnAllAssociations()).toHaveLength(2);
+    expect(Author.reflectOnAllAssociations("hasMany").map((r) => r.name)).toEqual(["books"]);
+  });
+
   // Rails: test_reflect_on_all_associations_with_macro_filter
   it("test_reflect_on_all_associations_filtered_by_macro", () => {
     class Author extends Base {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -818,11 +818,15 @@ export class Base extends Model {
     return _isSuppressed(this);
   }
 
-  /**
-   * Mirrors: ActiveRecord::Reflection::ClassMethods#_reflect_on_association
-   * Implementation in reflection.ts, wired via extend() below.
-   */
-  declare static _reflectOnAssociation: typeof _Reflection._reflectOnAssociationClassMethod;
+  // --- Reflection::ClassMethods (wired via extend() after class body) ---
+  declare static _reflectOnAssociation: typeof _Reflection.ClassMethods._reflectOnAssociation;
+  declare static reflections: typeof _Reflection.ClassMethods.reflections;
+  declare static normalizedReflections: typeof _Reflection.ClassMethods.normalizedReflections;
+  declare static reflectOnAssociation: typeof _Reflection.ClassMethods.reflectOnAssociation;
+  declare static reflectOnAllAssociations: typeof _Reflection.ClassMethods.reflectOnAllAssociations;
+  declare static reflectOnAllAggregations: typeof _Reflection.ClassMethods.reflectOnAllAggregations;
+  declare static reflectOnAggregation: typeof _Reflection.ClassMethods.reflectOnAggregation;
+  declare static reflectOnAllAutosaveAssociations: typeof _Reflection.ClassMethods.reflectOnAllAutosaveAssociations;
 
   /**
    * Mirrors: ActiveRecord::Validations.validates
@@ -3269,9 +3273,7 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, { enum: _EnumModule.enumMethod });
-extend(Base, {
-  _reflectOnAssociation: _Reflection._reflectOnAssociationClassMethod,
-});
+extend(Base, _Reflection.ClassMethods);
 extend(Base, {
   defaultScope: _defaultScope,
   unscoped: _unscoped,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -108,6 +108,7 @@ import {
 import * as _Core from "./core.js";
 import * as _Persistence from "./persistence.js";
 import * as _EnumModule from "./enum.js";
+import * as _Reflection from "./reflection.js";
 import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
@@ -819,10 +820,9 @@ export class Base extends Model {
 
   /**
    * Mirrors: ActiveRecord::Reflection::ClassMethods#_reflect_on_association
+   * Implementation in reflection.ts, wired via extend() below.
    */
-  static _reflectOnAssociation(name: string): any {
-    return (this as any)._reflections?.[name] ?? null;
-  }
+  declare static _reflectOnAssociation: typeof _Reflection._reflectOnAssociationClassMethod;
 
   /**
    * Mirrors: ActiveRecord::Validations.validates
@@ -3217,10 +3217,6 @@ export class Base extends Model {
     return this.findByBang(conditions);
   }
 
-  previouslyNewRecord(): boolean {
-    return this.isPreviouslyNewRecord();
-  }
-
   static async tableExists(): Promise<boolean> {
     return true; // TODO: query adapter for table existence
   }
@@ -3273,6 +3269,9 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, { enum: _EnumModule.enumMethod });
+extend(Base, {
+  _reflectOnAssociation: _Reflection._reflectOnAssociationClassMethod,
+});
 extend(Base, {
   defaultScope: _defaultScope,
   unscoped: _unscoped,

--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -28,7 +28,7 @@ describe("CloneTest", () => {
     expect(topic.isPersisted()).toBe(true);
     expect(cloned.isPersisted()).toBe(true);
     expect(cloned.isNewRecord()).toBe(false);
-    expect(cloned.previouslyNewRecord()).toBe(false);
+    expect(cloned.isPreviouslyNewRecord()).toBe(false);
   });
 
   it("shallow", async () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1657,7 +1657,9 @@ export function addAggregateReflection(
 // functions that take the model class as the first argument.
 // ---------------------------------------------------------------------------
 
-export function reflections(modelClass: typeof Base): Record<string, any> {
+export function reflections(
+  modelClass: typeof Base,
+): Record<string, AssociationReflection | ThroughReflection> {
   return normalizedReflections(modelClass);
 }
 
@@ -1800,7 +1802,7 @@ export type AssociationLikeReflection = AssociationReflection | ThroughReflectio
 // ---------------------------------------------------------------------------
 
 export const ClassMethods = {
-  reflections(this: typeof Base): Record<string, any> {
+  reflections(this: typeof Base): Record<string, AssociationReflection | ThroughReflection> {
     return reflections(this);
   },
   normalizedReflections(

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1659,18 +1659,18 @@ export function addAggregateReflection(
 
 export function reflections(
   modelClass: typeof Base,
-): Record<string, AssociationReflection | ThroughReflection> {
+): Readonly<Record<string, AssociationReflection | ThroughReflection>> {
   return normalizedReflections(modelClass);
 }
 
 const _normalizedReflectionsCache = new WeakMap<
   typeof Base,
-  Record<string, AssociationReflection | ThroughReflection>
+  Readonly<Record<string, AssociationReflection | ThroughReflection>>
 >();
 
 export function normalizedReflections(
   modelClass: typeof Base,
-): Record<string, AssociationReflection | ThroughReflection> {
+): Readonly<Record<string, AssociationReflection | ThroughReflection>> {
   const cached = _normalizedReflectionsCache.get(modelClass);
   if (cached) return cached;
 
@@ -1802,12 +1802,14 @@ export type AssociationLikeReflection = AssociationReflection | ThroughReflectio
 // ---------------------------------------------------------------------------
 
 export const ClassMethods = {
-  reflections(this: typeof Base): Record<string, AssociationReflection | ThroughReflection> {
+  reflections(
+    this: typeof Base,
+  ): Readonly<Record<string, AssociationReflection | ThroughReflection>> {
     return reflections(this);
   },
   normalizedReflections(
     this: typeof Base,
-  ): Record<string, AssociationReflection | ThroughReflection> {
+  ): Readonly<Record<string, AssociationReflection | ThroughReflection>> {
     return normalizedReflections(this);
   },
   reflectOnAssociation(

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1719,6 +1719,20 @@ export function _reflectOnAssociation(
   return rawReflections[name] ?? null;
 }
 
+/**
+ * `this`-typed class-method variant of {@link _reflectOnAssociation} for
+ * wiring onto Base via `extend()`. Same behavior — reads the raw
+ * `_reflections` registry without normalization.
+ *
+ * Mirrors: ActiveRecord::Reflection::ClassMethods#_reflect_on_association
+ */
+export function _reflectOnAssociationClassMethod(
+  this: typeof Base,
+  name: string,
+): AssociationReflection | ThroughReflection | null {
+  return _reflectOnAssociation(this, name);
+}
+
 export function reflectOnAssociation(
   modelClass: typeof Base,
   name: string,

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1790,3 +1790,44 @@ export function reflectOnAllAutosaveAssociations(
  * Union type for reflections returned by the public API.
  */
 export type AssociationLikeReflection = AssociationReflection | ThroughReflection;
+
+// ---------------------------------------------------------------------------
+// `this`-typed wrappers for wiring onto Base via extend(). The module-level
+// functions above take `modelClass` as the first arg for internal callers;
+// these variants read `this` so user code can call them Rails-style:
+// `Post.reflectOnAssociation("comments")`.
+// Mirrors: ActiveRecord::Reflection::ClassMethods — methods on the class.
+// ---------------------------------------------------------------------------
+
+export const ClassMethods = {
+  reflections(this: typeof Base): Record<string, any> {
+    return reflections(this);
+  },
+  normalizedReflections(
+    this: typeof Base,
+  ): Record<string, AssociationReflection | ThroughReflection> {
+    return normalizedReflections(this);
+  },
+  reflectOnAssociation(
+    this: typeof Base,
+    name: string,
+  ): AssociationReflection | ThroughReflection | null {
+    return reflectOnAssociation(this, name);
+  },
+  reflectOnAllAssociations(
+    this: typeof Base,
+    macro?: "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany",
+  ): Array<AssociationReflection | ThroughReflection> {
+    return reflectOnAllAssociations(this, macro);
+  },
+  reflectOnAllAggregations(this: typeof Base): AggregateReflection[] {
+    return reflectOnAllAggregations(this);
+  },
+  reflectOnAggregation(this: typeof Base, name: string): AggregateReflection | null {
+    return reflectOnAggregation(this, name);
+  },
+  reflectOnAllAutosaveAssociations(this: typeof Base): AssociationLikeReflection[] {
+    return reflectOnAllAutosaveAssociations(this);
+  },
+  _reflectOnAssociation: _reflectOnAssociationClassMethod,
+};


### PR DESCRIPTION
## Summary
PR 6a of the Base → Rails-module extraction plan. Three coordinated improvements:

1. **`Base._reflectOnAssociation` extracted** to `reflection.ts` as a `this`-typed class-method wrapper, wired onto `Base` via `extend()`. Implementation file now matches [Rails' `Reflection::ClassMethods`](scripts/api-compare/.rails-source/activerecord/lib/active_record/reflection.rb) location.

2. **Full `Reflection::ClassMethods` wired onto `Base`** — users can now call the Rails-idiomatic forms on any model class:
   - `Post.reflectOnAssociation("comments")`
   - `Post.reflectOnAllAssociations()` / `.reflectOnAllAssociations("hasMany")`
   - `Post.reflectOnAggregation(name)` / `.reflectOnAllAggregations()`
   - `Post.reflectOnAllAutosaveAssociations()`
   - `Post.reflections` / `Post.normalizedReflections`
   
   (The module-level `reflectOnAssociation(modelClass, name)` form stays for internal callers that need to pass modelClass explicitly.)

3. **Removed the redundant `previouslyNewRecord()` instance alias** — it was a 2-line wrapper around `isPreviouslyNewRecord()` that Rails doesn't have (Rails exposes only `previously_new_record?`, which maps to our `isPreviouslyNewRecord`). Updates the one test caller.

No behavior change to the existing public surface; (2) adds ergonomic reachability. PR 6b will tackle the instance methods `association` / `loadBelongsTo` / `loadHasOne`, which depend on several private Base helpers and need their own scope.

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17797 tests, +1 new)
- [x] New test covers `Base.reflectOnAssociation` + `Base.reflectOnAllAssociations` on a concrete model with belongsTo/hasMany
- [x] `pnpm run api:compare` steady (2514/2819, moves 208, inheritance 95.2%)