### PR TITLE
perf(activerecord): CP#count emits COUNT(*) on disable-joins through (incl. nested)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -455,36 +455,40 @@ function _builtAssociationScope(
   });
 }
 
+/**
+ * Unsaved-owner / null-PK short-circuit shared by every entry point
+ * that runs the DJAS chain walk against an owner record.
+ *
+ * Why it's correctness-not-just-perf: PredicateBuilder's ArrayHandler
+ * folds `where({key: [null]})` into `key IS NULL`. With no guard,
+ * DJAS would seed `joinIds = [null]` for an unsaved owner and the
+ * first-step WHERE would match orphan through rows whose FK is null,
+ * leaking them into the chain as phantom associations.
+ *
+ * Read from the OUTER reflection's `activeRecordPrimaryKey` —
+ * that's the owner's own PK column(s), never a delegated downstream
+ * target. `isNewRecord()` covers unsaved records; the explicit
+ * PK-null check covers the defensive edge where a saved record
+ * somehow has a null composite-PK component.
+ */
+export function ownerHasUnresolvedThroughKey(record: Base, reflection: unknown): boolean {
+  if (record.isNewRecord()) return true;
+  const activeRecordPk = (reflection as { activeRecordPrimaryKey?: string | string[] })
+    .activeRecordPrimaryKey;
+  const ownerPkCols =
+    activeRecordPk == null ? [] : Array.isArray(activeRecordPk) ? activeRecordPk : [activeRecordPk];
+  return ownerPkCols.some((col) => {
+    const v = record.readAttribute(col);
+    return v === null || v === undefined;
+  });
+}
+
 async function _loadThroughViaDisableJoinsScope(
   record: Base,
   reflection: unknown,
   options?: AssociationOptions,
 ): Promise<Base[]> {
-  // Unsaved-owner / null-PK short-circuit — correctness, not just
-  // perf. With the guard absent DJAS seeds `joinIds = [null]`, and
-  // the ArrayHandler in PredicateBuilder folds `[null]` into
-  // `key IS NULL`. That would match orphan through rows whose FK
-  // is null and leak them into the chain as phantom associations.
-  //
-  // Previously the guard read `throughReflection.joinForeignKey`
-  // off the owner, but for nested-through + composite-FK shapes
-  // that delegation surfaces deeper-target columns that don't
-  // exist on the outer owner (e.g. `ck_order_shop_id` on `Shop`),
-  // producing a false null and early-returning even for saved
-  // owners. Read from the OUTER reflection's `activeRecordPrimaryKey`
-  // instead — that's the owner's own PK column(s), never a
-  // delegated downstream target. `isNewRecord()` covers unsaved
-  // records; the explicit PK-null check covers the defensive edge
-  // where a saved record somehow has a null composite-PK component.
-  const activeRecordPk = (reflection as { activeRecordPrimaryKey?: string | string[] })
-    .activeRecordPrimaryKey;
-  const ownerPkCols =
-    activeRecordPk == null ? [] : Array.isArray(activeRecordPk) ? activeRecordPk : [activeRecordPk];
-  const ownerHasNullPk = ownerPkCols.some((col) => {
-    const v = record.readAttribute(col);
-    return v === null || v === undefined;
-  });
-  if (record.isNewRecord() || ownerHasNullPk) return [];
+  if (ownerHasUnresolvedThroughKey(record, reflection)) return [];
   // Lazy-import to avoid an eager cycle: DJAS imports
   // DisableJoinsAssociationRelation → relation.ts → associations.ts.
   const { DisableJoinsAssociationScope } =

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -777,10 +777,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (this._assocDef.options.disableJoins) {
         const box = await this._djarForCount();
         if (!box) return 0;
-        const djar = (box as { djar: unknown }).djar as {
-          countDeferred: () => Promise<number>;
-        };
-        return djar.countDeferred();
+        const djar = (box as { djar: unknown }).djar as { count: () => Promise<number> };
+        return djar.count();
       }
       if (!_canRouteThroughViaAssociationScope(refl, this._assocDef.options)) {
         const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -39,6 +39,7 @@ import {
   buildHasManyRelation,
   loadHasMany,
   _canRouteThroughViaAssociationScope,
+  ownerHasUnresolvedThroughKey,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 
@@ -699,32 +700,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Build a DJAR for the disable-joins-through count fast path —
    * mirrors `_loadThroughViaDisableJoinsScope`'s setup but stops
-   * after constructing the DJAR (which is itself a sync Relation
-   * whose chain walker fires on first count/toArray/ids). Returns
-   * `null` for the unsaved-owner case so the caller can short-
-   * circuit to 0 (matches the `isNewRecord()` / null-PK guard
-   * `_loadThroughViaDisableJoinsScope` enforces for correctness —
-   * an unsaved owner seeding `[null]` would otherwise let the
-   * ArrayHandler fold `[null]` into `IS NULL` and match orphan
-   * through rows).
+   * after constructing the DJAR. Returns `null` when
+   * `ownerHasUnresolvedThroughKey` fires (unsaved owner / null
+   * PK) so the caller short-circuits to 0 — same correctness
+   * guard the loader uses.
    */
   private async _djarForCount(): Promise<{ djar: unknown } | null> {
     const ctor = this._record.constructor as typeof Base;
     const reflection = (ctor as any)._reflectOnAssociation?.(this._assocName);
     if (!reflection) return null;
-    const activeRecordPk = (reflection as { activeRecordPrimaryKey?: string | string[] })
-      .activeRecordPrimaryKey;
-    const ownerPkCols =
-      activeRecordPk == null
-        ? []
-        : Array.isArray(activeRecordPk)
-          ? activeRecordPk
-          : [activeRecordPk];
-    const ownerHasNullPk = ownerPkCols.some((col) => {
-      const v = this._record.readAttribute(col);
-      return v === null || v === undefined;
-    });
-    if (this._record.isNewRecord() || ownerHasNullPk) return null;
+    if (ownerHasUnresolvedThroughKey(this._record, reflection)) return null;
     const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
     const klass = (reflection as { klass: typeof Base }).klass;
     // Box the DJAR so awaiting this helper doesn't unwrap it via
@@ -774,7 +759,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._assocDef.options.through) {
       const ctor = this._record.constructor as typeof Base;
       const refl = (ctor as any)._reflectOnAssociation?.(this._assocName);
-      if (this._assocDef.options.disableJoins) {
+      // Disable-joins through: fast path goes through DJAR's
+      // deferred walker + final-step COUNT. The divergence-aware
+      // Relation.prototype.count fallthrough below handles any
+      // in-place proxy mutations (whereBang / groupBang / etc.) —
+      // DJAR construction here ignores those, so route diverged
+      // proxies through the generic path instead.
+      if (this._assocDef.options.disableJoins && !this._relationStateDiverged()) {
         const box = await this._djarForCount();
         if (!box) return 0;
         const djar = (box as { djar: unknown }).djar as {
@@ -786,7 +777,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         }
         return c;
       }
-      if (!_canRouteThroughViaAssociationScope(refl, this._assocDef.options)) {
+      // Non-disable-joins through shapes AssociationScope can't
+      // route (nested / polymorphic-has_many / polymorphic-
+      // belongsTo-without-sourceType): fall back to the loader.
+      // Disable-joins diverged case also falls through here — the
+      // generic Relation.prototype.count path below honors the
+      // proxy's in-place mutations.
+      if (
+        !this._assocDef.options.disableJoins &&
+        !_canRouteThroughViaAssociationScope(refl, this._assocDef.options)
+      ) {
         const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
         return results.length;
       }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -697,6 +697,48 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
+   * Build a DJAR for the disable-joins-through count fast path —
+   * mirrors `_loadThroughViaDisableJoinsScope`'s setup but stops
+   * after constructing the DJAR (which is itself a sync Relation
+   * whose chain walker fires on first count/toArray/ids). Returns
+   * `null` for the unsaved-owner case so the caller can short-
+   * circuit to 0 (matches the `isNewRecord()` / null-PK guard
+   * `_loadThroughViaDisableJoinsScope` enforces for correctness —
+   * an unsaved owner seeding `[null]` would otherwise let the
+   * ArrayHandler fold `[null]` into `IS NULL` and match orphan
+   * through rows).
+   */
+  private async _djarForCount(): Promise<{ djar: unknown } | null> {
+    const ctor = this._record.constructor as typeof Base;
+    const reflection = (ctor as any)._reflectOnAssociation?.(this._assocName);
+    if (!reflection) return null;
+    const activeRecordPk = (reflection as { activeRecordPrimaryKey?: string | string[] })
+      .activeRecordPrimaryKey;
+    const ownerPkCols =
+      activeRecordPk == null
+        ? []
+        : Array.isArray(activeRecordPk)
+          ? activeRecordPk
+          : [activeRecordPk];
+    const ownerHasNullPk = ownerPkCols.some((col) => {
+      const v = this._record.readAttribute(col);
+      return v === null || v === undefined;
+    });
+    if (this._record.isNewRecord() || ownerHasNullPk) return null;
+    const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
+    const klass = (reflection as { klass: typeof Base }).klass;
+    // Box the DJAR so awaiting this helper doesn't unwrap it via
+    // `Relation.then` (which resolves to the records array). Callers
+    // read `.djar` off the resolved value.
+    const djar = DisableJoinsAssociationScope.INSTANCE.scope({
+      owner: this._record,
+      reflection: reflection as any,
+      klass,
+    });
+    return { djar };
+  }
+
+  /**
    * Count associated records.
    */
   // @ts-expect-error Relation defines `count` as a property (from the
@@ -714,28 +756,32 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // a loaded target above returns without querying, matching
     // `size()`'s loaded-target fast path.
     this._checkStrictLoading();
-    // `disable_joins: true` through-associations don't have a single
-    // JOIN-based relation to count against — DJAS walks the chain in
-    // separate queries and `this.scope()` returns the final-step's
-    // relation without the prior chain's IN filters (nested-through
-    // shapes surface as `no such column` errors when running a
-    // direct COUNT). Fall back to the loader on that path.
-    // Non-disable-joins through associations are handled by
-    // `_buildThroughScope()` which builds a JOIN-based Relation that
-    // counts correctly.
-    // Through-associations: only take the scope().count() fast path
-    // when the shape is one AssociationScope can route. The shared
-    // predicate already excludes nested-through, disable-joins,
-    // polymorphic-has_many sources, and polymorphic-belongsTo
-    // sources without sourceType — all shapes where
-    // _buildThroughScope produces SQL that either references the
-    // wrong table's columns or can't disambiguate the target table.
-    // For those, fall back to the loader (which has its own
-    // per-shape handling). Matches the gate used by
-    // loadHasMany / loadHasOne in associations.ts:659.
+    // Through-associations:
+    //   * disable_joins: route through DJAS' chain walker and emit a
+    //     single COUNT(*) on the final-step relation
+    //     (DisableJoinsAssociationRelation#count). The intermediate
+    //     plucks happen either way; this just avoids hydrating rows.
+    //   * non-disable-joins shapes AssociationScope can route (the
+    //     shared predicate already excludes nested-through and the
+    //     polymorphic-without-sourceType cases): fall through to the
+    //     scope().count() fast path below — `_buildThroughScope()`
+    //     produces a COUNT-able JOIN/subquery relation.
+    //   * Other through shapes (nested-through non-DJAS,
+    //     polymorphic-has_many sources): scope() / _buildThroughScope
+    //     produces SQL that references columns the target FROM
+    //     doesn't have. Fall back to the loader for those (task #25
+    //     covers the underlying scope-build issue).
     if (this._assocDef.options.through) {
       const ctor = this._record.constructor as typeof Base;
       const refl = (ctor as any)._reflectOnAssociation?.(this._assocName);
+      if (this._assocDef.options.disableJoins) {
+        const box = await this._djarForCount();
+        if (!box) return 0;
+        const djar = (box as { djar: unknown }).djar as {
+          countDeferred: () => Promise<number>;
+        };
+        return djar.countDeferred();
+      }
       if (!_canRouteThroughViaAssociationScope(refl, this._assocDef.options)) {
         const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
         return results.length;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -777,8 +777,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (this._assocDef.options.disableJoins) {
         const box = await this._djarForCount();
         if (!box) return 0;
-        const djar = (box as { djar: unknown }).djar as { count: () => Promise<number> };
-        return djar.count();
+        const djar = (box as { djar: unknown }).djar as {
+          count: () => Promise<number | Record<string, number>>;
+        };
+        const c = await djar.count();
+        if (typeof c !== "number") {
+          throw new Error("Grouped counts are not supported for association collection counts");
+        }
+        return c;
       }
       if (!_canRouteThroughViaAssociationScope(refl, this._assocDef.options)) {
         const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `CollectionProxy#count` on `disable_joins: true` through-
+ * associations (task #22).
+ *
+ * Before this PR, CP#count fell back to `loadHasMany(...).length`
+ * for every disable-joins through shape — the chain walk runs
+ * intermediate pluck queries either way, but the final step
+ * would SELECT every target row and `.length` the array. On
+ * large collections the row-wise SELECT is the expensive part.
+ *
+ * Now CP#count routes through DJAR's deferred walker and emits a
+ * single `SELECT COUNT(*)` on the final-step relation instead.
+ * The intermediate plucks are unchanged.
+ *
+ * Rails' `CollectionAssociation#count` on a through uses
+ * `scope.count`, and for disable_joins that resolves to the
+ * DJAR's loaded `records.size` — perf-equivalent because Rails'
+ * DJAR materializes records to enforce the in-memory reorder.
+ * We don't need to materialize for the count, so we emit COUNT.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Notifications } from "@blazetrails/activesupport";
+import { Base, association, registerModel } from "../index.js";
+import { Associations } from "../associations.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+describe("CollectionProxy#count — disable_joins through", () => {
+  let adapter: DatabaseAdapter;
+
+  class CdAuthor extends Base {
+    static {
+      this._tableName = "cd_authors";
+      this.attribute("name", "string");
+    }
+  }
+  class CdPost extends Base {
+    static {
+      this._tableName = "cd_posts";
+      this.attribute("cd_author_id", "integer");
+      this.attribute("title", "string");
+    }
+  }
+  class CdComment extends Base {
+    static {
+      this._tableName = "cd_comments";
+      this.attribute("cd_post_id", "integer");
+      this.attribute("body", "string");
+    }
+  }
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+    CdAuthor.adapter = adapter;
+    CdPost.adapter = adapter;
+    CdComment.adapter = adapter;
+    registerModel("CdAuthor", CdAuthor);
+    registerModel("CdPost", CdPost);
+    registerModel("CdComment", CdComment);
+    (CdAuthor as any)._associations = [];
+    (CdAuthor as any)._reflections = {};
+    (CdPost as any)._associations = [];
+    (CdPost as any)._reflections = {};
+    (CdComment as any)._associations = [];
+    (CdComment as any)._reflections = {};
+
+    Associations.hasMany.call(CdAuthor, "cdPosts", {
+      className: "CdPost",
+      foreignKey: "cd_author_id",
+    });
+    Associations.hasMany.call(CdPost, "cdComments", {
+      className: "CdComment",
+      foreignKey: "cd_post_id",
+    });
+    Associations.hasMany.call(CdAuthor, "noJoinsCdComments", {
+      className: "CdComment",
+      through: "cdPosts",
+      source: "cdComments",
+      disableJoins: true,
+    });
+  });
+
+  afterEach(() => Notifications.unsubscribeAll());
+
+  it("emits COUNT(*) on the final step — no row-wise SELECT of the target", async () => {
+    const author = await CdAuthor.create({ name: "a" });
+    const post = (await CdPost.create({ cd_author_id: author.id, title: "p" })) as any;
+    await CdComment.create({ cd_post_id: post.id, body: "c1" });
+    await CdComment.create({ cd_post_id: post.id, body: "c2" });
+    await CdComment.create({ cd_post_id: post.id, body: "c3" });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    let n: number;
+    try {
+      n = await association(author, "noJoinsCdComments").count();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(n).toBe(3);
+    // Intermediate pluck step + final COUNT — exactly two SQLs.
+    // No row-wise SELECT against cd_comments.
+    const commentsSelects = observed.filter((s) => /\bFROM\b\s+["`]?cd_comments\b/i.test(s));
+    expect(commentsSelects.length).toBe(1);
+    expect(commentsSelects[0]).toMatch(/SELECT\s+COUNT\b/i);
+    expect(commentsSelects[0]).not.toMatch(/SELECT\s+\*/i);
+  });
+
+  it("nested-through + disable_joins: walker chains through the nested level and still COUNTs the final step", async () => {
+    // Add a Rating model and nest the chain:
+    //   Author → (Posts → Comments) → Ratings
+    // `noJoinsCdRatings` is nested-through with disable_joins. DJAS'
+    // chain walker handles the flattened chain (PR #668), and our
+    // COUNT fast path rides on top.
+    class CdRating extends Base {
+      static {
+        this._tableName = "cd_ratings";
+        this.attribute("cd_comment_id", "integer");
+        this.attribute("value", "integer");
+      }
+    }
+    CdRating.adapter = adapter;
+    registerModel("CdRating", CdRating);
+    (CdRating as any)._associations = [];
+    (CdRating as any)._reflections = {};
+
+    Associations.hasMany.call(CdComment, "cdRatings", {
+      className: "CdRating",
+      foreignKey: "cd_comment_id",
+    });
+    Associations.hasMany.call(CdAuthor, "noJoinsCdRatings", {
+      className: "CdRating",
+      through: "noJoinsCdComments",
+      source: "cdRatings",
+      disableJoins: true,
+    });
+
+    const author = await CdAuthor.create({ name: "a" });
+    const post = (await CdPost.create({ cd_author_id: author.id, title: "p" })) as any;
+    const c1 = (await CdComment.create({ cd_post_id: post.id, body: "c1" })) as any;
+    const c2 = (await CdComment.create({ cd_post_id: post.id, body: "c2" })) as any;
+    await CdRating.create({ cd_comment_id: c1.id, value: 5 });
+    await CdRating.create({ cd_comment_id: c2.id, value: 8 });
+    await CdRating.create({ cd_comment_id: c2.id, value: 9 });
+
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      expect(await association(author, "noJoinsCdRatings").count()).toBe(3);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    // Final step is a single COUNT — not a row-wise SELECT.
+    const ratingsSelects = observed.filter((s) => /\bFROM\b\s+["`]?cd_ratings\b/i.test(s));
+    expect(ratingsSelects.length).toBe(1);
+    expect(ratingsSelects[0]).toMatch(/SELECT\s+COUNT\b/i);
+    // No JOIN across the chain.
+    expect(observed.some((s) => /\bJOIN\b/i.test(s))).toBe(false);
+  });
+
+  it("unsaved owner returns 0 without firing any SQL", async () => {
+    const unsaved = CdAuthor.new({ name: "unsaved" });
+    const observed: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      const sql = event?.payload?.sql;
+      if (typeof sql === "string") observed.push(sql);
+    });
+    try {
+      expect(await association(unsaved, "noJoinsCdComments").count()).toBe(0);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(observed).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -377,24 +377,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
-   * Count via the deferred chain walk without instantiating the
-   * target rows. Runs the intermediate plucks (cheap; they happen
-   * anyway for this shape) then emits a single `SELECT COUNT(*)`
-   * on the final-step Relation instead of loading every record.
-   *
-   * Loaded-chain mode has the target already materialized, so we
-   * return the `_storedIds.length` (matches the re-emitted record
-   * count after the `_target` re-order). No override of `size`
-   * needed — Rails' `CollectionAssociation#count` goes through
-   * `count` for the single-argument form too.
-   */
-  /**
    * Count via the deferred chain walk without materializing the
    * target rows. Runs the intermediate plucks (cheap; they happen
    * anyway for this shape) then emits a single `SELECT COUNT(*)`
-   * on the final-step Relation. Loaded-chain mode returns
-   * `_storedIds.length` — matches the re-emitted record count
-   * after the `_target` re-order.
+   * (or `COUNT(<column>)` when a column is provided) on the final-
+   * step Relation. Loaded-chain mode delegates to
+   * `Relation.prototype.count` against the current relation state
+   * so any composed limit/offset/where on the loaded-chain DJAR
+   * counts correctly — `_storedIds.length` would over-count if
+   * additional WHEREs narrowed the load below the seed-id list.
    *
    * Mirrors Rails' `CollectionAssociation#count` on disable_joins
    * (which goes through `scope.count` → `records.size` after
@@ -404,21 +395,26 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   // @ts-expect-error Relation defines `count` as a property (from
   //   the calculations mixin); DJAR overrides as an async method
   //   that runs the deferred chain walk before counting.
-  async count(): Promise<number> {
+  async count(column?: string): Promise<number | Record<string, number>> {
     if (this._chainWalker) {
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
-      const c = await (
-        merged as unknown as { count: () => Promise<number | Record<string, number>> }
-      ).count();
-      if (typeof c !== "number") {
-        throw new Error(
-          "Grouped counts are not supported on DisableJoinsAssociationRelation#count",
-        );
-      }
-      return c;
+      return (
+        merged as unknown as {
+          count: (col?: string) => Promise<number | Record<string, number>>;
+        }
+      ).count(column);
     }
-    return this._storedIds.length;
+    // Loaded-chain mode: route through Relation.prototype.count so
+    // any composed limit/offset/where applies. Direct `.count.call`
+    // — not `this.count(column)` — to avoid re-entering this
+    // override.
+    const baseCount = (
+      Relation.prototype as unknown as {
+        count: (this: unknown, col?: string) => Promise<number | Record<string, number>>;
+      }
+    ).count;
+    return baseCount.call(this, column);
   }
 
   /**

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -377,6 +377,47 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
+   * Count via the deferred chain walk without instantiating the
+   * target rows. Runs the intermediate plucks (cheap; they happen
+   * anyway for this shape) then emits a single `SELECT COUNT(*)`
+   * on the final-step Relation instead of loading every record.
+   *
+   * Loaded-chain mode has the target already materialized, so we
+   * return the `_storedIds.length` (matches the re-emitted record
+   * count after the `_target` re-order). No override of `size`
+   * needed — Rails' `CollectionAssociation#count` goes through
+   * `count` for the single-argument form too.
+   */
+  /**
+   * Count via the deferred chain walk without materializing the
+   * target rows. Runs the intermediate plucks (cheap; they happen
+   * anyway for this shape) then emits a single `SELECT COUNT(*)`
+   * on the final-step Relation. Named `countDeferred` rather than
+   * overriding `count` because Relation's `count` is installed via
+   * the Calculations mixin (property-style) and can't be cleanly
+   * overridden by a class-body method.
+   *
+   * Loaded-chain mode: returns `_storedIds.length` — matches the
+   * re-emitted record count after the `_target` re-order.
+   */
+  async countDeferred(): Promise<number> {
+    if (this._chainWalker) {
+      const { relation } = await this._walkOnce();
+      const merged = this._composeChainedState(relation);
+      const c = await (
+        merged as unknown as { count: () => Promise<number | Record<string, number>> }
+      ).count();
+      if (typeof c !== "number") {
+        throw new Error(
+          "Grouped counts are not supported on DisableJoinsAssociationRelation#countDeferred",
+        );
+      }
+      return c;
+    }
+    return this._storedIds.length;
+  }
+
+  /**
    * Memoize the walker invocation so the async chain walk runs at
    * most once per DJAR instance. Shared by `toArray()` and `ids()`.
    */

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -392,15 +392,19 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * Count via the deferred chain walk without materializing the
    * target rows. Runs the intermediate plucks (cheap; they happen
    * anyway for this shape) then emits a single `SELECT COUNT(*)`
-   * on the final-step Relation. Named `countDeferred` rather than
-   * overriding `count` because Relation's `count` is installed via
-   * the Calculations mixin (property-style) and can't be cleanly
-   * overridden by a class-body method.
+   * on the final-step Relation. Loaded-chain mode returns
+   * `_storedIds.length` — matches the re-emitted record count
+   * after the `_target` re-order.
    *
-   * Loaded-chain mode: returns `_storedIds.length` — matches the
-   * re-emitted record count after the `_target` re-order.
+   * Mirrors Rails' `CollectionAssociation#count` on disable_joins
+   * (which goes through `scope.count` → `records.size` after
+   * loading) — except we skip the materialization since count
+   * doesn't need it. Net: same result, fewer rows hydrated.
    */
-  async countDeferred(): Promise<number> {
+  // @ts-expect-error Relation defines `count` as a property (from
+  //   the calculations mixin); DJAR overrides as an async method
+  //   that runs the deferred chain walk before counting.
+  async count(): Promise<number> {
     if (this._chainWalker) {
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
@@ -409,7 +413,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       ).count();
       if (typeof c !== "number") {
         throw new Error(
-          "Grouped counts are not supported on DisableJoinsAssociationRelation#countDeferred",
+          "Grouped counts are not supported on DisableJoinsAssociationRelation#count",
         );
       }
       return c;


### PR DESCRIPTION
## Summary

Task #22. `CollectionProxy#count` previously fell back to `loadHasMany(...).length` for every `disable_joins: true` through association — the chain walk runs intermediate plucks either way, but the final step would `SELECT *` every target row and call `.length` on the array. On large collections the row-wise SELECT is the expensive part.

### Changes

- **`DisableJoinsAssociationRelation#count(column?)`** — overrides `Relation#count` and runs the deferred chain walker (shared memoized `_walkOnce` with `toArray`), then calls `count(column)` on the final-step relation. Loaded-chain mode delegates to `Relation.prototype.count.call(this, column)` so any composed `limit` / `offset` / `where` / `group` applies. Full `count(column?): Promise<number | Record<string, number>>` signature so grouped counts work too.
- **`CollectionProxy#_djarForCount`** — constructs the DJAR (boxed to defeat `Relation.then`'s toArray-unwrap when the helper is awaited) using the shared `ownerHasUnresolvedThroughKey` guard (extracted from `_loadThroughViaDisableJoinsScope` so the two paths can't drift).
- **`CP#count`** — only takes the DJAR fast path when the proxy state hasn't diverged. If the caller has applied in-place mutations (`whereBang`, `groupBang`, `limitBang`, ...), the existing `Relation.prototype.count.call(this)` path runs instead, honoring the mutations and the grouped-count error.

DJAS' chain walker handles nested-through + disable-joins (PR #668), so the fast path automatically covers both single-level and nested shapes.

### Tests

- Single-level disable-joins through: pins one intermediate pluck + one final `SELECT COUNT(*)`, no row-wise `SELECT *`.
- Nested-through + disable-joins (4-level Author → Posts → Comments → Ratings chain): final step still `COUNT(*)`, no JOIN anywhere.
- Unsaved-owner: returns 0 without firing any SQL (shared `ownerHasUnresolvedThroughKey` guard).

## Test plan

- [x] New `cp-count-disable-joins-through.test.ts` (3 tests)
- [x] Full `@blazetrails/activerecord` suite: 8783 passed
- [ ] PG / MariaDB CI