### PR TITLE
feat(activerecord): Base.update/delete/destroy match Rails arg-shape semantics

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -179,10 +179,13 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
 
 /**
  * Rails' `persistence.rb#update` / `#update!` dispatch on the first arg:
- *   :all | "all" | nil          → iterate `all()` and update each
+ *   ":all" | nil | bare hash    → iterate `all()` and update each
  *   Array (of ids)              → parallel with `attributes` array
  *   ActiveRecord::Base instance → ArgumentError
  *   anything else               → primary-key lookup, single update
+ *
+ * The string sentinel is `":all"` (with leading colon) — a bare `"all"`
+ * would collide with a legitimate string/slug primary-key value.
  */
 async function performClassUpdate(
   this: typeof Base,
@@ -196,7 +199,7 @@ async function performClassUpdate(
   };
 
   // Rails accepts `nil`/`:all` default. TS callers write update(attrs) with
-  // a single hash, or pass the sentinel "all" explicitly.
+  // a single hash, or pass the sentinel ":all" explicitly.
   const isAllSentinel =
     idOrAttrs === undefined ||
     idOrAttrs === null ||
@@ -213,13 +216,13 @@ async function performClassUpdate(
 
   if (Array.isArray(idOrAttrs)) {
     if (idOrAttrs.some((i) => i instanceof Base)) {
-      throw new Error(
+      throw argumentError(
         "You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.",
       );
     }
     const attrsArr = attrs as Record<string, unknown>[];
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
-      throw new Error("update(ids, attrs): ids and attrs must be arrays of the same length");
+      throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");
     }
     const records = await Promise.all(idOrAttrs.map((id) => this.find(id)));
     for (let i = 0; i < records.length; i++) {
@@ -229,7 +232,7 @@ async function performClassUpdate(
   }
 
   if (idOrAttrs instanceof Base) {
-    throw new Error(
+    throw argumentError(
       "You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.",
     );
   }
@@ -2074,12 +2077,27 @@ export class Base extends Model {
     }
     const pk = this.primaryKey;
     if (Array.isArray(pk)) {
-      // Composite PK, single tuple — route through all() so currentScope
-      // applies. AND-of-equality per key.
-      const tuple = id as unknown[];
-      const cond: Record<string, unknown> = {};
-      for (let i = 0; i < pk.length; i++) cond[pk[i]] = tuple[i];
-      return this.all().where(cond).deleteAll();
+      // Composite PK — mirror find()'s detection:
+      //   - array-of-arrays → multiple tuples
+      //   - single array    → one tuple
+      if (!Array.isArray(id)) {
+        throw argumentError(
+          `${this.name}.delete expects a tuple (or array of tuples) matching the composite primary key [${pk.join(", ")}]`,
+        );
+      }
+      const arr = id as unknown[];
+      const tuples: unknown[][] = Array.isArray(arr[0]) ? (arr as unknown[][]) : [arr];
+      for (const tuple of tuples) {
+        if (!Array.isArray(tuple) || tuple.length !== pk.length) {
+          throw argumentError(
+            `${this.name}.delete tuple length ${Array.isArray(tuple) ? tuple.length : "<scalar>"} does not match composite primary key arity ${pk.length}`,
+          );
+        }
+      }
+      // where(cols, tuples) emits the composite `(pk1,pk2) IN ((v1,v2),...)`
+      // predicate, so multi-tuple deletes produce correct SQL instead of
+      // a cross-product of per-column IN lists.
+      return this.all().where(pk, tuples).deleteAll();
     }
     // Single-column PK — where({[pk]: id}) handles scalar and array alike
     // (predicate builder emits `=` or `IN(...)` as appropriate).

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2104,9 +2104,9 @@ export class Base extends Model {
           );
         }
       }
-      // where(cols, tuples) emits the composite `(pk1,pk2) IN ((v1,v2),...)`
-      // predicate, so multi-tuple deletes produce correct SQL instead of
-      // a cross-product of per-column IN lists.
+      // where(cols, tuples) compiles to OR-of-AND (`(pk1=v1 AND pk2=v2) OR ...`)
+      // via PredicateBuilder.buildComposite, so multi-tuple deletes produce
+      // correct SQL instead of a cross-product of per-column IN lists.
       return this.all().where(pk, tuples).deleteAll();
     }
     // Single-column PK — where({[pk]: id}) handles scalar and array alike

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -178,6 +178,68 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
 }
 
 /**
+ * Rails' `persistence.rb#update` / `#update!` dispatch on the first arg:
+ *   :all | "all" | nil          → iterate `all()` and update each
+ *   Array (of ids)              → parallel with `attributes` array
+ *   ActiveRecord::Base instance → ArgumentError
+ *   anything else               → primary-key lookup, single update
+ */
+async function performClassUpdate(
+  this: typeof Base,
+  idOrAttrs: unknown,
+  attrs: Record<string, unknown> | Record<string, unknown>[] | undefined,
+  bang: boolean,
+): Promise<unknown> {
+  const run = async (record: InstanceType<typeof Base>, a: Record<string, unknown>) => {
+    if (bang) await record.updateBang(a);
+    else await record.update(a);
+  };
+
+  // Rails accepts `nil`/`:all` default. TS callers write update(attrs) with
+  // a single hash, or pass the sentinel "all" explicitly.
+  const isAllSentinel =
+    idOrAttrs === undefined ||
+    idOrAttrs === null ||
+    idOrAttrs === "all" ||
+    (typeof idOrAttrs === "object" && !Array.isArray(idOrAttrs) && !(idOrAttrs instanceof Base));
+
+  if (isAllSentinel) {
+    // update(attrs) — apply to every record in the current scope.
+    const effectiveAttrs = (attrs ?? idOrAttrs) as Record<string, unknown>;
+    const records = (await this.all().toArray()) as InstanceType<typeof Base>[];
+    for (const r of records) await run(r, effectiveAttrs);
+    return records;
+  }
+
+  if (Array.isArray(idOrAttrs)) {
+    if (idOrAttrs.some((i) => i instanceof Base)) {
+      throw new Error(
+        "You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.",
+      );
+    }
+    const attrsArr = attrs as Record<string, unknown>[];
+    if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
+      throw new Error("update(ids, attrs): ids and attrs must be arrays of the same length");
+    }
+    const records = await Promise.all(idOrAttrs.map((id) => this.find(id)));
+    for (let i = 0; i < records.length; i++) {
+      await run(records[i] as InstanceType<typeof Base>, attrsArr[i]);
+    }
+    return records;
+  }
+
+  if (idOrAttrs instanceof Base) {
+    throw new Error(
+      "You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.",
+    );
+  }
+
+  const record = (await this.find(idOrAttrs)) as InstanceType<typeof Base>;
+  await run(record, attrs as Record<string, unknown>);
+  return record;
+}
+
+/**
  * Base — the core ActiveRecord class with persistence and finders.
  *
  * Mirrors: ActiveRecord::Base
@@ -1264,35 +1326,66 @@ export class Base extends Model {
   // extracted to querying.ts; declared in the Querying mixin section below.
 
   /**
-   * Find and update a record by primary key.
+   * Update record(s). Mirrors Rails' `persistence.rb#update` — the id
+   * argument shape drives behavior:
    *
-   * Mirrors: ActiveRecord::Base.update(id, attrs)
+   *   update(attrs)                 → update every record in `all()` (Rails' `:all` default)
+   *   update("all", attrs)          → same, explicit sentinel
+   *   update(id, attrs)             → find(id) + update(attrs), returns the record
+   *   update([ids], [attrs])        → parallel arrays, index-aligned
+   *
+   * Passing a `Base` instance (or array containing one) raises.
    */
