### PR TITLE
Improve stats:sync defaults and skip non-docs CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   # Preflight that sets `docs_only=true` when every changed path is under
   # top-level `docs/`. Downstream jobs gate on this via `if:` so they're
-  # reported as skipped (not cancelled) — GitHub treats skipped required
-  # status checks as passing, so this keeps branch protection happy on
-  # docs-only PRs. `packages/website/docs` does not qualify; it lives
-  # under `packages/website/` and affects the site build.
+  # reported as skipped on docs-only PRs. Skipped required checks in
+  # branch protection DO block merges, so point branch protection at the
+  # aggregate `CI` job at the bottom of this file instead of individual
+  # jobs — `CI` always runs and treats skipped needs as success.
+  # `packages/website/docs` does not qualify; it lives under
+  # `packages/website/` and affects the site build.
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,12 +346,10 @@ jobs:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           echo "$NEEDS_JSON"
-          echo "$NEEDS_JSON" | python3 -c '
-          import json, sys
-          data = json.load(sys.stdin)
-          bad = [name for name, job in data.items() if job["result"] in ("failure", "cancelled")]
-          if bad:
-              print("Failed/cancelled jobs:", bad)
-              sys.exit(1)
-          print("All jobs passed or were intentionally skipped.")
-          '
+          bad=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
+          if [ -n "$bad" ]; then
+            echo "Failed/cancelled jobs:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "All jobs passed or were intentionally skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
 
 jobs:
+  # Preflight that sets `docs_only=true` when every changed path is under
+  # top-level `docs/`. Downstream jobs gate on this via `if:` so they're
+  # reported as skipped (not cancelled) — GitHub treats skipped required
+  # status checks as passing, so this keeps branch protection happy on
+  # docs-only PRs. `packages/website/docs` does not qualify; it lives
+  # under `packages/website/` and affects the site build.
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
@@ -18,6 +24,7 @@ jobs:
           fetch-depth: 0
       - id: filter
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
             head="${{ github.event.pull_request.head.sha }}"
@@ -25,17 +32,25 @@ jobs:
             base="${{ github.event.before }}"
             head="${{ github.sha }}"
           fi
+          # First push to a branch has a zero-SHA base; force-push may
+          # rewrite history out from under us. In either case we can't
+          # reliably compute a diff — fall back to running the full matrix.
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(git diff --name-only "$base" "$head")
+          if ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
+            echo "git diff failed (base may be unreachable after force-push) — running full matrix"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "Changed files:"
           echo "$files"
           if [ -z "$files" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Any line that does NOT start with `docs/` flips the switch.
           if echo "$files" | grep -qv '^docs/'; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,45 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(git diff --name-only "$base" "$head")
+          echo "Changed files:"
+          echo "$files"
+          if [ -z "$files" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "$files" | grep -qv '^docs/'; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-typecheck:
     name: Build & Type Check
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +61,8 @@ jobs:
       - run: pnpm typecheck
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +92,8 @@ jobs:
 
   guides-typecheck:
     name: Guides Code Type Check
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +110,8 @@ jobs:
 
   dx-type-tests:
     name: DX Type Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +127,8 @@ jobs:
 
   virtualized-dx-type-tests:
     name: Virtualized DX Type Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +144,8 @@ jobs:
 
   unit-tests:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -123,6 +170,8 @@ jobs:
 
   sqlite-tests:
     name: SQLite Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -138,6 +187,8 @@ jobs:
 
   postgres-tests:
     name: PostgreSQL Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -169,6 +220,8 @@ jobs:
 
   mariadb-tests:
     name: MariaDB Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     services:
       mariadb:
@@ -202,6 +255,8 @@ jobs:
 
   website:
     name: Website
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -221,6 +276,8 @@ jobs:
 
   rails-comparison:
     name: Rails API/Test Comparison
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,3 +321,37 @@ jobs:
         run: pnpm exec tsx scripts/api-compare/lint-deps.ts
       - name: Test comparison
         run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts
+
+  ci:
+    name: CI
+    if: ${{ always() }}
+    needs:
+      - changes
+      - build-and-typecheck
+      - lint
+      - prettier
+      - guides-typecheck
+      - dx-type-tests
+      - virtualized-dx-type-tests
+      - unit-tests
+      - sqlite-tests
+      - postgres-tests
+      - mariadb-tests
+      - website
+      - rails-comparison
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          echo "$NEEDS_JSON" | python3 -c '
+          import json, sys
+          data = json.load(sys.stdin)
+          bad = [name for name, job in data.items() if job["result"] in ("failure", "cancelled")]
+          if bad:
+              print("Failed/cancelled jobs:", bad)
+              sys.exit(1)
+          print("All jobs passed or were intentionally skipped.")
+          '

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -839,7 +839,7 @@ async function syncPullRequests(mode: "latest" | "refresh"): Promise<number> {
     "isDraft",
   ].join(",");
 
-  const limit = mode === "latest" ? 100 : 5000;
+  const limit = mode === "latest" ? 1000 : 5000;
   const allPrs = ghJson<GhPrData[]>(
     `pr list --repo ${REPO} --state all --limit ${limit} --json ${fields} --jq '[.[] | select(.number > ${lastSynced})]'`,
   );
@@ -899,22 +899,20 @@ async function syncPullRequests(mode: "latest" | "refresh"): Promise<number> {
         `UPDATE pull_requests SET is_draft = 0 WHERE is_draft IS NULL`,
       );
     }
+  }
 
