### PR TITLE
feat(activerecord): pg column predicates, unquoteIdentifier, checkAllForeignKeysValidBang (PR A)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -855,4 +855,69 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].val).toBeNull();
     });
   });
+
+  // ── Column reflection ──────────────────────────────────────────────
+  describe("Column reflection", () => {
+    afterEach(async () => {
+      await adapter.execute(`DROP TABLE IF EXISTS col_reflection_test CASCADE`);
+      await adapter.execute(`DROP TYPE IF EXISTS col_reflection_mood CASCADE`);
+    });
+
+    it("reflects identity column", async () => {
+      await adapter.execute(`
+        CREATE TABLE col_reflection_test (
+          id   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+          name TEXT
+        )
+      `);
+      const cols = await adapter.columns("col_reflection_test");
+      const id = cols.find((c) => c.name === "id")!;
+      expect(id.isIdentity).toBe(true);
+      expect(id.isAutoIncrementedByDb()).toBe(true);
+    });
+
+    it("reflects generated (virtual stored) column", async () => {
+      await adapter.execute(`
+        CREATE TABLE col_reflection_test (
+          id  SERIAL PRIMARY KEY,
+          a   INT NOT NULL,
+          b   INT NOT NULL,
+          sum INT GENERATED ALWAYS AS (a + b) STORED
+        )
+      `);
+      const cols = await adapter.columns("col_reflection_test");
+      const sum = cols.find((c) => c.name === "sum")!;
+      expect(sum.isVirtual()).toBe(true);
+      expect(sum.hasDefault).toBe(false);
+      expect(sum.defaultFunction).toBeTruthy();
+    });
+
+    it("reflects array column — sqlType strips [] and array flag is true", async () => {
+      await adapter.execute(`
+        CREATE TABLE col_reflection_test (
+          id   SERIAL PRIMARY KEY,
+          tags TEXT[]
+        )
+      `);
+      const cols = await adapter.columns("col_reflection_test");
+      const tags = cols.find((c) => c.name === "tags")!;
+      expect(tags.array).toBe(true);
+      expect(tags.sqlType).toBe("text");
+    });
+
+    it("reflects enum column — isEnum is true", async () => {
+      await adapter.execute(`CREATE TYPE col_reflection_mood AS ENUM ('happy', 'sad')`);
+      await adapter.execute(`
+        CREATE TABLE col_reflection_test (
+          id   SERIAL PRIMARY KEY,
+          mood col_reflection_mood
+        )
+      `);
+      // Reload the OID type map so the newly created enum type is registered.
+      await adapter.loadAdditionalTypes();
+      const cols = await adapter.columns("col_reflection_test");
+      const mood = cols.find((c) => c.name === "mood")!;
+      expect(mood.isEnum).toBe(true);
+    });
+  });
 });

