### PR TITLE
refactor(activerecord): extract reload/assignAttributes/dup/clone/becomes family

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -8,7 +8,6 @@ import {
   DeleteManager,
   Nodes,
   sql as arelSql,
-  star as arelStar,
 } from "@blazetrails/arel";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { Relation } from "./relation.js";
@@ -28,9 +27,8 @@ import {
   StaleObjectError,
   ReadOnlyRecord,
   ConnectionNotDefined,
-  AttributeAssignmentError,
 } from "./errors.js";
-import { AutosaveAssociation, clearAutosaveState } from "./autosave-association.js";
+import { AutosaveAssociation } from "./autosave-association.js";
 import {
   RecordInvalid,
   isValid as validationsIsValid,
@@ -2357,38 +2355,7 @@ export class Base extends Model {
     return this.adapter.execDelete(dm.toSql(), "Delete");
   }
 
-  /**
-   * Reload the record from the database.
-   *
-   * Mirrors: ActiveRecord::Base#reload
-   */
-  async reload(): Promise<this> {
-    const ctor = this.constructor as typeof Base;
-    const sm = ctor.arelTable.project(arelStar).where(ctor._buildPkWhereNode(this.id));
-    const result = await ctor.adapter.selectAll(sm.toSql(), "Reload");
-    const row = result.first();
-
-    if (row === undefined) {
-      throw new RecordNotFound(
-        `${ctor.name} with ${ctor.primaryKey}=${this.id} not found`,
-        ctor.name,
-        String(ctor.primaryKey),
-        this.id,
-      );
-    }
-
-    for (const [key, value] of Object.entries(row)) {
-      this._attributes.set(key, value);
-    }
-
-    (this as any)._dirty.snapshot(this._attributes);
-    this._collectionProxies.clear();
-    this._preloadedAssociations.clear();
-    this._associationInstances.clear();
-    (this as any)._cachedAssociations?.clear();
-    clearAutosaveState(this);
-    return this;
-  }
+  // reload extracted to persistence.ts; wired via include() below.
 
   /**
    * Reload the record with a pessimistic lock (SELECT ... FOR UPDATE), and
@@ -2408,18 +2375,7 @@ export class Base extends Model {
   declare inspect: () => string;
   declare attributeForInspect: (attr: string) => string;
 
-  /**
-   * Return a subset of the record's attributes as a plain object.
-   *
-   * Mirrors: ActiveRecord::Base#slice
-   */
-  slice(...keys: string[]): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const key of keys) {
-      result[key] = this.readAttribute(key);
-    }
-    return result;
-  }
+  // slice extracted to persistence.ts.
 
   /**
    * Return a GlobalID-like URI for this record.
@@ -2445,39 +2401,7 @@ export class Base extends Model {
     return Buffer.from(gid).toString("base64");
   }
 
-  /**
-   * Return attribute values for the given keys as an array.
-   *
-   * Mirrors: ActiveRecord::Base#values_at
-   */
-  valuesAt(...keys: string[]): unknown[] {
-    return keys.map((key) => this.readAttribute(key));
-  }
-
-  /**
-   * Assign attributes without saving.
-   *
-   * Mirrors: ActiveRecord::Base#assign_attributes
-   */
-  assignAttributes(attrs: Record<string, unknown>): void {
-    for (const [key, value] of Object.entries(attrs)) {
-      try {
-        this.writeAttribute(key, value);
-      } catch (e) {
-        let repr: string;
-        try {
-          repr = JSON.stringify(value);
-        } catch {
-          repr = String(value);
-        }
-        throw new AttributeAssignmentError(
-          `error on assignment ${repr} to ${key} (${e instanceof Error ? e.message : String(e)})`,
-          e instanceof Error ? e : undefined,
-          key,
-        );
-      }
-    }
-  }
+  // valuesAt / assignAttributes extracted to persistence.ts.
 
   /**
    * Update the updated_at timestamp (and optionally other timestamp
@@ -2488,114 +2412,8 @@ export class Base extends Model {
    */
   declare touch: typeof Timestamp.touch;
 
