### PR TITLE
feat(activerecord): delegate any?/many?/one?/empty? from Base to all

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1491,6 +1491,10 @@ export class Base extends Model {
   declare static exists: typeof Querying.exists;
   declare static findOrCreateBy: typeof Querying.findOrCreateBy;
   declare static findOrInitializeBy: typeof Querying.findOrInitializeBy;
+  declare static isAny: typeof Querying.isAny;
+  declare static isMany: typeof Querying.isMany;
+  declare static isOne: typeof Querying.isOne;
+  declare static isEmpty: typeof Querying.isEmpty;
 
   /**
    * Increment counter columns for a record by primary key.

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -4523,6 +4523,46 @@ describe("CalculationsTest", () => {
     expect(await Topic.all().isMany()).toBe(true);
   });
 
+  // Rails: test "one?"
+  it("isOne returns true for exactly one record", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    expect(await Topic.isOne()).toBe(false);
+    await Topic.create({ title: "A" });
+    expect(await Topic.isOne()).toBe(true);
+    await Topic.create({ title: "B" });
+    expect(await Topic.isOne()).toBe(false);
+  });
+
+  // Rails: test Base.any? / .many? / .empty? delegate to all
+  it("Base.isAny / isMany / isEmpty delegate through all()", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    expect(await Topic.isEmpty()).toBe(true);
+    expect(await Topic.isAny()).toBe(false);
+    expect(await Topic.isMany()).toBe(false);
+    await Topic.create({ title: "A" });
+    expect(await Topic.isEmpty()).toBe(false);
+    expect(await Topic.isAny()).toBe(true);
+    expect(await Topic.isMany()).toBe(false);
+    await Topic.create({ title: "B" });
+    expect(await Topic.isMany()).toBe(true);
+  });
+
   // =====================================================================
   // inspect — activerecord/test/cases/base_test.rb
   // =====================================================================

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -463,3 +463,33 @@ export function findOrInitializeBy<T extends typeof Base>(
 ): Promise<InstanceType<T>> {
   return this.all().findOrInitializeBy(conditions, extra);
 }
+
+/**
+ * Mirrors: ActiveRecord::Querying#any? — delegates to all().any?
+ */
+export function isAny<T extends typeof Base>(this: T): Promise<boolean> {
+  return this.all().isAny();
+}
+
+/**
+ * Mirrors: ActiveRecord::Querying#many? — delegates to all().many?
+ */
+export function isMany<T extends typeof Base>(this: T): Promise<boolean> {
+  return this.all().isMany();
+}
+
+/**
+ * Mirrors: ActiveRecord::Querying#one? — delegates to all().one?
+ */
+export function isOne<T extends typeof Base>(this: T): Promise<boolean> {
+  return this.all().isOne();
+}
+
+/**
+ * Mirrors: ActiveRecord::Querying#empty? — delegates to all().empty?.
+ * Rails' `none?` (no block/args) falls through to `empty?`, so this
+ * predicate also covers that semantic.
+ */
+export function isEmpty<T extends typeof Base>(this: T): Promise<boolean> {
+  return this.all().isEmpty();
+}

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -486,7 +486,7 @@ export function isOne<T extends typeof Base>(this: T): Promise<boolean> {
 }
 
 /**
- * Mirrors: ActiveRecord::Querying#empty? — delegates to all().empty?.
+ * Mirrors: ActiveRecord::Querying#empty? — delegates to `all().empty?`.
  * Rails' `none?` (no block/args) falls through to `empty?`, so this
  * predicate also covers that semantic.
  */


### PR DESCRIPTION
## Summary

- Adds \`Base.isAny\`, \`Base.isMany\`, \`Base.isOne\`, \`Base.isEmpty\` as thin \`this.all()\` delegators in \`querying.ts\`, matching Rails' \`delegate(*QUERYING_METHODS, to: :all)\`.
- Rails' \`FinderMethods#none?\` (no block/args) falls through to \`empty?\`, so \`isEmpty\` covers both. We preserve the existing \`Relation#isNone()\` sync predicate for the \`.none\` scope-applied check.
- Adds Base-level regression tests covering \`isOne\` and the four delegators under the empty / one-record / many-records transitions.

## Test plan

- [x] \`pnpm vitest run packages/activerecord\` — 237 files, 8789 passed
- [x] \`pnpm run api:compare\` — querying.rb stays at 100%