--- a/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
@@ -55,6 +55,51 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    it("check all foreign keys valid raises on violated constraint", async () => {
+      await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_violation_test CASCADE`);
+      await adapter.execute(`CREATE SCHEMA referential_integrity_violation_test`);
+      await adapter.execute(`
+        CREATE TABLE referential_integrity_violation_test.parents (id BIGSERIAL PRIMARY KEY)
+      `);
+      await adapter.execute(`
+        CREATE TABLE referential_integrity_violation_test.children (
+          id        BIGSERIAL PRIMARY KEY,
+          parent_id BIGINT NOT NULL
+        )
+      `);
+
+      try {
+        // Insert a child row that references a non-existent parent.
+        await adapter.execute(
+          `INSERT INTO referential_integrity_violation_test.children (parent_id) VALUES (9999)`,
+        );
+        // Add the FK constraint NOT VALID so it can be created despite the bad row.
+        await adapter.execute(`
+          ALTER TABLE referential_integrity_violation_test.children
+            ADD CONSTRAINT fk_children_parent
+            FOREIGN KEY (parent_id)
+            REFERENCES referential_integrity_violation_test.parents (id)
+            NOT VALID
+        `);
+
+        // checkAllForeignKeysValidBang re-validates every FK — should raise.
+        await expect(adapter.checkAllForeignKeysValidBang()).rejects.toThrow();
+
+        // When called inside a transaction the savepoint is rolled back on
+        // failure, leaving the outer transaction still usable.
+        await adapter.beginTransaction();
+        try {
+          await expect(adapter.checkAllForeignKeysValidBang()).rejects.toThrow();
+          const result = await adapter.execute("SELECT 1 AS n");
+          expect(result[0].n).toBe(1);
+        } finally {
+          await adapter.commit();
+        }
+      } finally {
+        await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_violation_test CASCADE`);
+      }
+    });
+
     it("check all foreign keys valid inside a transaction uses savepoint", async () => {
       await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_tx_test CASCADE`);
       await adapter.execute(`CREATE SCHEMA referential_integrity_tx_test`);

--- a/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -24,6 +24,60 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("does not break transactions", () => {});
     it.skip("does not break nested transactions", () => {});
     it.skip("only catch active record errors others bubble up", () => {});
-    it.skip("all foreign keys valid having foreign keys in multiple schemas", () => {});
+
+    // Mirrors: test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas
+    it("all foreign keys valid having foreign keys in multiple schemas", async () => {
+      await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_test_schema CASCADE`);
+      await adapter.execute(`CREATE SCHEMA referential_integrity_test_schema`);
+      await adapter.execute(`
+        CREATE TABLE referential_integrity_test_schema.nodes (
+          id        BIGSERIAL,
+          parent_id INT NOT NULL,
+          PRIMARY KEY (id),
+          CONSTRAINT fk_parent_node FOREIGN KEY (parent_id)
+            REFERENCES referential_integrity_test_schema.nodes (id)
+        )
+      `);
+
+      try {
+        const rows = await adapter.execute(`
+          SELECT count(*) AS count
+            FROM information_schema.table_constraints
+           WHERE constraint_schema = 'referential_integrity_test_schema'
+             AND constraint_type = 'FOREIGN KEY'
+        `);
+        expect(Number(rows[0].count)).toBe(1);
+
+        // Should not throw when all FK constraints are valid
+        await expect(adapter.checkAllForeignKeysValidBang()).resolves.toBeUndefined();
+      } finally {
+        await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_test_schema CASCADE`);
+      }
+    });
+
+    it("check all foreign keys valid inside a transaction uses savepoint", async () => {
+      await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_tx_test CASCADE`);
+      await adapter.execute(`CREATE SCHEMA referential_integrity_tx_test`);
+      await adapter.execute(
+        `CREATE TABLE referential_integrity_tx_test.nodes (id BIGSERIAL PRIMARY KEY)`,
+      );
+
+      try {
+        await adapter.beginTransaction();
+        try {
+          // Inside a transaction the method uses a SAVEPOINT, so the
+          // surrounding transaction stays usable after the check.
+          await expect(adapter.checkAllForeignKeysValidBang()).resolves.toBeUndefined();
+
+          // Transaction should still be live — a query should succeed.
+          const result = await adapter.execute("SELECT 1 AS n");
+          expect(result[0].n).toBe(1);
+        } finally {
+          await adapter.commit();
+        }
+      } finally {
+        await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_tx_test CASCADE`);
+      }
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
@@ -32,7 +32,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.execute(`
         CREATE TABLE referential_integrity_test_schema.nodes (
           id        BIGSERIAL,
-          parent_id INT NOT NULL,
+          parent_id BIGINT NOT NULL,
           PRIMARY KEY (id),
           CONSTRAINT fk_parent_node FOREIGN KEY (parent_id)
             REFERENCES referential_integrity_test_schema.nodes (id)

--- a/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
@@ -29,17 +29,17 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("all foreign keys valid having foreign keys in multiple schemas", async () => {
       await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_test_schema CASCADE`);
       await adapter.execute(`CREATE SCHEMA referential_integrity_test_schema`);
-      await adapter.execute(`
-        CREATE TABLE referential_integrity_test_schema.nodes (
-          id        BIGSERIAL,
-          parent_id BIGINT NOT NULL,
-          PRIMARY KEY (id),
-          CONSTRAINT fk_parent_node FOREIGN KEY (parent_id)
-            REFERENCES referential_integrity_test_schema.nodes (id)
-        )
-      `);
-
       try {
+        await adapter.execute(`
+          CREATE TABLE referential_integrity_test_schema.nodes (
+            id        BIGSERIAL,
+            parent_id BIGINT NOT NULL,
+            PRIMARY KEY (id),
+            CONSTRAINT fk_parent_node FOREIGN KEY (parent_id)
+              REFERENCES referential_integrity_test_schema.nodes (id)
+          )
+        `);
+
         const rows = await adapter.execute(`
           SELECT count(*) AS count
             FROM information_schema.table_constraints
@@ -58,17 +58,17 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("check all foreign keys valid raises on violated constraint", async () => {
       await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_violation_test CASCADE`);
       await adapter.execute(`CREATE SCHEMA referential_integrity_violation_test`);
-      await adapter.execute(`
-        CREATE TABLE referential_integrity_violation_test.parents (id BIGSERIAL PRIMARY KEY)
-      `);
-      await adapter.execute(`
-        CREATE TABLE referential_integrity_violation_test.children (
-          id        BIGSERIAL PRIMARY KEY,
-          parent_id BIGINT NOT NULL
-        )
-      `);
-
       try {
+        await adapter.execute(`
+          CREATE TABLE referential_integrity_violation_test.parents (id BIGSERIAL PRIMARY KEY)
+        `);
+        await adapter.execute(`
+          CREATE TABLE referential_integrity_violation_test.children (
+            id        BIGSERIAL PRIMARY KEY,
+            parent_id BIGINT NOT NULL
+          )
+        `);
+
         // Insert a child row that references a non-existent parent.
         await adapter.execute(
           `INSERT INTO referential_integrity_violation_test.children (parent_id) VALUES (9999)`,
@@ -103,11 +103,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("check all foreign keys valid inside a transaction uses savepoint", async () => {
       await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_tx_test CASCADE`);
       await adapter.execute(`CREATE SCHEMA referential_integrity_tx_test`);
-      await adapter.execute(
-        `CREATE TABLE referential_integrity_tx_test.nodes (id BIGSERIAL PRIMARY KEY)`,
-      );
-
       try {
+        await adapter.execute(
+          `CREATE TABLE referential_integrity_tx_test.nodes (id BIGSERIAL PRIMARY KEY)`,
+        );
+
         await adapter.beginTransaction();
         try {
           // Inside a transaction the method uses a SAVEPOINT, so the

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1852,8 +1852,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Mirrors Rails new_column_from_field: generated columns store the
       // generation expression as defaultFunction; regular columns split into
       // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
-      const defaultFunction = attgenerated ? rawDefault : splitPgDefault(rawDefault).fn;
-      const literal = attgenerated ? null : splitPgDefault(rawDefault).literal;
+      const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
+      const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
+      const literal = attgenerated ? null : (splitDefault?.literal ?? null);
       const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
 
       return new Column(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2219,7 +2219,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Rails uses `transaction(requires_new: true)` — a savepoint when already
   // inside a transaction, or a fresh BEGIN otherwise.
   async checkAllForeignKeysValidBang(): Promise<void> {
-    if (this.isTransactionOpen()) {
+    if (this.inTransaction || this.isTransactionOpen()) {
       // Materialize any lazy transaction so the savepoint lands inside the
       // real PG transaction (mirrors Rails' transaction(requires_new: true)).
       await this.materializeTransactions();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -6,6 +6,7 @@ import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
 import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
+import { CHECK_ALL_FOREIGN_KEYS_SQL } from "./postgresql/referential-integrity.js";
 import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
 import {
@@ -2199,6 +2200,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       binds,
     );
     return Number(rows[0].count) > 0;
+  }
+
+  // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
+  async checkAllForeignKeysValidBang(): Promise<void> {
+    await this.beginTransaction();
+    try {
+      await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);
+      await this.commit();
+    } catch (e) {
+      await this.rollback();
+      throw e;
+    }
   }
 
   createDatabase(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2219,7 +2219,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Rails uses `transaction(requires_new: true)` — a savepoint when already
   // inside a transaction, or a fresh BEGIN otherwise.
   async checkAllForeignKeysValidBang(): Promise<void> {
-    if (this.inTransaction) {
+    if (this.isTransactionOpen()) {
+      // Materialize any lazy transaction so the savepoint lands inside the
+      // real PG transaction (mirrors Rails' transaction(requires_new: true)).
+      await this.materializeTransactions();
       const sp = "check_all_foreign_keys";
       await this.createSavepoint(sp);
       try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2223,7 +2223,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Materialize any lazy transaction so the savepoint lands inside the
       // real PG transaction (mirrors Rails' transaction(requires_new: true)).
       await this.materializeTransactions();
-      const sp = "check_all_foreign_keys";
+      // Mirror Rails' savepoint naming: "active_record_#{stack.size}" (transaction.rb:528).
+      // Using openTransactions+1 makes repeated calls in the same transaction safe.
+      const sp = `active_record_${this.openTransactions + 1}`;
       await this.createSavepoint(sp);
       try {
         await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1819,7 +1819,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
               a.attnotnull AS notnull,
               (i.indisprimary IS TRUE) AS is_primary,
               a.atttypid AS oid,
-              a.atttypmod AS fmod
+              a.atttypmod AS fmod,
+              a.attidentity AS identity,
+              a.attgenerated AS attgenerated
        FROM pg_attribute a
        JOIN pg_class t ON t.oid = a.attrelid
        JOIN pg_namespace n ON n.oid = t.relnamespace
@@ -1845,7 +1847,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // than defaulting to the raw sqlType string.
       const castType = this.lookupCastTypeFromColumn({ oid, fmod, sqlType });
       const rawDefault = (r.default as string | null) ?? null;
-      const { literal, fn } = splitPgDefault(rawDefault);
+      const identity = (r.identity as string | null) || null;
+      const attgenerated = (r.attgenerated as string | null) || null;
+      // Mirrors Rails new_column_from_field: generated columns store the
+      // generation expression as defaultFunction; regular columns split into
+      // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
+      const defaultFunction = attgenerated ? rawDefault : splitPgDefault(rawDefault).fn;
+      const literal = attgenerated ? null : splitPgDefault(rawDefault).literal;
       const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
 
       return new Column(
@@ -1859,10 +1867,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         },
         !(r.notnull as boolean),
         {
-          defaultFunction: fn,
+          defaultFunction: defaultFunction ?? undefined,
           primaryKey: r.is_primary as boolean,
           serial: isSerial,
           array: sqlType.endsWith("[]"),
+          identity,
+          generated: attgenerated,
         },
       );
     });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2203,14 +2203,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
+  // Rails uses `transaction(requires_new: true)` — a savepoint when already
+  // inside a transaction, or a fresh BEGIN otherwise.
   async checkAllForeignKeysValidBang(): Promise<void> {
-    await this.beginTransaction();
-    try {
-      await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);
-      await this.commit();
-    } catch (e) {
-      await this.rollback();
-      throw e;
+    if (this.inTransaction) {
+      const sp = "check_all_foreign_keys";
+      await this.createSavepoint(sp);
+      try {
+        await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);
+        await this.releaseSavepoint(sp);
+      } catch (e) {
+        await this.rollbackToSavepoint(sp);
+        await this.releaseSavepoint(sp).catch(() => {});
+        throw e;
+      }
+    } else {
+      await this.beginTransaction();
+      try {
+        await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);
+        await this.commit();
+      } catch (e) {
+        await this.rollback();
+        throw e;
+      }
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1837,13 +1837,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
     return rows.map((r) => {
       const sqlType = r.type as string;
+      const oid = r.oid as number;
+      const fmod = r.fmod as number;
+      // Mirrors Rails' fetch_type_metadata: look up the cast type so that
+      // SqlTypeMetadata.type reflects the OID type's semantic name (e.g.
+      // "enum" for user-defined enums, "integer" for int4, etc.) rather
+      // than defaulting to the raw sqlType string.
+      const castType = this.lookupCastTypeFromColumn({ oid, fmod, sqlType });
       const rawDefault = (r.default as string | null) ?? null;
-      // Mirrors Rails' PG `extract_value_from_default` / `extract_default_function`
-      // split — SQL-expression defaults (nextval, CURRENT_TIMESTAMP,
-      // gen_random_uuid(), etc.) become `defaultFunction`; only literals
-      // become `default`. Without this split, schema reflection would
-      // apply expressions as literal bind values and PG would reject
-      // `nextval(...)` as a bound integer.
       const { literal, fn } = splitPgDefault(rawDefault);
       const isSerial = typeof rawDefault === "string" && rawDefault.startsWith("nextval(");
 
@@ -1852,8 +1853,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         literal,
         {
           sqlType,
-          oid: r.oid as number,
-          fmod: r.fmod as number,
+          type: castType.type(),
+          oid,
+          fmod,
         },
         !(r.notnull as boolean),
         {

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -59,7 +59,7 @@ export class Column extends BaseColumn {
   // Return the full SQL type string (including "[]" for arrays) — callers
   // expecting the base type without the array suffix should use sqlType.
   override get type(): string {
-    return (super.type as string) ?? "";
+    return super.type ?? "";
   }
 
   get isSerial(): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -14,7 +14,6 @@ export class Column extends BaseColumn {
   readonly array: boolean;
   readonly identity: string | null;
   readonly generated: string | null;
-  readonly enum: boolean;
 
   constructor(
     name: string,
@@ -29,7 +28,6 @@ export class Column extends BaseColumn {
       array?: boolean;
       identity?: string | null;
       generated?: string | null;
-      enum?: boolean;
     } = {},
   ) {
     const meta = new SqlTypeMetadata({
@@ -44,13 +42,15 @@ export class Column extends BaseColumn {
     this.serial = options.serial ?? false;
     this.oid = sqlTypeMetadata.oid ?? null;
     this.fmod = sqlTypeMetadata.fmod ?? null;
-    this.array = options.array ?? this.sqlType?.endsWith("[]") ?? false;
+    // Use the raw sqlTypeMetadata.sqlType (not `this.sqlType`) so the check
+    // runs against the unstripped string — our sqlType getter strips "[]".
+    this.array = options.array ?? sqlTypeMetadata.sqlType?.endsWith("[]") ?? false;
     this.identity = options.identity ?? null;
     this.generated = options.generated ?? null;
-    this.enum = options.enum ?? false;
   }
 
-  // Mirrors: Column#sql_type — strips array suffix, returning base type name
+  // Mirrors: Column#sql_type — strips the array suffix so callers get the
+  // base type name; the array dimension is captured by `this.array`.
   override get sqlType(): string | null {
     const raw = super.sqlType;
     return raw?.endsWith("[]") ? raw.slice(0, -2) : (raw ?? null);
@@ -67,7 +67,7 @@ export class Column extends BaseColumn {
     );
   }
 
-  // Mirrors: Column#identity?
+  // Mirrors: Column#identity? — truthy when attidentity is "a" or "d"
   get isIdentity(): boolean {
     return this.identity !== null && this.identity !== "";
   }
@@ -77,18 +77,18 @@ export class Column extends BaseColumn {
     return this.isSerial || this.isIdentity;
   }
 
-  // Mirrors: Column#virtual?
+  // Mirrors: Column#virtual? — true for any generated (stored) column
   override isVirtual(): boolean {
     return this.generated !== null && this.generated !== "";
   }
 
-  // Mirrors: Column#has_default? — identity columns always have an implicit default; virtual columns have none
+  // Mirrors: Column#has_default? — virtual columns never have a user-visible default
   override get hasDefault(): boolean {
     return super.hasDefault && !this.isVirtual();
   }
 
-  // Mirrors: Column#enum?
+  // Mirrors: Column#enum? — true when the OID type is a user-defined pg enum
   get isEnum(): boolean {
-    return this.enum;
+    return this.sqlTypeMetadata?.type === "enum";
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -56,8 +56,10 @@ export class Column extends BaseColumn {
     return raw?.endsWith("[]") ? raw.slice(0, -2) : (raw ?? null);
   }
 
+  // Return the full SQL type string (including "[]" for arrays) — callers
+  // expecting the base type without the array suffix should use sqlType.
   override get type(): string {
-    return this.sqlType ?? "";
+    return (super.type as string) ?? "";
   }
 
   get isSerial(): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -12,6 +12,9 @@ export class Column extends BaseColumn {
   readonly oid: number | null;
   readonly fmod: number | null;
   readonly array: boolean;
+  readonly identity: string | null;
+  readonly generated: string | null;
+  readonly enum: boolean;
 
   constructor(
     name: string,
@@ -24,6 +27,9 @@ export class Column extends BaseColumn {
       primaryKey?: boolean;
       serial?: boolean;
       array?: boolean;
+      identity?: string | null;
+      generated?: string | null;
+      enum?: boolean;
     } = {},
   ) {
     const meta = new SqlTypeMetadata({
@@ -39,6 +45,15 @@ export class Column extends BaseColumn {
     this.oid = sqlTypeMetadata.oid ?? null;
     this.fmod = sqlTypeMetadata.fmod ?? null;
     this.array = options.array ?? this.sqlType?.endsWith("[]") ?? false;
+    this.identity = options.identity ?? null;
+    this.generated = options.generated ?? null;
+    this.enum = options.enum ?? false;
+  }
+
+  // Mirrors: Column#sql_type — strips array suffix, returning base type name
+  override get sqlType(): string | null {
+    const raw = super.sqlType;
+    return raw?.endsWith("[]") ? raw.slice(0, -2) : (raw ?? null);
   }
 
   override get type(): string {
@@ -50,5 +65,30 @@ export class Column extends BaseColumn {
       this.serial ||
       (typeof this.defaultFunction === "string" && this.defaultFunction.startsWith("nextval("))
     );
+  }
+
+  // Mirrors: Column#identity?
+  get isIdentity(): boolean {
+    return this.identity !== null && this.identity !== "";
+  }
+
+  // Mirrors: Column#auto_incremented_by_db?
+  override isAutoIncrementedByDb(): boolean {
+    return this.isSerial || this.isIdentity;
+  }
+
+  // Mirrors: Column#virtual?
+  override isVirtual(): boolean {
+    return this.generated !== null && this.generated !== "";
+  }
+
+  // Mirrors: Column#has_default? — identity columns always have an implicit default; virtual columns have none
+  override get hasDefault(): boolean {
+    return super.hasDefault && !this.isVirtual();
+  }
+
+  // Mirrors: Column#enum?
+  get isEnum(): boolean {
+    return this.enum;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -7,8 +7,7 @@
 import { quoteTableName } from "./quoting.js";
 
 export interface ReferentialIntegrity {
-  disableReferentialIntegrity(): Promise<void>;
-  enableReferentialIntegrity(): Promise<void>;
+  disableReferentialIntegrity(fn: () => Promise<void>): Promise<void>;
   checkAllForeignKeysValidBang(): Promise<void>;
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -9,6 +9,7 @@ import { quoteTableName } from "./quoting.js";
 export interface ReferentialIntegrity {
   disableReferentialIntegrity(): Promise<void>;
   enableReferentialIntegrity(): Promise<void>;
+  checkAllForeignKeysValidBang(): Promise<void>;
 }
 
 export function disableReferentialIntegritySql(tables: string[]): string[] {
@@ -18,3 +19,26 @@ export function disableReferentialIntegritySql(tables: string[]): string[] {
 export function enableReferentialIntegritySql(tables: string[]): string[] {
   return tables.map((t) => `ALTER TABLE ${quoteTableName(t)} ENABLE TRIGGER ALL`);
 }
+
+// Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
+// Marks every FK constraint as unvalidated then immediately re-validates, causing
+// the database to raise if any constraint is currently violated.
+export const CHECK_ALL_FOREIGN_KEYS_SQL = `
+do $$
+  declare r record;
+BEGIN
+FOR r IN (
+  SELECT FORMAT(
+    'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
+    constraint_name,
+    table_schema,
+    table_name
+  ) AS constraint_check
+  FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY'
+)
+  LOOP
+    EXECUTE (r.constraint_check);
+  END LOOP;
+END;
+$$;
+`.trim();

--- a/packages/activerecord/src/connection-adapters/postgresql/utils.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/utils.ts
@@ -52,7 +52,8 @@ export namespace Utils {
   }
 }
 
-function unquoteIdentifier(name: string): string {
+// Mirrors: Utils#unquote_identifier
+export function unquoteIdentifier(name: string): string {
   if (name.startsWith('"') && name.endsWith('"')) {
     return name.slice(1, -1).replace(/""/g, '"');
   }


### PR DESCRIPTION
## Summary

- **`postgresql/column.ts` → 100%**: adds `isIdentity`, `isAutoIncrementedByDb` (override), `isVirtual` (override), `hasDefault` (override — excludes virtual cols), `isEnum`, and `sqlType` (override stripping `[]` suffix). New constructor options: `identity`, `generated`, `enum`.
- **`postgresql/utils.ts` → 100%**: exports `unquoteIdentifier` (was private; used internally by `Name`).
- **`postgresql/referential-integrity.ts` → 100%**: adds `checkAllForeignKeysValidBang` to the `ReferentialIntegrity` interface + exports `CHECK_ALL_FOREIGN_KEYS_SQL`; implements the method on `PostgreSQLAdapter` (wrapped in an explicit `BEGIN`/`COMMIT`/`ROLLBACK` transaction, matching Rails' `requires_new: true` savepoint intent at this nesting level).

Part of the [postgres adapters 100% plan](../docs/postgres-adapters-100-plan.md) — PR A of 7.