### PR TITLE
feat(activerecord): array + block on Relation/CollectionProxy build/create (PR J)

### DIFF
--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -98,8 +98,13 @@ describe("associations DX", () => {
     expectTypeOf(proxy.find(1)).resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.find([1, 2])).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.find(1, 2)).resolves.toMatchTypeOf<Post | Post[]>();
-    expectTypeOf(proxy.build).returns.toEqualTypeOf<Post>();
-    expectTypeOf(proxy.create).returns.resolves.toEqualTypeOf<Post>();
+    // build / create are overloaded: (attrs?) → T, (attrs[]) → T[].
+    expectTypeOf(proxy.build()).toEqualTypeOf<Post>();
+    expectTypeOf(proxy.build({})).toEqualTypeOf<Post>();
+    expectTypeOf(proxy.build([{}, {}])).toEqualTypeOf<Post[]>();
+    expectTypeOf(proxy.create()).resolves.toEqualTypeOf<Post>();
+    expectTypeOf(proxy.create({})).resolves.toEqualTypeOf<Post>();
+    expectTypeOf(proxy.create([{}, {}])).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();
   });
 

--- a/packages/activerecord/dx-tests/associations.test-d.ts
+++ b/packages/activerecord/dx-tests/associations.test-d.ts
@@ -98,13 +98,16 @@ describe("associations DX", () => {
     expectTypeOf(proxy.find(1)).resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.find([1, 2])).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.find(1, 2)).resolves.toMatchTypeOf<Post | Post[]>();
-    // build / create are overloaded: (attrs?) → T, (attrs[]) → T[].
+    // build / create / createBang are overloaded: (attrs?) → T, (attrs[]) → T[].
     expectTypeOf(proxy.build()).toEqualTypeOf<Post>();
     expectTypeOf(proxy.build({})).toEqualTypeOf<Post>();
     expectTypeOf(proxy.build([{}, {}])).toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.create()).resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.create({})).resolves.toEqualTypeOf<Post>();
     expectTypeOf(proxy.create([{}, {}])).resolves.toEqualTypeOf<Post[]>();
+    expectTypeOf(proxy.createBang()).resolves.toEqualTypeOf<Post>();
+    expectTypeOf(proxy.createBang({})).resolves.toEqualTypeOf<Post>();
+    expectTypeOf(proxy.createBang([{}, {}])).resolves.toEqualTypeOf<Post[]>();
     expectTypeOf(proxy.target).toEqualTypeOf<Post[]>();
   });
 

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -36,6 +36,20 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(User.new({ name: "y" })).toEqualTypeOf<User>();
   });
 
