### PR TITLE
feat(parity): canonical schema format spec (PR 1 of 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,16 @@
     "lint:deps": "bash scripts/api-compare/fetch-rails.sh && ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/fetch-rails-tests.sh && ruby scripts/test-compare/extract-ruby-tests.rb && pnpm tsx scripts/test-compare/extract-ts-tests.ts && pnpm tsx scripts/test-compare/test-compare.ts",
     "test:stubs": "pnpm test:compare -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",
-    "stats:sync": "pnpm tsx scripts/sync-stats/sync.ts"
+    "stats:sync": "pnpm tsx scripts/sync-stats/sync.ts",
+    "parity:validate": "ajv compile -s scripts/parity/canonical/schema.schema.json --spec=draft2020"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/pg": "^8.18.0",
     "@vitest/eslint-plugin": "^1.6.12",
+    "ajv": "^8.18.0",
+    "ajv-cli": "^5.0.0",
     "eslint": "^10.0.3",
     "eslint-plugin-unused-imports": "^4.4.1",
     "husky": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,12 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.6.12
         version: 1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@25.3.5)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
+      ajv-cli:
+        specifier: ^5.0.0
+        version: 5.0.0
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
@@ -1671,8 +1677,20 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-cli@5.0.0:
+    resolution: {integrity: sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   algoliasearch@5.50.1:
     resolution: {integrity: sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==}
@@ -1698,6 +1716,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1719,6 +1740,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1746,6 +1770,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1819,6 +1846,9 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2170,6 +2200,11 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2206,14 +2241,24 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-patch@2.2.1:
+    resolution: {integrity: sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==}
+    engines: {node: '>= 0.4.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2252,6 +2297,9 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2273,6 +2321,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2327,6 +2379,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2386,6 +2442,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   jsdom@29.0.1:
     resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -2398,11 +2458,22 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-migrate@2.0.0:
+    resolution: {integrity: sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   katex@0.16.44:
     resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
@@ -2616,6 +2687,9 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -2700,6 +2774,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2948,6 +3026,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sql-escaper@1.3.3:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
@@ -4699,12 +4780,29 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-cli@5.0.0:
+    dependencies:
+      ajv: 8.18.0
+      fast-json-patch: 2.2.1
+      glob: 7.2.3
+      js-yaml: 3.14.2
+      json-schema-migrate: 2.0.0
+      json5: 2.2.3
+      minimist: 1.2.8
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   algoliasearch@5.50.1:
     dependencies:
@@ -4735,6 +4833,10 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -4748,6 +4850,8 @@ snapshots:
   aws-ssl-profiles@1.1.2: {}
 
   axobject-query@4.1.0: {}
+
+  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -4775,6 +4879,11 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.4:
     dependencies:
@@ -4843,6 +4952,8 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
+
+  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -5287,6 +5398,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -5316,11 +5429,19 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@2.0.1: {}
+
   fast-deep-equal@3.1.3: {}
+
+  fast-json-patch@2.2.1:
+    dependencies:
+      fast-deep-equal: 2.0.1
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -5354,6 +5475,8 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -5372,6 +5495,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   graceful-fs@4.2.11: {}
 
@@ -5425,6 +5557,11 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -5465,6 +5602,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   jsdom@29.0.1:
     dependencies:
       '@asamuzakjp/css-color': 5.1.1
@@ -5493,9 +5635,17 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-migrate@2.0.0:
+    dependencies:
+      ajv: 8.18.0
+
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   katex@0.16.44:
     dependencies:
@@ -5716,6 +5866,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
   minimist@1.2.8: {}
 
   minisearch@7.2.0: {}
@@ -5806,6 +5960,8 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -6072,6 +6228,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   split2@4.2.0: {}
+
+  sprintf-js@1.0.3: {}
 
   sql-escaper@1.3.3: {}
 

--- a/scripts/parity/canonical/README.md
+++ b/scripts/parity/canonical/README.md
@@ -1,0 +1,72 @@
+# Canonical schema format
+
+`schema.schema.json` is the JSON Schema (draft 2020-12) for the neutral
+canonical representation used by the parity test suite. Both the Rails-side
+and trails-side canonicalizers must produce output that validates against it.
+
+`types.ts` contains the TypeScript types derived from the schema.
+
+## Purpose
+
+Neither `ActiveRecord::SchemaDumper` (Rails) nor `trails-schema-dump` (trails)
+is "the truth." Both sides run a `canonicalize` step that lowers their native
+output into this format. This decouples parity tests from the internal shape of
+either dumper — a change to `dumpSchemaColumns` or `SchemaDumper` that doesn't
+affect semantic meaning won't break the diff.
+
+## Version policy (D9)
+
+The current version is **1**. Bumping `version` requires a single PR that:
+
+1. Updates `schema.schema.json` (change `const: 1` to `const: 2` etc.).
+2. Updates `types.ts`.
+3. Updates both canonicalizers:
+   `scripts/parity/schema/ruby/canonicalize.rb` and
+   `scripts/parity/schema/node/canonicalize.ts`.
+4. Updates or regenerates any checked-in baseline JSON files.
+
+Never bump the version in a PR that also changes canonicalizer behavior — split
+them so bisect remains useful.
+
+## Ordering rules (D1)
+
+- `tables` — sorted by `name` ASC.
+- `columns` — **preserved declaration order** (order is semantic; affects
+  `SELECT *` and row iteration).
+- `indexes` — sorted by `name` ASC.
+- `columns` within an index — preserved declaration order (semantic for
+  composite indexes).
+
+## Filtered entries (D2, D3)
+
+The following are excluded from canonical output by both canonicalizers:
+
+- Tables: `schema_migrations`, `ar_internal_metadata`.
+- Indexes: any index whose name matches `/^sqlite_autoindex_/`.
+
+Fixtures never declare these tables; the filter is belt-and-suspenders.
+
+## Type alphabet (D4)
+
+The `type` field on each column is a member of the closed enum in
+`schema.schema.json#/$defs/CanonicalType`:
+
+```
+string · text · integer · bigint · float · decimal
+datetime · date · time · boolean · binary · json
+```
+
+Canonicalizers **must throw** on any type not in this list, with a message
+naming the table, column, and raw type string. Do not silently coerce or drop
+unknown types — a thrown error surfaces a gap that needs an explicit decision.
+
+## Deferred to v2+
+
+- Foreign keys
+- Check constraints
+- Generated / virtual columns
+- Default expressions (e.g. `CURRENT_TIMESTAMP`) — `default` is `null` in v1
+  for expression defaults
+- Collations
+- Composite PK ordering beyond a `string[]`
+- SQLite `WITHOUT ROWID` tables

--- a/scripts/parity/canonical/README.md
+++ b/scripts/parity/canonical/README.md
@@ -18,11 +18,11 @@ affect semantic meaning won't break the diff.
 
 The current version is **1**. Bumping `version` requires a single PR that:
 
-1. Updates `schema.schema.json` (change `const: 1` to `const: 2` etc.).
+1. Updates `schema.schema.json`: change the `version` const, update `$id` to end in `/v2` (or `/v3` etc.), add/remove fields.
 2. Updates `types.ts`.
 3. Updates both canonicalizers:
-   `scripts/parity/schema/ruby/canonicalize.rb` and
-   `scripts/parity/schema/node/canonicalize.ts`.
+   `scripts/parity/schema/ruby/canonicalize.rb` (added in PR4) and
+   `scripts/parity/schema/node/canonicalize.ts` (added in PR3).
 4. Updates or regenerates any checked-in baseline JSON files.
 
 Never bump the version in a PR that also changes canonicalizer behavior — split
@@ -68,5 +68,5 @@ unknown types — a thrown error surfaces a gap that needs an explicit decision.
 - Default expressions (e.g. `CURRENT_TIMESTAMP`) — `default` is `null` in v1
   for expression defaults
 - Collations
-- Composite PK ordering beyond a `string[]`
+- Composite PK ordering guarantees beyond `[string, string, ...string[]]`
 - SQLite `WITHOUT ROWID` tables

--- a/scripts/parity/canonical/schema.schema.json
+++ b/scripts/parity/canonical/schema.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://blazetrails.dev/schemas/parity/canonical-schema/v1",
+  "title": "CanonicalSchema",
+  "description": "Version 1 canonical schema dump — tables, columns, and indexes only.",
+  "type": "object",
+  "required": ["version", "tables"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Schema version. Bump in a single PR that also updates both canonicalizers and any checked-in baselines."
+    },
+    "tables": {
+      "type": "array",
+      "description": "User tables, sorted by name ASC. Does not include schema_migrations or ar_internal_metadata.",
+      "items": { "$ref": "#/$defs/CanonicalTable" }
+    }
+  },
+  "$defs": {
+    "CanonicalTable": {
+      "type": "object",
+      "required": ["name", "primaryKey", "columns", "indexes"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "primaryKey": {
+          "description": "Single-column PK: string. Composite PK: string[]. No PK: null.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "minItems": 2 },
+            { "type": "null" }
+          ]
+        },
+        "columns": {
+          "type": "array",
+          "description": "Columns in declaration order (not sorted).",
+          "items": { "$ref": "#/$defs/CanonicalColumn" }
+        },
+        "indexes": {
+          "type": "array",
+          "description": "Explicit indexes, sorted by name ASC. sqlite_autoindex_* entries are excluded.",
+          "items": { "$ref": "#/$defs/CanonicalIndex" }
+        }
+      }
+    },
+    "CanonicalColumn": {
+      "type": "object",
+      "required": ["name", "type", "null", "default", "limit", "precision", "scale"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "type": { "$ref": "#/$defs/CanonicalType" },
+        "null": { "type": "boolean", "description": "true when the column is nullable." },
+        "default": {
+          "description": "Literal default value, or null when there is no default. Expression defaults (e.g. CURRENT_TIMESTAMP) are deferred to v2.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            { "type": "null" }
+          ]
+        },
+        "limit": { "type": ["integer", "null"] },
+        "precision": { "type": ["integer", "null"] },
+        "scale": { "type": ["integer", "null"] }
+      }
+    },
+    "CanonicalIndex": {
+      "type": "object",
+      "required": ["name", "columns", "unique", "where"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "columns": {
+          "type": "array",
+          "description": "Column names in index declaration order.",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "unique": { "type": "boolean" },
+        "where": {
+          "type": ["string", "null"],
+          "description": "Partial-index predicate string, or null."
+        }
+      }
+    },
+    "CanonicalType": {
+      "type": "string",
+      "enum": [
+        "string",
+        "text",
+        "integer",
+        "bigint",
+        "float",
+        "decimal",
+        "datetime",
+        "date",
+        "time",
+        "boolean",
+        "binary",
+        "json"
+      ],
+      "description": "Rails abstract type name. Canonicalizers must throw on any type not in this enum."
+    }
+  }
+}

