### PR TITLE
fix(activerecord): Relation#build/create/firstOrInitialize honor createWith

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -51,7 +51,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * Mirrors: ActiveRecord::AssociationRelation#_new / #build
    */
   build(attrs: Record<string, unknown> = {}): T {
-    const merged = { ...this._scopeAttributes(), ...attrs };
+    const merged = { ...this.scopeForCreate(), ...attrs };
     return this._association.build(merged) as T;
   }
 
@@ -61,7 +61,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * Mirrors: ActiveRecord::AssociationRelation#_create / #create
    */
   async create(attrs: Record<string, unknown> = {}): Promise<T> {
-    const merged = { ...this._scopeAttributes(), ...attrs };
+    const merged = { ...this.scopeForCreate(), ...attrs };
     return this._association.create(merged) as Promise<T>;
   }
 
@@ -74,7 +74,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * Mirrors: ActiveRecord::AssociationRelation#_create! / #create!
    */
   async createBang(attrs: Record<string, unknown> = {}): Promise<T> {
-    const merged = { ...this._scopeAttributes(), ...attrs };
+    const merged = { ...this.scopeForCreate(), ...attrs };
     return this._association.createBang(merged) as Promise<T>;
   }
 

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -676,6 +676,15 @@ describe("CollectionProxy", () => {
     expect(player.team_id).toBe(team.id);
   });
 
