### PR TITLE
build(api-compare): accept 3 TS root intermediates for AR inheritance

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -119,13 +119,6 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, ["Model"], "Base")).toBe(true);
   });
 
-  it("accepts AbstractAdapter extending AbstractAdapterBase when Ruby has no super", () => {
-    // Rails `AbstractAdapter` has no super; TS applies the
-    // DatabaseStatements mixin via `AbstractAdapterBase`, matching
-    // Rails' `include DatabaseStatements`.
-    expect(superclassesMatch(null, ["AbstractAdapterBase"], "AbstractAdapter")).toBe(true);
-  });
-
   it("accepts QueryCache Store extending QueryCacheStore when Ruby has no super", () => {
     // Rails' `ConnectionAdapters::QueryCache::Store` has no super; TS
     // factors the LRU implementation into `QueryCacheStore` (reused
@@ -138,7 +131,6 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Type"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Model"], "Something")).toBe(false);
-    expect(superclassesMatch(null, ["AbstractAdapterBase"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["QueryCacheStore"], "Something")).toBe(false);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -119,19 +119,11 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, ["Model"], "Base")).toBe(true);
   });
 
-  it("accepts QueryCache Store extending QueryCacheStore when Ruby has no super", () => {
-    // Rails' `ConnectionAdapters::QueryCache::Store` has no super; TS
-    // factors the LRU implementation into `QueryCacheStore` (reused
-    // by the QueryCacheAdapter wrapper) and has `Store` extend it.
-    expect(superclassesMatch(null, ["QueryCacheStore"], "Store")).toBe(true);
-  });
-
   it("does not auto-accept other classes extending the intermediates with null Ruby super", () => {
     // Only the whitelisted (tsName, intermediate) pairs above are accepted.
     expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Type"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Model"], "Something")).toBe(false);
-    expect(superclassesMatch(null, ["QueryCacheStore"], "Something")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -113,10 +113,33 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, ["Type"], "ValueType")).toBe(true);
   });
 
