### PR TITLE
feat(activerecord): implement defineAttribute and _defaultAttributes

### DIFF
--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -707,3 +707,53 @@ describe("DefaultAttributesTest", () => {
     expect(p.status).toBe("draft");
   });
 });
+
+describe("DefineAttributeSTITest", () => {
+  it("defineAttribute on STI subclass routes to the STI base", () => {
+    const adp = createTestAdapter();
+    const intType = typeRegistry.lookup("integer");
+    class Animal extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("type", "string");
+        (this as any)._inheritanceColumn = "type";
+        this.adapter = adp;
+      }
+    }
+    class Dog extends (Animal as any) {}
+    // Defining on subclass should land on the base
+    (Dog as any).defineAttribute("legs", intType, { default: 4 });
+    expect((Animal as any)._attributeDefinitions.has("legs")).toBe(true);
+    const d = new (Dog as any)({});
+    expect(d.legs).toBe(4);
+  });
+
+  it("_defaultAttributes on STI subclass uses the base cache", () => {
+    const adp = createTestAdapter();
+    class Vehicle extends Base {
+      static {
+        this.attribute("speed", "integer", { default: 60 });
+        this.adapter = adp;
+      }
+    }
+    class Car extends (Vehicle as any) {}
+    const baseDefaults = (Vehicle as any)._defaultAttributes();
+    const subDefaults = (Car as any)._defaultAttributes();
+    expect(baseDefaults).toBe(subDefaults);
+  });
+
+  it("defineAttribute for id does not install an accessor", () => {
+    const adp = createTestAdapter();
+    const strType = typeRegistry.lookup("string");
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    Post.defineAttribute("id", strType);
+    // Base.prototype.id (the CPK-aware getter) must still be used, not a plain accessor
+    const ownDesc = Object.getOwnPropertyDescriptor(Post.prototype, "id");
+    expect(ownDesc).toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
+import { typeRegistry } from "@blazetrails/activemodel";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -568,5 +569,141 @@ describe("CustomPropertiesTest", () => {
     expect(p1.active).toBe(1);
     const p2 = new Post({ active: 0 });
     expect(p2.active).toBe(0);
+  });
+});
+
+describe("DefineAttributeTest", () => {
+  it("define_attribute registers a type object directly", () => {
+    const adp = createTestAdapter();
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.adapter = adp;
+        this.defineAttribute("score", intType);
+      }
+    }
+    const p = new Post({ score: "42" });
+    expect(p.score).toBe(42);
+  });
+
+  it("define_attribute with default value", () => {
+    const adp = createTestAdapter();
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.adapter = adp;
+        this.defineAttribute("rating", intType, { default: 5 });
+      }
+    }
+    const p = new Post({});
+    expect(p.rating).toBe(5);
+  });
+
+  it("define_attribute preserves existing default when no default given", () => {
+    const adp = createTestAdapter();
+    const strType = typeRegistry.lookup("string");
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.adapter = adp;
+        this.defineAttribute("score", strType, { default: "10" });
+        this.defineAttribute("score", intType);
+      }
+    }
+    const p = new Post({});
+    expect(p.score).toBe(10);
+  });
+
+  it("define_attribute with userProvidedDefault false uses database cast", () => {
+    const adp = createTestAdapter();
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.adapter = adp;
+        this.defineAttribute("views", intType, { default: "0", userProvidedDefault: false });
+      }
+    }
+    const p = new Post({});
+    expect(p.views).toBe(0);
+  });
+
+  it("define_attribute invalidates _defaultAttributes cache", () => {
+    const adp = createTestAdapter();
+    const strType = typeRegistry.lookup("string");
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.adapter = adp;
+        this.defineAttribute("score", strType);
+      }
+    }
+    const before = Post._defaultAttributes();
+    Post.defineAttribute("score", intType);
+    const after = Post._defaultAttributes();
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("DefaultAttributesTest", () => {
+  it("_default_attributes returns an AttributeSet", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    const defaults = Post._defaultAttributes();
+    expect(typeof defaults.fetchValue).toBe("function");
+  });
+
+  it("_default_attributes includes declared attributes", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string", { default: "Untitled" });
+        this.adapter = adp;
+      }
+    }
+    const defaults = Post._defaultAttributes();
+    expect(defaults.fetchValue("title")).toBe("Untitled");
+  });
+
+  it("_default_attributes is cached", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    expect(Post._defaultAttributes()).toBe(Post._defaultAttributes());
+  });
+
+  it("_default_attributes cache is invalidated when attribute is defined", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    const first = Post._defaultAttributes();
+    Post.attribute("body", "string");
+    const second = Post._defaultAttributes();
+    expect(first).not.toBe(second);
+    expect(second.fetchValue("body")).toBeNull();
+  });
+
+  it("new record attributes are seeded from _default_attributes", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("status", "string", { default: "draft" });
+        this.adapter = adp;
+      }
+    }
+    const p = new Post({});
+    expect(p.status).toBe("draft");
   });
 });

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -11,6 +11,7 @@
 import { Attribute, AttributeSet, type Type } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import type { Base } from "./base.js";
