### PR TITLE
fix(activerecord): Relation#merge propagates _isNone

### DIFF
--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -299,15 +299,13 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * `.select(...)` chains conventionally APPEND elsewhere — so a
    * blanket merge would drop the walker's existing orders/projection
    * when the user chains `.order(...)`. Recompose those fields
-   * additively here. `_isNone` (used by `.none()`) is copied
-   * explicitly since `Relation#merge` doesn't propagate it today.
+   * additively here.
    */
   private _composeChainedState(walkerResult: Relation<T>): Relation<T> {
     type ComposeFields = {
       _orderClauses?: unknown[];
       _rawOrderClauses?: unknown[];
       _selectColumns?: unknown[];
-      _isNone?: boolean;
     };
     // Snapshot walker's pre-merge order/select state — the merge
     // would otherwise replace these.
@@ -345,7 +343,6 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       target._selectColumns = Array.from(new Set([...sourceSelects, ...overlaySelects]));
     }
 
-    if (overlay._isNone) target._isNone = true;
     return merged;
   }
 

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -40,6 +40,13 @@ export class Merger {
     if (this.other._lockValue) rel._lockValue = this.other._lockValue;
     if (this.other._isReadonly) rel._isReadonly = true;
     if (this.other._isStrictLoading) rel._isStrictLoading = true;
+    // `.none()` is sticky — a merged-in relation that was already
+    // empty stays empty so callers don't accidentally broaden the
+    // result by composing additional state on top. Mirrors Rails'
+    // `Relation::Merger#merge` implicitly propagating the null
+    // relation's short-circuit; we have to copy it explicitly
+    // because our none-check lives on a boolean field.
+    if (this.other._isNone) rel._isNone = true;
     rel._joinClauses.push(...this.other._joinClauses);
     rel._rawJoins.push(...this.other._rawJoins);
     rel._annotations.push(...this.other._annotations);

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -327,11 +327,11 @@ describe("merge()", () => {
     expect(items[0].name).toBe("A");
   });
 
-  it("propagates the none() short-circuit from the other relation", async () => {
-    // Rails: merging a null-relation keeps the result empty so
-    // callers don't accidentally broaden an already-empty scope by
-    // composing state on top. We mirror the sticky behavior on
-    // `_isNone`.
+  it("propagates the none() short-circuit across merge in either direction", async () => {
+    // Rails: a null-relation stays empty through merge so callers
+    // don't broaden an already-empty scope by composing state. We
+    // mirror the sticky behavior on `_isNone` and it has to hold
+    // whichever side the `.none()` is on.
     class Item extends Base {
       static _tableName = "items";
     }
@@ -342,10 +342,21 @@ describe("merge()", () => {
     await Item.create({ name: "A" });
     await Item.create({ name: "B" });
 
-    const emptyOther = Item.all().none();
-    const merged = Item.all().merge(emptyOther);
-    expect((merged as unknown as { _isNone: boolean })._isNone).toBe(true);
-    expect(await merged.toArray()).toEqual([]);
+    // populated.merge(none) — the propagation case the merger fix
+    // was written for.
+    const noneOther = Item.all().none();
+    const fromPopulated = Item.all().merge(noneOther);
+    expect((fromPopulated as unknown as { _isNone: boolean })._isNone).toBe(true);
+    expect(await fromPopulated.toArray()).toEqual([]);
+
+    // none.merge(populated) — already emptied by the left side; the
+    // merge must not accidentally un-empty it. Exercised here so a
+    // future refactor that rebuilds state from `other` on top of a
+    // fresh base can't regress this.
+    const populatedOther = Item.all().where({ name: "A" });
+    const fromNone = Item.all().none().merge(populatedOther);
+    expect((fromNone as unknown as { _isNone: boolean })._isNone).toBe(true);
+    expect(await fromNone.toArray()).toEqual([]);
   });
 
   it("merges order from other relation", async () => {

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -346,7 +346,7 @@ describe("merge()", () => {
     // was written for.
     const noneOther = Item.all().none();
     const fromPopulated = Item.all().merge(noneOther);
-    expect((fromPopulated as unknown as { _isNone: boolean })._isNone).toBe(true);
+    expect(fromPopulated.isNone()).toBe(true);
     expect(await fromPopulated.toArray()).toEqual([]);
 
     // none.merge(populated) — already emptied by the left side; the
@@ -355,8 +355,15 @@ describe("merge()", () => {
     // fresh base can't regress this.
     const populatedOther = Item.all().where({ name: "A" });
     const fromNone = Item.all().none().merge(populatedOther);
-    expect((fromNone as unknown as { _isNone: boolean })._isNone).toBe(true);
+    expect(fromNone.isNone()).toBe(true);
     expect(await fromNone.toArray()).toEqual([]);
+
+    // Same sticky behavior through the in-place `merge!` variant —
+    // the merger and spawn-methods paths stay in sync.
+    const bangTarget = Item.all();
+    (bangTarget as unknown as { mergeBang: (o: unknown) => unknown }).mergeBang(Item.all().none());
+    expect(bangTarget.isNone()).toBe(true);
+    expect(await bangTarget.toArray()).toEqual([]);
   });
 
   it("merges order from other relation", async () => {

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -327,6 +327,27 @@ describe("merge()", () => {
     expect(items[0].name).toBe("A");
   });
 
+  it("propagates the none() short-circuit from the other relation", async () => {
+    // Rails: merging a null-relation keeps the result empty so
+    // callers don't accidentally broaden an already-empty scope by
+    // composing state on top. We mirror the sticky behavior on
+    // `_isNone`.
+    class Item extends Base {
+      static _tableName = "items";
+    }
+    Item.attribute("id", "integer");
+    Item.attribute("name", "string");
+    Item.adapter = adapter;
+
+    await Item.create({ name: "A" });
+    await Item.create({ name: "B" });
+
+    const emptyOther = Item.all().none();
+    const merged = Item.all().merge(emptyOther);
+    expect((merged as unknown as { _isNone: boolean })._isNone).toBe(true);
+    expect(await merged.toArray()).toEqual([]);
+  });
+
   it("merges order from other relation", async () => {
     class Item extends Base {
       static _tableName = "items";

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -52,6 +52,8 @@ export function mergeBang(this: any, other: any): any {
     if (other._lockValue) this._lockValue = other._lockValue;
     if (other._isReadonly) this._isReadonly = true;
     if (other._isStrictLoading) this._isStrictLoading = true;
+    // Sticky `.none()` — kept in sync with `Merger#merge`.
+    if (other._isNone) this._isNone = true;
     this._joinClauses.push(...(other._joinClauses ?? []));
     this._rawJoins.push(...(other._rawJoins ?? []));
     this._annotations.push(...(other._annotations ?? []));


### PR DESCRIPTION
## Summary

Task #17. `Relation#merge` (via `Merger` in `relation/merger.ts`) copies fields explicitly rather than rebuilding the Relation wholesale. `_isNone` — the flag that makes `.none()` short-circuit to an empty result — wasn't in the copy list, so merging a null-relation onto another silently broadened the result to the full scope.

Rails' `Merger` carries the short-circuit implicitly (its callers check `empty_scope?` up front); ours has to copy the boolean. This lands the one-line fix plus a regression test.

DJAR's `_composeChainedState` (in `disable-joins-association-relation.ts`) had a local workaround that copied `_isNone` manually onto the merged result. Drop it now that the merger does the right thing — any other merge site benefits automatically too.

## Test plan

- [x] New test in `merging.test.ts`: merging an empty `.none()` relation keeps `_isNone` true and `toArray()` returns `[]`.
- [x] Full `@blazetrails/activerecord` suite: 8768 passed locally.
- [ ] PG / MariaDB CI.