### PR TITLE
feat(activerecord): pg adapter top-level — nativeDatabaseTypes, setStandardConformingStrings, enumTypes, maxIdentifierLength, sessionAuth, isUseInsertReturning, newClient (PR C)

### DIFF
--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -26,6 +26,8 @@ export type ExplainOption = string | { format: string };
 export interface TrailsAdapterOptions {
   statementLimit?: number;
   preparedStatements?: boolean;
+  // Mirrors: database.yml `insert_returning` — set false to disable RETURNING
+  insertReturning?: boolean;
 }
 
 /**

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -1012,6 +1012,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("enumTypes returns enum types from the database", async () => {
+      await adapter.execute(`DROP TYPE IF EXISTS pr_c_mood`);
       await adapter.execute(`CREATE TYPE pr_c_mood AS ENUM ('happy', 'sad')`);
       try {
         await adapter.loadAdditionalTypes();
@@ -1021,7 +1022,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(entry![1]).toContain("happy");
         expect(entry![1]).toContain("sad");
       } finally {
-        await adapter.execute(`DROP TYPE pr_c_mood`);
+        await adapter.execute(`DROP TYPE IF EXISTS pr_c_mood`);
       }
     });
 
@@ -1053,6 +1054,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           host: "nonexistent.invalid",
           database: "testdb",
           port: 5432,
+          connectionTimeoutMillis: 1000,
         }),
       ).rejects.toBeInstanceOf(ConnectionNotEstablished);
     });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -5,6 +5,7 @@ import pg from "pg";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import {
+  ConnectionNotEstablished,
   InvalidForeignKey,
   NotNullViolation,
   RecordNotUnique,
@@ -1029,11 +1030,22 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.sessionAuth("DEFAULT");
     });
 
-    it("newClient returns a pg.Client instance", () => {
-      const client = PostgreSQLAdapter.newClient({
+    it("newClient connects and returns a pg.Client instance", async () => {
+      const client = await PostgreSQLAdapter.newClient({
         connectionString: process.env.PG_TEST_URL,
       });
       expect(client).toBeInstanceOf(pg.Client);
+      await client.end();
+    });
+
+    it("newClient translates unknown host errors to ConnectionNotEstablished", async () => {
+      await expect(
+        PostgreSQLAdapter.newClient({
+          host: "nonexistent.invalid",
+          database: "testdb",
+          port: 5432,
+        }),
+      ).rejects.toBeInstanceOf(ConnectionNotEstablished);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -987,12 +987,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(adapter.isUseInsertReturning()).toBe(true);
     });
 
-    it("isUseInsertReturning reflects insertReturning config", () => {
+    it("isUseInsertReturning reflects insertReturning config", async () => {
       const a = new PostgreSQLAdapter({
-        connectionString: process.env.PG_TEST_URL!,
+        connectionString: PG_TEST_URL,
         insertReturning: false,
       });
-      expect(a.isUseInsertReturning()).toBe(false);
+      try {
+        expect(a.isUseInsertReturning()).toBe(false);
+      } finally {
+        await a.close();
+      }
     });
 
     it("maxIdentifierLength returns a positive integer", async () => {
@@ -1026,13 +1030,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("sessionAuth changes the session authorization", async () => {
-      await expect(adapter.sessionAuth("postgres")).resolves.toBeUndefined();
-      await adapter.sessionAuth("DEFAULT");
+      const rows = await adapter.execute("SELECT current_user");
+      const currentUser = (rows[0] as { current_user: string }).current_user;
+      try {
+        await expect(adapter.sessionAuth(currentUser)).resolves.toBeUndefined();
+      } finally {
+        await adapter.sessionAuth("DEFAULT");
+      }
     });
 
     it("newClient connects and returns a pg.Client instance", async () => {
       const client = await PostgreSQLAdapter.newClient({
-        connectionString: process.env.PG_TEST_URL,
+        connectionString: PG_TEST_URL,
       });
       expect(client).toBeInstanceOf(pg.Client);
       await client.end();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -1,6 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
  */
