### PR TITLE
feat(activerecord): Encryptor compression surface — compressor reader, isCompress

### DIFF
--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -65,6 +65,11 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     /* needs key provider integration with metadata */
   });
 
+  it("compress? returns the compress setting", () => {
+    expect(new Encryptor({ compress: true }).isCompress()).toBe(true);
+    expect(new Encryptor({ compress: false }).isCompress()).toBe(false);
+  });
+
   it("binary? returns false (delegates to the JSON serializer)", () => {
     expect(new Encryptor().isBinary()).toBe(false);
   });
@@ -81,7 +86,28 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     /* needs encoding preservation in compression */
   });
 
-  it.skip("accept a custom compressor", () => {
-    /* needs compressor option wiring */
+  it("accept a custom compressor", () => {
+    const originalText = "x".repeat(1000);
+    const compressedMagic = "COMPRESSED";
+    let deflated = false;
+    let inflated = false;
+    const customCompressor = {
+      deflate(_data: string) {
+        deflated = true;
+        return Buffer.from(compressedMagic, "utf-8");
+      },
+      inflate(_data: Buffer) {
+        inflated = true;
+        return originalText;
+      },
+    };
+    const enc = new Encryptor({ compress: true, compressor: customCompressor });
+    expect(enc.compressor).toBe(customCompressor);
+    const key = generateKey();
+    const encrypted = enc.encrypt(originalText, { key });
+    const decrypted = enc.decrypt(encrypted, { key });
+    expect(decrypted).toBe(originalText);
+    expect(deflated).toBe(true);
+    expect(inflated).toBe(true);
   });
 });

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -139,4 +139,12 @@ export class Encryptor {
   isBinary(): boolean {
     return this._serializer.isBinary();
   }
+
+  get compressor(): Compressor {
+    return this._compressor;
+  }
+
+  isCompress(): boolean {
+    return this._compress;
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `compressor` getter and `isCompress()` to `Encryptor`, mirroring Rails' `attr_reader :compressor` and `compress?`
- Unskips the "accept a custom compressor" test with a real implementation

## Test plan

- [ ] `encryptor.test.ts` passes with custom compressor test unskipped
- [ ] `pnpm api:compare -- --package activerecord` shows `encryptor.rb` at 100%

Stacks on #725. Part of encryption 100% series (PR 2/12).