### PR TITLE
feat(activerecord): pg schema-statements — DB/schema mgmt, table introspection, sequences (PR E)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -21,7 +21,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQLActiveSchemaTest", () => {
-    it("create database with encoding", async () => {
+    it("create database with encoding", { timeout: 30000 }, async () => {
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
       try {
         await adapter.createDatabase(tmpDb1, { encoding: "utf8" });
@@ -35,7 +35,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it("create database with collation and ctype", async () => {
+    it("create database with collation and ctype", { timeout: 30000 }, async () => {
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
       try {
         await adapter.createDatabase(tmpDb2, {

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -34,11 +34,17 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("create database with collation and ctype", async () => {
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
-      await adapter.createDatabase(tmpDb2, { encoding: "UTF8" });
-      const rows = await adapter.schemaQuery(`SELECT 1 AS ok FROM pg_database WHERE datname = $1`, [
-        tmpDb2,
-      ]);
-      expect(rows.length).toBe(1);
+      await adapter.createDatabase(tmpDb2, {
+        encoding: "UTF8",
+        collation: "en_US.utf8",
+        ctype: "en_US.utf8",
+      });
+      const rows = await adapter.schemaQuery(
+        `SELECT datcollate AS col, datctype AS ct FROM pg_database WHERE datname = $1`,
+        [tmpDb2],
+      );
+      expect(rows[0].col).toBe("en_US.utf8");
+      expect(rows[0].ct).toBe("en_US.utf8");
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
     });
 

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -40,15 +40,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.createDatabase(tmpDb2, {
           encoding: "UTF8",
-          collation: "en_US.utf8",
-          ctype: "en_US.utf8",
+          collation: "C",
+          ctype: "C",
+          template: "template0",
         });
         const rows = await adapter.schemaQuery(
           `SELECT datcollate AS col, datctype AS ct FROM pg_database WHERE datname = $1`,
           [tmpDb2],
         );
-        expect(rows[0].col).toBe("en_US.utf8");
-        expect(rows[0].ct).toBe("en_US.utf8");
+        expect(rows[0].col).toBe("C");
+        expect(rows[0].ct).toBe("C");
       } finally {
         await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
       }

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -23,29 +23,35 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgreSQLActiveSchemaTest", () => {
     it("create database with encoding", async () => {
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
-      await adapter.createDatabase(tmpDb1, { encoding: "utf8" });
-      const rows = await adapter.schemaQuery(
-        `SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = $1`,
-        [tmpDb1],
-      );
-      expect(rows[0].enc).toMatch(/utf8|UTF8/i);
-      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
+      try {
+        await adapter.createDatabase(tmpDb1, { encoding: "utf8" });
+        const rows = await adapter.schemaQuery(
+          `SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = $1`,
+          [tmpDb1],
+        );
+        expect(rows[0].enc).toMatch(/utf8|UTF8/i);
+      } finally {
+        await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
+      }
     });
 
     it("create database with collation and ctype", async () => {
       await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
-      await adapter.createDatabase(tmpDb2, {
-        encoding: "UTF8",
-        collation: "en_US.utf8",
-        ctype: "en_US.utf8",
-      });
-      const rows = await adapter.schemaQuery(
-        `SELECT datcollate AS col, datctype AS ct FROM pg_database WHERE datname = $1`,
-        [tmpDb2],
-      );
-      expect(rows[0].col).toBe("en_US.utf8");
-      expect(rows[0].ct).toBe("en_US.utf8");
-      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
+      try {
+        await adapter.createDatabase(tmpDb2, {
+          encoding: "UTF8",
+          collation: "en_US.utf8",
+          ctype: "en_US.utf8",
+        });
+        const rows = await adapter.schemaQuery(
+          `SELECT datcollate AS col, datctype AS ct FROM pg_database WHERE datname = $1`,
+          [tmpDb2],
+        );
+        expect(rows[0].col).toBe("en_US.utf8");
+        expect(rows[0].ct).toBe("en_US.utf8");
+      } finally {
+        await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
+      }
     });
 
     it("add index", async () => {

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -1,12 +1,14 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/active_schema_test.rb
  *
- * The Rails version stubs `execute` to return SQL strings, making these
- * pure SQL-generation tests. We test `createDatabase` (which only returns SQL)
- * directly, and for index operations we test against a real table.
+ * The Rails version stubs `execute` to return SQL strings. We test against a
+ * real database instead — createDatabase, dropDatabase, and index operations.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+
+const tmpDb1 = "trails_test_active_schema_matt";
+const tmpDb2 = "trails_test_active_schema_aimonetti";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -20,22 +22,24 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLActiveSchemaTest", () => {
     it("create database with encoding", async () => {
-      expect(adapter.createDatabase("matt")).toBe(`CREATE DATABASE "matt" ENCODING = 'utf8'`);
-      expect(adapter.createDatabase("aimonetti", { encoding: "latin1" })).toBe(
-        `CREATE DATABASE "aimonetti" ENCODING = 'latin1'`,
+      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
+      await adapter.createDatabase(tmpDb1, { encoding: "utf8" });
+      const rows = await adapter.schemaQuery(
+        `SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = $1`,
+        [tmpDb1],
       );
+      expect(rows[0].enc).toMatch(/utf8|UTF8/i);
+      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
     });
 
     it("create database with collation and ctype", async () => {
-      expect(
-        adapter.createDatabase("aimonetti", {
-          encoding: "UTF8",
-          collation: "ja_JP.UTF8",
-          ctype: "ja_JP.UTF8",
-        }),
-      ).toBe(
-        `CREATE DATABASE "aimonetti" ENCODING = 'UTF8' LC_COLLATE = 'ja_JP.UTF8' LC_CTYPE = 'ja_JP.UTF8'`,
-      );
+      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
+      await adapter.createDatabase(tmpDb2, { encoding: "UTF8" });
+      const rows = await adapter.schemaQuery(`SELECT 1 AS ok FROM pg_database WHERE datname = $1`, [
+        tmpDb2,
+      ]);
+      expect(rows.length).toBe(1);
+      await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
     });
 
     it("add index", async () => {

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -31,7 +31,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         expect(rows[0].enc).toMatch(/utf8|UTF8/i);
       } finally {
-        await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb1}`);
+        await adapter.dropDatabase(tmpDb1).catch(() => {});
       }
     });
 
@@ -51,7 +51,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(rows[0].col).toBe("C");
         expect(rows[0].ct).toBe("C");
       } finally {
-        await adapter.exec(`DROP DATABASE IF EXISTS ${tmpDb2}`);
+        await adapter.dropDatabase(tmpDb2).catch(() => {});
       }
     });
 

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -276,7 +276,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("ignore nil schema search path", async () => {
       await adapter.setSchemaSearchPath(null);
-      const path = await adapter.schemaSearchPath;
+      const path = await adapter.schemaSearchPath();
       expect(path).toBeDefined();
     });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2492,8 +2492,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (options.template) optionString += ` TEMPLATE = ${this.quoteIdentifier(options.template)}`;
     if (options.tablespace)
       optionString += ` TABLESPACE = ${this.quoteIdentifier(options.tablespace)}`;
-    if (options.connectionLimit != null)
-      optionString += ` CONNECTION LIMIT = ${Math.trunc(Number(options.connectionLimit))}`;
+    if (options.connectionLimit != null) {
+      const limit = Math.trunc(Number(options.connectionLimit));
+      if (!Number.isFinite(limit) || (limit < 0 && limit !== -1)) {
+        throw new Error(
+          `connectionLimit must be -1 (unlimited) or a non-negative integer, got: ${options.connectionLimit}`,
+        );
+      }
+      optionString += ` CONNECTION LIMIT = ${limit}`;
+    }
     await this.exec(`CREATE DATABASE ${this.quoteIdentifier(name)}${optionString}`);
   }
 
@@ -2816,7 +2823,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async tableOptions(tableName: string): Promise<Record<string, unknown>> {
     const options: Record<string, unknown> = {};
     const comment = await this.tableComment(tableName);
-    if (comment) options.comment = comment;
+    if (comment !== null) options.comment = comment;
     const inherited = await this.inheritedTableNames(tableName);
     if (inherited.length > 0) {
       options.options = `INHERITS (${inherited.join(", ")})`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2493,10 +2493,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (options.tablespace)
       optionString += ` TABLESPACE = ${this.quoteIdentifier(options.tablespace)}`;
     if (options.connectionLimit != null) {
-      const limit = Math.trunc(Number(options.connectionLimit));
-      if (!Number.isFinite(limit) || (limit < 0 && limit !== -1)) {
+      const limit = options.connectionLimit;
+      if (!Number.isInteger(limit) || (limit < 0 && limit !== -1)) {
         throw new Error(
-          `connectionLimit must be -1 (unlimited) or a non-negative integer, got: ${options.connectionLimit}`,
+          `connectionLimit must be -1 (unlimited) or a non-negative integer, got: ${limit}`,
         );
       }
       optionString += ` CONNECTION LIMIT = ${limit}`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2896,12 +2896,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const maxVal = maxRows[0]?.max_val;
     if (maxVal == null) {
       const dbVersion = await this.getDatabaseVersion();
-      const minRows = await this.schemaQuery(
+      const minRows =
         dbVersion >= 100000
-          ? `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = $1::regclass`
-          : `SELECT min_value AS minvalue FROM ${quotedSeq}`,
-        [quotedSeq],
-      );
+          ? await this.schemaQuery(
+              `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = $1::regclass`,
+              [quotedSeq],
+            )
+          : await this.schemaQuery(`SELECT min_value AS minvalue FROM ${quotedSeq}`);
       await this.schemaQuery(`SELECT setval($1::regclass, $2, false)`, [
         quotedSeq,
         minRows[0]?.minvalue ?? 1,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1978,13 +1978,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (rows.length === 0) return null;
 
     const pk = rows[0].pk as string;
-    const schemaName = rows[0].schema_name as string;
+    const tableSchema = rows[0].schema_name as string;
+    let seqSchema: string;
     let seqName: string;
 
     if (rows[0].seq) {
       const fullSeq = rows[0].seq as string;
       const parts = splitQuotedIdentifier(fullSeq);
-      seqName = parts.length > 1 ? parts[1] : parts[0];
+      if (parts.length > 1) {
+        seqSchema = parts[0];
+        seqName = parts[1];
+      } else {
+        seqSchema = tableSchema;
+        seqName = parts[0];
+      }
     } else {
       const defaultExpr = rows[0].default_expr as string | null;
       if (defaultExpr) {
@@ -1992,7 +1999,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         if (match) {
           const seqRef = match[1];
           const parts = splitQuotedIdentifier(seqRef);
-          seqName = parts.length > 1 ? parts[1] : parts[0];
+          if (parts.length > 1) {
+            seqSchema = parts[0];
+            seqName = parts[1];
+          } else {
+            seqSchema = tableSchema;
+            seqName = parts[0];
+          }
         } else {
           return null;
         }
@@ -2001,7 +2014,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     }
 
-    return [pk, { schema: schemaName, name: seqName }];
+    return [pk, { schema: seqSchema, name: seqName }];
   }
 
   async resetPkSequence(tableName: string): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2482,20 +2482,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  createDatabase(
+  async createDatabase(
     name: string,
     options: {
       encoding?: string;
       collation?: string;
       ctype?: string;
+      owner?: string;
+      template?: string;
+      tablespace?: string;
+      connectionLimit?: number;
     } = {},
-  ): string {
-    let sql = `CREATE DATABASE ${this.quoteIdentifier(name)}`;
+  ): Promise<void> {
     const encoding = options.encoding ?? "utf8";
-    sql += ` ENCODING = ${this.quoteLiteral(encoding)}`;
-    if (options.collation) sql += ` LC_COLLATE = ${this.quoteLiteral(options.collation)}`;
-    if (options.ctype) sql += ` LC_CTYPE = ${this.quoteLiteral(options.ctype)}`;
-    return sql;
+    let optionString = ` ENCODING = ${this.quoteLiteral(encoding)}`;
+    if (options.collation) optionString += ` LC_COLLATE = ${this.quoteLiteral(options.collation)}`;
+    if (options.ctype) optionString += ` LC_CTYPE = ${this.quoteLiteral(options.ctype)}`;
+    if (options.owner) optionString += ` OWNER = ${this.quoteIdentifier(options.owner)}`;
+    if (options.template) optionString += ` TEMPLATE = ${this.quoteIdentifier(options.template)}`;
+    if (options.tablespace)
+      optionString += ` TABLESPACE = ${this.quoteIdentifier(options.tablespace)}`;
+    if (options.connectionLimit != null)
+      optionString += ` CONNECTION LIMIT = ${options.connectionLimit}`;
+    await this.exec(`CREATE DATABASE ${this.quoteTableName(name)}${optionString}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -2706,8 +2715,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    const idxs = await this.indexes(tableName);
-    return idxs.some((idx) => idx.name === indexName);
+    const table = this.pgQuotedScope(tableName, "BASE TABLE");
+    const idxName = this.quoteLiteral(indexName);
+    const rows = await this.schemaQuery(`
+      SELECT COUNT(*) AS cnt
+      FROM pg_class t
+      INNER JOIN pg_index d ON t.oid = d.indrelid
+      INNER JOIN pg_class i ON d.indexrelid = i.oid
+      LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE i.relkind IN ('i', 'I')
+        AND i.relname = ${idxName}
+        AND t.relname = ${table.name}
+        AND n.nspname = ${table.schema}
+    `);
+    return Number(rows[0].cnt) > 0;
   }
 
   async currentDatabase(): Promise<string> {
@@ -2829,7 +2850,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       if (!result) return null;
       return Utils.extractSchemaQualifiedName(result).toString();
     } catch {
-      return `${tableName}_${pk}_seq`;
+      const { identifier } = Utils.extractSchemaQualifiedName(tableName);
+      return `${identifier ?? tableName}_${pk}_seq`;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2699,11 +2699,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     let tableNames: string[];
     let options: { ifExists?: boolean; force?: "cascade" } = {};
     const last = args[args.length - 1];
-    if (typeof last === "object" && last !== null) {
+    if (last !== null && last !== undefined && typeof last === "object") {
       tableNames = args.slice(0, -1) as string[];
       options = last as { ifExists?: boolean; force?: "cascade" };
     } else {
-      tableNames = args as string[];
+      tableNames = args.filter((a) => a !== undefined) as string[];
     }
     if (tableNames.length === 0) {
       throw new Error("dropTable requires at least one table name");

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1903,8 +1903,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    const idxs = await this.indexes(tableName);
-    return idxs.some((idx) => idx.name === indexName);
+    const table = this.pgQuotedScope(tableName, "BASE TABLE");
+    const idxName = this.quoteLiteral(indexName);
+    const rows = await this.schemaQuery(`
+      SELECT COUNT(*) AS cnt
+      FROM pg_class t
+      INNER JOIN pg_index d ON t.oid = d.indrelid
+      INNER JOIN pg_class i ON d.indexrelid = i.oid
+      LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE i.relkind IN ('i', 'I')
+        AND i.relname = ${idxName}
+        AND t.relname = ${table.name}
+        AND n.nspname = ${table.schema}
+    `);
+    return Number(rows[0].cnt) > 0;
   }
 
   async primaryKey(tableName: string): Promise<string | string[] | null> {
@@ -2733,23 +2745,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const cascade = options.force === "cascade" ? " CASCADE" : "";
     const quoted = tableNames.map((t) => this.quoteTableName(t)).join(", ");
     await this.exec(`DROP TABLE${ifExists} ${quoted}${cascade}`);
-  }
-
-  async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    const table = this.pgQuotedScope(tableName, "BASE TABLE");
-    const idxName = this.quoteLiteral(indexName);
-    const rows = await this.schemaQuery(`
-      SELECT COUNT(*) AS cnt
-      FROM pg_class t
-      INNER JOIN pg_index d ON t.oid = d.indrelid
-      INNER JOIN pg_class i ON d.indexrelid = i.oid
-      LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
-      WHERE i.relkind IN ('i', 'I')
-        AND i.relname = ${idxName}
-        AND t.relname = ${table.name}
-        AND n.nspname = ${table.schema}
-    `);
-    return Number(rows[0].cnt) > 0;
   }
 
   async currentDatabase(): Promise<string> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2017,9 +2017,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
     const maxVal = Number(maxRows[0].max_val);
     if (maxVal === 0) {
-      await this.schemaQuery(`SELECT setval($1::regclass, 1, false)`, [seqName]);
+      await this.schemaQuery(`SELECT setval($1::regclass, 1, false)`, [
+        this.quoteTableName(seqName),
+      ]);
     } else {
-      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [seqName, maxVal]);
+      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [
+        this.quoteTableName(seqName),
+        maxVal,
+      ]);
     }
   }
 
@@ -2028,7 +2033,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!result) return;
     const [, seq] = result;
     const seqName = `${seq.schema}.${seq.name}`;
-    await this.schemaQuery(`SELECT setval($1::regclass, $2)`, [seqName, value]);
+    await this.schemaQuery(`SELECT setval($1::regclass, $2)`, [
+      this.quoteTableName(seqName),
+      value,
+    ]);
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
@@ -2703,7 +2711,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       tableNames = args.slice(0, -1) as string[];
       options = last as { ifExists?: boolean; force?: "cascade" };
     } else {
-      tableNames = args.filter((a) => a !== undefined) as string[];
+      tableNames = args as string[];
     }
     if (tableNames.length === 0) {
       throw new Error("dropTable requires at least one table name");
@@ -2890,18 +2898,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       const dbVersion = await this.getDatabaseVersion();
       const minRows = await this.schemaQuery(
         dbVersion >= 100000
-          ? `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = ${this.quoteLiteral(quotedSeq)}::regclass`
+          ? `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = $1::regclass`
           : `SELECT min_value AS minvalue FROM ${quotedSeq}`,
+        [quotedSeq],
       );
       await this.schemaQuery(`SELECT setval($1::regclass, $2, false)`, [
-        this.quoteTableName(sequence),
+        quotedSeq,
         minRows[0]?.minvalue ?? 1,
       ]);
     } else {
-      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [
-        this.quoteTableName(sequence),
-        maxVal,
-      ]);
+      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [quotedSeq, maxVal]);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -38,7 +38,7 @@ import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { transactionIsolationLevels, typeCastedBinds } from "./abstract/database-statements.js";
 import { READ_QUERY } from "./postgresql/database-statements.js";
-import type { CreateDatabaseOptions } from "./postgresql/schema-statements.js";
+import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -2950,14 +2950,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 }
 
-export interface IndexDefinition {
-  table: string;
-  name: string;
-  unique: boolean;
-  columns: string[];
-  using: string;
-  orders?: Record<string, string> | string;
-}
+export type IndexDefinition = PgIndexDefinition;
 
 class SimpleTableBuilder {
   private _columns: { name: string; type: string }[] = [];

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2853,8 +2853,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       if (!result) return null;
       return Utils.extractSchemaQualifiedName(result).toString();
     } catch {
-      const { identifier } = Utils.extractSchemaQualifiedName(tableName);
-      return `${identifier ?? tableName}_${pk}_seq`;
+      return `${tableName}_${pk}_seq`;
     }
   }
 
@@ -2863,7 +2862,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!result) return;
     const [, seq] = result;
     const seqName = `${seq.schema}.${seq.name}`;
-    await this.schemaQuery(`SELECT setval($1::regclass, $2)`, [seqName, value]);
+    await this.schemaQuery(`SELECT setval($1::regclass, $2)`, [
+      this.quoteTableName(seqName),
+      value,
+    ]);
   }
 
   async resetPkSequenceBang(
@@ -2892,11 +2894,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           : `SELECT min_value AS minvalue FROM ${quotedSeq}`,
       );
       await this.schemaQuery(`SELECT setval($1::regclass, $2, false)`, [
-        sequence,
+        this.quoteTableName(sequence),
         minRows[0]?.minvalue ?? 1,
       ]);
     } else {
-      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [sequence, maxVal]);
+      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [
+        this.quoteTableName(sequence),
+        maxVal,
+      ]);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1727,15 +1727,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return rows[0].schema as string;
   }
 
-  get schemaSearchPath(): Promise<string> {
-    return this.schemaQuery("SHOW search_path").then((rows) => rows[0].search_path as string);
-  }
-
-  async setSchemaSearchPath(searchPath: string | null): Promise<void> {
-    if (searchPath == null) return;
-    await this.schemaQuery("SELECT set_config('search_path', $1, false)", [searchPath]);
-  }
-
   async dataSourceExists(name: string): Promise<boolean> {
     const { schema, table } = this.parseSchemaQualifiedName(name);
     if (schema) {
@@ -2197,11 +2188,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const quotedTable = this.quoteTableName(tableName);
     const columnDefs = table.getColumns().map((c) => `${this.quoteIdentifier(c.name)} ${c.type}`);
     await this.exec(`CREATE TABLE ${quotedTable} (${columnDefs.join(", ")})`);
-  }
-
-  async dropTable(tableName: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.exec(`DROP TABLE${ifExists} ${this.quoteTableName(tableName)}`);
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
@@ -2688,6 +2674,234 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         }
         return e;
     }
+  }
+
+  async dropDatabase(name: string): Promise<void> {
+    await this.exec(`DROP DATABASE IF EXISTS ${this.quoteIdentifier(name)}`);
+  }
+
+  async recreateDatabase(name: string, options: Record<string, unknown> = {}): Promise<void> {
+    await this.dropDatabase(name);
+    await this.createDatabase(name, options);
+  }
+
+  async dropTable(
+    ...args:
+      | [...tableNames: string[], options: { ifExists?: boolean; force?: "cascade" }]
+      | string[]
+  ): Promise<void> {
+    let tableNames: string[];
+    let options: { ifExists?: boolean; force?: "cascade" } = {};
+    const last = args[args.length - 1];
+    if (typeof last === "object" && last !== null) {
+      tableNames = args.slice(0, -1) as string[];
+      options = last as { ifExists?: boolean; force?: "cascade" };
+    } else {
+      tableNames = args as string[];
+    }
+    const ifExists = options.ifExists ? " IF EXISTS" : "";
+    const cascade = options.force === "cascade" ? " CASCADE" : "";
+    const quoted = tableNames.map((t) => this.quoteTableName(t)).join(", ");
+    await this.exec(`DROP TABLE${ifExists} ${quoted}${cascade}`);
+  }
+
+  async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {
+    const idxs = await this.indexes(tableName);
+    return idxs.some((idx) => idx.name === indexName);
+  }
+
+  async currentDatabase(): Promise<string> {
+    const rows = await this.schemaQuery("SELECT current_database() AS name");
+    return rows[0].name as string;
+  }
+
+  async encoding(): Promise<string> {
+    const rows = await this.schemaQuery(
+      "SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = current_database()",
+    );
+    return rows[0].enc as string;
+  }
+
+  async collation(): Promise<string> {
+    const rows = await this.schemaQuery(
+      "SELECT datcollate AS col FROM pg_database WHERE datname = current_database()",
+    );
+    return rows[0].col as string;
+  }
+
+  async ctype(): Promise<string> {
+    const rows = await this.schemaQuery(
+      "SELECT datctype AS ct FROM pg_database WHERE datname = current_database()",
+    );
+    return rows[0].ct as string;
+  }
+
+  async schemaSearchPath(): Promise<string> {
+    const rows = await this.schemaQuery("SHOW search_path");
+    return rows[0].search_path as string;
+  }
+
+  async setSchemaSearchPath(searchPath: string | null): Promise<void> {
+    if (searchPath == null) return;
+    await this.exec(`SET search_path TO ${searchPath}`);
+  }
+
+  async clientMinMessages(): Promise<string> {
+    const rows = await this.schemaQuery("SHOW client_min_messages");
+    return rows[0].client_min_messages as string;
+  }
+
+  async setClientMinMessages(level: string): Promise<void> {
+    await this.exec(`SET client_min_messages TO '${level}'`);
+  }
+
+  async tableComment(tableName: string): Promise<string | null> {
+    const { schema, name } = this.pgQuotedScope(tableName, "BASE TABLE");
+    if (!name) return null;
+    const rows = await this.schemaQuery(`
+      SELECT pg_catalog.obj_description(c.oid, 'pg_class') AS comment
+      FROM pg_catalog.pg_class c
+      LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = ${name}
+        AND c.relkind IN ('r','p')
+        AND n.nspname = ${schema}
+    `);
+    return (rows[0]?.comment as string | null) ?? null;
+  }
+
+  async tablePartitionDefinition(tableName: string): Promise<string | null> {
+    const { schema, name } = this.pgQuotedScope(tableName, "BASE TABLE");
+    if (!name) return null;
+    const rows = await this.schemaQuery(`
+      SELECT pg_catalog.pg_get_partkeydef(c.oid) AS def
+      FROM pg_catalog.pg_class c
+      LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = ${name}
+        AND c.relkind IN ('r','p')
+        AND n.nspname = ${schema}
+    `);
+    return (rows[0]?.def as string | null) ?? null;
+  }
+
+  async inheritedTableNames(tableName: string): Promise<string[]> {
+    const { schema, name } = this.pgQuotedScope(tableName, "BASE TABLE");
+    if (!name) return [];
+    const rows = await this.schemaQuery(`
+      SELECT parent.relname AS name
+      FROM pg_catalog.pg_inherits i
+      JOIN pg_catalog.pg_class child  ON i.inhrelid  = child.oid
+      JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
+      LEFT JOIN pg_namespace n ON n.oid = child.relnamespace
+      WHERE child.relname = ${name}
+        AND child.relkind IN ('r','p')
+        AND n.nspname = ${schema}
+    `);
+    return rows.map((r) => r.name as string);
+  }
+
+  async tableOptions(tableName: string): Promise<Record<string, unknown>> {
+    const options: Record<string, unknown> = {};
+    const comment = await this.tableComment(tableName);
+    if (comment) options.comment = comment;
+    const inherited = await this.inheritedTableNames(tableName);
+    if (inherited.length > 0) {
+      options.options = `INHERITS (${inherited.join(", ")})`;
+    }
+    if (!options.options) {
+      const partDef = await this.tablePartitionDefinition(tableName);
+      if (partDef) options.options = `PARTITION BY ${partDef}`;
+    }
+    return options;
+  }
+
+  async serialSequence(tableName: string, column: string): Promise<string | null> {
+    const rows = await this.schemaQuery(`SELECT pg_get_serial_sequence($1, $2) AS seq`, [
+      tableName,
+      column,
+    ]);
+    return (rows[0]?.seq as string | null) ?? null;
+  }
+
+  async defaultSequenceName(tableName: string, pk = "id"): Promise<string | null> {
+    if (Array.isArray(pk)) return null;
+    try {
+      const result = await this.serialSequence(tableName, pk);
+      if (!result) return null;
+      return Utils.extractSchemaQualifiedName(result).toString();
+    } catch {
+      return `${tableName}_${pk}_seq`;
+    }
+  }
+
+  async setPkSequenceBang(tableName: string, value: number): Promise<void> {
+    const result = await this.pkAndSequenceFor(tableName);
+    if (!result) return;
+    const [, seq] = result;
+    const seqName = `${seq.schema}.${seq.name}`;
+    await this.schemaQuery(`SELECT setval($1::regclass, $2)`, [seqName, value]);
+  }
+
+  async resetPkSequenceBang(
+    tableName: string,
+    pk: string | null = null,
+    sequence: string | null = null,
+  ): Promise<void> {
+    if (!pk || !sequence) {
+      const result = await this.pkAndSequenceFor(tableName);
+      if (!result) return;
+      const [defaultPk, defaultSeq] = result;
+      pk = pk ?? defaultPk;
+      sequence = sequence ?? `${defaultSeq.schema}.${defaultSeq.name}`;
+    }
+    if (!pk || !sequence) return;
+    const quotedSeq = this.quoteTableName(sequence);
+    const maxRows = await this.schemaQuery(
+      `SELECT MAX(${this.quoteIdentifier(pk)}) AS max_val FROM ${this.quoteTableName(tableName)}`,
+    );
+    const maxVal = maxRows[0]?.max_val;
+    if (maxVal == null) {
+      const dbVersion = await this.getDatabaseVersion();
+      const minRows = await this.schemaQuery(
+        dbVersion >= 100000
+          ? `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = ${this.quoteLiteral(quotedSeq)}::regclass`
+          : `SELECT min_value AS minvalue FROM ${quotedSeq}`,
+      );
+      await this.schemaQuery(`SELECT setval($1::regclass, $2, false)`, [
+        sequence,
+        minRows[0]?.minvalue ?? 1,
+      ]);
+    } else {
+      await this.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [sequence, maxVal]);
+    }
+  }
+
+  async primaryKeys(tableName: string): Promise<string[]> {
+    const rows = await this.schemaQuery(
+      `SELECT a.attname AS name
+       FROM (
+         SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
+           FROM pg_index
+          WHERE indrelid = ${this.quoteLiteral(this.quoteTableName(tableName))}::regclass
+            AND indisprimary
+       ) i
+       JOIN pg_attribute a
+         ON a.attrelid = i.indrelid
+        AND a.attnum = i.indkey[i.idx]
+       ORDER BY i.idx`,
+    );
+    return rows.map((r) => r.name as string);
+  }
+
+  private pgQuotedScope(
+    name: string,
+    _type: "BASE TABLE" | null,
+  ): { schema: string; name: string | null } {
+    const pgName = Utils.extractSchemaQualifiedName(name);
+    const schema = pgName.schema
+      ? this.quoteLiteral(pgName.schema)
+      : "ANY (current_schemas(false))";
+    const quotedName = pgName.identifier ? this.quoteLiteral(pgName.identifier) : null;
+    return { schema, name: quotedName };
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -38,6 +38,7 @@ import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { transactionIsolationLevels, typeCastedBinds } from "./abstract/database-statements.js";
 import { READ_QUERY } from "./postgresql/database-statements.js";
+import type { CreateDatabaseOptions } from "./postgresql/schema-statements.js";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -2482,18 +2483,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
   }
 
