### PR TITLE
refactor(activerecord): extract Validations surface from Base to validations.ts

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -30,20 +30,16 @@ import {
   ConnectionNotDefined,
   AttributeAssignmentError,
 } from "./errors.js";
-import { AssociatedValidator } from "./validations/associated.js";
-import { AbsenceValidator as ARAbsenceValidator } from "./validations/absence.js";
-import { PresenceValidator as ARPresenceValidator } from "./validations/presence.js";
-import { LengthValidator as ARLengthValidator } from "./validations/length.js";
-import { NumericalityValidator as ARNumericalityValidator } from "./validations/numericality.js";
 import { AutosaveAssociation, clearAutosaveState } from "./autosave-association.js";
 import {
   RecordInvalid,
   isValid as validationsIsValid,
-  customValidationContext,
   defaultValidationContext,
   performValidations,
   _setSuperIsValid,
+  _setSuperValidates,
 } from "./validations.js";
+import * as _Validations from "./validations.js";
 import {
   encrypts as _encrypts,
   applyPendingEncryptions,
@@ -822,75 +818,9 @@ export class Base extends Model {
   declare static reflectOnAggregation: typeof _Reflection.ClassMethods.reflectOnAggregation;
   declare static reflectOnAllAutosaveAssociations: typeof _Reflection.ClassMethods.reflectOnAllAutosaveAssociations;
 
-  /**
-   * Mirrors: ActiveRecord::Validations.validates
-   *
-   * Overrides Model.validates to use AR-specific validator classes for
-   * presence/absence/length/numericality. These AR validators add
-   * association awareness (filtering destroyed records, column precision).
-   */
-  static override validates(attribute: string, rules: Record<string, unknown>): void {
-    const arRules = { ...rules };
-    const shared = extractShared(arRules);
-    const { allowNil: sharedAllowNil, allowBlank: sharedAllowBlank, ...sharedRest } = shared;
-
-    // Build options for an AR validator, respecting per-validator allowNil/allowBlank
-    // precedence (only apply shared value when per-validator option is undefined).
-    const buildOpts = (opts: Record<string, unknown>) => ({
-      ...opts,
-      attributes: [attribute],
-      ...sharedRest,
-      ...(opts.allowNil === undefined && sharedAllowNil !== undefined
-        ? { allowNil: sharedAllowNil }
-        : {}),
-      ...(opts.allowBlank === undefined && sharedAllowBlank !== undefined
-        ? { allowBlank: sharedAllowBlank }
-        : {}),
-    });
-
-    if (arRules.presence) {
-      const opts = arRules.presence === true ? {} : (arRules.presence as Record<string, unknown>);
-      delete arRules.presence;
-      this.validatesWith(ARPresenceValidator, buildOpts(opts));
-    }
-    if (arRules.absence) {
-      const opts = arRules.absence === true ? {} : (arRules.absence as Record<string, unknown>);
-      delete arRules.absence;
-      this.validatesWith(ARAbsenceValidator, buildOpts(opts));
-    }
-    if (arRules.length) {
-      const opts = arRules.length as Record<string, unknown>;
-      delete arRules.length;
-      this.validatesWith(ARLengthValidator, buildOpts(opts));
-    }
-    if (arRules.numericality) {
-      const opts =
-        arRules.numericality === true ? {} : (arRules.numericality as Record<string, unknown>);
-      delete arRules.numericality;
-      this.validatesWith(ARNumericalityValidator, buildOpts(opts));
-    }
-    // Delegate remaining rules (inclusion, exclusion, format, etc.) to Model
-    const hasRemaining = Object.keys(arRules).some(
-      (k) => !["on", "if", "unless", "strict", "allowNil", "allowBlank"].includes(k),
-    );
-    if (hasRemaining) {
-      super.validates(attribute, arRules);
-    }
-  }
-
-  /**
-   * Validates that all named associations are themselves valid.
-   *
-   * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
-   */
-  static validatesAssociated(...args: (string | Record<string, unknown>)[]): void {
-    const last = args[args.length - 1];
-    const opts =
-      typeof last === "object" && last !== null ? (args.pop() as Record<string, unknown>) : {};
-    for (const name of args as string[]) {
-      this.validatesWith(AssociatedValidator, { ...opts, attributes: [name] });
-    }
-  }
+  // --- Validations::ClassMethods (wired via extend() after class body) ---
+  declare static validates: typeof _Validations.validates;
+  declare static validatesAssociated: typeof _Validations.validatesAssociated;
 
   // -- Enums --
   static _enums: Map<string, Record<string, number>> = new Map();
@@ -2130,15 +2060,7 @@ export class Base extends Model {
    *
    * Mirrors: validates uniqueness: true
    */
-  static validatesUniqueness(
-    attribute: string,
-    options: { scope?: string | string[]; message?: string; conditions?: (this: any) => any } = {},
-  ): void {
-    if (!Object.prototype.hasOwnProperty.call(this, "_asyncValidations")) {
-      (this as any)._asyncValidations = [...((this as any)._asyncValidations ?? [])];
-    }
-    (this as any)._asyncValidations.push({ attribute, options });
-  }
+  declare static validatesUniqueness: typeof _Validations.validatesUniqueness;
 
   /**
    * Save the record. Returns true if successful, false if validation fails.
@@ -2957,36 +2879,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Validations#validate
    */
-  /**
-   * Mirrors: ActiveModel::Validations#read_attribute_for_validation
-   *
-   * Rails aliases this to `send`, so calling it with an association name
-   * returns the association target (loaded records). We resolve from
-   * association caches first,
-   * falling back to readAttribute for regular columns.
-   */
-  readAttributeForValidation(attribute: string): unknown {
-    const cached = (this as any)._cachedAssociations?.get?.(attribute);
-    if (cached !== undefined) return cached;
-    const preloaded = (this as any)._preloadedAssociations?.get?.(attribute);
-    if (preloaded !== undefined) return preloaded;
-    const proxy = (this as any)._collectionProxies?.get?.(attribute);
-    if (
-      proxy &&
-      (proxy.loaded === true || (Array.isArray(proxy.target) && proxy.target.length > 0))
-    ) {
-      return proxy.target;
-    }
-    if (typeof this.association === "function") {
-      try {
-        const assoc = this.association(attribute);
-        if (assoc?.loaded === true && assoc.target !== undefined) return assoc.target;
-      } catch {
-        // Not an association — fall through
-      }
-    }
-    return this.readAttribute(attribute);
-  }
+  // readAttributeForValidation: wired via include() below.
 
   /**
    * Mirrors: ActiveRecord::Validations#valid?
@@ -3005,20 +2898,7 @@ export class Base extends Model {
     return result && !this.errors.any;
   }
 
-  /**
-   * Mirrors: ActiveRecord::Validations#validate (alias of valid?)
-   */
-  validate(context?: string): this {
-    this.isValid(context);
-    return this;
-  }
-
-  /**
-   * Mirrors: ActiveRecord::Validations#custom_validation_context?
-   */
-  customValidationContext(): boolean {
-    return customValidationContext.call(this);
-  }
+  // validate / customValidationContext: wired via include() below.
 
   declare isPresent: () => boolean;
   declare isBlank: () => boolean;
@@ -3087,17 +2967,6 @@ export interface Base extends Included<typeof AutosaveAssociation> {
 // exact generics, `this` parameter, and return type of their implementations.
 // ---------------------------------------------------------------------------
 
-function extractShared(rules: Record<string, unknown>): Record<string, unknown> {
-  const shared: Record<string, unknown> = {};
-  if (rules.on !== undefined) shared.on = rules.on;
-  if (rules.if !== undefined) shared.if = rules.if;
-  if (rules.unless !== undefined) shared.unless = rules.unless;
-  if (rules.strict) shared.strict = rules.strict;
-  if (rules.allowNil !== undefined) shared.allowNil = rules.allowNil;
-  if (rules.allowBlank !== undefined) shared.allowBlank = rules.allowBlank;
-  return shared;
-}
-
 extend(Base, ConnectionHandling.ClassMethods);
 extend(Base, Querying);
 extend(Base, {
@@ -3112,6 +2981,7 @@ extend(Base, ReadonlyAttributes.ClassMethods);
 extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
+extend(Base, _Validations.ClassMethods);
 extend(Base, { enum: _EnumModule.enumMethod });
 extend(Base, _Reflection.ClassMethods);
 extend(Base, {
@@ -3160,7 +3030,14 @@ include(Base, LockingPessimistic.InstanceMethods);
 include(Base, Timestamp.InstanceMethods);
 include(Base, AutosaveAssociation);
 include(Base, _AssocInstance.InstanceMethods);
+include(Base, {
+  readAttributeForValidation: _Validations.readAttributeForValidation,
+  validate: _Validations.validate,
+  customValidationContext: _Validations.customValidationContext,
+});
 
-// Register Model.isValid as the super for the Validations module's isValid.
-// Breaks the recursion: Base.isValid → validations.isValid → Model.isValid.
+// Register Model's super methods for the Validations module.
+// Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid)
+// and on validates (AR's validates routes remaining rules through Model.validates).
 _setSuperIsValid(Model.prototype.isValid);
+_setSuperValidates(Model.validates);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2951,6 +2951,9 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   association(name: string): AssociationInstance;
   loadBelongsTo(name: string): Promise<Base | null>;
   loadHasOne(name: string): Promise<Base | null>;
+  readAttributeForValidation(attribute: string): unknown;
+  validate(context?: string): this;
+  customValidationContext(): boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -7,10 +7,11 @@
  */
 import { ActiveRecordError } from "./errors.js";
 import { AbsenceValidator } from "./validations/absence.js";
-import { AssociatedValidator } from "./validations/associated.js";
+import { AssociatedValidator, validatesAssociated } from "./validations/associated.js";
 import { LengthValidator } from "./validations/length.js";
 import { NumericalityValidator } from "./validations/numericality.js";
 import { PresenceValidator } from "./validations/presence.js";
+import { UniquenessValidator, validatesUniqueness } from "./validations/uniqueness.js";
 
 // Re-export all validators matching Rails' require at bottom of validations.rb
 export {
@@ -19,8 +20,10 @@ export {
   LengthValidator,
   NumericalityValidator,
   PresenceValidator,
+  UniquenessValidator,
+  validatesAssociated,
+  validatesUniqueness,
 };
-export { UniquenessValidator } from "./validations/uniqueness.js";
 
 /**
  * Mirrors: ActiveRecord::RecordInvalid
@@ -258,43 +261,11 @@ export function _setSuperValidates(
 }
 
 /**
- * Validates that all named associations are themselves valid.
- *
- * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
- */
-export function validatesAssociated(
-  this: { validatesWith(vc: unknown, opts: Record<string, unknown>): void },
-  ...args: (string | Record<string, unknown>)[]
-): void {
-  const last = args[args.length - 1];
-  const opts =
-    typeof last === "object" && last !== null ? (args.pop() as Record<string, unknown>) : {};
-  for (const name of args as string[]) {
-    this.validatesWith(AssociatedValidator, { ...opts, attributes: [name] });
-  }
-}
-
-/**
- * Register a deferred uniqueness validation to run on save (since uniqueness
- * requires a DB round-trip, it's kept off the synchronous validator chain).
- *
- * Mirrors: validates uniqueness: true / ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
- */
-export function validatesUniqueness(
-  this: unknown,
-  attribute: string,
-  options: { scope?: string | string[]; message?: string; conditions?: (this: any) => any } = {},
-): void {
-  const klass = this as { _asyncValidations?: Array<unknown> };
-  if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
-    klass._asyncValidations = [...(klass._asyncValidations ?? [])];
-  }
-  (klass._asyncValidations as Array<unknown>).push({ attribute, options });
-}
-
-/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveRecord::Validations::ClassMethods` / `ActiveSupport::Concern#ClassMethods`.
+ * `validatesAssociated` and `validatesUniqueness` live next to their
+ * validator classes in validations/associated.ts and validations/uniqueness.ts
+ * matching Rails' file layout.
  */
 export const ClassMethods = {
   validates,

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -242,8 +242,13 @@ export function validates(
     (k) => !["on", "if", "unless", "strict", "allowNil", "allowBlank"].includes(k),
   );
   if (hasRemaining) {
+    if (_parentValidates == null) {
+      throw new ActiveRecordError(
+        "ActiveRecord::Validations#validates called before Base registered the super validates",
+      );
+    }
     // `super.validates` — reach the parent (Model) prototype's version.
-    _parentValidates?.call(this, attribute, arRules);
+    _parentValidates.call(this, attribute, arRules);
   }
 }
 

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -13,7 +13,9 @@ import { NumericalityValidator } from "./validations/numericality.js";
 import { PresenceValidator } from "./validations/presence.js";
 import { UniquenessValidator, validatesUniqueness } from "./validations/uniqueness.js";
 
-// Re-export all validators matching Rails' require at bottom of validations.rb
+// Re-export validators (matching Rails' requires at the bottom of validations.rb)
+// plus the validator-adjacent ClassMethods registrars that Rails colocates
+// with each validator (validates_associated / validates_uniqueness_of).
 export {
   AbsenceValidator,
   AssociatedValidator,
@@ -195,7 +197,8 @@ function extractShared(rules: Record<string, unknown>): Record<string, unknown> 
 export function validates(
   this: {
     validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
-    // Model.prototype.validates reached via the parent prototype chain.
+    // The Model.validates class method is reached via _parentValidates,
+    // registered by Base at module load via _setSuperValidates.
   },
   attribute: string,
   rules: Record<string, unknown>,
@@ -247,12 +250,12 @@ export function validates(
         "ActiveRecord::Validations#validates called before Base registered the super validates",
       );
     }
-    // `super.validates` — reach the parent (Model) prototype's version.
+    // `super.validates` — delegate to Model's `validates` class method.
     _parentValidates.call(this, attribute, arRules);
   }
 }
 
-// Late-bound reference to Model.prototype.validates — registered by
+// Late-bound reference to Model's `validates` class method — registered by
 // Base to break the circular-import chain.
 let _parentValidates:
   | ((this: unknown, attribute: string, rules: Record<string, unknown>) => void)

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -6,13 +6,20 @@
  * and overrides save/valid? to run validations with context awareness.
  */
 import { ActiveRecordError } from "./errors.js";
+import { AbsenceValidator } from "./validations/absence.js";
+import { AssociatedValidator } from "./validations/associated.js";
+import { LengthValidator } from "./validations/length.js";
+import { NumericalityValidator } from "./validations/numericality.js";
+import { PresenceValidator } from "./validations/presence.js";
 
 // Re-export all validators matching Rails' require at bottom of validations.rb
-export { AbsenceValidator } from "./validations/absence.js";
-export { AssociatedValidator } from "./validations/associated.js";
-export { LengthValidator } from "./validations/length.js";
-export { NumericalityValidator } from "./validations/numericality.js";
-export { PresenceValidator } from "./validations/presence.js";
+export {
+  AbsenceValidator,
+  AssociatedValidator,
+  LengthValidator,
+  NumericalityValidator,
+  PresenceValidator,
+};
 export { UniquenessValidator } from "./validations/uniqueness.js";
 
 /**
@@ -124,3 +131,173 @@ export function performValidations(
   if (options?.validate === false) return true;
   return this.isValid(options?.context);
 }
+
+/**
+ * Mirrors: ActiveModel::Validations#read_attribute_for_validation
+ *
+ * Rails aliases this to `send`, so calling it with an association name
+ * returns the association target (loaded records). We resolve from
+ * association caches first, falling back to readAttribute for regular
+ * columns.
+ */
+export function readAttributeForValidation(this: any, attribute: string): unknown {
+  const cached = this._cachedAssociations?.get?.(attribute);
+  if (cached !== undefined) return cached;
+  const preloaded = this._preloadedAssociations?.get?.(attribute);
+  if (preloaded !== undefined) return preloaded;
+  const proxy = this._collectionProxies?.get?.(attribute);
+  if (
+    proxy &&
+    (proxy.loaded === true || (Array.isArray(proxy.target) && proxy.target.length > 0))
+  ) {
+    return proxy.target;
+  }
+  if (typeof this.association === "function") {
+    try {
+      const assoc = this.association(attribute);
+      if (assoc?.loaded === true && assoc.target !== undefined) return assoc.target;
+    } catch {
+      // Not an association — fall through
+    }
+  }
+  return this.readAttribute(attribute);
+}
+
+// ---------------------------------------------------------------------------
+// Class methods — Mirrors ActiveRecord::Validations::ClassMethods.
+// Wired onto Base via extend(Base, Validations.ClassMethods) in base.ts.
+// ---------------------------------------------------------------------------
+
+// Options passed alongside any validator: on/if/unless/strict plus
+// allowNil/allowBlank that are shared across all validators.
+function extractShared(rules: Record<string, unknown>): Record<string, unknown> {
+  const shared: Record<string, unknown> = {};
+  if (rules.on !== undefined) shared.on = rules.on;
+  if (rules.if !== undefined) shared.if = rules.if;
+  if (rules.unless !== undefined) shared.unless = rules.unless;
+  if (rules.strict) shared.strict = rules.strict;
+  if (rules.allowNil !== undefined) shared.allowNil = rules.allowNil;
+  if (rules.allowBlank !== undefined) shared.allowBlank = rules.allowBlank;
+  return shared;
+}
+
+/**
+ * Route AR-specific rules (presence/absence/length/numericality) through AR
+ * validator classes that add association/column awareness, and delegate the
+ * rest (inclusion/exclusion/format/...) to ActiveModel's `validates`.
+ *
+ * Mirrors: ActiveRecord::Validations::ClassMethods#validates (the override
+ * over ActiveModel::Validations::ClassMethods#validates).
+ */
+export function validates(
+  this: {
+    validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
+    // Model.prototype.validates reached via the parent prototype chain.
+  },
+  attribute: string,
+  rules: Record<string, unknown>,
+): void {
+  const arRules = { ...rules };
+  const shared = extractShared(arRules);
+  const { allowNil: sharedAllowNil, allowBlank: sharedAllowBlank, ...sharedRest } = shared;
+
+  const buildOpts = (opts: Record<string, unknown>) => ({
+    ...opts,
+    attributes: [attribute],
+    ...sharedRest,
+    ...(opts.allowNil === undefined && sharedAllowNil !== undefined
+      ? { allowNil: sharedAllowNil }
+      : {}),
+    ...(opts.allowBlank === undefined && sharedAllowBlank !== undefined
+      ? { allowBlank: sharedAllowBlank }
+      : {}),
+  });
+
+  if (arRules.presence) {
+    const opts = arRules.presence === true ? {} : (arRules.presence as Record<string, unknown>);
+    delete arRules.presence;
+    this.validatesWith(PresenceValidator, buildOpts(opts));
+  }
+  if (arRules.absence) {
+    const opts = arRules.absence === true ? {} : (arRules.absence as Record<string, unknown>);
+    delete arRules.absence;
+    this.validatesWith(AbsenceValidator, buildOpts(opts));
+  }
+  if (arRules.length) {
+    const opts = arRules.length as Record<string, unknown>;
+    delete arRules.length;
+    this.validatesWith(LengthValidator, buildOpts(opts));
+  }
+  if (arRules.numericality) {
+    const opts =
+      arRules.numericality === true ? {} : (arRules.numericality as Record<string, unknown>);
+    delete arRules.numericality;
+    this.validatesWith(NumericalityValidator, buildOpts(opts));
+  }
+  // Delegate remaining rules (inclusion/exclusion/format/...) to ActiveModel's validates.
+  const hasRemaining = Object.keys(arRules).some(
+    (k) => !["on", "if", "unless", "strict", "allowNil", "allowBlank"].includes(k),
+  );
+  if (hasRemaining) {
+    // `super.validates` — reach the parent (Model) prototype's version.
+    _parentValidates?.call(this, attribute, arRules);
+  }
+}
+
+// Late-bound reference to Model.prototype.validates — registered by
+// Base to break the circular-import chain.
+let _parentValidates:
+  | ((this: unknown, attribute: string, rules: Record<string, unknown>) => void)
+  | null = null;
+
+/** @internal Called by Base to register Model's validates as the super. */
+export function _setSuperValidates(
+  fn: (this: unknown, attribute: string, rules: Record<string, unknown>) => void,
+): void {
+  _parentValidates = fn;
+}
+
+/**
+ * Validates that all named associations are themselves valid.
+ *
+ * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
+ */
+export function validatesAssociated(
+  this: { validatesWith(vc: unknown, opts: Record<string, unknown>): void },
+  ...args: (string | Record<string, unknown>)[]
+): void {
+  const last = args[args.length - 1];
+  const opts =
+    typeof last === "object" && last !== null ? (args.pop() as Record<string, unknown>) : {};
+  for (const name of args as string[]) {
+    this.validatesWith(AssociatedValidator, { ...opts, attributes: [name] });
+  }
+}
+
+/**
+ * Register a deferred uniqueness validation to run on save (since uniqueness
+ * requires a DB round-trip, it's kept off the synchronous validator chain).
+ *
+ * Mirrors: validates uniqueness: true / ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
+ */
+export function validatesUniqueness(
+  this: unknown,
+  attribute: string,
+  options: { scope?: string | string[]; message?: string; conditions?: (this: any) => any } = {},
+): void {
+  const klass = this as { _asyncValidations?: Array<unknown> };
+  if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
+    klass._asyncValidations = [...(klass._asyncValidations ?? [])];
+  }
+  (klass._asyncValidations as Array<unknown>).push({ attribute, options });
+}
+
+/**
+ * Module methods wired onto Base as static methods via `extend()` in base.ts.
+ * Mirrors Rails' `ActiveRecord::Validations::ClassMethods` / `ActiveSupport::Concern#ClassMethods`.
+ */
+export const ClassMethods = {
+  validates,
+  validatesAssociated,
+  validatesUniqueness,
+};

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -10,6 +10,23 @@
  */
 import { EachValidator } from "@blazetrails/activemodel";
 
+/**
+ * Registers AssociatedValidator(s) for the named associations.
+ *
+ * Mirrors: ActiveRecord::Validations::ClassMethods#validates_associated
+ */
+export function validatesAssociated(
+  this: { validatesWith(vc: unknown, opts: Record<string, unknown>): void },
+  ...args: (string | Record<string, unknown>)[]
+): void {
+  const last = args[args.length - 1];
+  const opts =
+    typeof last === "object" && last !== null ? (args.pop() as Record<string, unknown>) : {};
+  for (const name of args as string[]) {
+    this.validatesWith(AssociatedValidator, { ...opts, attributes: [name] });
+  }
+}
+
 export class AssociatedValidator extends EachValidator {
   validateEach(record: any, attribute: string, value: unknown): void {
     const context = this._recordValidationContextForAssociation(record);

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -7,6 +7,24 @@
  */
 import { EachValidator } from "@blazetrails/activemodel";
 
+/**
+ * Register a deferred uniqueness validation to run on save (since uniqueness
+ * requires a DB round-trip, it's kept off the synchronous validator chain).
+ *
+ * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
+ */
+export function validatesUniqueness(
+  this: unknown,
+  attribute: string,
+  options: { scope?: string | string[]; message?: string; conditions?: (this: any) => any } = {},
+): void {
+  const klass = this as { _asyncValidations?: Array<unknown> };
+  if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
+    klass._asyncValidations = [...(klass._asyncValidations ?? [])];
+  }
+  (klass._asyncValidations as Array<unknown>).push({ attribute, options });
+}
+
 export class UniquenessValidator extends EachValidator {
   private _klass: any;
 


### PR DESCRIPTION
## Summary
PR 7 of the Base → Rails-module extraction plan. Moves the `ActiveRecord::Validations` surface out of `base.ts` and into `validations.ts` where [Rails' `validations.rb`](scripts/api-compare/.rails-source/activerecord/lib/active_record/validations.rb) keeps it, wired back onto `Base` via the existing `extend()` / `include()` plumbing.

### Class methods (extend via `Validations.ClassMethods`)
- **`validates`** — the AR override that routes `presence` / `absence` / `length` / `numericality` rules to the AR-specific validator subclasses (which add association/column awareness), then delegates remaining rules (`inclusion` / `exclusion` / `format` / ...) through to ActiveModel's `validates` via a late-bound super (`_setSuperValidates`, matching the existing `_setSuperIsValid` pattern for isValid).
- **`validatesAssociated`** — the AssociatedValidator registrar.
- **`validatesUniqueness`** — pushes onto `_asyncValidations` for deferred save-time execution.

### Instance methods (wired via `include()`)
- **`readAttributeForValidation`** — Rails aliases this to `send`, so it needs to resolve association names from preloaded/cached/proxy state before falling back to `readAttribute`.
- **`validate`** / **`customValidationContext`** — already existed as module functions; now also reachable as instance methods on `Base`, dropping the hand-rolled Base wrappers.

The `extractShared` helper moved alongside `validates`.

### Late-bound super chain
`validates`'s "remaining rules" path needs `Model.validates` — importing it eagerly into validations.ts would close a cycle back through Base. Uses the same `_setSuperValidates(Model.validates)` late-bind pattern already used for `_setSuperIsValid(Model.prototype.isValid)` to break it.

Pure delegation — no behavior change.

## api:compare impact
| | before | after |
|-|--------|-------|
| matched | 2513/2819 (89.1%) | 2513/2819 (89.1%) |
| moves | 208 | 208 |
| inheritance | 201/210 (95.7%) | 201/210 (95.7%) |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17800 tests)
- [x] `pnpm test:types` (DX Type Tests) passes
- [x] `pnpm build` + `pnpm guides:typecheck` pass
- [x] `pnpm run api:compare` steady