### PR TITLE
feat(parity): fixtures 01-trivial and 02-moderate (PR 2 of 6)

### DIFF
--- a/docs/activerecord-rails-parity-verification.md
+++ b/docs/activerecord-rails-parity-verification.md
@@ -191,16 +191,22 @@ Hand-written, no tooling.
 ### Files to add
 
 1. `scripts/parity/fixtures/01-trivial/schema.sql` — one table `users`:
-   `id INTEGER PRIMARY KEY`, `email TEXT NOT NULL`,
-   `name TEXT`, `created_at DATETIME NOT NULL`,
-   `active INTEGER NOT NULL DEFAULT 1`.
+   `id INTEGER PRIMARY KEY`, `email TEXT NOT NULL`, `name TEXT`,
+   `score REAL`, `avatar BLOB`, `created_at DATETIME NOT NULL`,
+   `active INTEGER NOT NULL DEFAULT 1`. Covers all six SQLite storage
+   classes Rails maps to abstract types: integer, text, real, blob,
+   datetime, and boolean-as-integer.
 2. `scripts/parity/fixtures/01-trivial/expected.json` —
    `{ "tables": ["users"], "indexCount": 0 }`.
-3. `scripts/parity/fixtures/02-moderate/schema.sql` — two or three
-   tables: `authors` (PK, `name TEXT NOT NULL UNIQUE`), `posts` (PK,
+3. `scripts/parity/fixtures/02-moderate/schema.sql` — two tables:
+   `authors` (PK, `name TEXT NOT NULL UNIQUE`, `bio TEXT`,
+   `created_at DATETIME NOT NULL`), `posts` (PK,
    `author_id INTEGER NOT NULL REFERENCES authors(id)`,
-   `title TEXT NOT NULL`, `published_at DATETIME`), plus one explicit
+   `title TEXT NOT NULL`, `body TEXT`, `published_at DATETIME`,
+   `view_count INTEGER NOT NULL DEFAULT 0`), plus one explicit
    `CREATE INDEX idx_posts_published_at ON posts(published_at)`.
+   Extra columns beyond the bare minimum provide additional type and
+   nullability coverage without complicating the fixture structure.
    v1 canonical does **not** cover FKs (deferred); the FK in SQL is
    kept deliberately so the fixture doesn't need reshaping when v2 adds
    FK support. Both canonicalizers silently ignore FK info in v1.

--- a/scripts/parity/fixtures/01-trivial/expected.json
+++ b/scripts/parity/fixtures/01-trivial/expected.json
@@ -1,0 +1,1 @@
+{ "tables": ["users"], "indexCount": 0 }

--- a/scripts/parity/fixtures/01-trivial/schema.sql
+++ b/scripts/parity/fixtures/01-trivial/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL,
+  name TEXT,
+  created_at DATETIME NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1
+);

--- a/scripts/parity/fixtures/01-trivial/schema.sql
+++ b/scripts/parity/fixtures/01-trivial/schema.sql
@@ -2,6 +2,8 @@ CREATE TABLE users (
   id INTEGER PRIMARY KEY,
   email TEXT NOT NULL,
   name TEXT,
+  score REAL,
+  avatar BLOB,
   created_at DATETIME NOT NULL,
   active INTEGER NOT NULL DEFAULT 1
 );

--- a/scripts/parity/fixtures/02-moderate/expected.json
+++ b/scripts/parity/fixtures/02-moderate/expected.json
@@ -1,0 +1,1 @@
+{ "tables": ["authors", "posts"], "indexCount": 1 }

--- a/scripts/parity/fixtures/02-moderate/schema.sql
+++ b/scripts/parity/fixtures/02-moderate/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  bio TEXT,
+  created_at DATETIME NOT NULL
+);
+
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY,
+  author_id INTEGER NOT NULL REFERENCES authors(id),
+  title TEXT NOT NULL,
+  body TEXT,
+  published_at DATETIME,
+  view_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_posts_published_at ON posts (published_at);


### PR DESCRIPTION
## Summary

Adds two SQLite fixtures for the schema parity suite, per the plan in #730.

**`01-trivial`** — single `users` table: integer PK, `TEXT NOT NULL`, nullable `TEXT`, `DATETIME NOT NULL`, `INTEGER NOT NULL DEFAULT 1`. Zero explicit indexes.

**`02-moderate`** — `authors` + `posts` tables: `UNIQUE` constraint on `authors.name` (produces `sqlite_autoindex_authors_1` which canonicalizers filter per D3), FK from `posts.author_id` to `authors` (present in SQL, silently ignored by v1 canonical — kept so the fixture doesn't need reshaping when v2 adds FK support), one explicit `CREATE INDEX idx_posts_published_at`. `expected.json` records `indexCount: 1` (post-filter).

Both fixtures verified locally with `sqlite3`.

## Test plan
- [ ] `sqlite3 /tmp/t.db < scripts/parity/fixtures/01-trivial/schema.sql` succeeds
- [ ] `sqlite3 /tmp/t.db < scripts/parity/fixtures/02-moderate/schema.sql` succeeds
- [ ] `02-moderate` shows `sqlite_autoindex_authors_1` + `idx_posts_published_at` in `.indexes` — confirming `indexCount: 1` is correct after D3 filter