### PR TITLE
ci: build packages before api:compare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
         with:
           ruby-version: "3.3"
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - name: Fetch Rails source
         run: bash scripts/api-compare/fetch-rails.sh
       - name: Fetch Rails test source + Rack


### PR DESCRIPTION
## Summary

- Adds `pnpm build` to the Rails API/Test Comparison job before the extract/compare steps

## Problem

The api:compare TS extraction was consistently under-counting implemented methods in CI (~40 fewer than local). Root cause: `@blazetrails/activesupport` resolves its types via `dist/index.d.ts`, but CI never runs `pnpm build`, so `dist/` doesn't exist. Without it, TypeScript can't resolve the `Included<>` type, making interface merges like `extends Included<typeof QueryMethodBangs>` on `Relation` invisible to `extract-ts-api.ts`. The 39 missing methods were all QueryMethods-family methods that reach `Relation` through that merge.

## Test plan

- [ ] CI Rails API/Test Comparison job shows ~2609/2819 (matching local) instead of ~2569/2819