+  it("accepts AR Base extending Model when Ruby Base has no super", () => {
+    // `ActiveRecord::Base` has no Ruby super; TS `Base extends Model`
+    // to expose the ActiveModel host class on subclasses.
+    expect(superclassesMatch(null, ["Model"], "Base")).toBe(true);
+  });
+
+  it("accepts AbstractAdapter extending AbstractAdapterBase when Ruby has no super", () => {
+    // Rails `AbstractAdapter` has no super; TS applies the
+    // DatabaseStatements mixin via `AbstractAdapterBase`, matching
+    // Rails' `include DatabaseStatements`.
+    expect(superclassesMatch(null, ["AbstractAdapterBase"], "AbstractAdapter")).toBe(true);
+  });
+
+  it("accepts QueryCache Store extending QueryCacheStore when Ruby has no super", () => {
+    // Rails' `ConnectionAdapters::QueryCache::Store` has no super; TS
+    // factors the LRU implementation into `QueryCacheStore` (reused
+    // by the QueryCacheAdapter wrapper) and has `Store` extend it.
+    expect(superclassesMatch(null, ["QueryCacheStore"], "Store")).toBe(true);
+  });
+
   it("does not auto-accept other classes extending the intermediates with null Ruby super", () => {
-    // Only Table/Attribute/ValueType are on the intermediate whitelist.
+    // Only the whitelisted (tsName, intermediate) pairs above are accepted.
     expect(superclassesMatch(null, ["Node"], "Something")).toBe(false);
     expect(superclassesMatch(null, ["Type"], "Something")).toBe(false);
+    expect(superclassesMatch(null, ["Model"], "Something")).toBe(false);
+    expect(superclassesMatch(null, ["AbstractAdapterBase"], "Something")).toBe(false);
+    expect(superclassesMatch(null, ["QueryCacheStore"], "Something")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -192,11 +192,6 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   // `ActiveRecord::Base` has no Ruby super; TS `Base` extends `Model`
   // so the ActiveModel mixin surface is type-visible on subclasses.
   ["Base", "Model"],
-  // `ActiveRecord::ConnectionAdapters::AbstractAdapter` has no Ruby
-  // super; TS mixes DatabaseStatements into an anonymous base via
-  // `AbstractAdapterBase = DatabaseStatementsMixin(class {})` so
-  // its methods are inherited as in Rails' `include`.
-  ["AbstractAdapter", "AbstractAdapterBase"],
   // `ActiveRecord::ConnectionAdapters::QueryCache::Store` has no Ruby
   // super; TS factors the LRU implementation into `QueryCacheStore`
   // (reused by the QueryCacheAdapter wrapper) and has `Store` extend it.

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -192,10 +192,6 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   // `ActiveRecord::Base` has no Ruby super; TS `Base` extends `Model`
   // so the ActiveModel mixin surface is type-visible on subclasses.
   ["Base", "Model"],
-  // `ActiveRecord::ConnectionAdapters::QueryCache::Store` has no Ruby
-  // super; TS factors the LRU implementation into `QueryCacheStore`
-  // (reused by the QueryCacheAdapter wrapper) and has `Store` extend it.
-  ["Store", "QueryCacheStore"],
 ]);
 
 // Per-class TS renames that don't fit the systematic alias patterns

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -189,6 +189,18 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   ["ValueType", "Type"],
   ["LockingType", "ValueType"],
   ["Serialized", "ValueType"],
+  // `ActiveRecord::Base` has no Ruby super; TS `Base` extends `Model`
+  // so the ActiveModel mixin surface is type-visible on subclasses.
+  ["Base", "Model"],
+  // `ActiveRecord::ConnectionAdapters::AbstractAdapter` has no Ruby
+  // super; TS mixes DatabaseStatements into an anonymous base via
+  // `AbstractAdapterBase = DatabaseStatementsMixin(class {})` so
+  // its methods are inherited as in Rails' `include`.
+  ["AbstractAdapter", "AbstractAdapterBase"],
+  // `ActiveRecord::ConnectionAdapters::QueryCache::Store` has no Ruby
+  // super; TS factors the LRU implementation into `QueryCacheStore`
+  // (reused by the QueryCacheAdapter wrapper) and has `Store` extend it.
+  ["Store", "QueryCacheStore"],
 ]);
 
 // Per-class TS renames that don't fit the systematic alias patterns


### PR DESCRIPTION
## Summary

Adds one entry to \`TS_ROOT_INTERMEDIATE\` so api-compare accepts a Rails-equivalent TS class that interposes a single intermediate when Ruby has no superclass:

- \`Base → Model\` — \`ActiveRecord::Base\` has no Ruby super; TS \`Base\` extends \`Model\` to inherit ActiveModel's per-subclass static state (attribute definitions, callback chain, validators, normalizations), its dynamic-access instance shape (\`[key: string]: unknown\`), and to keep \`Model\` usable as a standalone ActiveModel class that non-AR consumers can extend.

Two other intermediates I had originally included here — \`AbstractAdapter → AbstractAdapterBase\` and \`Store → QueryCacheStore\` — were removed structurally instead:
- **#674** dropped \`AbstractAdapterBase\` and applied \`DatabaseStatements\` to \`AbstractAdapter\` directly via \`include()\`.
- **#679** merged the outer \`QueryCacheStore\` into \`abstract/query-cache.ts\`'s \`Store\` so there's one class, not a chain.

activerecord inheritance: **201/210 (95.7%) → 202/210 (96.2%)** via this entry. (#674 and #679 each bumped by one independently.)

## Test plan
- [x] \`pnpm exec vitest run scripts/api-compare\` passes
- [x] \`pnpm exec tsx scripts/api-compare/compare.ts --package activerecord --inheritance\` confirms the Base → Model match