### PR TITLE
feat(activerecord): fire after_initialize on DB-loaded records in Rails order

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -979,12 +979,8 @@ export class Model {
     // Fire after_initialize callbacks (suppressed for DB-loaded records so
     // _instantiate can fire after_find first, then after_initialize in order —
     // flag is set on Base in activerecord, unknown to Model in activemodel)
-    if (
-      !(
-        "_suppressInitializeCallback" in ctor &&
-        ctor["_suppressInitializeCallback" as keyof typeof ctor]
-      )
-    ) {
+    const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
+    if (callbackSuppressor._suppressInitializeCallback !== true) {
       ctor._callbackChain.runAfter("initialize", this);
     }
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -976,9 +976,10 @@ export class Model {
     // Snapshot after construction — the initial state is "clean"
     this._dirty.snapshot(this._attributes);
 
-    // Fire after_initialize callbacks (suppressed for DB-loaded records so
-    // _instantiate can fire after_find first, then after_initialize in order —
-    // flag is set on Base in activerecord, unknown to Model in activemodel)
+    // Fire after_initialize callbacks. ActiveRecord intentionally uses the
+    // duck-typed `_suppressInitializeCallback` hook during DB hydration so it
+    // can defer constructor-time after_initialize, run after_find first, and
+    // then fire after_initialize in Rails-compatible order.
     const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
     if (callbackSuppressor._suppressInitializeCallback !== true) {
       ctor._callbackChain.runAfter("initialize", this);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -976,8 +976,17 @@ export class Model {
     // Snapshot after construction — the initial state is "clean"
     this._dirty.snapshot(this._attributes);
 
-    // Fire after_initialize callbacks
-    ctor._callbackChain.runAfter("initialize", this);
+    // Fire after_initialize callbacks (suppressed for DB-loaded records so
+    // _instantiate can fire after_find first, then after_initialize in order —
+    // flag is set on Base in activerecord, unknown to Model in activemodel)
+    if (
+      !(
+        "_suppressInitializeCallback" in ctor &&
+        ctor["_suppressInitializeCallback" as keyof typeof ctor]
+      )
+    ) {
+      ctor._callbackChain.runAfter("initialize", this);
+    }
   }
 
   // -- Attribute access --

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1786,8 +1786,12 @@ export class Base extends Model {
     (ModelSchema.loadSchema as any).call(this);
 
     this._suppressInitializeCallback = true;
-    const record = new this() as InstanceType<T>;
-    this._suppressInitializeCallback = false;
+    let record: InstanceType<T>;
+    try {
+      record = new this() as InstanceType<T>;
+    } finally {
+      this._suppressInitializeCallback = false;
+    }
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {
       record._attributes.writeFromDatabase(key, value);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1785,13 +1785,21 @@ export class Base extends Model {
 
     (ModelSchema.loadSchema as any).call(this);
 
+    const hadOwnSuppress = Object.prototype.hasOwnProperty.call(
+      this,
+      "_suppressInitializeCallback",
+    );
     const prevSuppress = this._suppressInitializeCallback;
     this._suppressInitializeCallback = true;
     let record: InstanceType<T>;
     try {
       record = new this() as InstanceType<T>;
     } finally {
-      this._suppressInitializeCallback = prevSuppress;
+      if (hadOwnSuppress) {
+        this._suppressInitializeCallback = prevSuppress;
+      } else {
+        delete (this as any)._suppressInitializeCallback;
+      }
     }
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -892,6 +892,11 @@ export class Base extends Model {
   // -- Readonly attributes --
   static _readonlyAttributes: Set<string> = new Set();
 
+  // Suppresses after_initialize in the constructor when set by _instantiate /
+  // directInstantiate (inheritance.ts) so we can fire after_find first, then
+  // after_initialize — matching Rails' init_with_attributes call order.
+  static _suppressInitializeCallback = false;
+
   // --- ReadonlyAttributes mixin (wired via extend() after class) ---
   declare static attrReadonly: typeof ReadonlyAttributes.attrReadonly;
   declare static readonlyAttributeQ: typeof ReadonlyAttributes.readonlyAttributeQ;
@@ -1780,7 +1785,9 @@ export class Base extends Model {
 
     (ModelSchema.loadSchema as any).call(this);
 
+    this._suppressInitializeCallback = true;
     const record = new this() as InstanceType<T>;
+    this._suppressInitializeCallback = false;
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {
       record._attributes.writeFromDatabase(key, value);
@@ -1792,8 +1799,9 @@ export class Base extends Model {
     if (this._strictLoadingByDefault) {
       record._strictLoading = true;
     }
-    // Fire after_find callbacks
+    // Rails' init_with_attributes fires after_find then after_initialize
     this._callbackChain.runAfter("find", record);
+    this._callbackChain.runAfter("initialize", record);
     return record;
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1785,12 +1785,13 @@ export class Base extends Model {
 
     (ModelSchema.loadSchema as any).call(this);
 
+    const prevSuppress = this._suppressInitializeCallback;
     this._suppressInitializeCallback = true;
     let record: InstanceType<T>;
     try {
       record = new this() as InstanceType<T>;
     } finally {
-      this._suppressInitializeCallback = false;
+      this._suppressInitializeCallback = prevSuppress;
     }
     // Load DB values through deserialize (not cast) so encrypted types decrypt
     for (const [key, value] of Object.entries(row)) {

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -50,11 +50,14 @@ describe("CallbacksTest", () => {
       }
     }
     const log: string[] = [];
+    Topic.afterFind(function (this: any) {
+      log.push("after_find");
+    });
     Topic.afterInitialize(function (this: any) {
       log.push("after_initialize");
     });
     new Topic({ title: "a" });
-    expect(log).toContain("after_initialize");
+    expect(log).toEqual(["after_initialize"]);
   });
 
   it("find", async () => {
@@ -69,8 +72,11 @@ describe("CallbacksTest", () => {
     Topic.afterFind(function (this: any) {
       log.push("after_find");
     });
+    Topic.afterInitialize(function (this: any) {
+      log.push("after_initialize");
+    });
     await Topic.find(created.id);
-    expect(log).toContain("after_find");
+    expect(log).toEqual(["after_find", "after_initialize"]);
   });
 });
 
@@ -1492,6 +1498,26 @@ describe("CallbacksTest", () => {
     await Developer.all().toArray();
     expect(found).toEqual(["Alice", "Bob"]);
   });
+
+  // after_initialize fires with DB-loaded values available
+  it("after_initialize on loaded record sees DB values", async () => {
+    const seen: string[] = [];
+    class Developer extends Base {
+      static {
+        this._tableName = "developers";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.afterInitialize((r: any) => seen.push(r.name));
+      }
+    }
+
+    await Developer.create({ name: "Carol" });
+    seen.length = 0;
+
+    await Developer.find(1);
+    expect(seen).toEqual(["Carol"]);
+  });
 });
 
 describe("CallbacksTest", () => {
@@ -1573,71 +1599,5 @@ describe("CallbacksTest", () => {
     record.locked = true;
     const result = await record.save();
     expect(result).toBe(false);
-  });
-});
-
-describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-
-  beforeEach(() => {
-    adapter = freshAdapter();
-  });
-
-  // Rails: test "initialize" — only after_initialize fires on new
-  it("initialize", () => {
-    const order: string[] = [];
-    class Developer extends Base {
-      static {
-        this._tableName = "developers";
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        this.afterFind(() => order.push("after_find"));
-        this.afterInitialize(() => order.push("after_initialize"));
-      }
-    }
-    new Developer({ name: "Alice" });
-    expect(order).toEqual(["after_initialize"]);
-  });
-
-  // Rails: test "find" — after_find fires before after_initialize
-  it("find", async () => {
-    const order: string[] = [];
-    class Developer extends Base {
-      static {
-        this._tableName = "developers";
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        this.afterFind(() => order.push("after_find"));
-        this.afterInitialize(() => order.push("after_initialize"));
-      }
-    }
-
-    await Developer.create({ name: "Alice" });
-    order.length = 0;
-
-    await Developer.find(1);
-    expect(order).toEqual(["after_find", "after_initialize"]);
-  });
-
-  // after_initialize fires with DB-loaded values available
-  it("after_initialize on loaded record sees DB values", async () => {
-    const seen: string[] = [];
-    class Developer extends Base {
-      static {
-        this._tableName = "developers";
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        this.afterInitialize((r: any) => seen.push(r.name));
-      }
-    }
-
-    await Developer.create({ name: "Carol" });
-    seen.length = 0;
-
-    await Developer.find(1);
-    expect(seen).toEqual(["Carol"]);
   });
 });

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -1575,3 +1575,69 @@ describe("CallbacksTest", () => {
     expect(result).toBe(false);
   });
 });
+
+describe("CallbacksTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
+  // Rails: test "initialize" — only after_initialize fires on new
+  it("initialize", () => {
+    const order: string[] = [];
+    class Developer extends Base {
+      static {
+        this._tableName = "developers";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.afterFind(() => order.push("after_find"));
+        this.afterInitialize(() => order.push("after_initialize"));
+      }
+    }
+    new Developer({ name: "Alice" });
+    expect(order).toEqual(["after_initialize"]);
+  });
+
+  // Rails: test "find" — after_find fires before after_initialize
+  it("find", async () => {
+    const order: string[] = [];
+    class Developer extends Base {
+      static {
+        this._tableName = "developers";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.afterFind(() => order.push("after_find"));
+        this.afterInitialize(() => order.push("after_initialize"));
+      }
+    }
+
+    await Developer.create({ name: "Alice" });
+    order.length = 0;
+
+    await Developer.find(1);
+    expect(order).toEqual(["after_find", "after_initialize"]);
+  });
+
+  // after_initialize fires with DB-loaded values available
+  it("after_initialize on loaded record sees DB values", async () => {
+    const seen: string[] = [];
+    class Developer extends Base {
+      static {
+        this._tableName = "developers";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.afterInitialize((r: any) => seen.push(r.name));
+      }
+    }
+
+    await Developer.create({ name: "Carol" });
+    seen.length = 0;
+
+    await Developer.find(1);
+    expect(seen).toEqual(["Carol"]);
+  });
+});

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -3,7 +3,14 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, transaction, RecordNotDestroyed } from "./index.js";
+import {
+  Base,
+  transaction,
+  RecordNotDestroyed,
+  enableSti,
+  registerSubclass,
+  registerModel,
+} from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1517,6 +1524,37 @@ describe("CallbacksTest", () => {
 
     await Developer.find(1);
     expect(seen).toEqual(["Carol"]);
+  });
+
+  // STI subclass loaded from DB fires after_find then after_initialize in order
+  it("after_find and after_initialize fire in Rails order for STI subclasses", async () => {
+    const order: string[] = [];
+    class Animal extends Base {
+      static {
+        this._tableName = "animals";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("type", "string");
+        this.adapter = adapter;
+        enableSti(this);
+      }
+    }
+    class Dog extends Animal {
+      static {
+        registerSubclass(this);
+        registerModel(this);
+        this.afterFind(() => order.push("after_find"));
+        this.afterInitialize(() => order.push("after_initialize"));
+      }
+    }
+    void Dog;
+
+    await Animal.create({ name: "Rex", type: "Dog" });
+    order.length = 0;
+
+    const loaded = await Animal.find(1);
+    expect(loaded).toBeInstanceOf(Dog);
+    expect(order).toEqual(["after_find", "after_initialize"]);
   });
 });
 

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -161,7 +161,7 @@ export function afterDestroy<T extends ModelCtor>(
  */
 export function afterFind<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "find", fn, options);
@@ -176,7 +176,7 @@ export function afterFind<T extends ModelCtor>(
  */
 export function afterInitialize<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void,
+  fn: (record: InstanceType<T>) => void | Promise<void>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "initialize", fn, options);

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -152,6 +152,36 @@ export function afterDestroy<T extends ModelCtor>(
   registerCallback(modelClass, "after", "destroy", fn, options);
 }
 
+/**
+ * Register an after_find callback. Fires on every record loaded from the DB.
+ *
+ * Rails defines :find with only: :after, so there is no before_find or around_find.
+ *
+ * Mirrors: ActiveRecord::Callbacks.after_find
+ */
+export function afterFind<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void,
+  options?: CallbackOptions<InstanceType<T>>,
+): void {
+  registerCallback(modelClass, "after", "find", fn, options);
+}
+
+/**
+ * Register an after_initialize callback. Fires on every new or loaded record.
+ *
+ * Rails defines :initialize with only: :after, so there is no before_initialize or around_initialize.
+ *
+ * Mirrors: ActiveRecord::Callbacks.after_initialize
+ */
+export function afterInitialize<T extends ModelCtor>(
+  modelClass: T,
+  fn: (record: InstanceType<T>) => void,
+  options?: CallbackOptions<InstanceType<T>>,
+): void {
+  registerCallback(modelClass, "after", "initialize", fn, options);
+}
+
 type AnyCallbackOptions = CallbackOptions<never> | ValidationCallbackOptions<never>;
 
 function registerCallback(

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -177,7 +177,9 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
  */
 function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Base {
   (klass as any)._skipEncryption = true;
+  (klass as any)._suppressInitializeCallback = true;
   const record = new klass(row);
+  (klass as any)._suppressInitializeCallback = false;
   (klass as any)._skipEncryption = false;
   record._newRecord = false;
   (record as any)._dirty.snapshot(record._attributes);
@@ -185,7 +187,9 @@ function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Ba
   if ((klass as any)._strictLoadingByDefault) {
     (record as any)._strictLoading = true;
   }
+  // Rails' init_with_attributes fires after_find then after_initialize
   (klass as any)._callbackChain?.runAfter?.("find", record);
+  (klass as any)._callbackChain?.runAfter?.("initialize", record);
   return record;
 }
 

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -177,12 +177,12 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
  */
 function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Base {
   (klass as any)._skipEncryption = true;
-  (klass as any)._suppressInitializeCallback = true;
+  klass._suppressInitializeCallback = true;
   let record: Base;
   try {
     record = new klass(row);
   } finally {
-    (klass as any)._suppressInitializeCallback = false;
+    klass._suppressInitializeCallback = false;
     (klass as any)._skipEncryption = false;
   }
   record._newRecord = false;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -178,9 +178,13 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
 function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Base {
   (klass as any)._skipEncryption = true;
   (klass as any)._suppressInitializeCallback = true;
-  const record = new klass(row);
-  (klass as any)._suppressInitializeCallback = false;
-  (klass as any)._skipEncryption = false;
+  let record: Base;
+  try {
+    record = new klass(row);
+  } finally {
+    (klass as any)._suppressInitializeCallback = false;
+    (klass as any)._skipEncryption = false;
+  }
   record._newRecord = false;
   (record as any)._dirty.snapshot(record._attributes);
   record.changesApplied();

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -177,12 +177,13 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
  */
 function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Base {
   (klass as any)._skipEncryption = true;
+  const prevSuppress = klass._suppressInitializeCallback;
   klass._suppressInitializeCallback = true;
   let record: Base;
   try {
     record = new klass(row);
   } finally {
-    klass._suppressInitializeCallback = false;
+    klass._suppressInitializeCallback = prevSuppress;
     (klass as any)._skipEncryption = false;
   }
   record._newRecord = false;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -177,13 +177,18 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
  */
 function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Base {
   (klass as any)._skipEncryption = true;
+  const hadOwnSuppress = Object.prototype.hasOwnProperty.call(klass, "_suppressInitializeCallback");
   const prevSuppress = klass._suppressInitializeCallback;
   klass._suppressInitializeCallback = true;
   let record: Base;
   try {
     record = new klass(row);
   } finally {
-    klass._suppressInitializeCallback = prevSuppress;
+    if (hadOwnSuppress) {
+      klass._suppressInitializeCallback = prevSuppress;
+    } else {
+      delete (klass as any)._suppressInitializeCallback;
+    }
     (klass as any)._skipEncryption = false;
   }
   record._newRecord = false;


### PR DESCRIPTION
## Summary

- **Bug fixed**: `after_initialize` was firing too early on DB-loaded records — it fired in `Model.constructor` before `writeFromDatabase` populated the record's attributes, and before `after_find`
- **Rails spec**: `init_with_attributes` fires `after_find` then `after_initialize` (in that order) after the record is fully hydrated
- **Fix**: added `_suppressInitializeCallback` static flag on `Base`; `_instantiate` and `directInstantiate` (STI path) set it before `new()` so `Model.constructor` skips the early fire, then fires `after_find` → `after_initialize` in correct order with DB values available
- **New helpers**: `afterFind` / `afterInitialize` functional-style exports in `callbacks.ts` (complement to `Model.afterFind` / `Model.afterInitialize` static methods)
- **3 new tests**: pin callback order (only `after_initialize` on `new`, `after_find` then `after_initialize` on `find`), and verify `after_initialize` sees DB values on load