+import { applyPendingEncryptions } from "./encryption.js";
 
 type AnyClass = any;
 
@@ -69,13 +70,18 @@ export function defineAttribute(
   const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
 
   this._attributeDefinitions.set(name, {
+    // Spread existing to preserve metadata fields (source, virtual, etc.)
+    // that other code paths (resetColumnInformation, schema reflection) rely on.
+    ...existing,
     name,
     type: castType,
     defaultValue: resolvedDefault ?? null,
     userProvided: userProvidedDefault,
+    source: userProvidedDefault ? "user" : "schema",
   });
 
   this._cachedDefaultAttributes = null;
+  applyPendingEncryptions(this);
 
   // Install prototype accessor so the attribute is readable/writable by name,
   // matching what applyColumnsHash does for schema-reflected columns.

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -81,6 +81,7 @@ export function defineAttribute(
   });
 
   this._cachedDefaultAttributes = null;
+  this._attributesBuilder = undefined;
   applyPendingEncryptions(this);
 
   // Install prototype accessor so the attribute is readable/writable by name,

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -9,6 +9,8 @@
  */
 
 import { Attribute, AttributeSet, type Type } from "@blazetrails/activemodel";
+import { isStiSubclass, getStiBase } from "./inheritance.js";
+import type { Base } from "./base.js";
 
 type AnyClass = any;
 
