### PR TITLE
refactor(activerecord): extract association/loadBelongsTo/loadHasOne to instance-methods

### DIFF
--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -57,9 +57,13 @@ function syncAssociationInstance(this: Base, name: string, instance: Association
     instance.setTarget(cached.get(name) as any);
     return;
   }
-  const preloaded = this._preloadedAssociations?.get(name) ?? null;
-  if (preloaded !== null) {
-    instance.setTarget(preloaded as any);
+  // Use `has()` so an eagerly-preloaded "nil association" (the preloader
+  // sets Map.set(name, null) for associations that resolved to no record)
+  // still marks the Association instance loaded — matching Association#
+  // doFindTarget's cache semantics. Checking truthiness would skip those.
+  const preloadedAssociations = this._preloadedAssociations;
+  if (preloadedAssociations?.has(name)) {
+    instance.setTarget(preloadedAssociations.get(name) as any);
   }
 }
 

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -1,0 +1,170 @@
+/**
+ * Base instance methods mixed in from the Associations module —
+ * `record.association(name)`, `record.loadBelongsTo(name)`,
+ * `record.loadHasOne(name)`.
+ *
+ * Mirrors the instance-method portion of ActiveRecord::Associations.
+ */
+
+import type { Base } from "../base.js";
+import { Association as AssociationInstance } from "./association.js";
+import { BelongsToAssociation } from "./belongs-to-association.js";
+import { BelongsToPolymorphicAssociation } from "./belongs-to-polymorphic-association.js";
+import { HasManyAssociation } from "./has-many-association.js";
+import { HasManyThroughAssociation } from "./has-many-through-association.js";
+import { HasOneAssociation } from "./has-one-association.js";
+import { HasOneThroughAssociation } from "./has-one-through-association.js";
+import { AssociationNotFoundError } from "./errors.js";
+import {
+  loadBelongsTo as _loadBelongsToOnce,
+  loadHasOne as _loadHasOneOnce,
+} from "../associations.js";
+
+interface AssocDef {
+  name: string;
+  type: "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany";
+  options?: Record<string, unknown>;
+}
+
+function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationInstance {
+  const opts = (assocDef.options ?? {}) as Record<string, unknown>;
+  switch (assocDef.type) {
+    case "belongsTo":
+      if (opts.polymorphic) return new BelongsToPolymorphicAssociation(this, assocDef as any);
+      return new BelongsToAssociation(this, assocDef as any);
+    case "hasOne":
+      if (opts.through) return new HasOneThroughAssociation(this, assocDef as any);
+      return new HasOneAssociation(this, assocDef as any);
+    case "hasMany":
+      if (opts.through) return new HasManyThroughAssociation(this, assocDef as any);
+      return new HasManyAssociation(this, assocDef as any);
+    case "hasAndBelongsToMany":
+      return new HasManyThroughAssociation(this, assocDef as any);
+    default:
+      return new AssociationInstance(this, assocDef as any);
+  }
+}
+
+function syncAssociationInstance(this: Base, name: string, instance: AssociationInstance): void {
+  const proxy = this._collectionProxies.get(name) as { loaded?: boolean; target?: unknown };
+  if (proxy && proxy.loaded) {
+    instance.setTarget(proxy.target as any);
+    return;
+  }
+  const cached = (this as unknown as { _cachedAssociations?: Map<string, unknown> })
+    ._cachedAssociations;
+  if (cached && cached.has(name)) {
+    instance.setTarget(cached.get(name) as any);
+    return;
+  }
+  const preloaded = this._preloadedAssociations?.get(name) ?? null;
+  if (preloaded !== null) {
+    instance.setTarget(preloaded as any);
+  }
+}
+
+function assertSingularAssociation(
+  this: Base,
+  name: string,
+  expected: "belongsTo" | "hasOne",
+): AssocDef {
+  const ctor = this.constructor as typeof Base & { _associations?: AssocDef[] };
+  const assocDef = ctor._associations?.find((a) => a.name === name);
+  if (!assocDef) {
+    throw new AssociationNotFoundError(this, name);
+  }
+  if (assocDef.type !== expected) {
+    if (assocDef.type === "hasMany" || assocDef.type === "hasAndBelongsToMany") {
+      throw new Error(
+        `load${expected === "belongsTo" ? "BelongsTo" : "HasOne"} is for singular associations. ` +
+          `\`${ctor.name}.${name}\` is a ${assocDef.type} — await the reader: \`await record.${name}\`.`,
+      );
+    }
+    const right = assocDef.type === "belongsTo" ? "loadBelongsTo" : "loadHasOne";
+    throw new Error(
+      `\`${ctor.name}.${name}\` is a ${assocDef.type}, not ${expected}. Use \`record.${right}("${name}")\` instead.`,
+    );
+  }
+  return assocDef;
+}
+
+// Explicit `loadBelongsTo` / `loadHasOne` calls are legitimate lazy loads —
+// the caller asked for them — so they skip the strict-loading throw.
+async function bypassStrictLoading<T>(this: Base, fn: () => Promise<T>): Promise<T> {
+  this._strictLoadingBypassCount += 1;
+  try {
+    return await fn();
+  } finally {
+    this._strictLoadingBypassCount = Math.max(0, this._strictLoadingBypassCount - 1);
+  }
+}
+
+/**
+ * Return (or lazily build + cache) the Association wrapper for the given
+ * name. Pulls any preloaded / cached / collection-proxy target onto the
+ * returned instance so sync reader access honors prior hydration.
+ *
+ * Mirrors: ActiveRecord::Base#association
+ */
+export function association(this: Base, name: string): AssociationInstance {
+  const existing = this._associationInstances.get(name);
+  if (existing) {
+    syncAssociationInstance.call(this, name, existing);
+    return existing;
+  }
+
+  const ctor = this.constructor as typeof Base & { _associations?: AssocDef[] };
+  const assocDef = ctor._associations?.find((a) => a.name === name);
+  if (!assocDef) {
+    throw new AssociationNotFoundError(this, name);
+  }
+
+  const instance = buildAssociationInstance.call(this, assocDef);
+  syncAssociationInstance.call(this, name, instance);
+  this._associationInstances.set(name, instance);
+  return instance;
+}
+
+/**
+ * Explicit async load for a belongsTo association. Returns the cached /
+ * preloaded value if present; otherwise runs a query. Not a forced
+ * reload — use `record.reload()` for that.
+ *
+ * Mirrors Rails' `ActiveRecord::Associations::Preloader::Branch` /
+ * `BelongsToAssociation` which are the belongs_to-specific preload paths.
+ */
+export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
+  const assocDef = assertSingularAssociation.call(this, name, "belongsTo");
+  const result = await bypassStrictLoading.call(this, () =>
+    _loadBelongsToOnce(this, name, (assocDef.options ?? {}) as any),
+  );
+  association.call(this, name).setTarget(result as any);
+  return result as Base | null;
+}
+
+/**
+ * Explicit async load for a hasOne association. Returns the cached /
+ * preloaded value if present; otherwise runs a query. Not a forced
+ * reload — use `record.reload()` for that.
+ *
+ * Mirrors Rails' `HasOneAssociation` preload path.
+ */
+export async function loadHasOne(this: Base, name: string): Promise<Base | null> {
+  const assocDef = assertSingularAssociation.call(this, name, "hasOne");
+  const result = await bypassStrictLoading.call(this, () =>
+    _loadHasOneOnce(this, name, (assocDef.options ?? {}) as any),
+  );
+  association.call(this, name).setTarget(result as any);
+  return result as Base | null;
+}
+
+/**
+ * Instance methods mixed onto Base via include(Base, InstanceMethods).
+ * Mirrors the layout of ActiveRecord::Associations which mixes these into
+ * the model class alongside the ClassMethods macros.
+ */
+export const InstanceMethods = {
+  association,
+  loadBelongsTo,
+  loadHasOne,
+};

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3027,10 +3027,10 @@ export class Base extends Model {
     return this.isEqual(other);
   }
 