--- a/scripts/parity/canonical/types.ts
+++ b/scripts/parity/canonical/types.ts
@@ -26,8 +26,8 @@ export interface CanonicalColumn {
 
 export interface CanonicalIndex {
   name: string;
-  /** Column names in index declaration order */
-  columns: string[];
+  /** Column names in index declaration order (at least one) */
+  columns: [string, ...string[]];
   unique: boolean;
   /** Partial-index predicate, or null */
   where: string | null;
@@ -35,8 +35,8 @@ export interface CanonicalIndex {
 
 export interface CanonicalTable {
   name: string;
-  /** string = single-column PK, string[] = composite PK, null = no PK */
-  primaryKey: string | string[] | null;
+  /** string = single-column PK, tuple of ≥2 = composite PK, null = no PK */
+  primaryKey: string | [string, string, ...string[]] | null;
   /** Columns in declaration order */
   columns: CanonicalColumn[];
   /** Explicit indexes sorted by name ASC; sqlite_autoindex_* excluded */

--- a/scripts/parity/canonical/types.ts
+++ b/scripts/parity/canonical/types.ts
@@ -1,0 +1,50 @@
+export type CanonicalType =
+  | "string"
+  | "text"
+  | "integer"
+  | "bigint"
+  | "float"
+  | "decimal"
+  | "datetime"
+  | "date"
+  | "time"
+  | "boolean"
+  | "binary"
+  | "json";
+
+export interface CanonicalColumn {
+  name: string;
+  type: CanonicalType;
+  /** true when the column is nullable */
+  null: boolean;
+  /** Literal default value; null when there is no default */
+  default: string | number | boolean | null;
+  limit: number | null;
+  precision: number | null;
+  scale: number | null;
+}
+
+export interface CanonicalIndex {
+  name: string;
+  /** Column names in index declaration order */
+  columns: string[];
+  unique: boolean;
+  /** Partial-index predicate, or null */
+  where: string | null;
+}
+
+export interface CanonicalTable {
+  name: string;
+  /** string = single-column PK, string[] = composite PK, null = no PK */
+  primaryKey: string | string[] | null;
+  /** Columns in declaration order */
+  columns: CanonicalColumn[];
+  /** Explicit indexes sorted by name ASC; sqlite_autoindex_* excluded */
+  indexes: CanonicalIndex[];
+}
+
+export interface CanonicalSchema {
+  version: 1;
+  /** User tables sorted by name ASC */
+  tables: CanonicalTable[];
+}


### PR DESCRIPTION
## Summary

Adds `scripts/parity/canonical/` — the neutral format both Rails-side and trails-side canonicalizers must produce, per the plan in #730.

- `schema.schema.json` — JSON Schema draft 2020-12 encoding tables + columns + indexes (v1). `additionalProperties: false` everywhere; closed 12-type enum for `CanonicalType`; explicit rules for column ordering (declaration order), table/index ordering (name ASC), and filtered entries (`schema_migrations`, `ar_internal_metadata`, `sqlite_autoindex_*`).
- `types.ts` — TypeScript interfaces derived from the schema. Typechecks clean (`tsc --noEmit --strict`).
- `README.md` — version bump policy (D9), ordering rules (D1), filter rules (D2/D3), type alphabet (D4), deferred-to-v2+ list.
- `package.json` — adds `ajv` + `ajv-cli` dev-deps and a `parity:validate` script that verifies `schema.schema.json` is itself a valid JSON Schema.

`better-sqlite3` was already a root dev-dep; no new workspace packages.

## Test plan
- [ ] `pnpm parity:validate` exits 0 (verified locally: `schema is valid`)
- [ ] `tsc --noEmit scripts/parity/canonical/types.ts` clean
- [ ] `schema.schema.json` closed type enum matches `README.md` type alphabet (12 types)