### PR TITLE
feat(activerecord): nested_attributes._destroy, readonly_attributes._writeAttribute/isReadonlyAttribute, store.localStoredAttributes (PR M)

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3,7 +3,13 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, RecordNotFound, AttributeAssignmentError, NotImplementedError, ReadonlyAttributeError } from "./index.js";
+import {
+  Base,
+  RecordNotFound,
+  AttributeAssignmentError,
+  NotImplementedError,
+  ReadonlyAttributeError,
+} from "./index.js";
 import { SubclassNotFound, NameError } from "./errors.js";
 
 import { createTestAdapter } from "./test-adapter.js";

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3,7 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, RecordNotFound, AttributeAssignmentError, NotImplementedError } from "./index.js";
+import { Base, RecordNotFound, AttributeAssignmentError, NotImplementedError, ReadonlyAttributeError } from "./index.js";
 import { SubclassNotFound, NameError } from "./errors.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -1848,7 +1848,36 @@ describe("BasicsTest", () => {
      * We don't expose that knob yet — the default behavior (raise) is covered
      * by the `attrReadonly prevents updating readonly attributes` test. */
   });
-  it.skip("readonly attributes on belongs to association", () => {});
+  it("readonly attributes on belongs to association", async () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class ReadonlyAuthorPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        this.attrReadonly("author_id");
+        this.adapter = adapter;
+      }
+    }
+    expect(ReadonlyAuthorPost.readonlyAttributes).toEqual(["author_id"]);
+
+    const author1 = await Author.create({ name: "Alex" });
+    const author2 = await Author.create({ name: "Not Alex" });
+
+    // Updating non-readonly attributes on a persisted record is fine
+    const post = await ReadonlyAuthorPost.create({ title: "Hi", author_id: author1.id });
+    await post.update({ title: "Hello" });
+    const reloaded = await ReadonlyAuthorPost.find(post.id);
+    expect(reloaded.readAttribute("author_id")).toBe(author1.id);
+
+    // Attempting to change the readonly FK throws ReadonlyAttributeError
+    const post2 = await ReadonlyAuthorPost.create({ title: "Hi", author_id: author1.id });
+    await expect(post2.update({ author_id: author2.id })).rejects.toThrow(ReadonlyAttributeError);
+  });
   it.skip("respect internal encoding", () => {
     /* Ruby-specific: tests Encoding.default_internal (EUC-JP) on column names — no JS equivalent */
   });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -939,6 +939,7 @@ export class Base extends Model {
   // --- ReadonlyAttributes mixin (wired via extend() after class) ---
   declare static attrReadonly: typeof ReadonlyAttributes.attrReadonly;
   declare static readonlyAttributeQ: typeof ReadonlyAttributes.readonlyAttributeQ;
+  declare static isReadonlyAttribute: typeof ReadonlyAttributes.readonlyAttributeQ;
 
   /**
    * Return the list of readonly attribute names.

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -3,7 +3,7 @@ import { modelRegistry } from "./associations.js";
 import { ActiveRecordError, UnknownAttributeError } from "./errors.js";
 import { singularize, camelize, underscore } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
-import { markedForDestruction } from "./autosave-association.js";
+import { isMarkedForDestruction } from "./autosave-association.js";
 
 /**
  * Raised when more nested-attribute records are provided than the
@@ -26,7 +26,7 @@ export class TooManyRecords extends ActiveRecordError {
  * Mirrors: ActiveRecord::NestedAttributes#_destroy
  */
 export function _destroy(this: Base): boolean {
-  return markedForDestruction.call(this as any);
+  return isMarkedForDestruction(this);
 }
 
 interface NestedAttributeOptions {

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -3,6 +3,7 @@ import { modelRegistry } from "./associations.js";
 import { ActiveRecordError, UnknownAttributeError } from "./errors.js";
 import { singularize, camelize, underscore } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
+import { markedForDestruction } from "./autosave-association.js";
 
 /**
  * Raised when more nested-attribute records are provided than the
@@ -15,6 +16,17 @@ export class TooManyRecords extends ActiveRecordError {
     super(message);
     this.name = "TooManyRecords";
   }
+}
+
+/**
+ * Returns whether the record is marked for destruction in the context of
+ * nested attributes. Mirrors Rails' NestedAttributes instance method `_destroy`,
+ * which delegates to `marked_for_destruction?`.
+ *
+ * Mirrors: ActiveRecord::NestedAttributes#_destroy
+ */
+export function _destroy(this: Base): boolean {
+  return markedForDestruction.call(this as any);
 }
 
 interface NestedAttributeOptions {

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -101,6 +101,19 @@ export function writeAttribute(this: Base, name: string, value: unknown): void {
 }
 
 /**
+ * Low-level write that checks readonly but bypasses the frozen-record guard.
+ *
+ * Mirrors: ActiveRecord::HasReadonlyAttributes#_write_attribute
+ */
+export function _writeAttribute(this: Base, name: string, value: unknown): void {
+  const ctor = this.constructor as typeof Base;
+  if (this._newRecord === false && ctor.readonlyAttributeQ(String(name))) {
+    throw new ReadonlyAttributeError(String(name));
+  }
+  Model.prototype.writeAttribute.call(this, name, value);
+}
+
+/**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
  *
@@ -112,4 +125,5 @@ export function writeAttribute(this: Base, name: string, value: unknown): void {
 export const ClassMethods = {
   attrReadonly,
   readonlyAttributeQ,
+  isReadonlyAttribute: readonlyAttributeQ,
 };

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -15,6 +15,30 @@ export function storedAttributes(modelClass: typeof Base): Record<string, string
 }
 
 /**
+ * Returns only the stored attributes defined directly on this class (not
+ * inherited ones). Mirrors Rails' `attr_accessor :local_stored_attributes`
+ * on `ActiveRecord::Store` — each class has its own hash of store→keys[].
+ *
+ * Mirrors: ActiveRecord::Store#local_stored_attributes
+ */
+export function localStoredAttributes(modelClass: typeof Base): Record<string, string[]> {
+  return _storedAttributes.get(modelClass) ?? {};
+}
+
+/**
+ * Sets the local stored attributes for a model class directly. Used internally
+ * during store/store_accessor setup.
+ *
+ * Mirrors: ActiveRecord::Store#local_stored_attributes= (the attr_accessor setter)
+ */
+export function setLocalStoredAttributes(
+  modelClass: typeof Base,
+  attrs: Record<string, string[]>,
+): void {
+  _storedAttributes.set(modelClass, attrs);
+}
+
+/**
  * Reads/writes hash keys on a store attribute.
  *
  * Mirrors: ActiveRecord::Store::HashAccessor


### PR DESCRIPTION
## Summary

Closes remaining api:compare gaps in three attribute files:

- `nested-attributes.ts`: add `_destroy()` instance method — delegates to `markedForDestruction?` (mirrors Rails' `NestedAttributes#_destroy`)
- `readonly-attributes.ts`: add `_writeAttribute()` (readonly check without frozen guard) and `isReadonlyAttribute` alias for `readonlyAttributeQ` on `ClassMethods`
- `store.ts`: add `localStoredAttributes()` and `setLocalStoredAttributes()` — mirrors Rails' `attr_accessor :local_stored_attributes` on `ActiveRecord::Store`

Note: `_writeAttribute` in `readonly-attributes.ts` is the Rails-parity version that enforces readonly. The internal `_writeAttribute` wired on `Base` remains the bypass version from `attribute-methods/write.ts` since internal callers (FK writes, timestamps) need to bypass readonly enforcement.