### PR TITLE
feat(activerecord): encryption binary? / encrypted? predicates

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -24,17 +24,18 @@ import type { EncryptorLike } from "./encryption/encryptor.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
- * If the encryptor implements `encrypted(text)` it will be consulted
+ * If the encryptor implements `isEncrypted(text)` it will be consulted
  * directly; otherwise the shim probes by calling `decrypt(text)` and
  * treats a non-throwing decrypt as encrypted (see
- * `LegacyEncryptorShim.encrypted`). Custom encryptors whose `decrypt`
+ * `LegacyEncryptorShim.isEncrypted`). Custom encryptors whose `decrypt`
  * accepts plaintext without throwing should also implement
- * `encrypted(text)` to avoid misclassification.
+ * `isEncrypted(text)` to avoid misclassification.
  */
 export interface Encryptor {
   encrypt(value: string): string;
   decrypt(ciphertext: string): string;
-  encrypted?(text: string): boolean;
+  isEncrypted?(text: string): boolean;
+  isBinary?(): boolean;
 }
 
 const ENCRYPTED_PREFIX = "AR_ENC:";
@@ -49,7 +50,7 @@ export const defaultEncryptor: Encryptor = {
     }
     return Buffer.from(ciphertext.slice(ENCRYPTED_PREFIX.length), "base64").toString("utf-8");
   },
-  encrypted(text: string): boolean {
+  isEncrypted(text: string): boolean {
     return typeof text === "string" && text.startsWith(ENCRYPTED_PREFIX);
   },
 };
