### PR TITLE
refactor(activerecord): extract save/destroy and bangs to persistence.ts

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1703,7 +1703,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Persistence#save (the super that Transactions#save calls)
    */
-  async _createOrUpdate(): Promise<boolean> {
+  private async _createOrUpdate(): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
     const { autosaveBelongsTo, autosaveChildren } = await import("./autosave-association.js");
 
@@ -1764,8 +1764,8 @@ export class Base extends Model {
     return saved;
   }
 
-  _pendingOperation: Promise<void> | null = null;
-  _skipTouch = false;
+  private _pendingOperation: Promise<void> | null = null;
+  private _skipTouch = false;
 
   private _performInsert(): void {
     const ctor = this.constructor as typeof Base;
@@ -1911,7 +1911,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Persistence#destroy (the super that Transactions#destroy calls)
    */
-  async _destroyRow(): Promise<boolean> {
+  private async _destroyRow(): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -20,20 +20,12 @@ import {
   subclasses as inheritanceSubclasses,
   descendants as inheritanceDescendants,
 } from "./inheritance.js";
-import {
-  RecordNotFound,
-  RecordNotSaved,
-  RecordNotDestroyed,
-  StaleObjectError,
-  ReadOnlyRecord,
-  ConnectionNotDefined,
-} from "./errors.js";
+import { RecordNotFound, StaleObjectError, ConnectionNotDefined } from "./errors.js";
 import { AutosaveAssociation } from "./autosave-association.js";
 import {
   RecordInvalid,
   isValid as validationsIsValid,
   defaultValidationContext,
-  performValidations,
   _setSuperIsValid,
   _setSuperValidates,
 } from "./validations.js";
@@ -1702,46 +1694,7 @@ export class Base extends Model {
    */
   declare static validatesUniqueness: typeof _Validations.validatesUniqueness;
 
-  /**
-   * Save the record. Returns true if successful, false if validation fails.
-   * Raises if the record has been destroyed.
-   *
-   * Mirrors: ActiveRecord::Base#save
-   */
-  async save(options?: { validate?: boolean; touch?: boolean }): Promise<boolean> {
-    if (this._destroyed) {
-      throw new RecordNotSaved(
-        `Cannot save a destroyed ${(this.constructor as typeof Base).name}`,
-        this,
-      );
-    }
-    if (this._readonly) {
-      throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
-    }
-    if (!performValidations.call(this, options)) return false;
-    if (options?.validate !== false) {
-      if (!(await this._runAsyncValidations())) return false;
-    }
-
-    this._skipTouch = options?.touch === false;
-    const ctor = this.constructor as typeof Base;
-
-    // Auto-set STI type column on new records
-    if (this._newRecord && isStiSubclass(ctor)) {
-      const col = getInheritanceColumn(getStiBase(ctor));
-      if (col && !this.readAttribute(col)) {
-        this._attributes.set(col, ctor.name);
-      }
-    }
-
-    // Mirrors: ActiveRecord::Transactions#save
-    const { withTransactionReturningStatus } = await import("./transactions.js");
-    try {
-      return await withTransactionReturningStatus(this, () => this._createOrUpdate());
-    } finally {
-      this._skipTouch = false;
-    }
-  }
+  // save / saveBang extracted to persistence.ts; wired via include() below.
 
   /**
    * The persistence half of save — runs callbacks, performs INSERT or UPDATE,
@@ -1750,7 +1703,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Persistence#save (the super that Transactions#save calls)
    */
-  private async _createOrUpdate(): Promise<boolean> {
+  async _createOrUpdate(): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
     const { autosaveBelongsTo, autosaveChildren } = await import("./autosave-association.js");
 
@@ -1811,21 +1764,8 @@ export class Base extends Model {
     return saved;
   }
 
-  /**
-   * Save the record or throw if validation fails.
-   *
-   * Mirrors: ActiveRecord::Base#save!
-   */
-  async saveBang(): Promise<true> {
-    const result = await this.save();
-    if (!result) {
-      throw new RecordInvalid(this);
-    }
-    return true;
-  }
-
-  private _pendingOperation: Promise<void> | null = null;
-  private _skipTouch = false;
+  _pendingOperation: Promise<void> | null = null;
+  _skipTouch = false;
 
   private _performInsert(): void {
     const ctor = this.constructor as typeof Base;
@@ -1962,22 +1902,7 @@ export class Base extends Model {
 
   // update / updateBang extracted to persistence.ts; wired via include() below.
 
-  /**
-   * Destroy the record. Returns `false` if a beforeDestroy callback
-   * halts the chain, otherwise returns the destroyed record.
-   *
-   * Mirrors: ActiveRecord::Base#destroy
-   */
-  async destroy(): Promise<this | false> {
-    if (this._readonly) {
-      throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
-    }
-
-    // Mirrors: ActiveRecord::Transactions#destroy
-    const { withTransactionReturningStatus } = await import("./transactions.js");
-    const result = await withTransactionReturningStatus(this, () => this._destroyRow());
-    return result ? this : false;
-  }
+  // destroy / destroyBang extracted to persistence.ts; wired via include() below.
 
   /**
    * The persistence half of destroy — runs callbacks, performs DELETE,
@@ -1986,7 +1911,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Persistence#destroy (the super that Transactions#destroy calls)
    */
-  private async _destroyRow(): Promise<boolean> {
+  async _destroyRow(): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
@@ -2033,19 +1958,6 @@ export class Base extends Model {
     }
 
     return true;
-  }
-
-  /**
-   * Destroy the record or throw.
-   *
-   * Mirrors: ActiveRecord::Base#destroy!
-   */
-  async destroyBang(): Promise<this> {
-    const result = await this.destroy();
-    if (result === false) {
-      throw new RecordNotDestroyed("Failed to destroy the record", this);
-    }
-    return result;
   }
 
   // delete extracted to persistence.ts; wired via include() below.
@@ -2350,6 +2262,10 @@ export interface Base extends Included<typeof AutosaveAssociation> {
     options?: { touch?: boolean | string | string[] },
   ): Promise<this>;
   toggleBang(attribute: string): Promise<boolean>;
+  save(options?: { validate?: boolean; touch?: boolean }): Promise<boolean>;
+  saveBang(): Promise<true>;
+  destroy(): Promise<this | false>;
+  destroyBang(): Promise<this>;
   update(attrs: Record<string, unknown>): Promise<boolean>;
   updateBang(attrs: Record<string, unknown>): Promise<true>;
   delete(): Promise<this>;
@@ -2419,6 +2335,10 @@ include(Base, {
   incrementBang: _Persistence.incrementBang,
   decrementBang: _Persistence.decrementBang,
   toggleBang: _Persistence.toggleBang,
+  save: _Persistence.save,
+  saveBang: _Persistence.saveBang,
+  destroy: _Persistence.destroy,
+  destroyBang: _Persistence.destroyBang,
   update: _Persistence.update,
   updateBang: _Persistence.updateBang,
   delete: _Persistence.deleteRow,

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -492,8 +492,11 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
 
 // ---------------------------------------------------------------------------
 // save / save! / destroy / destroy! — the callback- and transaction-wrapped
-// entry points. The private helpers they rely on (_createOrUpdate,
-// _destroyRow, _performInsert, _performUpdate) remain on Base.
+// entry points. They rely on Base-provided internal helpers/state
+// (_createOrUpdate, _destroyRow, _performInsert, _performUpdate,
+// _skipTouch, _pendingOperation) which remain `private` on Base; the
+// extracted functions reach them through `(this as any)` since those
+// members intentionally aren't part of the public Persistence API.
 // Mirrors ActiveRecord::Persistence#save, #save!, #destroy, #destroy!
 // (merged with Transactions#save / #destroy and Validations#save which, in
 // Rails, override the same method through module layering).
@@ -503,10 +506,7 @@ interface SaveRecord {
   _destroyed: boolean;
   _readonly: boolean;
   _newRecord: boolean;
-  _skipTouch: boolean;
   _attributes: { set(key: string, val: unknown): void };
-  _runAsyncValidations(): Promise<boolean>;
-  _createOrUpdate(): Promise<boolean>;
   readAttribute(name: string): unknown;
   constructor: {
     name: string;
@@ -533,11 +533,12 @@ export async function save<T extends SaveRecord>(
     throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
   }
   if (!performValidations.call(this, options)) return false;
+  const self = this as any;
   if (options?.validate !== false) {
-    if (!(await this._runAsyncValidations())) return false;
+    if (!(await self._runAsyncValidations())) return false;
   }
 
-  this._skipTouch = options?.touch === false;
+  self._skipTouch = options?.touch === false;
   const ctor = this.constructor as unknown as Parameters<typeof isStiSubclass>[0];
 
   // Auto-set STI type column on new records
@@ -551,9 +552,9 @@ export async function save<T extends SaveRecord>(
   // Mirrors: ActiveRecord::Transactions#save
   const { withTransactionReturningStatus } = await import("./transactions.js");
   try {
-    return await withTransactionReturningStatus(this as any, () => this._createOrUpdate());
+    return await withTransactionReturningStatus(self, () => self._createOrUpdate());
   } finally {
-    this._skipTouch = false;
+    self._skipTouch = false;
   }
 }
 
@@ -570,7 +571,6 @@ export async function saveBang<
 
 interface DestroyRecord {
   _readonly: boolean;
-  _destroyRow(): Promise<boolean>;
   constructor: { name: string };
 }
 
@@ -582,7 +582,8 @@ export async function destroy<T extends DestroyRecord>(this: T): Promise<T | fal
 
   // Mirrors: ActiveRecord::Transactions#destroy
   const { withTransactionReturningStatus } = await import("./transactions.js");
-  const result = await withTransactionReturningStatus(this as any, () => this._destroyRow());
+  const self = this as any;
+  const result = await withTransactionReturningStatus(self, () => self._destroyRow());
   return result ? this : false;
 }
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -15,12 +15,14 @@ import {
 import {
   AttributeAssignmentError,
   ReadOnlyRecord,
+  RecordNotDestroyed,
   RecordNotFound,
   RecordNotSaved,
   UnknownAttributeError,
 } from "./errors.js";
 import { clearAutosaveState } from "./autosave-association.js";
 import { getStiBase, getInheritanceColumn, isStiSubclass } from "./inheritance.js";
+import { RecordInvalid, performValidations } from "./validations.js";
 
 interface PersistenceHost {
   new (attrs?: Record<string, unknown>): any;
@@ -486,6 +488,113 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
   this._previouslyNewRecord = false;
   this.freeze();
   return this;
+}
+
+// ---------------------------------------------------------------------------
+// save / save! / destroy / destroy! — the callback- and transaction-wrapped
+// entry points. The private helpers they rely on (_createOrUpdate,
+// _destroyRow, _performInsert, _performUpdate) remain on Base.
+// Mirrors ActiveRecord::Persistence#save, #save!, #destroy, #destroy!
+// (merged with Transactions#save / #destroy and Validations#save which, in
+// Rails, override the same method through module layering).
+// ---------------------------------------------------------------------------
+
+interface SaveRecord {
+  _destroyed: boolean;
+  _readonly: boolean;
+  _newRecord: boolean;
+  _skipTouch: boolean;
+  _attributes: { set(key: string, val: unknown): void };
+  _runAsyncValidations(): Promise<boolean>;
+  _createOrUpdate(): Promise<boolean>;
+  readAttribute(name: string): unknown;
+  constructor: {
+    name: string;
+    _attributeDefinitions: Map<string, unknown>;
+  };
+}
+
+/**
+ * Mirrors: ActiveRecord::Base#save — runs validations, opens a
+ * transaction-returning-status, and delegates the insert/update to
+ * `_createOrUpdate` (Rails' Persistence#save super).
+ */
+export async function save<T extends SaveRecord>(
+  this: T,
+  options?: { validate?: boolean; touch?: boolean },
+): Promise<boolean> {
+  if (this._destroyed) {
+    throw new RecordNotSaved(
+      `Cannot save a destroyed ${this.constructor.name}`,
+      this as unknown as object,
+    );
+  }
+  if (this._readonly) {
+    throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
+  }
+  if (!performValidations.call(this, options)) return false;
+  if (options?.validate !== false) {
+    if (!(await this._runAsyncValidations())) return false;
+  }
+
+  this._skipTouch = options?.touch === false;
+  const ctor = this.constructor as unknown as Parameters<typeof isStiSubclass>[0];
+
+  // Auto-set STI type column on new records
+  if (this._newRecord && isStiSubclass(ctor)) {
+    const col = getInheritanceColumn(getStiBase(ctor));
+    if (col && !this.readAttribute(col)) {
+      this._attributes.set(col, this.constructor.name);
+    }
+  }
+
+  // Mirrors: ActiveRecord::Transactions#save
+  const { withTransactionReturningStatus } = await import("./transactions.js");
+  try {
+    return await withTransactionReturningStatus(this as any, () => this._createOrUpdate());
+  } finally {
+    this._skipTouch = false;
+  }
+}
+
+/** Mirrors: ActiveRecord::Base#save! */
+export async function saveBang<
+  T extends SaveRecord & { save(o?: { validate?: boolean; touch?: boolean }): Promise<boolean> },
+>(this: T): Promise<true> {
+  const result = await this.save();
+  if (!result) {
+    throw new RecordInvalid(this as unknown as object);
+  }
+  return true;
+}
+
+interface DestroyRecord {
+  _readonly: boolean;
+  _destroyRow(): Promise<boolean>;
+  constructor: { name: string };
+}
+
+/** Mirrors: ActiveRecord::Base#destroy */
+export async function destroy<T extends DestroyRecord>(this: T): Promise<T | false> {
+  if (this._readonly) {
+    throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
+  }
+
+  // Mirrors: ActiveRecord::Transactions#destroy
+  const { withTransactionReturningStatus } = await import("./transactions.js");
+  const result = await withTransactionReturningStatus(this as any, () => this._destroyRow());
+  return result ? this : false;
+}
+
+/** Mirrors: ActiveRecord::Base#destroy! */
+export async function destroyBang<T extends DestroyRecord & { destroy(): Promise<T | false> }>(
+  this: T,
+): Promise<T> {
+  const result = await this.destroy();
+  if (result === false) {
+    throw new RecordNotDestroyed("Failed to destroy the record", this as unknown as object);
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moves \`save\`, \`saveBang\`, \`destroy\`, \`destroyBang\` from \`base.ts\` into \`persistence.ts\` as \`this\`-typed module functions, wired onto \`Base\` via \`include()\` (matching Rails' source layout — these live in \`ActiveRecord::Persistence\`, merged with the \`Transactions\`/\`Validations\` overrides).
- Private implementation helpers (\`_createOrUpdate\`, \`_destroyRow\`, \`_performInsert\`, \`_performUpdate\`, \`_pendingOperation\`, \`_skipTouch\`) remain on \`Base\`. They're not part of Rails' public \`Persistence\` API and reference a wide surface of private instance state; moving just the public boundary keeps the diff focused without sacrificing fidelity.
- Adds method signatures to the merged \`interface Base\` so subclass call-sites keep their types.

## Test plan

- [x] \`pnpm run build\`
- [x] \`pnpm vitest run packages/activerecord\` — 237 files, 8787 passed
- [x] \`pnpm run api:compare\` — \`persistence.rb\` stays at 100%