### PR TITLE
fix(activerecord): DJAS handles composite-FK nested-through

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -460,24 +460,16 @@ async function _loadThroughViaDisableJoinsScope(
   reflection: unknown,
   options?: AssociationOptions,
 ): Promise<Base[]> {
-  // Null-PK short-circuit: an unsaved owner has no through-table FK to
-  // chain off, so DJAS would build `WHERE through.<fk> IN ([null])` and
-  // either return 0 rows or (worse) match rows with null FKs. Read the
-  // owner-side column the chain seeds from — `joinForeignKey` on the
-  // through_reflection is the owner's PK column on the through table,
-  // and on the owner record itself it's the owner's PK attribute. For
-  // chain length 1 (non-through), this code isn't reached. For through,
-  // the chain reverse walk seeds with `owner.readAttribute(throughRefl
-  // .joinForeignKey)`, so checking that here matches what DJAS reads.
-  const throughRefl = (reflection as { throughReflection?: unknown }).throughReflection as
-    | { joinForeignKey?: string | string[] }
-    | undefined;
-  const fk = throughRefl?.joinForeignKey;
-  const fkCols = Array.isArray(fk) ? fk : fk ? [fk] : [];
-  for (const col of fkCols) {
-    const v = record.readAttribute(col);
-    if (v === null || v === undefined) return [];
-  }
+  // (Previously had a null-PK short-circuit here that read
+  // `throughReflection.joinForeignKey` off the owner. For nested-
+  // through + composite-FK shapes the delegation chain surfaces
+  // columns that belong to a downstream target, not the owner —
+  // producing a false null and an empty result set. The underlying
+  // DJAS walk handles unsaved owners correctly on its own: seeds
+  // `joinIds` with null, the chain's first pluck returns [], and
+  // the subsequent composite/scalar WHERE runs against an empty
+  // list. One extra round-trip for unsaved-owner case, trivially
+  // cheap — and correct for every shape.
   // Lazy-import to avoid an eager cycle: DJAS imports
   // DisableJoinsAssociationRelation → relation.ts → associations.ts.
   const { DisableJoinsAssociationScope } =

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -460,16 +460,23 @@ async function _loadThroughViaDisableJoinsScope(
   reflection: unknown,
   options?: AssociationOptions,
 ): Promise<Base[]> {
-  // (Previously had a null-PK short-circuit here that read
-  // `throughReflection.joinForeignKey` off the owner. For nested-
-  // through + composite-FK shapes the delegation chain surfaces
-  // columns that belong to a downstream target, not the owner —
-  // producing a false null and an empty result set. The underlying
-  // DJAS walk handles unsaved owners correctly on its own: seeds
-  // `joinIds` with null, the chain's first pluck returns [], and
-  // the subsequent composite/scalar WHERE runs against an empty
-  // list. One extra round-trip for unsaved-owner case, trivially
-  // cheap — and correct for every shape.
+  // Unsaved-owner short-circuit — correctness, not just perf.
+  // With the guard absent DJAS seeds `joinIds = [null]`, and the
+  // ArrayHandler in PredicateBuilder turns `where({key: [null]})`
+  // into `key IS NULL` (array-handler.ts:21). That would match
+  // orphan through rows whose FK is null and leak downstream into
+  // the chain, producing phantom associations for unsaved owners.
+  //
+  // Previously the guard read `throughReflection.joinForeignKey`
+  // off the owner, but for nested-through + composite-FK shapes
+  // that delegation surfaces deeper-target columns that don't
+  // exist on the outer owner (e.g. `ck_order_shop_id` on `Shop`),
+  // producing a false null and early-returning even for saved
+  // owners. Route through `isNewRecord()` instead — the same
+  // predicate Rails uses (`new_record?`). It's chain-shape-agnostic
+  // and exactly the question being asked: does the owner have
+  // nothing to chain from yet?
+  if (record.isNewRecord()) return [];
   // Lazy-import to avoid an eager cycle: DJAS imports
   // DisableJoinsAssociationRelation → relation.ts → associations.ts.
   const { DisableJoinsAssociationScope } =

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -462,10 +462,9 @@ async function _loadThroughViaDisableJoinsScope(
 ): Promise<Base[]> {
   // Unsaved-owner / null-PK short-circuit — correctness, not just
   // perf. With the guard absent DJAS seeds `joinIds = [null]`, and
-  // the ArrayHandler in PredicateBuilder turns `where({key: [null]})`
-  // into `key IS NULL` (array-handler.ts:21). That would match
-  // orphan through rows whose FK is null and leak them into the
-  // chain as phantom associations.
+  // the ArrayHandler in PredicateBuilder folds `[null]` into
+  // `key IS NULL`. That would match orphan through rows whose FK
+  // is null and leak them into the chain as phantom associations.
   //
   // Previously the guard read `throughReflection.joinForeignKey`
   // off the owner, but for nested-through + composite-FK shapes

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -460,23 +460,32 @@ async function _loadThroughViaDisableJoinsScope(
   reflection: unknown,
   options?: AssociationOptions,
 ): Promise<Base[]> {
-  // Unsaved-owner short-circuit — correctness, not just perf.
-  // With the guard absent DJAS seeds `joinIds = [null]`, and the
-  // ArrayHandler in PredicateBuilder turns `where({key: [null]})`
+  // Unsaved-owner / null-PK short-circuit — correctness, not just
+  // perf. With the guard absent DJAS seeds `joinIds = [null]`, and
+  // the ArrayHandler in PredicateBuilder turns `where({key: [null]})`
   // into `key IS NULL` (array-handler.ts:21). That would match
-  // orphan through rows whose FK is null and leak downstream into
-  // the chain, producing phantom associations for unsaved owners.
+  // orphan through rows whose FK is null and leak them into the
+  // chain as phantom associations.
   //
   // Previously the guard read `throughReflection.joinForeignKey`
   // off the owner, but for nested-through + composite-FK shapes
   // that delegation surfaces deeper-target columns that don't
   // exist on the outer owner (e.g. `ck_order_shop_id` on `Shop`),
   // producing a false null and early-returning even for saved
-  // owners. Route through `isNewRecord()` instead — the same
-  // predicate Rails uses (`new_record?`). It's chain-shape-agnostic
-  // and exactly the question being asked: does the owner have
-  // nothing to chain from yet?
-  if (record.isNewRecord()) return [];
+  // owners. Read from the OUTER reflection's `activeRecordPrimaryKey`
+  // instead — that's the owner's own PK column(s), never a
+  // delegated downstream target. `isNewRecord()` covers unsaved
+  // records; the explicit PK-null check covers the defensive edge
+  // where a saved record somehow has a null composite-PK component.
+  const activeRecordPk = (reflection as { activeRecordPrimaryKey?: string | string[] })
+    .activeRecordPrimaryKey;
+  const ownerPkCols =
+    activeRecordPk == null ? [] : Array.isArray(activeRecordPk) ? activeRecordPk : [activeRecordPk];
+  const ownerHasNullPk = ownerPkCols.some((col) => {
+    const v = record.readAttribute(col);
+    return v === null || v === undefined;
+  });
+  if (record.isNewRecord() || ownerHasNullPk) return [];
   // Lazy-import to avoid an eager cycle: DJAS imports
   // DisableJoinsAssociationRelation → relation.ts → associations.ts.
   const { DisableJoinsAssociationScope } =

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -171,25 +171,21 @@ describe("DJAS composite-key + nested-through", () => {
   });
 
   it("unsaved owner returns [] even when orphan through rows have NULL FKs", async () => {
-    // PredicateBuilder's ArrayHandler turns `where({key: [null]})`
-    // into `key IS NULL`. Without the `isNewRecord()` short-circuit,
+    // PredicateBuilder's ArrayHandler folds `[null]` into
+    // `key IS NULL`. Without the `isNewRecord()` short-circuit,
     // an unsaved owner whose PK is null would seed DJAS with
-    // `[null]`, and the first-step WHERE would match any orphan
-    // through row whose FK is null — leaking into the chain as a
-    // phantom association. This test creates exactly that orphan
-    // scenario and pins the short-circuit.
-    const orphanOrder = (await CkOrder.create({
-      shop_id: null as any,
-      order_number: 999,
-      label: "orphan",
-    })) as any;
+    // `[null]`, and the first-step WHERE would match orphan through
+    // rows whose FK is null — leaking into the chain as a phantom
+    // association. Create the orphan on CkLineItem (its composite
+    // FK columns are nullable) rather than CkOrder (whose shop_id
+    // is part of its composite PK and implicitly NOT NULL on
+    // PG/MySQL).
     const orphanLi = (await CkLineItem.create({
       ck_order_shop_id: null as any,
-      ck_order_number: 999,
+      ck_order_number: null as any,
       sku: "orphan-sku",
     })) as any;
     await CkTag.create({ ck_line_item_id: orphanLi.id, value: "orphan-tag" });
-    expect(orphanOrder.shop_id).toBeNull();
 
     const unsaved = CkShop.new({ name: "unsaved" });
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemTags");

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -1,0 +1,172 @@
+/**
+ * DJAS composite-key + nested-through intersection (task #19).
+ *
+ * PR #645 shipped composite-key support via
+ * `PredicateBuilder.buildComposite`; PR #668 dropped the nested-
+ * through routing gate. Each PR has its own test coverage, but
+ * the combination — a nested-through whose composite-key edge
+ * forces the buildComposite predicate into the reverseChain walk —
+ * wasn't exercised directly.
+ *
+ * Chain here:
+ *   CkShop
+ *     has_many :ckOrders (shop_id → shop.id)
+ *     has_many :ckLineItemsThroughOrders, through: :ckOrders,
+ *                                         source: :ckLineItems
+ *       # source edge uses composite FK
+ *       # (ck_order_shop_id, ck_order_number) →
+ *       # CkOrder's composite PK (shop_id, order_number)
+ *     has_many :ckLineItemTags, through: :ckLineItemsThroughOrders,
+ *                               source: :ckTags,
+ *                               disable_joins: true
+ *       # Nested-through — `through:` is itself a through
+ *
+ * The walk runs three step queries (orders → line_items →
+ * line_item_tags) — the middle step emits an Arel OR-of-AND
+ * composite predicate from PredicateBuilder.buildComposite.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import { Base, registerModel } from "../index.js";
+import { Associations, loadHasMany } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("DJAS composite-key + nested-through", () => {
+  let adapter: DatabaseAdapter;
+
+  class CkShop extends Base {
+    static {
+      this._tableName = "ck_shops";
+      this.attribute("name", "string");
+    }
+  }
+  class CkOrder extends Base {
+    static {
+      this._tableName = "ck_orders";
+      this.primaryKey = ["shop_id", "order_number"];
+      this.attribute("shop_id", "integer");
+      this.attribute("order_number", "integer");
+      this.attribute("label", "string");
+    }
+  }
+  class CkLineItem extends Base {
+    static {
+      this._tableName = "ck_line_items";
+      this.attribute("ck_order_shop_id", "integer");
+      this.attribute("ck_order_number", "integer");
+      this.attribute("sku", "string");
+    }
+  }
+  class CkTag extends Base {
+    static {
+      this._tableName = "ck_tags";
+      this.attribute("ck_line_item_id", "integer");
+      this.attribute("value", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    CkShop.adapter = adapter;
+    CkOrder.adapter = adapter;
+    CkLineItem.adapter = adapter;
+    CkTag.adapter = adapter;
+    registerModel("CkShop", CkShop);
+    registerModel("CkOrder", CkOrder);
+    registerModel("CkLineItem", CkLineItem);
+    registerModel("CkTag", CkTag);
+    (CkShop as any)._associations = [];
+    (CkShop as any)._reflections = {};
+    (CkOrder as any)._associations = [];
+    (CkOrder as any)._reflections = {};
+    (CkLineItem as any)._associations = [];
+    (CkLineItem as any)._reflections = {};
+
+    Associations.hasMany.call(CkShop, "ckOrders", {
+      className: "CkOrder",
+      foreignKey: "shop_id",
+    });
+    Associations.hasMany.call(CkOrder, "ckLineItems", {
+      className: "CkLineItem",
+      foreignKey: ["ck_order_shop_id", "ck_order_number"],
+      primaryKey: ["shop_id", "order_number"],
+    });
+    Associations.hasMany.call(CkLineItem, "ckTags", {
+      className: "CkTag",
+      foreignKey: "ck_line_item_id",
+    });
+    Associations.hasMany.call(CkShop, "ckLineItemsThroughOrders", {
+      className: "CkLineItem",
+      through: "ckOrders",
+      source: "ckLineItems",
+    });
+    // Nested through + composite FK on the middle edge + disable_joins.
+    Associations.hasMany.call(CkShop, "ckLineItemTags", {
+      className: "CkTag",
+      through: "ckLineItemsThroughOrders",
+      source: "ckTags",
+      disableJoins: true,
+    });
+  });
+
+  afterEach(() => Notifications.unsubscribeAll());
+
+  it("loads through a nested-through whose middle edge is composite-FK, with no JOIN", async () => {
+    const shop = await CkShop.create({ name: "S" });
+    const order = (await CkOrder.create({
+      shop_id: shop.id,
+      order_number: 100,
+      label: "ord",
+    })) as any;
+    const li = (await CkLineItem.create({
+      ck_order_shop_id: order.shop_id,
+      ck_order_number: order.order_number,
+      sku: "sku-1",
+    })) as any;
+    await CkTag.create({ ck_line_item_id: li.id, value: "red" });
+    await CkTag.create({ ck_line_item_id: li.id, value: "sale" });
+
+    // Another shop's chain — must not leak. Proves the walk's
+    // first-step filter by shop.id is holding.
+    const other = await CkShop.create({ name: "Other" });
+    const otherOrder = (await CkOrder.create({
+      shop_id: other.id,
+      order_number: 999,
+      label: "other-ord",
+    })) as any;
+    const otherLi = (await CkLineItem.create({
+      ck_order_shop_id: otherOrder.shop_id,
+      ck_order_number: otherOrder.order_number,
+      sku: "other-sku",
+    })) as any;
+    await CkTag.create({ ck_line_item_id: otherLi.id, value: "leak-check" });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemTags");
+      const tags = await loadHasMany(shop, "ckLineItemTags", reflection.options);
+      expect(tags.map((t: any) => t.value).sort()).toEqual(["red", "sale"]);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(observed.length).toBeGreaterThan(0);
+    // DJAS walks step-by-step — three SELECTs, no JOIN across the
+    // chain. A regression that fell back to AssociationScope (or
+    // regressed buildComposite into an IN-subquery in the nested
+    // case) would show a JOIN.
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
+    // The composite edge must fire the OR-of-AND predicate shape
+    // PredicateBuilder.buildComposite emits — referring to both
+    // composite columns alongside each other in the WHERE.
+    expect(
+      observed.some(
+        (s) => /ck_order_shop_id/i.test(s) && /ck_order_number/i.test(s) && /\bAND\b/i.test(s),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -169,4 +169,18 @@ describe("DJAS composite-key + nested-through", () => {
       ),
     ).toBe(true);
   });
+
+  it("unsaved owner returns [] (DJAS walker handles null seeds without the dropped guard)", async () => {
+    // The old null-PK short-circuit in _loadThroughViaDisableJoinsScope
+    // existed to save a round-trip for unsaved owners. Dropping it
+    // means the walker runs — seeds joinIds with null, the first
+    // step's pluck returns [], and subsequent queries short-circuit
+    // via PredicateBuilder.buildComposite / Relation#none(). Net:
+    // still [] for unsaved owners, just with one round-trip instead
+    // of zero.
+    const unsaved = CkShop.new({ name: "unsaved" });
+    const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemTags");
+    const tags = await loadHasMany(unsaved, "ckLineItemTags", reflection.options);
+    expect(tags).toEqual([]);
+  });
 });

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -170,17 +170,31 @@ describe("DJAS composite-key + nested-through", () => {
     ).toBe(true);
   });
 
-  it("unsaved owner returns [] (DJAS walker handles null seeds without the dropped guard)", async () => {
-    // The old null-PK short-circuit in _loadThroughViaDisableJoinsScope
-    // existed to save a round-trip for unsaved owners. Dropping it
-    // means the walker runs — seeds joinIds with null, the first
-    // step's pluck returns [], and subsequent queries short-circuit
-    // via PredicateBuilder.buildComposite / Relation#none(). Net:
-    // still [] for unsaved owners, just with one round-trip instead
-    // of zero.
+  it("unsaved owner returns [] even when orphan through rows have NULL FKs", async () => {
+    // PredicateBuilder's ArrayHandler turns `where({key: [null]})`
+    // into `key IS NULL`. Without the `isNewRecord()` short-circuit,
+    // an unsaved owner whose PK is null would seed DJAS with
+    // `[null]`, and the first-step WHERE would match any orphan
+    // through row whose FK is null — leaking into the chain as a
+    // phantom association. This test creates exactly that orphan
+    // scenario and pins the short-circuit.
+    const orphanOrder = (await CkOrder.create({
+      shop_id: null as any,
+      order_number: 999,
+      label: "orphan",
+    })) as any;
+    const orphanLi = (await CkLineItem.create({
+      ck_order_shop_id: null as any,
+      ck_order_number: 999,
+      sku: "orphan-sku",
+    })) as any;
+    await CkTag.create({ ck_line_item_id: orphanLi.id, value: "orphan-tag" });
+    expect(orphanOrder.shop_id).toBeNull();
+
     const unsaved = CkShop.new({ name: "unsaved" });
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemTags");
     const tags = await loadHasMany(unsaved, "ckLineItemTags", reflection.options);
     expect(tags).toEqual([]);
+    expect(tags.map((t: any) => t.value)).not.toContain("orphan-tag");
   });
 });


### PR DESCRIPTION
## Summary

Tasks #19 and #24. Shipping task #19's composite-key + nested-through intersection test uncovered task #24: DJAS silently returned `[]` for that exact shape, no SQL emitted.

### Root cause

`_loadThroughViaDisableJoinsScope` had a null-PK short-circuit that read `throughReflection.joinForeignKey` off the owner record. For nested-through whose intermediate edge uses a composite FK, the delegation chain surfaces columns that belong to a deeper target — e.g. `ck_order_shop_id` on a `Shop` owner. Reading a non-existent column yields null, the guard fires, and the whole chain walk skips.

### Fix

Keep the unsaved-owner short-circuit (it's a **correctness** guard, not just perf — `PredicateBuilder`'s `ArrayHandler` folds `[null]` into `key IS NULL`, which would match orphan through rows with null FKs), but change the column it reads:

- Route through `record.isNewRecord()` (same predicate Rails uses, `new_record?`) for unsaved owners.
- Plus an explicit null-check against the outer reflection's `activeRecordPrimaryKey` column(s) for the defensive edge where a saved record somehow has a null composite-PK component.

Both reads come from the OUTER reflection / owner directly — never from a delegated `throughReflection` chain, so nested-through + composite-FK shapes don't mis-read downstream columns.

### Tests

New `disable-joins-composite-nested.test.ts` with two cases:

1. **3-level nested-through with composite-FK middle edge**: `Shop → Orders → LineItems (composite FK) → Tags`. Asserts records load correctly, no JOIN in any emitted query, the composite OR-of-AND predicate lands on the line-items step, and a cross-owner row doesn't leak.
2. **Unsaved owner with orphan through rows**: creates an orphan `CkLineItem` whose composite FK is null (and a downstream tag). Pins that `unsavedShop.ckLineItemTags` still returns `[]` — the guard prevents the `IS NULL` predicate from matching the orphan.

## Test plan

- [x] New test: `disable-joins-composite-nested.test.ts` (2 tests)
- [x] Full `@blazetrails/activerecord` suite: 8775 passed
- [ ] PG / MariaDB CI