### PR TITLE
docs: promote conventions to CLAUDE.md and update api:compare numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,12 @@ idiom table.
   sparse checkout lives at `scripts/api-compare/.rails-source/` in the main
   repo — no need to clone or go hunting. Populate it with
   `bash scripts/api-compare/fetch-rails.sh` if missing.
+  **Before accepting any Copilot review suggestion on a Rails-port PR**, verify
+  it against the Rails source — Copilot frequently suggests "safer" behavior
+  that silently deviates from Rails semantics (e.g. adding fallbacks Rails
+  doesn't have, using equality that differs from Rails' `Object#==` identity,
+  extra index-keyed lookups Rails doesn't do). Reject suggestions that diverge;
+  only accept perf improvements with no semantic change or genuine bugs.
 - **Read existing code before writing new code.** Trace how the codebase
   already handles the concern. Use the real persistence API (`isNewRecord()`,
   `isPersisted()`, `readAttribute()`, `writeAttribute()`) — not ad-hoc state.
@@ -78,6 +84,14 @@ When NOT to use this:
   Code" lines to PR descriptions.
 - Tests live next to source files as `*.test.ts`.
 - Prefer small, focused modules.
+- **PRs: max 20 methods each** unless they are very simple one-liners/getters,
+  which can be grouped more liberally.
+- **camelCase everywhere** — no snake_case identifiers, property names, or
+  payload keys, even when the Rails equivalent uses snake_case. Never add
+  `payload.lock_wait ?? payload.lockWait`-style fallbacks.
+- **Never pipe long test runs to grep.** The full AR test suite takes ~8
+  minutes. Redirect to a temp file (`>/tmp/x.log 2>&1`), then grep the file
+  as many times as needed without re-running.
 - Do NOT use subagents unless explicitly requested.
 - Do use worktrees for any changes; leave the default worktree for the user.
   Always create them with the `EnterWorktree` skill so they land under

--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ Ruby-to-TypeScript translation table.
 
 | Package                      | Rails Equivalent                                                        | API       | Tests     | Description                                                |
 | ---------------------------- | ----------------------------------------------------------------------- | --------- | --------- | ---------------------------------------------------------- |
-| `@blazetrails/activerecord`  | [ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord.html)   | **87%**   | **65.3%** | ORM — persistence, querying, associations, migrations      |
+| `@blazetrails/activerecord`  | [ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord.html)   | **91.5%** | **65.3%** | ORM — persistence, querying, associations, migrations      |
 | `@blazetrails/activesupport` | [ActiveSupport](https://api.rubyonrails.org/classes/ActiveSupport.html) | **24.8%** | **29.3%** | Core utilities, inflection, caching, notifications         |
 | `@blazetrails/arel`          | [Arel](https://api.rubyonrails.org/classes/Arel.html)                   | **100%**  | **91.2%** | SQL AST builder and query generation                       |
 | `@blazetrails/activemodel`   | [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel.html)     | **99.7%** | **93.4%** | Attributes, validations, callbacks, dirty tracking, i18n   |
 | `@blazetrails/rack`          | [Rack](https://rack.github.io/)                                         | —         | **98.7%** | Modular web server interface, request/response, middleware |
 
-**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **90.7% API** | **70.6% Tests**
+**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **93.1% API** | **70.6% Tests**
 
 Per-package deviation guides catalog the places where Trails diverges
 from Rails on purpose (and why): [ActiveRecord](packages/website/docs/guides/activerecord-rails-deviations.md)
@@ -203,7 +203,7 @@ from Rails on purpose (and why): [ActiveRecord](packages/website/docs/guides/act
 
 **Tests** = `test:compare` — matches our test names against the Rails test suite. **API** = `api:compare` — matches individual public methods against Rails source (method-level, not class/module wrappers). Rack doesn't have API comparison yet (it's not a Rails gem).
 
-**51.2%** overall API coverage (3,794 / 7,415 methods). CI runs both comparisons on every push.
+**52.3%** overall API coverage (3,877 / 7,415 methods). CI runs both comparisons on every push.
 
 ## Design Principles
 

--- a/docs/activerecord-100-percent.md
+++ b/docs/activerecord-100-percent.md
@@ -1,6 +1,6 @@
 # ActiveRecord: Road to 100%
 
-Current: **87% API** (2,453 / 2,819 methods). **78% inheritance** (163 / 209).
+Current: **91.5% API** (2,578 / 2,819 methods). **97.1% inheritance** (204 / 210).
 
 ```bash
 pnpm run api:compare -- --package activerecord

--- a/docs/launch-roadmap.md
+++ b/docs/launch-roadmap.md
@@ -20,7 +20,7 @@ Live counts via `pnpm test:compare` (real matches only — stubs don't count).
 | trailties        | —            | —     | —        | Early            |
 
 API-surface coverage is a separate metric (`pnpm api:compare`) — arel +
-rack are at 100%, activerecord is at 87%, activemodel at 99.7%,
+rack are at 100%, activerecord is at 91.5%, activemodel at 99.7%,
 activesupport at 24.8%, actioncontroller at 66.4%, actiondispatch at
 6.1%, actionview at 3.6%.
 


### PR DESCRIPTION
## Summary

- Promotes four conventions from session memory into `CLAUDE.md` so they apply to any agent or contributor, not just the current session:
  - PR size limit: max 20 methods per PR unless they are very simple
  - camelCase everywhere — no snake_case identifiers or payload keys, no dual-key fallbacks
  - Never pipe long test runs to grep — redirect to a file and grep that
  - Before accepting Copilot suggestions on Rails-port PRs, verify against the Rails source
- Updates README API coverage numbers from latest `api:compare` run: activerecord 87% → 91.5%, data layer 90.7% → 93.1%, overall 51.2% → 52.3% (3,877/7,415 methods)

## Test plan

- [ ] Verify `CLAUDE.md` reads naturally alongside existing conventions
- [ ] Verify README numbers match current `pnpm run api:compare` output