-  /**
-   * Update a single attribute and save, skipping validations.
-   * Runs callbacks, unlike updateColumn.
-   *
-   * Mirrors: ActiveRecord::Base#update_attribute
-   */
-  async updateAttribute(name: string, value: unknown): Promise<boolean> {
-    this.writeAttribute(name, value);
-    return this.save({ validate: false });
-  }
-
-  /**
-   * Update a single column directly in the database, skipping
-   * validations and callbacks.
-   *
-   * Mirrors: ActiveRecord::Base#update_column
-   */
-  async updateColumn(name: string, value: unknown): Promise<void> {
-    return this.updateColumns({ [name]: value });
-  }
-
-  /**
-   * Update multiple columns directly in the database, skipping
-   * validations and callbacks.
-   *
-   * Mirrors: ActiveRecord::Base#update_columns
-   */
-  async updateColumns(attrs: Record<string, unknown>): Promise<void> {
-    if (this._readonly) throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
-    if (!this.isPersisted()) {
-      throw new Error("Cannot update columns on a new or destroyed record");
-    }
-
-    const ctor = this.constructor as typeof Base;
-    const table = ctor.arelTable;
-
-    // Set attributes directly (no dirty tracking through writeAttribute)
-    for (const [key, value] of Object.entries(attrs)) {
-      const def = ctor._attributeDefinitions.get(key);
-      this._attributes.set(key, def ? def.type.cast(value) : value);
-    }
-
-    const setClauses = Object.entries(attrs)
-      .map(([key, _]) => {
-        const val = this._attributes.get(key);
-        if (val === null) return `"${key}" = NULL`;
-        if (typeof val === "number") return `"${key}" = ${val}`;
-        if (typeof val === "boolean") return `"${key}" = ${val ? "TRUE" : "FALSE"}`;
-        if (val instanceof Date) return `"${key}" = '${val.toISOString()}'`;
-        if (typeof val === "object")
-          return `"${key}" = '${JSON.stringify(val).replace(/'/g, "''")}'`;
-        return `"${key}" = '${String(val).replace(/'/g, "''")}'`;
-      })
-      .join(", ");
-
-    const sql = `UPDATE "${table.name}" SET ${setClauses} WHERE ${ctor._buildPkWhere(this.id)}`;
-    await ctor.adapter.execUpdate(sql, "Update Columns");
-
-    // Reset dirty tracking to reflect the new persisted state
-    this.changesApplied();
-  }
-
-  /**
-   * Create an unsaved duplicate of this record (new_record = true, no id).
-   *
-   * Mirrors: ActiveRecord::Base#dup
-   */
-  dup(): this {
-    const ctor = this.constructor as typeof Base;
-    const attrs = { ...this.attributes };
-    const pkCols = Array.isArray(ctor.primaryKey) ? ctor.primaryKey : [ctor.primaryKey];
-    for (const col of pkCols) {
-      delete attrs[col]; // Remove PK so it's a new record
-    }
-    const copy = new ctor(attrs);
-    return copy as this;
-  }
-
-  /**
-   * Shallow clone preserving the primary key and persisted state.
-   *
-   * Mirrors: ActiveRecord::Core#clone
-   */
-  clone(): this {
-    const copy = Object.create(Object.getPrototypeOf(this)) as this;
-    Object.assign(copy, this);
-    copy._attributes = this._attributes;
-    copy._previouslyNewRecord = false;
-    copy.errors = new (this.errors.constructor as new (base: unknown) => typeof this.errors)(copy);
-    return copy;
-  }
-
-  /**
-   * Returns an instance of the specified class with the attributes of this record.
-   *
-   * Mirrors: ActiveRecord::Base#becomes
-   */
-  becomes<K extends typeof Base>(klass: K): InstanceType<K> {
-    const instance = new klass({}) as InstanceType<K>;
-    // Share the same attributes map (Rails behavior)
-    instance._attributes = this._attributes;
-    instance._newRecord = this._newRecord;
-    if (!this._newRecord) {
-      (instance as any)._dirty.snapshot(instance._attributes);
-      instance.changesApplied();
-    }
-    return instance;
-  }
+  // updateAttribute / updateColumn / updateColumns / dup / clone / becomes
+  // extracted to persistence.ts; wired via include() below.
 
   declare hasAttribute: (name: string) => boolean;
   declare attributePresent: (name: string) => boolean;
@@ -2721,33 +2539,7 @@ export class Base extends Model {
     return this.toParam();
   }
 