+  it("AssociationRelation#createBang honors createWith defaults", async () => {
+    const team = await Team.create({ name: "Bulls" });
+    const proxy = association(team, "players");
+    const player = await proxy.createWith({ name: "rookie!" }).createBang({});
+    expect(player.isPersisted()).toBe(true);
+    expect(player.name).toBe("rookie!");
+    expect(player.team_id).toBe(team.id);
+  });
+
   // Rails: test_count
   it("test_count", async () => {
     const team = await Team.create({ name: "Bulls" });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -656,6 +656,26 @@ describe("CollectionProxy", () => {
     expect(player.team_id).toBe(team.id);
   });
 
+  // AssociationRelation#build/create must honor createWith via
+  // scope_for_create (blog.posts.createWith(...).build/create).
+  it("AssociationRelation#build honors createWith defaults", async () => {
+    const team = await Team.create({ name: "Bulls" });
+    const proxy = association(team, "players");
+    const player = proxy.createWith({ name: "rookie" }).build({});
+    expect(player.isNewRecord()).toBe(true);
+    expect(player.name).toBe("rookie");
+    expect(player.team_id).toBe(team.id);
+  });
+
+  it("AssociationRelation#create honors createWith defaults", async () => {
+    const team = await Team.create({ name: "Bulls" });
+    const proxy = association(team, "players");
+    const player = await proxy.createWith({ name: "rookie" }).create({});
+    expect(player.isPersisted()).toBe(true);
+    expect(player.name).toBe("rookie");
+    expect(player.team_id).toBe(team.id);
+  });
+
   // Rails: test_count
   it("test_count", async () => {
     const team = await Team.create({ name: "Bulls" });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -23,7 +23,6 @@ import {
 import { RecordNotFound, StaleObjectError, ConnectionNotDefined } from "./errors.js";
 import { AutosaveAssociation } from "./autosave-association.js";
 import {
-  RecordInvalid,
   isValid as validationsIsValid,
   defaultValidationContext,
   _setSuperIsValid,
@@ -1355,18 +1354,16 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.create_or_find_by
    */
-  static async createOrFindBy<T extends typeof Base>(
+  static createOrFindBy<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
   ): Promise<InstanceType<T>> {
-    try {
-      return await this.create({ ...conditions, ...extra });
-    } catch {
-      const record = await this.findBy(conditions);
-      if (record) return record;
-      throw new RecordNotFound(`${this.name} not found`, this.name);
-    }
+    // Rails: `delegate :create_or_find_by, to: :all`. Routing through all()
+    // picks up the current scope + uses the narrow RecordNotUnique retry
+    // Relation#createOrFindBy implements, so validation failures and
+    // other adapter errors propagate unchanged.
+    return this.all().createOrFindBy(conditions, extra) as Promise<InstanceType<T>>;
   }
 
   /**
@@ -1375,19 +1372,12 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.create_or_find_by!
    */
-  static async createOrFindByBang<T extends typeof Base>(
+  static createOrFindByBang<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
   ): Promise<InstanceType<T>> {
-    try {
-      return await this.createBang({ ...conditions, ...extra });
-    } catch (e) {
-      if (e instanceof RecordInvalid) throw e;
-      const record = await this.findBy(conditions);
-      if (record) return record;
-      throw new RecordNotFound(`${this.name} not found`, this.name);
-    }
+    return this.all().createOrFindByBang(conditions, extra) as Promise<InstanceType<T>>;
   }
 
   /**

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3607,6 +3607,27 @@ describe("CalculationsTest", () => {
     expect(topic.status).toBe("from-conditions");
   });
 
+  // Rails: create_or_find_by!'s rescue narrows to RecordNotUnique, so
+  // validation failures propagate unchanged rather than getting masked
+  // as RecordNotFound. Our narrow-catch refactor must preserve that.
+  it("Relation#createOrFindByBang rethrows validation failures (not RecordNotUnique)", async () => {
+    const { RecordInvalid } = await import("./validations.js");
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        this.validatesPresenceOf("title");
+      }
+    }
+
+    // No title → validation fails → RecordInvalid. Should propagate.
+    await expect(Topic.all().createOrFindByBang({ title: "" })).rejects.toBeInstanceOf(
+      RecordInvalid,
+    );
+  });
+
   it("Relation#firstOrInitialize merges createWith attrs when initializing", async () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3506,6 +3506,67 @@ describe("CalculationsTest", () => {
     expect(topic.status).toBe("draft"); // kept original
   });
 
+  // Rails' Relation#build/create call scope_for_create, which merges
+  // where_values_hash with create_with_value. A bare `rel.build()` /
+  // `rel.create()` must pick up createWith attrs the same way
+  // findOrCreateBy does.
+  it("Relation#build merges createWith attrs via scope_for_create", () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = Topic.all().createWith({ status: "draft" }).build({ title: "T" });
+    expect(topic.isNewRecord()).toBe(true);
+    expect(topic.status).toBe("draft");
+    expect(topic.title).toBe("T");
+  });
+
+  it("Relation#create persists with createWith attrs via scope_for_create", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = await Topic.all()
+      .createWith({ status: "published" })
+      .create({ title: "Via create" });
+    expect(topic.isPersisted()).toBe(true);
+    expect(topic.status).toBe("published");
+    const reloaded = await Topic.find(topic.id);
+    expect(reloaded.status).toBe("published");
+  });
+
+  it("Relation#firstOrInitialize merges createWith attrs when initializing", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = await Topic.all()
+      .createWith({ status: "init-default" })
+      .where({ title: "ToInit" })
+      .firstOrInitialize();
+    expect(topic.isNewRecord()).toBe(true);
+    expect(topic.status).toBe("init-default");
+    expect(topic.title).toBe("ToInit");
+  });
+
   // =====================================================================
   // unscope — activerecord/test/cases/relation/where_test.rb
   // =====================================================================

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3565,6 +3565,48 @@ describe("CalculationsTest", () => {
     expect(topic.status).toBe("bang-default");
   });
 
+  // Rails: create_or_find_by runs `create(attributes)` on the current
+  // relation, which uses scope_for_create. With a same-named column set
+  // in both where() and createWith(), createWith must win (the pre-fix
+  // merge order had scope overwriting createWith).
+  it("Relation#createOrFindBy: createWith overrides same-named where-scope attrs", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = await Topic.all()
+      .where({ status: "from-where" })
+      .createWith({ status: "from-create-with" })
+      .createOrFindBy({ title: "cof-topic" });
+    expect(topic.isPersisted()).toBe(true);
+    expect(topic.status).toBe("from-create-with");
+  });
+
+  // Explicit conditions still win over both createWith and where-scope.
+  it("Relation#createOrFindBy: caller's conditions win over createWith + where", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = await Topic.all()
+      .where({ status: "from-where" })
+      .createWith({ status: "from-create-with" })
+      .createOrFindBy({ title: "cof-override", status: "from-conditions" });
+    expect(topic.status).toBe("from-conditions");
+  });
+
   it("Relation#firstOrInitialize merges createWith attrs when initializing", async () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3547,6 +3547,24 @@ describe("CalculationsTest", () => {
     expect(reloaded.status).toBe("published");
   });
 
+  it("Relation#createBang persists with createWith attrs via scope_for_create", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const topic = await Topic.all()
+      .createWith({ status: "bang-default" })
+      .createBang({ title: "Via createBang" });
+    expect(topic.isPersisted()).toBe(true);
+    expect(topic.status).toBe("bang-default");
+  });
+
   it("Relation#firstOrInitialize merges createWith attrs when initializing", async () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -10,7 +10,7 @@ import {
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
-import { RecordNotFound } from "./errors.js";
+import { RecordNotFound, RecordNotUnique } from "./errors.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2290,7 +2290,11 @@ export class Relation<T extends Base> {
         ...conditions,
         ...extra,
       })) as T;
-    } catch {
+    } catch (e) {
+      // Rails' create_or_find_by only retries on ActiveRecord::RecordNotUnique;
+      // any other error (validation failure, connection error, etc.) must
+      // propagate unchanged.
+      if (!(e instanceof RecordNotUnique)) throw e;
       const records = await this.where(conditions).limit(1).toArray();
       if (records.length > 0) return records[0];
       throw new RecordNotFound(`${this._modelClass.name} not found`, this._modelClass.name);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2249,8 +2249,7 @@ export class Relation<T extends Base> {
     // scope attrs first, createWith overrides, then the caller's conditions
     // and the optional extra hash win over both.
     return this._modelClass.create({
-      ...this._scopeAttributes(),
-      ...this._createWithAttrs,
+      ...this.scopeForCreate(),
       ...conditions,
       ...extra,
     }) as Promise<T>;
@@ -2270,8 +2269,7 @@ export class Relation<T extends Base> {
     // Same scope_for_create precedence as findOrCreateBy: scope attrs
     // first, createWith overrides, caller's conditions + extra win.
     return new (this._modelClass as any)({
-      ...this._scopeAttributes(),
-      ...this._createWithAttrs,
+      ...this.scopeForCreate(),
       ...conditions,
       ...extra,
     }) as T;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1296,8 +1296,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#build
    */
   build(attrs: Record<string, unknown> = {}): T {
-    const scopeAttrs = this._scopeAttributes();
-    return new this._modelClass({ ...scopeAttrs, ...attrs }) as T;
+    return new this._modelClass({ ...this.scopeForCreate(), ...attrs }) as T;
   }
 
   /**
@@ -1306,8 +1305,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#create
    */
   async create(attrs: Record<string, unknown> = {}): Promise<T> {
-    const scopeAttrs = this._scopeAttributes();
-    return this._modelClass.create({ ...scopeAttrs, ...attrs }) as Promise<T>;
+    return this._modelClass.create({ ...this.scopeForCreate(), ...attrs }) as Promise<T>;
   }
 
   /**
@@ -1316,8 +1314,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#create!
    */
   async createBang(attrs: Record<string, unknown> = {}): Promise<T> {
-    const scopeAttrs = this._scopeAttributes();
-    return this._modelClass.createBang({ ...scopeAttrs, ...attrs }) as Promise<T>;
+    return this._modelClass.createBang({ ...this.scopeForCreate(), ...attrs }) as Promise<T>;
   }
 
   /**
@@ -2291,8 +2288,7 @@ export class Relation<T extends Base> {
   ): Promise<T> {
     try {
       return (await this._modelClass.create({
-        ...this._createWithAttrs,
-        ...this._scopeAttributes(),
+        ...this.scopeForCreate(),
         ...conditions,
         ...extra,
       })) as T;
@@ -2334,7 +2330,7 @@ export class Relation<T extends Base> {
   async firstOrInitialize(extra?: Record<string, unknown>): Promise<T> {
     const records = await this.limit(1).toArray();
     if (records.length > 0) return records[0];
-    return new (this._modelClass as any)({ ...this._scopeAttributes(), ...extra }) as T;
+    return new (this._modelClass as any)({ ...this.scopeForCreate(), ...extra }) as T;
   }
 
   /**

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -8,8 +8,7 @@
  * Mirrors: ActiveRecord::FinderMethods
  */
 
-import { RecordNotFound, SoleRecordExceeded } from "../errors.js";
-import { RecordInvalid } from "../validations.js";
+import { RecordNotFound, RecordNotUnique, SoleRecordExceeded } from "../errors.js";
 
 // ---------------------------------------------------------------------------
 // Shared id-normalization + not-found helpers.
@@ -202,6 +201,7 @@ interface FinderRelation {
   _rawOrderClauses: string[];
   _createWithAttrs: Record<string, unknown>;
   _scopeAttributes(): Record<string, unknown>;
+  scopeForCreate(): Record<string, unknown>;
   _clone(): any;
   where(conditions: Record<string, unknown>): any;
   limit(n: number): any;
@@ -462,8 +462,7 @@ export async function performFindOrCreateByBang(
   const records = await this.where(conditions).limit(1).toArray();
   if (records.length > 0) return records[0];
   return this._modelClass.createBang({
-    ...this._createWithAttrs,
-    ...this._scopeAttributes(),
+    ...this.scopeForCreate(),
     ...conditions,
     ...extra,
   });
@@ -476,13 +475,14 @@ export async function performCreateOrFindByBang(
 ): Promise<any> {
   try {
     return await this._modelClass.createBang({
-      ...this._createWithAttrs,
-      ...this._scopeAttributes(),
+      ...this.scopeForCreate(),
       ...conditions,
       ...extra,
     });
   } catch (error) {
-    if (error instanceof RecordInvalid) throw error;
+    // Rails' create_or_find_by! only retries on RecordNotUnique; validation
+    // failures and other adapter errors must propagate unchanged.
+    if (!(error instanceof RecordNotUnique)) throw error;
     const records = await this.where(conditions).limit(1).toArray();
     if (records.length > 0) return records[0];
     throw new RecordNotFound(`${this._modelClass.name} not found`, this._modelClass.name);


### PR DESCRIPTION
## Summary

Route \`Relation#build\`, \`#create\`, \`#createBang\`, and \`#firstOrInitialize\` through the existing \`scopeForCreate()\` helper (which already implements Rails' \`scope_for_create = where_values_hash.merge(create_with_value)\`). Before this, they only merged \`_scopeAttributes()\` and silently dropped \`_createWithAttrs\` — a Rails-fidelity gap that surfaced while writing regression tests for PR #693.

Also fixes \`createOrFindBy\`'s merge order: it spread \`_createWithAttrs\` before \`_scopeAttributes()\`, inverting Rails' precedence when a column appeared in both.

Adds regression tests covering:
- \`rel.createWith({...}).build({...})\` applies createWith to the new unsaved record.
- \`rel.createWith({...}).create({...})\` persists with createWith attrs.
- \`rel.createWith({...}).where({...}).firstOrInitialize()\` merges createWith into the initialized record.

## Test plan

- [x] \`pnpm vitest run packages/activerecord\` — 8807 passed
- [x] \`pnpm run build\`