### PR TITLE
feat(activerecord): SQLite3 Column#hasDefault, connection-handling gaps (PR L)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -340,6 +340,8 @@ async function performClassUpdate(
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
+  static readonly _isBaseClass = true;
+
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -340,8 +340,6 @@ async function performClassUpdate(
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
-  static readonly _isBaseClass = true;
-
   // --- Translation mixin (wired via extend() after class) ---
   declare static lookupAncestors: typeof Translation.lookupAncestors;
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -770,6 +770,10 @@ export class Base extends Model {
     (this as any)._connectionSpecificationName = name;
   }
   declare static isConnectedQ: typeof ConnectionHandling.isConnectedQ;
+  declare static isConnected: typeof ConnectionHandling.isConnected;
+  declare static connection: typeof ConnectionHandling.connection;
+  declare static isPrimaryClass: typeof ConnectionHandling.isPrimaryClass;
+  declare static adapterClass: typeof ConnectionHandling.adapterClass;
   declare static removeConnection: typeof ConnectionHandling.removeConnection;
   declare static schemaCache: typeof ConnectionHandling.schemaCache;
   declare static clearCacheBang: typeof ConnectionHandling.clearCacheBang;

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.test.ts
@@ -6,9 +6,15 @@ function makeColumn(options: {
   defaultValue?: unknown;
   generatedType?: "stored" | "virtual" | null;
 }): Column {
-  return new Column("col", options.defaultValue ?? null, new SqlTypeMetadata({ sqlType: "text" }), true, {
-    generatedType: options.generatedType,
-  });
+  return new Column(
+    "col",
+    options.defaultValue ?? null,
+    new SqlTypeMetadata({ sqlType: "text" }),
+    true,
+    {
+      generatedType: options.generatedType,
+    },
+  );
 }
 
 describe("SQLite3::Column#hasDefault", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { Column } from "./column.js";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
+
+function makeColumn(options: {
+  defaultValue?: unknown;
+  generatedType?: "stored" | "virtual" | null;
+}): Column {
+  return new Column("col", options.defaultValue ?? null, new SqlTypeMetadata({ sqlType: "text" }), true, {
+    generatedType: options.generatedType,
+  });
+}
+
+describe("SQLite3::Column#hasDefault", () => {
+  it("returns true for a regular column with a default value", () => {
+    const col = makeColumn({ defaultValue: "hello" });
+    expect(col.hasDefault).toBe(true);
+  });
+
+  it("returns false for a STORED generated column even with a default", () => {
+    const col = makeColumn({ defaultValue: "hello", generatedType: "stored" });
+    expect(col.isVirtual()).toBe(true);
+    expect(col.hasDefault).toBe(false);
+  });
+
+  it("returns false for a VIRTUAL generated column", () => {
+    const col = makeColumn({ generatedType: "virtual" });
+    expect(col.isVirtual()).toBe(true);
+    expect(col.hasDefault).toBe(false);
+  });
+
+  it("returns false for a non-virtual column with no default", () => {
+    const col = makeColumn({ defaultValue: null });
+    expect(col.hasDefault).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -51,4 +51,8 @@ export class Column extends BaseColumn {
   isVirtualStored(): boolean {
     return this.isVirtual() && this._generatedType === "stored";
   }
+
+  override get hasDefault(): boolean {
+    return super.hasDefault && !this.isVirtual();
+  }
 }

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -286,4 +286,39 @@ describe("ConnectionHandlingTest", () => {
     expect(currentRole.call(Base)).toBe("writing");
     expect(connectedToStack()).toHaveLength(0);
   });
+
+  it("#isConnected delegates to isConnectedQ", () => {
+    expect(Base.isConnected()).toBe(Base.isConnectedQ());
+  });
+
+  it("#connection leases a connection when none is active", () => {
+    const pool = Base.connectionPool();
+    expect(pool.activeConnection).toBeNull();
+    const conn = Base.connection();
+    expect(conn).toBeTruthy();
+    expect(pool.activeConnection).toBeTruthy();
+    Base.releaseConnection();
+  });
+
+  it("#connection returns the active connection inside withConnection", () => {
+    Base.withConnection((leased) => {
+      const conn = Base.connection();
+      expect(conn).toBe(leased);
+    });
+  });
+
+  it("#isPrimaryClass returns true for Base", () => {
+    expect(Base.isPrimaryClass()).toBe(true);
+  });
+
+  it("#isPrimaryClass returns false for a normal model subclass", () => {
+    class Post extends Base {}
+    expect(Post.isPrimaryClass()).toBe(false);
+  });
+
+  it("#adapterClass resolves to the SQLite3Adapter constructor", async () => {
+    const Klass = await Base.adapterClass();
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    expect(Klass).toBe(SQLite3Adapter);
+  });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -258,7 +258,7 @@ export function connection(this: typeof Base): DatabaseAdapter {
 }
 
 export function isPrimaryClass(this: typeof Base): boolean {
-  return coreIsApplicationRecordClass.call(this as any);
+  return (this as any)._isBaseClass === true || coreIsApplicationRecordClass.call(this as any);
 }
 
 export function adapterClass(this: typeof Base): Promise<new (...args: unknown[]) => unknown> {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -254,11 +254,13 @@ export function isConnectedQ(this: typeof Base): boolean {
 export const isConnected = isConnectedQ;
 
 export function connection(this: typeof Base): DatabaseAdapter {
-  return connectionPool.call(this).activeConnection ?? leaseConnection.call(this);
+  const pool = connectionPool.call(this);
+  if (pool.isPermanentLease()) return pool.leaseConnection();
+  return pool.activeConnection ?? pool.leaseConnection();
 }
 
 export function isPrimaryClass(this: typeof Base): boolean {
-  return (this as any)._isBaseClass === true || coreIsApplicationRecordClass.call(this as any);
+  return this.name === "Base" || coreIsApplicationRecordClass.call(this as any);
 }
 
 export function adapterClass(this: typeof Base): Promise<new (...args: unknown[]) => unknown> {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -263,8 +263,10 @@ export function isPrimaryClass(this: typeof Base): boolean {
   return this.name === "Base" || coreIsApplicationRecordClass.call(this as any);
 }
 
-export function adapterClass(this: typeof Base): Promise<new (...args: unknown[]) => unknown> {
-  return connectionPool.call(this).dbConfig.adapterClass();
+export function adapterClass(this: typeof Base): Promise<new (...args: any[]) => DatabaseAdapter> {
+  return connectionPool.call(this).dbConfig.adapterClass() as Promise<
+    new (...args: any[]) => DatabaseAdapter
+  >;
 }
 
 export function removeConnection(this: typeof Base): void {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -18,6 +18,7 @@ import {
   connectedToStack,
   currentRole as coreCurrentRole,
   currentShard as coreCurrentShard,
+  isApplicationRecordClass as coreIsApplicationRecordClass,
 } from "./core.js";
 import { getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
@@ -248,6 +249,20 @@ export function isConnectedQ(this: typeof Base): boolean {
     role: coreCurrentRole.call(this as any),
     shard: coreCurrentShard.call(this as any),
   });
+}
+
+export const isConnected = isConnectedQ;
+
+export function connection(this: typeof Base): DatabaseAdapter {
+  return connectionPool.call(this).activeConnection ?? leaseConnection.call(this);
+}
+
+export function isPrimaryClass(this: typeof Base): boolean {
+  return coreIsApplicationRecordClass.call(this as any);
+}
+
+export function adapterClass(this: typeof Base): Promise<new (...args: unknown[]) => unknown> {
+  return connectionPool.call(this).dbConfig.adapterClass();
 }
 
 export function removeConnection(this: typeof Base): void {
@@ -644,6 +659,10 @@ export const ClassMethods = {
   connectionPool,
   retrieveConnection,
   isConnectedQ,
+  isConnected,
+  connection,
+  isPrimaryClass,
+  adapterClass,
   removeConnection,
   schemaCache,
   clearCacheBang,


### PR DESCRIPTION
## Summary

- `connection-adapters/sqlite3/column.ts`: add `hasDefault` override — mirrors Rails' `SQLite3::Column#has_default?` which returns `super && !virtual?` (virtual columns never have a default)
- `connection-handling.ts`: add four missing methods:
  - `connection()` — returns the active connection or leases one, mirrors `Base.connection`
  - `isPrimaryClass()` — returns true for ApplicationRecord-style root classes, mirrors `Base.primary_class?`
  - `adapterClass()` — delegates to `connectionPool.dbConfig.adapterClass()`, mirrors `Base.adapter_class`
  - `isConnected` — alias for `isConnectedQ`, matches the `connected?` → `isConnected` naming convention