### PR TITLE
feat(arel): manager table constructors + complete Crud interface

### DIFF
--- a/packages/arel/src/crud.ts
+++ b/packages/arel/src/crud.ts
@@ -12,7 +12,7 @@ export interface Crud {
   compileInsert(values: [Node, unknown][]): InsertManager;
   createInsert(): InsertManager;
   compileUpdate(
-    values: [Node, unknown][] | string,
+    values: [Node, unknown][] | string | Node,
     key?: Node | null,
     havingClause?: Node | null,
     groupValuesColumns?: Node[],

--- a/packages/arel/src/crud.ts
+++ b/packages/arel/src/crud.ts
@@ -1,4 +1,25 @@
+import type { Node } from "./nodes/node.js";
+import type { InsertManager } from "./insert-manager.js";
+import type { UpdateManager } from "./update-manager.js";
+import type { DeleteManager } from "./delete-manager.js";
+
+/**
+ * Crud — mixed into query-like managers to build CRUD statements.
+ *
+ * Mirrors: Arel::Crud
+ */
 export interface Crud {
-  createInsert(): unknown;
-  compile(): string;
+  compileInsert(values: [Node, unknown][]): InsertManager;
+  createInsert(): InsertManager;
+  compileUpdate(
+    values: [Node, unknown][] | string,
+    key?: Node | null,
+    havingClause?: Node | null,
+    groupValuesColumns?: Node[],
+  ): UpdateManager;
+  compileDelete(
+    key?: Node | null,
+    havingClause?: Node | null,
+    groupValuesColumns?: Node[],
+  ): DeleteManager;
 }

--- a/packages/arel/src/crud.ts
+++ b/packages/arel/src/crud.ts
@@ -1,7 +1,11 @@
 import type { Node } from "./nodes/node.js";
+import type { SqlLiteral } from "./nodes/sql-literal.js";
+import type { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
 import type { InsertManager } from "./insert-manager.js";
 import type { UpdateManager } from "./update-manager.js";
 import type { DeleteManager } from "./delete-manager.js";
+
+export type UpdateValues = [Node, unknown][] | string | SqlLiteral | BoundSqlLiteral;
 
 /**
  * Crud — mixed into query-like managers to build CRUD statements.
@@ -12,7 +16,7 @@ export interface Crud {
   compileInsert(values: [Node, unknown][]): InsertManager;
   createInsert(): InsertManager;
   compileUpdate(
-    values: [Node, unknown][] | string | Node,
+    values: UpdateValues,
     key?: Node | null,
     havingClause?: Node | null,
     groupValuesColumns?: Node[],

--- a/packages/arel/src/delete-manager.ts
+++ b/packages/arel/src/delete-manager.ts
@@ -22,9 +22,9 @@ export class DeleteManager extends TreeManager {
   declare offset: (offset: unknown) => this;
   declare order: (...expr: Node[]) => this;
 
-  constructor() {
+  constructor(table: Table | null = null) {
     super();
-    this.ast = new DeleteStatement();
+    this.ast = new DeleteStatement(table);
   }
 
   /**

--- a/packages/arel/src/delete-manager.ts
+++ b/packages/arel/src/delete-manager.ts
@@ -22,7 +22,7 @@ export class DeleteManager extends TreeManager {
   declare offset: (offset: unknown) => this;
   declare order: (...expr: Node[]) => this;
 
-  constructor(table: Table | null = null) {
+  constructor(table: Table | Node | null = null) {
     super();
     this.ast = new DeleteStatement(table);
   }

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -15,9 +15,9 @@ export class DeleteStatement extends Node {
   offset: Node | null;
   key: Node | Node[] | null;
 
-  constructor() {
+  constructor(relation: Node | null = null) {
     super();
-    this.relation = null;
+    this.relation = relation;
     this.wheres = [];
     this.orders = [];
     this.groups = [];

--- a/packages/arel/src/nodes/update-statement.ts
+++ b/packages/arel/src/nodes/update-statement.ts
@@ -16,9 +16,9 @@ export class UpdateStatement extends Node {
   offset: Node | null;
   key: Node | null;
 
-  constructor() {
+  constructor(relation: Node | null = null) {
     super();
-    this.relation = null;
+    this.relation = relation;
     this.values = [];
     this.wheres = [];
     this.orders = [];

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -621,7 +621,7 @@ describe("SelectManagerTest", () => {
     it("takes a string", () => {
       const mgr = new SelectManager();
       mgr.from(users);
-      const stmt = mgr.compileUpdate(new Nodes.SqlLiteral("foo = bar"), users.get("id"));
+      const stmt = mgr.compileUpdate("foo = bar", users.get("id"));
       expect(stmt.toSql()).toBe('UPDATE "users" SET foo = bar');
     });
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -625,6 +625,16 @@ describe("SelectManagerTest", () => {
       expect(stmt.toSql()).toBe('UPDATE "users" SET foo = bar');
     });
 
+    it("takes a bound sql literal", () => {
+      const mgr = new SelectManager();
+      mgr.from(users);
+      const stmt = mgr.compileUpdate(
+        new Nodes.BoundSqlLiteral("foo = ?", [1], {}),
+        users.get("id"),
+      );
+      expect(stmt.toSql()).toBe('UPDATE "users" SET foo = 1');
+    });
+
     it("copies limits", () => {
       const mgr = new SelectManager();
       mgr.from(users).take(1);

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -571,10 +571,17 @@ describe("SelectManagerTest", () => {
 
   describe("delete", () => {
     it("copies from", () => {
-      const mgr = new SelectManager(users);
-      mgr.from(posts);
-      const sql = mgr.toSql();
-      expect(sql).toContain('"posts"');
+      const mgr = new SelectManager();
+      mgr.from(users);
+      const stmt = mgr.compileDelete();
+      expect(stmt.toSql()).toBe('DELETE FROM "users"');
+    });
+
+    it("copies where", () => {
+      const mgr = new SelectManager();
+      mgr.from(users).where(users.get("id").eq(10));
+      const stmt = mgr.compileDelete();
+      expect(stmt.toSql()).toBe('DELETE FROM "users" WHERE "users"."id" = 10');
     });
   });
 
@@ -605,40 +612,51 @@ describe("SelectManagerTest", () => {
 
   describe("update", () => {
     it("creates an update statement", () => {
-      const mgr = users.project(star);
-      mgr.where(users.get("id").eq(1));
-      // compileUpdate exists on SelectManager
-      expect(mgr).toHaveProperty("compileUpdate");
+      const mgr = new SelectManager();
+      mgr.from(users);
+      const stmt = mgr.compileUpdate([[users.get("id"), 1]], users.get("id"));
+      expect(stmt.toSql()).toBe('UPDATE "users" SET "id" = 1');
     });
 
     it("takes a string", () => {
-      const mgr = users.project(new Nodes.SqlLiteral("count(*)"));
-      expect(mgr.toSql()).toContain("count(*)");
+      const mgr = new SelectManager();
+      mgr.from(users);
+      const stmt = mgr.compileUpdate(new Nodes.SqlLiteral("foo = bar"), users.get("id"));
+      expect(stmt.toSql()).toBe('UPDATE "users" SET foo = bar');
     });
 
     it("copies limits", () => {
-      const mgr = users.project(star).take(10);
-      expect(mgr.toSql()).toContain("LIMIT 10");
+      const mgr = new SelectManager();
+      mgr.from(users).take(1);
+      const stmt = mgr.compileUpdate(new Nodes.SqlLiteral("foo = bar"), users.get("id"));
+      expect(stmt.toSql()).toBe(
+        'UPDATE "users" SET foo = bar WHERE ("users"."id") IN (SELECT "users"."id" FROM "users" LIMIT 1)',
+      );
     });
 
     it("copies order", () => {
-      const mgr = users.project(star).order(users.get("id").asc());
-      expect(mgr.toSql()).toContain("ORDER BY");
+      const mgr = new SelectManager();
+      mgr.from(users).order(new Nodes.SqlLiteral("foo"));
+      const stmt = mgr.compileUpdate(new Nodes.SqlLiteral("foo = bar"), users.get("id"));
+      expect(stmt.toSql()).toBe(
+        'UPDATE "users" SET foo = bar WHERE ("users"."id") IN (SELECT "users"."id" FROM "users" ORDER BY foo)',
+      );
     });
 
     it("copies where clauses", () => {
-      const mgr = users.project(star).where(users.get("id").eq(1));
-      expect(mgr.toSql()).toContain("WHERE");
+      const mgr = new SelectManager();
+      mgr.where(users.get("id").eq(10)).from(users);
+      const stmt = mgr.compileUpdate([[users.get("id"), 1]], users.get("id"));
+      expect(stmt.toSql()).toBe('UPDATE "users" SET "id" = 1 WHERE "users"."id" = 10');
     });
 
     it("copies where clauses when nesting is triggered", () => {
-      const mgr = users
-        .project(star)
-        .where(users.get("id").eq(1))
-        .where(users.get("name").eq("test"));
-      const result = mgr.toSql();
-      expect(result).toContain('"users"."id" = 1');
-      expect(result).toContain("AND");
+      const mgr = new SelectManager();
+      mgr.where(users.get("foo").eq(10)).take(42).from(users);
+      const stmt = mgr.compileUpdate([[users.get("id"), 1]], users.get("id"));
+      expect(stmt.toSql()).toBe(
+        'UPDATE "users" SET "id" = 1 WHERE ("users"."id") IN (SELECT "users"."id" FROM "users" WHERE "users"."foo" = 10 LIMIT 42)',
+      );
     });
   });
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -20,9 +20,8 @@ import { TableAlias } from "./nodes/table-alias.js";
 import { Exists } from "./nodes/function.js";
 import { NamedWindow } from "./nodes/window.js";
 import { Table } from "./table.js";
-import { UpdateStatement } from "./nodes/update-statement.js";
-import { Assignment } from "./nodes/binary.js";
-import { DeleteStatement } from "./nodes/delete-statement.js";
+import { UpdateManager } from "./update-manager.js";
+import { DeleteManager } from "./delete-manager.js";
 import { Comment } from "./nodes/comment.js";
 import { Lateral } from "./nodes/unary.js";
 import { True } from "./nodes/true.js";
@@ -474,32 +473,55 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * Create an UpdateStatement from values.
+   * Build an UpdateManager that applies this SELECT's constraints,
+   * ordering, limit, offset, and grouping to an UPDATE.
    *
    * Mirrors: Arel::SelectManager#compile_update
    */
-  compileUpdate(values: [Node, unknown][], key?: Node): UpdateStatement {
-    const stmt = new UpdateStatement();
-    stmt.relation = this.core.source.left;
-    stmt.values = values.map(([col, val]) => {
-      const right = val instanceof Node ? val : new Quoted(val);
-      return new Assignment(col, right);
-    });
-    stmt.wheres = [...this.core.wheres];
-    if (key) stmt.key = key;
-    return stmt;
+  compileUpdate(
+    values: [Node, unknown][] | string | SqlLiteral,
+    key: Node | null = null,
+    havingClause: Node | null = null,
+    groupValuesColumns: Node[] = [],
+  ): UpdateManager {
+    const um = new UpdateManager(this.source);
+    um.set(values);
+    um.take((this.ast.limit as Limit | null)?.expr ?? null);
+    um.offset((this.ast.offset as Offset | null)?.expr ?? null);
+    um.order(...this.orders);
+    um.wheres = this.constraints;
+    if (key !== null) um.key = key;
+    if (groupValuesColumns.length > 0) {
+      const [first, ...rest] = groupValuesColumns;
+      um.group(first, ...rest);
+    }
+    if (havingClause !== null) um.having(havingClause);
+    return um;
   }
 
   /**
-   * Create a DeleteStatement from this SelectManager.
+   * Build a DeleteManager that applies this SELECT's constraints,
+   * ordering, limit, offset, and grouping to a DELETE.
    *
    * Mirrors: Arel::SelectManager#compile_delete
    */
-  compileDelete(): DeleteStatement {
-    const stmt = new DeleteStatement();
-    stmt.relation = this.core.source.left;
-    stmt.wheres = [...this.core.wheres];
-    return stmt;
+  compileDelete(
+    key: Node | null = null,
+    havingClause: Node | null = null,
+    groupValuesColumns: Node[] = [],
+  ): DeleteManager {
+    const dm = new DeleteManager(this.source);
+    dm.take((this.ast.limit as Limit | null)?.expr ?? null);
+    dm.offset((this.ast.offset as Offset | null)?.expr ?? null);
+    dm.order(...this.orders);
+    dm.wheres = this.constraints;
+    if (key !== null) dm.key = key;
+    if (groupValuesColumns.length > 0) {
+      const [first, ...rest] = groupValuesColumns;
+      dm.group(first, ...rest);
+    }
+    if (havingClause !== null) dm.having(havingClause);
+    return dm;
   }
 
   // -- FactoryMethods (via TreeManager) --

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -22,6 +22,7 @@ import { NamedWindow } from "./nodes/window.js";
 import { Table } from "./table.js";
 import { UpdateManager } from "./update-manager.js";
 import { DeleteManager } from "./delete-manager.js";
+import type { UpdateValues } from "./crud.js";
 import { Comment } from "./nodes/comment.js";
 import { Lateral } from "./nodes/unary.js";
 import { True } from "./nodes/true.js";
@@ -479,7 +480,7 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#compile_update
    */
   compileUpdate(
-    values: [Node, unknown][] | string | SqlLiteral,
+    values: UpdateValues,
     key: Node | null = null,
     havingClause: Node | null = null,
     groupValuesColumns: Node[] = [],

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -86,8 +86,22 @@ describe("UpdateManagerTest", () => {
     it("takes a string", () => {
       const mgr = new UpdateManager();
       mgr.table(users);
-      mgr.set([[users.get("name"), "test"]]);
-      expect(mgr.toSql()).toContain("test");
+      mgr.set(new Nodes.SqlLiteral("foo = bar"));
+      expect(mgr.toSql()).toBe('UPDATE "users" SET foo = bar');
+    });
+
+    it("takes a plain string literal", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set("foo = bar");
+      expect(mgr.toSql()).toBe('UPDATE "users" SET foo = bar');
+    });
+
+    it("takes a BoundSqlLiteral", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set(new Nodes.BoundSqlLiteral("name = ?", ["dean"], {}));
+      expect(mgr.toSql()).toBe(`UPDATE "users" SET name = 'dean'`);
     });
   });
 

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -8,6 +8,7 @@ import { Group } from "./nodes/unary.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
 import { Table } from "./table.js";
+import type { UpdateValues } from "./crud.js";
 
 /**
  * UpdateManager — chainable API for building UPDATE statements.
@@ -45,7 +46,7 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#set
    */
-  set(values: [Node, unknown][] | string | SqlLiteral | BoundSqlLiteral): this {
+  set(values: UpdateValues): this {
     if (typeof values === "string") {
       this.ast.values = [new SqlLiteral(values)];
     } else if (values instanceof SqlLiteral || values instanceof BoundSqlLiteral) {

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -24,9 +24,9 @@ export class UpdateManager extends TreeManager {
   declare offset: (offset: unknown) => this;
   declare order: (...expr: Node[]) => this;
 
-  constructor() {
+  constructor(table: Table | null = null) {
     super();
-    this.ast = new UpdateStatement();
+    this.ast = new UpdateStatement(table);
   }
 
   /**

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -6,6 +6,7 @@ import { Assignment } from "./nodes/binary.js";
 import { Quoted } from "./nodes/casted.js";
 import { Group } from "./nodes/unary.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
+import { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
 import { Table } from "./table.js";
 
 /**
@@ -24,7 +25,7 @@ export class UpdateManager extends TreeManager {
   declare offset: (offset: unknown) => this;
   declare order: (...expr: Node[]) => this;
 
-  constructor(table: Table | null = null) {
+  constructor(table: Table | Node | null = null) {
     super();
     this.ast = new UpdateStatement(table);
   }
@@ -44,11 +45,17 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#set
    */
-  set(values: [Node, unknown][]): this {
-    this.ast.values = values.map(([col, val]) => {
-      const right = val instanceof Node ? val : new Quoted(val);
-      return new Assignment(col, right);
-    });
+  set(values: [Node, unknown][] | string | SqlLiteral | BoundSqlLiteral): this {
+    if (typeof values === "string") {
+      this.ast.values = [new SqlLiteral(values)];
+    } else if (values instanceof SqlLiteral || values instanceof BoundSqlLiteral) {
+      this.ast.values = [values];
+    } else {
+      this.ast.values = values.map(([col, val]) => {
+        const right = val instanceof Node ? val : new Quoted(val);
+        return new Assignment(col, right);
+      });
+    }
     return this;
   }
 


### PR DESCRIPTION
## Summary

Closes the Rails-parity gaps in Arel's CRUD compile path:

- `SelectManager#compileUpdate` / `compileDelete` now return fully-configured `UpdateManager` / `DeleteManager` matching `Arel::Crud#compile_update` / `#compile_delete`: `source`, `set(values)`, `take(limit)`, `offset`, `order(*orders)`, `wheres = constraints`, `key`, `group(group_values_columns)`, `having(having_clause)`. Previously they returned bare `UpdateStatement` / `DeleteStatement` with only `relation` + `wheres` wired up — limits, offsets, orders, group, having, and the full `key`-driven nested subquery path were silently dropped.
- `UpdateManager#set` now accepts `String` / `SqlLiteral` / `BoundSqlLiteral` in addition to column-value pairs, wrapping them as a single literal value (Rails parity).
- `UpdateManager` / `DeleteManager` / `UpdateStatement` / `DeleteStatement` constructors accept an optional table/relation (JoinSource or Table), matching Rails' `initialize(table = nil)`.
- `Crud` interface declares the full Rails surface: `compileInsert`, `createInsert`, `compileUpdate`, `compileDelete`.

## Test plan

- [x] `packages/arel/src/select-manager.test.ts` `update` / `delete` describe blocks rewritten to Rails' test bodies, including the nested-subquery case (`UPDATE ... WHERE (key) IN (SELECT key FROM ... LIMIT n)`) — 138/138 pass.
- [x] `pnpm vitest run packages/arel/src` — 997/997 pass.
- [x] `pnpm vitest run packages/activerecord/src` — 8765 pass, no regressions in downstream callers (`relation.ts`, `persistence.ts`, `internal-metadata.ts` use `UpdateManager#set`).
- [x] `pnpm run api:compare -- --package arel` — 344/344 methods, 62/62 files.