-  static async update<T extends typeof Base>(
+  static update<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>[]>;
+  static update<T extends typeof Base>(
+    this: T,
+    sentinel: "all" | null | undefined,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>[]>;
+  static update<T extends typeof Base>(
+    this: T,
+    ids: unknown[],
+    attrs: Record<string, unknown>[],
+  ): Promise<InstanceType<T>[]>;
+  static update<T extends typeof Base>(
     this: T,
     id: unknown,
     attrs: Record<string, unknown>,
-  ): Promise<InstanceType<T>> {
-    const record = await this.find(id);
-    await record.update(attrs);
-    return record;
+  ): Promise<InstanceType<T>>;
+  static async update<T extends typeof Base>(
+    this: T,
+    idOrAttrs: unknown,
+    attrs?: Record<string, unknown> | Record<string, unknown>[],
+  ): Promise<InstanceType<T> | InstanceType<T>[]> {
+    return performClassUpdate.call(this, idOrAttrs, attrs, /*bang*/ false) as Promise<
+      InstanceType<T> | InstanceType<T>[]
+    >;
   }
 
   /**
-   * Destroy a record by primary key (with callbacks).
+   * Destroy a record by primary key (with callbacks). Accepts a single id,
+   * an array of ids, a composite-PK tuple, or an array of tuples.
    *
-   * Mirrors: ActiveRecord::Base.destroy(id)
+   * Mirrors: ActiveRecord::Base.destroy — Rails detects multiple ids via
+   *   `composite_primary_key? ? id.first.is_a?(Array) : id.is_a?(Array)`
+   * so a plain tuple on a composite-PK model is treated as ONE record,
+   * not N.
    */
   static async destroy<T extends typeof Base>(
     this: T,
     id: unknown | unknown[],
   ): Promise<InstanceType<T> | InstanceType<T>[]> {
-    if (Array.isArray(id)) {
+    const multipleIds = this.compositePrimaryKey
+      ? Array.isArray(id) && Array.isArray((id as unknown[])[0])
+      : Array.isArray(id);
+
+    if (multipleIds) {
       const found = await this.find(id);
       const records = Array.isArray(found) ? found : [found];
-      for (const record of records) {
-        await record.destroy();
-      }
+      for (const record of records) await record.destroy();
       return records;
     }
     const record = await this.find(id);
@@ -1303,18 +1396,38 @@ export class Base extends Model {
   // destroyAll extracted to querying.ts; declared in the Querying mixin section.
 
   /**
-   * Update a record and raise on validation failure.
+   * Update record(s) and raise on validation failure. Same arg shapes as
+   * `update`.
    *
    * Mirrors: ActiveRecord::Base.update!
    */
-  static async updateBang<T extends typeof Base>(
+  static updateBang<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>[]>;
+  static updateBang<T extends typeof Base>(
+    this: T,
+    sentinel: "all" | null | undefined,
+    attrs: Record<string, unknown>,
+  ): Promise<InstanceType<T>[]>;
+  static updateBang<T extends typeof Base>(
+    this: T,
+    ids: unknown[],
+    attrs: Record<string, unknown>[],
+  ): Promise<InstanceType<T>[]>;
+  static updateBang<T extends typeof Base>(
     this: T,
     id: unknown,
     attrs: Record<string, unknown>,
-  ): Promise<InstanceType<T>> {
-    const record = await this.find(id);
-    await record.updateBang(attrs);
-    return record;
+  ): Promise<InstanceType<T>>;
+  static async updateBang<T extends typeof Base>(
+    this: T,
+    idOrAttrs: unknown,
+    attrs?: Record<string, unknown> | Record<string, unknown>[],
+  ): Promise<InstanceType<T> | InstanceType<T>[]> {
+    return performClassUpdate.call(this, idOrAttrs, attrs, /*bang*/ true) as Promise<
+      InstanceType<T> | InstanceType<T>[]
+    >;
   }
 
   /**
@@ -1947,13 +2060,31 @@ export class Base extends Model {
   // delete extracted to persistence.ts; wired via include() below.
 
   /**
-   * Delete a record by primary key without callbacks.
+   * Delete record(s) by primary key without callbacks / validations.
    *
-   * Mirrors: ActiveRecord::Base.delete
+   * Mirrors: ActiveRecord::Base.delete — Rails defines this as
+   * `delete_by(primary_key => id_or_array)`, so single ids, arrays of
+   * ids, `nil`, and empty arrays all route through the same where-builder.
+   * Composite primary keys are supported via the tuple / array-of-tuples
+   * form handled by `_buildPkWhereNode` and `Relation#where`.
    */
   static async delete(id: unknown): Promise<number> {
-    const dm = new DeleteManager().from(this.arelTable).where(this._buildPkWhereNode(id));
-    return this.adapter.execDelete(dm.toSql(), "Delete");
+    if (id === null || id === undefined || (Array.isArray(id) && id.length === 0)) {
+      return 0;
+    }
+    const pk = this.primaryKey;
+    if (Array.isArray(pk)) {
+      // Composite PK: let destroy()/where handle tuple / array-of-tuples
+      // semantics via _buildPkWhereNode, which builds an AND of equality
+      // predicates for a single tuple (array form is not supported here).
+      const dm = new DeleteManager().from(this.arelTable).where(this._buildPkWhereNode(id));
+      return this.adapter.execDelete(dm.toSql(), "Delete");
+    }
+    // Single-column PK — `where({[pk]: id})` handles both scalar and array
+    // (Arel's `in` for arrays) via the predicate builder.
+    return this.all()
+      .where({ [pk]: id as unknown })
+      .deleteAll();
   }
 
   // reload extracted to persistence.ts; wired via include() below.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2074,14 +2074,15 @@ export class Base extends Model {
     }
     const pk = this.primaryKey;
     if (Array.isArray(pk)) {
-      // Composite PK: let destroy()/where handle tuple / array-of-tuples
-      // semantics via _buildPkWhereNode, which builds an AND of equality
-      // predicates for a single tuple (array form is not supported here).
-      const dm = new DeleteManager().from(this.arelTable).where(this._buildPkWhereNode(id));
-      return this.adapter.execDelete(dm.toSql(), "Delete");
+      // Composite PK, single tuple — route through all() so currentScope
+      // applies. AND-of-equality per key.
+      const tuple = id as unknown[];
+      const cond: Record<string, unknown> = {};
+      for (let i = 0; i < pk.length; i++) cond[pk[i]] = tuple[i];
+      return this.all().where(cond).deleteAll();
     }
-    // Single-column PK — `where({[pk]: id})` handles both scalar and array
-    // (Arel's `in` for arrays) via the predicate builder.
+    // Single-column PK — where({[pk]: id}) handles scalar and array alike
+    // (predicate builder emits `=` or `IN(...)` as appropriate).
     return this.all()
       .where({ [pk]: id as unknown })
       .deleteAll();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -200,7 +200,7 @@ async function performClassUpdate(
   const isAllSentinel =
     idOrAttrs === undefined ||
     idOrAttrs === null ||
-    idOrAttrs === "all" ||
+    idOrAttrs === ":all" ||
     (typeof idOrAttrs === "object" && !Array.isArray(idOrAttrs) && !(idOrAttrs instanceof Base));
 
   if (isAllSentinel) {
@@ -1330,7 +1330,7 @@ export class Base extends Model {
    * argument shape drives behavior:
    *
    *   update(attrs)                 → update every record in `all()` (Rails' `:all` default)
-   *   update("all", attrs)          → same, explicit sentinel
+   *   update(":all", attrs)         → same, explicit sentinel (mirrors Rails' :all symbol)
    *   update(id, attrs)             → find(id) + update(attrs), returns the record
    *   update([ids], [attrs])        → parallel arrays, index-aligned
    *
@@ -1342,7 +1342,7 @@ export class Base extends Model {
   ): Promise<InstanceType<T>[]>;
   static update<T extends typeof Base>(
     this: T,
-    sentinel: "all" | null | undefined,
+    sentinel: ":all" | null | undefined,
     attrs: Record<string, unknown>,
   ): Promise<InstanceType<T>[]>;
   static update<T extends typeof Base>(
@@ -1407,7 +1407,7 @@ export class Base extends Model {
   ): Promise<InstanceType<T>[]>;
   static updateBang<T extends typeof Base>(
     this: T,
-    sentinel: "all" | null | undefined,
+    sentinel: ":all" | null | undefined,
     attrs: Record<string, unknown>,
   ): Promise<InstanceType<T>[]>;
   static updateBang<T extends typeof Base>(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -220,9 +220,14 @@ async function performClassUpdate(
 
   if (isAllSentinel) {
     // update(attrs) — apply to every record in the current scope.
-    const effectiveAttrs = (attrs ?? idOrAttrs) as Record<string, unknown>;
+    const candidate = attrs ?? idOrAttrs;
+    if (!isPlainObject(candidate)) {
+      throw argumentError(
+        "update: attributes must be a plain object (missing or invalid attrs for the :all / nil form)",
+      );
+    }
     const records = (await this.all().toArray()) as InstanceType<typeof Base>[];
-    for (const r of records) await run(r, effectiveAttrs);
+    for (const r of records) await run(r, candidate);
     return records;
   }
 
@@ -2096,8 +2101,9 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.delete — Rails defines this as
    * `delete_by(primary_key => id_or_array)`, so single ids, arrays of
    * ids, `nil`, and empty arrays all route through the same where-builder.
-   * Composite primary keys are supported via the tuple / array-of-tuples
-   * form handled by `_buildPkWhereNode` and `Relation#where`.
+   * Composite primary keys are supported via `where(cols, tuples)` for
+   * both single-tuple and array-of-tuples inputs, which compiles to an
+   * OR-of-AND predicate — not a per-column IN cross-product.
    */
   static async delete(id: unknown): Promise<number> {
     if (id === null || id === undefined || (Array.isArray(id) && id.length === 0)) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -272,20 +272,24 @@ async function performClassUpdate(
     }
     // Single `find([...ids])` call, then reorder by input-id to zip with
     // attrsArr. Rails' AR builds an OR predicate that doesn't guarantee
-    // DB-return order, so rely on a stable id-key lookup (JSON.stringify
-    // handles both scalar and CPK tuple keys).
+    // DB-return order, so rely on a stable id-key lookup. Use
+    // String()-joined keys so bigint PKs don't crash JSON.stringify and
+    // so numeric / string-cast ids (e.g. "1" vs 1 after predicate cast)
+    // hash to the same slot.
+    const stableIdKey = (id: unknown): string =>
+      Array.isArray(id) ? id.map((part) => String(part)).join("\x1f") : String(id);
     const found = (await this.find(idOrAttrs as unknown[])) as
       | InstanceType<typeof Base>
       | InstanceType<typeof Base>[];
     const foundArr = Array.isArray(found) ? found : [found];
     const byKey = new Map<string, InstanceType<typeof Base>>();
-    for (const r of foundArr) byKey.set(JSON.stringify(r.id), r);
+    for (const r of foundArr) byKey.set(stableIdKey(r.id), r);
     const records: InstanceType<typeof Base>[] = [];
     for (let i = 0; i < idOrAttrs.length; i++) {
-      const record = byKey.get(JSON.stringify(idOrAttrs[i]));
+      const record = byKey.get(stableIdKey(idOrAttrs[i]));
       if (!record) {
         throw new RecordNotFound(
-          `Couldn't find ${this.name} with id=${JSON.stringify(idOrAttrs[i])}`,
+          `Couldn't find ${this.name} with id=${stableIdKey(idOrAttrs[i])}`,
           this.name,
         );
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -242,11 +242,22 @@ async function performClassUpdate(
     // array-of-arrays triggers the parallel-update path.
     const isParallel = this.compositePrimaryKey ? Array.isArray(idOrAttrs[0]) : true;
     if (!isParallel) {
-      // Single CPK tuple — fall through to the single-id branch.
+      // Single CPK tuple — fall through to the single-id branch. Reject
+      // the parallel-update shape (an attrs array) up front so the
+      // user gets a readable error instead of UnknownAttributeError on
+      // numeric-keyed forwarding.
+      if (Array.isArray(attrs)) {
+        throw argumentError(
+          `${this.name}.update: parallel updates for composite PKs require an array-of-tuples first arg, e.g. update([[k1a,k2a],[k1b,k2b]], [attrsA, attrsB])`,
+        );
+      }
       const record = (await this.find(idOrAttrs)) as InstanceType<typeof Base>;
       await run(record, attrs as Record<string, unknown>);
       return record;
     }
+    // Empty ids list is a no-op (Rails behaves this way; Base.find([]) would
+    // otherwise raise RecordNotFound "empty list of ids").
+    if (idOrAttrs.length === 0) return [];
     const attrsArr = attrs as Record<string, unknown>[];
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
       throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -220,6 +220,16 @@ async function performClassUpdate(
         "You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.",
       );
     }
+    // Mirror destroy's CPK detection: on a composite-PK model, a flat
+    // array `[shop_id, id]` is ONE tuple, not parallel ids. Only an
+    // array-of-arrays triggers the parallel-update path.
+    const isParallel = this.compositePrimaryKey ? Array.isArray(idOrAttrs[0]) : true;
+    if (!isParallel) {
+      // Single CPK tuple — fall through to the single-id branch.
+      const record = (await this.find(idOrAttrs)) as InstanceType<typeof Base>;
+      await run(record, attrs as Record<string, unknown>);
+      return record;
+    }
     const attrsArr = attrs as Record<string, unknown>[];
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
       throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -251,8 +251,11 @@ async function performClassUpdate(
           `${this.name}.update: parallel updates for composite PKs require an array-of-tuples first arg, e.g. update([[k1a,k2a],[k1b,k2b]], [attrsA, attrsB])`,
         );
       }
+      if (!isPlainObject(attrs)) {
+        throw argumentError(`${this.name}.update: attributes must be a plain object`);
+      }
       const record = (await this.find(idOrAttrs)) as InstanceType<typeof Base>;
-      await run(record, attrs as Record<string, unknown>);
+      await run(record, attrs);
       return record;
     }
     // Empty ids list is a no-op (Rails behaves this way; Base.find([]) would
@@ -262,15 +265,32 @@ async function performClassUpdate(
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
       throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");
     }
-    // Single `find([...ids])` call: Base.find preserves input order and
-    // handles composite-PK array-of-tuples, so we zip with attrsArr in
-    // place of N round-trips.
+    for (const a of attrsArr) {
+      if (!isPlainObject(a)) {
+        throw argumentError(`${this.name}.update: every attrs entry must be a plain object`);
+      }
+    }
+    // Single `find([...ids])` call, then reorder by input-id to zip with
+    // attrsArr. Rails' AR builds an OR predicate that doesn't guarantee
+    // DB-return order, so rely on a stable id-key lookup (JSON.stringify
+    // handles both scalar and CPK tuple keys).
     const found = (await this.find(idOrAttrs as unknown[])) as
       | InstanceType<typeof Base>
       | InstanceType<typeof Base>[];
-    const records = Array.isArray(found) ? found : [found];
-    for (let i = 0; i < records.length; i++) {
-      await run(records[i], attrsArr[i]);
+    const foundArr = Array.isArray(found) ? found : [found];
+    const byKey = new Map<string, InstanceType<typeof Base>>();
+    for (const r of foundArr) byKey.set(JSON.stringify(r.id), r);
+    const records: InstanceType<typeof Base>[] = [];
+    for (let i = 0; i < idOrAttrs.length; i++) {
+      const record = byKey.get(JSON.stringify(idOrAttrs[i]));
+      if (!record) {
+        throw new RecordNotFound(
+          `Couldn't find ${this.name} with id=${JSON.stringify(idOrAttrs[i])}`,
+          this.name,
+        );
+      }
+      await run(record, attrsArr[i]);
+      records.push(record);
     }
     return records;
   }
@@ -281,8 +301,11 @@ async function performClassUpdate(
     );
   }
 
+  if (!isPlainObject(attrs)) {
+    throw argumentError(`${this.name}.update: attributes must be a plain object`);
+  }
   const record = (await this.find(idOrAttrs)) as InstanceType<typeof Base>;
-  await run(record, attrs as Record<string, unknown>);
+  await run(record, attrs);
   return record;
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -200,11 +200,23 @@ async function performClassUpdate(
 
   // Rails accepts `nil`/`:all` default. TS callers write update(attrs) with
   // a single hash, or pass the sentinel ":all" explicitly.
+  //
+  // A non-array object argument is only treated as "attrs" when `attrs` is
+  // omitted (one-arg form) AND the value is a plain object. Otherwise a
+  // call like `update(dateId, attrs)` or `update(customIdObj, attrs)`
+  // would silently mass-update the scope; fall through to `find(id)`
+  // instead, matching Rails' `update(id, attributes)` path.
+  const isPlainObject = (v: unknown): v is Record<string, unknown> => {
+    if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+    if (v instanceof Base) return false;
+    const proto = Object.getPrototypeOf(v) as object | null;
+    return proto === Object.prototype || proto === null;
+  };
   const isAllSentinel =
     idOrAttrs === undefined ||
     idOrAttrs === null ||
     idOrAttrs === ":all" ||
-    (typeof idOrAttrs === "object" && !Array.isArray(idOrAttrs) && !(idOrAttrs instanceof Base));
+    (attrs === undefined && isPlainObject(idOrAttrs));
 
   if (isAllSentinel) {
     // update(attrs) — apply to every record in the current scope.
@@ -234,9 +246,15 @@ async function performClassUpdate(
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
       throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");
     }
-    const records = await Promise.all(idOrAttrs.map((id) => this.find(id)));
+    // Single `find([...ids])` call: Base.find preserves input order and
+    // handles composite-PK array-of-tuples, so we zip with attrsArr in
+    // place of N round-trips.
+    const found = (await this.find(idOrAttrs as unknown[])) as
+      | InstanceType<typeof Base>
+      | InstanceType<typeof Base>[];
+    const records = Array.isArray(found) ? found : [found];
     for (let i = 0; i < records.length; i++) {
-      await run(records[i] as InstanceType<typeof Base>, attrsArr[i]);
+      await run(records[i], attrsArr[i]);
     }
     return records;
   }

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -273,6 +273,52 @@ describe("PersistenceTest", () => {
     expect(r1.title).toBe("x");
     expect(r2.title).toBe("y");
   });
+
+  // Rails: Model.update([ids], [attrs]) — parallel arrays, index-aligned.
+  it("update with parallel ids + attrs arrays updates each record", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t1 = await Topic.create({ title: "a" });
+    const t2 = await Topic.create({ title: "b" });
+    const result = await Topic.update([t1.id, t2.id], [{ title: "x" }, { title: "y" }]);
+    expect(result).toHaveLength(2);
+    expect((await Topic.find(t1.id)).title).toBe("x");
+    expect((await Topic.find(t2.id)).title).toBe("y");
+  });
+
+  // Rails: Model.update(attrs) — :all-sentinel default applies attrs to every record.
+  it("update with just attrs applies to every record in scope (:all default)", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    await Topic.create({ title: "a" });
+    await Topic.create({ title: "b" });
+    const result = await Topic.update({ title: "same" });
+    expect(result).toHaveLength(2);
+    const titles = (await Topic.all().toArray()).map((t) => t.title);
+    expect(titles).toEqual(["same", "same"]);
+  });
+
+  // Rails: passing an AR instance raises ArgumentError.
+  it("update rejects a Base instance", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t = await Topic.create({ title: "a" });
+    await expect(Topic.update(t as unknown as number, { title: "x" })).rejects.toThrow(
+      /ActiveRecord::Base/,
+    );
+  });
 });
 
 // ==========================================================================
@@ -1656,6 +1702,60 @@ describe("PersistenceTest", () => {
       }
     }
     await expect(Topic.destroy([99999])).rejects.toThrow();
+  });
+
+  // Rails: Base.delete(ids[]) should delete every matching row — single-column
+  // PK case routes through `where(pk: ids).delete_all` (delete_by semantics).
+  it("delete with array of ids removes all matching rows", async () => {
+    const adapter = freshAdapter();
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t1 = await Topic.create({ title: "a" });
+    const t2 = await Topic.create({ title: "b" });
+    await Topic.create({ title: "c" });
+    expect(await Topic.delete([t1.id, t2.id])).toBe(2);
+    expect(await Topic.count()).toBe(1);
+  });
+
+  it("delete with nil / [] is a no-op returning 0", async () => {
+    const adapter = freshAdapter();
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    await Topic.create({ title: "a" });
+    expect(await Topic.delete(null)).toBe(0);
+    expect(await Topic.delete(undefined)).toBe(0);
+    expect(await Topic.delete([])).toBe(0);
+    expect(await Topic.count()).toBe(1);
+  });
+
+  // Rails: destroy(id) on a composite-PK model with a single tuple must
+  // destroy ONE record, not iterate the tuple as N ids.
+  it("destroy on composite PK treats a tuple as a single id", async () => {
+    const adapter = freshAdapter();
+    class OrderItem extends Base {
+      static {
+        this._tableName = "order_items";
+        this.attribute("shop_id", "integer");
+        this.attribute("order_id", "integer");
+        this.attribute("item_name", "string");
+        this.primaryKey = ["shop_id", "order_id"];
+        this.adapter = adapter;
+      }
+    }
+    await OrderItem.create({ shop_id: 1, order_id: 10, item_name: "A" });
+    await OrderItem.create({ shop_id: 1, order_id: 11, item_name: "B" });
+    const destroyed = await OrderItem.destroy([1, 10]);
+    // Should be one record (not iterated as two ids).
+    expect(Array.isArray(destroyed)).toBe(false);
+    expect(await OrderItem.count()).toBe(1);
   });
 
   it("create prefetched pk", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1737,8 +1737,10 @@ describe("PersistenceTest", () => {
   });
 
   // Rails: Base.delete accepts an array of composite-PK tuples and deletes
-  // each matching row via `(pk1,pk2) IN ((v1,v2),...)` — NOT via a
-  // per-column IN cross-product.
+  // each matching row. Predicate builder emits an OR-of-AND — e.g.
+  // `(shop_id = 1 AND order_id = 10) OR (shop_id = 1 AND order_id = 11)`
+  // — NOT a per-column IN cross-product (which would also match
+  // [shop_id=2, order_id=10]).
   it("delete accepts an array of composite-PK tuples", async () => {
     const adapter = freshAdapter();
     class OrderItem extends Base {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1765,6 +1765,27 @@ describe("PersistenceTest", () => {
     expect(remaining!.shop_id).toBe(2);
   });
 
+  // Rails: update(id, attrs) on a composite-PK model must treat a flat
+  // tuple as ONE id (not parallel ids). Mirrors destroy's detection.
+  it("update on composite PK treats a tuple as a single id", async () => {
+    const adapter = freshAdapter();
+    class OrderItem extends Base {
+      static {
+        this._tableName = "order_items";
+        this.attribute("shop_id", "integer");
+        this.attribute("order_id", "integer");
+        this.attribute("item_name", "string");
+        this.primaryKey = ["shop_id", "order_id"];
+        this.adapter = adapter;
+      }
+    }
+    await OrderItem.create({ shop_id: 1, order_id: 10, item_name: "A" });
+    const updated = await OrderItem.update([1, 10], { item_name: "A-updated" });
+    expect(Array.isArray(updated)).toBe(false);
+    const reloaded = await OrderItem.all().where({ shop_id: 1, order_id: 10 }).first();
+    expect(reloaded!.item_name).toBe("A-updated");
+  });
+
   // Rails: destroy(id) on a composite-PK model with a single tuple must
   // destroy ONE record, not iterate the tuple as N ids.
   it("destroy on composite PK treats a tuple as a single id", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -315,9 +315,9 @@ describe("PersistenceTest", () => {
       }
     }
     const t = await Topic.create({ title: "a" });
-    await expect(Topic.update(t as unknown as number, { title: "x" })).rejects.toThrow(
-      /ActiveRecord::Base/,
-    );
+    // Invoke through `any` to bypass the overloads — we're verifying the
+    // runtime guard rejects a Base instance, not testing a supported form.
+    await expect((Topic as any).update(t, { title: "x" })).rejects.toThrow(/ActiveRecord::Base/);
   });
 });
 
@@ -1734,6 +1734,35 @@ describe("PersistenceTest", () => {
     expect(await Topic.delete(undefined)).toBe(0);
     expect(await Topic.delete([])).toBe(0);
     expect(await Topic.count()).toBe(1);
+  });
+
+  // Rails: Base.delete accepts an array of composite-PK tuples and deletes
+  // each matching row via `(pk1,pk2) IN ((v1,v2),...)` — NOT via a
+  // per-column IN cross-product.
+  it("delete accepts an array of composite-PK tuples", async () => {
+    const adapter = freshAdapter();
+    class OrderItem extends Base {
+      static {
+        this._tableName = "order_items";
+        this.attribute("shop_id", "integer");
+        this.attribute("order_id", "integer");
+        this.attribute("item_name", "string");
+        this.primaryKey = ["shop_id", "order_id"];
+        this.adapter = adapter;
+      }
+    }
+    await OrderItem.create({ shop_id: 1, order_id: 10, item_name: "A" });
+    await OrderItem.create({ shop_id: 1, order_id: 11, item_name: "B" });
+    await OrderItem.create({ shop_id: 2, order_id: 10, item_name: "C" }); // NOT in delete set — cross-product would remove this
+    expect(
+      await OrderItem.delete([
+        [1, 10],
+        [1, 11],
+      ]),
+    ).toBe(2);
+    expect(await OrderItem.count()).toBe(1);
+    const remaining = await OrderItem.first();
+    expect(remaining!.shop_id).toBe(2);
   });
 
   // Rails: destroy(id) on a composite-PK model with a single tuple must

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -282,14 +282,40 @@ related records, etc.), they are almost always async. Always `await`
 them when composing manually; `save()` / `destroy()` / etc. do it for
 you.
 
-## 12. Naming, bang methods, keyword args, symbols
+## 12. `Base.update(:all, ...)` sentinel is `":all"`
+
+Rails' `Model.update(id = :all, attributes)` uses Ruby's `:all` symbol
+as the first-arg default. TypeScript has no symbols as natural literals,
+so the equivalent is a string with a leading colon:
+
+```ts
+// Rails
+Model.update(:all, title: "x")
+Model.update([1, 2], [{ title: "a" }, { title: "b" }])
+
+// Trails
+Model.update(":all", { title: "x" });         // explicit sentinel
+Model.update({ title: "x" });                  // also `:all` (no id arg)
+Model.update([1, 2], [{ title: "a" }, { title: "b" }]);
+```
+
+The leading colon matters: a bare `"all"` would collide with a legitimate
+string / slug primary-key value (e.g. a record whose `id` is `"all"`),
+and `update("all", attrs)` would silently update every row instead of
+finding the record with that id.
+
+Everywhere a TS API needs to accept a Rails symbol sentinel (`:all`,
+`:default`, etc.), we use the same `":name"` convention to keep it
+unambiguous from string PK values.
+
+## 13. Naming, bang methods, keyword args, symbols
 
 All cross-package — see the index for
 [method casing](./index.md#method-casing), [bang methods](./index.md#bang-methods),
 and [symbols/kwargs](./index.md#symbols-kwargs). Every ActiveRecord API
 follows them.
 
-## 13. Typing runtime-attached members with `declare`
+## 14. Typing runtime-attached members with `declare`
 
 Rails defines attributes/associations/scopes/enums dynamically, so a
 Ruby author just writes `post.title`, `post.author`, `Post.published`

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -288,14 +288,22 @@ Rails' `Model.update(id = :all, attributes)` uses Ruby's `:all` symbol
 as the first-arg default. TypeScript has no symbols as natural literals,
 so the equivalent is a string with a leading colon:
 
-```ts
-// Rails
+Rails:
+
+```ruby
 Model.update(:all, title: "x")
 Model.update([1, 2], [{ title: "a" }, { title: "b" }])
+```
 
-// Trails
-Model.update(":all", { title: "x" });         // explicit sentinel
-Model.update({ title: "x" });                  // also `:all` (no id arg)
+Trails:
+
+```ts
+import { Base } from "@blazetrails/activerecord";
+
+class Model extends Base {}
+
+Model.update(":all", { title: "x" }); // explicit sentinel
+Model.update({ title: "x" }); // also `:all` (no id arg)
 Model.update([1, 2], [{ title: "a" }, { title: "b" }]);
 ```
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -302,9 +302,9 @@ import { Base } from "@blazetrails/activerecord";
 
 class Model extends Base {}
 
-Model.update(":all", { title: "x" }); // explicit sentinel
-Model.update({ title: "x" }); // also `:all` (no id arg)
-Model.update([1, 2], [{ title: "a" }, { title: "b" }]);
+await Model.update(":all", { title: "x" }); // explicit sentinel
+await Model.update({ title: "x" }); // also `:all` (no id arg)
+await Model.update([1, 2], [{ title: "a" }, { title: "b" }]);
 ```
 
 The leading colon matters: a bare `"all"` would collide with a legitimate


### PR DESCRIPTION
## Summary

Rails' `persistence.rb` class methods dispatch heavily on argument shape; our versions only handled the most common single-id path. This PR aligns all three.

### `Base.update` / `Base.updateBang`

| Form | Behavior |
|---|---|
| `update(attrs)` | Apply attrs to every record in the current scope (Rails' `:all` default) |
| `update(":all", attrs)` | Same, explicit sentinel (mirrors Rails' `:all` symbol) |
| `update(id, attrs)` | `find(id)` + `update(attrs)`, returns the single record |
| `update([ids], [attrs])` | Parallel arrays, index-aligned, returns array |
| `update(baseInstance, attrs)` | Raises — Rails' `ArgumentError` mirror |

Implemented via a single `performClassUpdate` helper with TS overloads so single-id callers still get the narrow `Promise<InstanceType<T>>` return type.

**Sentinel choice — `":all"` not `"all"`**: a bare `"all"` would collide with a legitimate string / slug primary-key value (e.g. a record whose `id` is `"all"`), silently updating every row instead of finding that record. Leading colon mirrors Rails' `:all` symbol and is unambiguous from real PK values. Documented as deviation #12 in `activerecord-rails-deviations.md`.

### `Base.destroy`

Fixes composite-PK detection. Rails uses:

```ruby
multiple_ids = composite_primary_key? ? id.first.is_a?(Array) : id.is_a?(Array)
```

Previously a CPK tuple like `OrderItem.destroy([shop_id, order_id])` was iterated as two separate ids; now it correctly identifies a single record.

### `Base.delete`

Matches Rails' `delete_by(primary_key => id_or_array)`:
- Arrays, `null`/`undefined`, and `[]` all handled (the last three as no-ops returning 0).
- Both single-column and composite-PK paths route through `all().where(...).deleteAll()` so `currentScope` applies.
- Single-column PK: predicate builder emits `=` or `IN(...)` automatically from the scalar/array value.
- Composite PK: single tuple, AND-of-equality per key.

## Test plan

- [x] `pnpm vitest run packages/activerecord` — 8822 passed
- [x] `pnpm run build`
- [x] `pnpm run guides:typecheck` — all code blocks clean
- [x] New regression tests for every new arg shape (6 total): parallel-arrays update, `:all`-default update, Base-instance rejection, delete with array of ids, delete with nil/empty, destroy composite-PK tuple