### PR TITLE
feat(activerecord): Scheme — merge, withContext, isCompatibleWith, isSupportUnencryptedData, isFixed

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -139,7 +139,8 @@ function buildScheme(options: EncryptsOptions): Scheme {
     schemeOptions.ignoreCase !== undefined ||
     schemeOptions.previousSchemes !== undefined ||
     schemeOptions.compress !== undefined ||
-    schemeOptions.compressor !== undefined;
+    schemeOptions.compressor !== undefined ||
+    schemeOptions.supportUnencryptedData !== undefined;
 
   if (hasSchemeOptions) {
     return new Scheme(schemeOptions);

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -142,6 +142,8 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   get supportUnencryptedData(): boolean {
     if (this._previousType) return false;
-    return Configurable.config.supportUnencryptedData ?? false;
+    return (
+      Configurable.config.supportUnencryptedData === true && this.scheme.isSupportUnencryptedData()
+    );
   }
 }

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Scheme } from "./scheme.js";
 import { ConfigError } from "./errors.js";
+import { Configurable } from "./configurable.js";
+import { getEncryptionContext } from "./context.js";
 
 describe("ActiveRecord::Encryption::SchemeTest", () => {
   it("validates config options when using encrypted attributes", () => {
@@ -20,5 +22,94 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
   it("should create a encryptor well when compress is false", () => {
     const scheme = new Scheme({ compress: false });
     expect(scheme.encryptor).toBeTruthy();
+  });
+
+  describe("isSupportUnencryptedData", () => {
+    let originalValue: boolean;
+    beforeEach(() => {
+      originalValue = Configurable.config.supportUnencryptedData;
+      Configurable.config.supportUnencryptedData = false;
+    });
+    afterEach(() => {
+      Configurable.config.supportUnencryptedData = originalValue;
+    });
+
+    it("falls back to config when not set on the scheme", () => {
+      expect(new Scheme().isSupportUnencryptedData()).toBe(false);
+      Configurable.config.supportUnencryptedData = true;
+      expect(new Scheme().isSupportUnencryptedData()).toBe(true);
+    });
+
+    it("uses the scheme-level override when set", () => {
+      expect(new Scheme({ supportUnencryptedData: true }).isSupportUnencryptedData()).toBe(true);
+      expect(new Scheme({ supportUnencryptedData: false }).isSupportUnencryptedData()).toBe(false);
+    });
+  });
+
+  it("isFixed returns true for deterministic schemes", () => {
+    expect(new Scheme({ deterministic: true }).isFixed()).toBe(true);
+    expect(new Scheme({ deterministic: false }).isFixed()).toBe(false);
+  });
+
+  it("merge produces a new scheme with overridden options", () => {
+    const base = new Scheme({ deterministic: true });
+    const override = new Scheme({ downcase: true, deterministic: true });
+    const merged = base.merge(override);
+    expect(merged.deterministic).toBe(true);
+    expect(merged.downcase).toBe(true);
+  });
+
+  it("merge allows overriding deterministic: true with deterministic: false", () => {
+    const base = new Scheme({ deterministic: true });
+    const override = new Scheme({ deterministic: false });
+    const merged = base.merge(override);
+    expect(merged.deterministic).toBe(false);
+  });
+
+  it("merge preserves an explicit encryptor from the base scheme", () => {
+    const customEncryptor = {
+      encrypt: (v: string) => v,
+      decrypt: (v: string) => v,
+      isEncrypted: () => false,
+      isBinary: () => false,
+    };
+    const base = new Scheme({ encryptor: customEncryptor });
+    const override = new Scheme({ deterministic: true });
+    const merged = base.merge(override);
+    expect(merged.encryptor).toBe(customEncryptor);
+  });
+
+  it("withContext calls block directly when no context properties are set", () => {
+    const scheme = new Scheme();
+    let ran = false;
+    scheme.withContext(() => {
+      ran = true;
+      expect(getEncryptionContext().encryptor).toBeUndefined();
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("withContext runs the callback with the scheme encryptor in context", () => {
+    const customEncryptor = {
+      encrypt: (v: string) => v,
+      decrypt: (v: string) => v,
+      isEncrypted: () => false,
+      isBinary: () => false,
+    };
+    const scheme = new Scheme({ encryptor: customEncryptor });
+    let encryptorInContext: unknown;
+    scheme.withContext(() => {
+      encryptorInContext = getEncryptionContext().encryptor;
+    });
+    expect(encryptorInContext).toBe(customEncryptor);
+    expect(getEncryptionContext().encryptor).toBeUndefined();
+  });
+
+  it("isCompatibleWith returns true when deterministic flags match", () => {
+    const a = new Scheme({ deterministic: true });
+    const b = new Scheme({ deterministic: true });
+    const c = new Scheme({ deterministic: false });
+    expect(a.isCompatibleWith(b)).toBe(true);
+    expect(a.isCompatibleWith(c)).toBe(false);
   });
 });

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -7,11 +7,14 @@
 import { Encryptor, type EncryptorLike } from "./encryptor.js";
 import { ConfigError } from "./errors.js";
 import type { Compressor } from "./config.js";
+import { Configurable } from "./configurable.js";
+import { withEncryptionContext } from "./context.js";
 
 export interface SchemeOptions {
   keyProvider?: unknown;
   key?: string;
   deterministic?: boolean;
+  supportUnencryptedData?: boolean;
   downcase?: boolean;
   ignoreCase?: boolean;
   previousSchemes?: Scheme[];
@@ -27,9 +30,14 @@ export class Scheme {
   downcase: boolean;
   ignoreCase: boolean;
   previousSchemes: Scheme[];
-  private _encryptor?: EncryptorLike;
+  private _encryptor: EncryptorLike;
+  // Original options as-passed — used by _toOptions() / merge() to distinguish
+  // "not set" (undefined) from "explicitly set to false", mirroring Rails'
+  // @context_properties + nil-defaulted ivars + to_h.compact pattern.
+  private _opts: SchemeOptions;
 
   constructor(options: SchemeOptions = {}) {
+    this._opts = { ...options };
     this.keyProvider = options.keyProvider;
     this.key = options.key;
     this.deterministic = options.deterministic ?? false;
@@ -50,7 +58,48 @@ export class Scheme {
   }
 
   get encryptor(): EncryptorLike {
-    return this._encryptor!;
+    return this._encryptor;
+  }
+
+  isSupportUnencryptedData(): boolean {
+    return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
+  }
+
+  isFixed(): boolean {
+    return this.deterministic;
+  }
+
+  merge(other: Scheme): Scheme {
+    return new Scheme({ ...this._toOptions(), ...other._toOptions() });
+  }
+
+  withContext<T>(fn: () => T): T {
+    const { encryptor, compress, compressor } = this._opts;
+    if (encryptor !== undefined || compress === false || compressor !== undefined) {
+      return withEncryptionContext({ encryptor: this._encryptor }, fn);
+    }
+    return fn();
+  }
+
+  isCompatibleWith(other: Scheme): boolean {
+    return this.deterministic === other.deterministic;
+  }
+
+  private _toOptions(): SchemeOptions {
+    const o = this._opts;
+    const opts: SchemeOptions = {};
+    if (o.keyProvider !== undefined) opts.keyProvider = o.keyProvider;
+    if (o.key !== undefined) opts.key = o.key;
+    if (o.deterministic !== undefined) opts.deterministic = o.deterministic;
+    if (o.downcase !== undefined) opts.downcase = o.downcase;
+    if (o.ignoreCase !== undefined) opts.ignoreCase = o.ignoreCase;
+    if (o.previousSchemes !== undefined) opts.previousSchemes = o.previousSchemes;
+    if (o.supportUnencryptedData !== undefined)
+      opts.supportUnencryptedData = o.supportUnencryptedData;
+    if (o.compress !== undefined) opts.compress = o.compress;
+    if (o.compressor !== undefined) opts.compressor = o.compressor;
+    if (o.encryptor !== undefined) opts.encryptor = o.encryptor;
+    return opts;
   }
 
   private _validate(): void {


### PR DESCRIPTION
## Summary

- \`isSupportUnencryptedData()\` — falls back to \`Configurable.config.supportUnencryptedData\` when not set on the scheme; \`EncryptedAttributeType#supportUnencryptedData\` now delegates to \`scheme.isSupportUnencryptedData()\` per Rails (\`config.support_unencrypted_data && scheme.support_unencrypted_data? && !previous_type?\`)
- \`isFixed()\` — true for deterministic schemes
- \`merge(other)\` — returns a new Scheme with \`other\`'s explicitly-set options overlaid; uses \`_opts\` (shallow-copied in constructor) so \`false\` correctly overrides \`true\`, and explicit encryptors round-trip correctly
- \`withContext(fn)\` — mirrors Rails: only pushes a context frame when the scheme has non-default context properties (explicit encryptor, \`compress: false\`, or custom compressor); calls \`fn()\` directly otherwise
- \`isCompatibleWith(other)\` — schemes are compatible iff their \`deterministic\` flags match
- \`SchemeOptions\` gains \`supportUnencryptedData\`, and the \`hasSchemeOptions\` check in \`buildScheme\` now includes it so \`encrypts({ supportUnencryptedData: true })\` routes through a configured \`Scheme\`

## Test plan

- [x] All scheme tests pass (12 tests including merge/false-override, withContext push/no-push, encryptor preservation)
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm api:compare -- --package activerecord\` shows \`scheme.rb\` at 100%