+  it("Relation build / create / createBang array overloads return T[]", async () => {
+    const rel = User.where({ admin: false });
+    // single-attrs form
+    expectTypeOf(rel.build()).toEqualTypeOf<User>();
+    expectTypeOf(rel.build({})).toEqualTypeOf<User>();
+    expectTypeOf(await rel.create({})).toEqualTypeOf<User>();
+    expectTypeOf(await rel.createBang({})).toEqualTypeOf<User>();
+    // array form
+    expectTypeOf(rel.build([{}, {}])).toEqualTypeOf<User[]>();
+    expectTypeOf(await rel.create([{}, {}])).toEqualTypeOf<User[]>();
+    expectTypeOf(await rel.createBang([{}, {}])).toEqualTypeOf<User[]>();
+    expectTypeOf(rel.new([{}, {}])).toEqualTypeOf<User[]>();
+  });
+
   it("User.find(id) resolves to a single User", async () => {
     const u = await User.find(1);
     expectTypeOf(u).toEqualTypeOf<User>();

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -50,9 +50,17 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::AssociationRelation#_new / #build
    */
-  build(attrs: Record<string, unknown> = {}): T {
+  build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
+  build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
+  build(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): T | T[] {
+    if (Array.isArray(attrs)) {
+      return attrs.map((a) => this.build(a, block));
+    }
     const merged = { ...this.scopeForCreate(), ...attrs };
-    return this._association.build(merged) as T;
+    return this._association.build(merged, block) as T;
   }
 
   /**
@@ -60,9 +68,19 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::AssociationRelation#_create / #create
    */
-  async create(attrs: Record<string, unknown> = {}): Promise<T> {
+  async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async create(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) records.push((await this.create(a, block)) as T);
+      return records;
+    }
     const merged = { ...this.scopeForCreate(), ...attrs };
-    return this._association.create(merged) as Promise<T>;
+    return this._association.create(merged, block) as Promise<T>;
   }
 
   /**
@@ -73,9 +91,19 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::AssociationRelation#_create! / #create!
    */
-  async createBang(attrs: Record<string, unknown> = {}): Promise<T> {
+  async createBang(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async createBang(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async createBang(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) records.push((await this.createBang(a, block)) as T);
+      return records;
+    }
     const merged = { ...this.scopeForCreate(), ...attrs };
-    return this._association.createBang(merged) as Promise<T>;
+    return this._association.createBang(merged, block) as Promise<T>;
   }
 
   /**

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -686,15 +686,14 @@ describe("CollectionProxy", () => {
   });
 
   it("Relation#build with array yields each record", async () => {
-    const team = await Team.create({ name: "Rockets" });
-    const rel = Team.where({ id: team.id });
-    const yielded: Base[] = [];
-    const players = rel.build([{ name: "A" }, { name: "B" }], (r) => yielded.push(r));
-    expect(players).toHaveLength(2);
-    expect((players[0] as any).name).toBe("A");
-    expect((players[1] as any).name).toBe("B");
-    expect(yielded).toHaveLength(2);
-    expect(players[0].isNewRecord()).toBe(true);
+    const rel = Team.all();
+    const yieldedTeams: Team[] = [];
+    const teams = rel.build([{ name: "A" }, { name: "B" }], (r) => yieldedTeams.push(r));
+    expect(teams).toHaveLength(2);
+    expect((teams[0] as any).name).toBe("A");
+    expect((teams[1] as any).name).toBe("B");
+    expect(yieldedTeams).toHaveLength(2);
+    expect(teams[0].isNewRecord()).toBe(true);
   });
 
   it("Relation#create with array returns array of saved records", async () => {

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -685,6 +685,27 @@ describe("CollectionProxy", () => {
     expect(player.team_id).toBe(team.id);
   });
 
+  it("Relation#build with array yields each record", async () => {
+    const team = await Team.create({ name: "Rockets" });
+    const rel = Team.where({ id: team.id });
+    const yielded: Base[] = [];
+    const players = rel.build([{ name: "A" }, { name: "B" }], (r) => yielded.push(r));
+    expect(players).toHaveLength(2);
+    expect((players[0] as any).name).toBe("A");
+    expect((players[1] as any).name).toBe("B");
+    expect(yielded).toHaveLength(2);
+    expect(players[0].isNewRecord()).toBe(true);
+  });
+
+  it("Relation#create with array returns array of saved records", async () => {
+    const team = await Team.create({ name: "Celtics" });
+    const proxy = association(team, "players");
+    const players = await proxy.create([{ name: "X" }, { name: "Y" }]);
+    expect(players).toHaveLength(2);
+    expect(players.every((p) => p.isPersisted())).toBe(true);
+    expect(players.every((p) => (p as any).team_id === team.id)).toBe(true);
+  });
+
   // Rails: test_count
   it("test_count", async () => {
     const team = await Team.create({ name: "Bulls" });
@@ -1856,6 +1877,64 @@ describe("Rails-guided: association features", () => {
     const entry = await proxy.create({ content: "Day 1" });
     expect(entry.isPersisted()).toBe(true);
     expect(await proxy.count()).toBe(1);
+  });
+
+  it("CollectionProxy#build with array fires beforeAdd per element", async () => {
+    class Widget extends Base {
+      static {
+        this.attribute("label", "string");
+        this.attribute("box_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Box extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const beforeAdds: Base[] = [];
+    Associations.hasMany.call(Box, "widgets", {
+      className: "Widget",
+      foreignKey: "box_id",
+      beforeAdd: (_owner: Base, record: Base) => void beforeAdds.push(record),
+    });
+    registerModel(Box);
+    registerModel(Widget);
+
+    const box = await Box.create({ name: "Toolbox" });
+    const proxy = association(box, "widgets");
+    const widgets = proxy.build([{ label: "Wrench" }, { label: "Hammer" }]);
+    expect(widgets).toHaveLength(2);
+    expect(beforeAdds).toHaveLength(2);
+    expect(widgets[0].isNewRecord()).toBe(true);
+    expect(widgets[0].box_id).toBe(box.id);
+  });
+
+  it("CollectionProxy#create with array sets FK on every element", async () => {
+    class Ticket extends Base {
+      static {
+        this.attribute("subject", "string");
+        this.attribute("event_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Event extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Event, "tickets", { className: "Ticket", foreignKey: "event_id" });
+    registerModel(Event);
+    registerModel(Ticket);
+
+    const event = await Event.create({ name: "Concert" });
+    const proxy = association(event, "tickets");
+    const tickets = await proxy.create([{ subject: "GA" }, { subject: "VIP" }]);
+    expect(tickets).toHaveLength(2);
+    expect(tickets.every((t) => t.isPersisted())).toBe(true);
+    expect(tickets.every((t) => t.event_id === event.id)).toBe(true);
   });
 
   it("includes preloads hasMany and uses cache", async () => {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -597,10 +597,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * For through associations, builds the target without FK — the join
    * record is created later via create() or push().
    */
-  build(attrs: Record<string, unknown> = {}): T {
+  build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
+  build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
+  build(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): T | T[] {
+    if (Array.isArray(attrs)) {
+      return attrs.map((a) => this.build(a, block));
+    }
     // Through association: build the target record (no FK on target)
     if (this._isThrough) {
       const record = this._buildThrough(attrs) as T;
+      if (block) block(record);
       const allowed = fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record);
       if (allowed) {
         this._target.push(record);
@@ -610,6 +619,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
 
     const record = this._buildRaw(attrs) as T;
+    if (block) block(record);
     const allowed = fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record);
     if (allowed) {
       this._target.push(record);
@@ -665,12 +675,25 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Build and save a new associated record.
    */
-  async create(attrs: Record<string, unknown> = {}): Promise<T> {
+  async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async create(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) {
+        records.push((await this.create(a, block)) as T);
+      }
+      return records;
+    }
     this._ensureThroughWritable();
     if (this._isThrough) {
       return (await this._createThrough(attrs)) as T;
     }
     const record = this._buildRaw(attrs) as T;
+    if (block) block(record);
     if (!fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record)) {
       return record;
     }
@@ -1797,7 +1820,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#create!
    */
-  async createBang(attrs: Record<string, unknown> = {}): Promise<T> {
+  async createBang(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async createBang(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async createBang(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) records.push((await this.createBang(a, block)) as T);
+      return records;
+    }
     this._ensureThroughWritable();
     if (this._isThrough) {
       const ctor = this._record.constructor as typeof Base;
@@ -1807,6 +1840,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         );
       }
       const record = this._buildThrough(attrs) as T;
+      if (block) block(record);
       if (!fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record)) {
         throw new RecordNotSaved("Callback prevented record creation", record);
       }
@@ -1821,6 +1855,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return record;
     }
     const record = this._buildRaw(attrs) as T;
+    if (block) block(record);
     if (!fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record)) {
       throw new RecordNotSaved("Callback prevented record creation", record);
     }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -690,7 +690,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
     this._ensureThroughWritable();
     if (this._isThrough) {
-      return (await this._createThrough(attrs)) as T;
+      return (await this._createThrough(attrs, block)) as T;
     }
     const record = this._buildRaw(attrs) as T;
     if (block) block(record);
@@ -708,12 +708,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // NOTE: If _pushThrough fails after the target is saved, the target record
   // will be orphaned (no join row). Rails wraps this in a transaction. We don't
   // have transaction support yet — tracked in the roadmap under "Transactions".
-  private async _createThrough(attrs: Record<string, unknown> = {}): Promise<Base> {
+  private async _createThrough(
+    attrs: Record<string, unknown> = {},
+    block?: (r: T) => void,
+  ): Promise<Base> {
     const ctor = this._record.constructor as typeof Base;
     if (this._record.isNewRecord()) {
       throw new Error(`Cannot create through association on an unpersisted ${ctor.name}`);
     }
     const record = this._buildThrough(attrs) as T;
+    if (block) block(record);
     const saved = await record.save();
     if (!saved) return record;
     await this._pushThrough([record]);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3001,7 +3001,8 @@ export class Relation<T extends Base> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): T | T[] {
-    return Array.isArray(attrs) ? this.build(attrs, block) : this.build(attrs, block);
+    if (Array.isArray(attrs)) return this.build(attrs, block);
+    return this.build(attrs, block);
   }
 
   // -- Mutation methods --

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1295,8 +1295,18 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#build
    */
-  build(attrs: Record<string, unknown> = {}): T {
-    return new this._modelClass({ ...this.scopeForCreate(), ...attrs }) as T;
+  build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
+  build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
+  build(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): T | T[] {
+    if (Array.isArray(attrs)) {
+      return attrs.map((a) => this.build(a, block));
+    }
+    const record = new this._modelClass({ ...this.scopeForCreate(), ...attrs }) as T;
+    if (block) block(record);
+    return record;
   }
 
   /**
@@ -1304,8 +1314,23 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#create
    */
-  async create(attrs: Record<string, unknown> = {}): Promise<T> {
-    return this._modelClass.create({ ...this.scopeForCreate(), ...attrs }) as Promise<T>;
+  async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async create(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) {
+        records.push((await this.create(a, block)) as T);
+      }
+      return records;
+    }
+    return this._modelClass.create(
+      { ...this.scopeForCreate(), ...attrs },
+      block as ((r: InstanceType<typeof Base>) => void) | undefined,
+    ) as Promise<T>;
   }
 
   /**
@@ -1313,8 +1338,23 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#create!
    */
-  async createBang(attrs: Record<string, unknown> = {}): Promise<T> {
-    return this._modelClass.createBang({ ...this.scopeForCreate(), ...attrs }) as Promise<T>;
+  async createBang(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
+  async createBang(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
+  async createBang(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): Promise<T | T[]> {
+    if (Array.isArray(attrs)) {
+      const records: T[] = [];
+      for (const a of attrs) {
+        records.push((await this.createBang(a, block)) as T);
+      }
+      return records;
+    }
+    return this._modelClass.createBang(
+      { ...this.scopeForCreate(), ...attrs },
+      block as ((r: InstanceType<typeof Base>) => void) | undefined,
+    ) as Promise<T>;
   }
 
   /**
@@ -2955,8 +2995,13 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#new
    */
-  new(attrs: Record<string, unknown> = {}): T {
-    return this.build(attrs);
+  new(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
+  new(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
+  new(
+    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
+    block?: (r: T) => void,
+  ): T | T[] {
+    return Array.isArray(attrs) ? this.build(attrs, block) : this.build(attrs, block);
   }
 
   // -- Mutation methods --

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1327,10 +1327,9 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    return this._modelClass.create(
-      { ...this.scopeForCreate(), ...attrs },
-      block as ((r: InstanceType<typeof Base>) => void) | undefined,
-    ) as Promise<T>;
+    const record = this.build(attrs, block);
+    await record.save();
+    return record;
   }
 
   /**
@@ -1351,10 +1350,9 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    return this._modelClass.createBang(
-      { ...this.scopeForCreate(), ...attrs },
-      block as ((r: InstanceType<typeof Base>) => void) | undefined,
-    ) as Promise<T>;
+    const record = this.build(attrs, block);
+    await record.saveBang();
+    return record;
   }
 
   /**


### PR DESCRIPTION
## Summary

Extends the array + block form of `create` / `new` (already on `Base`) to `Relation` and `CollectionProxy`:

- `Relation#build` / `#create` / `#createBang` / `#new` now accept `Record<string, unknown>[]` and yield each record to an optional block.
- `AssociationRelation` overrides honor the same signature, threading through `scopeForCreate()` per element.
- `CollectionProxy#build` / `#create` / `#createBang` support arrays; each element independently fires `beforeAdd` / `afterAdd` (matching Rails' `concat_records` → `add_to_target` per record).

## Test plan

- [x] `Relation#build with array yields each record`
- [x] `Relation#create with array returns array of saved records`
- [x] `CollectionProxy#build with array fires beforeAdd per element`
- [x] `CollectionProxy#create with array sets FK on every element`
- [x] All 345 existing associations tests still pass