### PR TITLE
feat(activerecord): Base.create/createBang/new accept arrays + block

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1581,6 +1581,30 @@ export class Base extends Model {
   }
 
   /**
+   * Alias for `new` (Rails 7.2+). Handy when `new` reads awkwardly in
+   * fluent chains or template literals.
+   *
+   * Mirrors: ActiveRecord::Persistence::ClassMethods#build
+   */
+  static build<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown>[],
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T>[];
+  static build<T extends typeof Base>(
+    this: T,
+    attrs?: Record<string, unknown>,
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T>;
+  static build<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T> | InstanceType<T>[] {
+    return (this as T).new(attrs as Record<string, unknown>, block);
+  }
+
+  /**
    * Create a record and save it to the database.
    *
    * Rails: `Base.create(attributes = nil, &block)` — recurses on arrays

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1601,7 +1601,7 @@ export class Base extends Model {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (record: InstanceType<T>) => void,
   ): InstanceType<T> | InstanceType<T>[] {
-    return (this as T).new(attrs as Record<string, unknown>, block);
+    return Array.isArray(attrs) ? (this as T).new(attrs, block) : (this as T).new(attrs, block);
   }
 
   /**
@@ -1653,7 +1653,7 @@ export class Base extends Model {
    * Create a record or throw if validation fails.
    *
    * Rails: `Base.create!(attributes = nil, &block)` — recurses on arrays
-   * and yields each record to the block before save!.
+   * and yields each record to the block before `saveBang()`.
    */
   static async createBang<T extends typeof Base>(
     this: T,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1554,16 +1554,37 @@ export class Base extends Model {
   /**
    * Instantiate a new record (not yet saved).
    *
-   * Mirrors: ActiveRecord::Base.new (Ruby convention)
+   * Rails: `Base.new(attributes = nil, &block)` — recurses on arrays and
+   * yields each record to the block before returning. Aliased as `build`.
    */
-  static new<T extends typeof Base>(this: T, attrs: Record<string, unknown> = {}): InstanceType<T> {
-    return new this(attrs) as InstanceType<T>;
+  static new<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown>[],
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T>[];
+  static new<T extends typeof Base>(
+    this: T,
+    attrs?: Record<string, unknown>,
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T>;
+  static new<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (record: InstanceType<T>) => void,
+  ): InstanceType<T> | InstanceType<T>[] {
+    if (Array.isArray(attrs)) {
+      return attrs.map((a) => (this as T).new(a, block));
+    }
+    const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
+    if (block) block(record);
+    return record;
   }
 
   /**
    * Create a record and save it to the database.
    *
-   * Mirrors: ActiveRecord::Base.create
+   * Rails: `Base.create(attributes = nil, &block)` — recurses on arrays
+   * and yields each record to the block before save.
    */
   private static _mergeCurrentScopeAttrs(attrs: Record<string, unknown>): Record<string, unknown> {
     const scope = this.currentScope;
@@ -1576,9 +1597,24 @@ export class Base extends Model {
 
   static async create<T extends typeof Base>(
     this: T,
-    attrs: Record<string, unknown> = {},
-  ): Promise<InstanceType<T>> {
+    attrs: Record<string, unknown>[],
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T>[]>;
+  static async create<T extends typeof Base>(
+    this: T,
+    attrs?: Record<string, unknown>,
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T>>;
+  static async create<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T> | InstanceType<T>[]> {
+    if (Array.isArray(attrs)) {
+      return Promise.all(attrs.map((a) => (this as T).create(a, block)));
+    }
     const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
+    if (block) block(record);
     await record.save();
     return record;
   }
@@ -1586,13 +1622,29 @@ export class Base extends Model {
   /**
    * Create a record or throw if validation fails.
    *
-   * Mirrors: ActiveRecord::Base.create!
+   * Rails: `Base.create!(attributes = nil, &block)` — recurses on arrays
+   * and yields each record to the block before save!.
    */
   static async createBang<T extends typeof Base>(
     this: T,
-    attrs: Record<string, unknown> = {},
-  ): Promise<InstanceType<T>> {
+    attrs: Record<string, unknown>[],
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T>[]>;
+  static async createBang<T extends typeof Base>(
+    this: T,
+    attrs?: Record<string, unknown>,
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T>>;
+  static async createBang<T extends typeof Base>(
+    this: T,
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (record: InstanceType<T>) => void,
+  ): Promise<InstanceType<T> | InstanceType<T>[]> {
+    if (Array.isArray(attrs)) {
+      return Promise.all(attrs.map((a) => (this as T).createBang(a, block)));
+    }
     const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
+    if (block) block(record);
     await record.saveBang();
     return record;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1555,7 +1555,7 @@ export class Base extends Model {
    * Instantiate a new record (not yet saved).
    *
    * Rails: `Base.new(attributes = nil, &block)` — recurses on arrays and
-   * yields each record to the block before returning. Aliased as `build`.
+   * yields each record to the block before returning.
    */
   static new<T extends typeof Base>(
     this: T,
@@ -1611,7 +1611,13 @@ export class Base extends Model {
     block?: (record: InstanceType<T>) => void,
   ): Promise<InstanceType<T> | InstanceType<T>[]> {
     if (Array.isArray(attrs)) {
-      return Promise.all(attrs.map((a) => (this as T).create(a, block)));
+      // Sequential, matching Rails' `attributes.collect { create(attr, &block) }`.
+      // Promise.all would interleave saves and fire callbacks out of order.
+      const records: InstanceType<T>[] = [];
+      for (const a of attrs) {
+        records.push((await (this as T).create(a, block)) as InstanceType<T>);
+      }
+      return records;
     }
     const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
     if (block) block(record);
@@ -1641,7 +1647,14 @@ export class Base extends Model {
     block?: (record: InstanceType<T>) => void,
   ): Promise<InstanceType<T> | InstanceType<T>[]> {
     if (Array.isArray(attrs)) {
-      return Promise.all(attrs.map((a) => (this as T).createBang(a, block)));
+      // Sequential + short-circuit on failure: Rails' create! stops at the
+      // first exception, so later elements are never attempted. Promise.all
+      // would fire every save concurrently and partial-write.
+      const records: InstanceType<T>[] = [];
+      for (const a of attrs) {
+        records.push((await (this as T).createBang(a, block)) as InstanceType<T>);
+      }
+      return records;
     }
     const record = new this(this._mergeCurrentScopeAttrs(attrs)) as InstanceType<T>;
     if (block) block(record);

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -333,6 +333,25 @@ describe("PersistenceTest", () => {
     expect(result.every((t) => t.isPersisted())).toBe(true);
   });
 
+  // Rails 7.2+: `Base.build` is an alias for `Base.new`.
+  it("build is an alias for new and supports array + block", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const single = Topic.build({ title: "a" }, (r) => {
+      r.title = "mutated";
+    });
+    expect(single.isNewRecord()).toBe(true);
+    expect(single.title).toBe("mutated");
+
+    const many = Topic.build([{ title: "b" }, { title: "c" }]);
+    expect(many).toHaveLength(2);
+    expect(many.every((t) => t.isNewRecord())).toBe(true);
+  });
+
   it("new with an array returns unsaved records", () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -306,6 +306,77 @@ describe("PersistenceTest", () => {
     expect(titles).toEqual(["same", "same"]);
   });
 
+  // Rails: Base.create([{...}, {...}]) recurses and returns an array of
+  // persisted records. Same for new() and createBang().
+  it("create with an array recurses and returns an array of records", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const result = await Topic.create([{ title: "a" }, { title: "b" }]);
+    expect(result).toHaveLength(2);
+    expect(result[0].isPersisted()).toBe(true);
+    expect(result.map((t) => t.title)).toEqual(["a", "b"]);
+  });
+
+  it("createBang with an array recurses and returns an array of records", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const result = await Topic.createBang([{ title: "a" }, { title: "b" }]);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.isPersisted())).toBe(true);
+  });
+
+  it("new with an array returns unsaved records", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const result = Topic.new([{ title: "a" }, { title: "b" }]);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.isNewRecord())).toBe(true);
+  });
+
+  // Rails: Base.create(attrs, &block) yields each record to the block
+  // before save, so the block can mutate it.
+  it("create yields to block before save", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const t = await Topic.create({ title: "a" }, (record) => {
+      record.title = "mutated-by-block";
+    });
+    expect(t.title).toBe("mutated-by-block");
+    expect(t.isPersisted()).toBe(true);
+    const reloaded = await Topic.find(t.id);
+    expect(reloaded.title).toBe("mutated-by-block");
+  });
+
+  it("create with array yields to block for each record", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    let calls = 0;
+    await Topic.create([{ title: "a" }, { title: "b" }], () => {
+      calls++;
+    });
+    expect(calls).toBe(2);
+  });
+
   // Rails: passing an AR instance raises ArgumentError.
   it("update rejects a Base instance", async () => {
     class Topic extends Base {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -363,6 +363,27 @@ describe("PersistenceTest", () => {
     expect(reloaded.title).toBe("mutated-by-block");
   });
 
+  // Rails: create! stops at the first exception, so records after the
+  // failed element are not persisted.
+  it("createBang with an array stops at the first invalid record", async () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+        this.validatesPresenceOf("title");
+      }
+    }
+
+    await expect(
+      Topic.createBang([{ title: "first" }, { title: "" }, { title: "third" }]),
+    ).rejects.toThrow();
+
+    // First element committed before the failure.
+    expect(await Topic.all().where({ title: "first" }).exists()).toBe(true);
+    // Third element never attempted.
+    expect(await Topic.all().where({ title: "third" }).exists()).toBe(false);
+  });
+
   it("create with array yields to block for each record", async () => {
     class Topic extends Base {
       static {


### PR DESCRIPTION
## Summary

Rails' class-level constructors recurse on array input and yield each record to an optional block before persist. Our versions treated an array as a single attrs hash with numeric keys and ignored blocks.

\`\`\`ruby
# Rails
Model.create([{a: 1}, {a: 2}])      # [<Model>, <Model>]
Model.create({...}) { |r| ... }     # yields before save
Model.new([{...}, {...}])           # Array<Model>, unsaved
Model.create!([...], &block)        # both combined
\`\`\`

\`\`\`ts
// Trails (this PR)
await Model.create([{ a: 1 }, { a: 2 }]);
await Model.create({ /* ... */ }, (record) => { /* mutate */ });
Model.new([{ /* ... */ }, { /* ... */ }]);
await Model.createBang([{ /* ... */ }], (record) => { /* mutate */ });
\`\`\`

Implemented via TS overloads on all three methods. The block fires after currentScope's \`scope_for_create\` merge and before \`save\` / \`saveBang\`, matching the point Rails' \`&block\` runs.

## Test plan

- [x] 5 new regression tests for create/createBang/new array recursion and block-yield timing
- [x] \`pnpm vitest run packages/activerecord\` — 8829 passed
- [x] \`pnpm run build\`