### PR TITLE
feat(activerecord): pg DatabaseStatements — isWriteQuery, beginIsolatedDbTransaction, execRollback/Restart, highPrecisionCurrentTimestamp, setConstraints (PR B)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -855,4 +855,43 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].val).toBeNull();
     });
   });
+
+  // ── DatabaseStatements ────────────────────────────────────────────
+  describe("DatabaseStatements", () => {
+    it("isWriteQuery returns false for read-like statements", () => {
+      expect(adapter.isWriteQuery("SELECT 1")).toBe(true);
+      expect(adapter.isWriteQuery("SET search_path TO public")).toBe(false);
+      expect(adapter.isWriteQuery("SHOW server_version")).toBe(false);
+    });
+
+    it("highPrecisionCurrentTimestamp returns CURRENT_TIMESTAMP literal", () => {
+      const ts = adapter.highPrecisionCurrentTimestamp();
+      expect(ts.toSql()).toBe("CURRENT_TIMESTAMP");
+    });
+
+    it("setConstraints ALL DEFERRED executes without error", async () => {
+      await adapter.beginTransaction();
+      try {
+        await expect(adapter.setConstraints("deferred")).resolves.toBeUndefined();
+      } finally {
+        await adapter.commit();
+      }
+    });
+
+    it("setConstraints rejects invalid deferred value", async () => {
+      await expect(adapter.setConstraints("invalid" as "deferred" | "immediate")).rejects.toThrow();
+    });
+
+    it("beginIsolatedDbTransaction starts a transaction with isolation level", async () => {
+      await adapter.beginIsolatedDbTransaction("serializable");
+      try {
+        const rows = await adapter.execute(
+          `SELECT current_setting('transaction_isolation') AS iso`,
+        );
+        expect((rows[0] as { iso: string }).iso.toLowerCase()).toBe("serializable");
+      } finally {
+        await adapter.commit();
+      }
+    });
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -914,13 +914,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
   async execRollbackDbTransaction(): Promise<void> {
-    await this._cancelAnyRunningQuery();
+    this._cancelAnyRunningQuery();
     return this.rollback();
   }
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
-    await this._cancelAnyRunningQuery();
+    this._cancelAnyRunningQuery();
     await this.execute("ROLLBACK AND CHAIN");
   }
 
@@ -928,7 +928,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Sends a CancelRequest to abort any in-flight query on the transaction connection
   // before issuing ROLLBACK / ROLLBACK AND CHAIN, so the rollback isn't blocked
   // waiting for a long-running query to finish. Best-effort: errors are swallowed.
-  private async _cancelAnyRunningQuery(): Promise<void> {
+  private _cancelAnyRunningQuery(): void {
     type PgClientInternals = {
       activeQuery?: unknown;
       processID?: number | null;
@@ -936,15 +936,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     };
     const txClient = this._client as (pg.PoolClient & PgClientInternals) | null;
     if (!txClient?.activeQuery || txClient.processID == null) return;
-    const pool = this._driverPool;
-    if (!pool) return;
     try {
-      const cancelConn = await pool.connect();
-      try {
-        (cancelConn as unknown as PgClientInternals).cancel(txClient, txClient.activeQuery);
-      } finally {
-        cancelConn.release();
-      }
+      // pg.Client.cancel(target, query) opens a fresh raw TCP connection to send
+      // the libpq CancelRequest — it does NOT consume a pool slot, so this is
+      // safe even when the pool is at max capacity.
+      txClient.cancel(txClient, txClient.activeQuery);
     } catch {
       // cancel is best-effort
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -909,17 +909,45 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async rollbackDbTransaction(): Promise<void> {
-    return this.rollback();
+    return this.execRollbackDbTransaction();
   }
 
   // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
   async execRollbackDbTransaction(): Promise<void> {
+    await this._cancelAnyRunningQuery();
     return this.rollback();
   }
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
+    await this._cancelAnyRunningQuery();
     await this.execute("ROLLBACK AND CHAIN");
+  }
+
+  // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb private)
+  // Sends a CancelRequest to abort any in-flight query on the transaction connection
+  // before issuing ROLLBACK / ROLLBACK AND CHAIN, so the rollback isn't blocked
+  // waiting for a long-running query to finish. Best-effort: errors are swallowed.
+  private async _cancelAnyRunningQuery(): Promise<void> {
+    type PgClientInternals = {
+      activeQuery?: unknown;
+      processID?: number | null;
+      cancel: (target: PgClientInternals, query: unknown) => void;
+    };
+    const txClient = this._client as (pg.PoolClient & PgClientInternals) | null;
+    if (!txClient?.activeQuery || txClient.processID == null) return;
+    const pool = this._driverPool;
+    if (!pool) return;
+    try {
+      const cancelConn = await pool.connect();
+      try {
+        (cancelConn as unknown as PgClientInternals).cancel(txClient, txClient.activeQuery);
+      } finally {
+        cancelConn.release();
+      }
+    } catch {
+      // cancel is best-effort
+    }
   }
 
   // Mirrors: DatabaseStatements#begin_isolated_db_transaction (database_statements.rb:68)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,7 +1,7 @@
 import pg from "pg";
 import { type Type, ValueType } from "@blazetrails/activemodel";
 import { singularize, underscore, Notifications } from "@blazetrails/activesupport";
-import { Visitors } from "@blazetrails/arel";
+import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
@@ -32,7 +32,8 @@ import {
 } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
-import { typeCastedBinds } from "./abstract/database-statements.js";
+import { transactionIsolationLevels, typeCastedBinds } from "./abstract/database-statements.js";
+import { READ_QUERY } from "./postgresql/database-statements.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -909,6 +910,49 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async rollbackDbTransaction(): Promise<void> {
     return this.rollback();
+  }
+
+  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
+  async execRollbackDbTransaction(): Promise<void> {
+    return this.rollback();
+  }
+
+  // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
+  async execRestartDbTransaction(): Promise<void> {
+    await this.execute("ROLLBACK AND CHAIN");
+  }
+
+  // Mirrors: DatabaseStatements#begin_isolated_db_transaction (database_statements.rb:68)
+  async beginIsolatedDbTransaction(isolation: string): Promise<void> {
+    const levels = transactionIsolationLevels();
+    const level = levels[isolation];
+    if (!level) throw new Error(`Unknown isolation level: ${isolation}`);
+    await this.execute(`BEGIN ISOLATION LEVEL ${level}`);
+    this._inTransaction = true;
+  }
+
+  // Mirrors: DatabaseStatements#write_query? (database_statements.rb:24)
+  override isWriteQuery(sql: string): boolean {
+    return !READ_QUERY.test(sql);
+  }
+
+  // Mirrors: DatabaseStatements#high_precision_current_timestamp (database_statements.rb:92)
+  // Rails: HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP")
+  highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
+    return arelSql("CURRENT_TIMESTAMP");
+  }
+
+  // Mirrors: DatabaseStatements#set_constraints (database_statements.rb:110)
+  async setConstraints(
+    deferred: "deferred" | "immediate",
+    ...constraints: string[]
+  ): Promise<void> {
+    if (deferred !== "deferred" && deferred !== "immediate") {
+      throw new Error(`deferred must be "deferred" or "immediate"`);
+    }
+    const list =
+      constraints.length === 0 ? "ALL" : constraints.map((c) => this.quoteTableName(c)).join(", ");
+    await this.execute(`SET CONSTRAINTS ${list} ${deferred.toUpperCase()}`);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -927,8 +927,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const levels = transactionIsolationLevels();
     const level = levels[isolation];
     if (!level) throw new Error(`Unknown isolation level: ${isolation}`);
-    await this.execute(`BEGIN ISOLATION LEVEL ${level}`);
-    this._inTransaction = true;
+    this._client = await this._acquireFreshClient();
+    try {
+      await this._client.query(`BEGIN ISOLATION LEVEL ${level}`);
+      this._inTransaction = true;
+    } catch (error) {
+      const client = this._client;
+      this._client = null;
+      this._inTransaction = false;
+      client?.release(error instanceof Error ? error : undefined);
+      throw error;
+    }
   }
 
   // Mirrors: DatabaseStatements#write_query? (database_statements.rb:24)

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,7 +4,8 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
-import { Nodes } from "@blazetrails/arel";
+import type { Nodes } from "@blazetrails/arel";
+import type { ExplainOption } from "../../adapter.js";
 import type { Result } from "../../result.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
@@ -40,7 +41,7 @@ export interface DatabaseStatements {
   // Mirrors: database_statements.rb:24
   isWriteQuery(sql: string): boolean;
   // Mirrors: database_statements.rb:39
-  execute(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
+  execute(sql: string, binds?: unknown[], name?: string | null): Promise<unknown[]>;
   // Mirrors: database_statements.rb:64
   beginDbTransaction(): Promise<void>;
   // Mirrors: database_statements.rb:68
@@ -54,7 +55,7 @@ export interface DatabaseStatements {
   // Mirrors: database_statements.rb:92
   highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;
   // Mirrors: database_statements.rb:96
-  buildExplainClause(options?: string[]): string;
+  buildExplainClause(options?: ExplainOption[]): string;
   // Mirrors: database_statements.rb:110
   setConstraints(deferred: "deferred" | "immediate", ...constraints: string[]): Promise<void>;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,7 +4,12 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
+import { Nodes } from "@blazetrails/arel";
 import type { Result } from "../../result.js";
+
+// Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
+// SQL statements that do not modify data — write_query? returns false for these.
+export const READ_QUERY = /^[\s]*(?:close|declare|fetch|move|set|show)\b/i;
 
 export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -17,6 +22,7 @@ export interface DatabaseStatements {
     pk?: string,
     sequenceName?: string,
   ): Promise<unknown>;
+  // Mirrors: database_statements.rb:7
   explain(
     sql: string,
     binds?: unknown[],
@@ -28,6 +34,27 @@ export interface DatabaseStatements {
       format?: string;
     },
   ): Promise<string>;
+  // Mirrors: database_statements.rb:14
   query(sql: string, name?: string | null): Promise<unknown[][]>;
   executeAndClear(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
+  // Mirrors: database_statements.rb:24
+  isWriteQuery(sql: string): boolean;
+  // Mirrors: database_statements.rb:39
+  execute(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
+  // Mirrors: database_statements.rb:64
+  beginDbTransaction(): Promise<void>;
+  // Mirrors: database_statements.rb:68
+  beginIsolatedDbTransaction(isolation: string): Promise<void>;
+  // Mirrors: database_statements.rb:73
+  commitDbTransaction(): Promise<void>;
+  // Mirrors: database_statements.rb:78
+  execRollbackDbTransaction(): Promise<void>;
+  // Mirrors: database_statements.rb:83
+  execRestartDbTransaction(): Promise<void>;
+  // Mirrors: database_statements.rb:92
+  highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;
+  // Mirrors: database_statements.rb:96
+  buildExplainClause(options?: string[]): string;
+  // Mirrors: database_statements.rb:110
+  setConstraints(deferred: "deferred" | "immediate", ...constraints: string[]): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Extends `PostgreSQL::DatabaseStatements` interface to declare all 8 methods missing from api:compare
- Implements PG-specific overrides on `PostgreSQLAdapter`:
  - `isWriteQuery`: READ_QUERY regexp (`close|declare|fetch|move|set|show`) — mirrors `database_statements.rb:19-28`
  - `beginIsolatedDbTransaction`: `BEGIN ISOLATION LEVEL <level>` — mirrors `database_statements.rb:68`
  - `execRollbackDbTransaction`: delegates to `this.rollback()` — mirrors `database_statements.rb:78`
  - `execRestartDbTransaction`: `ROLLBACK AND CHAIN` — mirrors `database_statements.rb:83`
  - `highPrecisionCurrentTimestamp`: `Arel.sql("CURRENT_TIMESTAMP")` — mirrors `database_statements.rb:92`
  - `setConstraints(deferred, ...constraints)`: `SET CONSTRAINTS <ALL|list> <DEFERRED|IMMEDIATE>` — mirrors `database_statements.rb:110`
  - `execute`, `buildExplainClause`: already implemented on adapter, now declared in interface
- `connection_adapters/postgresql/database-statements.ts`: 38% → 100% ✓

## Part of series
Part of the postgres-adapters-100-plan (PR B of 7).