-    const openRows = await PullRequest.findBySql(
-      `SELECT number FROM pull_requests WHERE state = 'open' ORDER BY number DESC`,
-    );
-    if (openRows.length > 0) {
-      console.log(`Re-fetching ${openRows.length} open PRs to check for state changes...`);
-      for (const row of openRows) {
-        const num = row.readAttribute("number") as number;
-        try {
-          const pr = ghJson<GhPrData>(`pr view ${num} --repo ${REPO} --json ${fields}`);
-          await PullRequest.upsertAll([mapPr(pr)], { uniqueBy: "number" });
-        } catch (err) {
-          console.warn(
-            `  Failed to refresh PR #${num}: ${err instanceof Error ? err.message : err}`,
-          );
-        }
+  const openRows = await PullRequest.findBySql(
+    `SELECT number FROM pull_requests WHERE state = 'open' ORDER BY number DESC`,
+  );
+  if (openRows.length > 0) {
+    console.log(`Re-fetching ${openRows.length} open PRs to check for state changes...`);
+    for (const row of openRows) {
+      const num = row.readAttribute("number") as number;
+      try {
+        const pr = ghJson<GhPrData>(`pr view ${num} --repo ${REPO} --json ${fields}`);
+        await PullRequest.upsertAll([mapPr(pr)], { uniqueBy: "number" });
+      } catch (err) {
+        console.warn(`  Failed to refresh PR #${num}: ${err instanceof Error ? err.message : err}`);
       }
     }
   }
@@ -1911,7 +1909,9 @@ async function main() {
       : "latest";
 
   if (mode === "latest") {
-    console.log("Running in latest mode (default). Use --refresh for full sync.\n");
+    console.log(
+      "Running in latest mode (default): re-verify open PRs, fetch new PRs, and deep-sync. Use --refresh for full sync.\n",
+    );
   } else if (mode === "compare-only") {
     console.log("Running compare-only mode: syncing PRs, workflow runs, and compare logs.\n");
   } else {
@@ -1929,28 +1929,26 @@ async function main() {
     console.log("=== Syncing PR data ===");
     const prsSynced = await syncPullRequests(fetchMode);
 
-    if (mode === "refresh") {
-      console.log("\n=== Syncing PR files ===");
-      await syncPrFiles();
+    console.log("\n=== Syncing PR files ===");
+    await syncPrFiles();
 
-      console.log("\n=== Syncing PR commits ===");
-      await syncPrCommits();
+    console.log("\n=== Syncing PR commits ===");
+    await syncPrCommits();
 
-      console.log("\n=== Syncing PR comments & reviews ===");
-      await syncPrComments();
+    console.log("\n=== Syncing PR comments & reviews ===");
+    await syncPrComments();
 
-      console.log("\n=== Syncing PR requested reviewers ===");
-      await syncPrRequestedReviewers();
+    console.log("\n=== Syncing PR requested reviewers ===");
+    await syncPrRequestedReviewers();
 
-      console.log("\n=== Syncing PR linked issues ===");
-      await syncPrLinkedIssues();
+    console.log("\n=== Syncing PR linked issues ===");
+    await syncPrLinkedIssues();
 
-      console.log("\n=== Syncing PR timeline events ===");
-      await syncPrTimelineEvents();
+    console.log("\n=== Syncing PR timeline events ===");
+    await syncPrTimelineEvents();
 
-      console.log("\n=== Syncing PR reactions ===");
-      await syncPrReactions();
-    }
+    console.log("\n=== Syncing PR reactions ===");
+    await syncPrReactions();
 
     console.log("\n=== Syncing workflow runs ===");
     const runsSynced = await syncWorkflowRuns(fetchMode);

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1764,7 +1764,7 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
 // Summary
 // ---------------------------------------------------------------------------
 
-async function printSummary(mode: "latest" | "refresh") {
+async function printSummary() {
   const count = async (table: string) => {
     const rows = await Base.adapter.execute(`SELECT COUNT(*) as cnt FROM ${table}`);
     return (rows[0] as { cnt: number }).cnt;
@@ -1969,7 +1969,7 @@ async function main() {
       logs_parsed: logsParsed,
     });
 
-    await printSummary(mode === "refresh" ? "refresh" : "latest");
+    await printSummary();
   } finally {
     adapter.close();
   }

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1802,38 +1802,36 @@ async function printSummary() {
   console.log("\n=== Database Summary ===");
   console.log(`  PRs: ${prCount} (${stateParts})`);
 
-  if (mode === "refresh") {
-    const [
-      fileCount,
-      commitCount,
-      commentCount,
-      reviewCount,
-      requestedReviewerCount,
-      linkedIssueCount,
-      timelineEventCount,
-      reactionCount,
-      annotationCount,
-    ] = await Promise.all([
-      count("pr_files"),
-      count("pr_commits"),
-      count("pr_comments"),
-      count("pr_reviews"),
-      count("pr_requested_reviewers"),
-      count("pr_linked_issues"),
-      count("pr_timeline_events"),
-      count("pr_reactions"),
-      count("check_annotations"),
-    ]);
-    console.log(`  PR files: ${fileCount}`);
-    console.log(`  PR commits: ${commitCount}`);
-    console.log(`  PR comments: ${commentCount}`);
-    console.log(`  PR reviews: ${reviewCount}`);
-    console.log(`  PR requested reviewers: ${requestedReviewerCount}`);
-    console.log(`  PR linked issues: ${linkedIssueCount}`);
-    console.log(`  PR timeline events: ${timelineEventCount}`);
-    console.log(`  PR reactions: ${reactionCount}`);
-    console.log(`  Check annotations: ${annotationCount}`);
-  }
+  const [
+    fileCount,
+    commitCount,
+    commentCount,
+    reviewCount,
+    requestedReviewerCount,
+    linkedIssueCount,
+    timelineEventCount,
+    reactionCount,
+    annotationCount,
+  ] = await Promise.all([
+    count("pr_files"),
+    count("pr_commits"),
+    count("pr_comments"),
+    count("pr_reviews"),
+    count("pr_requested_reviewers"),
+    count("pr_linked_issues"),
+    count("pr_timeline_events"),
+    count("pr_reactions"),
+    count("check_annotations"),
+  ]);
+  console.log(`  PR files: ${fileCount}`);
+  console.log(`  PR commits: ${commitCount}`);
+  console.log(`  PR comments: ${commentCount}`);
+  console.log(`  PR reviews: ${reviewCount}`);
+  console.log(`  PR requested reviewers: ${requestedReviewerCount}`);
+  console.log(`  PR linked issues: ${linkedIssueCount}`);
+  console.log(`  PR timeline events: ${timelineEventCount}`);
+  console.log(`  PR reactions: ${reactionCount}`);
+  console.log(`  Check annotations: ${annotationCount}`);
 
   console.log(`  Workflow runs: ${runCount}`);
   console.log(`  Workflow jobs: ${jobCount} (${rawLogCount} logs fetched)`);

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -902,7 +902,7 @@ async function syncPullRequests(mode: "latest" | "refresh"): Promise<number> {
   }
 
   const openRows = await PullRequest.findBySql(
-    `SELECT number FROM pull_requests WHERE state = 'open' ORDER BY number DESC`,
+    `SELECT number FROM pull_requests WHERE state = 'open' OR state IS NULL ORDER BY number DESC`,
   );
   if (openRows.length > 0) {
     console.log(`Re-fetching ${openRows.length} open PRs to check for state changes...`);
@@ -1929,26 +1929,28 @@ async function main() {
     console.log("=== Syncing PR data ===");
     const prsSynced = await syncPullRequests(fetchMode);
 
-    console.log("\n=== Syncing PR files ===");
-    await syncPrFiles();
+    if (mode !== "compare-only") {
+      console.log("\n=== Syncing PR files ===");
+      await syncPrFiles();
 
-    console.log("\n=== Syncing PR commits ===");
-    await syncPrCommits();
+      console.log("\n=== Syncing PR commits ===");
+      await syncPrCommits();
 
-    console.log("\n=== Syncing PR comments & reviews ===");
-    await syncPrComments();
+      console.log("\n=== Syncing PR comments & reviews ===");
+      await syncPrComments();
 
-    console.log("\n=== Syncing PR requested reviewers ===");
-    await syncPrRequestedReviewers();
+      console.log("\n=== Syncing PR requested reviewers ===");
+      await syncPrRequestedReviewers();
 
-    console.log("\n=== Syncing PR linked issues ===");
-    await syncPrLinkedIssues();
+      console.log("\n=== Syncing PR linked issues ===");
+      await syncPrLinkedIssues();
 
-    console.log("\n=== Syncing PR timeline events ===");
-    await syncPrTimelineEvents();
+      console.log("\n=== Syncing PR timeline events ===");
+      await syncPrTimelineEvents();
 
-    console.log("\n=== Syncing PR reactions ===");
-    await syncPrReactions();
+      console.log("\n=== Syncing PR reactions ===");
+      await syncPrReactions();
+    }
 
     console.log("\n=== Syncing workflow runs ===");
     const runsSynced = await syncWorkflowRuns(fetchMode);


### PR DESCRIPTION
## Summary

- **stats:sync default mode**: re-verifies all open PRs, bumps the new-PR `pr list` limit 100 → 1000, and always runs the deep-sync steps (files, commits, comments, reviewers, linked issues, timeline, reactions). The default now uses refresh fetch semantics for workflow runs / annotations / job logs / compare stats too, so a single invocation fully catches up rather than chasing 10–50 rows per run. `printSummary` always emits the expanded deep-sync counts.
- **CI**: adds a `changes` preflight job that computes a `docs_only` flag from the diff. When every changed path starts with `docs/`, only the `Prettier` job runs; every other job is skipped. Any non-docs file triggers the full matrix.
- **CI aggregator**: adds a final `CI` job that always runs and only fails when a needed job actually failed/cancelled (skipped counts as success). This makes `docs_only` skips compatible with GitHub branch protection — point required status checks at `CI` instead of the individual jobs.

## Branch-protection follow-up (repo admin)

Require only `CI` in branch protection. Remove any per-job required checks, or docs-only PRs will hang on skipped checks.

## Test plan

- [x] `pnpm stats:sync` against real GitHub data — imported 112 new PRs + re-verified open PRs + all deep-sync steps.
- [ ] Verify this PR's full CI matrix runs (non-docs changes).
- [ ] Follow-up docs-only PR should show only `Detect changed paths`, `Prettier`, and `CI` running/green.

## Notes

- `docs_only` is scoped to top-level `docs/`. `packages/website/docs` still triggers the full matrix.
- Force-push safety: when `github.event.before` is the zero-SHA, the filter defaults to `docs_only=false`.