### PR TITLE
feat(activerecord): validate ThroughReflection sourceType shape at first use

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -40,6 +40,7 @@ import {
 } from "./associations/errors.js";
 import { ForeignAssociation } from "./associations/foreign-association.js";
 import { AssociationScope } from "./associations/association-scope.js";
+import { validateThroughSourceType } from "./associations/validate-source-type.js";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./inheritance.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
@@ -1740,6 +1741,10 @@ export function association<T extends Base = Base>(
   if (!assocDef) {
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }
+  // Matches Rails' first-use check_validity! for ThroughReflection —
+  // surface the sourceType misconfigurations loudly here too, since
+  // `association()` is the other entry point besides Association#ctor.
+  validateThroughSourceType(ctor, assocName);
   if (!_CollectionProxyCtor) {
     // Deliberate constraint: `associations.ts`, `relation.ts`,
     // `collection-proxy.ts`, and `base.ts` form a mandatory mutual

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -634,6 +634,9 @@ export async function loadHasOne(
   assocName: string,
   options: AssociationOptions,
 ): Promise<Base | null> {
+  if (options.through) {
+    validateThroughSourceType(record.constructor as typeof Base, assocName);
+  }
   // Check cached (inverse_of) first, then preloaded
   if ((record as any)._cachedAssociations?.has(assocName)) {
     return (record as any)._cachedAssociations.get(assocName) as Base | null;
@@ -835,6 +838,9 @@ export async function loadHasMany(
   assocName: string,
   options: AssociationOptions,
 ): Promise<Base[]> {
+  if (options.through) {
+    validateThroughSourceType(record.constructor as typeof Base, assocName);
+  }
   // Check cached (inverse_of) first, then preloaded
   if ((record as any)._cachedAssociations?.has(assocName)) {
     return (record as any)._cachedAssociations.get(assocName) as Base[];
@@ -1741,9 +1747,6 @@ export function association<T extends Base = Base>(
   if (!assocDef) {
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }
-  // Matches Rails' first-use check_validity! for ThroughReflection —
-  // surface the sourceType misconfigurations loudly here too, since
-  // `association()` is the other entry point besides Association#ctor.
   validateThroughSourceType(ctor, assocName);
   if (!_CollectionProxyCtor) {
     // Deliberate constraint: `associations.ts`, `relation.ts`,

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -2,6 +2,7 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
 import { resolveModel, buildHasManyRelation } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
+import { validateThroughSourceType } from "./validate-source-type.js";
 import { camelize, singularize } from "@blazetrails/activesupport";
 
 /**
@@ -39,6 +40,14 @@ export class Association {
     this.disableJoins = reflection.options.disableJoins || false;
     this.loaded = false;
     this.target = null;
+
+    // Rails' `Association#initialize` calls `reflection.check_validity!`
+    // so misconfigurations surface at first use. We run a narrow
+    // subset of that check (the two sourceType-shape cases) via
+    // the shared helper; the full `checkValidityBang` wire-up is
+    // deferred because several test fixtures trip the stricter
+    // checks (tracked separately).
+    validateThroughSourceType(owner.constructor as typeof Base, reflection.name);
   }
 
   get name(): string {

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -15,8 +15,12 @@
  * unguarded polymorphic-source case has no type filter and mixes
  * ids across polymorphic target tables).
  *
- * This test exercises both error paths via `association()`, which
- * constructs the `Association` instance that runs the check.
+ * The suite covers: both error paths via `association()` (which
+ * runs the check during `Association#constructor`), the loader
+ * entry point (`loadHasMany`) so direct callers that bypass the
+ * proxy still surface the misconfiguration, and the valid shape
+ * (polymorphic source paired with `sourceType`) to pin the
+ * no-false-positive contract.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * ThroughReflection sourceType validation (task #18).
+ *
+ * Rails' `ThroughReflection#check_validity!` raises at first use
+ * (`Association#initialize`) for two misconfigurations:
+ *   - polymorphic source without `source_type` →
+ *     `HasManyThroughAssociationPolymorphicSourceError`
+ *   - `source_type` with a non-polymorphic source →
+ *     `HasManyThroughAssociationPointlessSourceTypeError`
+ *
+ * Without this check the misconfiguration silently produces
+ * invalid SQL downstream (reflection.ts injects a
+ * `PolymorphicReflection` whose `foreignType` resolves to `null`,
+ * so `_sourceTypeScope()` emits `where({[null]: sourceType})`; the
+ * unguarded polymorphic-source case has no type filter and mixes
+ * ids across polymorphic target tables).
+ *
+ * This test exercises both error paths via `association()`, which
+ * constructs the `Association` instance that runs the check.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { Associations, association } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("ThroughReflection — sourceType validation", () => {
+  let adapter: DatabaseAdapter;
+
+  class StvAuthor extends Base {
+    static {
+      this._tableName = "stv_authors";
+      this.attribute("name", "string");
+    }
+  }
+  class StvComment extends Base {
+    static {
+      this._tableName = "stv_comments";
+      this.attribute("stv_author_id", "integer");
+      this.attribute("origin_id", "integer");
+      this.attribute("origin_type", "string");
+    }
+  }
+  class StvPost extends Base {
+    static {
+      this._tableName = "stv_posts";
+      this.attribute("stv_author_id", "integer");
+    }
+  }
+  class StvMember extends Base {
+    static {
+      this._tableName = "stv_members";
+      this.attribute("name", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    StvAuthor.adapter = adapter;
+    StvComment.adapter = adapter;
+    StvPost.adapter = adapter;
+    StvMember.adapter = adapter;
+    registerModel("StvAuthor", StvAuthor);
+    registerModel("StvComment", StvComment);
+    registerModel("StvPost", StvPost);
+    registerModel("StvMember", StvMember);
+    (StvAuthor as any)._associations = [];
+    (StvAuthor as any)._reflections = {};
+    (StvComment as any)._associations = [];
+    (StvComment as any)._reflections = {};
+    (StvPost as any)._associations = [];
+    (StvPost as any)._reflections = {};
+  });
+
+  it("raises PolymorphicSourceError when source is polymorphic but sourceType is missing", async () => {
+    Associations.hasMany.call(StvAuthor, "stvComments", {
+      className: "StvComment",
+      foreignKey: "stv_author_id",
+    });
+    Associations.belongsTo.call(StvComment, "origin", {
+      className: "StvMember",
+      foreignKey: "origin_id",
+      polymorphic: true,
+    });
+    // Missing sourceType — the chain walker has no type filter to
+    // disambiguate the polymorphic target.
+    Associations.hasMany.call(StvAuthor, "originFromComments", {
+      className: "StvMember",
+      through: "stvComments",
+      source: "origin",
+    });
+    const author = await StvAuthor.create({ name: "a" });
+    expect(() => association(author, "originFromComments")).toThrow(
+      /polymorphic association 'origin'/,
+    );
+  });
+
+  it("raises PointlessSourceTypeError when sourceType is set but source is not polymorphic", async () => {
+    // Non-polymorphic belongsTo source + sourceType is meaningless
+    // (and would inject a PolymorphicReflection whose foreignType
+    // resolves to null downstream).
+    Associations.hasMany.call(StvAuthor, "stvPosts", {
+      className: "StvPost",
+      foreignKey: "stv_author_id",
+    });
+    Associations.belongsTo.call(StvPost, "author", {
+      className: "StvAuthor",
+      foreignKey: "stv_author_id",
+    });
+    Associations.hasMany.call(StvAuthor, "authorsByPost", {
+      className: "StvAuthor",
+      through: "stvPosts",
+      source: "author",
+      sourceType: "StvAuthor",
+    });
+    const author = await StvAuthor.create({ name: "a" });
+    expect(() => association(author, "authorsByPost")).toThrow(/:source_type/);
+  });
+
+  it("accepts the valid shape: polymorphic source with sourceType", async () => {
+    Associations.hasMany.call(StvAuthor, "stvComments", {
+      className: "StvComment",
+      foreignKey: "stv_author_id",
+    });
+    Associations.belongsTo.call(StvComment, "origin", {
+      className: "StvMember",
+      foreignKey: "origin_id",
+      polymorphic: true,
+    });
+    Associations.hasMany.call(StvAuthor, "stvMembersViaComments", {
+      className: "StvMember",
+      through: "stvComments",
+      source: "origin",
+      sourceType: "StvMember",
+    });
+    const author = await StvAuthor.create({ name: "a" });
+    expect(() => association(author, "stvMembersViaComments")).not.toThrow();
+  });
+});

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -20,7 +20,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { Associations, association } from "../associations.js";
+import { Associations, association, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -115,6 +115,36 @@ describe("ThroughReflection — sourceType validation", () => {
     });
     const author = await StvAuthor.create({ name: "a" });
     expect(() => association(author, "authorsByPost")).toThrow(/:source_type/);
+  });
+
+  it("fires at the loadHasMany entry point too (not just association() / Association#ctor)", async () => {
+    // loadHasMany is the loader path direct callers (preloader,
+    // tests) hit without going through `association()`. The
+    // validation has to surface there too — matching Rails'
+    // Association#initialize check_validity! which runs on every
+    // first use regardless of entry point.
+    Associations.hasMany.call(StvAuthor, "stvComments", {
+      className: "StvComment",
+      foreignKey: "stv_author_id",
+    });
+    Associations.belongsTo.call(StvComment, "origin", {
+      className: "StvMember",
+      foreignKey: "origin_id",
+      polymorphic: true,
+    });
+    Associations.hasMany.call(StvAuthor, "originFromComments", {
+      className: "StvMember",
+      through: "stvComments",
+      source: "origin",
+    });
+    const author = await StvAuthor.create({ name: "a" });
+    await expect(
+      loadHasMany(author, "originFromComments", {
+        className: "StvMember",
+        through: "stvComments",
+        source: "origin",
+      }),
+    ).rejects.toThrow(/polymorphic association 'origin'/);
   });
 
   it("accepts the valid shape: polymorphic source with sourceType", async () => {

--- a/packages/activerecord/src/associations/validate-source-type.ts
+++ b/packages/activerecord/src/associations/validate-source-type.ts
@@ -44,10 +44,7 @@ export function validateThroughSourceType(modelClass: typeof Base, assocName: st
   const refl = full as
     | {
         isThroughReflection?: () => boolean;
-        options?: { sourceType?: unknown };
-        sourceReflection?: { isPolymorphic?: () => boolean; name?: string };
-        name?: string;
-        activeRecord?: { name?: string };
+        checkValidityBang?: () => void;
         [CHECKED]?: boolean;
       }
     | null
@@ -55,28 +52,29 @@ export function validateThroughSourceType(modelClass: typeof Base, assocName: st
   if (!refl || refl[CHECKED]) return;
   // AssociationReflection.sourceReflection returns `this`
   // (reflection.ts:793), so non-through polymorphic belongsTo would
-  // misfire here. Gate on `isThroughReflection`.
+  // misfire if we delegated without gating. ThroughReflection is
+  // the only shape that needs the sourceType checks.
   const isThrough = typeof refl.isThroughReflection === "function" && refl.isThroughReflection();
-  if (!isThrough || !refl.sourceReflection || !refl.options) return;
+  if (!isThrough || typeof refl.checkValidityBang !== "function") return;
 
-  const srcPoly =
-    typeof refl.sourceReflection.isPolymorphic === "function"
-      ? refl.sourceReflection.isPolymorphic()
-      : false;
-  const hasSourceType = refl.options.sourceType != null;
-  if (hasSourceType && !srcPoly) {
-    throw new HasManyThroughAssociationPointlessSourceTypeError(
-      refl.activeRecord?.name ?? "<unknown>",
-      refl.name ?? "<unknown>",
-      refl.sourceReflection.name ?? "<unknown>",
-    );
-  }
-  if (srcPoly && !hasSourceType) {
-    throw new HasManyThroughAssociationPolymorphicSourceError(
-      refl.activeRecord?.name ?? "<unknown>",
-      refl.name ?? "<unknown>",
-      refl.sourceReflection.name ?? "<unknown>",
-    );
+  // Delegate to the full `ThroughReflection#checkValidityBang` so
+  // the sourceType logic stays in one place (reflection.ts), but
+  // only re-throw the two sourceType errors this PR targets. Other
+  // checks (PolymorphicThrough, missing source, has-one-through-
+  // collection) trip pre-existing test fixtures — task #23 widens
+  // the set once those fixtures are addressed.
+  try {
+    refl.checkValidityBang();
+  } catch (err) {
+    if (
+      err instanceof HasManyThroughAssociationPointlessSourceTypeError ||
+      err instanceof HasManyThroughAssociationPolymorphicSourceError
+    ) {
+      throw err;
+    }
+    // Swallow other validity errors for now; once task #23 widens
+    // the check, all errors propagate and this `catch` goes away.
+    return;
   }
   refl[CHECKED] = true;
 }

--- a/packages/activerecord/src/associations/validate-source-type.ts
+++ b/packages/activerecord/src/associations/validate-source-type.ts
@@ -1,0 +1,82 @@
+import type { Base } from "../base.js";
+import {
+  HasManyThroughAssociationPointlessSourceTypeError,
+  HasManyThroughAssociationPolymorphicSourceError,
+} from "./errors.js";
+
+/**
+ * Module-private marker: set on a reflection the first time the
+ * sourceType validation succeeds, so subsequent resolutions don't
+ * re-run (cheap, idempotent — safety net only).
+ */
+const CHECKED = Symbol("ThroughReflection.checkedSourceType");
+
+/**
+ * Validate the two sourceType-shape constraints Rails enforces in
+ * `ThroughReflection#check_validity!`:
+ *
+ *   - polymorphic source without `source_type`
+ *     → `HasManyThroughAssociationPolymorphicSourceError`
+ *   - `source_type` with a non-polymorphic source
+ *     → `HasManyThroughAssociationPointlessSourceTypeError`
+ *
+ * Either misconfiguration produces invalid SQL downstream:
+ * reflection.ts#_collectJoinReflections injects a `PolymorphicReflection`
+ * when `options.sourceType` is set, and its `foreignType` is `null`
+ * unless the source reflection is actually polymorphic
+ * (reflection.ts:544). The polymorphic-source-without-source_type
+ * case has no type filter, so the chain-walker mixes ids across
+ * polymorphic target tables.
+ *
+ * Called from `Association#constructor` (matching Rails'
+ * `Association#initialize → reflection.check_validity!` hook) and
+ * from `association(record, name)` so both entry points surface
+ * the error loudly at first use. Results are memoized on the
+ * reflection via a module-private symbol.
+ *
+ * Mirrors: `ActiveRecord::Reflection::ThroughReflection#check_validity!`
+ * (activerecord/lib/active_record/reflection.rb:1157-1163).
+ */
+export function validateThroughSourceType(modelClass: typeof Base, assocName: string): void {
+  const full = (
+    modelClass as unknown as { _reflectOnAssociation?: (n: string) => unknown }
+  )._reflectOnAssociation?.(assocName);
+  const refl = full as
+    | {
+        isThroughReflection?: () => boolean;
+        options?: { sourceType?: unknown };
+        sourceReflection?: { isPolymorphic?: () => boolean; name?: string };
+        name?: string;
+        activeRecord?: { name?: string };
+        [CHECKED]?: boolean;
+      }
+    | null
+    | undefined;
+  if (!refl || refl[CHECKED]) return;
+  // AssociationReflection.sourceReflection returns `this`
+  // (reflection.ts:793), so non-through polymorphic belongsTo would
+  // misfire here. Gate on `isThroughReflection`.
+  const isThrough = typeof refl.isThroughReflection === "function" && refl.isThroughReflection();
+  if (!isThrough || !refl.sourceReflection || !refl.options) return;
+
+  const srcPoly =
+    typeof refl.sourceReflection.isPolymorphic === "function"
+      ? refl.sourceReflection.isPolymorphic()
+      : false;
+  const hasSourceType = refl.options.sourceType != null;
+  if (hasSourceType && !srcPoly) {
+    throw new HasManyThroughAssociationPointlessSourceTypeError(
+      refl.activeRecord?.name ?? "<unknown>",
+      refl.name ?? "<unknown>",
+      refl.sourceReflection.name ?? "<unknown>",
+    );
+  }
+  if (srcPoly && !hasSourceType) {
+    throw new HasManyThroughAssociationPolymorphicSourceError(
+      refl.activeRecord?.name ?? "<unknown>",
+      refl.name ?? "<unknown>",
+      refl.sourceReflection.name ?? "<unknown>",
+    );
+  }
+  refl[CHECKED] = true;
+}

--- a/packages/activerecord/src/associations/validate-source-type.ts
+++ b/packages/activerecord/src/associations/validate-source-type.ts
@@ -74,6 +74,10 @@ export function validateThroughSourceType(modelClass: typeof Base, assocName: st
     }
     // Swallow other validity errors for now; once task #23 widens
     // the check, all errors propagate and this `catch` goes away.
+    // Mark as checked even on swallow so a static misconfiguration
+    // doesn't re-run checkValidityBang on every first-use call —
+    // the outcome is stable until the reflection changes.
+    refl[CHECKED] = true;
     return;
   }
   refl[CHECKED] = true;


### PR DESCRIPTION
## Summary

Task #18. Surface the two sourceType-shape misconfigurations Rails rejects via `ThroughReflection#check_validity!` (reflection.rb:1157-1163):

- polymorphic source without `source_type` → `HasManyThroughAssociationPolymorphicSourceError`
- `source_type` with a non-polymorphic source → `HasManyThroughAssociationPointlessSourceTypeError`

Both were silently producing invalid SQL before: `reflection.ts#_collectJoinReflections` injects a `PolymorphicReflection` whenever `options.sourceType` is set, but its `foreignType` is `null` unless the source is actually polymorphic (reflection.ts:544). The polymorphic-without-source_type case has no type filter and the chain walker mixes ids across polymorphic target tables.

## Changes

- Introduce `validateThroughSourceType(klass, name)` (associations/validate-source-type.ts) that reads the full reflection, gates on `isThroughReflection()`, and raises the appropriate Rails-named error. Result is memoized on the reflection via a module-private symbol.
- Call it from `Association#constructor` (mirroring Rails' first-use hook) and from the top-level `association(record, name)` function so both entry points surface the error.

The full `ThroughReflection#checkValidityBang` stays unwired for now — several pre-existing test fixtures ship shapes the stricter check would reject (has_one :through a has_many, inverse-of misses, etc.). Expanding the wire-up is tracked as task #23.

## Test plan

- [x] New `source-type-validation.test.ts` (3 tests): both error paths + the valid shape.
- [x] Full `@blazetrails/activerecord` suite: 8772 passed.
- [ ] PG / MariaDB CI.