### PR TITLE
feat(activerecord): pg schema-statements — constraints, index helpers, schema creation (PR G)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -646,7 +646,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const constraints = await adapter.checkConstraints("check_test");
       expect(constraints).toHaveLength(1);
       expect(constraints[0].name).toBe("chk_age");
-      expect(constraints[0].expression).toContain("age > 0");
+      expect(constraints[0].expression).toBe("age > 0");
       expect(constraints[0].validate).toBe(true);
     });
 
@@ -744,10 +744,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("addExclusionConstraint / removeExclusionConstraint", () => {
     beforeEach(async () => {
-      await adapter.exec(`CREATE EXTENSION IF NOT EXISTS btree_gist`);
-      await adapter.exec(
-        `CREATE TABLE "excl_test" ("id" SERIAL PRIMARY KEY, "room" TEXT, "during" int4range)`,
-      );
+      await adapter.exec(`CREATE TABLE "excl_test" ("id" SERIAL PRIMARY KEY, "during" tsrange)`);
     });
 
     afterEach(async () => {
@@ -755,18 +752,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("adds and introspects an exclusion constraint", async () => {
-      await adapter.addExclusionConstraint("excl_test", `"room" WITH =, "during" WITH &&`, {
-        name: "excl_room_during",
+      await adapter.addExclusionConstraint("excl_test", `"during" WITH &&`, {
+        name: "excl_during",
         using: "gist",
       });
       const rows = await adapter.execute(
-        `SELECT conname FROM pg_constraint WHERE conname = 'excl_room_during' AND contype = 'x'`,
+        `SELECT conname FROM pg_constraint WHERE conname = 'excl_during' AND contype = 'x'`,
       );
       expect(rows as any[]).toHaveLength(1);
     });
 
-    it("removes an exclusion constraint by name", async () => {
-      await adapter.addExclusionConstraint("excl_test", `"room" WITH =, "during" WITH &&`, {
+    it("removes an exclusion constraint by name via options object", async () => {
+      await adapter.addExclusionConstraint("excl_test", `"during" WITH &&`, {
         name: "excl_to_remove",
         using: "gist",
       });
@@ -775,6 +772,26 @@ describeIfPg("PostgreSQLAdapter", () => {
         `SELECT conname FROM pg_constraint WHERE conname = 'excl_to_remove'`,
       );
       expect(rows as any[]).toHaveLength(0);
+    });
+
+    it("removes an exclusion constraint by expression string", async () => {
+      await adapter.addExclusionConstraint("excl_test", `"during" WITH &&`, {
+        name: "excl_by_expr",
+        using: "gist",
+      });
+      await adapter.removeExclusionConstraint("excl_test", `"during" WITH &&`, {
+        name: "excl_by_expr",
+      });
+      const rows = await adapter.execute(
+        `SELECT conname FROM pg_constraint WHERE conname = 'excl_by_expr'`,
+      );
+      expect(rows as any[]).toHaveLength(0);
+    });
+
+    it("throws when neither expression nor name provided", async () => {
+      await expect(adapter.removeExclusionConstraint("excl_test")).rejects.toThrow(
+        /expression.*name/,
+      );
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -631,6 +631,199 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   // ── Rails-matching test stubs ──
+
+  describe("checkConstraints", () => {
+    beforeEach(async () => {
+      await adapter.exec(`CREATE TABLE "check_test" ("id" SERIAL PRIMARY KEY, "age" INTEGER)`);
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "check_test" CASCADE`);
+    });
+
+    it("returns check constraints with expression and valid flag", async () => {
+      await adapter.exec(`ALTER TABLE "check_test" ADD CONSTRAINT "chk_age" CHECK (age > 0)`);
+      const constraints = await adapter.checkConstraints("check_test");
+      expect(constraints).toHaveLength(1);
+      expect(constraints[0].name).toBe("chk_age");
+      expect(constraints[0].expression).toContain("age > 0");
+      expect(constraints[0].validate).toBe(true);
+    });
+
+    it("returns valid: false for NOT VALID check constraints", async () => {
+      await adapter.exec(
+        `ALTER TABLE "check_test" ADD CONSTRAINT "chk_age_nv" CHECK (age > 0) NOT VALID`,
+      );
+      const constraints = await adapter.checkConstraints("check_test");
+      expect(constraints).toHaveLength(1);
+      expect(constraints[0].name).toBe("chk_age_nv");
+      expect(constraints[0].validate).toBe(false);
+    });
+
+    it("returns empty array when no check constraints exist", async () => {
+      const constraints = await adapter.checkConstraints("check_test");
+      expect(constraints).toHaveLength(0);
+    });
+  });
+
+  describe("addForeignKey options", () => {
+    beforeEach(async () => {
+      await adapter.exec(`CREATE TABLE "fk_parents" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(
+        `CREATE TABLE "fk_children" ("id" SERIAL PRIMARY KEY, "parent_id" INTEGER)`,
+      );
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "fk_children" CASCADE`);
+      await adapter.exec(`DROP TABLE IF EXISTS "fk_parents" CASCADE`);
+    });
+
+    it("adds FK with ON DELETE CASCADE", async () => {
+      await adapter.addForeignKey("fk_children", "fk_parents", {
+        column: "parent_id",
+        name: "fk_cascade",
+        onDelete: "cascade",
+      });
+      const rows = await adapter.execute(
+        `SELECT confdeltype FROM pg_constraint WHERE conname = 'fk_cascade'`,
+      );
+      // 'a'=no action 'r'=restrict 'c'=cascade 'n'=set null 'd'=set default
+      expect((rows as any[])[0].confdeltype).toBe("c");
+    });
+
+    it("adds FK with ON UPDATE RESTRICT", async () => {
+      await adapter.addForeignKey("fk_children", "fk_parents", {
+        column: "parent_id",
+        name: "fk_restrict",
+        onUpdate: "restrict",
+      });
+      const rows = await adapter.execute(
+        `SELECT confupdtype FROM pg_constraint WHERE conname = 'fk_restrict'`,
+      );
+      expect((rows as any[])[0].confupdtype).toBe("r");
+    });
+
+    it("adds FK with ON DELETE SET NULL (nullify)", async () => {
+      await adapter.addForeignKey("fk_children", "fk_parents", {
+        column: "parent_id",
+        name: "fk_nullify",
+        onDelete: "nullify",
+      });
+      const rows = await adapter.execute(
+        `SELECT confdeltype FROM pg_constraint WHERE conname = 'fk_nullify'`,
+      );
+      expect((rows as any[])[0].confdeltype).toBe("n");
+    });
+
+    it("adds FK with DEFERRABLE INITIALLY DEFERRED", async () => {
+      await adapter.addForeignKey("fk_children", "fk_parents", {
+        column: "parent_id",
+        name: "fk_deferred",
+        deferrable: "deferred",
+      });
+      const row = await adapter.execute(
+        `SELECT condeferrable, condeferred FROM pg_constraint WHERE conname = 'fk_deferred'`,
+      );
+      expect((row as any[])[0].condeferrable).toBe(true);
+      expect((row as any[])[0].condeferred).toBe(true);
+    });
+
+    it("adds FK with validate: false (NOT VALID)", async () => {
+      await adapter.addForeignKey("fk_children", "fk_parents", {
+        column: "parent_id",
+        name: "fk_not_valid",
+        validate: false,
+      });
+      const row = await adapter.execute(
+        `SELECT convalidated FROM pg_constraint WHERE conname = 'fk_not_valid'`,
+      );
+      expect((row as any[])[0].convalidated).toBe(false);
+    });
+  });
+
+  describe("addExclusionConstraint / removeExclusionConstraint", () => {
+    beforeEach(async () => {
+      await adapter.exec(`CREATE EXTENSION IF NOT EXISTS btree_gist`);
+      await adapter.exec(
+        `CREATE TABLE "excl_test" ("id" SERIAL PRIMARY KEY, "room" TEXT, "during" int4range)`,
+      );
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "excl_test" CASCADE`);
+    });
+
+    it("adds and introspects an exclusion constraint", async () => {
+      await adapter.addExclusionConstraint("excl_test", `"room" WITH =, "during" WITH &&`, {
+        name: "excl_room_during",
+        using: "gist",
+      });
+      const rows = await adapter.execute(
+        `SELECT conname FROM pg_constraint WHERE conname = 'excl_room_during' AND contype = 'x'`,
+      );
+      expect(rows as any[]).toHaveLength(1);
+    });
+
+    it("removes an exclusion constraint by name", async () => {
+      await adapter.addExclusionConstraint("excl_test", `"room" WITH =, "during" WITH &&`, {
+        name: "excl_to_remove",
+        using: "gist",
+      });
+      await adapter.removeExclusionConstraint("excl_test", { name: "excl_to_remove" });
+      const rows = await adapter.execute(
+        `SELECT conname FROM pg_constraint WHERE conname = 'excl_to_remove'`,
+      );
+      expect(rows as any[]).toHaveLength(0);
+    });
+  });
+
+  describe("addUniqueConstraint / removeUniqueConstraint", () => {
+    beforeEach(async () => {
+      await adapter.exec(
+        `CREATE TABLE "uniq_test" ("id" SERIAL PRIMARY KEY, "email" TEXT, "username" TEXT)`,
+      );
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "uniq_test" CASCADE`);
+    });
+
+    it("adds a unique constraint on a single column", async () => {
+      await adapter.addUniqueConstraint("uniq_test", "email", { name: "uniq_email" });
+      const rows = await adapter.execute(
+        `SELECT conname FROM pg_constraint WHERE conname = 'uniq_email' AND contype = 'u'`,
+      );
+      expect(rows as any[]).toHaveLength(1);
+    });
+
+    it("adds a DEFERRABLE unique constraint", async () => {
+      await adapter.addUniqueConstraint("uniq_test", "username", {
+        name: "uniq_username_deferred",
+        deferrable: "deferred",
+      });
+      const row = await adapter.execute(
+        `SELECT condeferrable, condeferred FROM pg_constraint WHERE conname = 'uniq_username_deferred'`,
+      );
+      expect((row as any[])[0].condeferrable).toBe(true);
+      expect((row as any[])[0].condeferred).toBe(true);
+    });
+
+    it("removes a unique constraint by name", async () => {
+      await adapter.addUniqueConstraint("uniq_test", "email", { name: "uniq_to_remove" });
+      await adapter.removeUniqueConstraint("uniq_test", { name: "uniq_to_remove" });
+      const rows = await adapter.execute(
+        `SELECT conname FROM pg_constraint WHERE conname = 'uniq_to_remove'`,
+      );
+      expect(rows as any[]).toHaveLength(0);
+    });
+
+    it("throws if neither columnName nor usingIndex provided to addUniqueConstraint", async () => {
+      await expect(adapter.addUniqueConstraint("uniq_test", null)).rejects.toThrow(
+        /columnName.*usingIndex/,
+      );
+    });
+  });
 });
 
 describe("PostgreSQLAdapter supports_* predicates (unit)", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,6 @@
 import pg from "pg";
 import { type Type, ValueType } from "@blazetrails/activemodel";
-import { singularize, underscore, Notifications } from "@blazetrails/activesupport";
+import { singularize, underscore, Notifications, getCrypto } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
@@ -51,7 +51,6 @@ import {
 import { CheckConstraintDefinition } from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
-import { createHash } from "node:crypto";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -3321,7 +3320,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
        JOIN pg_class t ON c.conrelid = t.oid
        JOIN pg_namespace n ON n.oid = c.connamespace
        WHERE c.contype = 'c'
-         AND t.relname = ${scope.name ?? "NULL"}
+         AND t.relname = ${scope.name!}
          AND n.nspname = ${scope.schema}`,
     );
     return rows.map((row) => {
@@ -3429,17 +3428,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   addIndexOptions(
-    tableName: string,
-    columnName: string | string[],
+    _tableName: string,
+    _columnName: string | string[],
     options: Record<string, unknown> = {},
-  ): unknown {
-    const opts = { ...options };
-    const where = opts.where as string | undefined;
-    if (where) {
-      // Delegate to abstract; where-is-column-name quoting requires tableExists + columnExists
-      // which are async. For synchronous callers, pass where as-is.
-    }
-    return opts;
+  ): Record<string, unknown> {
+    return { ...options };
   }
 
   schemaCreation(): PgSchemaCreation {
@@ -3460,7 +3453,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     _options: Record<string, unknown>,
   ): string {
     const identifier = `${tableName}_${expression}_excl`;
-    const hashed = createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+    const hashed = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
     return `excl_rails_${hashed}`;
   }
 
@@ -3488,7 +3481,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           ? [options.usingIndex as string]
           : [];
     const identifier = `${tableName}_${cols.join("_and_")}_unique`;
-    const hashed = createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+    const hashed = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
     return `uniq_rails_${hashed}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3460,9 +3460,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   indexName(tableName: string, options: { column?: string | string[] }): string {
-    const { table } = this.parseSchemaQualifiedName(tableName);
+    const normalizedTableName = tableName.replace(/[."]/g, "_");
     const cols = Array.isArray(options.column) ? options.column : [options.column ?? ""];
-    return `index_${table}_on_${cols.join("_and_")}`;
+    return `index_${normalizedTableName}_on_${cols.join("_and_")}`;
   }
 
   addIndexOptions(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2791,7 +2791,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       name?: string;
       onDelete?: ReferentialAction;
       onUpdate?: ReferentialAction;
-      deferrable?: boolean | "immediate" | "deferred";
+      deferrable?: "immediate" | "deferred";
       validate?: boolean;
     } = {},
   ): Promise<void> {
@@ -2811,8 +2811,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     let sql = `ALTER TABLE ${qualifiedFrom} ADD CONSTRAINT ${qi(name)} FOREIGN KEY (${qi(column)}) REFERENCES ${qualifiedTo} (${qi(pk)})`;
     if (options.onDelete) sql += ` ${sc.actionSql("DELETE", options.onDelete)}`;
     if (options.onUpdate) sql += ` ${sc.actionSql("UPDATE", options.onUpdate)}`;
-    if (options.validate === false) sql += " NOT VALID";
     sql += this.deferrable(options.deferrable);
+    if (options.validate === false) sql += " NOT VALID";
 
     await this.exec(sql);
   }
@@ -3360,7 +3360,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const name = this.quoteIdentifier(opts.name as string);
     const using = opts.using ? ` USING ${opts.using}` : "";
     const where = opts.where ? ` WHERE (${opts.where})` : "";
-    const deferParts = this.deferrable(opts.deferrable as ExclusionConstraintOptions["deferrable"]);
+    const deferParts = this.deferrable(opts.deferrable as "immediate" | "deferred" | undefined);
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(tableName)} ADD CONSTRAINT ${name} EXCLUDE${using} (${expression})${where}${deferParts}`,
     );
@@ -3379,6 +3379,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       typeof expressionOrOptions === "object" && expressionOrOptions !== null
         ? expressionOrOptions
         : options;
+    if (!expression && !opts.name) {
+      throw new Error(
+        "Either expression or `name` option must be provided for removeExclusionConstraint.",
+      );
+    }
     const excl = this.exclusionConstraintForBang(tableName, expression ?? null, opts);
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(excl.name!)}`,
@@ -3392,7 +3397,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Record<string, unknown> {
     this.assertValidDeferrable(options.deferrable);
     if (columnName && options.usingIndex) {
-      throw new Error("Cannot specify both column_name and :usingIndex options.");
+      throw new Error("Cannot specify both `columnName` and `usingIndex` options.");
     }
     const opts = { ...options };
     if (!opts.name) {
@@ -3411,7 +3416,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const name = this.quoteIdentifier(opts.name as string);
-    const deferParts = this.deferrable(opts.deferrable as UniqueConstraintOptions["deferrable"]);
+    const deferParts = this.deferrable(opts.deferrable as "immediate" | "deferred" | undefined);
     let constraintSql: string;
     if (opts.usingIndex) {
       constraintSql = `UNIQUE USING INDEX ${this.quoteIdentifier(opts.usingIndex as string)}`;
@@ -3443,6 +3448,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       !Array.isArray(columnNameOrOptions)
         ? columnNameOrOptions
         : options;
+    if (!columnName && !opts.name && !opts.usingIndex) {
+      throw new Error(
+        "Either `columnName`, `name`, or `usingIndex` option must be provided for removeUniqueConstraint.",
+      );
+    }
     const uniq = this.uniqueConstraintForBang(tableName, columnName, opts);
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(uniq.name!)}`,
@@ -3524,9 +3534,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return new UniqueConstraintDefinition(tableName, columnName ?? [], { ...options, name });
   }
 
-  private deferrable(deferrable: boolean | "immediate" | "deferred" | undefined): string {
+  private deferrable(deferrable: "immediate" | "deferred" | undefined): string {
     if (!deferrable) return "";
-    if (deferrable === true) return " DEFERRABLE";
     return ` DEFERRABLE INITIALLY ${deferrable.toUpperCase()}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -40,6 +40,18 @@ import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import { transactionIsolationLevels, typeCastedBinds } from "./abstract/database-statements.js";
 import { READ_QUERY } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
+import {
+  ExclusionConstraintDefinition,
+  UniqueConstraintDefinition,
+  Table as PgTable,
+  type ExclusionConstraintOptions,
+  type UniqueConstraintOptions,
+  type SchemaStatementsConstraintLike,
+} from "./postgresql/schema-definitions.js";
+import { CheckConstraintDefinition } from "./abstract/schema-definitions.js";
+import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
+import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
+import { createHash } from "node:crypto";
 
 /**
  * PostgreSQL adapter — connects ActiveRecord to a real PostgreSQL database.
@@ -2771,8 +2783,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async addForeignKey(
     fromTable: string,
     toTable: string,
-    options: { column?: string; primaryKey?: string; name?: string } = {},
+    options: {
+      column?: string;
+      primaryKey?: string;
+      name?: string;
+      onDelete?: string;
+      onUpdate?: string;
+      deferrable?: boolean | "immediate" | "deferred";
+      validate?: boolean;
+    } = {},
   ): Promise<void> {
+    this.assertValidDeferrable(options.deferrable);
     const { schema: fromSchema, table: fromTbl } = this.parseSchemaQualifiedName(fromTable);
     const { schema: toSchema, table: toTbl } = this.parseSchemaQualifiedName(toTable);
 
@@ -2784,9 +2805,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qualifiedFrom = fromSchema ? `${qi(fromSchema)}.${qi(fromTbl)}` : qi(fromTbl);
     const qualifiedTo = toSchema ? `${qi(toSchema)}.${qi(toTbl)}` : qi(toTbl);
 
-    await this.exec(
-      `ALTER TABLE ${qualifiedFrom} ADD CONSTRAINT ${qi(name)} FOREIGN KEY (${qi(column)}) REFERENCES ${qualifiedTo} (${qi(pk)})`,
-    );
+    let sql = `ALTER TABLE ${qualifiedFrom} ADD CONSTRAINT ${qi(name)} FOREIGN KEY (${qi(column)}) REFERENCES ${qualifiedTo} (${qi(pk)})`;
+    if (options.onDelete) sql += ` ON DELETE ${options.onDelete.toUpperCase().replace(/_/g, " ")}`;
+    if (options.onUpdate) sql += ` ON UPDATE ${options.onUpdate.toUpperCase().replace(/_/g, " ")}`;
+    if (options.validate === false) sql += " NOT VALID";
+    sql += this.deferrable(options.deferrable);
+
+    await this.exec(sql);
   }
 
   async foreignKeyExists(fromTable: string, toTable: string): Promise<boolean> {
@@ -3286,6 +3311,202 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
        ORDER BY i.idx`,
     );
     return rows.map((r) => r.name as string);
+  }
+
+  async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
+    const scope = this.quotedScope(tableName);
+    const rows = await this.schemaQuery(
+      `SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
+       FROM pg_constraint c
+       JOIN pg_class t ON c.conrelid = t.oid
+       JOIN pg_namespace n ON n.oid = c.connamespace
+       WHERE c.contype = 'c'
+         AND t.relname = ${scope.name ?? "NULL"}
+         AND n.nspname = ${scope.schema}`,
+    );
+    return rows.map((row) => {
+      const expression = (row.constraintdef as string).match(/CHECK \((.+)\)/s)?.[1] ?? "";
+      return new CheckConstraintDefinition(
+        tableName,
+        expression,
+        row.conname as string,
+        row.valid as boolean,
+      );
+    });
+  }
+
+  exclusionConstraintOptions(
+    tableName: string,
+    expression: string,
+    options: Record<string, unknown>,
+  ): Record<string, unknown> {
+    this.assertValidDeferrable(options.deferrable);
+    const opts = { ...options };
+    if (!opts.name) {
+      opts.name = this.exclusionConstraintName(tableName, expression, opts);
+    }
+    return opts;
+  }
+
+  async addExclusionConstraint(
+    tableName: string,
+    expression: string,
+    options: ExclusionConstraintOptions = {},
+  ): Promise<void> {
+    const opts = this.exclusionConstraintOptions(tableName, expression, options);
+    const name = this.quoteIdentifier(opts.name as string);
+    const using = opts.using ? ` USING ${opts.using}` : "";
+    const where = opts.where ? ` WHERE (${opts.where})` : "";
+    const deferParts = this.deferrable(opts.deferrable as ExclusionConstraintOptions["deferrable"]);
+    await this.exec(
+      `ALTER TABLE ${this.quoteTableName(tableName)} ADD CONSTRAINT ${name} EXCLUDE${using} (${expression})${where}${deferParts}`,
+    );
+  }
+
+  async removeExclusionConstraint(
+    tableName: string,
+    expression?: string | null,
+    options: Record<string, unknown> = {},
+  ): Promise<void> {
+    const excl = this.exclusionConstraintForBang(tableName, expression ?? null, options);
+    await this.exec(
+      `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(excl.name!)}`,
+    );
+  }
+
+  uniqueConstraintOptions(
+    tableName: string,
+    columnName: string | string[] | null | undefined,
+    options: Record<string, unknown>,
+  ): Record<string, unknown> {
+    this.assertValidDeferrable(options.deferrable);
+    if (columnName && options.usingIndex) {
+      throw new Error("Cannot specify both column_name and :usingIndex options.");
+    }
+    const opts = { ...options };
+    if (!opts.name) {
+      opts.name = this.uniqueConstraintName(tableName, columnName, opts);
+    }
+    return opts;
+  }
+
+  async addUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options: UniqueConstraintOptions = {},
+  ): Promise<void> {
+    const opts = this.uniqueConstraintOptions(tableName, columnName, options);
+    const name = this.quoteIdentifier(opts.name as string);
+    const deferParts = this.deferrable(opts.deferrable as UniqueConstraintOptions["deferrable"]);
+    let constraintSql: string;
+    if (opts.usingIndex) {
+      constraintSql = `UNIQUE USING INDEX ${this.quoteIdentifier(opts.usingIndex as string)}`;
+    } else {
+      const cols = Array.isArray(columnName) ? columnName : [columnName!];
+      const nullsNotDistinct = opts.nullsNotDistinct ? " NULLS NOT DISTINCT" : "";
+      constraintSql = `UNIQUE${nullsNotDistinct} (${cols.map((c) => this.quoteIdentifier(c)).join(", ")})`;
+    }
+    await this.exec(
+      `ALTER TABLE ${this.quoteTableName(tableName)} ADD CONSTRAINT ${name} ${constraintSql}${deferParts}`,
+    );
+  }
+
+  async removeUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options: Record<string, unknown> = {},
+  ): Promise<void> {
+    const uniq = this.uniqueConstraintForBang(tableName, columnName, options);
+    await this.exec(
+      `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(uniq.name!)}`,
+    );
+  }
+
+  indexName(tableName: string, options: { column?: string | string[] }): string {
+    const { table } = this.parseSchemaQualifiedName(tableName);
+    const cols = Array.isArray(options.column) ? options.column : [options.column ?? ""];
+    return `index_${table}_on_${cols.join("_and_")}`;
+  }
+
+  addIndexOptions(
+    tableName: string,
+    columnName: string | string[],
+    options: Record<string, unknown> = {},
+  ): unknown {
+    const opts = { ...options };
+    const where = opts.where as string | undefined;
+    if (where) {
+      // Delegate to abstract; where-is-column-name quoting requires tableExists + columnExists
+      // which are async. For synchronous callers, pass where as-is.
+    }
+    return opts;
+  }
+
+  schemaCreation(): PgSchemaCreation {
+    return new PgSchemaCreation();
+  }
+
+  updateTableDefinition(tableName: string, base: unknown): PgTable {
+    return new PgTable(tableName, base as SchemaStatementsConstraintLike);
+  }
+
+  createSchemaDumper(_options: unknown): PgSchemaDumper {
+    return new PgSchemaDumper(this);
+  }
+
+  private exclusionConstraintName(
+    tableName: string,
+    expression: string,
+    _options: Record<string, unknown>,
+  ): string {
+    const identifier = `${tableName}_${expression}_excl`;
+    const hashed = createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+    return `excl_rails_${hashed}`;
+  }
+
+  private exclusionConstraintForBang(
+    tableName: string,
+    expression: string | null,
+    options: Record<string, unknown>,
+  ): ExclusionConstraintDefinition {
+    const name =
+      (options.name as string | undefined) ??
+      this.exclusionConstraintName(tableName, expression ?? "", options);
+    return new ExclusionConstraintDefinition(tableName, expression ?? "", { ...options, name });
+  }
+
+  private uniqueConstraintName(
+    tableName: string,
+    columnName: string | string[] | null | undefined,
+    options: Record<string, unknown>,
+  ): string {
+    const cols = Array.isArray(columnName)
+      ? columnName
+      : columnName
+        ? [columnName as string]
+        : options.usingIndex
+          ? [options.usingIndex as string]
+          : [];
+    const identifier = `${tableName}_${cols.join("_and_")}_unique`;
+    const hashed = createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+    return `uniq_rails_${hashed}`;
+  }
+
+  private uniqueConstraintForBang(
+    tableName: string,
+    columnName: string | string[] | null | undefined,
+    options: Record<string, unknown>,
+  ): UniqueConstraintDefinition {
+    const name =
+      (options.name as string | undefined) ??
+      this.uniqueConstraintName(tableName, columnName, options);
+    return new UniqueConstraintDefinition(tableName, columnName ?? [], { ...options, name });
+  }
+
+  private deferrable(deferrable: boolean | "immediate" | "deferred" | undefined): string {
+    if (!deferrable) return "";
+    if (deferrable === true) return " DEFERRABLE";
+    return ` DEFERRABLE INITIALLY ${deferrable.toUpperCase()}`;
   }
 
   private pgQuotedScope(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -48,7 +48,10 @@ import {
   type UniqueConstraintOptions,
   type SchemaStatementsConstraintLike,
 } from "./postgresql/schema-definitions.js";
-import { CheckConstraintDefinition } from "./abstract/schema-definitions.js";
+import {
+  CheckConstraintDefinition,
+  type ReferentialAction,
+} from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
 
@@ -2786,8 +2789,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       column?: string;
       primaryKey?: string;
       name?: string;
-      onDelete?: string;
-      onUpdate?: string;
+      onDelete?: ReferentialAction;
+      onUpdate?: ReferentialAction;
       deferrable?: boolean | "immediate" | "deferred";
       validate?: boolean;
     } = {},
@@ -2803,10 +2806,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const qi = (s: string) => this.quoteIdentifier(s);
     const qualifiedFrom = fromSchema ? `${qi(fromSchema)}.${qi(fromTbl)}` : qi(fromTbl);
     const qualifiedTo = toSchema ? `${qi(toSchema)}.${qi(toTbl)}` : qi(toTbl);
+    const sc = this.schemaCreation();
 
     let sql = `ALTER TABLE ${qualifiedFrom} ADD CONSTRAINT ${qi(name)} FOREIGN KEY (${qi(column)}) REFERENCES ${qualifiedTo} (${qi(pk)})`;
-    if (options.onDelete) sql += ` ON DELETE ${options.onDelete.toUpperCase().replace(/_/g, " ")}`;
-    if (options.onUpdate) sql += ` ON UPDATE ${options.onUpdate.toUpperCase().replace(/_/g, " ")}`;
+    if (options.onDelete) sql += ` ${sc.actionSql("DELETE", options.onDelete)}`;
+    if (options.onUpdate) sql += ` ${sc.actionSql("UPDATE", options.onUpdate)}`;
     if (options.validate === false) sql += " NOT VALID";
     sql += this.deferrable(options.deferrable);
 
@@ -3364,10 +3368,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async removeExclusionConstraint(
     tableName: string,
-    expression?: string | null,
+    expressionOrOptions?: string | Record<string, unknown> | null,
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    const excl = this.exclusionConstraintForBang(tableName, expression ?? null, options);
+    const expression =
+      typeof expressionOrOptions === "string" || expressionOrOptions == null
+        ? expressionOrOptions
+        : null;
+    const opts =
+      typeof expressionOrOptions === "object" && expressionOrOptions !== null
+        ? expressionOrOptions
+        : options;
+    const excl = this.exclusionConstraintForBang(tableName, expression ?? null, opts);
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(excl.name!)}`,
     );
@@ -3394,6 +3406,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     columnName?: string | string[] | null,
     options: UniqueConstraintOptions = {},
   ): Promise<void> {
+    if (!columnName && !options.usingIndex) {
+      throw new Error("Either columnName or usingIndex must be provided for addUniqueConstraint.");
+    }
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const name = this.quoteIdentifier(opts.name as string);
     const deferParts = this.deferrable(opts.deferrable as UniqueConstraintOptions["deferrable"]);
@@ -3412,10 +3427,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async removeUniqueConstraint(
     tableName: string,
-    columnName?: string | string[] | null,
+    columnNameOrOptions?: string | string[] | Record<string, unknown> | null,
     options: Record<string, unknown> = {},
   ): Promise<void> {
-    const uniq = this.uniqueConstraintForBang(tableName, columnName, options);
+    const columnName =
+      columnNameOrOptions === null ||
+      typeof columnNameOrOptions === "string" ||
+      Array.isArray(columnNameOrOptions) ||
+      columnNameOrOptions === undefined
+        ? columnNameOrOptions
+        : undefined;
+    const opts =
+      typeof columnNameOrOptions === "object" &&
+      columnNameOrOptions !== null &&
+      !Array.isArray(columnNameOrOptions)
+        ? columnNameOrOptions
+        : options;
+    const uniq = this.uniqueConstraintForBang(tableName, columnName, opts);
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(uniq.name!)}`,
     );

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -4,6 +4,8 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
  */
 
+import type { CheckConstraintDefinition } from "../abstract/schema-definitions.js";
+
 export interface PgIndexDefinition {
   table: string;
   name: string;
@@ -160,7 +162,7 @@ export interface SchemaStatements {
       validate?: boolean;
     },
   ): Promise<void>;
-  checkConstraints(tableName: string): Promise<unknown[]>;
+  checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]>;
   addExclusionConstraint(
     tableName: string,
     expression: string,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -110,6 +110,101 @@ export interface SchemaStatements {
   ): Promise<void>;
   changeColumnComment(tableName: string, columnName: string, comment: string | null): Promise<void>;
   changeTableComment(tableName: string, comment: string | null): Promise<void>;
+  renameTable(tableName: string, newName: string): Promise<void>;
+  changeColumn(
+    tableName: string,
+    columnName: string,
+    type: string,
+    options?: {
+      using?: string;
+      castAs?: string;
+      default?: unknown;
+      null?: boolean;
+      array?: boolean;
+    },
+  ): Promise<void>;
+  addIndex(
+    tableName: string,
+    columnName: string | string[],
+    options?: {
+      name?: string;
+      unique?: boolean;
+      using?: string;
+      where?: string;
+      algorithm?: string;
+      order?: Record<string, string> | string;
+      opclass?: Record<string, string>;
+      ifNotExists?: boolean;
+      nullsNotDistinct?: boolean;
+      include?: string[];
+    },
+  ): Promise<void>;
+  buildCreateIndexDefinition(
+    tableName: string,
+    columnName: string | string[],
+    options?: Record<string, unknown>,
+  ): unknown;
+  removeIndex(
+    tableName: string,
+    columnNameOrOptions?: string | string[] | { name: string; algorithm?: string },
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  renameIndex(tableName: string, oldName: string, newName: string): Promise<void>;
+  indexName(tableName: string, options: { column?: string | string[] }): string;
+  addForeignKey(
+    fromTable: string,
+    toTable: string,
+    options?: {
+      column?: string;
+      primaryKey?: string;
+      name?: string;
+      onDelete?: string;
+      onUpdate?: string;
+      deferrable?: boolean | "immediate" | "deferred";
+      validate?: boolean;
+    },
+  ): Promise<void>;
+  checkConstraints(tableName: string): Promise<unknown[]>;
+  addExclusionConstraint(
+    tableName: string,
+    expression: string,
+    options?: {
+      name?: string;
+      using?: string;
+      where?: string;
+      deferrable?: boolean | "immediate" | "deferred";
+    },
+  ): Promise<void>;
+  exclusionConstraintOptions(
+    tableName: string,
+    expression: string,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+  removeExclusionConstraint(
+    tableName: string,
+    expression?: string | null,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  addUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options?: {
+      name?: string;
+      deferrable?: boolean | "immediate" | "deferred";
+      usingIndex?: string;
+      nullsNotDistinct?: boolean;
+    },
+  ): Promise<void>;
+  uniqueConstraintOptions(
+    tableName: string,
+    columnName: string | string[] | null | undefined,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+  removeUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
   typeToSql(
     type: string,
     options?: {
@@ -120,7 +215,15 @@ export interface SchemaStatements {
       enumType?: string;
     },
   ): string;
+  columnsForDistinct(columns: string, orders: string[]): string;
+  updateTableDefinition(tableName: string, base: unknown): unknown;
+  createSchemaDumper(options: unknown): unknown;
   foreignKeyColumnFor(tableName: string, columnName?: string): string;
+  addIndexOptions(
+    tableName: string,
+    columnName: string | string[],
+    options?: Record<string, unknown>,
+  ): unknown;
   sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string;
   assertValidDeferrable(deferrable: unknown): void;
   extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
@@ -138,4 +241,5 @@ export interface SchemaStatements {
   foreignTables(): Promise<string[]>;
   foreignTableExists(tableName: string): Promise<boolean>;
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string;
+  schemaCreation(): unknown;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -138,17 +138,13 @@ export interface SchemaStatements {
       nullsNotDistinct?: boolean;
       include?: string[];
     },
-  ): Promise<void>;
+  ): Promise<string>;
   buildCreateIndexDefinition(
     tableName: string,
     columnName: string | string[],
     options?: Record<string, unknown>,
   ): unknown;
-  removeIndex(
-    tableName: string,
-    columnNameOrOptions?: string | string[] | { name: string; algorithm?: string },
-    options?: Record<string, unknown>,
-  ): Promise<void>;
+  removeIndex(tableName: string, options: { name: string; algorithm?: string }): Promise<void>;
   renameIndex(tableName: string, oldName: string, newName: string): Promise<void>;
   indexName(tableName: string, options: { column?: string | string[] }): string;
   addForeignKey(
@@ -160,7 +156,7 @@ export interface SchemaStatements {
       name?: string;
       onDelete?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
       onUpdate?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
-      deferrable?: boolean | "immediate" | "deferred";
+      deferrable?: "immediate" | "deferred";
       validate?: boolean;
     },
   ): Promise<void>;
@@ -172,7 +168,7 @@ export interface SchemaStatements {
       name?: string;
       using?: string;
       where?: string;
-      deferrable?: boolean | "immediate" | "deferred";
+      deferrable?: "immediate" | "deferred";
     },
   ): Promise<void>;
   exclusionConstraintOptions(
@@ -190,7 +186,7 @@ export interface SchemaStatements {
     columnName?: string | string[] | null,
     options?: {
       name?: string;
-      deferrable?: boolean | "immediate" | "deferred";
+      deferrable?: "immediate" | "deferred";
       usingIndex?: string;
       nullsNotDistinct?: boolean;
     },

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -158,8 +158,8 @@ export interface SchemaStatements {
       column?: string;
       primaryKey?: string;
       name?: string;
-      onDelete?: string;
-      onUpdate?: string;
+      onDelete?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
+      onUpdate?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
       deferrable?: boolean | "immediate" | "deferred";
       validate?: boolean;
     },
@@ -182,7 +182,7 @@ export interface SchemaStatements {
   ): Record<string, unknown>;
   removeExclusionConstraint(
     tableName: string,
-    expression?: string | null,
+    expressionOrOptions?: string | Record<string, unknown> | null,
     options?: Record<string, unknown>,
   ): Promise<void>;
   addUniqueConstraint(
@@ -202,7 +202,7 @@ export interface SchemaStatements {
   ): Record<string, unknown>;
   removeUniqueConstraint(
     tableName: string,
-    columnName?: string | string[] | null,
+    columnNameOrOptions?: string | string[] | Record<string, unknown> | null,
     options?: Record<string, unknown>,
   ): Promise<void>;
   typeToSql(


### PR DESCRIPTION
## Summary

- Adds 20 missing methods to the `postgresql/schema-statements` interface to push coverage from 67% (44/66) to 97% (64/66)
- Implements `checkConstraints`, `addExclusionConstraint`, `removeExclusionConstraint`, `addUniqueConstraint`, `removeUniqueConstraint`, `exclusionConstraintOptions`, `uniqueConstraintOptions`, `indexName`, `addIndexOptions`, `schemaCreation`, `updateTableDefinition`, `createSchemaDumper` on the adapter
- Wire-ups for `renameTable`, `changeColumn`, `addIndex`, `removeIndex`, `addForeignKey`, `renameIndex`, `columnsForDistinct` (already implemented, now in interface)
- Expands `addForeignKey` to validate deferrable and support `onDelete`/`onUpdate`/`validate` options
- Remaining 2 methods (`buildChangeColumnDefinition`, `buildChangeColumnDefaultDefinition`) require new `ChangeColumnDefinition`/`ChangeColumnDefaultDefinition` classes — deferred to PR H

## Test plan

- [ ] TypeScript compiles without errors in changed files
- [ ] `api:compare` moves `postgresql/schema-statements` from 67% → 97%
- [ ] Existing schema-definitions tests pass