### PR TITLE
feat(activemodel,activerecord): reset_default_attributes cascade to subclasses

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -309,4 +309,45 @@ describe("AttributeRegistrationTest", () => {
     const defaults = (Child as any)._defaultAttributes();
     expect(defaults.getAttribute("role").value).toBe("admin");
   });
+
+  it("adding an attribute to a superclass after a subclass has cached _defaultAttributes invalidates the subclass cache", () => {
+    class Parent extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class Child extends Parent {}
+
+    // Prime the subclass cache
+    const before = (Child as any)._defaultAttributes();
+    expect(before.keys()).toContain("name");
+    expect(before.keys()).not.toContain("age");
+
+    // Add a new attribute to the superclass at runtime
+    Parent.attribute("age", "integer", { default: 42 });
+
+    // Child's cache must be invalidated and rebuilt
+    const after = (Child as any)._defaultAttributes();
+    expect(after.getAttribute("age").value).toBe(42);
+  });
+
+  it("reset_default_attributes cascade propagates through multiple inheritance levels", () => {
+    class Base extends Model {
+      static {
+        this.attribute("base_attr", "string");
+      }
+    }
+    class Mid extends Base {}
+    class Leaf extends Mid {}
+
+    // Prime all caches
+    (Base as any)._defaultAttributes();
+    (Mid as any)._defaultAttributes();
+    (Leaf as any)._defaultAttributes();
+
+    // Add to root — all descendants must recompute
+    Base.attribute("new_attr", "integer", { default: 7 });
+
+    expect((Leaf as any)._defaultAttributes().getAttribute("new_attr").value).toBe(7);
+  });
 });

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -139,11 +139,13 @@ function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
  */
 export function resetDefaultAttributes(cls: AnyAttributeHost): void {
   cls._cachedDefaultAttributes = null;
-  // _attributesBuilder is an AR-specific derived cache; clear it when this
-  // class owns it (not inherited) so AR models get fresh state.
-  if (Object.prototype.hasOwnProperty.call(cls, "_attributesBuilder")) {
-    cls._attributesBuilder = undefined;
-  }
+  // _attributesBuilder is an AR-specific derived cache derived from
+  // _attributeDefinitions. Always clear it (creating an own-property shadow
+  // if needed) so that prototype-chain lookup doesn't return a stale
+  // superclass builder on a subclass that has just had attributes changed.
+  // Skip only classes that have never participated in AR schema building
+  // (i.e., the property is absent from the entire chain).
+  if ("_attributesBuilder" in cls) cls._attributesBuilder = undefined;
   for (const sub of getDirectSubclasses(cls)) {
     resetDefaultAttributes(sub);
   }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,3 +1,4 @@
+import { DescendantsTracker } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
@@ -85,49 +86,24 @@ class PendingDecorator implements PendingModification {
 // ---------------------------------------------------------------------------
 
 /**
- * Maps each class to its set of known direct subclasses (as WeakRefs to avoid
- * preventing GC). Populated lazily when _defaultAttributes() is first built
- * for a class that has a superclass in the attribute system.
+ * Register cls as a direct subclass of its prototype-chain superclass so
+ * resetDefaultAttributes() can cascade to it.
  *
- * Mirrors: ActiveSupport::DescendantsTracker (Rails registers via `inherited`
- * hook; we register lazily on first _defaultAttributes() call instead).
+ * Delegates to DescendantsTracker (WeakRef-backed, dedup'd) — the same
+ * infrastructure Rails uses via ActiveSupport::DescendantsTracker. Rails
+ * registers via the `inherited` hook; we register lazily on the first
+ * _defaultAttributes() call instead (same effect: only classes that have
+ * a cache worth invalidating are tracked).
+ *
+ * Mirrors: ActiveSupport::DescendantsTracker registration triggered by
+ * Class.inherited in Rails.
  */
-const directSubclasses = new WeakMap<object, Set<WeakRef<object>>>();
-// Tracks (superclass, subclass) pairs already registered so each relationship
-// is recorded exactly once, even after repeated _defaultAttributes() rebuilds.
-const registeredPairs = new WeakMap<object, WeakSet<object>>();
-
 export function registerWithSuperclass(cls: AnyAttributeHost): void {
   const superclass = Object.getPrototypeOf(cls);
   if (!superclass || superclass === Function.prototype) return;
   // Only register if the superclass participates in the attribute system.
   if (!("_attributeDefinitions" in superclass)) return;
-  // Deduplicate: each (superclass, subclass) pair registered only once.
-  if (!registeredPairs.has(superclass)) {
-    registeredPairs.set(superclass, new WeakSet());
-  }
-  const seen = registeredPairs.get(superclass)!;
-  if (seen.has(cls)) return;
-  seen.add(cls);
-  if (!directSubclasses.has(superclass)) {
-    directSubclasses.set(superclass, new Set());
-  }
-  directSubclasses.get(superclass)!.add(new WeakRef(cls));
-}
-
-function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
-  const refs = directSubclasses.get(cls);
-  if (!refs) return [];
-  const alive: AnyAttributeHost[] = [];
-  for (const ref of refs) {
-    const sub = ref.deref();
-    if (sub) {
-      alive.push(sub);
-    } else {
-      refs.delete(ref);
-    }
-  }
-  return alive;
+  DescendantsTracker.registerSubclass(superclass, cls);
 }
 
 /**
@@ -147,7 +123,7 @@ export function resetDefaultAttributes(cls: AnyAttributeHost): void {
   // AM-only classes that never call attributesBuilder() carry the undefined
   // own property harmlessly (a single extra slot per class).
   cls._attributesBuilder = undefined;
-  for (const sub of getDirectSubclasses(cls)) {
+  for (const sub of DescendantsTracker.subclasses(cls)) {
     resetDefaultAttributes(sub);
   }
 }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -139,13 +139,14 @@ function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
  */
 export function resetDefaultAttributes(cls: AnyAttributeHost): void {
   cls._cachedDefaultAttributes = null;
-  // _attributesBuilder is an AR-specific derived cache derived from
-  // _attributeDefinitions. Always clear it (creating an own-property shadow
-  // if needed) so that prototype-chain lookup doesn't return a stale
-  // superclass builder on a subclass that has just had attributes changed.
-  // Skip only classes that have never participated in AR schema building
-  // (i.e., the property is absent from the entire chain).
-  if ("_attributesBuilder" in cls) cls._attributesBuilder = undefined;
+  // _attributesBuilder is an AR-specific derived cache. Unconditionally
+  // shadow it with undefined so prototype-chain lookup never returns a stale
+  // superclass builder after this class's attributes change. For STI
+  // subclasses, attributesBuilder() removes the shadow after writing the
+  // fresh builder to cacheHost, restoring normal prototype-chain access.
+  // AM-only classes that never call attributesBuilder() carry the undefined
+  // own property harmlessly (a single extra slot per class).
+  cls._attributesBuilder = undefined;
   for (const sub of getDirectSubclasses(cls)) {
     resetDefaultAttributes(sub);
   }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -93,13 +93,22 @@ class PendingDecorator implements PendingModification {
  * hook; we register lazily on first _defaultAttributes() call instead).
  */
 const directSubclasses = new WeakMap<object, Set<WeakRef<object>>>();
+// Tracks (superclass, subclass) pairs already registered so each relationship
+// is recorded exactly once, even after repeated _defaultAttributes() rebuilds.
+const registeredPairs = new WeakMap<object, WeakSet<object>>();
 
-function registerWithSuperclass(cls: AnyAttributeHost): void {
+export function registerWithSuperclass(cls: AnyAttributeHost): void {
   const superclass = Object.getPrototypeOf(cls);
   if (!superclass || superclass === Function.prototype) return;
-  // Only register if the superclass participates in the attribute system
-  // (has _cachedDefaultAttributes or _attributeDefinitions as own or inherited).
+  // Only register if the superclass participates in the attribute system.
   if (!("_attributeDefinitions" in superclass)) return;
+  // Deduplicate: each (superclass, subclass) pair registered only once.
+  if (!registeredPairs.has(superclass)) {
+    registeredPairs.set(superclass, new WeakSet());
+  }
+  const seen = registeredPairs.get(superclass)!;
+  if (seen.has(cls)) return;
+  seen.add(cls);
   if (!directSubclasses.has(superclass)) {
     directSubclasses.set(superclass, new Set());
   }
@@ -130,9 +139,11 @@ function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
  */
 export function resetDefaultAttributes(cls: AnyAttributeHost): void {
   cls._cachedDefaultAttributes = null;
-  // _attributesBuilder is an AR-specific derived cache; clear it when present
-  // so AR models rebuilding from a new attribute declaration get fresh state.
-  if ("_attributesBuilder" in cls) cls._attributesBuilder = undefined;
+  // _attributesBuilder is an AR-specific derived cache; clear it when this
+  // class owns it (not inherited) so AR models get fresh state.
+  if (Object.prototype.hasOwnProperty.call(cls, "_attributesBuilder")) {
+    cls._attributesBuilder = undefined;
+  }
   for (const sub of getDirectSubclasses(cls)) {
     resetDefaultAttributes(sub);
   }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -80,6 +80,62 @@ class PendingDecorator implements PendingModification {
 }
 
 // ---------------------------------------------------------------------------
+// Subclass registry
+// Mirrors: ActiveSupport::DescendantsTracker used by reset_default_attributes
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each class to its set of known direct subclasses (as WeakRefs to avoid
+ * preventing GC). Populated lazily when _defaultAttributes() is first built
+ * for a class that has a superclass in the attribute system.
+ *
+ * Mirrors: ActiveSupport::DescendantsTracker (Rails registers via `inherited`
+ * hook; we register lazily on first _defaultAttributes() call instead).
+ */
+const directSubclasses = new WeakMap<object, Set<WeakRef<object>>>();
+
+function registerWithSuperclass(cls: AnyAttributeHost): void {
+  const superclass = Object.getPrototypeOf(cls);
+  if (!superclass || superclass === Function.prototype) return;
+  // Only register if the superclass participates in the attribute system
+  // (has _cachedDefaultAttributes or _attributeDefinitions as own or inherited).
+  if (!("_attributeDefinitions" in superclass)) return;
+  if (!directSubclasses.has(superclass)) {
+    directSubclasses.set(superclass, new Set());
+  }
+  directSubclasses.get(superclass)!.add(new WeakRef(cls));
+}
+
+function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
+  const refs = directSubclasses.get(cls);
+  if (!refs) return [];
+  const alive: AnyAttributeHost[] = [];
+  for (const ref of refs) {
+    const sub = ref.deref();
+    if (sub) {
+      alive.push(sub);
+    } else {
+      refs.delete(ref);
+    }
+  }
+  return alive;
+}
+
+/**
+ * Clear the cached default AttributeSet on this class and all known
+ * subclasses, so the next call to _defaultAttributes() recomputes.
+ *
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#reset_default_attributes
+ * which calls reset_default_attributes! then recurses via subclasses.each.
+ */
+export function resetDefaultAttributes(cls: AnyAttributeHost): void {
+  cls._cachedDefaultAttributes = null;
+  for (const sub of getDirectSubclasses(cls)) {
+    resetDefaultAttributes(sub);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -161,6 +217,11 @@ export function pushPendingDecorator(
  */
 export function _defaultAttributes(this: AnyAttributeHost): AttributeSet {
   if (!this._cachedDefaultAttributes) {
+    // Register with our superclass so resetDefaultAttributes() cascades to us
+    // when the superclass gains new attribute declarations. Mirrors the
+    // ActiveSupport::DescendantsTracker registration that Rails does via
+    // the `inherited` hook; we do it lazily here instead.
+    registerWithSuperclass(this);
     const attributeSet = new AttributeSet(new Map<string, Attribute>());
     applyPendingAttributeModifications(this, attributeSet);
     this._cachedDefaultAttributes = attributeSet;
@@ -201,7 +262,7 @@ export function decorateAttributes(
     }
   }
 
-  this._cachedDefaultAttributes = null;
+  resetDefaultAttributes(this);
 }
 
 /**

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -130,6 +130,9 @@ function getDirectSubclasses(cls: AnyAttributeHost): AnyAttributeHost[] {
  */
 export function resetDefaultAttributes(cls: AnyAttributeHost): void {
   cls._cachedDefaultAttributes = null;
+  // _attributesBuilder is an AR-specific derived cache; clear it when present
+  // so AR models rebuilding from a new attribute declaration get fresh state.
+  if ("_attributesBuilder" in cls) cls._attributesBuilder = undefined;
   for (const sub of getDirectSubclasses(cls)) {
     resetDefaultAttributes(sub);
   }

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -2,7 +2,11 @@ import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
-import { pushPendingType, pushPendingDefault } from "./attribute-registration.js";
+import {
+  pushPendingType,
+  pushPendingDefault,
+  resetDefaultAttributes,
+} from "./attribute-registration.js";
 
 export interface AttributeDefinition {
   name: string;
@@ -99,8 +103,9 @@ export function attribute(
     pushPendingDefault(this, name, defaultValue);
   }
 
-  // Mirrors: Rails reset_default_attributes — clear cached AttributeSet
-  this._cachedDefaultAttributes = null;
+  // Mirrors: Rails reset_default_attributes — invalidate cache on this class
+  // and all known subclasses so they recompute on next _defaultAttributes() call.
+  resetDefaultAttributes(this);
 
   if (!Object.prototype.hasOwnProperty.call(this.prototype, name)) {
     Object.defineProperty(this.prototype, name, {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   applyPendingAttributeModifications,
   pushPendingDecorator,
+  resetDefaultAttributes,
 } from "./attribute-registration.js";
 export { Attribute, FromDatabase, FromUser, WithCastValue } from "./attribute.js";
 export { UserProvidedDefault } from "./attribute/user-provided-default.js";

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -23,6 +23,7 @@ export {
   applyPendingAttributeModifications,
   pushPendingDecorator,
   resetDefaultAttributes,
+  registerWithSuperclass,
 } from "./attribute-registration.js";
 export { Attribute, FromDatabase, FromUser, WithCastValue } from "./attribute.js";
 export { UserProvidedDefault } from "./attribute/user-provided-default.js";

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -807,3 +807,29 @@ describe("DefineAttributeSTITest", () => {
     expect(ownDesc).toBeUndefined();
   });
 });
+
+describe("ResetDefaultAttributesCascadeTest", () => {
+  it("adding an attribute to a superclass invalidates an AR subclass _defaultAttributes cache", () => {
+    const adp = createTestAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+      }
+    }
+    class SpecialPost extends (Post as any) {}
+
+    // Prime the subclass cache via AR's _defaultAttributes path
+    const before = (SpecialPost as any)._defaultAttributes();
+    expect(before.keys()).toContain("title");
+    expect(before.keys()).not.toContain("score");
+
+    // Add attribute to superclass at runtime
+    Post.attribute("score", "integer", { default: 0 });
+
+    // Subclass cache must be invalidated and rebuilt with the new attribute
+    const after = (SpecialPost as any)._defaultAttributes();
+    expect(after.keys()).toContain("score");
+    expect(after.getAttribute("score").value).toBe(0);
+  });
+});

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,6 +13,7 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
+  resetDefaultAttributes,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import type { Base } from "./base.js";
@@ -86,7 +87,7 @@ export function defineAttribute(
     source: userProvidedDefault ? "user" : "schema",
   });
 
-  this._cachedDefaultAttributes = null;
+  resetDefaultAttributes(this);
   this._attributesBuilder = undefined;
   applyPendingEncryptions(this);
 

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -88,7 +88,6 @@ export function defineAttribute(
   });
 
   resetDefaultAttributes(this);
-  this._attributesBuilder = undefined;
   applyPendingEncryptions(this);
 
   // Install prototype accessor so the attribute is readable/writable by name,

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -14,6 +14,7 @@ import {
   type Type,
   applyPendingAttributeModifications,
   resetDefaultAttributes,
+  registerWithSuperclass,
 } from "@blazetrails/activemodel";
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import type { Base } from "./base.js";
@@ -132,6 +133,10 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     : this;
 
   if (!cacheHost._cachedDefaultAttributes) {
+    // Register cacheHost with its superclass so resetDefaultAttributes()
+    // cascades here when the superclass gains new attribute declarations.
+    registerWithSuperclass(cacheHost);
+
     // Phase 1: seed from _attributeDefinitions (all entries — schema-reflected
     // columns and direct defineAttribute() calls). Schema entries use
     // Attribute.fromDatabase; user entries use withCastValue + withUserDefault.

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -452,6 +452,17 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
     ? (getStiBase(this as unknown as typeof Base) as unknown as SchemaHost)
     : this;
   cacheHost._attributesBuilder = new AttributeSetBuilder(types, defaults);
+  // If we are an STI subclass, resetDefaultAttributes() may have placed an
+  // own-property shadow of `undefined` on `this` to block stale inheritance.
+  // Now that cacheHost has a fresh builder, remove the shadow so subsequent
+  // calls on this STI subclass find cacheHost's builder via prototype chain
+  // instead of rebuilding on every access.
+  if (
+    cacheHost !== (this as unknown) &&
+    Object.prototype.hasOwnProperty.call(this, "_attributesBuilder")
+  ) {
+    delete (this as unknown as Record<string, unknown>)._attributesBuilder;
+  }
   return cacheHost._attributesBuilder;
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining gap from #724: `reset_default_attributes` now cascades to all known subclasses when a superclass gains a new attribute declaration at runtime.

- `directSubclasses` WeakMap tracks known direct subclasses with `WeakRef` entries (GC-safe). Classes self-register with their superclass on the first `_defaultAttributes()` call — lazy registration matches the point where a stale cache would first matter, and avoids tracking classes that never participate in the attribute system.
- `resetDefaultAttributes(cls)` — clears `_cachedDefaultAttributes` on `cls` then recurses to all known direct subclasses. Mirrors Rails' `reset_default_attributes!` + `subclasses.each { |s| s.send(:reset_default_attributes) }` from `ActiveModel::AttributeRegistration`.
- `attribute()`, `decorateAttributes()`, and AR `defineAttribute()` now call `resetDefaultAttributes()` instead of directly nulling the cache.
- `resetDefaultAttributes` exported from `@blazetrails/activemodel`.

## Rails source
`activemodel/lib/active_model/attribute_registration.rb` lines 91–98: `reset_default_attributes` calls `reset_default_attributes!` then `subclasses.each`. Rails gets `subclasses` from `ActiveSupport::DescendantsTracker` which registers via the `inherited` hook; we register lazily in `_defaultAttributes()` instead since TypeScript has no `inherited` equivalent.

## Test plan
- Adding a new attribute to a superclass after a subclass has cached `_defaultAttributes` correctly invalidates the subclass cache
- Multi-level inheritance (Leaf → Mid → Base) cascades all the way down