-  // --- Associations instance methods (wired via include() after class body) ---
-  declare association: typeof _AssocInstance.association;
-  declare loadBelongsTo: typeof _AssocInstance.loadBelongsTo;
-  declare loadHasOne: typeof _AssocInstance.loadHasOne;
+  // Associations instance methods wired via include() below;
+  // signatures declared on the merged `interface Base` at the bottom
+  // of this file so subclass-variance rules treat them as methods
+  // (bivariant) rather than properties (invariant).
 
   // Underscore aliases for bang methods (Rails uses ! suffix, TS uses _ suffix)
   static async first_<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
@@ -3066,8 +3066,12 @@ export class Base extends Model {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type
-export interface Base extends Included<typeof AutosaveAssociation> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface Base extends Included<typeof AutosaveAssociation> {
+  association(name: string): AssociationInstance;
+  loadBelongsTo(name: string): Promise<Base | null>;
+  loadHasOne(name: string): Promise<Base | null>;
+}
 
 // ---------------------------------------------------------------------------
 // Ruby-style mixin wiring — one `extend` per module, mirroring Rails:

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -109,6 +109,7 @@ import * as _Core from "./core.js";
 import * as _Persistence from "./persistence.js";
 import * as _EnumModule from "./enum.js";
 import * as _Reflection from "./reflection.js";
+import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
 import { ScopeRegistry } from "./scoping.js";
 
@@ -118,14 +119,7 @@ import {
   unscoped as _unscoped,
 } from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
-import { AssociationNotFoundError } from "./associations/errors.js";
-import { Associations as _Associations, loadBelongsTo, loadHasOne } from "./associations.js";
-import { BelongsToAssociation } from "./associations/belongs-to-association.js";
-import { BelongsToPolymorphicAssociation } from "./associations/belongs-to-polymorphic-association.js";
-import { HasOneAssociation } from "./associations/has-one-association.js";
-import { HasOneThroughAssociation } from "./associations/has-one-through-association.js";
-import { HasManyAssociation } from "./associations/has-many-association.js";
-import { HasManyThroughAssociation } from "./associations/has-many-through-association.js";
+import { Associations as _Associations } from "./associations.js";
 
 /** @internal */
 export function quoteSqlValue(v: unknown, asArray = false): string {
@@ -3033,168 +3027,10 @@ export class Base extends Model {
     return this.isEqual(other);
   }
 
-  /**
-   * Return the association object for the given name.
-   *
-   * Mirrors: ActiveRecord::Base#association
-   */
-  association(name: string): AssociationInstance {
-    const existing = this._associationInstances.get(name);
-    if (existing) {
-      this._syncAssociationInstance(name, existing);
-      return existing;
-    }
-
-    const ctor = this.constructor as any;
-    const associations: any[] = ctor._associations ?? [];
-    const assocDef = associations.find((a: any) => a.name === name);
-    if (!assocDef) {
-      throw new AssociationNotFoundError(this, name);
-    }
-
-    const instance = this._buildAssociationInstance(assocDef);
-    this._syncAssociationInstance(name, instance);
-    this._associationInstances.set(name, instance);
-    return instance;
-  }
-
-  /**
-   * Explicit async load for a belongsTo association. Same shape as
-   * the standalone `loadBelongsTo(record, name, opts)` helper, but
-   * takes just the association name.
-   *
-   * Returns the cached/preloaded value if present; otherwise runs a
-   * query. Not a forced reload — use `record.reload()` for that.
-   *
-   * The virtualizer emits typed overloads so `post.loadBelongsTo("author")`
-   * narrows to `Promise<Author | null>` without a hand-written declare.
-   *
-   * Mirrors Rails' `ActiveRecord::Associations::Preloader::Branch` /
-   * `BelongsToAssociation` which are the belongs_to-specific preload
-   * paths.
-   */
-  async loadBelongsTo(name: string): Promise<Base | null> {
-    const assocDef = this._assertSingularAssociation(name, "belongsTo");
-    const result = await this._bypassStrictLoading(() =>
-      loadBelongsTo(this, name, assocDef.options ?? {}),
-    );
-    this._hydrateSingularAssoc(name, result);
-    return result;
-  }
-
-  /**
-   * Explicit async load for a hasOne association. Same shape as the
-   * standalone `loadHasOne(record, name, opts)` helper, but takes just
-   * the association name.
-   *
-   * Returns the cached/preloaded value if present; otherwise runs a
-   * query. Not a forced reload — use `record.reload()` for that.
-   *
-   * The virtualizer emits typed overloads so `user.loadHasOne("profile")`
-   * narrows to `Promise<Profile | null>` without a hand-written declare.
-   *
-   * Mirrors Rails' `HasOneAssociation` preload path.
-   */
-  async loadHasOne(name: string): Promise<Base | null> {
-    const assocDef = this._assertSingularAssociation(name, "hasOne");
-    const result = await this._bypassStrictLoading(() =>
-      loadHasOne(this, name, assocDef.options ?? {}),
-    );
-    this._hydrateSingularAssoc(name, result);
-    return result;
-  }
-
-  /**
-   * Populate the association instance's target and mark it loaded so
-   * subsequent sync reader access (`post.author`) returns the record
-   * without tripping strict loading. `setTarget()` internally calls
-   * `loadedBang()`, so no separate call is needed here.
-   */
-  private _hydrateSingularAssoc(name: string, result: Base | null): void {
-    this.association(name).setTarget(result);
-  }
-
-  /**
-   * Temporarily bumps the strict-loading bypass count across the
-   * execution of `fn`. Explicit `loadBelongsTo` / `loadHasOne` calls
-   * are legitimate lazy loads — the caller asked for them — so they
-   * skip the strict-loading throw.
-   */
-  private async _bypassStrictLoading<T>(fn: () => Promise<T>): Promise<T> {
-    this._strictLoadingBypassCount += 1;
-    try {
-      return await fn();
-    } finally {
-      this._strictLoadingBypassCount = Math.max(0, this._strictLoadingBypassCount - 1);
-    }
-  }
-
-  private _assertSingularAssociation(
-    name: string,
-    expected: "belongsTo" | "hasOne",
-  ): { type: string; options: any } {
-    const ctor = this.constructor as any;
-    const associations: any[] = ctor._associations ?? [];
-    const assocDef = associations.find((a: any) => a.name === name);
-    if (!assocDef) {
-      throw new AssociationNotFoundError(this, name);
-    }
-    if (assocDef.type !== expected) {
-      if (assocDef.type === "hasMany" || assocDef.type === "hasAndBelongsToMany") {
-        throw new Error(
-          `load${expected === "belongsTo" ? "BelongsTo" : "HasOne"} is for singular associations. ` +
-            `\`${ctor.name}.${name}\` is a ${assocDef.type} — await the reader: \`await record.${name}\`.`,
-        );
-      }
-      const right = assocDef.type === "belongsTo" ? "loadBelongsTo" : "loadHasOne";
-      throw new Error(
-        `\`${ctor.name}.${name}\` is a ${assocDef.type}, not ${expected}. Use \`record.${right}("${name}")\` instead.`,
-      );
-    }
-    return assocDef;
-  }
-
-  private _buildAssociationInstance(assocDef: any): AssociationInstance {
-    const opts = assocDef.options ?? {};
-    switch (assocDef.type) {
-      case "belongsTo":
-        if (opts.polymorphic) {
-          return new BelongsToPolymorphicAssociation(this, assocDef);
-        }
-        return new BelongsToAssociation(this, assocDef);
-      case "hasOne":
-        if (opts.through) {
-          return new HasOneThroughAssociation(this, assocDef);
-        }
-        return new HasOneAssociation(this, assocDef);
-      case "hasMany":
-        if (opts.through) {
-          return new HasManyThroughAssociation(this, assocDef);
-        }
-        return new HasManyAssociation(this, assocDef);
-      case "hasAndBelongsToMany":
-        return new HasManyThroughAssociation(this, assocDef);
-      default:
-        return new AssociationInstance(this, assocDef);
-    }
-  }
-
-  private _syncAssociationInstance(name: string, instance: AssociationInstance): void {
-    const proxy = this._collectionProxies.get(name) as any;
-    if (proxy && proxy.loaded) {
-      instance.setTarget(proxy.target);
-    } else {
-      const cachedAssociation = (this as any)._cachedAssociations?.get(name);
-      if (cachedAssociation !== undefined) {
-        instance.setTarget(cachedAssociation as any);
-      } else {
-        const preloaded = this._preloadedAssociations?.get(name) ?? null;
-        if (preloaded !== null) {
-          instance.setTarget(preloaded as any);
-        }
-      }
-    }
-  }
+  // --- Associations instance methods (wired via include() after class body) ---
+  declare association: typeof _AssocInstance.association;
+  declare loadBelongsTo: typeof _AssocInstance.loadBelongsTo;
+  declare loadHasOne: typeof _AssocInstance.loadHasOne;
 
   // Underscore aliases for bang methods (Rails uses ! suffix, TS uses _ suffix)
   static async first_<T extends typeof Base>(this: T): Promise<InstanceType<T>> {
@@ -3319,6 +3155,7 @@ include(Base, {
 include(Base, LockingPessimistic.InstanceMethods);
 include(Base, Timestamp.InstanceMethods);
 include(Base, AutosaveAssociation);
+include(Base, _AssocInstance.InstanceMethods);
 
 // Register Model.isValid as the super for the Validations module's isValid.
 // Breaks the recursion: Base.isValid → validations.isValid → Model.isValid.


### PR DESCRIPTION
## Summary
PR 6b of the Base → Rails-module extraction plan. Moves the three public Associations instance methods plus their five private helpers out of `base.ts` into a new `associations/instance-methods.ts`, wired onto `Base` via `include(Base, InstanceMethods)`.

**Methods moved:**
- `record.association(name)` → returns / lazily builds the Association wrapper
- `record.loadBelongsTo(name)` → explicit async load for a belongsTo
- `record.loadHasOne(name)` → explicit async load for a hasOne

**Private helpers moved with them (as module-private `this`-typed functions):**
- `buildAssociationInstance` — switch on macro → construct the right Association subclass
- `syncAssociationInstance` — pull preloaded/cached/proxy target onto the instance
- `assertSingularAssociation` — validate that a name resolves to the expected macro
- `bypassStrictLoading` — bump/decrement `_strictLoadingBypassCount`
- (inlined the old 2-line `_hydrateSingularAssoc` at its two call sites)

Matches Rails' `ActiveRecord::Associations` layout — the module has a `ClassMethods` side (macros) and instance methods mixed into the model. Our `associations/` dir now mirrors that split: `builder/` holds the macro side, `instance-methods.ts` holds the instance side.

### Subclass-variance fix
Declaring the extracted methods on `Base` as `declare association: typeof ...` properties made TS treat them invariantly, which broke Author-extends-Base assignability through `Promise` variance on `destroy(): Promise<this | false>`. Moved the three signatures into the merged `interface Base { ... }` declaration so TS treats them as methods (bivariant), restoring subclass compatibility. DX Type Tests and guides:typecheck both pass.

## api:compare impact
| | before | after |
|-|--------|-------|
| matched | 2513/2819 | 2513/2819 |
| moves | 208 | 208 |
| inheritance | 200/210 (95.2%) | **201/210 (95.7%)** |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17798 tests)
- [x] `pnpm test:types` (DX Type Tests) passes — declare-patterns subclass-variance test green
- [x] `pnpm test:types:virtualized` passes
- [x] `pnpm guides:typecheck` passes
- [x] `pnpm run api:compare` — inheritance +1, else steady