### PR TITLE
feat(activerecord): add _readAttribute, _writeAttribute, _queryAttribute

### DIFF
--- a/packages/activerecord/src/attribute-methods/query.test.ts
+++ b/packages/activerecord/src/attribute-methods/query.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+
+describe("QueryTest", () => {
+  beforeEach(() => {
+    createTestAdapter();
+  });
+
+  it("query attribute returns false for nil", () => {
+    class Post extends Base {
+      static {
+        this.attribute("published", "boolean");
+      }
+    }
+    const p = new Post({});
+    expect(p.queryAttribute("published")).toBe(false);
+  });
+
+  it("query attribute returns true for true", () => {
+    class Post extends Base {
+      static {
+        this.attribute("published", "boolean");
+      }
+    }
+    const p = new Post({ published: true });
+    expect(p.queryAttribute("published")).toBe(true);
+  });
+
+  it("query attribute returns false for false", () => {
+    class Post extends Base {
+      static {
+        this.attribute("published", "boolean");
+      }
+    }
+    const p = new Post({ published: false });
+    expect(p.queryAttribute("published")).toBe(false);
+  });
+
+  it("query attribute returns false for zero integer", () => {
+    class Post extends Base {
+      static {
+        this.attribute("views", "integer");
+      }
+    }
+    const p = new Post({ views: 0 });
+    expect(p.queryAttribute("views")).toBe(false);
+  });
+
+  it("query attribute returns true for non-zero integer", () => {
+    class Post extends Base {
+      static {
+        this.attribute("views", "integer");
+      }
+    }
+    const p = new Post({ views: 5 });
+    expect(p.queryAttribute("views")).toBe(true);
+  });
+
+  it("query attribute respects overridden getter", () => {
+    class Post extends Base {
+      static {
+        this.attribute("views", "integer");
+      }
+      get views() {
+        return 42;
+      }
+    }
+    const p = new Post({ views: 0 });
+    expect(p.queryAttribute("views")).toBe(true);
+  });
+
+  it("_query_attribute uses _readAttribute bypassing getter", () => {
+    class Post extends Base {
+      static {
+        this.attribute("views", "integer");
+      }
+    }
+    const p = new Post({ views: 7 });
+    expect(p._queryAttribute("views")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/attribute-methods/query.test.ts
+++ b/packages/activerecord/src/attribute-methods/query.test.ts
@@ -75,8 +75,13 @@ describe("QueryTest", () => {
       static {
         this.attribute("views", "integer");
       }
+      get views() {
+        return 42;
+      }
     }
-    const p = new Post({ views: 7 });
-    expect(p._queryAttribute("views")).toBe(true);
+    const p = new Post({ views: 0 });
+    // queryAttribute calls the getter (42 → true); _queryAttribute reads raw (0 → false)
+    expect(p.queryAttribute("views")).toBe(true);
+    expect(p._queryAttribute("views")).toBe(false);
   });
 });

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -10,6 +10,7 @@ const booleanType = new BooleanType();
 
 interface Queryable {
   readAttribute(name: string): unknown;
+  _readAttribute(name: string): unknown;
 }
 
 /**
@@ -22,7 +23,20 @@ interface Queryable {
  * Mirrors: ActiveRecord::AttributeMethods::Query#query_attribute
  */
 export function queryAttribute(this: Queryable, name: string): boolean {
-  const value = this.readAttribute(name);
+  return castToBoolean(this.readAttribute(name));
+}
+
+/**
+ * Like queryAttribute but reads via _readAttribute, bypassing alias
+ * resolution — used internally where the name is already canonical.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::Query#_query_attribute
+ */
+export function _queryAttribute(this: Queryable, name: string): boolean {
+  return castToBoolean(this._readAttribute(name));
+}
+
+function castToBoolean(value: unknown): boolean {
   if (value === null || value === undefined) return false;
   if (typeof value === "number") return value !== 0;
   const cast = booleanType.cast(value);

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -9,21 +9,21 @@ import { BooleanType } from "@blazetrails/activemodel";
 const booleanType = new BooleanType();
 
 interface Queryable {
-  readAttribute(name: string): unknown;
   _readAttribute(name: string): unknown;
+  [key: string]: unknown;
 }
 
 /**
  * Query whether an attribute value is truthy.
- * Equivalent to Ruby's `record.attribute?` pattern.
  *
- * Uses ActiveModel's BooleanType for consistent casting with the
- * rest of the framework (handles "0", "f", "false", "off", "no", etc.).
+ * Calls the getter method by name (like Rails' public_send), so overridden
+ * getters and virtual attributes are respected.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Query#query_attribute
  */
 export function queryAttribute(this: Queryable, name: string): boolean {
-  return castToBoolean(this.readAttribute(name));
+  const value = (this as Record<string, unknown>)[name];
+  return castToBoolean(value);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -22,7 +22,8 @@ interface Queryable {
  * Mirrors: ActiveRecord::AttributeMethods::Query#query_attribute
  */
 export function queryAttribute(this: Queryable, name: string): boolean {
-  const value = (this as Record<string, unknown>)[name];
+  const prop = (this as Record<string, unknown>)[name];
+  const value = typeof prop === "function" ? (prop as () => unknown).call(this) : prop;
   return castToBoolean(value);
 }
 

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -22,9 +22,21 @@ interface Queryable {
  * Mirrors: ActiveRecord::AttributeMethods::Query#query_attribute
  */
 export function queryAttribute(this: Queryable, name: string): boolean {
-  const prop = (this as Record<string, unknown>)[name];
-  const value = typeof prop === "function" ? (prop as () => unknown).call(this) : prop;
-  return castToBoolean(value);
+  return castToBoolean(publicSend(this, name));
+}
+
+function publicSend(obj: object, name: string): unknown {
+  let proto = Object.getPrototypeOf(obj) as object | null;
+  while (proto) {
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (desc) {
+      if (desc.get) return (obj as Record<string, unknown>)[name];
+      if (typeof desc.value === "function") return (desc.value as () => unknown).call(obj);
+      break;
+    }
+    proto = Object.getPrototypeOf(proto) as object | null;
+  }
+  return (obj as Record<string, unknown>)[name];
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -8,9 +8,12 @@ import { BooleanType } from "@blazetrails/activemodel";
 
 const booleanType = new BooleanType();
 
-interface Queryable {
-  _readAttribute(name: string): unknown;
+interface PublicSendable {
   [key: string]: unknown;
+}
+
+interface RawReadable {
+  _readAttribute(name: string): unknown;
 }
 
 /**
@@ -21,7 +24,7 @@ interface Queryable {
  *
  * Mirrors: ActiveRecord::AttributeMethods::Query#query_attribute
  */
-export function queryAttribute(this: Queryable, name: string): boolean {
+export function queryAttribute(this: PublicSendable, name: string): boolean {
   return castToBoolean(publicSend(this, name));
 }
 
@@ -53,7 +56,7 @@ function publicSend(obj: object, name: string): unknown {
  *
  * Mirrors: ActiveRecord::AttributeMethods::Query#_query_attribute
  */
-export function _queryAttribute(this: Queryable, name: string): boolean {
+export function _queryAttribute(this: RawReadable, name: string): boolean {
   return castToBoolean(this._readAttribute(name));
 }
 

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -26,6 +26,14 @@ export function queryAttribute(this: Queryable, name: string): boolean {
 }
 
 function publicSend(obj: object, name: string): unknown {
+  // Check own property first (singleton methods assigned per-instance)
+  const ownDesc = Object.getOwnPropertyDescriptor(obj, name);
+  if (ownDesc) {
+    if (ownDesc.get) return (obj as Record<string, unknown>)[name];
+    if (typeof ownDesc.value === "function") return (ownDesc.value as () => unknown).call(obj);
+    return ownDesc.value;
+  }
+  // Walk prototype chain for accessor getters and prototype methods
   let proto = Object.getPrototypeOf(obj) as object | null;
   while (proto) {
     const desc = Object.getOwnPropertyDescriptor(proto, name);

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -1,6 +1,43 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
 
 describe("ReadTest", () => {
   it.skip("define attribute methods", () => {});
   it.skip("attribute methods generated?", () => {});
+
+  it("_read_attribute returns value for existing attribute", () => {
+    createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const p = new Post({ title: "hello" });
+    expect(p._readAttribute("title")).toBe("hello");
+  });
+
+  it("_read_attribute returns null for unset attribute", () => {
+    createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const p = new Post({});
+    expect(p._readAttribute("title")).toBeNull();
+  });
+
+  it("_read_attribute does not apply alias resolution", () => {
+    createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("body", "string");
+        this.aliasAttribute("content", "body");
+      }
+    }
+    const p = new Post({ body: "text" });
+    expect(p._readAttribute("body")).toBe("text");
+    expect(p._readAttribute("content")).toBeNull();
+  });
 });

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -8,7 +8,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Read
  */
 
-import { AttributeSet } from "@blazetrails/activemodel";
+import type { AttributeSet } from "@blazetrails/activemodel";
 
 /**
  * The Read module interface.

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -25,14 +25,13 @@ interface AttributeHolder {
 }
 
 /**
- * Skips alias resolution and the primary-key "id" redirect — used internally
- * where attribute names are already canonical.
+ * Reads directly from the attribute store, bypassing any model-level
+ * overrides of `readAttribute` (e.g. alias resolution or the serialize.ts
+ * patch). Used internally where the attribute name is already canonical.
  *
- * In Rails, `_read_attribute` returns the deserialized value because
- * serialization lives inside the attribute type. In this codebase,
- * serialize.ts patches `readAttribute` at the model level, so
- * `_readAttribute` bypasses that patch and returns the raw stored value
- * for serialized columns. This matches Rails' intent; the gap is architectural.
+ * Rails' public `read_attribute` also resolves `"id"` to the primary-key
+ * column name. That redirect will live in our AR-level `readAttribute`
+ * override once implemented; `_readAttribute` intentionally skips it.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Read#_read_attribute
  */

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -28,6 +28,12 @@ interface AttributeHolder {
  * Skips alias resolution and the primary-key "id" redirect — used internally
  * where attribute names are already canonical.
  *
+ * In Rails, `_read_attribute` returns the deserialized value because
+ * serialization lives inside the attribute type. In this codebase,
+ * serialize.ts patches `readAttribute` at the model level, so
+ * `_readAttribute` bypasses that patch and returns the raw stored value
+ * for serialized columns. This matches Rails' intent; the gap is architectural.
+ *
  * Mirrors: ActiveRecord::AttributeMethods::Read#_read_attribute
  */
 export function _readAttribute(this: AttributeHolder, name: string): unknown {

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -8,6 +8,8 @@
  * Mirrors: ActiveRecord::AttributeMethods::Read
  */
 
+import { AttributeSet } from "@blazetrails/activemodel";
+
 /**
  * The Read module interface.
  *
@@ -15,4 +17,19 @@
  */
 export interface Read {
   readAttribute(name: string): unknown;
+  _readAttribute(name: string): unknown;
+}
+
+interface AttributeHolder {
+  _attributes: AttributeSet;
+}
+
+/**
+ * Skips alias resolution and the primary-key "id" redirect — used internally
+ * where attribute names are already canonical.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::Read#_read_attribute
+ */
+export function _readAttribute(this: AttributeHolder, name: string): unknown {
+  return this._attributes.fetchValue(name) ?? null;
 }

--- a/packages/activerecord/src/attribute-methods/write.test.ts
+++ b/packages/activerecord/src/attribute-methods/write.test.ts
@@ -15,7 +15,7 @@ describe("WriteTest", () => {
     expect(p.readAttribute("title")).toBe("new");
   });
 
-  it("_write_attribute writes to canonical name, not through aliases", () => {
+  it("_write_attribute writes directly without alias resolution", () => {
     createTestAdapter();
     class Post extends Base {
       static {
@@ -24,9 +24,11 @@ describe("WriteTest", () => {
       }
     }
     const p = new Post({ body: "original" });
-    // alias "content" → "body"; _writeAttribute("body") writes directly to body
-    p._writeAttribute("body", "updated");
-    expect(p.readAttribute("body")).toBe("updated");
+    // _writeAttribute("content", ...) writes to the "content" slot directly,
+    // not to "body" — alias resolution is what writeAttribute() would add.
+    p._writeAttribute("content", "via alias");
+    expect(p._readAttribute("body")).toBe("original");
+    expect(p._readAttribute("content")).toBe("via alias");
   });
 
   it("_write_attribute bypasses readonly check", () => {

--- a/packages/activerecord/src/attribute-methods/write.test.ts
+++ b/packages/activerecord/src/attribute-methods/write.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+
+describe("WriteTest", () => {
+  it("_write_attribute writes value to attribute", () => {
+    createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const p = new Post({ title: "old" });
+    p._writeAttribute("title", "new");
+    expect(p.readAttribute("title")).toBe("new");
+  });
+
+  it("_write_attribute writes to canonical name, not through aliases", () => {
+    createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("body", "string");
+        this.aliasAttribute("content", "body");
+      }
+    }
+    const p = new Post({ body: "original" });
+    // alias "content" → "body"; _writeAttribute("body") writes directly to body
+    p._writeAttribute("body", "updated");
+    expect(p.readAttribute("body")).toBe("updated");
+  });
+
+  it("_write_attribute bypasses readonly check", () => {
+    createTestAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("code", "string");
+        this.attrReadonly("code");
+      }
+    }
+    const item = new Item({ code: "A" });
+    (item as any)._newRecord = false;
+    expect(() => item._writeAttribute("code", "B")).not.toThrow();
+    expect(item.readAttribute("code")).toBe("B");
+  });
+});

--- a/packages/activerecord/src/attribute-methods/write.test.ts
+++ b/packages/activerecord/src/attribute-methods/write.test.ts
@@ -24,8 +24,9 @@ describe("WriteTest", () => {
       }
     }
     const p = new Post({ body: "original" });
-    // _writeAttribute("content", ...) writes to the "content" slot directly,
-    // not to "body" — alias resolution is what writeAttribute() would add.
+    // _writeAttribute("content", ...) writes to the "content" slot directly.
+    // Neither writeAttribute nor _writeAttribute resolve aliases today;
+    // that redirect will live in a future AR-level writeAttribute override.
     p._writeAttribute("content", "via alias");
     expect(p._readAttribute("body")).toBe("original");
     expect(p._readAttribute("content")).toBe("via alias");

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -9,6 +9,8 @@
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */
 
+import { Model } from "@blazetrails/activemodel";
+
 /**
  * The Write module interface.
  *
@@ -16,4 +18,15 @@
  */
 export interface Write {
   writeAttribute(name: string, value: unknown): void;
+  _writeAttribute(name: string, value: unknown): void;
+}
+
+/**
+ * Skips the primary-key "id" redirect and AR's readonly/frozen checks.
+ * Used internally where the attribute name is already canonical.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::Write#_write_attribute
+ */
+export function _writeAttribute(this: Model, name: string, value: unknown): void {
+  Model.prototype.writeAttribute.call(this, name, value);
 }

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -22,8 +22,9 @@ export interface Write {
 }
 
 /**
- * Bypasses Base/ReadonlyAttributes' readonly and frozen guards. Used
- * internally where the attribute name is already canonical.
+ * Bypasses Base/ReadonlyAttributes' readonly attribute checks. Used
+ * internally where the attribute name is already canonical. A frozen
+ * attribute store will still raise at the AttributeSet level.
  *
  * Rails' public `write_attribute` also resolves `"id"` to the primary-key
  * column name and resolves aliases. Those redirects will live in our

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -22,8 +22,13 @@ export interface Write {
 }
 
 /**
- * Skips the primary-key "id" redirect and Base/ReadonlyAttributes' readonly
- * guards. Used internally where the attribute name is already canonical.
+ * Bypasses Base/ReadonlyAttributes' readonly and frozen guards. Used
+ * internally where the attribute name is already canonical.
+ *
+ * Rails' public `write_attribute` also resolves `"id"` to the primary-key
+ * column name and resolves aliases. Those redirects will live in our
+ * AR-level `writeAttribute` override once implemented; `_writeAttribute`
+ * intentionally skips them.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Write#_write_attribute
  */

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -22,8 +22,8 @@ export interface Write {
 }
 
 /**
- * Skips the primary-key "id" redirect and AR's readonly/frozen checks.
- * Used internally where the attribute name is already canonical.
+ * Skips the primary-key "id" redirect and Base/ReadonlyAttributes' readonly
+ * guards. Used internally where the attribute name is already canonical.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Write#_write_attribute
  */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -81,6 +81,12 @@ import {
   accessedFields as _accessedFields,
 } from "./attribute-methods.js";
 import { toKey as _toKey } from "./attribute-methods/primary-key.js";
+import { _readAttribute as _readAttributeFn } from "./attribute-methods/read.js";
+import { _writeAttribute as _writeAttributeFn } from "./attribute-methods/write.js";
+import {
+  queryAttribute as _queryAttribute,
+  _queryAttribute as _queryAttributeFn,
+} from "./attribute-methods/query.js";
 import {
   toParam as _toParam,
   cacheKey as _cacheKey,
@@ -2401,6 +2407,10 @@ export class Base extends Model {
   declare attributePresent: (name: string) => boolean;
   declare toKey: () => unknown[] | null;
   declare accessedFields: () => string[];
+  declare queryAttribute: (name: string) => boolean;
+  declare _queryAttribute: (name: string) => boolean;
+  declare _readAttribute: (name: string) => unknown;
+  declare _writeAttribute: (name: string, value: unknown) => void;
 
   get attributeNamesList(): string[] {
     return _attributeNamesList.call(this as any);
@@ -2742,6 +2752,10 @@ include(Base, {
   hasAttribute: _hasAttribute,
   attributePresent: _attributePresent,
   accessedFields: _accessedFields,
+  queryAttribute: _queryAttribute,
+  _queryAttribute: _queryAttributeFn,
+  _readAttribute: _readAttributeFn,
+  _writeAttribute: _writeAttributeFn,
   // PrimaryKey
   toKey: _toKey,
 });


### PR DESCRIPTION
## Summary

- Adds `_readAttribute`, `_writeAttribute`, `_queryAttribute` to their respective `attribute-methods/` files, matching Rails' `:nodoc:` fast-path variants
- These bypass alias resolution and the `id`→primary_key redirect — Rails uses them internally wherever the attribute name is already canonical
- Also wires `queryAttribute` onto `Base` (was defined but never included)
- Brings `attribute-methods/query.ts`, `read.ts`, and `write.ts` from 50% → 100% in `api:compare`

## Test plan

- [ ] `pnpm run api:compare --package activerecord` — query/read/write all show 100%
- [ ] `pnpm run typecheck` passes