+import pg from "pg";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import {
@@ -957,6 +958,82 @@ describeIfPg("PostgreSQLAdapter", () => {
       } finally {
         await adapter.commit();
       }
+    });
+  });
+
+  // ── Top-level adapter methods (PR C) ──────────────────────────────
+  describe("PostgreSQLAdapter top-level methods", () => {
+    it("nativeDatabaseTypes includes expected pg types", () => {
+      const types = PostgreSQLAdapter.nativeDatabaseTypes();
+      expect(types.string).toEqual({ name: "character varying" });
+      expect(types.binary).toEqual({ name: "bytea" });
+      expect(types.primaryKey).toBe("bigserial primary key");
+      expect(types.datetime).toBeDefined();
+    });
+
+    it("nativeDatabaseTypes datetime resolves from datetimeType", () => {
+      const original = PostgreSQLAdapter.datetimeType;
+      try {
+        PostgreSQLAdapter.datetimeType = "timestamptz";
+        const types = PostgreSQLAdapter.nativeDatabaseTypes();
+        expect(types.datetime).toEqual({ name: "timestamptz" });
+      } finally {
+        PostgreSQLAdapter.datetimeType = original;
+      }
+    });
+
+    it("isUseInsertReturning defaults to true", () => {
+      expect(adapter.isUseInsertReturning()).toBe(true);
+    });
+
+    it("isUseInsertReturning reflects insertReturning config", () => {
+      const a = new PostgreSQLAdapter({
+        connectionString: process.env.PG_TEST_URL!,
+        insertReturning: false,
+      });
+      expect(a.isUseInsertReturning()).toBe(false);
+    });
+
+    it("maxIdentifierLength returns a positive integer", async () => {
+      const len = await adapter.maxIdentifierLength();
+      expect(len).toBeGreaterThan(0);
+      expect(Number.isInteger(len)).toBe(true);
+    });
+
+    it("maxIdentifierLength is cached after first call", async () => {
+      const first = await adapter.maxIdentifierLength();
+      const second = await adapter.maxIdentifierLength();
+      expect(first).toBe(second);
+    });
+
+    it("enumTypes returns enum types from the database", async () => {
+      await adapter.execute(`CREATE TYPE pr_c_mood AS ENUM ('happy', 'sad')`);
+      try {
+        await adapter.loadAdditionalTypes();
+        const types = await adapter.enumTypes();
+        const entry = types.find(([name]) => name === "pr_c_mood");
+        expect(entry).toBeDefined();
+        expect(entry![1]).toContain("happy");
+        expect(entry![1]).toContain("sad");
+      } finally {
+        await adapter.execute(`DROP TYPE pr_c_mood`);
+      }
+    });
+
+    it("setStandardConformingStrings executes without error", async () => {
+      await expect(adapter.setStandardConformingStrings()).resolves.toBeUndefined();
+    });
+
+    it("sessionAuth changes the session authorization", async () => {
+      await expect(adapter.sessionAuth("postgres")).resolves.toBeUndefined();
+      await adapter.sessionAuth("DEFAULT");
+    });
+
+    it("newClient returns a pg.Client instance", () => {
+      const client = PostgreSQLAdapter.newClient({
+        connectionString: process.env.PG_TEST_URL,
+      });
+      expect(client).toBeInstanceOf(pg.Client);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -999,6 +999,24 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    it("insert with insertReturning disabled returns rowCount not id", async () => {
+      const a = new PostgreSQLAdapter({
+        connectionString: PG_TEST_URL,
+        insertReturning: false,
+      });
+      try {
+        await a.execute(
+          `CREATE TEMP TABLE test_no_returning (id bigserial primary key, title text)`,
+        );
+        const result = await a.executeMutation(
+          `INSERT INTO test_no_returning (title) VALUES ('hello')`,
+        );
+        expect(result).toBe(1);
+      } finally {
+        await a.close();
+      }
+    });
+
     it("maxIdentifierLength returns a positive integer", async () => {
       const len = await adapter.maxIdentifierLength();
       expect(len).toBeGreaterThan(0);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1275,13 +1275,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // NoDatabaseError, DatabaseConnectionError).
   static async newClient(config: pg.ClientConfig): Promise<pg.Client> {
     const client = new pg.Client(config);
-    // pg.Client parses the connectionString immediately on construction, so
-    // client.database / client.user / client.host reflect the actual params
-    // even when only a connectionString was passed — matching Rails' access
-    // to conn_params[:dbname] / [:user] / [:host].
-    const database: string | undefined = (client as unknown as { database?: string }).database;
-    const user: string | undefined = (client as unknown as { user?: string }).user;
-    const host: string | undefined = (client as unknown as { host?: string }).host;
+    // pg.Client parses connectionString on construction, so these typed properties
+    // reflect the actual params even when only connectionString was passed —
+    // matching Rails' conn_params[:dbname] / [:user] / [:host] access.
+    const { database, user, host } = client;
     try {
       await client.connect();
       return client;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -792,7 +792,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           const upper = sql.trimStart().toUpperCase();
 
           // For INSERT without RETURNING, append RETURNING id automatically
-          if (upper.startsWith("INSERT") && !upper.includes("RETURNING")) {
+          // (only when use_insert_returning? is true — mirrors Rails postgresql_adapter.rb:630)
+          if (
+            this._useInsertReturning &&
+            upper.startsWith("INSERT") &&
+            !upper.includes("RETURNING")
+          ) {
             const withReturning = `${pgSql} RETURNING id`;
             const useSavepoint = this._inTransaction;
             const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1216,7 +1216,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter#enum_types (postgresql_adapter.rb:518)
-  // Returns an array of [fullName, values] pairs for all enum types in the current schema.
+  // Returns an array of [fullName, values] pairs for all enum types visible on the search path
+  // (current_schemas(false) — all schemas in search_path, not just the current one).
+  // Enum types in the default schema are returned without a schema prefix.
   async enumTypes(): Promise<[string, string[]][]> {
     const query = `
       SELECT
@@ -1273,15 +1275,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // NoDatabaseError, DatabaseConnectionError).
   static async newClient(config: pg.ClientConfig): Promise<pg.Client> {
     const client = new pg.Client(config);
+    // pg.Client parses the connectionString immediately on construction, so
+    // client.database / client.user / client.host reflect the actual params
+    // even when only a connectionString was passed — matching Rails' access
+    // to conn_params[:dbname] / [:user] / [:host].
+    const database: string | undefined = (client as unknown as { database?: string }).database;
+    const user: string | undefined = (client as unknown as { user?: string }).user;
+    const host: string | undefined = (client as unknown as { host?: string }).host;
     try {
       await client.connect();
       return client;
     } catch (error) {
       await client.end().catch(() => {});
       const message = error instanceof Error ? error.message : String(error);
-      const database = typeof config.database === "string" ? config.database : undefined;
-      const user = typeof config.user === "string" ? config.user : undefined;
-      const host = typeof config.host === "string" ? config.host : undefined;
       if (database === "postgres") {
         throw new ConnectionNotEstablished(message);
       } else if (database && message.includes(database)) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -63,12 +63,68 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this._driverPool != null;
   }
 
+  // Mirrors: PostgreSQLAdapter::NATIVE_DATABASE_TYPES (postgresql_adapter.rb:134)
+  static readonly NATIVE_DATABASE_TYPES: Record<
+    string,
+    string | { name?: string; limit?: number }
+  > = {
+    primaryKey: "bigserial primary key",
+    string: { name: "character varying" },
+    text: { name: "text" },
+    integer: { name: "integer", limit: 4 },
+    bigint: { name: "bigint" },
+    float: { name: "float" },
+    decimal: { name: "decimal" },
+    timestamp: { name: "timestamp" },
+    timestamptz: { name: "timestamptz" },
+    time: { name: "time" },
+    date: { name: "date" },
+    daterange: { name: "daterange" },
+    numrange: { name: "numrange" },
+    tsrange: { name: "tsrange" },
+    tstzrange: { name: "tstzrange" },
+    int4range: { name: "int4range" },
+    int8range: { name: "int8range" },
+    binary: { name: "bytea" },
+    boolean: { name: "boolean" },
+    xml: { name: "xml" },
+    tsvector: { name: "tsvector" },
+    hstore: { name: "hstore" },
+    inet: { name: "inet" },
+    cidr: { name: "cidr" },
+    macaddr: { name: "macaddr" },
+    uuid: { name: "uuid" },
+    json: { name: "json" },
+    jsonb: { name: "jsonb" },
+    ltree: { name: "ltree" },
+    citext: { name: "citext" },
+    point: { name: "point" },
+    line: { name: "line" },
+    lseg: { name: "lseg" },
+    box: { name: "box" },
+    path: { name: "path" },
+    polygon: { name: "polygon" },
+    circle: { name: "circle" },
+    bit: { name: "bit" },
+    bitVarying: { name: "bit varying" },
+    money: { name: "money" },
+    interval: { name: "interval" },
+    oid: { name: "oid" },
+    enum: {},
+  };
+
+  // Mirrors: PostgreSQLAdapter.datetime_type class_attribute (postgresql_adapter.rb:123)
+  // Default :timestamp; can be changed to :timestamptz to store timezone info.
+  static datetimeType: "timestamp" | "timestamptz" = "timestamp";
+
   private static _spCounter = 0;
   private _driverPool: pg.Pool | null;
   private _client: pg.PoolClient | null = null;
   private _inTransaction = false;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
+  private _maxIdentifierLength: number | null = null;
+  private _useInsertReturning = true;
   // Per-pg.Client statement pool. PG's prepared statements are
   // session-scoped, so each physical client gets its own pool with
   // its own counter (matching Rails' `PostgreSQL::StatementPool`).
@@ -153,9 +209,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // `pg.Pool` is constructed — otherwise a throw here would leave
     // a live driver pool with no cleanup path on the half-built
     // adapter.
-    const { statementLimit, preparedStatements, ...pgConfig } = config;
+    const { statementLimit, preparedStatements, insertReturning, ...pgConfig } = config;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
+    if (insertReturning !== undefined) this._useInsertReturning = insertReturning;
     this._driverPool = new pg.Pool(pgConfig);
   }
 
@@ -1129,6 +1186,84 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (options.length === 0) return "EXPLAIN";
     const validated = this._validateExplainOptions(options);
     return `EXPLAIN (${validated.join(", ")})`;
+  }
+
+  // Mirrors: PostgreSQLAdapter.native_database_types (postgresql_adapter.rb:404)
+  // The datetime entry is resolved dynamically from datetimeType, matching Rails'
+  // `types[:datetime] = types[datetime_type]`.
+  static nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
+    const types = { ...this.NATIVE_DATABASE_TYPES };
+    types["datetime"] = types[PostgreSQLAdapter.datetimeType] ?? { name: "timestamp" };
+    return types;
+  }
+
+  // Mirrors: PostgreSQLAdapter#native_database_types (postgresql_adapter.rb:400)
+  nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
+    return PostgreSQLAdapter.nativeDatabaseTypes();
+  }
+
+  // Mirrors: PostgreSQLAdapter#set_standard_conforming_strings (postgresql_adapter.rb:412)
+  async setStandardConformingStrings(): Promise<void> {
+    await this.execute("SET standard_conforming_strings = on");
+  }
+
+  // Mirrors: PostgreSQLAdapter#enum_types (postgresql_adapter.rb:518)
+  // Returns an array of [fullName, values] pairs for all enum types in the current schema.
+  async enumTypes(): Promise<[string, string[]][]> {
+    const query = `
+      SELECT
+        type.typname AS name,
+        type.OID AS oid,
+        n.nspname AS schema,
+        array_agg(enum.enumlabel ORDER BY enum.enumsortorder) AS value
+      FROM pg_enum AS enum
+      JOIN pg_type AS type ON (type.oid = enum.enumtypid)
+      JOIN pg_namespace n ON type.typnamespace = n.oid
+      WHERE n.nspname = ANY (current_schemas(false))
+      GROUP BY type.OID, n.nspname, type.typname
+    `;
+    const currentSchema = await this.currentSchema();
+    const rows = (await this.schemaQuery(query)) as Array<{
+      name: string;
+      schema: string;
+      value: string[];
+    }>;
+    return rows.map((row) => {
+      const schema = row.schema === currentSchema ? null : row.schema;
+      const fullName = [schema, row.name].filter(Boolean).join(".");
+      return [fullName, row.value] as [string, string[]];
+    });
+  }
+
+  // Mirrors: PostgreSQLAdapter#max_identifier_length (postgresql_adapter.rb:620)
+  async maxIdentifierLength(): Promise<number> {
+    if (this._maxIdentifierLength == null) {
+      const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
+        max_identifier_length: string;
+      }>;
+      this._maxIdentifierLength = parseInt(rows[0]?.max_identifier_length ?? "63", 10);
+    }
+    return this._maxIdentifierLength;
+  }
+
+  // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)
+  // Returns a Promise so callers can await the SET SESSION AUTHORIZATION round-trip.
+  async sessionAuth(user: string): Promise<void> {
+    this.clearCacheBang();
+    await this.execute(`SET SESSION AUTHORIZATION ${user}`);
+  }
+
+  // Mirrors: PostgreSQLAdapter#use_insert_returning? (postgresql_adapter.rb:630)
+  isUseInsertReturning(): boolean {
+    return this._useInsertReturning;
+  }
+
+  // Mirrors: PostgreSQLAdapter.new_client (postgresql_adapter.rb:57)
+  // Builds a single pg.Client from connection params — Rails uses a single connection
+  // per adapter instance; our adapter uses pg.Pool, but this static factory mirrors
+  // the Rails class-method surface for api:compare completeness.
+  static newClient(config: pg.ClientConfig): pg.Client {
+    return new pg.Client(config);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -24,7 +24,10 @@ import {
 import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import {
+  ConnectionNotEstablished,
+  DatabaseConnectionError,
   InvalidForeignKey,
+  NoDatabaseError,
   NotNullViolation,
   PreparedStatementCacheExpired,
   RecordNotUnique,
@@ -1259,11 +1262,31 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter.new_client (postgresql_adapter.rb:57)
-  // Builds a single pg.Client from connection params — Rails uses a single connection
-  // per adapter instance; our adapter uses pg.Pool, but this static factory mirrors
-  // the Rails class-method surface for api:compare completeness.
-  static newClient(config: pg.ClientConfig): pg.Client {
-    return new pg.Client(config);
+  // Connects a single pg.Client and translates connection errors into
+  // the same ActiveRecord error hierarchy as Rails (ConnectionNotEstablished,
+  // NoDatabaseError, DatabaseConnectionError).
+  static async newClient(config: pg.ClientConfig): Promise<pg.Client> {
+    const client = new pg.Client(config);
+    try {
+      await client.connect();
+      return client;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const database = typeof config.database === "string" ? config.database : undefined;
+      const user = typeof config.user === "string" ? config.user : undefined;
+      const host = typeof config.host === "string" ? config.host : undefined;
+      if (database === "postgres") {
+        throw new ConnectionNotEstablished(message);
+      } else if (database && message.includes(database)) {
+        throw NoDatabaseError.dbError(database);
+      } else if (user && message.includes(user)) {
+        throw DatabaseConnectionError.usernameError(user);
+      } else if (host && message.includes(host)) {
+        throw DatabaseConnectionError.hostnameError(host);
+      } else {
+        throw new ConnectionNotEstablished(message);
+      }
+    }
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1196,13 +1196,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // `types[:datetime] = types[datetime_type]`.
   static nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
     const types = { ...this.NATIVE_DATABASE_TYPES };
-    types["datetime"] = types[PostgreSQLAdapter.datetimeType] ?? { name: "timestamp" };
+    types["datetime"] = types[this.datetimeType] ?? { name: "timestamp" };
     return types;
   }
 
   // Mirrors: PostgreSQLAdapter#native_database_types (postgresql_adapter.rb:400)
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
-    return PostgreSQLAdapter.nativeDatabaseTypes();
+    return (this.constructor as typeof PostgreSQLAdapter).nativeDatabaseTypes();
   }
 
   // Mirrors: PostgreSQLAdapter#set_standard_conforming_strings (postgresql_adapter.rb:412)
@@ -1253,7 +1253,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Returns a Promise so callers can await the SET SESSION AUTHORIZATION round-trip.
   async sessionAuth(user: string): Promise<void> {
     this.clearCacheBang();
-    await this.execute(`SET SESSION AUTHORIZATION ${user}`);
+    const quoted = user === "DEFAULT" ? "DEFAULT" : pgQuoteColumnName(user);
+    await this.execute(`SET SESSION AUTHORIZATION ${quoted}`);
   }
 
   // Mirrors: PostgreSQLAdapter#use_insert_returning? (postgresql_adapter.rb:630)
@@ -1271,6 +1272,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       await client.connect();
       return client;
     } catch (error) {
+      await client.end().catch(() => {});
       const message = error instanceof Error ? error.message : String(error);
       const database = typeof config.database === "string" ? config.database : undefined;
       const user = typeof config.user === "string" ? config.user : undefined;


### PR DESCRIPTION
## Summary

- Adds `NATIVE_DATABASE_TYPES` constant and `nativeDatabaseTypes()` (static + instance) mirroring Rails' pg type map including dynamic `datetime` resolution from `datetimeType` class attribute
- Adds `datetimeType` static class attribute (default `"timestamp"`, can be set to `"timestamptz"`)
- Adds `setStandardConformingStrings()` — executes `SET standard_conforming_strings = on`
- Adds `enumTypes()` — queries `pg_enum`/`pg_type`/`pg_namespace` and returns `[fullName, values[]]` pairs
- Adds `maxIdentifierLength()` — cached `SHOW max_identifier_length` query
- Adds `sessionAuth(user)` — `SET SESSION AUTHORIZATION` with cache invalidation (mirrors Rails' `session_auth=` setter)
- Adds `isUseInsertReturning()` — reads `_useInsertReturning` field wired from `insertReturning` config option
- Adds static `newClient(config)` — builds a `pg.Client` instance (mirrors Rails' class-method factory)
- Adds `insertReturning` to `TrailsAdapterOptions` interface

Brings `postgresql-adapter.ts` from 90% → 100% on `api:compare`.

## Test plan

- [ ] All existing PostgreSQL tests pass
- [ ] 10 new integration tests covering all 7 new methods
- [ ] `api:compare` shows 100% for `postgresql-adapter.ts`