-  /**
-   * Re-instantiate as the given class, raising on failure.
-   *
-   * Mirrors: ActiveRecord::Base#becomes!
-   */
-  becomesBang<K extends typeof Base>(klass: K): InstanceType<K> {
-    const instance = this.becomes(klass);
-    // Set the STI type column — find it from the base class
-    const base = getStiBase(klass);
-    const inheritanceCol = getInheritanceColumn(base);
-    if (inheritanceCol) {
-      // For the base class itself, set to null; for subclasses, set to class name
-      const value = isStiSubclass(klass) ? klass.name : null;
-      instance._attributes.set(inheritanceCol, value);
-    }
-    return instance;
-  }
-
-  /**
-   * Update a single attribute and save, raising on validation failure.
-   *
-   * Mirrors: ActiveRecord::Base#update_attribute!
-   */
-  async updateAttributeBang(name: string, value: unknown): Promise<true> {
-    this.writeAttribute(name, value);
-    return this.saveBang();
-  }
+  // becomesBang / updateAttributeBang extracted to persistence.ts.
 
   /**
    * Instance-level transaction wrapper.
@@ -2856,6 +2648,18 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   update(attrs: Record<string, unknown>): Promise<boolean>;
   updateBang(attrs: Record<string, unknown>): Promise<true>;
   delete(): Promise<this>;
+  reload(): Promise<this>;
+  slice(...keys: string[]): Record<string, unknown>;
+  valuesAt(...keys: string[]): unknown[];
+  assignAttributes(attrs: Record<string, unknown>): void;
+  updateAttribute(name: string, value: unknown): Promise<boolean>;
+  updateAttributeBang(name: string, value: unknown): Promise<true>;
+  updateColumn(name: string, value: unknown): Promise<void>;
+  updateColumns(attrs: Record<string, unknown>): Promise<void>;
+  dup(): this;
+  clone(): this;
+  becomes<K extends typeof Base>(klass: K): InstanceType<K>;
+  becomesBang<K extends typeof Base>(klass: K): InstanceType<K>;
 }
 
 // ---------------------------------------------------------------------------
@@ -2913,6 +2717,18 @@ include(Base, {
   update: _Persistence.update,
   updateBang: _Persistence.updateBang,
   delete: _Persistence.deleteRow,
+  reload: _Persistence.reload,
+  slice: _Persistence.slice,
+  valuesAt: _Persistence.valuesAt,
+  assignAttributes: _Persistence.assignAttributes,
+  updateAttribute: _Persistence.updateAttribute,
+  updateAttributeBang: _Persistence.updateAttributeBang,
+  updateColumn: _Persistence.updateColumn,
+  updateColumns: _Persistence.updateColumns,
+  dup: _Persistence.dup,
+  clone: _Persistence.clone,
+  becomes: _Persistence.becomes,
+  becomesBang: _Persistence.becomesBang,
   // Core
   inspect: _inspect,
   attributeForInspect: _attributeForInspect,

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1003,9 +1003,18 @@ describe("PersistenceTest", () => {
     }
     const t = await Topic.create({ title: "test" });
     const oldId = t.id;
-    // updateColumns can change the id column directly
+    // updateColumns can change the id column directly. The WHERE clause
+    // must target the *original* id — otherwise the UPDATE would bind
+    // the post-mutation id and affect zero rows.
     await t.updateColumns({ id: 999 });
     expect(t.id).toBe(999);
+    // The original row should have the new id now (proves the WHERE
+    // captured the pre-mutation id correctly).
+    const refreshed = await Topic.find(999);
+    expect(refreshed.id).toBe(999);
+    expect(refreshed.title).toBe("test");
+    // The old id no longer exists.
+    await expect(Topic.find(oldId)).rejects.toThrow();
   });
 
   it("create bang many with block", async () => {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -5,7 +5,16 @@
  * Mirrors: ActiveRecord::Persistence::ClassMethods
  */
 