@@ -49,6 +51,14 @@ export function defineAttribute(
   castType: Type,
   options: { default?: unknown; userProvidedDefault?: boolean } = {},
 ): void {
+  // STI subclasses share the base's _attributeDefinitions — route to the
+  // base to avoid forking a subclass-local map that drifts from the base.
+  if (isStiSubclass(this as typeof Base)) {
+    const stiBase = getStiBase(this as typeof Base);
+    (stiBase as AnyClass).defineAttribute(name, castType, options);
+    return;
+  }
+
   const { default: defaultValue = NO_DEFAULT, userProvidedDefault = true } = options;
 
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
@@ -70,9 +80,11 @@ export function defineAttribute(
   // Install prototype accessor so the attribute is readable/writable by name,
   // matching what applyColumnsHash does for schema-reflected columns.
   if (this.prototype) {
-    if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
+    if (name === "id") {
       // Let Base.prototype.id (the CPK-aware getter) take precedence.
-      delete (this.prototype as Record<string, unknown>)["id"];
+      if (Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
+        delete (this.prototype as Record<string, unknown>)["id"];
+      }
     } else if (!Object.prototype.hasOwnProperty.call(this.prototype, name)) {
       Object.defineProperty(this.prototype, name, {
         get(this: { readAttribute(n: string): unknown }) {
@@ -100,8 +112,14 @@ export function defineAttribute(
  * Mirrors: ActiveRecord::Attributes::ClassMethods#_default_attributes
  */
 export function _defaultAttributes(this: AnyClass): AttributeSet {
-  if (!this._cachedDefaultAttributes) {
-    const defs: Map<string, AttributeDefinition> = this._attributeDefinitions;
+  // For STI subclasses, delegate to the STI base so cache invalidation
+  // from Base.attribute/defineAttribute (always routed to the base) is coherent.
+  const cacheHost = isStiSubclass(this as typeof Base)
+    ? (getStiBase(this as typeof Base) as AnyClass)
+    : this;
+
+  if (!cacheHost._cachedDefaultAttributes) {
+    const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attrMap = new Map<string, Attribute>();
 
     for (const [name, def] of defs) {
@@ -118,7 +136,7 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
       }
     }
 
-    this._cachedDefaultAttributes = new AttributeSet(attrMap);
+    cacheHost._cachedDefaultAttributes = new AttributeSet(attrMap);
   }
-  return this._cachedDefaultAttributes;
+  return cacheHost._cachedDefaultAttributes;
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -8,6 +8,17 @@
  * Mirrors: ActiveRecord::Attributes
  */
 
+import { Attribute, AttributeSet, type Type } from "@blazetrails/activemodel";
+
+type AnyClass = any;
+
+interface AttributeDefinition {
+  name: string;
+  type: Type;
+  defaultValue?: unknown;
+  userProvided?: boolean;
+}
+
 /**
  * Static interface for the Attributes module.
  *
@@ -15,4 +26,94 @@
  */
 export interface Attributes {
   attribute(name: string, type: string, options?: { default?: unknown }): void;
+  defineAttribute(
+    name: string,
+    castType: Type,
+    options?: { default?: unknown; userProvidedDefault?: boolean },
+  ): void;
+  _defaultAttributes(): AttributeSet;
+}
+
+const NO_DEFAULT = Symbol("NO_DEFAULT");
+
+/**
+ * Lower-level attribute registration that accepts a resolved type object
+ * directly, bypassing string-based type lookup. Used by adapters after
+ * `lookupCastTypeFromColumn` and by code that already has a type in hand.
+ *
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#define_attribute
+ */
+export function defineAttribute(
+  this: AnyClass,
+  name: string,
+  castType: Type,
+  options: { default?: unknown; userProvidedDefault?: boolean } = {},
+): void {
+  const { default: defaultValue = NO_DEFAULT, userProvidedDefault = true } = options;
+
+  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
+    this._attributeDefinitions = new Map(this._attributeDefinitions);
+  }
+
+  const existing: AttributeDefinition | undefined = this._attributeDefinitions.get(name);
+  const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
+
+  this._attributeDefinitions.set(name, {
+    name,
+    type: castType,
+    defaultValue: resolvedDefault ?? null,
+    userProvided: userProvidedDefault,
+  });
+
+  this._cachedDefaultAttributes = null;
+
+  // Install prototype accessor so the attribute is readable/writable by name,
+  // matching what applyColumnsHash does for schema-reflected columns.
+  if (this.prototype && !Object.prototype.hasOwnProperty.call(this.prototype, name)) {
+    Object.defineProperty(this.prototype, name, {
+      get(this: { readAttribute(n: string): unknown }) {
+        return this.readAttribute(name);
+      },
+      set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
+        this.writeAttribute(name, value);
+      },
+      configurable: true,
+    });
+  }
+}
+
+/**
+ * Build the AttributeSet that seeds every new record's `_attributes`.
+ *
+ * Rails seeds from `columns_hash` (with `Attribute.from_database` for each
+ * column default) then calls `apply_pending_attribute_modifications`. Our
+ * architecture merges those two steps: schema reflection populates
+ * `_attributeDefinitions` with column defaults and types, and this method
+ * converts that map into an `AttributeSet` using the same Attribute factory
+ * methods Rails uses. The result is semantically equivalent.
+ *
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#_default_attributes
+ */
+export function _defaultAttributes(this: AnyClass): AttributeSet {
+  if (!this._cachedDefaultAttributes) {
+    const defs: Map<string, AttributeDefinition> = this._attributeDefinitions;
+    const attrMap = new Map<string, Attribute>();
+
+    for (const [name, def] of defs) {
+      const userProvided = def.userProvided ?? true;
+      if (def.defaultValue != null) {
+        if (userProvided) {
+          const base = Attribute.withCastValue(name, null, def.type);
+          attrMap.set(name, base.withUserDefault(def.defaultValue));
+        } else {
+          attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
+        }
+      } else {
+        attrMap.set(name, Attribute.withCastValue(name, null, def.type));
+      }
+    }
+
+    this._cachedDefaultAttributes = new AttributeSet(attrMap);
+  }
+  return this._cachedDefaultAttributes;
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -69,16 +69,21 @@ export function defineAttribute(
 
   // Install prototype accessor so the attribute is readable/writable by name,
   // matching what applyColumnsHash does for schema-reflected columns.
-  if (this.prototype && !Object.prototype.hasOwnProperty.call(this.prototype, name)) {
-    Object.defineProperty(this.prototype, name, {
-      get(this: { readAttribute(n: string): unknown }) {
-        return this.readAttribute(name);
-      },
-      set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
-        this.writeAttribute(name, value);
-      },
-      configurable: true,
-    });
+  if (this.prototype) {
+    if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
+      // Let Base.prototype.id (the CPK-aware getter) take precedence.
+      delete (this.prototype as Record<string, unknown>)["id"];
+    } else if (!Object.prototype.hasOwnProperty.call(this.prototype, name)) {
+      Object.defineProperty(this.prototype, name, {
+        get(this: { readAttribute(n: string): unknown }) {
+          return this.readAttribute(name);
+        },
+        set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
+          this.writeAttribute(name, value);
+        },
+        configurable: true,
+      });
+    }
   }
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -45,6 +45,10 @@ import {
 } from "./encryption.js";
 import * as CounterCache from "./counter-cache.js";
 import * as ReadonlyAttributes from "./readonly-attributes.js";
+import {
+  defineAttribute as _defineAttribute,
+  _defaultAttributes as _arDefaultAttributes,
+} from "./attributes.js";
 import * as Timestamp from "./timestamp.js";
 import { Association as AssociationInstance } from "./associations/association.js";
 import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
@@ -771,6 +775,10 @@ export class Base extends Model {
   declare static isSharded: typeof ConnectionHandling.isSharded;
 
   // --- ModelSchema mixin (wired via extend() after class) ---
+  // Mirrors: ActiveRecord::Attributes
+  declare static defineAttribute: typeof _defineAttribute;
+  declare static _defaultAttributes: typeof _arDefaultAttributes;
+
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
   declare static columnNames: typeof ModelSchema.columnNames;
   declare static hasAttributeDefinition: typeof ModelSchema.hasAttributeDefinition;
@@ -2694,6 +2702,10 @@ extend(Base, {
   unscoped: _unscoped,
 });
 extend(Base, ModelSchema.ClassMethods);
+extend(Base, {
+  defineAttribute: _defineAttribute,
+  _defaultAttributes: _arDefaultAttributes,
+});
 
 include(Base, {
   // ReadonlyAttributes

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2440,12 +2440,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base.column_defaults
    */
   static get columnDefaults(): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const [name, def] of this._attributeDefinitions) {
-      result[name] =
-        typeof def.defaultValue === "function" ? def.defaultValue() : (def.defaultValue ?? null);
-    }
-    return result;
+    return this._defaultAttributes().deepDup().toHash();
   }
 
   // -- Strict loading class-level default --


### PR DESCRIPTION
## Summary

- **`defineAttribute(name, castType, options?)`** — lower-level class method accepting a resolved `Type` object directly. Bypasses string-based type lookup, registers the attribute in `_attributeDefinitions`, installs the prototype accessor, and invalidates the `_defaultAttributes` cache. Used by adapters after `lookupCastTypeFromColumn` and by code that already has a type object in hand. Mirrors `ActiveRecord::Attributes::ClassMethods#define_attribute` (attributes.rb:231).

- **`_defaultAttributes()`** — AR-level class method that converts `_attributeDefinitions` into an `AttributeSet`. Uses `Attribute.fromDatabase` for schema-sourced defaults and `Attribute.withUserDefault` for user-declared defaults — the same factory methods Rails uses. Semantically equivalent to Rails' `columns_hash → apply_pending_attribute_modifications` path (attributes.rb:241).

Both wired onto `Base` via `extend()`. `attributes.ts` → 0% → **100%** in `api:compare`.

## Test plan

- [ ] `pnpm run api:compare --package activerecord` — `attributes.rb` shows 100%
- [ ] `pnpm test` — all 615 test files pass; `attributes.test.ts` gains 10 new tests for `defineAttribute` and `_defaultAttributes`