### PR TITLE
feat(activerecord): remaining Rails QUERYING_METHODS delegators + exists string/array

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1487,6 +1487,12 @@ export class Base extends Model {
   declare static isMany: typeof Querying.isMany;
   declare static isOne: typeof Querying.isOne;
   declare static isEmpty: typeof Querying.isEmpty;
+  declare static firstOrCreate: typeof Querying.firstOrCreate;
+  declare static firstOrCreateBang: typeof Querying.firstOrCreateBang;
+  declare static firstOrInitialize: typeof Querying.firstOrInitialize;
+  declare static findEach: typeof Querying.findEach;
+  declare static findInBatches: typeof Querying.findInBatches;
+  declare static inBatches: typeof Querying.inBatches;
 
   /**
    * Increment counter columns for a record by primary key.

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6958,6 +6958,17 @@ describe("CalculationsTest", () => {
     it("returns false for empty result set", async () => {
       expect(await Product.all().where({ category: "meat" }).exists()).toBe(false);
     });
+
+    // Rails FinderMethods#exists? accepts a raw SQL string or [sql, ...binds]
+    it("accepts a string SQL condition", async () => {
+      expect(await Product.all().exists("price > 0")).toBe(true);
+      expect(await Product.all().exists("price < 0")).toBe(false);
+    });
+
+    it("accepts a [sql, ...binds] array condition", async () => {
+      expect(await Product.all().exists(["price > ?", 0])).toBe(true);
+      expect(await Product.all().exists(["price > ?", 100])).toBe(false);
+    });
   });
 
   describe("count via class method", async () => {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6977,6 +6977,94 @@ describe("CalculationsTest", () => {
     });
   });
 
+  // Rails' Querying delegators route through `all()`, so class-level calls
+  // inherit default scopes / active scoping's createWith + where attrs.
+  // These regressions lock in that behavior for the firstOr* / batch
+  // entry points added alongside the exists arg-form changes.
+  // Rails' Querying delegators route through `all()`, so class-level calls
+  // inherit default scopes / active scoping's createWith + where attrs.
+  // These regressions lock in that behavior for the firstOr* / batch
+  // entry points added alongside the exists arg-form changes.
+  const makeTopicClass = () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+    return Topic;
+  };
+
+  it("Base.firstOrCreate inherits createWith attrs from currentScope", async () => {
+    const Topic = makeTopicClass();
+    let captured: InstanceType<typeof Topic> | null = null;
+    await Topic.all()
+      .createWith({ status: "scoped-default" })
+      .scoping(async () => {
+        captured = await Topic.firstOrCreate({ title: "via-class-firstOrCreate" });
+      });
+    if (captured === null) throw new Error("Expected topic to be present");
+    const topic = captured as InstanceType<typeof Topic>;
+    expect(topic.status).toBe("scoped-default");
+    expect(topic.title).toBe("via-class-firstOrCreate");
+  });
+
+  it("Base.firstOrInitialize inherits where-scope attrs from currentScope", async () => {
+    const Topic = makeTopicClass();
+    let captured: InstanceType<typeof Topic> | null = null;
+    // `where({title: ...})` seeds scope_for_create with that equality attr,
+    // which the initialized record should pick up when no match exists.
+    await Topic.all()
+      .where({ title: "to-be-initialized", status: "draft" })
+      .scoping(async () => {
+        captured = await Topic.firstOrInitialize();
+      });
+    if (captured === null) throw new Error("Expected topic to be present");
+    const topic = captured as InstanceType<typeof Topic>;
+    expect(topic.isNewRecord()).toBe(true);
+    expect(topic.title).toBe("to-be-initialized");
+    expect(topic.status).toBe("draft");
+  });
+
+  it("Base.findEach iterates the default scope via all()", async () => {
+    const Topic = makeTopicClass();
+    await Topic.create({ title: "a" });
+    await Topic.create({ title: "b" });
+    await Topic.create({ title: "c" });
+    const seen: string[] = [];
+    for await (const t of Topic.findEach({ batchSize: 2 })) {
+      seen.push(t.title as string);
+    }
+    expect(seen.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("Base.findInBatches yields arrays sized to batchSize", async () => {
+    const Topic = makeTopicClass();
+    await Topic.create({ title: "a" });
+    await Topic.create({ title: "b" });
+    await Topic.create({ title: "c" });
+    const batches: number[] = [];
+    for await (const batch of Topic.findInBatches({ batchSize: 2 })) {
+      batches.push(batch.length);
+    }
+    expect(batches).toEqual([2, 1]);
+  });
+
+  it("Base.inBatches returns a BatchEnumerator scoped to all()", async () => {
+    const Topic = makeTopicClass();
+    await Topic.create({ title: "a" });
+    await Topic.create({ title: "b" });
+    const titles: string[] = [];
+    for await (const relBatch of Topic.inBatches({ batchSize: 1 })) {
+      const records = await relBatch.toArray();
+      for (const t of records) titles.push(t.title as string);
+    }
+    expect(titles.sort()).toEqual(["a", "b"]);
+  });
+
   describe("count via class method", async () => {
     it("delegates to relation", async () => {
       expect(await Product.count()).toBe(4);

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6959,15 +6959,23 @@ describe("CalculationsTest", () => {
       expect(await Product.all().where({ category: "meat" }).exists()).toBe(false);
     });
 
-    // Rails FinderMethods#exists? accepts a raw SQL string or [sql, ...binds]
-    it("accepts a string SQL condition", async () => {
-      expect(await Product.all().exists("price > 0")).toBe(true);
-      expect(await Product.all().exists("price < 0")).toBe(false);
+    // Rails FinderMethods#exists? treats Array as a condition spec —
+    // [sql, ...binds] routes through where() as a SQL fragment. Bare strings
+    // fall to the PK-lookup branch (see Rails' construct_relation_for_exists),
+    // so string ids / UUID PKs stay unambiguous.
+    it("accepts a [sql] single-element array condition", async () => {
+      expect(await Product.all().exists(["price > 0"])).toBe(true);
+      expect(await Product.all().exists(["price < 0"])).toBe(false);
     });
 
     it("accepts a [sql, ...binds] array condition", async () => {
       expect(await Product.all().exists(["price > ?", 0])).toBe(true);
       expect(await Product.all().exists(["price > ?", 100])).toBe(false);
+    });
+
+    it("treats a bare string argument as a primary-key lookup", async () => {
+      // With no matching PK, returns false (not SQL-parsed).
+      expect(await Product.all().exists("not-a-real-pk")).toBe(false);
     });
 
     // Rails: `return false if !conditions` — false/null short-circuits
@@ -6977,10 +6985,6 @@ describe("CalculationsTest", () => {
     });
   });
 
-  // Rails' Querying delegators route through `all()`, so class-level calls
-  // inherit default scopes / active scoping's createWith + where attrs.
-  // These regressions lock in that behavior for the firstOr* / batch
-  // entry points added alongside the exists arg-form changes.
   // Rails' Querying delegators route through `all()`, so class-level calls
   // inherit default scopes / active scoping's createWith + where attrs.
   // These regressions lock in that behavior for the firstOr* / batch

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6969,6 +6969,12 @@ describe("CalculationsTest", () => {
       expect(await Product.all().exists(["price > ?", 0])).toBe(true);
       expect(await Product.all().exists(["price > ?", 100])).toBe(false);
     });
+
+    // Rails: `return false if !conditions` — false/null short-circuits
+    it("returns false immediately for a false/null condition", async () => {
+      expect(await Product.all().exists(false)).toBe(false);
+      expect(await Product.all().exists(null)).toBe(false);
+    });
   });
 
   describe("count via class method", async () => {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6974,8 +6974,11 @@ describe("CalculationsTest", () => {
     });
 
     it("treats a bare string argument as a primary-key lookup", async () => {
-      // With no matching PK, returns false (not SQL-parsed).
-      expect(await Product.all().exists("not-a-real-pk")).toBe(false);
+      // A numeric-looking string that doesn't match any existing row.
+      // Proves the PK-lookup branch (not SQL parsing): if the arg were
+      // treated as a SQL fragment we'd get true back (every row has price),
+      // and DBs with strict integer PKs would error on non-numeric strings.
+      expect(await Product.all().exists("999999999")).toBe(false);
     });
 
     // Rails: `return false if !conditions` — false/null short-circuits

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -497,25 +497,29 @@ export function isEmpty<T extends typeof Base>(this: T): Promise<boolean> {
 /** Mirrors: ActiveRecord::Querying#first_or_create — delegates through all(). */
 export function firstOrCreate<T extends typeof Base>(
   this: T,
-  extra?: Record<string, unknown>,
-): Promise<InstanceType<T>> {
-  return this.all().firstOrCreate(extra) as Promise<InstanceType<T>>;
+  extra?: Parameters<ReturnType<T["all"]>["firstOrCreate"]>[0],
+): ReturnType<ReturnType<T["all"]>["firstOrCreate"]> {
+  return this.all().firstOrCreate(extra) as ReturnType<ReturnType<T["all"]>["firstOrCreate"]>;
 }
 
 /** Mirrors: ActiveRecord::Querying#first_or_create! — delegates through all(). */
 export function firstOrCreateBang<T extends typeof Base>(
   this: T,
-  extra?: Record<string, unknown>,
-): Promise<InstanceType<T>> {
-  return this.all().firstOrCreateBang(extra) as Promise<InstanceType<T>>;
+  extra?: Parameters<ReturnType<T["all"]>["firstOrCreateBang"]>[0],
+): ReturnType<ReturnType<T["all"]>["firstOrCreateBang"]> {
+  return this.all().firstOrCreateBang(extra) as ReturnType<
+    ReturnType<T["all"]>["firstOrCreateBang"]
+  >;
 }
 
 /** Mirrors: ActiveRecord::Querying#first_or_initialize — delegates through all(). */
 export function firstOrInitialize<T extends typeof Base>(
   this: T,
-  extra?: Record<string, unknown>,
-): Promise<InstanceType<T>> {
-  return this.all().firstOrInitialize(extra) as Promise<InstanceType<T>>;
+  extra?: Parameters<ReturnType<T["all"]>["firstOrInitialize"]>[0],
+): ReturnType<ReturnType<T["all"]>["firstOrInitialize"]> {
+  return this.all().firstOrInitialize(extra) as ReturnType<
+    ReturnType<T["all"]>["firstOrInitialize"]
+  >;
 }
 
 /** Mirrors: ActiveRecord::Querying#find_each — delegates through all(). */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -493,3 +493,51 @@ export function isOne<T extends typeof Base>(this: T): Promise<boolean> {
 export function isEmpty<T extends typeof Base>(this: T): Promise<boolean> {
   return this.all().isEmpty();
 }
+
+/** Mirrors: ActiveRecord::Querying#first_or_create — delegates through all(). */
+export function firstOrCreate<T extends typeof Base>(
+  this: T,
+  extra?: Record<string, unknown>,
+): Promise<InstanceType<T>> {
+  return this.all().firstOrCreate(extra) as Promise<InstanceType<T>>;
+}
+
+/** Mirrors: ActiveRecord::Querying#first_or_create! — delegates through all(). */
+export function firstOrCreateBang<T extends typeof Base>(
+  this: T,
+  extra?: Record<string, unknown>,
+): Promise<InstanceType<T>> {
+  return this.all().firstOrCreateBang(extra) as Promise<InstanceType<T>>;
+}
+
+/** Mirrors: ActiveRecord::Querying#first_or_initialize — delegates through all(). */
+export function firstOrInitialize<T extends typeof Base>(
+  this: T,
+  extra?: Record<string, unknown>,
+): Promise<InstanceType<T>> {
+  return this.all().firstOrInitialize(extra) as Promise<InstanceType<T>>;
+}
+
+/** Mirrors: ActiveRecord::Querying#find_each — delegates through all(). */
+export function findEach<T extends typeof Base>(
+  this: T,
+  opts?: Parameters<ReturnType<T["all"]>["findEach"]>[0],
+): ReturnType<ReturnType<T["all"]>["findEach"]> {
+  return this.all().findEach(opts) as ReturnType<ReturnType<T["all"]>["findEach"]>;
+}
+
+/** Mirrors: ActiveRecord::Querying#find_in_batches — delegates through all(). */
+export function findInBatches<T extends typeof Base>(
+  this: T,
+  opts?: Parameters<ReturnType<T["all"]>["findInBatches"]>[0],
+): ReturnType<ReturnType<T["all"]>["findInBatches"]> {
+  return this.all().findInBatches(opts) as ReturnType<ReturnType<T["all"]>["findInBatches"]>;
+}
+
+/** Mirrors: ActiveRecord::Querying#in_batches — delegates through all(). */
+export function inBatches<T extends typeof Base>(
+  this: T,
+  opts?: Parameters<ReturnType<T["all"]>["inBatches"]>[0],
+): ReturnType<ReturnType<T["all"]>["inBatches"]> {
+  return this.all().inBatches(opts) as ReturnType<ReturnType<T["all"]>["inBatches"]>;
+}

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1968,11 +1968,27 @@ export class Relation<T extends Base> {
       // the PK-lookup branch; only Array / Hash become condition specs.
       if (Array.isArray(conditions)) {
         // Array form: [sql, ...binds] — delegate to where's string+binds overload.
-        rel = this.where(conditions[0] as string, ...(conditions.slice(1) as unknown[]));
+        // Reject malformed arrays (empty / non-string head) up front so we
+        // don't fall into where(undefined) which returns a WhereChain and
+        // crashes downstream when we read rel._modelClass.
+        if (conditions.length === 0 || typeof conditions[0] !== "string") {
+          throw new Error(
+            "Relation#exists array conditions must be [sql, ...binds] with a SQL string as the first element",
+          );
+        }
+        rel = this.where(conditions[0], ...(conditions.slice(1) as unknown[]));
       } else if (typeof conditions === "object" && conditions !== null) {
         rel = this.where(conditions as Record<string, unknown>);
       } else {
-        rel = this.where({ [this._modelClass.primaryKey as string]: conditions });
+        // Primary-key lookup. Honor composite primary keys by routing
+        // through _buildPkWhereNode; Rails' construct_relation_for_exists
+        // reaches the same branch via where(primary_key => conditions).
+        const pk = this._modelClass.primaryKey;
+        if (Array.isArray(pk)) {
+          rel = this.where(this._modelClass._buildPkWhereNode(conditions));
+        } else {
+          rel = this.where({ [pk]: conditions });
+        }
       }
     }
     // Mirrors Rails' `SELECT 1 AS one FROM ... LIMIT 1`: a dedicated

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1954,6 +1954,9 @@ export class Relation<T extends Base> {
    */
   async exists(conditions?: Record<string, unknown> | unknown): Promise<boolean> {
     if (this._isNone) return false;
+    // Rails FinderMethods#exists?: `return false if !conditions` — treats an
+    // explicit `false` / `null` argument as "no match possible".
+    if (conditions === false || conditions === null) return false;
     let rel: Relation<T> = this;
     if (conditions !== undefined) {
       // Mirrors Rails' FinderMethods#exists? argument handling:

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1956,10 +1956,21 @@ export class Relation<T extends Base> {
     if (this._isNone) return false;
     let rel: Relation<T> = this;
     if (conditions !== undefined) {
-      if (typeof conditions === "object" && conditions !== null && !Array.isArray(conditions)) {
+      // Mirrors Rails' FinderMethods#exists? argument handling:
+      //   - Hash → where(conditions)
+      //   - String or [sql, ...binds] → where(sql, ...binds) (SQL fragment)
+      //   - Anything else (Integer/String PK, Array of PKs) → where(pk: ...)
+      if (Array.isArray(conditions) && typeof conditions[0] === "string") {
+        rel = this.where(conditions[0] as string, ...(conditions.slice(1) as unknown[]));
+      } else if (typeof conditions === "string") {
+        rel = this.where(conditions);
+      } else if (
+        typeof conditions === "object" &&
+        conditions !== null &&
+        !Array.isArray(conditions)
+      ) {
         rel = this.where(conditions as Record<string, unknown>);
       } else {
-        // Primary key lookup
         rel = this.where({ [this._modelClass.primaryKey as string]: conditions });
       }
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1959,19 +1959,17 @@ export class Relation<T extends Base> {
     if (conditions === false || conditions === null) return false;
     let rel: Relation<T> = this;
     if (conditions !== undefined) {
-      // Mirrors Rails' FinderMethods#exists? argument handling:
-      //   - Hash → where(conditions)
-      //   - String or [sql, ...binds] → where(sql, ...binds) (SQL fragment)
-      //   - Anything else (Integer/String PK, Array of PKs) → where(pk: ...)
-      if (Array.isArray(conditions) && typeof conditions[0] === "string") {
+      // Mirrors Rails' FinderMethods#exists? argument handling
+      // (construct_relation_for_exists):
+      //   case conditions
+      //   when Array, Hash → where!(conditions)
+      //   else             → where!(primary_key => conditions)
+      // So strings, numbers, and UUID-shaped PK values all route through
+      // the PK-lookup branch; only Array / Hash become condition specs.
+      if (Array.isArray(conditions)) {
+        // Array form: [sql, ...binds] — delegate to where's string+binds overload.
         rel = this.where(conditions[0] as string, ...(conditions.slice(1) as unknown[]));
-      } else if (typeof conditions === "string") {
-        rel = this.where(conditions);
-      } else if (
-        typeof conditions === "object" &&
-        conditions !== null &&
-        !Array.isArray(conditions)
-      ) {
+      } else if (typeof conditions === "object" && conditions !== null) {
         rel = this.where(conditions as Record<string, unknown>);
       } else {
         rel = this.where({ [this._modelClass.primaryKey as string]: conditions });


### PR DESCRIPTION
## Summary

Closes the remaining Rails `delegate(*QUERYING_METHODS, to: :all)` gaps on `Base`:

- **firstOrCreate / firstOrCreateBang / firstOrInitialize** — thin `this.all()` delegators.
- **findEach / findInBatches / inBatches** — delegators derive `Parameters` / `ReturnType` from the Relation methods so the `AsyncGenerator` / `BatchEnumerator` return shapes flow through.

Also tightens `Relation#exists` argument handling to match Rails' `FinderMethods#construct_relation_for_exists`:

- `false` / `null` → short-circuit return `false` (Rails' `return false if !conditions`).
- `Hash` → `where(conditions)`.
- `Array` → `[sql, ...binds]` SQL-fragment form; malformed arrays (empty / non-string head) throw with a descriptive message.
- Anything else (numbers, **strings including UUID/slug PKs**, etc.) → primary-key lookup via `where(pk => conditions)`. Composite PKs route through `_buildPkWhereNode`.

Bare strings are **not** treated as SQL fragments — that matches Rails and keeps string-PK lookups unambiguous.

Tasks #3 (touchAll) and #4 (findBySql/countBySql) were already wired on an earlier PR — verified during this audit. Task #8 (calc return-type audit) also confirmed clean: count/minimum/maximum/average/sum/pluck/pick all derive types from `ReturnType<T["all"]>[fn]`.

## Test plan

- [x] `pnpm vitest run packages/activerecord` — 238 files passing
- [x] `pnpm run api:compare` — querying.rb 100%, finder_methods.rb 100%
- [x] Base-level regression tests for every new delegator exercise `Topic.firstOrCreate / firstOrInitialize / findEach / findInBatches / inBatches` through scoping to lock in `delegate ... to: :all` semantics.