### PR TITLE
fix(activerecord): uniqueness uses bind params + composite/string PK + id_in_database semantics

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1942,26 +1942,26 @@ export class Base extends Model {
         relation = options.conditions.call(relation);
       }
 
-      // Exclude self if persisted — mirrors uniqueness.rb:26-30
+      // Exclude self if persisted — mirrors uniqueness.rb:26-30:
       // `relation.where.not(primary_key => [record.id_in_database])`
-      // Use the DB value (attributeWas) when the PK has been changed in memory.
+      // Array form generates NOT IN, matching Rails. attributeWas() provides
+      // the DB value when the PK has been changed in memory (id_in_database).
       if (this.isPersisted()) {
         const pk = ctor.primaryKey;
         if (Array.isArray(pk)) {
           const selfConditions: Record<string, unknown> = {};
           for (const col of pk) {
-            const dirty = this._dirty;
-            selfConditions[col] = dirty.attributeChanged(col)
-              ? dirty.attributeWas(col)
+            const dbVal = this._dirty.attributeChanged(col)
+              ? this._dirty.attributeWas(col)
               : this.readAttribute(col);
+            selfConditions[col] = [dbVal];
           }
           relation = relation.whereNot(selfConditions);
         } else {
-          const dirty = this._dirty;
-          const pkVal = dirty.attributeChanged(pk)
-            ? dirty.attributeWas(pk)
+          const dbVal = this._dirty.attributeChanged(pk)
+            ? this._dirty.attributeWas(pk)
             : this.readAttribute(pk);
-          relation = relation.whereNot({ [pk]: pkVal });
+          relation = relation.whereNot({ [pk]: [dbVal] });
         }
       }
       const existing = await relation.first();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1949,14 +1949,12 @@ export class Base extends Model {
       if (this.isPersisted()) {
         const pk = ctor.primaryKey;
         if (Array.isArray(pk)) {
-          const selfConditions: Record<string, unknown> = {};
-          for (const col of pk) {
-            const dbVal = this._dirty.attributeChanged(col)
+          const dbVals = pk.map((col) =>
+            this._dirty.attributeChanged(col)
               ? this._dirty.attributeWas(col)
-              : this.readAttribute(col);
-            selfConditions[col] = [dbVal];
-          }
-          relation = relation.whereNot(selfConditions);
+              : this.readAttribute(col),
+          );
+          relation = relation.whereNot(pk, [dbVals]);
         } else {
           const dbVal = this._dirty.attributeChanged(pk)
             ? this._dirty.attributeWas(pk)

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1942,11 +1942,27 @@ export class Base extends Model {
         relation = options.conditions.call(relation);
       }
 
-      // Exclude self if persisted
+      // Exclude self if persisted — mirrors uniqueness.rb:26-30
+      // `relation.where.not(primary_key => [record.id_in_database])`
+      // Use the DB value (attributeWas) when the PK has been changed in memory.
       if (this.isPersisted()) {
-        relation = relation.where(
-          `"${ctor.arelTable.name}"."${ctor.primaryKey}" != ${(this as any).id}`,
-        );
+        const pk = ctor.primaryKey;
+        if (Array.isArray(pk)) {
+          const selfConditions: Record<string, unknown> = {};
+          for (const col of pk) {
+            const dirty = this._dirty;
+            selfConditions[col] = dirty.attributeChanged(col)
+              ? dirty.attributeWas(col)
+              : this.readAttribute(col);
+          }
+          relation = relation.whereNot(selfConditions);
+        } else {
+          const dirty = this._dirty;
+          const pkVal = dirty.attributeChanged(pk)
+            ? dirty.attributeWas(pk)
+            : this.readAttribute(pk);
+          relation = relation.whereNot({ [pk]: pkVal });
+        }
       }
       const existing = await relation.first();
       if (existing) {

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -1484,6 +1484,75 @@ describe("UniquenessWithCompositeKey", () => {
   });
 });
 
+describe("UniquenessBindParamsTest", () => {
+  it("uniqueness excludes self with string primary key", async () => {
+    const adp = freshAdapter();
+    class Token extends Base {
+      static {
+        this.primaryKey = "token";
+        this.attribute("token", "string");
+        this.attribute("label", "string");
+        this.adapter = adp;
+        this.validatesUniqueness("label");
+      }
+    }
+    const t = await Token.create({ token: "abc-123", label: "my token" });
+    expect(t.isPersisted()).toBe(true);
+    // Re-saving same record should not conflict with itself (self-exclusion via bind param)
+    expect(await t.save()).toBe(true);
+    // A different record with the same label should fail
+    const t2 = new Token({ token: "def-456", label: "my token" });
+    expect(await t2.save()).toBe(false);
+  });
+
+  it("uniqueness excludes self with composite primary key", async () => {
+    const adp = freshAdapter();
+    class Slot extends Base {
+      static {
+        this.primaryKey = ["room_id", "slot_num"];
+        this.attribute("room_id", "integer");
+        this.attribute("slot_num", "integer");
+        this.attribute("title", "string");
+        this.adapter = adp;
+        this.validatesUniqueness("title");
+      }
+    }
+    const s = await Slot.create({ room_id: 1, slot_num: 1, title: "keynote" });
+    expect(s.isPersisted()).toBe(true);
+    // Re-saving same record should not conflict with itself
+    expect(await s.save()).toBe(true);
+    // A different record with the same title should fail
+    const s2 = new Slot({ room_id: 2, slot_num: 1, title: "keynote" });
+    expect(await s2.save()).toBe(false);
+  });
+
+  it("uniqueness uses id_in_database when pk was changed in memory", async () => {
+    const adp = freshAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adp;
+        this.validatesUniqueness("name");
+      }
+    }
+    const a = await Item.create({ name: "alpha" });
+    const b = await Item.create({ name: "beta" });
+    // Change b's PK in memory to a's PK — self-exclusion must use the DB PK (b's original id)
+    // so the uniqueness check for "beta" still correctly excludes b itself, not a
+    (b as any).id = a.id;
+    // "beta" is still unique (only a has "alpha"), so save should succeed
+    // because the self-exclusion uses b's DB id (original), not the in-memory a.id
+    expect(b._dirty.attributeChanged("id")).toBe(true);
+    const saved = await b.save();
+    // The name "beta" has no other record, so uniqueness passes regardless
+    expect(saved).toBe(true);
+    // Now test the case where changed-PK matters: if self-exclusion used in-memory PK,
+    // it would incorrectly exclude a instead of b, causing "alpha" to pass uniqueness
+    const c = new Item({ name: "alpha" });
+    expect(await c.save()).toBe(false); // "alpha" still taken by record a
+  });
+});
+
 describe("UniquenessValidationTest", () => {
   it("validate uniqueness", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -1537,19 +1537,14 @@ describe("UniquenessBindParamsTest", () => {
     }
     const a = await Item.create({ name: "alpha" });
     const b = await Item.create({ name: "beta" });
-    // Change b's PK in memory to a's PK — self-exclusion must use the DB PK (b's original id)
-    // so the uniqueness check for "beta" still correctly excludes b itself, not a
+    // Change b's PK in memory to a's PK, then change b's name to conflict with a.
+    // The uniqueness validator must exclude b using b's database id, not the mutated in-memory id.
     (b as any).id = a.id;
-    // "beta" is still unique (only a has "alpha"), so save should succeed
-    // because the self-exclusion uses b's DB id (original), not the in-memory a.id
+    b.name = "alpha";
     expect(b._dirty.attributeChanged("id")).toBe(true);
-    const saved = await b.save();
-    // The name "beta" has no other record, so uniqueness passes regardless
-    expect(saved).toBe(true);
-    // Now test the case where changed-PK matters: if self-exclusion used in-memory PK,
-    // it would incorrectly exclude a instead of b, causing "alpha" to pass uniqueness
-    const c = new Item({ name: "alpha" });
-    expect(await c.save()).toBe(false); // "alpha" still taken by record a
+    // If self-exclusion incorrectly used the in-memory PK, it would exclude a and allow this save.
+    // Using id_in_database correctly keeps a visible to the uniqueness query, so the save must fail.
+    expect(await b.save()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace raw SQL interpolation in `_runAsyncValidations` self-exclusion with `whereNot` bind params — mirrors `uniqueness.rb:26-30` (`relation.where.not(primary_key => [record.id_in_database])`)
- Supports string/UUID primary keys (no integer casting/quoting assumed)
- Supports composite primary keys (builds `whereNot` condition over all PK columns)
- Uses `attributeWas(pk)` when the PK has been changed in memory, matching Rails' `id_in_database` semantics

## Test plan

- [ ] `uniqueness excludes self with string primary key` — UUID/string PK, self-exclusion still works
- [ ] `uniqueness excludes self with composite primary key` — composite PK, self-exclusion still works
- [ ] `uniqueness uses id_in_database when pk was changed in memory` — self-exclusion uses DB value, not in-memory PK
- [ ] All 99 existing uniqueness tests still pass