-  async createDatabase(
-    name: string,
-    options: {
-      encoding?: string;
-      collation?: string;
-      ctype?: string;
-      owner?: string;
-      template?: string;
-      tablespace?: string;
-      connectionLimit?: number;
-    } = {},
-  ): Promise<void> {
+  async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
     const encoding = options.encoding ?? "utf8";
     let optionString = ` ENCODING = ${this.quoteLiteral(encoding)}`;
     if (options.collation) optionString += ` LC_COLLATE = ${this.quoteLiteral(options.collation)}`;
@@ -2504,7 +2494,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       optionString += ` TABLESPACE = ${this.quoteIdentifier(options.tablespace)}`;
     if (options.connectionLimit != null)
       optionString += ` CONNECTION LIMIT = ${options.connectionLimit}`;
-    await this.exec(`CREATE DATABASE ${this.quoteTableName(name)}${optionString}`);
+    await this.exec(`CREATE DATABASE ${this.quoteIdentifier(name)}${optionString}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -2689,7 +2679,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(`DROP DATABASE IF EXISTS ${this.quoteIdentifier(name)}`);
   }
 
-  async recreateDatabase(name: string, options: Record<string, unknown> = {}): Promise<void> {
+  async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
     await this.dropDatabase(name);
     await this.createDatabase(name, options);
   }
@@ -2707,6 +2697,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       options = last as { ifExists?: boolean; force?: "cascade" };
     } else {
       tableNames = args as string[];
+    }
+    if (tableNames.length === 0) {
+      throw new Error("dropTable requires at least one table name");
     }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     const cascade = options.force === "cascade" ? " CASCADE" : "";
@@ -2764,7 +2757,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async setSchemaSearchPath(searchPath: string | null): Promise<void> {
     if (searchPath == null) return;
-    await this.exec(`SET search_path TO ${searchPath}`);
+    await this.schemaQuery(`SELECT set_config('search_path', $1, false)`, [searchPath]);
   }
 
   async clientMinMessages(): Promise<string> {
@@ -2773,7 +2766,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async setClientMinMessages(level: string): Promise<void> {
-    await this.exec(`SET client_min_messages TO '${level}'`);
+    await this.exec(`SET client_min_messages TO ${this.quoteLiteral(level)}`);
   }
 
   async tableComment(tableName: string): Promise<string | null> {
@@ -2843,7 +2836,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return (rows[0]?.seq as string | null) ?? null;
   }
 
-  async defaultSequenceName(tableName: string, pk = "id"): Promise<string | null> {
+  async defaultSequenceName(
+    tableName: string,
+    pk: string | string[] = "id",
+  ): Promise<string | null> {
     if (Array.isArray(pk)) return null;
     try {
       const result = await this.serialSequence(tableName, pk);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2493,7 +2493,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (options.tablespace)
       optionString += ` TABLESPACE = ${this.quoteIdentifier(options.tablespace)}`;
     if (options.connectionLimit != null)
-      optionString += ` CONNECTION LIMIT = ${options.connectionLimit}`;
+      optionString += ` CONNECTION LIMIT = ${Math.trunc(Number(options.connectionLimit))}`;
     await this.exec(`CREATE DATABASE ${this.quoteIdentifier(name)}${optionString}`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -222,6 +222,28 @@ describeIfPg("PostgreSQLAdapter", () => {
       ).resolves.not.toThrow();
     });
 
+    it("drop table with force cascade drops dependent constraints", async () => {
+      await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.parent_tbl (id int PRIMARY KEY)`);
+      await adapter.exec(
+        `CREATE TABLE ${SCHEMA_NAME}.child_tbl (id int REFERENCES ${SCHEMA_NAME}.parent_tbl(id))`,
+      );
+      await expect(adapter.dropTable(`${SCHEMA_NAME}.parent_tbl`)).rejects.toThrow();
+      await adapter.dropTable(`${SCHEMA_NAME}.parent_tbl`, { force: "cascade" });
+      const parentRows = await adapter.schemaQuery(
+        `SELECT COUNT(*) AS c FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name = 'parent_tbl'`,
+        [SCHEMA_NAME],
+      );
+      expect(Number(parentRows[0].c)).toBe(0);
+      const fkRows = await adapter.schemaQuery(
+        `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+         WHERE constraint_schema = $1 AND table_name = 'child_tbl' AND constraint_type = 'FOREIGN KEY'`,
+        [SCHEMA_NAME],
+      );
+      expect(Number(fkRows[0].c)).toBe(0);
+      await adapter.exec(`DROP TABLE IF EXISTS ${SCHEMA_NAME}.child_tbl`);
+    });
+
     it("drop table multiple tables", async () => {
       await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.t1 (id int)`);
       await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.t2 (id int)`);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -56,7 +56,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("encoding", async () => {
       const enc = await adapter.encoding();
       expect(typeof enc).toBe("string");
-      expect(enc).toMatch(/^UTF8|UTF-8|unicode$/i);
+      expect(enc).toMatch(/^(UTF8|UTF-8|unicode)$/i);
     });
 
     it("collation", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -228,6 +228,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number(rows[0].c)).toBe(0);
     });
 
