### PR TITLE
feat(activerecord): ExtendedDeterministicQueries — where, isExists, scopeForCreate, findBy

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -139,7 +139,8 @@ function buildScheme(options: EncryptsOptions): Scheme {
     schemeOptions.ignoreCase !== undefined ||
     schemeOptions.previousSchemes !== undefined ||
     schemeOptions.compress !== undefined ||
-    schemeOptions.compressor !== undefined;
+    schemeOptions.compressor !== undefined ||
+    schemeOptions.supportUnencryptedData !== undefined;
 
   if (hasSchemeOptions) {
     return new Scheme(schemeOptions);

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -142,6 +142,6 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   get supportUnencryptedData(): boolean {
     if (this._previousType) return false;
-    return Configurable.config.supportUnencryptedData ?? false;
+    return Configurable.config.supportUnencryptedData && this.scheme.isSupportUnencryptedData();
   }
 }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,4 +1,36 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import {
+  AdditionalValue,
+  CoreQueries,
+  EncryptedQuery,
+  RelationQueries,
+} from "./extended-deterministic-queries.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+
+function fakeType(
+  opts: { deterministic?: boolean; previousTypes?: EncryptedAttributeType[] } = {},
+) {
+  const t = Object.create(EncryptedAttributeType.prototype) as EncryptedAttributeType;
+  Object.defineProperty(t, "deterministic", { value: opts.deterministic ?? true });
+  Object.defineProperty(t, "previousTypes", { value: opts.previousTypes ?? [] });
+  Object.defineProperty(t, "supportUnencryptedData", { value: false });
+  (t as any).serialize = (v: unknown) => v;
+  return t;
+}
+
+function fakeModel(attrs: Record<string, EncryptedAttributeType>) {
+  return {
+    _encryptedAttributes: new Set(Object.keys(attrs)),
+    _attributeDefinitions: new Map(Object.entries(attrs).map(([n, type]) => [n, { type }])),
+  };
+}
+
+function fakeRelation(model: any, whereHash: Record<string, unknown> = {}) {
+  return {
+    model,
+    whereValuesHash: () => whereHash,
+  };
+}
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
   it.skip("Finds records when data is unencrypted", () => {});
@@ -13,4 +45,131 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
   it.skip("If support_unencrypted_data is opted out at the attribute level, can find encrypted data", () => {});
   it.skip("If support_unencrypted_data is opted in at the attribute level, can find unencrypted data", () => {});
   it.skip("If support_unencrypted_data is opted in at the attribute level, can find encrypted data", () => {});
+
+  describe("EncryptedQuery.processArguments", () => {
+    it("returns args unchanged when model has no deterministic encrypted attributes", () => {
+      const model = fakeModel({ email: fakeType({ deterministic: false }) });
+      const args = [{ email: "a@b" }];
+      expect(EncryptedQuery.processArguments(model, args, true)).toBe(args);
+    });
+
+    it("returns args unchanged when attribute has no previous types", () => {
+      const model = fakeModel({ email: fakeType({ previousTypes: [] }) });
+      const args = [{ email: "a@b" }];
+      expect(EncryptedQuery.processArguments(model, args, true)).toBe(args);
+    });
+
+    it("expands plaintext into [current, previous] AdditionalValue list", () => {
+      const prev = fakeType();
+      const model = fakeModel({ email: fakeType({ previousTypes: [prev] }) });
+      const args = [{ email: "a@b" }];
+      const [out] = EncryptedQuery.processArguments(model, args, true) as [
+        Record<string, unknown[]>,
+      ];
+      expect(out.email).toHaveLength(2);
+      expect(out.email[0]).toBeInstanceOf(AdditionalValue);
+      expect(out.email[1]).toBeInstanceOf(AdditionalValue);
+    });
+
+    it("unwraps a Relation via its .model getter", () => {
+      const prev = fakeType();
+      const model = fakeModel({ email: fakeType({ previousTypes: [prev] }) });
+      const relation = fakeRelation(model);
+      const [out] = EncryptedQuery.processArguments(relation, [{ email: "x" }], true) as [
+        Record<string, unknown[]>,
+      ];
+      expect(out.email).toHaveLength(2);
+    });
+  });
+
+  describe("RelationQueries.scopeForCreate", () => {
+    it("returns original scope when no encrypted attributes", () => {
+      const rel = fakeRelation({
+        _encryptedAttributes: new Set<string>(),
+        _attributeDefinitions: new Map(),
+      });
+      const original = () => ({ foo: "bar" });
+      expect(RelationQueries.scopeForCreate(original, rel)).toEqual({ foo: "bar" });
+    });
+
+    it("strips AdditionalValue trailers to the plaintext for deterministic attrs", () => {
+      const type = fakeType();
+      const model = fakeModel({ email: type });
+      const rel = fakeRelation(model, {
+        email: ["plain@x", new AdditionalValue("plain@x", type)],
+      });
+      const original = () => ({ other: "untouched" });
+      const out = RelationQueries.scopeForCreate(original, rel);
+      expect(out).toEqual({ other: "untouched", email: "plain@x" });
+    });
+
+    it("accepts single-element arrays (Rails: values[1..].all? on [] is true)", () => {
+      const type = fakeType();
+      const model = fakeModel({ email: type });
+      const rel = fakeRelation(model, { email: ["only"] });
+      const out = RelationQueries.scopeForCreate(() => ({}), rel);
+      expect(out).toEqual({ email: "only" });
+    });
+
+    it("ignores entries whose trailers are not all AdditionalValue", () => {
+      const type = fakeType();
+      const model = fakeModel({ email: type });
+      const rel = fakeRelation(model, { email: ["plain@x", "not-additional"] });
+      const out = RelationQueries.scopeForCreate(() => ({}), rel);
+      expect(out).toEqual({});
+    });
+
+    it("ignores non-deterministic encrypted attributes", () => {
+      const type = fakeType({ deterministic: false });
+      const model = fakeModel({ secret: type });
+      const rel = fakeRelation(model, {
+        secret: ["plain", new AdditionalValue("plain", type)],
+      });
+      const out = RelationQueries.scopeForCreate(() => ({ keep: 1 }), rel);
+      expect(out).toEqual({ keep: 1 });
+    });
+  });
+
+  describe("RelationQueries.where / isExists", () => {
+    it("forwards processed args to the original where", () => {
+      const prev = fakeType();
+      const model = fakeModel({ email: fakeType({ previousTypes: [prev] }) });
+      const rel = fakeRelation(model);
+      let received: unknown[] = [];
+      const original = function (this: unknown, ...a: unknown[]) {
+        received = a;
+        return "result";
+      };
+      const ret = RelationQueries.where(original, rel, [{ email: "x" }]);
+      expect(ret).toBe("result");
+      expect((received[0] as any).email).toHaveLength(2);
+    });
+
+    it("forwards processed args to the original exists?", () => {
+      const prev = fakeType();
+      const model = fakeModel({ email: fakeType({ previousTypes: [prev] }) });
+      const rel = fakeRelation(model);
+      let received: unknown[] = [];
+      const original = function (this: unknown, ...a: unknown[]) {
+        received = a;
+        return true;
+      };
+      RelationQueries.isExists(original, rel, [{ email: "x" }]);
+      expect((received[0] as any).email).toHaveLength(2);
+    });
+  });
+
+  describe("CoreQueries.findBy", () => {
+    it("forwards processed args to the original findBy (checkForAdditionalValues=false)", () => {
+      const prev = fakeType();
+      const klass = fakeModel({ email: fakeType({ previousTypes: [prev] }) });
+      let received: unknown[] = [];
+      const original = function (this: unknown, ...a: unknown[]) {
+        received = a;
+        return "rec";
+      };
+      CoreQueries.findBy(original, klass, [{ email: "x" }]);
+      expect((received[0] as any).email).toHaveLength(2);
+    });
+  });
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,5 +1,9 @@
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
-import { getAttributeType } from "./encryptable-record.js";
+import { EncryptableRecord, getAttributeType } from "./encryptable-record.js";
+
+function modelFor(owner: any): any {
+  return typeof owner?.model !== "undefined" && owner.model !== owner ? owner.model : owner;
+}
 
 /**
  * Automatically expands encrypted arguments to support querying both
@@ -31,9 +35,9 @@ export class EncryptedQuery {
     args: unknown[],
     checkForAdditionalValues: boolean,
   ): unknown[] {
-    const model = owner._modelClass ?? owner;
-    const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
-    if (!encryptedAttrs?.size) return args;
+    const model = modelFor(owner);
+    const deterministicAttrs = EncryptableRecord.deterministicEncryptedAttributes(model);
+    if (!deterministicAttrs.size) return args;
 
     if (!Array.isArray(args) || args.length === 0) return args;
     const options = args[0];
@@ -42,10 +46,9 @@ export class EncryptedQuery {
     const result = { ...options } as Record<string, unknown>;
     let modified = false;
 
-    for (const attrName of encryptedAttrs) {
+    for (const attrName of deterministicAttrs) {
       const type = getAttributeType(model, attrName);
       if (!(type instanceof EncryptedAttributeType)) continue;
-      if (!type.deterministic) continue;
       if (!type.previousTypes.length) continue;
       const value = result[attrName];
       if (value === undefined) continue;
@@ -106,17 +109,16 @@ export class RelationQueries {
     originalScopeForCreate: () => Record<string, unknown>,
     relation: any,
   ): Record<string, unknown> {
-    const model = relation._modelClass ?? relation;
-    const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
-    if (!encryptedAttrs?.size) return originalScopeForCreate.call(relation);
+    const model = modelFor(relation);
+    const deterministicAttrs = EncryptableRecord.deterministicEncryptedAttributes(model);
+    if (!deterministicAttrs.size) return originalScopeForCreate.call(relation);
 
     const scopeAttrs = originalScopeForCreate.call(relation);
-    const wheres = relation.whereValuesHash?.() ?? {};
-    for (const attrName of encryptedAttrs) {
+    const wheres = relation.whereValuesHash();
+    for (const attrName of deterministicAttrs) {
       const values = wheres[attrName];
       if (
         Array.isArray(values) &&
-        values.length > 1 &&
         values.slice(1).every((v: unknown) => v instanceof AdditionalValue)
       ) {
         scopeAttrs[attrName] = values[0];

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -88,18 +88,41 @@ export class EncryptedQuery {
 }
 
 /**
- * Mixin that patches Relation#where and Relation#exists? to expand
- * encrypted query arguments via EncryptedQuery.processArguments.
+ * Mixin that patches Relation#where, #exists?, and #scope_for_create to
+ * expand encrypted query arguments via EncryptedQuery.processArguments.
  *
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQueries
  */
 export class RelationQueries {
-  static patchWhere(originalWhere: Function, relation: any, args: unknown[]): unknown {
+  static where(originalWhere: Function, relation: any, args: unknown[]): unknown {
     return originalWhere.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
   }
 
-  static patchExists(originalExists: Function, relation: any, args: unknown[]): unknown {
+  static isExists(originalExists: Function, relation: any, args: unknown[]): unknown {
     return originalExists.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
+  }
+
+  static scopeForCreate(
+    originalScopeForCreate: () => Record<string, unknown>,
+    relation: any,
+  ): Record<string, unknown> {
+    const model = relation._modelClass ?? relation;
+    const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
+    if (!encryptedAttrs?.size) return originalScopeForCreate.call(relation);
+
+    const scopeAttrs = originalScopeForCreate.call(relation);
+    const wheres = relation.whereValuesHash?.() ?? {};
+    for (const attrName of encryptedAttrs) {
+      const values = wheres[attrName];
+      if (
+        Array.isArray(values) &&
+        values.length > 1 &&
+        values.slice(1).every((v: unknown) => v instanceof AdditionalValue)
+      ) {
+        scopeAttrs[attrName] = values[0];
+      }
+    }
+    return scopeAttrs;
   }
 }
 
@@ -109,7 +132,7 @@ export class RelationQueries {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::CoreQueries
  */
 export class CoreQueries {
-  static patchFindBy(originalFindBy: Function, klass: any, args: unknown[]): unknown {
+  static findBy(originalFindBy: Function, klass: any, args: unknown[]): unknown {
     return originalFindBy.call(klass, ...EncryptedQuery.processArguments(klass, args, false));
   }
 }

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Scheme } from "./scheme.js";
 import { ConfigError } from "./errors.js";
+import { Configurable } from "./configurable.js";
+import { getEncryptionContext } from "./context.js";
 
 describe("ActiveRecord::Encryption::SchemeTest", () => {
   it("validates config options when using encrypted attributes", () => {
@@ -20,5 +22,94 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
   it("should create a encryptor well when compress is false", () => {
     const scheme = new Scheme({ compress: false });
     expect(scheme.encryptor).toBeTruthy();
+  });
+
+  describe("isSupportUnencryptedData", () => {
+    let originalValue: boolean;
+    beforeEach(() => {
+      originalValue = Configurable.config.supportUnencryptedData;
+      Configurable.config.supportUnencryptedData = false;
+    });
+    afterEach(() => {
+      Configurable.config.supportUnencryptedData = originalValue;
+    });
+
+    it("falls back to config when not set on the scheme", () => {
+      expect(new Scheme().isSupportUnencryptedData()).toBe(false);
+      Configurable.config.supportUnencryptedData = true;
+      expect(new Scheme().isSupportUnencryptedData()).toBe(true);
+    });
+
+    it("uses the scheme-level override when set", () => {
+      expect(new Scheme({ supportUnencryptedData: true }).isSupportUnencryptedData()).toBe(true);
+      expect(new Scheme({ supportUnencryptedData: false }).isSupportUnencryptedData()).toBe(false);
+    });
+  });
+
+  it("isFixed returns true for deterministic schemes", () => {
+    expect(new Scheme({ deterministic: true }).isFixed()).toBe(true);
+    expect(new Scheme({ deterministic: false }).isFixed()).toBe(false);
+  });
+
+  it("merge produces a new scheme with overridden options", () => {
+    const base = new Scheme({ deterministic: true });
+    const override = new Scheme({ downcase: true, deterministic: true });
+    const merged = base.merge(override);
+    expect(merged.deterministic).toBe(true);
+    expect(merged.downcase).toBe(true);
+  });
+
+  it("merge allows overriding deterministic: true with deterministic: false", () => {
+    const base = new Scheme({ deterministic: true });
+    const override = new Scheme({ deterministic: false });
+    const merged = base.merge(override);
+    expect(merged.deterministic).toBe(false);
+  });
+
+  it("merge preserves an explicit encryptor from the base scheme", () => {
+    const customEncryptor = {
+      encrypt: (v: string) => v,
+      decrypt: (v: string) => v,
+      isEncrypted: () => false,
+      isBinary: () => false,
+    };
+    const base = new Scheme({ encryptor: customEncryptor });
+    const override = new Scheme({ deterministic: true });
+    const merged = base.merge(override);
+    expect(merged.encryptor).toBe(customEncryptor);
+  });
+
+  it("withContext calls block directly when no context properties are set", () => {
+    const scheme = new Scheme();
+    let ran = false;
+    scheme.withContext(() => {
+      ran = true;
+      expect(getEncryptionContext().encryptor).toBeUndefined();
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("withContext runs the callback with the scheme encryptor in context", () => {
+    const customEncryptor = {
+      encrypt: (v: string) => v,
+      decrypt: (v: string) => v,
+      isEncrypted: () => false,
+      isBinary: () => false,
+    };
+    const scheme = new Scheme({ encryptor: customEncryptor });
+    let encryptorInContext: unknown;
+    scheme.withContext(() => {
+      encryptorInContext = getEncryptionContext().encryptor;
+    });
+    expect(encryptorInContext).toBe(customEncryptor);
+    expect(getEncryptionContext().encryptor).toBeUndefined();
+  });
+
+  it("isCompatibleWith returns true when deterministic flags match", () => {
+    const a = new Scheme({ deterministic: true });
+    const b = new Scheme({ deterministic: true });
+    const c = new Scheme({ deterministic: false });
+    expect(a.isCompatibleWith(b)).toBe(true);
+    expect(a.isCompatibleWith(c)).toBe(false);
   });
 });

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -7,11 +7,14 @@
 import { Encryptor, type EncryptorLike } from "./encryptor.js";
 import { ConfigError } from "./errors.js";
 import type { Compressor } from "./config.js";
+import { Configurable } from "./configurable.js";
+import { withEncryptionContext } from "./context.js";
 
 export interface SchemeOptions {
   keyProvider?: unknown;
   key?: string;
   deterministic?: boolean;
+  supportUnencryptedData?: boolean;
   downcase?: boolean;
   ignoreCase?: boolean;
   previousSchemes?: Scheme[];
@@ -27,9 +30,14 @@ export class Scheme {
   downcase: boolean;
   ignoreCase: boolean;
   previousSchemes: Scheme[];
-  private _encryptor?: EncryptorLike;
+  private _encryptor: EncryptorLike;
+  // Original options as-passed — used by _toOptions() / merge() to distinguish
+  // "not set" (undefined) from "explicitly set to false", mirroring Rails'
+  // @context_properties + nil-defaulted ivars + to_h.compact pattern.
+  private _opts: SchemeOptions;
 
   constructor(options: SchemeOptions = {}) {
+    this._opts = { ...options };
     this.keyProvider = options.keyProvider;
     this.key = options.key;
     this.deterministic = options.deterministic ?? false;
@@ -50,7 +58,48 @@ export class Scheme {
   }
 
   get encryptor(): EncryptorLike {
-    return this._encryptor!;
+    return this._encryptor;
+  }
+
+  isSupportUnencryptedData(): boolean {
+    return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
+  }
+
+  isFixed(): boolean {
+    return this.deterministic;
+  }
+
+  merge(other: Scheme): Scheme {
+    return new Scheme({ ...this._toOptions(), ...other._toOptions() });
+  }
+
+  withContext<T>(fn: () => T): T {
+    const { encryptor, compress, compressor } = this._opts;
+    if (encryptor !== undefined || compress === false || compressor !== undefined) {
+      return withEncryptionContext({ encryptor: this._encryptor }, fn);
+    }
+    return fn();
+  }
+
+  isCompatibleWith(other: Scheme): boolean {
+    return this.deterministic === other.deterministic;
+  }
+
+  private _toOptions(): SchemeOptions {
+    const o = this._opts;
+    const opts: SchemeOptions = {};
+    if (o.keyProvider !== undefined) opts.keyProvider = o.keyProvider;
+    if (o.key !== undefined) opts.key = o.key;
+    if (o.deterministic !== undefined) opts.deterministic = o.deterministic;
+    if (o.downcase !== undefined) opts.downcase = o.downcase;
+    if (o.ignoreCase !== undefined) opts.ignoreCase = o.ignoreCase;
+    if (o.previousSchemes !== undefined) opts.previousSchemes = o.previousSchemes;
+    if (o.supportUnencryptedData !== undefined)
+      opts.supportUnencryptedData = o.supportUnencryptedData;
+    if (o.compress !== undefined) opts.compress = o.compress;
+    if (o.compressor !== undefined) opts.compressor = o.compressor;
+    if (o.encryptor !== undefined) opts.encryptor = o.encryptor;
+    return opts;
   }
 
   private _validate(): void {


### PR DESCRIPTION
## Summary

- Renames `patchWhere` → `where`, `patchExists` → `isExists`, `patchFindBy` → `findBy` to match Rails method names
- Adds `scopeForCreate` to `RelationQueries`: strips `AdditionalValue` entries from the where hash when building the scope for `create`, keeping only the plaintext value

## Test plan

- [ ] `pnpm api:compare -- --package activerecord` shows `extended_deterministic_queries.rb` at 100%
- [ ] TypeScript builds clean

Stacks on #727. Part of encryption 100% series (PR 4/12).