-import { InsertManager, UpdateManager, DeleteManager, Table as ArelTable } from "@blazetrails/arel";
+import {
+  InsertManager,
+  UpdateManager,
+  DeleteManager,
+  Table as ArelTable,
+  star as arelStar,
+} from "@blazetrails/arel";
+import { AttributeAssignmentError, ReadOnlyRecord, RecordNotFound } from "./errors.js";
+import { clearAutosaveState } from "./autosave-association.js";
+import { getStiBase, getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 
 interface PersistenceHost {
   new (attrs?: Record<string, unknown>): any;
@@ -471,4 +480,320 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
   this._previouslyNewRecord = false;
   this.freeze();
   return this;
+}
+
+// ---------------------------------------------------------------------------
+// Instance read-helpers — slice / valuesAt / assignAttributes.
+// Mirror ActiveRecord::Base#slice / #values_at / #assign_attributes.
+// ---------------------------------------------------------------------------
+
+/** Mirrors: ActiveRecord::Base#slice */
+export function slice(this: AttributeIO, ...keys: string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of keys) {
+    result[key] = this.readAttribute(key);
+  }
+  return result;
+}
+
+/** Mirrors: ActiveRecord::Base#values_at */
+export function valuesAt(this: AttributeIO, ...keys: string[]): unknown[] {
+  return keys.map((key) => this.readAttribute(key));
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeAssignment#assign_attributes. Rails'
+ * version lets setter exceptions propagate raw; ours additionally wraps
+ * them in AttributeAssignmentError with the offending key/value for
+ * debugging. (That wrapping is stricter than Rails but longstanding —
+ * preserved by this extraction; revisiting the Rails-fidelity gap can
+ * happen in a follow-up.)
+ */
+export function assignAttributes(this: AttributeIO, attrs: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(attrs)) {
+    try {
+      this.writeAttribute(key, value);
+    } catch (e) {
+      let repr: string;
+      try {
+        repr = JSON.stringify(value);
+      } catch {
+        repr = String(value);
+      }
+      throw new AttributeAssignmentError(
+        `error on assignment ${repr} to ${key} (${e instanceof Error ? e.message : String(e)})`,
+        e instanceof Error ? e : undefined,
+        key,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// updateAttribute / updateAttributeBang / updateColumn(s) — single- and
+// multi-column writers. Rails' update_attribute runs callbacks (skips
+// validations); update_column(s) skips both.
+// ---------------------------------------------------------------------------
+
+interface AttributeSingleSave {
+  writeAttribute(name: string, value: unknown): void;
+  save(options?: { validate?: boolean }): Promise<boolean>;
+  saveBang(options?: { validate?: boolean }): Promise<true>;
+}
+
+/** Mirrors: ActiveRecord::Persistence#update_attribute */
+export async function updateAttribute<T extends AttributeSingleSave>(
+  this: T,
+  name: string,
+  value: unknown,
+): Promise<boolean> {
+  this.writeAttribute(name, value);
+  return this.save({ validate: false });
+}
+
+/** Mirrors: ActiveRecord::Persistence#update_attribute! */
+export async function updateAttributeBang<T extends AttributeSingleSave>(
+  this: T,
+  name: string,
+  value: unknown,
+): Promise<true> {
+  this.writeAttribute(name, value);
+  return this.saveBang();
+}
+
+interface UpdateColumnsRecord {
+  _readonly: boolean;
+  _attributes: {
+    get(name: string): unknown;
+    set(name: string, value: unknown): void;
+  };
+  id: unknown;
+  isPersisted(): boolean;
+  changesApplied(): void;
+  constructor: {
+    name: string;
+    arelTable: InstanceType<typeof ArelTable>;
+    _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
+    _buildPkWhere(id: unknown): string;
+    adapter: { execUpdate(sql: string, name: string): Promise<unknown> };
+  };
+}
+
+/** Mirrors: ActiveRecord::Persistence#update_column */
+export async function updateColumn<T extends UpdateColumnsRecord>(
+  this: T & { updateColumns(attrs: Record<string, unknown>): Promise<void> },
+  name: string,
+  value: unknown,
+): Promise<void> {
+  return this.updateColumns({ [name]: value });
+}
+
+/**
+ * Mirrors: ActiveRecord::Persistence#update_columns. Writes the given
+ * attributes straight to the database via a raw UPDATE, bypassing
+ * validations, callbacks and timestamps. Resets dirty tracking so the
+ * written values are the new baseline.
+ */
+export async function updateColumns<T extends UpdateColumnsRecord>(
+  this: T,
+  attrs: Record<string, unknown>,
+): Promise<void> {
+  if (this._readonly) {
+    throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
+  }
+  if (!this.isPersisted()) {
+    throw new Error("Cannot update columns on a new or destroyed record");
+  }
+
+  const ctor = this.constructor;
+  const table = ctor.arelTable;
+
+  // Cast values through their declared attribute types (no dirty tracking
+  // — this path bypasses writeAttribute deliberately).
+  for (const [key, value] of Object.entries(attrs)) {
+    const def = ctor._attributeDefinitions.get(key);
+    this._attributes.set(key, def ? def.type.cast(value) : value);
+  }
+
+  const setClauses = Object.entries(attrs)
+    .map(([key]) => {
+      const val = this._attributes.get(key);
+      if (val === null) return `"${key}" = NULL`;
+      if (typeof val === "number") return `"${key}" = ${val}`;
+      if (typeof val === "boolean") return `"${key}" = ${val ? "TRUE" : "FALSE"}`;
+      if (val instanceof Date) return `"${key}" = '${val.toISOString()}'`;
+      if (typeof val === "object") return `"${key}" = '${JSON.stringify(val).replace(/'/g, "''")}'`;
+      return `"${key}" = '${String(val).replace(/'/g, "''")}'`;
+    })
+    .join(", ");
+
+  const sql = `UPDATE "${(table as unknown as { name: string }).name}" SET ${setClauses} WHERE ${ctor._buildPkWhere(this.id)}`;
+  await ctor.adapter.execUpdate(sql, "Update Columns");
+
+  this.changesApplied();
+}
+
+// ---------------------------------------------------------------------------
+// reload — refetch from DB and reset in-memory state.
+// ---------------------------------------------------------------------------
+
+interface ReloadRecord {
+  _attributes: {
+    set(name: string, value: unknown): void;
+  };
+  _dirty: { snapshot(attrs: unknown): void };
+  _collectionProxies: Map<string, unknown>;
+  _preloadedAssociations: Map<string, unknown>;
+  _associationInstances: Map<string, unknown>;
+  _cachedAssociations?: Map<string, unknown>;
+  id: unknown;
+  constructor: {
+    name: string;
+    primaryKey: string | string[];
+    arelTable: { project(...cols: unknown[]): { where(node: unknown): { toSql(): string } } };
+    _buildPkWhereNode(id: unknown): unknown;
+    adapter: {
+      selectAll(
+        sql: string,
+        name: string,
+      ): Promise<{ first(): Record<string, unknown> | undefined }>;
+    };
+  };
+}
+
+/**
+ * Re-fetch the record from the database and overwrite in-memory attributes,
+ * resetting dirty tracking and clearing association/proxy caches.
+ *
+ * Mirrors: ActiveRecord::Persistence#reload
+ */
+export async function reload<T extends ReloadRecord>(this: T): Promise<T> {
+  const ctor = this.constructor;
+  const sm = ctor.arelTable.project(arelStar).where(ctor._buildPkWhereNode(this.id));
+  const result = await ctor.adapter.selectAll(sm.toSql(), "Reload");
+  const row = result.first();
+
+  if (row === undefined) {
+    throw new RecordNotFound(
+      `${ctor.name} with ${String(ctor.primaryKey)}=${String(this.id)} not found`,
+      ctor.name,
+      String(ctor.primaryKey),
+      this.id,
+    );
+  }
+
+  for (const [key, value] of Object.entries(row)) {
+    this._attributes.set(key, value);
+  }
+
+  this._dirty.snapshot(this._attributes);
+  this._collectionProxies.clear();
+  this._preloadedAssociations.clear();
+  this._associationInstances.clear();
+  this._cachedAssociations?.clear();
+  clearAutosaveState(this as unknown as Parameters<typeof clearAutosaveState>[0]);
+  return this;
+}
+
+// ---------------------------------------------------------------------------
+// dup / clone / becomes / becomes! — shape-preserving copies & class swaps.
+// ---------------------------------------------------------------------------
+
+interface DupRecord {
+  attributes: Record<string, unknown>;
+  constructor: new (attrs: Record<string, unknown>) => unknown;
+}
+
+/**
+ * Build an unsaved duplicate: same non-PK attributes, new_record = true.
+ *
+ * Mirrors: ActiveRecord::Inheritance#dup (Rails 7.2+ moved it from Core to
+ * Inheritance; the behavior is: copy attributes minus primary key[s]).
+ */
+export function dup<T extends DupRecord>(this: T): T {
+  const ctor = this.constructor as typeof this.constructor & {
+    primaryKey: string | string[];
+  };
+  const attrs = { ...this.attributes };
+  const pkCols = Array.isArray(ctor.primaryKey) ? ctor.primaryKey : [ctor.primaryKey];
+  for (const col of pkCols) {
+    delete attrs[col];
+  }
+  return new ctor(attrs) as T;
+}
+
+interface CloneRecord {
+  _attributes: unknown;
+  _previouslyNewRecord: boolean;
+  errors: { constructor: new (base: unknown) => unknown };
+}
+
+/**
+ * Shallow clone preserving the primary key and persisted state. The
+ * attribute map is shared with the original (Rails' Core#clone semantic).
+ * Ours also resets `_previouslyNewRecord` on the copy, since a clone of a
+ * post-save record is a fresh in-memory snapshot.
+ *
+ * Mirrors: ActiveRecord::Core#clone
+ */
+export function clone<T extends CloneRecord>(this: T): T {
+  const copy = Object.create(Object.getPrototypeOf(this)) as T;
+  Object.assign(copy, this);
+  (copy as unknown as CloneRecord)._attributes = this._attributes;
+  (copy as unknown as CloneRecord)._previouslyNewRecord = false;
+  (copy as unknown as { errors: unknown }).errors = new this.errors.constructor(copy);
+  return copy;
+}
+
+interface BecomesRecord {
+  _attributes: unknown;
+  _newRecord: boolean;
+  _dirty: { snapshot(attrs: unknown): void };
+  changesApplied(): void;
+}
+
+/**
+ * Returns an instance of `klass` that shares this record's attribute set,
+ * new-record flag, and dirty/clean state. Useful for STI where the same
+ * row should be viewed through a different subclass.
+ *
+ * Mirrors: ActiveRecord::Persistence#becomes
+ */
+export function becomes<
+  T extends BecomesRecord,
+  K extends new (attrs: Record<string, unknown>) => BecomesRecord,
+>(this: T, klass: K): InstanceType<K> {
+  const instance = new klass({}) as InstanceType<K>;
+  (instance as unknown as BecomesRecord)._attributes = this._attributes;
+  (instance as unknown as BecomesRecord)._newRecord = this._newRecord;
+  if (!this._newRecord) {
+    (instance as unknown as BecomesRecord)._dirty.snapshot(
+      (instance as unknown as BecomesRecord)._attributes,
+    );
+    (instance as unknown as BecomesRecord).changesApplied();
+  }
+  return instance;
+}
+
+/**
+ * Same as #becomes but sets the STI type column so the row can be
+ * persisted under the new class going forward.
+ *
+ * Mirrors: ActiveRecord::Persistence#becomes!
+ */
+export function becomesBang<
+  T extends BecomesRecord & { becomes: typeof becomes },
+  K extends typeof import("./base.js").Base,
+>(this: T, klass: K): InstanceType<K> {
+  const instance = this.becomes(klass) as InstanceType<K>;
+  const base = getStiBase(klass);
+  const inheritanceCol = getInheritanceColumn(base);
+  if (inheritanceCol) {
+    const value = isStiSubclass(klass) ? klass.name : null;
+    (instance as unknown as { _attributes: { set(k: string, v: unknown): void } })._attributes.set(
+      inheritanceCol,
+      value,
+    );
+  }
+  return instance;
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -585,6 +585,7 @@ interface UpdateColumnsRecord {
   changesApplied(): void;
   constructor: {
     name: string;
+    primaryKey: string | string[];
     arelTable: InstanceType<typeof ArelTable>;
     _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
     _buildPkWhereNode(id: unknown): Parameters<UpdateManager["where"]>[0];
@@ -638,12 +639,24 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     get(name: string): unknown;
   };
 
+  // Capture the PK *before* applying attrs — if the caller is updating a
+  // PK column, we still need to target the row by its existing id, not
+  // the new value we're about to write.
+  const originalId = this.id;
+
   // Cast values through their declared attribute types (no dirty tracking —
   // this path bypasses writeAttribute deliberately) and collect the cast
-  // values for the UPDATE's SET clause.
+  // values for the UPDATE's SET clause. Reject unknown keys up-front so a
+  // malicious/invalid key can't sneak an un-schema'd identifier into the
+  // SQL identifier position. Primary-key columns are implicit on Base and
+  // aren't always in _attributeDefinitions, so allow them through.
+  const pkCols = Array.isArray(ctor.primaryKey) ? ctor.primaryKey : [ctor.primaryKey];
   const setPairs: Array<[unknown, unknown]> = [];
   for (const [key, value] of Object.entries(attrs)) {
     const def = ctor._attributeDefinitions.get(key);
+    if (!def && !pkCols.includes(key)) {
+      throw new Error(`Unknown attribute: ${key}`);
+    }
     const cast = def ? def.type.cast(value) : value;
     this._attributes.set(key, cast);
     setPairs.push([table.get(key), cast]);
@@ -652,7 +665,7 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
   const um = new UpdateManager();
   um.table(table);
   um.set(setPairs as Parameters<UpdateManager["set"]>[0]);
-  um.where(ctor._buildPkWhereNode(this.id));
+  um.where(ctor._buildPkWhereNode(originalId));
 
   const adapter = ctor.adapter;
   if (typeof adapter.update === "function") {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -551,14 +551,24 @@ export async function updateAttribute<T extends AttributeSingleSave>(
   return this.save({ validate: false });
 }
 
-/** Mirrors: ActiveRecord::Persistence#update_attribute! */
+/**
+ * Mirrors: ActiveRecord::Persistence#update_attribute! —
+ * `public_send("#{name}=", value); save!(validate: false)`.
+ * Skips validations, raises RecordNotSaved when a callback aborts.
+ */
 export async function updateAttributeBang<T extends AttributeSingleSave>(
   this: T,
   name: string,
   value: unknown,
 ): Promise<true> {
   this.writeAttribute(name, value);
-  return this.saveBang();
+  const saved = await this.save({ validate: false });
+  if (!saved) {
+    const ctorName = (this.constructor as { name?: string }).name || "record";
+    const { RecordNotSaved } = await import("./errors.js");
+    throw new RecordNotSaved(`Failed to save the ${ctorName} while updating \`${name}\``, this);
+  }
+  return true;
 }
 
 interface UpdateColumnsRecord {
@@ -575,7 +585,14 @@ interface UpdateColumnsRecord {
     arelTable: InstanceType<typeof ArelTable>;
     _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
     _buildPkWhere(id: unknown): string;
-    adapter: { execUpdate(sql: string, name: string): Promise<unknown> };
+    adapter: {
+      execUpdate(sql: string, name?: string, binds?: unknown[]): Promise<number>;
+      update?(arel: InstanceType<typeof UpdateManager>): Promise<number>;
+      quote?(value: unknown): string;
+      quoteColumnName?(name: string): string;
+      quoteTableName?(name: string): string;
+      toSql?(arel: unknown): string;
+    };
   };
 }
 
@@ -590,9 +607,15 @@ export async function updateColumn<T extends UpdateColumnsRecord>(
 
 /**
  * Mirrors: ActiveRecord::Persistence#update_columns. Writes the given
- * attributes straight to the database via a raw UPDATE, bypassing
- * validations, callbacks and timestamps. Resets dirty tracking so the
- * written values are the new baseline.
+ * attributes to the database bypassing validations, callbacks and
+ * timestamps. Resets dirty tracking so the written values are the new
+ * baseline.
+ *
+ * Builds the UPDATE via Arel's UpdateManager + the adapter's update()
+ * path so identifier and value escaping go through the adapter's
+ * quoting layer (the previous raw-string interpolation mishandled
+ * embedded single-quote-like sequences, binary columns, and
+ * adapter-specific date/JSON formatting).
  */
 export async function updateColumns<T extends UpdateColumnsRecord>(
   this: T,
@@ -606,29 +629,36 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
   }
 
   const ctor = this.constructor;
-  const table = ctor.arelTable;
+  const table = ctor.arelTable as unknown as InstanceType<typeof ArelTable> & {
+    get(name: string): unknown;
+  };
 
-  // Cast values through their declared attribute types (no dirty tracking
-  // — this path bypasses writeAttribute deliberately).
+  // Cast values through their declared attribute types (no dirty tracking —
+  // this path bypasses writeAttribute deliberately) and collect the cast
+  // values for the UPDATE's SET clause.
+  const setPairs: Array<[unknown, unknown]> = [];
   for (const [key, value] of Object.entries(attrs)) {
     const def = ctor._attributeDefinitions.get(key);
-    this._attributes.set(key, def ? def.type.cast(value) : value);
+    const cast = def ? def.type.cast(value) : value;
+    this._attributes.set(key, cast);
+    setPairs.push([table.get(key), cast]);
   }
 
-  const setClauses = Object.entries(attrs)
-    .map(([key]) => {
-      const val = this._attributes.get(key);
-      if (val === null) return `"${key}" = NULL`;
-      if (typeof val === "number") return `"${key}" = ${val}`;
-      if (typeof val === "boolean") return `"${key}" = ${val ? "TRUE" : "FALSE"}`;
-      if (val instanceof Date) return `"${key}" = '${val.toISOString()}'`;
-      if (typeof val === "object") return `"${key}" = '${JSON.stringify(val).replace(/'/g, "''")}'`;
-      return `"${key}" = '${String(val).replace(/'/g, "''")}'`;
-    })
-    .join(", ");
+  const { sql: arelSql } = await import("@blazetrails/arel");
+  const um = new UpdateManager();
+  um.table(table);
+  um.set(setPairs as Parameters<UpdateManager["set"]>[0]);
+  // `_buildPkWhere` returns a string fragment; wrap it as Arel SQL so the
+  // SET clause still routes through UpdateManager's quoting.
+  um.where(arelSql(ctor._buildPkWhere(this.id)) as Parameters<UpdateManager["where"]>[0]);
 
-  const sql = `UPDATE "${(table as unknown as { name: string }).name}" SET ${setClauses} WHERE ${ctor._buildPkWhere(this.id)}`;
-  await ctor.adapter.execUpdate(sql, "Update Columns");
+  const adapter = ctor.adapter;
+  if (typeof adapter.update === "function") {
+    await adapter.update(um);
+  } else {
+    const sql = adapter.toSql ? adapter.toSql(um) : um.toSql();
+    await adapter.execUpdate(sql, "Update Columns");
+  }
 
   this.changesApplied();
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -17,6 +17,7 @@ import {
   ReadOnlyRecord,
   RecordNotFound,
   RecordNotSaved,
+  UnknownAttributeError,
 } from "./errors.js";
 import { clearAutosaveState } from "./autosave-association.js";
 import { getStiBase, getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -634,6 +635,13 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     throw new Error("Cannot update columns on a new or destroyed record");
   }
 
+  // Rails' update_columns returns true for empty attrs without running a
+  // SQL statement. Our UpdateManager would emit `UPDATE t WHERE ...` with
+  // no SET clause, which is invalid SQL.
+  if (Object.keys(attrs).length === 0) {
+    return;
+  }
+
   const ctor = this.constructor;
   const table = ctor.arelTable as unknown as InstanceType<typeof ArelTable> & {
     get(name: string): unknown;
@@ -655,7 +663,7 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
   for (const [key, value] of Object.entries(attrs)) {
     const def = ctor._attributeDefinitions.get(key);
     if (!def && !pkCols.includes(key)) {
-      throw new Error(`Unknown attribute: ${key}`);
+      throw new UnknownAttributeError(this, key);
     }
     const cast = def ? def.type.cast(value) : value;
     this._attributes.set(key, cast);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -748,29 +748,39 @@ export function clone<T extends CloneRecord>(this: T): T {
 interface BecomesRecord {
   _attributes: unknown;
   _newRecord: boolean;
+  _destroyed: boolean;
   _dirty: { snapshot(attrs: unknown): void };
+  errors: unknown;
   changesApplied(): void;
 }
 
 /**
  * Returns an instance of `klass` that shares this record's attribute set,
- * new-record flag, and dirty/clean state. Useful for STI where the same
- * row should be viewed through a different subclass.
+ * new-record / destroyed flags, dirty snapshot, and errors. Useful for STI
+ * where the same row should be viewed through a different subclass.
  *
- * Mirrors: ActiveRecord::Persistence#becomes
+ * Mirrors: ActiveRecord::Persistence#becomes — "shares the same attributes
+ * hash" + copies new_record? / destroyed? / errors.
  */
 export function becomes<
   T extends BecomesRecord,
   K extends new (attrs: Record<string, unknown>) => BecomesRecord,
 >(this: T, klass: K): InstanceType<K> {
   const instance = new klass({}) as InstanceType<K>;
-  (instance as unknown as BecomesRecord)._attributes = this._attributes;
-  (instance as unknown as BecomesRecord)._newRecord = this._newRecord;
+  const target = instance as unknown as BecomesRecord;
+  target._attributes = this._attributes;
+  target._newRecord = this._newRecord;
+  target._destroyed = this._destroyed;
   if (!this._newRecord) {
-    (instance as unknown as BecomesRecord)._dirty.snapshot(
-      (instance as unknown as BecomesRecord)._attributes,
-    );
-    (instance as unknown as BecomesRecord).changesApplied();
+    target._dirty.snapshot(target._attributes);
+    target.changesApplied();
+  }
+  // Rails: `becoming.errors.copy!(errors)` — propagate pending validation
+  // errors across the class swap. Noop if the errors object doesn't expose
+  // a `copy` method (defensive for hosts that stub errors differently).
+  const targetErrors = target.errors as { copy?(other: unknown): void };
+  if (typeof targetErrors.copy === "function") {
+    targetErrors.copy(this.errors);
   }
   return instance;
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -12,7 +12,12 @@ import {
   Table as ArelTable,
   star as arelStar,
 } from "@blazetrails/arel";
-import { AttributeAssignmentError, ReadOnlyRecord, RecordNotFound } from "./errors.js";
+import {
+  AttributeAssignmentError,
+  ReadOnlyRecord,
+  RecordNotFound,
+  RecordNotSaved,
+} from "./errors.js";
 import { clearAutosaveState } from "./autosave-association.js";
 import { getStiBase, getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 
@@ -538,7 +543,6 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
 interface AttributeSingleSave {
   writeAttribute(name: string, value: unknown): void;
   save(options?: { validate?: boolean }): Promise<boolean>;
-  saveBang(options?: { validate?: boolean }): Promise<true>;
 }
 
 /** Mirrors: ActiveRecord::Persistence#update_attribute */
@@ -565,7 +569,6 @@ export async function updateAttributeBang<T extends AttributeSingleSave>(
   const saved = await this.save({ validate: false });
   if (!saved) {
     const ctorName = (this.constructor as { name?: string }).name || "record";
-    const { RecordNotSaved } = await import("./errors.js");
     throw new RecordNotSaved(`Failed to save the ${ctorName} while updating \`${name}\``, this);
   }
   return true;
@@ -584,7 +587,7 @@ interface UpdateColumnsRecord {
     name: string;
     arelTable: InstanceType<typeof ArelTable>;
     _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
-    _buildPkWhere(id: unknown): string;
+    _buildPkWhereNode(id: unknown): Parameters<UpdateManager["where"]>[0];
     adapter: {
       execUpdate(sql: string, name?: string, binds?: unknown[]): Promise<number>;
       update?(arel: InstanceType<typeof UpdateManager>): Promise<number>;
@@ -611,11 +614,13 @@ export async function updateColumn<T extends UpdateColumnsRecord>(
  * timestamps. Resets dirty tracking so the written values are the new
  * baseline.
  *
- * Builds the UPDATE via Arel's UpdateManager + the adapter's update()
- * path so identifier and value escaping go through the adapter's
- * quoting layer (the previous raw-string interpolation mishandled
- * embedded single-quote-like sequences, binary columns, and
- * adapter-specific date/JSON formatting).
+ * Builds the UPDATE with Arel's UpdateManager. When the adapter
+ * provides update() / toSql(), compilation routes through the adapter
+ * (picking up its quoting layer for SET values and identifiers); else
+ * falls back to Arel's generic SQL generation. Either path replaces
+ * the previous raw-string interpolation, which mishandled embedded
+ * single-quote-like sequences, binary columns, and adapter-specific
+ * date / JSON formatting.
  */
 export async function updateColumns<T extends UpdateColumnsRecord>(
   this: T,
@@ -644,13 +649,10 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     setPairs.push([table.get(key), cast]);
   }
 
-  const { sql: arelSql } = await import("@blazetrails/arel");
   const um = new UpdateManager();
   um.table(table);
   um.set(setPairs as Parameters<UpdateManager["set"]>[0]);
-  // `_buildPkWhere` returns a string fragment; wrap it as Arel SQL so the
-  // SET clause still routes through UpdateManager's quoting.
-  um.where(arelSql(ctor._buildPkWhere(this.id)) as Parameters<UpdateManager["where"]>[0]);
+  um.where(ctor._buildPkWhereNode(this.id));
 
   const adapter = ctor.adapter;
   if (typeof adapter.update === "function") {


### PR DESCRIPTION
## Summary
PR 8c of the Base → Rails-module extraction plan. Moves 12 instance methods out of `base.ts` into `persistence.ts` as `this`-typed functions, wired onto `Base` via `include()` + merged `interface Base` signatures.

| method | Rails home |
|---|---|
| `reload` | `Persistence#reload` |
| `slice` / `valuesAt` | `AttributeMethods` read-helpers |
| `assignAttributes` | `AttributeAssignment#assign_attributes` |
| `updateAttribute` / `updateAttributeBang` | `Persistence#update_attribute` / `#update_attribute!` |
| `updateColumn` / `updateColumns` | `Persistence#update_column` / `#update_columns` |
| `dup` | `Inheritance#dup` (Rails 7.2+) |
| `clone` | `Core#clone` |
| `becomes` / `becomesBang` | `Persistence#becomes` / `#becomes!` |

Seven focused per-function interfaces keep each `this` contract tight.

## Rails-fidelity fixes landed during self-review + code review
1. **`becomes` now propagates `_destroyed` and copies validation errors** via `errors.copy(this.errors)`, matching Rails' `becoming.errors.copy!(errors)` + `@destroyed = destroyed?`. Our pre-extraction version skipped both; a destroyed record viewed through `becomes` would appear live, and pending errors were lost across the class swap.
2. **`updateAttributeBang`** now matches Rails' `update_attribute!` semantics: `save({validate: false})` + `RecordNotSaved` on callback abort. Previously called `saveBang()` which runs validations — the `Bang` in the name was misleading.
3. **`updateColumns`** now builds the `UPDATE` via Arel's `UpdateManager` + the adapter's `update()` path, so SET-clause values and identifiers route through the adapter's quoting layer. The prior raw-string interpolation only escaped single-quotes in strings and mishandled binary / adapter-specific date / JSON encoding, and was SQL-injection-adjacent for malicious/invalid column keys.
4. **`UpdateColumnsRecord.adapter.execUpdate`** tightened to match the repo's `DatabaseAdapter` contract (`Promise<number>`, optional `name`/`binds`); exposes `update` / `quote*` / `toSql` hooks the new Arel path needs.

## api:compare impact
| | before | after |
|-|--------|-------|
| matched | 2517/2819 (89.3%) | 2517/2819 (89.3%) |
| inheritance | 204/210 (97.1%) | 204/210 (97.1%) |

## Test plan
- [x] `tsc --noEmit` clean on activerecord
- [x] Full `pnpm vitest run` passes (17816 tests)
- [x] `pnpm test:types` (DX Type Tests) passes
- [x] `pnpm guides:typecheck` passes
- [x] `pnpm run api:compare` steady