### PR TITLE
refactor(activerecord): merge QueryCacheStore into abstract/query-cache Store

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,15 +1,74 @@
 import { Notifications } from "@blazetrails/activesupport";
-import { QueryCacheStore } from "../../query-cache.js";
 import type { DatabaseStatementsHost } from "./database-statements.js";
 
 const DEFAULT_SIZE = 100;
+const DEFAULT_MAX_SIZE = 100;
 
 /**
+ * LRU cache store for query results.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::Store
  */
-export class Store extends QueryCacheStore {
+export class Store {
+  private _map = new Map<string, Record<string, unknown>[]>();
+  private _maxSize: number;
+  enabled = false;
+  dirties = true;
+
+  constructor(maxSize: number = DEFAULT_MAX_SIZE) {
+    this._maxSize = maxSize;
+  }
+
+  get size(): number {
+    return this._map.size;
+  }
+
+  get empty(): boolean {
+    return this._map.size === 0;
+  }
+
   isDirties(): boolean {
     return this.dirties;
+  }
+
+  get(key: string): Record<string, unknown>[] | undefined {
+    if (!this.enabled) return undefined;
+    const entry = this._map.get(key);
+    if (entry) {
+      // Move to end (LRU)
+      this._map.delete(key);
+      this._map.set(key, entry);
+    }
+    return entry;
+  }
+
+  computeIfAbsent(
+    key: string,
+    compute: () => Promise<Record<string, unknown>[]>,
+  ): Promise<Record<string, unknown>[]> {
+    if (!this.enabled) return compute();
+
+    const cached = this.get(key);
+    if (cached !== undefined) {
+      return Promise.resolve(cached.map((row) => ({ ...row })));
+    }
+
+    return compute().then((result) => {
+      if (this._maxSize <= 0) {
+        // maxSize of 0 or negative disables caching — return without storing
+        return result;
+      }
+      if (this._map.size >= this._maxSize) {
+        const firstKey = this._map.keys().next().value;
+        if (firstKey !== undefined) this._map.delete(firstKey);
+      }
+      this._map.set(key, result);
+      return result.map((row) => ({ ...row }));
+    });
+  }
+
+  clear(): void {
+    this._map.clear();
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,7 +1,6 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseStatementsHost } from "./database-statements.js";
 
-const DEFAULT_SIZE = 100;
 const DEFAULT_MAX_SIZE = 100;
 
 /**
@@ -131,7 +130,7 @@ export class ConnectionPoolConfiguration {
     } else if (typeof queryCacheConfig === "number") {
       this._queryCacheMaxSize = queryCacheConfig;
     } else {
-      this._queryCacheMaxSize = DEFAULT_SIZE;
+      this._queryCacheMaxSize = DEFAULT_MAX_SIZE;
     }
   }
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -145,7 +145,10 @@ export {
   IndifferentHashAccessor,
   StringKeyedHashAccessor,
 } from "./store.js";
-export { QueryCache, QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
+export { QueryCache, QueryCacheAdapter } from "./query-cache.js";
+// `QueryCache::Store` in Rails; exported under a qualified TS name
+// so the package-level surface isn't shadowed by the generic `Store`.
+export { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
 export { QueryLogs, escapeComment, LegacyFormatter, SQLCommenter } from "./query-logs.js";
 export type { TagValue, TagHandler, TagDefinition, QueryLogsFormatter } from "./query-logs.js";
 export {

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
-import { QueryCache, QueryCacheAdapter, QueryCacheStore } from "./query-cache.js";
+import { QueryCache, QueryCacheAdapter } from "./query-cache.js";
+import { Store } from "./connection-adapters/abstract/query-cache.js";
 
 function setup() {
   const inner = createTestAdapter();
@@ -383,7 +384,7 @@ describe("QueryCacheExpiryTest", () => {
   });
 
   it("enable disable", async () => {
-    const store = new QueryCacheStore();
+    const store = new Store();
     expect(store.enabled).toBe(false);
     store.enabled = true;
     expect(store.enabled).toBe(true);
@@ -405,7 +406,7 @@ describe("QueryCacheExpiryTest", () => {
   });
 
   it("query cache lru eviction", async () => {
-    const store = new QueryCacheStore(3);
+    const store = new Store(3);
     store.enabled = true;
     for (let i = 0; i < 5; i++) {
       await store.computeIfAbsent(`query_${i}`, async () => [{ val: i }]);

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
-import { QueryCache, QueryCacheAdapter } from "./query-cache.js";
-import { Store } from "./connection-adapters/abstract/query-cache.js";
+import { QueryCache, QueryCacheAdapter, QueryCacheStore as Store } from "./query-cache.js";
+import { QueryCacheStore as RootQueryCacheStore } from "./index.js";
+import { Store as AbstractStore } from "./connection-adapters/abstract/query-cache.js";
 
 function setup() {
   const inner = createTestAdapter();
@@ -360,6 +361,17 @@ describe("QueryCacheTest", () => {
       expect(cached.cache.enabled).toBe(false);
     });
     expect(cached.cache.enabled).toBe(true);
+  });
+});
+
+describe("QueryCacheStore public re-export", () => {
+  it("is the same class via both the package root and the query-cache deep import", () => {
+    // Guards the re-export + alias surface against regressions: consumers
+    // reaching for `QueryCacheStore` from either `@blazetrails/activerecord`
+    // or `@blazetrails/activerecord/query-cache.js` should hit the
+    // canonical `Store` class in abstract/query-cache.ts.
+    expect(Store).toBe(AbstractStore);
+    expect(RootQueryCacheStore).toBe(AbstractStore);
   });
 });
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -14,6 +14,12 @@ import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { Result } from "./result.js";
 import { Store } from "./connection-adapters/abstract/query-cache.js";
 
+// Deep-import convenience: consumers doing
+// `import { ... } from "@blazetrails/activerecord/query-cache.js"`
+// can still reach the Store class from here under its
+// root-exported name.
+export { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
+
 /**
  * QueryCache executor hooks — enable/disable query caching per-request.
  *

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -12,13 +12,16 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { Result } from "./result.js";
-import { Store } from "./connection-adapters/abstract/query-cache.js";
+// Import under the qualified TS name so the public `QueryCacheAdapter`
+// surface (e.g. `.cache: QueryCacheStore`) doesn't leak the generic
+// `Store` symbol into the generated `.d.ts`.
+import { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
 
 // Deep-import convenience: consumers doing
 // `import { ... } from "@blazetrails/activerecord/query-cache.js"`
 // can still reach the Store class from here under its
 // root-exported name.
-export { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
+export { QueryCacheStore };
 
 /**
  * QueryCache executor hooks — enable/disable query caching per-request.
@@ -118,13 +121,13 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   }
 
   readonly inner: DatabaseAdapter;
-  readonly cache: Store;
+  readonly cache: QueryCacheStore;
   private _queryCount = 0;
   private _cacheHits = 0;
 
   constructor(inner: DatabaseAdapter, maxSize?: number) {
     this.inner = inner;
-    this.cache = new Store(maxSize);
+    this.cache = new QueryCacheStore(maxSize);
   }
 
   get queryCount(): number {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -12,6 +12,7 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { Result } from "./result.js";
+import { Store } from "./connection-adapters/abstract/query-cache.js";
 
 /**
  * QueryCache executor hooks — enable/disable query caching per-request.
@@ -77,71 +78,6 @@ export class QueryCache {
   }
 }
 
-const DEFAULT_MAX_SIZE = 100;
-
-/**
- * LRU cache store for query results.
- * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache::Store
- */
-export class QueryCacheStore {
-  private _map = new Map<string, Record<string, unknown>[]>();
-  private _maxSize: number;
-  enabled = false;
-  dirties = true;
-
-  constructor(maxSize: number = DEFAULT_MAX_SIZE) {
-    this._maxSize = maxSize;
-  }
-
-  get size(): number {
-    return this._map.size;
-  }
-
-  get empty(): boolean {
-    return this._map.size === 0;
-  }
-
-  get(key: string): Record<string, unknown>[] | undefined {
-    if (!this.enabled) return undefined;
-    const entry = this._map.get(key);
-    if (entry) {
-      // Move to end (LRU)
-      this._map.delete(key);
-      this._map.set(key, entry);
-    }
-    return entry;
-  }
-
-  computeIfAbsent(
-    key: string,
-    compute: () => Promise<Record<string, unknown>[]>,
-  ): Promise<Record<string, unknown>[]> {
-    if (!this.enabled) return compute();
-
-    const cached = this.get(key);
-    if (cached !== undefined) {
-      return Promise.resolve(cached.map((row) => ({ ...row })));
-    }
-
-    return compute().then((result) => {
-      if (this._maxSize <= 0) {
-        // maxSize of 0 or negative disables caching — return without storing
-        return result;
-      }
-      if (this._map.size >= this._maxSize) {
-        const firstKey = this._map.keys().next().value;
-        if (firstKey !== undefined) this._map.delete(firstKey);
-      }
-      this._map.set(key, result);
-      return result.map((row) => ({ ...row }));
-    });
-  }
-
-  clear(): void {
-    this._map.clear();
-  }
-}
-
 /**
  * Extract primitive values from bind objects, matching Rails' type_casted_binds.
  */
@@ -176,13 +112,13 @@ export class QueryCacheAdapter implements DatabaseAdapter {
   }
 
   readonly inner: DatabaseAdapter;
-  readonly cache: QueryCacheStore;
+  readonly cache: Store;
   private _queryCount = 0;
   private _cacheHits = 0;
 
   constructor(inner: DatabaseAdapter, maxSize?: number) {
     this.inner = inner;
-    this.cache = new QueryCacheStore(maxSize);
+    this.cache = new Store(maxSize);
   }
 
   get queryCount(): number {


### PR DESCRIPTION
## Summary

Rails has ONE \`ActiveRecord::ConnectionAdapters::QueryCache::Store\`. We had split it into two classes:
- \`QueryCacheStore\` (top-level \`query-cache.ts\`) — state + LRU.
- \`Store extends QueryCacheStore\` (\`abstract/query-cache.ts\`) — only added \`isDirties()\`.

The split existed because \`QueryCacheAdapter\` (a TS-only wrapper, no Rails equivalent) lived in \`query-cache.ts\` and wanted the LRU class without importing from \`abstract/\`.

This PR folds the LRU state and methods into the single \`Store\` class at its Rails-canonical home (\`abstract/query-cache.ts\`), drops the outer \`QueryCacheStore\`, and switches \`QueryCacheAdapter\` to import \`Store\` from abstract/. The package-level \`index.ts\` re-exports it as \`QueryCacheStore\` so the public name stays disambiguated from generic \`Store\` symbols.

With one class instead of two, the extends chain is gone — no \`TS_ROOT_INTERMEDIATE\` entry needed for this pair.

## Followup for #672

Once this lands, the \`Store → QueryCacheStore\` entry in #672 becomes dead. I'll drop it there (mirrors the AbstractAdapter cleanup we did after #674).

## Test plan
- [x] \`pnpm exec tsc --build\` clean
- [x] \`pnpm exec vitest run packages/activerecord\` — 8765 passed