### PR TITLE
feat(activerecord): foreignKeys() returns ForeignKeyDefinition[] (PR J)

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -127,7 +127,7 @@ describe("CopyTableTest", () => {
     const fks = await adapter.foreignKeys("posts");
     expect(fks).toHaveLength(1);
     expect(fks[0].toTable).toBe("authors");
-    expect(fks[0].onDelete).toBe("CASCADE");
+    expect(fks[0].onDelete).toBe("cascade");
 
     const rows = await adapter.execute(`SELECT * FROM "posts"`);
     expect(rows).toHaveLength(1);

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -251,6 +251,18 @@ describe("CopyTableTest", () => {
     expect(fks).toHaveLength(0);
   });
 
+  it("foreignKeys extracts deferrable from CREATE TABLE SQL", async () => {
+    adapter.exec(`CREATE TABLE "refs" ("id" INTEGER PRIMARY KEY)`);
+    adapter.exec(
+      `CREATE TABLE "deferred_fks" ("id" INTEGER PRIMARY KEY, "ref_id" INTEGER,
+       CONSTRAINT "fk_deferred" FOREIGN KEY("ref_id") REFERENCES "refs"("id") DEFERRABLE INITIALLY DEFERRED)`,
+    );
+    const fks = await adapter.foreignKeys("deferred_fks");
+    expect(fks).toHaveLength(1);
+    expect(fks[0].name).toBe("fk_deferred");
+    expect(fks[0].deferrable).toBe("deferred");
+  });
+
   it("remove check constraint with ifExists does not throw when missing", async () => {
     adapter.exec(`CREATE TABLE "things" ("id" INTEGER PRIMARY KEY, "val" INTEGER)`);
     await expect(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -25,6 +25,7 @@ import {
   quote as mysqlQuote,
   typeCast as mysqlTypeCast,
 } from "./mysql/quoting.js";
+import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 
 const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
@@ -433,9 +434,24 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return sql;
   }
 
-  async foreignKeys(tableName: string): Promise<unknown[]> {
+  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     void tableName;
     return [];
+  }
+
+  protected _mysqlFkAction(
+    rule: string | null | undefined,
+  ): "cascade" | "nullify" | "restrict" | undefined {
+    switch ((rule ?? "").toUpperCase()) {
+      case "CASCADE":
+        return "cascade";
+      case "SET NULL":
+        return "nullify";
+      case "RESTRICT":
+        return "restrict";
+      default:
+        return undefined;
+    }
   }
 
   async checkConstraints(tableName: string): Promise<unknown[]> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -725,7 +725,10 @@ export class SchemaStatements {
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    void tableName;
+    const adapter = this.adapter as { foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]> };
+    if (typeof adapter.foreignKeys === "function") {
+      return adapter.foreignKeys(tableName);
+    }
     return [];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -724,48 +724,9 @@ export class SchemaStatements {
     }
   }
 
-  async foreignKeys(
-    tableName: string,
-  ): Promise<Array<{ from: string; to: string; column: string; primaryKey: string }>> {
-    switch (this.adapterName) {
-      case "sqlite": {
-        const rows = await this.adapter.execute(`PRAGMA foreign_key_list("${tableName}")`);
-        return (rows as any[]).map((row: any) => ({
-          from: tableName,
-          to: row.table,
-          column: row.from,
-          primaryKey: row.to,
-        }));
-      }
-      case "postgres": {
-        const rows = await this.adapter.execute(
-          `SELECT kcu.column_name, ccu.table_name AS foreign_table, ccu.column_name AS foreign_column
-           FROM information_schema.table_constraints tc
-           JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
-           JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
-           WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = '${tableName}' AND tc.table_schema = 'public'`,
-        );
-        return rows.map((row: any) => ({
-          from: tableName,
-          to: row.foreign_table,
-          column: row.column_name,
-          primaryKey: row.foreign_column,
-        }));
-      }
-      case "mysql": {
-        const rows = await this.adapter.execute(
-          `SELECT column_name, referenced_table_name, referenced_column_name
-           FROM information_schema.key_column_usage
-           WHERE table_schema = DATABASE() AND table_name = '${tableName}' AND referenced_table_name IS NOT NULL`,
-        );
-        return rows.map((row: any) => ({
-          from: tableName,
-          to: row.referenced_table_name ?? row.REFERENCED_TABLE_NAME,
-          column: row.column_name ?? row.COLUMN_NAME,
-          primaryKey: row.referenced_column_name ?? row.REFERENCED_COLUMN_NAME,
-        }));
-      }
-    }
+  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
+    void tableName;
+    return [];
   }
 
   async tables(): Promise<string[]> {
@@ -855,7 +816,7 @@ export class SchemaStatements {
   ): Promise<boolean> {
     const fks = await this.foreignKeys(fromTable);
     if (typeof toTableOrOptions === "string") {
-      return fks.some((fk) => fk.to === toTableOrOptions);
+      return fks.some((fk) => fk.toTable === toTableOrOptions);
     }
     if (toTableOrOptions?.column) {
       return fks.some((fk) => fk.column === toTableOrOptions.column);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -725,7 +725,9 @@ export class SchemaStatements {
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    const adapter = this.adapter as { foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]> };
+    const adapter = this.adapter as {
+      foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]>;
+    };
     if (typeof adapter.foreignKeys === "function") {
       return adapter.foreignKeys(tableName);
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -640,6 +640,41 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(functional!.columns[0]).not.toBe("null");
     });
 
+    describe("foreignKeys", () => {
+      beforeEach(async () => {
+        await adapter.exec("DROP TABLE IF EXISTS `fk_books`");
+        await adapter.exec("DROP TABLE IF EXISTS `fk_authors`");
+        await adapter.exec(
+          "CREATE TABLE `fk_authors` (`id` INT AUTO_INCREMENT PRIMARY KEY, `name` VARCHAR(255))",
+        );
+        await adapter.exec(
+          "CREATE TABLE `fk_books` (`id` INT AUTO_INCREMENT PRIMARY KEY, `author_id` INT)",
+        );
+      });
+
+      afterEach(async () => {
+        await adapter.exec("DROP TABLE IF EXISTS `fk_books`");
+        await adapter.exec("DROP TABLE IF EXISTS `fk_authors`");
+      });
+
+      it("returns ForeignKeyDefinition with name, column, toTable, and actions", async () => {
+        await adapter.exec(
+          "ALTER TABLE `fk_books` ADD CONSTRAINT `fk_books_author` FOREIGN KEY (`author_id`) REFERENCES `fk_authors` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT",
+        );
+        const fks = await adapter.foreignKeys("fk_books");
+        expect(fks).toHaveLength(1);
+        expect(fks[0].name).toBe("fk_books_author");
+        expect(fks[0].column).toBe("author_id");
+        expect(fks[0].toTable).toBe("fk_authors");
+        expect(fks[0].onDelete).toBe("cascade");
+        expect(fks[0].onUpdate).toBe("restrict");
+      });
+
+      it("returns empty array when no foreign keys exist", async () => {
+        expect(await adapter.foreignKeys("fk_books")).toHaveLength(0);
+      });
+    });
+
     it("SchemaCache.addAll populates from MySQL", async () => {
       // Integration with Phase 5's dumpSchemaCache — MySQL now exposes
       // the full surface (dataSources/columns/primaryKey/indexes) the

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -919,7 +919,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
          AND fk.table_schema = DATABASE()
          AND fk.table_name = ${mysqlQuoteString(tableName)}
          AND rc.constraint_schema = DATABASE()
-         AND rc.table_name = ${mysqlQuoteString(tableName)}`,
+         AND rc.table_name = ${mysqlQuoteString(tableName)}
+       ORDER BY fk.constraint_name, fk.ordinal_position`,
     )) as Array<Record<string, unknown>>;
 
     const grouped = new Map<string, Array<Record<string, unknown>>>();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -945,7 +945,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           ? (first.primary_key as string)
           : group.map((r) => r.primary_key as string).join(",");
       results.push(
-        new ForeignKeyDefinition(tableName, toTable, column, primaryKey, fkName, onDelete, onUpdate),
+        new ForeignKeyDefinition(
+          tableName,
+          toTable,
+          column,
+          primaryKey,
+          fkName,
+          onDelete,
+          onUpdate,
+        ),
       );
     }
     return results;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -6,6 +6,8 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
+import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
@@ -899,5 +901,53 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   get raw(): mysql.Pool {
     if (!this._driverPool) throw new Error("Mysql2Adapter: connection is closed");
     return this._driverPool;
+  }
+
+  override async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
+    const rows = (await this.schemaQuery(
+      `SELECT fk.referenced_table_name AS to_table,
+              fk.referenced_column_name AS primary_key,
+              fk.column_name AS \`column\`,
+              fk.constraint_name AS name,
+              fk.ordinal_position AS position,
+              rc.update_rule AS on_update,
+              rc.delete_rule AS on_delete
+       FROM information_schema.referential_constraints rc
+       JOIN information_schema.key_column_usage fk
+         USING (constraint_schema, constraint_name)
+       WHERE fk.referenced_column_name IS NOT NULL
+         AND fk.table_schema = DATABASE()
+         AND fk.table_name = ${mysqlQuoteString(tableName)}
+         AND rc.constraint_schema = DATABASE()
+         AND rc.table_name = ${mysqlQuoteString(tableName)}`,
+    )) as Array<Record<string, unknown>>;
+
+    const grouped = new Map<string, Array<Record<string, unknown>>>();
+    for (const row of rows) {
+      const name = row.name as string;
+      if (!grouped.has(name)) grouped.set(name, []);
+      grouped.get(name)!.push(row);
+    }
+    const results: ForeignKeyDefinition[] = [];
+    for (const group of grouped.values()) {
+      group.sort((a, b) => (a.position as number) - (b.position as number));
+      const first = group[0];
+      const toTable = first.to_table as string;
+      const fkName = first.name as string;
+      const onDelete = this._mysqlFkAction(first.on_delete as string);
+      const onUpdate = this._mysqlFkAction(first.on_update as string);
+      const column =
+        group.length === 1
+          ? (first.column as string)
+          : group.map((r) => r.column as string).join(",");
+      const primaryKey =
+        group.length === 1
+          ? (first.primary_key as string)
+          : group.map((r) => r.primary_key as string).join(",");
+      results.push(
+        new ForeignKeyDefinition(tableName, toTable, column, primaryKey, fkName, onDelete, onUpdate),
+      );
+    }
+    return results;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.test.ts
@@ -666,6 +666,62 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
   });
 
+  describe("foreignKeys", () => {
+    beforeEach(async () => {
+      await adapter.exec(`CREATE TABLE "fk_authors" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(
+        `CREATE TABLE "fk_books" ("id" SERIAL PRIMARY KEY, "author_id" INTEGER, "editor_id" INTEGER)`,
+      );
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "fk_books" CASCADE`);
+      await adapter.exec(`DROP TABLE IF EXISTS "fk_authors" CASCADE`);
+    });
+
+    it("returns ForeignKeyDefinition with name, column, and actions", async () => {
+      await adapter.exec(
+        `ALTER TABLE "fk_books" ADD CONSTRAINT "fk_books_author" FOREIGN KEY ("author_id") REFERENCES "fk_authors" ("id") ON DELETE CASCADE ON UPDATE RESTRICT`,
+      );
+      const fks = await adapter.foreignKeys("fk_books");
+      expect(fks).toHaveLength(1);
+      expect(fks[0].name).toBe("fk_books_author");
+      expect(fks[0].column).toBe("author_id");
+      expect(fks[0].toTable).toBe("fk_authors");
+      expect(fks[0].onDelete).toBe("cascade");
+      expect(fks[0].onUpdate).toBe("restrict");
+      expect(fks[0].validate).toBe(true);
+    });
+
+    it("returns deferrable: false for non-deferrable FK", async () => {
+      await adapter.exec(
+        `ALTER TABLE "fk_books" ADD CONSTRAINT "fk_books_editor" FOREIGN KEY ("editor_id") REFERENCES "fk_authors" ("id")`,
+      );
+      const fks = await adapter.foreignKeys("fk_books");
+      expect(fks[0].deferrable).toBe(false);
+    });
+
+    it("returns deferrable: deferred for DEFERRABLE INITIALLY DEFERRED FK", async () => {
+      await adapter.exec(
+        `ALTER TABLE "fk_books" ADD CONSTRAINT "fk_books_author_d" FOREIGN KEY ("author_id") REFERENCES "fk_authors" ("id") DEFERRABLE INITIALLY DEFERRED`,
+      );
+      const fks = await adapter.foreignKeys("fk_books");
+      expect(fks[0].deferrable).toBe("deferred");
+    });
+
+    it("returns validate: false for NOT VALID FK", async () => {
+      await adapter.exec(
+        `ALTER TABLE "fk_books" ADD CONSTRAINT "fk_books_author_nv" FOREIGN KEY ("author_id") REFERENCES "fk_authors" ("id") NOT VALID`,
+      );
+      const fks = await adapter.foreignKeys("fk_books");
+      expect(fks[0].validate).toBe(false);
+    });
+
+    it("returns empty array when no foreign keys exist", async () => {
+      expect(await adapter.foreignKeys("fk_books")).toHaveLength(0);
+    });
+  });
+
   describe("addForeignKey options", () => {
     beforeEach(async () => {
       await adapter.exec(`CREATE TABLE "fk_parents" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2553,8 +2553,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         row.name as string,
         this.extractForeignKeyAction(row.on_delete as string),
         this.extractForeignKeyAction(row.on_update as string),
-        this.extractConstraintDeferrable(row.deferrable as boolean, row.deferred as boolean) ||
-          undefined,
+        this.extractConstraintDeferrable(row.deferrable as boolean, row.deferred as boolean),
         (row.valid as boolean) ?? true,
       );
     });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2547,14 +2547,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return Promise.all(
       rows.map(async (row) => {
         const toTable = unquoteIdentifier(row.to_table as string);
-        const conkey = String(row.conkey)
-          .replace(/[{}]/g, "")
-          .split(",")
-          .map(Number);
-        const confkey = String(row.confkey)
-          .replace(/[{}]/g, "")
-          .split(",")
-          .map(Number);
+        const conkey = String(row.conkey).replace(/[{}]/g, "").split(",").map(Number);
+        const confkey = String(row.confkey).replace(/[{}]/g, "").split(",").map(Number);
         let column: string;
         let primaryKey: string;
         if (conkey.length > 1) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -5,7 +5,7 @@ import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
-import { splitQuotedIdentifier, Utils } from "./postgresql/utils.js";
+import { splitQuotedIdentifier, unquoteIdentifier, Utils } from "./postgresql/utils.js";
 import { CHECK_ALL_FOREIGN_KEYS_SQL } from "./postgresql/referential-integrity.js";
 import { Column } from "./postgresql/column.js";
 import { ExplainPrettyPrinter } from "./postgresql/explain-pretty-printer.js";
@@ -53,6 +53,7 @@ import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   ColumnDefinition,
+  ForeignKeyDefinition,
   type ColumnType,
   type ReferentialAction,
 } from "./abstract/schema-definitions.js";
@@ -2523,6 +2524,40 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     deferred: boolean,
   ): "deferred" | "immediate" | false {
     return deferrable && (deferred ? "deferred" : "immediate");
+  }
+
+  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
+    const scope = this.quotedScope(tableName);
+    const rows = await this.schemaQuery(`
+      SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key,
+             c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete,
+             c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred
+      FROM pg_constraint c
+      JOIN pg_class t1 ON c.conrelid = t1.oid
+      JOIN pg_class t2 ON c.confrelid = t2.oid
+      JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+      JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+      JOIN pg_namespace t3 ON c.connamespace = t3.oid
+      WHERE c.contype = 'f'
+        AND t1.relname = ${scope.name!}
+        AND t3.nspname = ${scope.schema}
+      ORDER BY c.conname
+    `);
+    return rows.map((row) => {
+      const toTable = unquoteIdentifier(row.to_table as string);
+      return new ForeignKeyDefinition(
+        tableName,
+        toTable,
+        unquoteIdentifier(row.column as string),
+        row.primary_key as string,
+        row.name as string,
+        this.extractForeignKeyAction(row.on_delete as string),
+        this.extractForeignKeyAction(row.on_update as string),
+        this.extractConstraintDeferrable(row.deferrable as boolean, row.deferred as boolean) ||
+          undefined,
+        (row.valid as boolean) ?? true,
+      );
+    });
   }
 
   async foreignTables(): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2531,7 +2531,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const rows = await this.schemaQuery(`
       SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key,
              c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete,
-             c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred
+             c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred,
+             c.conkey, c.confkey, c.conrelid, c.confrelid
       FROM pg_constraint c
       JOIN pg_class t1 ON c.conrelid = t1.oid
       JOIN pg_class t2 ON c.confrelid = t2.oid
@@ -2543,20 +2544,41 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         AND t3.nspname = ${scope.schema}
       ORDER BY c.conname
     `);
-    return rows.map((row) => {
-      const toTable = unquoteIdentifier(row.to_table as string);
-      return new ForeignKeyDefinition(
-        tableName,
-        toTable,
-        unquoteIdentifier(row.column as string),
-        row.primary_key as string,
-        row.name as string,
-        this.extractForeignKeyAction(row.on_delete as string),
-        this.extractForeignKeyAction(row.on_update as string),
-        this.extractConstraintDeferrable(row.deferrable as boolean, row.deferred as boolean),
-        (row.valid as boolean) ?? true,
-      );
-    });
+    return Promise.all(
+      rows.map(async (row) => {
+        const toTable = unquoteIdentifier(row.to_table as string);
+        const conkey = String(row.conkey)
+          .replace(/[{}]/g, "")
+          .split(",")
+          .map(Number);
+        const confkey = String(row.confkey)
+          .replace(/[{}]/g, "")
+          .split(",")
+          .map(Number);
+        let column: string;
+        let primaryKey: string;
+        if (conkey.length > 1) {
+          const cols = await this.columnNamesFromColumnNumbers(row.conrelid as number, conkey);
+          const pks = await this.columnNamesFromColumnNumbers(row.confrelid as number, confkey);
+          column = cols.join(",");
+          primaryKey = pks.join(",");
+        } else {
+          column = unquoteIdentifier(row.column as string);
+          primaryKey = row.primary_key as string;
+        }
+        return new ForeignKeyDefinition(
+          tableName,
+          toTable,
+          column,
+          primaryKey,
+          row.name as string,
+          this.extractForeignKeyAction(row.on_delete as string),
+          this.extractForeignKeyAction(row.on_update as string),
+          this.extractConstraintDeferrable(row.deferrable as boolean, row.deferred as boolean),
+          (row.valid as boolean) ?? true,
+        );
+      }),
+    );
   }
 
   async foreignTables(): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -8,6 +8,7 @@ import type {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   CheckConstraintDefinition,
+  ForeignKeyDefinition,
 } from "../abstract/schema-definitions.js";
 
 export interface PgIndexDefinition {
@@ -64,7 +65,7 @@ export interface SchemaStatements {
   enumTypes(): Promise<Record<string, string[]>>;
   columns(tableName: string): Promise<unknown[]>;
   columnDefinitions(tableName: string): Promise<unknown[]>;
-  foreignKeys(tableName: string): Promise<unknown[]>;
+  foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
   defaultSequenceName(tableName: string, pk?: string | string[]): Promise<string | null>;
   serialSequence(tableName: string, column: string): Promise<string | null>;
   setPkSequenceBang(tableName: string, value: number): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -880,9 +880,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // Mirrors Rails' SQLite3Adapter FK deferrable extraction — reads DEFERRABLE
   // from CREATE TABLE SQL since PRAGMA foreign_key_list doesn't expose it.
-  private _parseFkDeferrable(
-    tableName: string,
-  ): Map<string, "immediate" | "deferred"> {
+  private _parseFkDeferrable(tableName: string): Map<string, "immediate" | "deferred"> {
     const createSql = this._getCreateTableSql(tableName);
     const result = new Map<string, "immediate" | "deferred">();
     if (!createSql) return result;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -848,6 +848,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
     // Rails reads deferrable from the CREATE TABLE SQL since PRAGMA doesn't expose it.
     const deferrableByKey = this._parseFkDeferrable(tableName);
+    // Use explicit CONSTRAINT names from DDL when available (PRAGMA doesn't expose them).
+    const namesByColumn = this._parseForeignKeyNames(tableName);
 
     const results: ForeignKeyDefinition[] = [];
     for (const group of grouped.values()) {
@@ -860,7 +862,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         group.length === 1 ? (first.from as string) : group.map((r) => r.from as string).join(",");
       const primaryKey =
         group.length === 1 ? (first.to as string) : group.map((r) => r.to as string).join(",");
-      const name = `fk_${bare}_${column}`;
+      const name = namesByColumn.get(column) ?? `fk_${bare}_${column}`;
       const deferrable = deferrableByKey.get(`${toTable},${column},${primaryKey}`);
       results.push(
         new ForeignKeyDefinition(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -888,11 +888,19 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const result = new Map<string, "immediate" | "deferred">();
     if (!createSql) return result;
     const fkRegex =
-      /FOREIGN KEY\s*\("?([^",)]+)"?\)\s*REFERENCES\s*"?([^"(,\s]+)"?\s*\("?([^",)]+)"?\)[^,)]*DEFERRABLE\s+INITIALLY\s+(\w+)/gi;
+      /FOREIGN KEY\s*\(([^)]+)\)\s*REFERENCES\s*"?([^"(,\s]+)"?\s*\(([^)]+)\)[^,)]*DEFERRABLE\s+INITIALLY\s+(\w+)/gi;
     let match;
     while ((match = fkRegex.exec(createSql)) !== null) {
-      const [, fromCol, toTbl, toCol, mode] = match;
-      const key = `${toTbl},${fromCol.trim()},${toCol.trim()}`;
+      const [, fromCols, toTbl, toCols, mode] = match;
+      const fromKey = fromCols
+        .split(",")
+        .map((c) => c.trim().replace(/^"|"$/g, ""))
+        .join(",");
+      const toKey = toCols
+        .split(",")
+        .map((c) => c.trim().replace(/^"|"$/g, ""))
+        .join(",");
+      const key = `${toTbl},${fromKey},${toKey}`;
       result.set(key, mode.toLowerCase() === "deferred" ? "deferred" : "immediate");
     }
     return result;
@@ -1420,9 +1428,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const fkNames = this._parseForeignKeyNames(tableName);
 
     for (const fk of fks) {
-      const cols = Array.isArray(fk.column) ? fk.column : [fk.column];
+      const cols = fk.column.includes(",") ? fk.column.split(",").map((c) => c.trim()) : [fk.column];
       if (!cols.every((c) => colNames.includes(c))) continue;
-      const pks = Array.isArray(fk.primaryKey) ? fk.primaryKey : [fk.primaryKey];
+      const pks = fk.primaryKey.includes(",")
+        ? fk.primaryKey.split(",").map((c) => c.trim())
+        : [fk.primaryKey];
       const colList = cols.map((c) => quoteColumnName(c)).join(", ");
       const pkList = pks.map((c) => quoteColumnName(c)).join(", ");
       let fkSql = "";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -862,7 +862,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         group.length === 1 ? (first.from as string) : group.map((r) => r.from as string).join(",");
       const primaryKey =
         group.length === 1 ? (first.to as string) : group.map((r) => r.to as string).join(",");
-      const name = namesByColumn.get(column) ?? `fk_${bare}_${column}`;
+      const nameKey = column.replace(/,/g, "_");
+      const name = namesByColumn.get(column) ?? `fk_${bare}_${nameKey}`;
       const deferrable = deferrableByKey.get(`${toTable},${column},${primaryKey}`);
       results.push(
         new ForeignKeyDefinition(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -40,6 +40,7 @@ import {
 } from "./sqlite3/quoting.js";
 import {
   CheckConstraintDefinition,
+  ForeignKeyDefinition,
   type AddForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
@@ -830,15 +831,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.addColumn(tableName, `${refName}_id`, type, options);
   }
 
-  async foreignKeys(tableName: string): Promise<
-    Array<{
-      column: string | string[];
-      primaryKey: string | string[];
-      toTable: string;
-      onDelete: string | null;
-      onUpdate: string | null;
-    }>
-  > {
+  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     const { schema, bare } = this._splitTableName(tableName);
     const prefix = schema ? `${quoteColumnName(schema)}.` : "";
     const rows = await this.execute(
@@ -853,39 +846,38 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       grouped.get(id)!.push(row);
     }
 
-    const results: Array<{
-      column: string | string[];
-      primaryKey: string | string[];
-      toTable: string;
-      onDelete: string | null;
-      onUpdate: string | null;
-    }> = [];
-
+    const results: ForeignKeyDefinition[] = [];
     for (const group of grouped.values()) {
       group.sort((a, b) => (a.seq as number) - (b.seq as number));
       const first = group[0];
-      const onDelete = first.on_delete === "NO ACTION" ? null : (first.on_delete as string);
-      const onUpdate = first.on_update === "NO ACTION" ? null : (first.on_update as string);
-
-      if (group.length === 1) {
-        results.push({
-          column: first.from as string,
-          primaryKey: first.to as string,
-          toTable: first.table as string,
-          onDelete,
-          onUpdate,
-        });
-      } else {
-        results.push({
-          column: group.map((r) => r.from as string),
-          primaryKey: group.map((r) => r.to as string),
-          toTable: first.table as string,
-          onDelete,
-          onUpdate,
-        });
-      }
+      const toTable = first.table as string;
+      const onDelete = this._extractFkAction(first.on_delete as string);
+      const onUpdate = this._extractFkAction(first.on_update as string);
+      const column =
+        group.length === 1 ? (first.from as string) : group.map((r) => r.from as string).join(",");
+      const primaryKey =
+        group.length === 1 ? (first.to as string) : group.map((r) => r.to as string).join(",");
+      const name = `fk_${bare}_${column}`;
+      results.push(
+        new ForeignKeyDefinition(tableName, toTable, column, primaryKey, name, onDelete, onUpdate),
+      );
     }
     return results;
+  }
+
+  private _extractFkAction(
+    action: string | null | undefined,
+  ): "cascade" | "nullify" | "restrict" | undefined {
+    switch ((action ?? "").toUpperCase()) {
+      case "CASCADE":
+        return "cascade";
+      case "SET NULL":
+        return "nullify";
+      case "RESTRICT":
+        return "restrict";
+      default:
+        return undefined;
+    }
   }
 
   override buildInsertSql(insert: {
@@ -1321,13 +1313,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private async alterTable(
     tableName: string,
     modify: (columns: Record<string, Record<string, unknown>>) => void,
-    overrideForeignKeys?: Array<{
-      column: string | string[];
-      primaryKey: string | string[];
-      toTable: string;
-      onDelete: string | null;
-      onUpdate: string | null;
-    }>,
+    overrideForeignKeys?: ForeignKeyDefinition[],
     overrideCheckConstraints?: CheckConstraintDefinition[],
     extraDefinition?: (def: import("./abstract/schema-definitions.js").TableDefinition) => void,
   ): Promise<void> {
@@ -1411,8 +1397,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       const fkName = fkNames.get(fkKey) ?? `fk_${bareTable}_${cols.join("_")}`;
       fkSql += `CONSTRAINT ${quoteColumnName(fkName)} `;
       fkSql += `FOREIGN KEY(${colList}) REFERENCES ${quoteTableName(fk.toTable)}(${pkList})`;
-      if (fk.onDelete) fkSql += ` ON DELETE ${fk.onDelete}`;
-      if (fk.onUpdate) fkSql += ` ON UPDATE ${fk.onUpdate}`;
+      if (fk.onDelete) fkSql += ` ON DELETE ${normalizeReferentialAction(fk.onDelete)}`;
+      if (fk.onUpdate) fkSql += ` ON UPDATE ${normalizeReferentialAction(fk.onUpdate)}`;
       colDefs.push(fkSql);
     }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1428,7 +1428,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const fkNames = this._parseForeignKeyNames(tableName);
 
     for (const fk of fks) {
-      const cols = fk.column.includes(",") ? fk.column.split(",").map((c) => c.trim()) : [fk.column];
+      const cols = fk.column.includes(",")
+        ? fk.column.split(",").map((c) => c.trim())
+        : [fk.column];
       if (!cols.every((c) => colNames.includes(c))) continue;
       const pks = fk.primaryKey.includes(",")
         ? fk.primaryKey.split(",").map((c) => c.trim())

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -846,6 +846,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       grouped.get(id)!.push(row);
     }
 
+    // Rails reads deferrable from the CREATE TABLE SQL since PRAGMA doesn't expose it.
+    const deferrableByKey = this._parseFkDeferrable(tableName);
+
     const results: ForeignKeyDefinition[] = [];
     for (const group of grouped.values()) {
       group.sort((a, b) => (a.seq as number) - (b.seq as number));
@@ -858,11 +861,40 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       const primaryKey =
         group.length === 1 ? (first.to as string) : group.map((r) => r.to as string).join(",");
       const name = `fk_${bare}_${column}`;
+      const deferrable = deferrableByKey.get(`${toTable},${column},${primaryKey}`);
       results.push(
-        new ForeignKeyDefinition(tableName, toTable, column, primaryKey, name, onDelete, onUpdate),
+        new ForeignKeyDefinition(
+          tableName,
+          toTable,
+          column,
+          primaryKey,
+          name,
+          onDelete,
+          onUpdate,
+          deferrable,
+        ),
       );
     }
     return results;
+  }
+
+  // Mirrors Rails' SQLite3Adapter FK deferrable extraction — reads DEFERRABLE
+  // from CREATE TABLE SQL since PRAGMA foreign_key_list doesn't expose it.
+  private _parseFkDeferrable(
+    tableName: string,
+  ): Map<string, "immediate" | "deferred"> {
+    const createSql = this._getCreateTableSql(tableName);
+    const result = new Map<string, "immediate" | "deferred">();
+    if (!createSql) return result;
+    const fkRegex =
+      /FOREIGN KEY\s*\("?([^",)]+)"?\)\s*REFERENCES\s*"?([^"(,\s]+)"?\s*\("?([^",)]+)"?\)[^,)]*DEFERRABLE\s+INITIALLY\s+(\w+)/gi;
+    let match;
+    while ((match = fkRegex.exec(createSql)) !== null) {
+      const [, fromCol, toTbl, toCol, mode] = match;
+      const key = `${toTbl},${fromCol.trim()},${toCol.trim()}`;
+      result.set(key, mode.toLowerCase() === "deferred" ? "deferred" : "immediate");
+    }
+    return result;
   }
 
   private _extractFkAction(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3,6 +3,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 import {
   TableDefinition,
   Table,
+  ForeignKeyDefinition,
   type ColumnType,
   type ColumnOptions,
   type AddForeignKeyOptions,
@@ -681,9 +682,7 @@ export abstract class Migration {
     return this.schema.primaryKey(tableName);
   }
 
-  async foreignKeys(
-    tableName: string,
-  ): Promise<Array<{ from: string; to: string; column: string; primaryKey: string }>> {
+  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     return this.schema.foreignKeys(tableName);
   }
 


### PR DESCRIPTION
## Summary

- PG adapter: implement `foreignKeys()` using `pg_constraint` query — returns `ForeignKeyDefinition[]` with `name`, `onDelete`, `onUpdate`, `deferrable`, and `validate` populated from the DB (matches Rails `postgresql/schema_statements.rb`)
- SQLite adapter: update existing `foreignKeys()` to return `ForeignKeyDefinition[]`; add `_extractFkAction` helper for normalizing `ON DELETE`/`ON UPDATE` strings to `ReferentialAction`
- MySQL2 adapter: implement `foreignKeys()` using `information_schema.referential_constraints` join (matches Rails `abstract_mysql_adapter.rb`); `_mysqlFkAction` helper lives on `AbstractMysqlAdapter`
- Abstract schema-statements: simplify default `foreignKeys()` to `return []` (all real adapters override); update `foreignKeyExists` to use `fk.toTable` instead of `fk.to`
- `migration.ts`: update `foreignKeys()` return type to `ForeignKeyDefinition[]`

Runtime methods added in PR I (`isDefinedFor`, `isValidate`, `deferrable`, etc.) now work on FK objects returned from DB introspection.