### PR TITLE
feat(activerecord): MySQL/Trilogy adapter gaps — quoting, schema statements, newClient (PR K)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -434,6 +434,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return sql;
   }
 
+  highPrecisionCurrentTimestamp(): string {
+    return "CURRENT_TIMESTAMP(6)";
+  }
+
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     void tableName;
     return [];

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -24,6 +24,11 @@ import {
   quoteString as mysqlQuoteString,
   quote as mysqlQuote,
   typeCast as mysqlTypeCast,
+  castBoundValue as mysqlCastBoundValue,
+  quotedBinary as mysqlQuotedBinary,
+  unquoteIdentifier as mysqlUnquoteIdentifier,
+  columnNameMatcher as mysqlColumnNameMatcher,
+  columnNameWithOrderMatcher as mysqlColumnNameWithOrderMatcher,
 } from "./mysql/quoting.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 
@@ -436,6 +441,26 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   highPrecisionCurrentTimestamp(): string {
     return "CURRENT_TIMESTAMP(6)";
+  }
+
+  castBoundValue(value: unknown): unknown {
+    return mysqlCastBoundValue(value);
+  }
+
+  quotedBinary(value: Buffer | string): string {
+    return mysqlQuotedBinary(value);
+  }
+
+  unquoteIdentifier(identifier: string | null | undefined): string | null {
+    return mysqlUnquoteIdentifier(identifier);
+  }
+
+  static columnNameMatcher(): RegExp {
+    return mysqlColumnNameMatcher();
+  }
+
+  static columnNameWithOrderMatcher(): RegExp {
+    return mysqlColumnNameWithOrderMatcher();
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -18,7 +18,7 @@ import {
   StatementInvalid,
   ValueTooLong,
 } from "../errors.js";
-import type { Nodes } from "@blazetrails/arel";
+import { sql as arelSql, type Nodes } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
 import {
   quoteString as mysqlQuoteString,
@@ -439,8 +439,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return sql;
   }
 
-  highPrecisionCurrentTimestamp(): string {
-    return "CURRENT_TIMESTAMP(6)";
+  highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
+    return arelSql("CURRENT_TIMESTAMP(6)");
   }
 
   castBoundValue(value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -13,4 +13,5 @@ export interface DatabaseStatements {
   execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;
   explain(sql: string, binds?: unknown[], options?: { extended?: boolean }): Promise<string>;
   lastInsertedId(result: unknown): number;
+  highPrecisionCurrentTimestamp(): string;
 }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements (module)
  */
 
+import type { Nodes } from "@blazetrails/arel";
 import type { Result } from "../../result.js";
 
 export interface DatabaseStatements {
@@ -13,5 +14,5 @@ export interface DatabaseStatements {
   execInsert(sql: string, name?: string | null, binds?: unknown[], pk?: string): Promise<unknown>;
   explain(sql: string, binds?: unknown[], options?: { extended?: boolean }): Promise<string>;
   lastInsertedId(result: unknown): number;
-  highPrecisionCurrentTimestamp(): string;
+  highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;
 }

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -61,6 +61,10 @@ describe("MySQL quoting — typeCast", () => {
     expect(typeCast(BigInt(9))).toBe(BigInt(9));
   });
 
+  it("quotes Buffer values as hex literals via quotedBinary", () => {
+    expect(quote(Buffer.from([0xca, 0xfe]))).toBe("x'cafe'");
+  });
+
   it("returns Date as the full unquoted datetime string (no surrounding quotes)", () => {
     // typeCast's contract: unquoted primitive suitable as a bind
     // value. It's `quote()`'s job to add the surrounding quotes.

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { quote, quotedDate, quotedTimeUtc, typeCast } from "./quoting.js";
+import {
+  quote,
+  quotedDate,
+  quotedTimeUtc,
+  typeCast,
+  quotedBinary,
+  unquoteIdentifier,
+  castBoundValue,
+  columnNameMatcher,
+  columnNameWithOrderMatcher,
+} from "./quoting.js";
 
 describe("MySQL quoting — quote", () => {
   it("returns NULL for null / undefined", () => {
@@ -79,5 +89,91 @@ describe("MySQL quoting — quotedDate / quotedTimeUtc", () => {
   it("quotedTimeUtc returns the time-only tail", () => {
     const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56));
     expect(quotedTimeUtc(d)).toBe("12:34:56");
+  });
+});
+
+describe("MySQL quoting — quotedBinary", () => {
+  it("formats a Buffer as hex literal", () => {
+    expect(quotedBinary(Buffer.from([0xde, 0xad, 0xbe, 0xef]))).toBe("x'deadbeef'");
+  });
+
+  it("formats a binary string as hex literal", () => {
+    expect(quotedBinary(Buffer.from("hello").toString("binary"))).toBe("x'68656c6c6f'");
+  });
+});
+
+describe("MySQL quoting — unquoteIdentifier", () => {
+  it("strips surrounding backticks", () => {
+    expect(unquoteIdentifier("`foo`")).toBe("foo");
+  });
+
+  it("unescapes doubled backticks", () => {
+    expect(unquoteIdentifier("`foo``bar`")).toBe("foo`bar");
+  });
+
+  it("returns identifier unchanged when not backtick-quoted", () => {
+    expect(unquoteIdentifier("foo")).toBe("foo");
+  });
+
+  it("returns null for null input", () => {
+    expect(unquoteIdentifier(null)).toBeNull();
+  });
+
+  it("does not strip when only start backtick present", () => {
+    expect(unquoteIdentifier("`foo")).toBe("`foo");
+  });
+});
+
+describe("MySQL quoting — castBoundValue", () => {
+  it("converts numbers to strings", () => {
+    expect(castBoundValue(42)).toBe("42");
+    expect(castBoundValue(3.14)).toBe("3.14");
+  });
+
+  it("converts true/false to '1'/'0'", () => {
+    expect(castBoundValue(true)).toBe("1");
+    expect(castBoundValue(false)).toBe("0");
+  });
+
+  it("passes strings through unchanged", () => {
+    expect(castBoundValue("hello")).toBe("hello");
+  });
+});
+
+describe("MySQL quoting — columnNameMatcher", () => {
+  const re = columnNameMatcher();
+
+  it("matches simple column names", () => {
+    expect(re.test("name")).toBe(true);
+    expect(re.test("`name`")).toBe(true);
+  });
+
+  it("matches table.column form", () => {
+    expect(re.test("`users`.`name`")).toBe(true);
+  });
+
+  it("matches column with alias", () => {
+    expect(re.test("name AS n")).toBe(true);
+  });
+
+  it("rejects SQL injection attempts", () => {
+    expect(re.test("name; DROP TABLE users")).toBe(false);
+  });
+});
+
+describe("MySQL quoting — columnNameWithOrderMatcher", () => {
+  const re = columnNameWithOrderMatcher();
+
+  it("matches column with ASC/DESC", () => {
+    expect(re.test("name ASC")).toBe(true);
+    expect(re.test("name DESC")).toBe(true);
+  });
+
+  it("matches column with COLLATE", () => {
+    expect(re.test("name COLLATE utf8mb4_unicode_ci")).toBe(true);
+  });
+
+  it("rejects injection", () => {
+    expect(re.test("name; DROP TABLE users")).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -159,6 +159,11 @@ describe("MySQL quoting — columnNameMatcher", () => {
   it("rejects SQL injection attempts", () => {
     expect(re.test("name; DROP TABLE users")).toBe(false);
   });
+
+  it("rejects boolean operators in function arguments", () => {
+    expect(re.test("concat(name OR 1=1)")).toBe(false);
+    expect(re.test("upper(name AND 1=1)")).toBe(false);
+  });
 });
 
 describe("MySQL quoting — columnNameWithOrderMatcher", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -122,16 +122,32 @@ export function castBoundValue(value: unknown): unknown {
   return value;
 }
 
-// Mirrors Rails' MySQL::Quoting.column_name_matcher — validates column name
-// expressions (including `table`.`column` and function call forms).
+// Mirrors Rails' MySQL::Quoting.column_name_matcher. JS can't replicate Ruby's
+// recursive \g<n> back-references, so we limit function arguments to plain
+// identifiers and column references (no nested expressions), which is stricter
+// than Rails but prevents injection via function call arguments.
 export function columnNameMatcher(): RegExp {
-  return /^(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:(?:\s+AS)?\s+(?:\w+|`\w+`))?(?:\s*,\s*(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:(?:\s+AS)?\s+(?:\w+|`\w+`))?)*$/i;
+  const id = String.raw`(?:\w+|` + "`" + String.raw`\w+` + "`" + String.raw`)`;
+  const col = String.raw`(?:${id}\.)?${id}`;
+  const fnArg = String.raw`(?:\*|${col})`;
+  const fnCall = String.raw`\w+\(\s*(?:${fnArg}(?:\s*,\s*${fnArg})*)?\s*\)`;
+  const expr = String.raw`(?:${col}|${fnCall})`;
+  const aliased = String.raw`${expr}(?:(?:\s+AS)?\s+${id})?`;
+  return new RegExp(`^${aliased}(?:\\s*,\\s*${aliased})*$`, "i");
 }
 
 // Mirrors Rails' MySQL::Quoting.column_name_with_order_matcher — like
 // columnNameMatcher but also allows COLLATE and ASC/DESC suffixes.
 export function columnNameWithOrderMatcher(): RegExp {
-  return /^(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s*,\s*(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?)*$/i;
+  const id = String.raw`(?:\w+|` + "`" + String.raw`\w+` + "`" + String.raw`)`;
+  const col = String.raw`(?:${id}\.)?${id}`;
+  const fnArg = String.raw`(?:\*|${col})`;
+  const fnCall = String.raw`\w+\(\s*(?:${fnArg}(?:\s*,\s*${fnArg})*)?\s*\)`;
+  const expr = String.raw`(?:${col}|${fnCall})`;
+  const collate = String.raw`(?:\s+COLLATE\s+(?:\w+|"\w+"))?`;
+  const dir = String.raw`(?:\s+ASC|\s+DESC)?`;
+  const ordered = String.raw`${expr}${collate}${dir}`;
+  return new RegExp(`^${ordered}(?:\\s*,\\s*${ordered})*$`, "i");
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -101,8 +101,9 @@ export function quotedBinaryString(value: Buffer): string {
   return `x'${value.toString("hex")}'`;
 }
 
-export function quotedBinary(value: { toS?: () => string; toString: () => string }): string {
-  return `x'${Buffer.from(value.toString(), "binary").toString("hex")}'`;
+export function quotedBinary(value: Buffer | string): string {
+  const hex = Buffer.isBuffer(value) ? value.toString("hex") : Buffer.from(value, "binary").toString("hex");
+  return `x'${hex}'`;
 }
 
 export function unquoteIdentifier(identifier: string | null | undefined): string | null {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -101,6 +101,34 @@ export function quotedBinaryString(value: Buffer): string {
   return `x'${value.toString("hex")}'`;
 }
 
+export function quotedBinary(value: { toS?: () => string; toString: () => string }): string {
+  return `x'${Buffer.from(value.toString(), "binary").toString("hex")}'`;
+}
+
+export function unquoteIdentifier(identifier: string | null | undefined): string | null {
+  if (identifier && identifier.startsWith("`")) return identifier.slice(1, -1);
+  return identifier ?? null;
+}
+
+export function castBoundValue(value: unknown): unknown {
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value === true) return "1";
+  if (value === false) return "0";
+  return value;
+}
+
+// Mirrors Rails' MySQL::Quoting.column_name_matcher — validates column name
+// expressions (including `table`.`column` and function call forms).
+export function columnNameMatcher(): RegExp {
+  return /^(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:(?:\s+AS)?\s+(?:\w+|`\w+`))?(?:\s*,\s*(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:(?:\s+AS)?\s+(?:\w+|`\w+`))?)*$/i;
+}
+
+// Mirrors Rails' MySQL::Quoting.column_name_with_order_matcher — like
+// columnNameMatcher but also allows COLLATE and ASC/DESC suffixes.
+export function columnNameWithOrderMatcher(): RegExp {
+  return /^(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s*,\s*(?:(?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)|\w+\([^)]*\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?)*$/i;
+}
+
 /**
  * Quote a value for inclusion in a SQL literal.
  *

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -109,7 +109,9 @@ export function quotedBinary(value: Buffer | string): string {
 }
 
 export function unquoteIdentifier(identifier: string | null | undefined): string | null {
-  if (identifier && identifier.startsWith("`")) return identifier.slice(1, -1);
+  if (identifier && identifier.startsWith("`") && identifier.endsWith("`")) {
+    return identifier.slice(1, -1).replace(/``/g, "`");
+  }
   return identifier ?? null;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -102,7 +102,9 @@ export function quotedBinaryString(value: Buffer): string {
 }
 
 export function quotedBinary(value: Buffer | string): string {
-  const hex = Buffer.isBuffer(value) ? value.toString("hex") : Buffer.from(value, "binary").toString("hex");
+  const hex = Buffer.isBuffer(value)
+    ? value.toString("hex")
+    : Buffer.from(value, "binary").toString("hex");
   return `x'${hex}'`;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -144,7 +144,7 @@ export function quote(value: unknown): string {
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   if (value instanceof Date) return `'${quotedDate(value)}'`;
-  if (value instanceof Buffer) return quotedBinaryString(value);
+  if (value instanceof Buffer) return quotedBinary(value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -57,9 +57,18 @@ export interface SchemaStatements {
   ): Promise<void>;
   columns(tableName: string): Promise<unknown[]>;
   columnDefinitions(tableName: string): Promise<unknown[]>;
-  removeColumn(tableName: string, columnName: string, type?: string, options?: Record<string, unknown>): Promise<void>;
+  removeColumn(
+    tableName: string,
+    columnName: string,
+    type?: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
   createTable(tableName: string, options?: Record<string, unknown>): Promise<void>;
-  removeForeignKey(fromTable: string, toTable?: string, options?: Record<string, unknown>): Promise<void>;
+  removeForeignKey(
+    fromTable: string,
+    toTable?: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
   internalStringOptionsForPrimaryKey(): Record<string, unknown>;
   updateTableDefinition(tableName: string, base: unknown): unknown;
   createSchemaDumper(options?: Record<string, unknown>): unknown;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -57,4 +57,13 @@ export interface SchemaStatements {
   ): Promise<void>;
   columns(tableName: string): Promise<unknown[]>;
   columnDefinitions(tableName: string): Promise<unknown[]>;
+  removeColumn(tableName: string, columnName: string, type?: string, options?: Record<string, unknown>): Promise<void>;
+  createTable(tableName: string, options?: Record<string, unknown>): Promise<void>;
+  removeForeignKey(fromTable: string, toTable?: string, options?: Record<string, unknown>): Promise<void>;
+  internalStringOptionsForPrimaryKey(): Record<string, unknown>;
+  updateTableDefinition(tableName: string, base: unknown): unknown;
+  createSchemaDumper(options?: Record<string, unknown>): unknown;
+  typeToSql(type: string, options?: Record<string, unknown>): string;
+  tableAliasLength(): number;
+  schemaCreation(): unknown;
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -960,7 +960,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return results;
   }
 
-  newClient(config: mysql.PoolOptions): mysql.Pool {
+  static newClient(config: mysql.PoolOptions): mysql.Pool {
     return mysql.createPool(config);
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -170,7 +170,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   constructor(config: string | (mysql.PoolOptions & TrailsAdapterOptions)) {
     super();
     if (typeof config === "string") {
-      this._driverPool = mysql.createPool({ uri: config });
+      this._driverPool = Mysql2Adapter.newClient({ uri: config });
       return;
     }
     // See PostgreSQLAdapter#constructor: Rails' database.yml merges
@@ -182,7 +182,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const { statementLimit, preparedStatements, ...mysqlConfig } = config;
     if (statementLimit !== undefined) this.statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
-    this._driverPool = mysql.createPool(mysqlConfig);
+    this._driverPool = Mysql2Adapter.newClient(mysqlConfig);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -959,4 +959,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }
     return results;
   }
+
+  newClient(config: mysql.PoolOptions): mysql.Pool {
+    return mysql.createPool(config);
+  }
 }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -9,11 +9,7 @@
  */
 
 import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
-import {
-  DatabaseConnectionError,
-  NoDatabaseError,
-  ConnectionNotEstablished,
-} from "../errors.js";
+import { DatabaseConnectionError, NoDatabaseError, ConnectionNotEstablished } from "../errors.js";
 
 const SSL_MODES: Record<string, number> = {
   SSL_MODE_DISABLED: 0,
@@ -35,9 +31,7 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
 
   static newClient(config: Record<string, unknown>): never {
     void config;
-    throw new Error(
-      "TrilogyAdapter: no Trilogy JS driver available. Use Mysql2Adapter instead.",
-    );
+    throw new Error("TrilogyAdapter: no Trilogy JS driver available. Use Mysql2Adapter instead.");
   }
 
   static parseSslMode(mode: number | string): number {

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -26,7 +26,7 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
 
   constructor(config: Record<string, unknown> = {}) {
     super();
-    void config;
+    TrilogyAdapter.newClient(config);
   }
 
   static newClient(config: Record<string, unknown>): never {

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -9,9 +9,58 @@
  */
 
 import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
+import {
+  DatabaseConnectionError,
+  NoDatabaseError,
+  ConnectionNotEstablished,
+} from "../errors.js";
+
+const SSL_MODES: Record<string, number> = {
+  SSL_MODE_DISABLED: 0,
+  SSL_MODE_PREFERRED: 1,
+  SSL_MODE_REQUIRED: 2,
+  SSL_MODE_VERIFY_CA: 3,
+  SSL_MODE_VERIFY_IDENTITY: 4,
+};
 
 export class TrilogyAdapter extends AbstractMysqlAdapter {
   override get adapterName(): string {
     return "Trilogy";
+  }
+
+  constructor(config: Record<string, unknown> = {}) {
+    super();
+    void config;
+  }
+
+  static newClient(config: Record<string, unknown>): never {
+    void config;
+    throw new Error(
+      "TrilogyAdapter: no Trilogy JS driver available. Use Mysql2Adapter instead.",
+    );
+  }
+
+  static parseSslMode(mode: number | string): number {
+    if (typeof mode === "number") return mode;
+    let m = mode.toUpperCase();
+    if (!m.startsWith("SSL_MODE_")) m = `SSL_MODE_${m}`;
+    return SSL_MODES[m] ?? (mode as unknown as number);
+  }
+
+  static translateConnectError(
+    config: Record<string, unknown>,
+    error: { message: string; errorCode?: number },
+  ): Error {
+    const code = error.errorCode;
+    if (code === 1044 || code === 1049) {
+      return new NoDatabaseError(`No database: ${config.database}`);
+    }
+    if (code === 1045) {
+      return new DatabaseConnectionError(`Access denied for user: ${config.username}`);
+    }
+    if (error.message.includes("TRILOGY_DNS_ERROR")) {
+      return new DatabaseConnectionError(`Unknown host: ${config.host}`);
+    }
+    return new ConnectionNotEstablished(error.message);
   }
 }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -38,7 +38,11 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
     if (typeof mode === "number") return mode;
     let m = mode.toUpperCase();
     if (!m.startsWith("SSL_MODE_")) m = `SSL_MODE_${m}`;
-    return SSL_MODES[m] ?? (mode as unknown as number);
+    const sslMode = SSL_MODES[m];
+    if (sslMode !== undefined) return sslMode;
+    const numeric = Number(mode);
+    if (Number.isFinite(numeric)) return numeric;
+    throw new Error(`Invalid SSL mode: ${mode}`);
   }
 
   static translateConnectError(
@@ -47,13 +51,13 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
   ): Error {
     const code = error.errorCode;
     if (code === 1044 || code === 1049) {
-      return new NoDatabaseError(`No database: ${config.database}`);
+      return NoDatabaseError.dbError(config.database as string);
     }
     if (code === 1045) {
-      return new DatabaseConnectionError(`Access denied for user: ${config.username}`);
+      return DatabaseConnectionError.usernameError(config.username as string);
     }
     if (error.message.includes("TRILOGY_DNS_ERROR")) {
-      return new DatabaseConnectionError(`Unknown host: ${config.host}`);
+      return DatabaseConnectionError.hostnameError(config.host as string);
     }
     return new ConnectionNotEstablished(error.message);
   }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -45,19 +45,27 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
     throw new Error(`Invalid SSL mode: ${mode}`);
   }
 
+  private static _configString(config: Record<string, unknown>, key: string): string | undefined {
+    const v = config[key];
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  }
+
   static translateConnectError(
     config: Record<string, unknown>,
     error: { message: string; errorCode?: number },
   ): Error {
     const code = error.errorCode;
-    if (code === 1044 || code === 1049) {
-      return NoDatabaseError.dbError(config.database as string);
+    const database = TrilogyAdapter._configString(config, "database");
+    const username = TrilogyAdapter._configString(config, "username");
+    const host = TrilogyAdapter._configString(config, "host");
+    if ((code === 1044 || code === 1049) && database) {
+      return NoDatabaseError.dbError(database);
     }
-    if (code === 1045) {
-      return DatabaseConnectionError.usernameError(config.username as string);
+    if (code === 1045 && username) {
+      return DatabaseConnectionError.usernameError(username);
     }
-    if (error.message.includes("TRILOGY_DNS_ERROR")) {
-      return DatabaseConnectionError.hostnameError(config.host as string);
+    if (error.message.includes("TRILOGY_DNS_ERROR") && host) {
+      return DatabaseConnectionError.hostnameError(host);
     }
     return new ConnectionNotEstablished(error.message);
   }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -26,22 +26,24 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
 
   constructor(config: Record<string, unknown> = {}) {
     super();
+    // Fail fast — no Trilogy JS driver available.
     TrilogyAdapter.newClient(config);
   }
 
-  static newClient(config: Record<string, unknown>): never {
+  static newClient(config: Record<string, unknown>): unknown {
     void config;
     throw new Error("TrilogyAdapter: no Trilogy JS driver available. Use Mysql2Adapter instead.");
   }
 
   static parseSslMode(mode: number | string): number {
     if (typeof mode === "number") return mode;
-    let m = mode.toUpperCase();
+    const trimmed = mode.trim();
+    if (trimmed.length === 0) throw new Error(`Invalid SSL mode: ${JSON.stringify(mode)}`);
+    let m = trimmed.toUpperCase();
     if (!m.startsWith("SSL_MODE_")) m = `SSL_MODE_${m}`;
     const sslMode = SSL_MODES[m];
     if (sslMode !== undefined) return sslMode;
-    const numeric = Number(mode);
-    if (Number.isFinite(numeric)) return numeric;
+    if (/^\d+$/.test(trimmed)) return Number(trimmed);
     throw new Error(`Invalid SSL mode: ${mode}`);
   }
 


### PR DESCRIPTION
## Summary

Closes the remaining api:compare gaps across MySQL adapter files:

- `mysql/database-statements.ts`: add `highPrecisionCurrentTimestamp()` (`CURRENT_TIMESTAMP(6)`) — implemented on `AbstractMysqlAdapter`
- `mysql/quoting.ts`: add `castBoundValue`, `quotedBinary`, `unquoteIdentifier`, `columnNameMatcher`, `columnNameWithOrderMatcher`
- `mysql/schema-statements.ts`: add missing interface entries — `removeColumn`, `createTable`, `removeForeignKey`, `internalStringOptionsForPrimaryKey`, `updateTableDefinition`, `createSchemaDumper`, `typeToSql`, `tableAliasLength`, `schemaCreation`
- `mysql2-adapter.ts`: add `newClient(config)` — creates and returns the driver pool
- `trilogy-adapter.ts`: add `constructor`, static `newClient`, `parseSslMode`, `translateConnectError` — mirrors Rails' TrilogyAdapter class methods and initialization