### PR TITLE
fix(activerecord): Base.findBy / findByBang route through all()

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1105,8 +1105,9 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.find_by — `delegate :find_by, to: :all`
    * (querying.rb QUERYING_METHODS). Routing through `all()` picks up
-   * the default scope, current scope, STI type filter, and any active
-   * scoping(...) + createWith attrs on the calling class.
+   * the default scope, current scope (from `scoping()`), and STI type
+   * filter. `createWith` doesn't affect lookups — it's applied only
+   * on downstream create paths like `findOrCreateBy`.
    */
   static findBy<T extends typeof Base>(
     this: T,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1113,7 +1113,7 @@ export class Base extends Model {
     this: T,
     conditions: Record<string, unknown>,
   ): Promise<InstanceType<T> | null> {
-    return this.all().findBy(conditions) as Promise<InstanceType<T> | null>;
+    return this.all().findBy(conditions);
   }
 
   /**
@@ -1125,7 +1125,7 @@ export class Base extends Model {
     this: T,
     conditions: Record<string, unknown>,
   ): Promise<InstanceType<T>> {
-    return this.all().findByBang(conditions) as Promise<InstanceType<T>>;
+    return this.all().findByBang(conditions);
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1103,45 +1103,28 @@ export class Base extends Model {
   /**
    * Find the first record matching conditions.
    *
-   * Mirrors: ActiveRecord::Base.find_by
+   * Mirrors: ActiveRecord::Base.find_by — `delegate :find_by, to: :all`
+   * (querying.rb QUERYING_METHODS). Routing through `all()` picks up
+   * the default scope, current scope, STI type filter, and any active
+   * scoping(...) + createWith attrs on the calling class.
    */
-  static async findBy<T extends typeof Base>(
+  static findBy<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
   ): Promise<InstanceType<T> | null> {
-    const table = this.arelTable;
-    const manager = table.project("*");
-
-    for (const [key, value] of Object.entries(conditions)) {
-      if (value === null) {
-        manager.where(table.get(key).isNull());
-      } else {
-        manager.where(table.get(key).eq(value));
-      }
-    }
-
-    manager.take(1);
-    const sql = manager.toSql();
-    const row = await this.adapter.selectOne(sql, "Find");
-    if (!row) return null;
-
-    return this._instantiate(row);
+    return this.all().findBy(conditions) as Promise<InstanceType<T> | null>;
   }
 
   /**
    * Find the first record matching conditions, or throw.
    *
-   * Mirrors: ActiveRecord::Base.find_by!
+   * Mirrors: ActiveRecord::Base.find_by! — `delegate :find_by!, to: :all`.
    */
-  static async findByBang<T extends typeof Base>(
+  static findByBang<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
   ): Promise<InstanceType<T>> {
-    const record = await this.findBy(conditions);
-    if (!record) {
-      throw new RecordNotFound(`${this.name} not found`, this.name);
-    }
-    return record;
+    return this.all().findByBang(conditions) as Promise<InstanceType<T>>;
   }
 
   /**

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3472,8 +3472,8 @@ describe("CalculationsTest", () => {
         insideScope = await Topic.findBy({ title: "published-only" });
         insideScopeOther = await Topic.findBy({ title: "draft-only" });
       });
-    expect(insideScope).not.toBeNull();
-    expect((insideScope as unknown as Topic).status).toBe("published");
+    if (insideScope === null) throw new Error("Expected insideScope to be present");
+    expect((insideScope as Topic).status).toBe("published");
     // draft-only is excluded by the active where(status: 'published') scope.
     expect(insideScopeOther).toBeNull();
   });

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3444,6 +3444,33 @@ describe("CalculationsTest", () => {
     expect(topic.title).toBe("Via class-level entry");
   });
 
+  // Rails' `delegate :find_by, to: :all` means Base.findBy picks up the
+  // current scope inside a scoping block. Before this PR, Base.findBy
+  // built a raw SELECT on arelTable and bypassed currentScope entirely.
+  it("Base.findBy honors currentScope under scoping()", async () => {
+    class Topic extends Base {
+      static {
+        this._tableName = "topics";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    await Topic.create({ title: "A", status: "draft" });
+    await Topic.create({ title: "A", status: "published" });
+
+    let captured: Topic | null = null;
+    await Topic.all()
+      .where({ status: "published" })
+      .scoping(async () => {
+        captured = await Topic.findBy({ title: "A" });
+      });
+    if (captured === null) throw new Error("Expected topic to be present");
+    expect((captured as Topic).status).toBe("published");
+  });
+
   // Rails' findOrInitializeBy merges create_with attrs into the new
   // unsaved record (same scope_for_create path as findOrCreateBy's
   // create branch).

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -3447,6 +3447,9 @@ describe("CalculationsTest", () => {
   // Rails' `delegate :find_by, to: :all` means Base.findBy picks up the
   // current scope inside a scoping block. Before this PR, Base.findBy
   // built a raw SELECT on arelTable and bypassed currentScope entirely.
+  // Deterministic check: a title that only exists OUTSIDE the scope must
+  // return null while the scope is active — the unscoped path would still
+  // return the row.
   it("Base.findBy honors currentScope under scoping()", async () => {
     class Topic extends Base {
       static {
@@ -3458,17 +3461,21 @@ describe("CalculationsTest", () => {
       }
     }
 
-    await Topic.create({ title: "A", status: "draft" });
-    await Topic.create({ title: "A", status: "published" });
+    await Topic.create({ title: "draft-only", status: "draft" });
+    await Topic.create({ title: "published-only", status: "published" });
 
-    let captured: Topic | null = null;
+    let insideScope: Topic | null = null;
+    let insideScopeOther: Topic | null = null;
     await Topic.all()
       .where({ status: "published" })
       .scoping(async () => {
-        captured = await Topic.findBy({ title: "A" });
+        insideScope = await Topic.findBy({ title: "published-only" });
+        insideScopeOther = await Topic.findBy({ title: "draft-only" });
       });
-    if (captured === null) throw new Error("Expected topic to be present");
-    expect((captured as Topic).status).toBe("published");
+    expect(insideScope).not.toBeNull();
+    expect((insideScope as unknown as Topic).status).toBe("published");
+    // draft-only is excluded by the active where(status: 'published') scope.
+    expect(insideScopeOther).toBeNull();
   });
 
   // Rails' findOrInitializeBy merges create_with attrs into the new

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -354,6 +354,48 @@ describe("InheritanceTest", () => {
     expect(types).toContain("Client");
   });
 
+  // Rails: `delegate :find_by, to: :all` means Base.find_by picks up
+  // the STI type filter that `all()` installs on subclasses.
+  it("findBy on an STI subclass filters by type column", async () => {
+    class Company extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("type", "string");
+        this._tableName = "companies";
+        this.adapter = adapter;
+        enableSti(Company);
+      }
+    }
+    class Firm extends Company {
+      static {
+        this.adapter = adapter;
+        registerModel(Firm);
+        registerSubclass(Firm);
+      }
+    }
+    class Client extends Company {
+      static {
+        this.adapter = adapter;
+        registerModel(Client);
+        registerSubclass(Client);
+      }
+    }
+
+    await Firm.create({ name: "37signals" });
+    await Client.create({ name: "37signals" }); // same name, different type
+
+    // Firm.findBy should only match the Firm row.
+    const firm = await Firm.findBy({ name: "37signals" });
+    expect(firm).not.toBeNull();
+    expect(firm!.constructor.name).toBe("Firm");
+
+    // Client.findBy should only match the Client row.
+    const client = await Client.findBy({ name: "37signals" });
+    expect(client).not.toBeNull();
+    expect(client!.constructor.name).toBe("Client");
+  });
+
   it("alt inheritance find all", async () => {
     class Vegetable extends Base {
       static {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -382,18 +382,20 @@ describe("InheritanceTest", () => {
       }
     }
 
-    await Firm.create({ name: "37signals" });
-    await Client.create({ name: "37signals" }); // same name, different type
+    const createdFirm = await Firm.create({ name: "37signals" });
+    const createdClient = await Client.create({ name: "37signals" }); // same name, different type
 
-    // Firm.findBy should only match the Firm row.
-    const firm = await Firm.findBy({ name: "37signals" });
+    // Firm.findBy must only match Firm rows, even when another subtype exists.
+    // Looking up by the OTHER subtype's PK must return null under the STI filter.
+    const firm = await Firm.findBy({ id: createdFirm.id });
     expect(firm).not.toBeNull();
     expect(firm!.constructor.name).toBe("Firm");
+    expect(await Firm.findBy({ id: createdClient.id })).toBeNull();
 
-    // Client.findBy should only match the Client row.
-    const client = await Client.findBy({ name: "37signals" });
+    const client = await Client.findBy({ id: createdClient.id });
     expect(client).not.toBeNull();
     expect(client!.constructor.name).toBe("Client");
+    expect(await Client.findBy({ id: createdFirm.id })).toBeNull();
   });
 
   it("alt inheritance find all", async () => {


### PR DESCRIPTION
## Summary

Base.findBy was building a raw Arel \`SELECT * FROM table\` and calling \`adapter.selectOne\` directly — bypassing default_scope, currentScope, and the STI type filter. Rails' \`Querying\` module wires this up as \`delegate :find_by, :find_by!, to: :all\`, so the class-level call should always route through \`all()\`.

Downstream callers (\`Base.findOrCreateBy\` internally, async uniqueness validations, \`Base.createOrFindBy\`'s retry fallback) inherit the fix.

## Regression tests

- \`Firm.findBy / Client.findBy\` filter by STI type column (previously could cross-match).
- \`Base.findBy\` picks up a \`where()\` condition when called through \`scoping()\`.

## Test plan

- [x] \`pnpm vitest run packages/activerecord\` — 8816 passed
- [x] \`pnpm run build\`