### PR TITLE
fix(activerecord): DJAS uses joinPrimaryKeyFor for polymorphic sourceType non-id PKs

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -49,6 +49,26 @@ function readTuple(owner: Base, cols: string[]): unknown[] {
 }
 
 /**
+ * Resolve a reflection's `joinPrimaryKey` using the runtime-klass
+ * form when the reflection exposes it. `BelongsToReflection#joinPrimaryKey`
+ * hard-codes `"id"` for polymorphic sources since the target class
+ * isn't known at definition time, but the resolved sourceType class
+ * may use a custom PK (`uuid`, a composite, ...). Routing through
+ * `joinPrimaryKeyFor(klass)` mirrors the AssociationScope walk
+ * (association-scope.ts:_nextChainScope) and Rails'
+ * `join_primary_key_for(klass)` (reflection.rb:968). Falls back to
+ * the static `joinPrimaryKey` when the method isn't exposed (e.g.
+ * chain entries that aren't Through / BelongsTo shapes).
+ */
+function resolveJoinPrimaryKey(reflection: unknown, klass?: typeof Base): string | string[] {
+  const r = reflection as {
+    joinPrimaryKey: string | string[];
+    joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
+  };
+  return typeof r.joinPrimaryKeyFor === "function" ? r.joinPrimaryKeyFor(klass) : r.joinPrimaryKey;
+}
+
+/**
  * Builds scopes for `:through` associations that disable joins, querying
  * each step's table separately and stitching results in memory via IN(...)
  * rather than emitting a multi-table JOIN. Used when the source and
@@ -101,8 +121,15 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         reverseChain,
         owner,
       );
-      const key = (lastReflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-      const keyCols = keyColumns(key, "joinPrimaryKey");
+      // Prefer the runtime-klass form — `BelongsToReflection#joinPrimaryKey`
+      // hard-codes `"id"` for polymorphic sources, but a sourceType
+      // target may use a different PK (e.g. `uuid`). Mirrors the
+      // AssociationScope chain walk which also routes through
+      // joinPrimaryKeyFor (reflection.rb:968).
+      const keyCols = keyColumns(
+        resolveJoinPrimaryKey(lastReflection, (lastReflection as { klass?: typeof Base }).klass),
+        "joinPrimaryKey",
+      );
       const relation = this._addConstraintsDj(
         lastReflection,
         keyCols,
@@ -143,8 +170,10 @@ export class DisableJoinsAssociationScope extends AssociationScope {
 
     for (const nextReflection of work) {
       const [reflection, ordered, joinIds] = acc;
-      const key = (reflection as { joinPrimaryKey: string | string[] }).joinPrimaryKey;
-      const keyCols = keyColumns(key, "joinPrimaryKey");
+      const keyCols = keyColumns(
+        resolveJoinPrimaryKey(reflection, (reflection as { klass?: typeof Base }).klass),
+        "joinPrimaryKey",
+      );
       const records = this._addConstraintsDj(reflection, keyCols, joinIds, owner, ordered);
       const foreignKey = (nextReflection as { joinForeignKey: string | string[] }).joinForeignKey;
       const foreignKeyCols = keyColumns(foreignKey, "joinForeignKey");

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -118,16 +118,20 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
       imageable_type: "DpNonIdPhoto",
     });
 
-    // Distraction row with COLLIDING imageable_uuid — shares the
-    // same FK value as the photo. Without the sourceType filter
+    // A second real photo whose uuid matches a distraction gallery's
+    // imageable_uuid. Without the sourceType filter
     // (imageable_type = 'DpNonIdPhoto'), the walk would collect
-    // `u-photo` from this gallery too and try to match it against
-    // dp_non_id_photos.uuid. Proves source_type is doing real work,
-    // not a lucky FK mismatch.
-    await DpNonIdArticle.create({ slug: "u-photo", headline: "h-collide" });
+    // BOTH uuids from the gallery step and incorrectly load
+    // `otherPhoto` alongside the real one — proving the filter is
+    // doing observable work, not just shaping SQL.
+    const otherPhoto = (await DpNonIdPhoto.create({
+      uuid: "u-other-photo",
+      title: "leak-check",
+    })) as any;
+    await DpNonIdArticle.create({ slug: otherPhoto.uuid, headline: "h-collide" });
     await DpGallery.create({
       dp_author_id: author.id,
-      imageable_uuid: "u-photo",
+      imageable_uuid: otherPhoto.uuid,
       imageable_type: "DpNonIdArticle",
     });
 

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -96,6 +96,13 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
       sourceType: "DpNonIdPhoto",
       disableJoins: true,
     });
+    Associations.hasOne.call(DpAuthor, "noJoinsDpOnePhoto", {
+      className: "DpNonIdPhoto",
+      through: "dpGalleries",
+      source: "imageable",
+      sourceType: "DpNonIdPhoto",
+      disableJoins: true,
+    });
   });
 
   afterEach(() => Notifications.unsubscribeAll());
@@ -111,13 +118,16 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
       imageable_type: "DpNonIdPhoto",
     });
 
-    // Distraction row: different polymorphic target (`DpNonIdArticle`).
-    // Shares no FK overlap with the photo, but proves the sourceType
-    // filter is what's discriminating on the gallery step.
-    await DpNonIdArticle.create({ slug: "slug-a", headline: "h1" });
+    // Distraction row with COLLIDING imageable_uuid — shares the
+    // same FK value as the photo. Without the sourceType filter
+    // (imageable_type = 'DpNonIdPhoto'), the walk would collect
+    // `u-photo` from this gallery too and try to match it against
+    // dp_non_id_photos.uuid. Proves source_type is doing real work,
+    // not a lucky FK mismatch.
+    await DpNonIdArticle.create({ slug: "u-photo", headline: "h-collide" });
     await DpGallery.create({
       dp_author_id: author.id,
-      imageable_uuid: "slug-a",
+      imageable_uuid: "u-photo",
       imageable_type: "DpNonIdArticle",
     });
 
@@ -147,5 +157,33 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     expect(observed.some((s) => /\bFROM\b\s+["`]?dp_non_id_photos\b.+\buuid\b/i.test(s))).toBe(
       true,
     );
+  });
+
+  it("has_one :through polymorphic-source + non-id target PK via DJAS", async () => {
+    // Same routing gate + chain walker as has_many — pinning the
+    // has_one variant since the fix touches both paths and
+    // CollectionAssociation / SingularAssociation share the DJAS
+    // scope infrastructure.
+    const author = await DpAuthor.create({ name: "a" });
+    const photo = (await DpNonIdPhoto.create({ uuid: "u-one", title: "only" })) as any;
+    await DpGallery.create({
+      dp_author_id: author.id,
+      imageable_uuid: photo.uuid,
+      imageable_type: "DpNonIdPhoto",
+    });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    let loaded: any;
+    try {
+      loaded = await (author as any).loadHasOne("noJoinsDpOnePhoto");
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(loaded?.uuid).toBe(photo.uuid);
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
   });
 });

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -1,0 +1,151 @@
+/**
+ * DJAS: polymorphic belongsTo-through with non-id target PK (task #20).
+ *
+ * The non-DJAS path has a regression test at
+ * `association-scope.test.ts` ("loadHasMany through with sourceType +
+ * non-id target PK uses correct join column"). The DJAS walk routes
+ * through the same reflection infrastructure (`joinPrimaryKeyFor`
+ * resolves the source target's actual PK column for a polymorphic
+ * belongsTo at runtime), but no direct DJAS coverage existed for
+ * that intersection. This file pins the DJAS shape end-to-end.
+ *
+ * Key setup:
+ *   Author  has_many :galleries (regular FK)
+ *   Gallery belongs_to :imageable, polymorphic: true, foreign_key: :imageable_uuid
+ *   Photo   primaryKey = "uuid"       # non-id PK
+ *   Author  has_many :photos, through: :galleries, source: :imageable,
+ *                    sourceType: "DpNonIdPhoto",
+ *                    disable_joins: true
+ *
+ * The walk must read the *source-target's* `uuid` column on the
+ * through step (not the default `"id"` that
+ * `BelongsToReflection#joinPrimaryKey` hard-codes for polymorphic
+ * sources). Rails resolves this via
+ * `BelongsToReflection#join_primary_key_for(klass)`
+ * (reflection.rb:968); our ReflectionProxy forwards it, and DJAS'
+ * `_addConstraintsDj` threads it through the chain walk.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import { Base, registerModel } from "../index.js";
+import { Associations, loadHasMany } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
+  let adapter: DatabaseAdapter;
+
+  class DpAuthor extends Base {
+    static {
+      this._tableName = "dp_authors";
+      this.attribute("name", "string");
+    }
+  }
+  class DpGallery extends Base {
+    static {
+      this._tableName = "dp_galleries";
+      this.attribute("dp_author_id", "integer");
+      this.attribute("imageable_uuid", "string");
+      this.attribute("imageable_type", "string");
+    }
+  }
+  class DpNonIdPhoto extends Base {
+    static {
+      this._tableName = "dp_non_id_photos";
+      this.primaryKey = "uuid";
+      this.attribute("uuid", "string");
+      this.attribute("title", "string");
+    }
+  }
+  class DpNonIdArticle extends Base {
+    static {
+      this._tableName = "dp_non_id_articles";
+      this.primaryKey = "slug";
+      this.attribute("slug", "string");
+      this.attribute("headline", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    DpAuthor.adapter = adapter;
+    DpGallery.adapter = adapter;
+    DpNonIdPhoto.adapter = adapter;
+    DpNonIdArticle.adapter = adapter;
+    registerModel("DpAuthor", DpAuthor);
+    registerModel("DpGallery", DpGallery);
+    registerModel("DpNonIdPhoto", DpNonIdPhoto);
+    registerModel("DpNonIdArticle", DpNonIdArticle);
+    (DpAuthor as any)._associations = [];
+    (DpAuthor as any)._reflections = {};
+    (DpGallery as any)._associations = [];
+    (DpGallery as any)._reflections = {};
+
+    Associations.hasMany.call(DpAuthor, "dpGalleries", {
+      className: "DpGallery",
+      foreignKey: "dp_author_id",
+    });
+    Associations.belongsTo.call(DpGallery, "imageable", {
+      polymorphic: true,
+      foreignKey: "imageable_uuid",
+    });
+    Associations.hasMany.call(DpAuthor, "noJoinsDpPhotos", {
+      className: "DpNonIdPhoto",
+      through: "dpGalleries",
+      source: "imageable",
+      sourceType: "DpNonIdPhoto",
+      disableJoins: true,
+    });
+  });
+
+  afterEach(() => Notifications.unsubscribeAll());
+
+  it("loads via DJAS using the sourceType target's non-id PK (no JOIN, origin_type filter applied)", async () => {
+    const author = await DpAuthor.create({ name: "a" });
+
+    // One matching photo (sourceType target uses `uuid` as PK).
+    const photo = (await DpNonIdPhoto.create({ uuid: "u-photo", title: "p1" })) as any;
+    await DpGallery.create({
+      dp_author_id: author.id,
+      imageable_uuid: photo.uuid,
+      imageable_type: "DpNonIdPhoto",
+    });
+
+    // Distraction row: different polymorphic target (`DpNonIdArticle`).
+    // Shares no FK overlap with the photo, but proves the sourceType
+    // filter is what's discriminating on the gallery step.
+    await DpNonIdArticle.create({ slug: "slug-a", headline: "h1" });
+    await DpGallery.create({
+      dp_author_id: author.id,
+      imageable_uuid: "slug-a",
+      imageable_type: "DpNonIdArticle",
+    });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      const reflection = (DpAuthor as any)._reflectOnAssociation("noJoinsDpPhotos");
+      const photos = await loadHasMany(author, "noJoinsDpPhotos", reflection.options);
+      expect(photos.map((p: any) => p.uuid)).toEqual([photo.uuid]);
+      expect(photos.map((p: any) => p.title)).toEqual(["p1"]);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(observed.length).toBeGreaterThan(0);
+    // DJAS walks step-by-step — no JOIN across the chain.
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
+    // The source-type filter fired at the gallery step.
+    expect(observed.some((s) => /imageable_type/i.test(s))).toBe(true);
+    // The final step reads `uuid` (the sourceType target's PK), not
+    // the hard-coded `id` that `BelongsToReflection#joinPrimaryKey`
+    // returns for polymorphic sources. Regression guard: if
+    // `joinPrimaryKeyFor(klass)` stops being routed correctly, the
+    // WHERE would reference `id` and return no rows.
+    expect(observed.some((s) => /\bFROM\b\s+["`]?dp_non_id_photos\b.+\buuid\b/i.test(s))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Task #20. Writing the polymorphic-source + non-id target PK + DJAS intersection test surfaced a real bug: DJAS read `reflection.joinPrimaryKey` at each chain step, but `BelongsToReflection#joinPrimaryKey` hard-codes `"id"` for polymorphic sources — the resolved sourceType target's actual PK (`uuid`, composite, etc.) never reached the WHERE. Result: `no such column: <target>.id` for any target whose PK is not `id`.

### Fix

Route DJAS through `joinPrimaryKeyFor(klass)` — the same helper AssociationScope already uses at `_nextChainScope` (mirrors Rails `reflection.rb:968`). Applied at both the seed step (`_lastScopeChain` head) and every intermediate step. Falls back to static `joinPrimaryKey` when the reflection doesn't expose the method.

### Test

New `disable-joins-polymorphic-nonid-pk.test.ts` (2 tests — has_many and has_one :through variants) sets up:

```
Author has_many :galleries
Gallery belongs_to :imageable, polymorphic: true, foreign_key: :imageable_uuid
Photo   primaryKey = "uuid"      # custom PK
Author has_many :photos, through: :galleries, source: :imageable,
                sourceType: "Photo", disable_joins: true
Author has_one  :photo,  through: :galleries, source: :imageable,
                sourceType: "Photo", disable_joins: true
```

A second real `Photo` row whose `uuid` matches a distraction article-gallery proves the `imageable_type` filter is doing observable work: without it, the walk would load both photos.

Pins via SQL capture:
- No JOIN across the chain (DJAS walk)
- `imageable_type` filter lands on the gallery step
- Final source-step references the target's `uuid` column, not `id`

## Test plan

- [x] New test file: `disable-joins-polymorphic-nonid-pk.test.ts` (2 tests)
- [x] Full `@blazetrails/activerecord` suite: 8779 passed
- [ ] PG / MariaDB CI