@@ -60,13 +61,13 @@ export const defaultEncryptor: Encryptor = {
  * Options are intentionally ignored — the legacy path has no key provider
  * or deterministic mode.
  *
- * `encrypted()` is what `supportUnencryptedData` consults to distinguish
+ * `isEncrypted()` is what `supportUnencryptedData` consults to distinguish
  * ciphertext from plaintext on read. Returning the wrong answer is
  * critical in both directions: false positive and the shim decrypts
  * plaintext (may corrupt it); false negative and it skips decryption
  * for real ciphertext (returns garbage to the caller). Resolution order:
  *
- *   1. Delegate to `inner.encrypted(text)` if the user supplied one —
+ *   1. Delegate to `inner.isEncrypted(text)` if the user supplied one —
  *      this is the only reliable answer for custom encryptors.
  *   2. Otherwise, try `inner.decrypt(text)` and treat a throw as
  *      "not encrypted". Matches Rails' own
@@ -76,13 +77,13 @@ export const defaultEncryptor: Encryptor = {
  * Two caveats with the fallback path:
  *
  * - A custom encryptor whose `decrypt` is permissive (doesn't throw
- *   on plaintext) MUST supply `encrypted()` to avoid misclassification.
+ *   on plaintext) MUST supply `isEncrypted()` to avoid misclassification.
  * - When `supportUnencryptedData` is enabled, the scheme consults
- *   `encrypted()` before decrypting, so the fallback path runs
+ *   `isEncrypted()` before decrypting, so the fallback path runs
  *   `decrypt` once for the probe and once for real — roughly 2x the
  *   CPU. Rails avoids this by probing with `serializer.load` (cheap
  *   parse, no cipher), but the simple `{ encrypt, decrypt }` surface
- *   has no equivalent cheap probe. Supplying `encrypted()` eliminates
+ *   has no equivalent cheap probe. Supplying `isEncrypted()` eliminates
  *   the double work; consider doing so in perf-sensitive paths.
  */
 class LegacyEncryptorShim implements EncryptorLike {
@@ -96,14 +97,18 @@ class LegacyEncryptorShim implements EncryptorLike {
     return this.inner.decrypt(encryptedText);
   }
 
-  encrypted(text: string): boolean {
-    if (this.inner.encrypted) return this.inner.encrypted(text);
+  isEncrypted(text: string): boolean {
+    if (this.inner.isEncrypted) return this.inner.isEncrypted(text);
     try {
       this.inner.decrypt(text);
       return true;
     } catch {
       return false;
     }
+  }
+
+  isBinary(): boolean {
+    return this.inner.isBinary?.() ?? false;
   }
 }
 

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -85,9 +85,9 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return oldValue !== newValue;
   }
 
-  encrypted(value: unknown): boolean {
+  isEncrypted(value: unknown): boolean {
     if (typeof value !== "string") return false;
-    return this._encryptor.encrypted(value);
+    return this._encryptor.isEncrypted(value);
   }
 
   get deterministic(): boolean {
@@ -113,7 +113,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     if (value === null || value === undefined) return value;
     if (this._default !== undefined && this._default === value) return value;
 
-    if (this.supportUnencryptedData && !this.encrypted(value)) {
+    if (this.supportUnencryptedData && !this.isEncrypted(value)) {
       return value;
     }
 

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -73,8 +73,8 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     const enc = new Encryptor();
     const key = generateKey();
     const encrypted = enc.encrypt("hello", { key });
-    expect(enc.encrypted(encrypted)).toBe(true);
-    expect(enc.encrypted("plain text")).toBe(false);
+    expect(enc.isEncrypted(encrypted)).toBe(true);
+    expect(enc.isEncrypted("plain text")).toBe(false);
   });
 
   it.skip("decrypt respects encoding even when compression is used", () => {

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -65,6 +65,10 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     /* needs key provider integration with metadata */
   });
 
+  it("binary? returns false (delegates to the JSON serializer)", () => {
+    expect(new Encryptor().isBinary()).toBe(false);
+  });
+
   it("encrypted? returns whether the passed text is encrypted", () => {
     const enc = new Encryptor();
     const key = generateKey();

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -26,7 +26,8 @@ export interface EncryptorOptions {
 export interface EncryptorLike {
   encrypt(clearText: string, options?: Record<string, unknown>): string;
   decrypt(encryptedText: string, options?: Record<string, unknown>): string;
-  encrypted(text: string): boolean;
+  isEncrypted(text: string): boolean;
+  isBinary(): boolean;
 }
 
 export interface KeyProviderLike {
@@ -126,7 +127,7 @@ export class Encryptor {
     return decrypted;
   }
 
-  encrypted(text: string): boolean {
+  isEncrypted(text: string): boolean {
     try {
       this._serializer.load(text);
       return true;

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -134,4 +134,8 @@ export class Encryptor {
       return false;
     }
   }
+
+  isBinary(): boolean {
+    return this._serializer.isBinary();
+  }
 }

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
@@ -1,6 +1,11 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
 
 describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
+  it("binary? returns true", () => {
+    expect(new MessagePackMessageSerializer().isBinary()).toBe(true);
+  });
+
   it.skip("serializes messages", () => {});
   it.skip("serializes messages with nested messages in their headers", () => {});
   it.skip("detects random data and raises a decryption error", () => {});

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
 
 describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
-  it("binary? returns true", () => {
-    expect(new MessagePackMessageSerializer().isBinary()).toBe(true);
+  it("binary? returns false because this implementation uses JSON, not MessagePack binary", () => {
+    expect(new MessagePackMessageSerializer().isBinary()).toBe(false);
   });
 
   it.skip("serializes messages", () => {});

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -29,4 +29,8 @@ export class MessagePackMessageSerializer {
   load(serialized: string): Message {
     return this._fallback.load(serialized);
   }
+
+  isBinary(): boolean {
+    return true;
+  }
 }

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -30,7 +30,12 @@ export class MessagePackMessageSerializer {
     return this._fallback.load(serialized);
   }
 
+  // Rails returns true here because real MessagePack is binary.
+  // This implementation delegates to JSON, so false is correct for
+  // our current output format — the guard in EncryptedAttributeType
+  // that prevents binary data from being stored in text columns must
+  // not fire while we're producing JSON strings.
   isBinary(): boolean {
-    return true;
+    return this._fallback.isBinary();
   }
 }

--- a/packages/activerecord/src/encryption/message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-serializer.test.ts
@@ -66,6 +66,10 @@ describe("ActiveRecord::Encryption::MessageSerializerTest", () => {
     expect(() => serializer.dump("not a message" as any)).toThrow(ForbiddenClass);
   });
 
+  it("binary? returns false", () => {
+    expect(new MessageSerializer().isBinary()).toBe(false);
+  });
+
   it("raises Decryption when trying to parse message with more than one nested message", () => {
     const serializer = new MessageSerializer();
     const data = JSON.stringify({

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -86,4 +86,8 @@ export class MessageSerializer {
 
     return message;
   }
+
+  isBinary(): boolean {
+    return false;
+  }
 }

--- a/packages/activerecord/src/encryption/null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.test.ts
@@ -14,7 +14,7 @@ describe("ActiveRecord::Encryption::NullEncryptorTest", () => {
 
   it("encrypted? returns false", () => {
     const enc = new NullEncryptor();
-    expect(enc.encrypted("hello")).toBe(false);
+    expect(enc.isEncrypted("hello")).toBe(false);
   });
 
   it("binary? returns false", () => {

--- a/packages/activerecord/src/encryption/null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.test.ts
@@ -16,4 +16,8 @@ describe("ActiveRecord::Encryption::NullEncryptorTest", () => {
     const enc = new NullEncryptor();
     expect(enc.encrypted("hello")).toBe(false);
   });
+
+  it("binary? returns false", () => {
+    expect(new NullEncryptor().isBinary()).toBe(false);
+  });
 });

--- a/packages/activerecord/src/encryption/null-encryptor.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.ts
@@ -13,7 +13,7 @@ export class NullEncryptor {
     return encryptedText;
   }
 
-  encrypted(_text: string): boolean {
+  isEncrypted(_text: string): boolean {
     return false;
   }
 

--- a/packages/activerecord/src/encryption/null-encryptor.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.ts
@@ -16,4 +16,8 @@ export class NullEncryptor {
   encrypted(_text: string): boolean {
     return false;
   }
+
+  isBinary(): boolean {
+    return false;
+  }
 }

--- a/packages/activerecord/src/encryption/read-only-null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/read-only-null-encryptor.test.ts
@@ -12,4 +12,12 @@ describe("ActiveRecord::Encryption::ReadOnlyNullEncryptorTest", () => {
     const enc = new ReadOnlyNullEncryptor();
     expect(() => enc.encrypt("hello")).toThrow(EncryptionError);
   });
+
+  it("encrypted? returns false", () => {
+    expect(new ReadOnlyNullEncryptor().isEncrypted("hello")).toBe(false);
+  });
+
+  it("binary? returns false", () => {
+    expect(new ReadOnlyNullEncryptor().isBinary()).toBe(false);
+  });
 });

--- a/packages/activerecord/src/encryption/read-only-null-encryptor.ts
+++ b/packages/activerecord/src/encryption/read-only-null-encryptor.ts
@@ -14,4 +14,12 @@ export class ReadOnlyNullEncryptor {
   decrypt(encryptedText: string, _options?: Record<string, unknown>): string {
     return encryptedText;
   }
+
+  isEncrypted(_text: string): boolean {
+    return false;
+  }
+
+  isBinary(): boolean {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

- Adds \`isBinary()\` to \`NullEncryptor\`, \`ReadOnlyNullEncryptor\`, \`MessageSerializer\`, \`MessagePackMessageSerializer\`, and \`Encryptor\`
- Adds \`isEncrypted()\` to \`NullEncryptor\` and \`ReadOnlyNullEncryptor\` (mirrors Rails \`encrypted?\` — both return false)
- \`Encryptor#isBinary\` delegates to its serializer; \`MessageSerializer#isBinary\` returns \`false\` (JSON output); \`MessagePackMessageSerializer#isBinary\` also returns \`false\` because the current implementation delegates to the JSON serializer — it will return \`true\` once real MessagePack serialization is wired
- Renames \`encrypted()\` → \`isEncrypted()\` consistently: \`EncryptorLike\` interface, \`Encryptor\`, \`NullEncryptor\`, \`EncryptedAttributeType\`, and \`LegacyEncryptorShim\` — \`encrypted?\` is a Rails question-mark predicate and maps to \`is*\` in this codebase
- \`EncryptorLike\` interface gains both \`isEncrypted\` and \`isBinary\` so all typed encryptors expose the full surface
- Outer \`Encryptor\` interface (accepted by \`Base.encrypts\`) gains optional \`isBinary?()\`, removing the \`any\` cast in \`LegacyEncryptorShim\`
- One-liner test assertions added to each class

## Test plan

- [x] All 5 test files pass with new assertions
- [x] \`pnpm api:compare -- --package activerecord\` shows \`null_encryptor\`, \`read_only_null_encryptor\`, \`message_serializer\`, \`message_pack_message_serializer\`, \`encryptor\` all at 100%
- [x] \`pnpm tsc --noEmit\` clean

Part of the encryption 100% series (PR 1/12). Stacked: #726 → #727 → #728.