+    it("drop database removes the database", async () => {
+      const tmpDb = "trails_test_drop_db_tmp";
+      const rootAdapter = new PostgreSQLAdapter(PG_TEST_URL.replace(/\/[^/]+$/, "/postgres"));
+      try {
+        await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
+        await rootAdapter.createDatabase(tmpDb);
+        const before = await rootAdapter.schemaQuery(
+          `SELECT 1 AS ok FROM pg_database WHERE datname = $1`,
+          [tmpDb],
+        );
+        expect(before.length).toBe(1);
+        await rootAdapter.dropDatabase(tmpDb);
+        const after = await rootAdapter.schemaQuery(
+          `SELECT 1 AS ok FROM pg_database WHERE datname = $1`,
+          [tmpDb],
+        );
+        expect(after.length).toBe(0);
+      } finally {
+        await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
+        await rootAdapter.close();
+      }
+    });
+
     it("recreate database drops and creates", async () => {
       const tmpDb = "trails_test_recreate_tmp";
       const rootAdapter = new PostgreSQLAdapter(PG_TEST_URL.replace(/\/[^/]+$/, "/postgres"));

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -1,6 +1,6 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/schema_test.rb
- * (schema-statements subset: recreateDatabase, dropTable, isIndexNameExists,
+ * (schema-statements subset: recreateDatabase, dropTable, indexNameExists,
  * currentDatabase, encoding, collation, ctype, schemaSearchPath,
  * clientMinMessages, tableOptions, tableComment, tablePartitionDefinition,
  * inheritedTableNames, defaultSequenceName, serialSequence, setPkSequenceBang,
@@ -107,10 +107,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("index name exists", async () => {
-      expect(await adapter.isIndexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, INDEX_A_NAME)).toBe(
+      expect(await adapter.indexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, INDEX_A_NAME)).toBe(
         true,
       );
-      expect(await adapter.isIndexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, "missing_index")).toBe(
+      expect(await adapter.indexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, "missing_index")).toBe(
         false,
       );
     });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/postgresql/schema_test.rb
+ * (schema-statements subset: recreateDatabase, dropTable, isIndexNameExists,
+ * currentDatabase, encoding, collation, ctype, schemaSearchPath,
+ * clientMinMessages, tableOptions, tableComment, tablePartitionDefinition,
+ * inheritedTableNames, defaultSequenceName, serialSequence, setPkSequenceBang,
+ * resetPkSequenceBang, pkAndSequenceFor, primaryKeys)
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  describeIfPg,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+} from "../../adapters/postgresql/test-helper.js";
+
+const SCHEMA_NAME = "test_schema_stmts";
+const TABLE_NAME = "things";
+const INDEX_A_NAME = "a_index_things_stmts";
+
+async function setup(adapter: PostgreSQLAdapter) {
+  await adapter.exec(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA_NAME}`);
+  await adapter.exec(
+    `CREATE TABLE ${SCHEMA_NAME}.${TABLE_NAME} (
+       id serial PRIMARY KEY,
+       name character varying(50),
+       email character varying(50)
+     )`,
+  );
+  await adapter.exec(`CREATE INDEX ${INDEX_A_NAME} ON ${SCHEMA_NAME}.${TABLE_NAME} (name)`);
+}
+
+async function teardown(adapter: PostgreSQLAdapter) {
+  await adapter.exec(`DROP SCHEMA IF EXISTS ${SCHEMA_NAME} CASCADE`);
+}
+
+describeIfPg("PostgreSQLAdapter", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await setup(adapter);
+  });
+
+  afterEach(async () => {
+    await teardown(adapter);
+    await adapter.close();
+  });
+
+  describe("SchemaTest", () => {
+    it("current database", async () => {
+      const db = await adapter.currentDatabase();
+      expect(typeof db).toBe("string");
+      expect(db.length).toBeGreaterThan(0);
+    });
+
+    it("encoding", async () => {
+      const enc = await adapter.encoding();
+      expect(typeof enc).toBe("string");
+      expect(enc).toMatch(/^UTF8|UTF-8|unicode$/i);
+    });
+
+    it("collation", async () => {
+      const col = await adapter.collation();
+      expect(typeof col).toBe("string");
+    });
+
+    it("ctype", async () => {
+      const ct = await adapter.ctype();
+      expect(typeof ct).toBe("string");
+    });
+
+    it("schema search path", async () => {
+      const path = await adapter.schemaSearchPath();
+      expect(typeof path).toBe("string");
+    });
+
+    it("set schema search path", async () => {
+      await adapter.setSchemaSearchPath(`${SCHEMA_NAME}, public`);
+      const path = await adapter.schemaSearchPath();
+      expect(path).toContain(SCHEMA_NAME);
+      await adapter.setSchemaSearchPath("public");
+    });
+
+    it("set schema search path with null is a no-op", async () => {
+      const before = await adapter.schemaSearchPath();
+      await adapter.setSchemaSearchPath(null);
+      const after = await adapter.schemaSearchPath();
+      expect(after).toBe(before);
+    });
+
+    it("client min messages", async () => {
+      const level = await adapter.clientMinMessages();
+      expect(typeof level).toBe("string");
+    });
+
+    it("set client min messages", async () => {
+      await expect(adapter.setClientMinMessages("warning")).resolves.not.toThrow();
+      const level = await adapter.clientMinMessages();
+      expect(level.toLowerCase()).toBe("warning");
+      await adapter.setClientMinMessages("notice");
+    });
+
+    it("index name exists", async () => {
+      expect(await adapter.isIndexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, INDEX_A_NAME)).toBe(
+        true,
+      );
+      expect(await adapter.isIndexNameExists(`${SCHEMA_NAME}.${TABLE_NAME}`, "missing_index")).toBe(
+        false,
+      );
+    });
+
+    it("pk and sequence for with schema specified", async () => {
+      const result = await adapter.pkAndSequenceFor(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(result).not.toBeNull();
+      const [pk, seq] = result!;
+      expect(pk).toBe("id");
+      expect(seq).toBeDefined();
+    });
+
+    it("primary keys", async () => {
+      const keys = await adapter.primaryKeys(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(keys).toEqual(["id"]);
+    });
+
+    it("primary keys returns empty array for table without pk", async () => {
+      await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.no_pk (name text)`);
+      const keys = await adapter.primaryKeys(`${SCHEMA_NAME}.no_pk`);
+      expect(keys).toEqual([]);
+      await adapter.exec(`DROP TABLE ${SCHEMA_NAME}.no_pk`);
+    });
+
+    it("serial sequence", async () => {
+      const seq = await adapter.serialSequence(`${SCHEMA_NAME}.${TABLE_NAME}`, "id");
+      expect(seq).not.toBeNull();
+      expect(seq).toMatch(/seq/i);
+    });
+
+    it("default sequence name", async () => {
+      const seqName = await adapter.defaultSequenceName(`${SCHEMA_NAME}.${TABLE_NAME}`, "id");
+      expect(seqName).not.toBeNull();
+      expect(typeof seqName).toBe("string");
+    });
+
+    it("reset pk sequence", async () => {
+      const tableName = `${SCHEMA_NAME}.${TABLE_NAME}`;
+      const result = await adapter.pkAndSequenceFor(tableName);
+      expect(result).not.toBeNull();
+      const [, seq] = result!;
+      const seqName = `${seq.schema}.${seq.name}`;
+      await adapter.schemaQuery(`SELECT setval($1::regclass, 123)`, [seqName]);
+      const before = await adapter.schemaQuery(`SELECT nextval($1::regclass) AS n`, [seqName]);
+      expect(Number(before[0].n)).toBe(124);
+      await adapter.resetPkSequenceBang(tableName);
+      const after = await adapter.schemaQuery(`SELECT nextval($1::regclass) AS n`, [seqName]);
+      expect(Number(after[0].n)).toBe(1);
+    });
+
+    it("set pk sequence", async () => {
+      const tableName = `${SCHEMA_NAME}.${TABLE_NAME}`;
+      const result = await adapter.pkAndSequenceFor(tableName);
+      expect(result).not.toBeNull();
+      const [, seq] = result!;
+      const seqName = `${seq.schema}.${seq.name}`;
+      await adapter.setPkSequenceBang(tableName, 123);
+      const rows = await adapter.schemaQuery(`SELECT nextval($1::regclass) AS n`, [seqName]);
+      expect(Number(rows[0].n)).toBe(124);
+      await adapter.resetPkSequenceBang(tableName);
+    });
+
+    it("table comment returns null for table without comment", async () => {
+      const comment = await adapter.tableComment(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(comment).toBeNull();
+    });
+
+    it("table comment returns comment when set", async () => {
+      await adapter.exec(`COMMENT ON TABLE ${SCHEMA_NAME}.${TABLE_NAME} IS 'test comment'`);
+      const comment = await adapter.tableComment(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(comment).toBe("test comment");
+    });
+
+    it("table partition definition returns null for non-partitioned table", async () => {
+      const def = await adapter.tablePartitionDefinition(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(def).toBeNull();
+    });
+
+    it("inherited table names returns empty for non-inherited table", async () => {
+      const names = await adapter.inheritedTableNames(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(names).toEqual([]);
+    });
+
+    it("table options returns empty object for plain table", async () => {
+      const opts = await adapter.tableOptions(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(opts).toEqual({});
+    });
+
+    it("table options includes comment when set", async () => {
+      await adapter.exec(`COMMENT ON TABLE ${SCHEMA_NAME}.${TABLE_NAME} IS 'my table'`);
+      const opts = await adapter.tableOptions(`${SCHEMA_NAME}.${TABLE_NAME}`);
+      expect(opts.comment).toBe("my table");
+    });
+
+    it("drop table removes a table", async () => {
+      await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.tmp_drop_test (id int)`);
+      await adapter.dropTable(`${SCHEMA_NAME}.tmp_drop_test`);
+      const rows = await adapter.schemaQuery(
+        `SELECT COUNT(*) AS c FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name = $2`,
+        [SCHEMA_NAME, "tmp_drop_test"],
+      );
+      expect(Number(rows[0].c)).toBe(0);
+    });
+
+    it("drop table with if exists does not throw for missing table", async () => {
+      await expect(
+        adapter.dropTable(`${SCHEMA_NAME}.nonexistent_table`, { ifExists: true }),
+      ).resolves.not.toThrow();
+    });
+
+    it("drop table multiple tables", async () => {
+      await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.t1 (id int)`);
+      await adapter.exec(`CREATE TABLE ${SCHEMA_NAME}.t2 (id int)`);
+      await adapter.dropTable(`${SCHEMA_NAME}.t1`, `${SCHEMA_NAME}.t2`);
+      const rows = await adapter.schemaQuery(
+        `SELECT COUNT(*) AS c FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name IN ('t1','t2')`,
+        [SCHEMA_NAME],
+      );
+      expect(Number(rows[0].c)).toBe(0);
+    });
+
+    it("recreate database drops and creates", async () => {
+      const dbName = await adapter.currentDatabase();
+      expect(typeof dbName).toBe("string");
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -17,6 +17,12 @@ const SCHEMA_NAME = "test_schema_stmts";
 const TABLE_NAME = "things";
 const INDEX_A_NAME = "a_index_things_stmts";
 
+function postgresUrl(): string {
+  const u = new URL(PG_TEST_URL);
+  u.pathname = "/postgres";
+  return u.toString();
+}
+
 async function setup(adapter: PostgreSQLAdapter) {
   await adapter.exec(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA_NAME}`);
   await adapter.exec(
@@ -230,7 +236,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("drop database removes the database", async () => {
       const tmpDb = "trails_test_drop_db_tmp";
-      const rootAdapter = new PostgreSQLAdapter(PG_TEST_URL.replace(/\/[^/]+$/, "/postgres"));
+      const rootAdapter = new PostgreSQLAdapter(postgresUrl());
       try {
         await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
         await rootAdapter.createDatabase(tmpDb);
@@ -253,7 +259,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("recreate database drops and creates", async () => {
       const tmpDb = "trails_test_recreate_tmp";
-      const rootAdapter = new PostgreSQLAdapter(PG_TEST_URL.replace(/\/[^/]+$/, "/postgres"));
+      const rootAdapter = new PostgreSQLAdapter(postgresUrl());
       try {
         await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
         await rootAdapter.createDatabase(tmpDb);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -229,8 +229,26 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("recreate database drops and creates", async () => {
-      const dbName = await adapter.currentDatabase();
-      expect(typeof dbName).toBe("string");
+      const tmpDb = "trails_test_recreate_tmp";
+      const rootAdapter = new PostgreSQLAdapter(PG_TEST_URL.replace(/\/[^/]+$/, "/postgres"));
+      try {
+        await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
+        await rootAdapter.createDatabase(tmpDb);
+        const existsBefore = await rootAdapter.schemaQuery(
+          `SELECT 1 AS ok FROM pg_database WHERE datname = $1`,
+          [tmpDb],
+        );
+        expect(existsBefore.length).toBe(1);
+        await rootAdapter.recreateDatabase(tmpDb);
+        const existsAfter = await rootAdapter.schemaQuery(
+          `SELECT 1 AS ok FROM pg_database WHERE datname = $1`,
+          [tmpDb],
+        );
+        expect(existsAfter.length).toBe(1);
+      } finally {
+        await rootAdapter.exec(`DROP DATABASE IF EXISTS ${tmpDb}`);
+        await rootAdapter.close();
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -256,7 +256,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(Number(rows[0].c)).toBe(0);
     });
 
-    it("drop database removes the database", async () => {
+    it("drop database removes the database", { timeout: 30000 }, async () => {
       const tmpDb = "trails_test_drop_db_tmp";
       const rootAdapter = new PostgreSQLAdapter(postgresUrl());
       try {
@@ -279,7 +279,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it("recreate database drops and creates", async () => {
+    it("recreate database drops and creates", { timeout: 30000 }, async () => {
       const tmpDb = "trails_test_recreate_tmp";
       const rootAdapter = new PostgreSQLAdapter(postgresUrl());
       try {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -4,10 +4,20 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
  */
 
+export interface CreateDatabaseOptions {
+  encoding?: string;
+  collation?: string;
+  ctype?: string;
+  owner?: string;
+  template?: string;
+  tablespace?: string;
+  connectionLimit?: number;
+}
+
 export interface SchemaStatements {
-  createDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
+  createDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
   dropDatabase(name: string): Promise<void>;
-  recreateDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
+  recreateDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
   createSchema(name: string, options?: { force?: boolean; ifNotExists?: boolean }): Promise<void>;
   dropSchema(name: string, options?: { ifExists?: boolean; cascade?: boolean }): Promise<void>;
   schemaExists(name: string): Promise<boolean>;
@@ -40,7 +50,7 @@ export interface SchemaStatements {
   columns(tableName: string): Promise<unknown[]>;
   columnDefinitions(tableName: string): Promise<unknown[]>;
   foreignKeys(tableName: string): Promise<unknown[]>;
-  defaultSequenceName(tableName: string, pk?: string): Promise<string | null>;
+  defaultSequenceName(tableName: string, pk?: string | string[]): Promise<string | null>;
   serialSequence(tableName: string, column: string): Promise<string | null>;
   setPkSequenceBang(tableName: string, value: number): Promise<void>;
   resetPkSequenceBang(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -7,12 +7,26 @@
 export interface SchemaStatements {
   createDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
   dropDatabase(name: string): Promise<void>;
-  createSchema(name: string): Promise<void>;
+  recreateDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
+  createSchema(name: string, options?: { force?: boolean; ifNotExists?: boolean }): Promise<void>;
   dropSchema(name: string, options?: { ifExists?: boolean; cascade?: boolean }): Promise<void>;
   schemaExists(name: string): Promise<boolean>;
   schemaNames(): Promise<string[]>;
   currentSchema(): Promise<string>;
-  indexes(tableName: string): Promise<unknown[]>;
+  schemaSearchPath(): Promise<string>;
+  setSchemaSearchPath(searchPath: string | null): Promise<void>;
+  currentDatabase(): Promise<string>;
+  encoding(): Promise<string>;
+  collation(): Promise<string>;
+  ctype(): Promise<string>;
+  clientMinMessages(): Promise<string>;
+  setClientMinMessages(level: string): Promise<void>;
+  indexes(tableName: string): Promise<{ name: string }[]>;
+  isIndexNameExists(tableName: string, indexName: string): Promise<boolean>;
+  tableOptions(tableName: string): Promise<Record<string, unknown>>;
+  tableComment(tableName: string): Promise<string | null>;
+  tablePartitionDefinition(tableName: string): Promise<string | null>;
+  inheritedTableNames(tableName: string): Promise<string[]>;
   createEnum(name: string, values: string[]): Promise<void>;
   dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
   renameEnum(name: string, newName: string): Promise<void>;
@@ -26,6 +40,21 @@ export interface SchemaStatements {
   columns(tableName: string): Promise<unknown[]>;
   columnDefinitions(tableName: string): Promise<unknown[]>;
   foreignKeys(tableName: string): Promise<unknown[]>;
+  defaultSequenceName(tableName: string, pk?: string): Promise<string | null>;
+  serialSequence(tableName: string, column: string): Promise<string | null>;
+  setPkSequenceBang(tableName: string, value: number): Promise<void>;
+  resetPkSequenceBang(
+    tableName: string,
+    pk?: string | null,
+    sequence?: string | null,
+  ): Promise<void>;
+  pkAndSequenceFor(tableName: string): Promise<[string, { schema: string; name: string }] | null>;
+  primaryKeys(tableName: string): Promise<string[]>;
+  dropTable(
+    ...args:
+      | [...tableNames: string[], options: { ifExists?: boolean; force?: "cascade" }]
+      | string[]
+  ): Promise<void>;
   validateConstraint(tableName: string, constraintName: string): Promise<void>;
   validateCheckConstraint(tableName: string, name: string): Promise<void>;
   validateForeignKey(tableName: string, name: string): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -4,6 +4,15 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
  */
 
+export interface PgIndexDefinition {
+  table: string;
+  name: string;
+  unique: boolean;
+  columns: string[];
+  using: string;
+  orders?: Record<string, string> | string;
+}
+
 export interface CreateDatabaseOptions {
   encoding?: string;
   collation?: string;
@@ -31,7 +40,7 @@ export interface SchemaStatements {
   ctype(): Promise<string>;
   clientMinMessages(): Promise<string>;
   setClientMinMessages(level: string): Promise<void>;
-  indexes(tableName: string): Promise<{ name: string }[]>;
+  indexes(tableName: string): Promise<PgIndexDefinition[]>;
   indexNameExists(tableName: string, indexName: string): Promise<boolean>;
   tableOptions(tableName: string): Promise<Record<string, unknown>>;
   tableComment(tableName: string): Promise<string | null>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -32,7 +32,7 @@ export interface SchemaStatements {
   clientMinMessages(): Promise<string>;
   setClientMinMessages(level: string): Promise<void>;
   indexes(tableName: string): Promise<{ name: string }[]>;
-  isIndexNameExists(tableName: string, indexName: string): Promise<boolean>;
+  indexNameExists(tableName: string, indexName: string): Promise<boolean>;
   tableOptions(tableName: string): Promise<Record<string, unknown>>;
   tableComment(tableName: string): Promise<string | null>;
   tablePartitionDefinition(tableName: string): Promise<string | null>;


### PR DESCRIPTION
## Summary

- Adds 19 new methods to `postgresql/schema-statements.ts` interface (database/schema management, table introspection, sequence management)
- Implements all 19 methods on `PostgreSQLAdapter`: `recreateDatabase`, `dropTable` (variadic + cascade), `isIndexNameExists`, `currentDatabase`, `encoding`, `collation`, `ctype`, `schemaSearchPath`, `setSchemaSearchPath`, `clientMinMessages`, `setClientMinMessages`, `tableComment`, `tablePartitionDefinition`, `inheritedTableNames`, `tableOptions`, `serialSequence`, `defaultSequenceName`, `setPkSequenceBang`, `resetPkSequenceBang`, `primaryKeys`
- Moves `dropDatabase` from stub to real implementation
- Adds `dropTable` with variadic multi-table + `force: :cascade` support (mirrors Rails `drop_table(*table_names, **options)`)
- Advances `connection-adapters/postgresql/schema-statements.ts` from 21% → 50% api:compare coverage (14→33 of 66 Rails methods)
- 27 real DB integration tests in `schema-statements.test.ts`

## Test plan

- [x] 27 integration tests pass against real PostgreSQL
- [x] TypeScript build clean
- [x] api:compare: `postgresql/schema-statements.ts` 50% (33/66)
- [x] `postgresql/schema-definitions.ts` still 100%