### PR TITLE
feat(api-compare): track private API surface behind --privates flag

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -902,16 +902,16 @@ def run
       extractor.process_file(filepath, pkg_dir)
     end
 
-    # Preserve every method; non-public methods are tagged with
-    # `internal: true` so --privates mode can select them.
+    # Normalize into the JSON shape. Non-public methods are kept (tagged
+    # `internal: true`) so consumers can opt into private-API coverage.
     classes = {}
     extractor.classes.each do |fqn, info|
-      classes[fqn] = tag_visibility(info)
+      classes[fqn] = normalize_class_info(info)
     end
 
     modules = {}
     extractor.modules.each do |fqn, info|
-      modules[fqn] = tag_visibility(info)
+      modules[fqn] = normalize_class_info(info)
     end
 
     manifest[:packages][pkg_name] = {
@@ -924,9 +924,12 @@ def run
   manifest[:packages].each do |pkg, data|
     class_count = data[:classes].length
     module_count = data[:modules].length
-    method_count = data[:classes].values.sum { |c| c[:instanceMethods].length + c[:classMethods].length } +
-                   data[:modules].values.sum { |m| m[:instanceMethods].length + m[:classMethods].length }
-    puts "  #{pkg}: #{class_count} classes, #{module_count} modules, #{method_count} methods (public + internal)"
+    all_methods = data[:classes].values.flat_map { |c| c[:instanceMethods] + c[:classMethods] } +
+                  data[:modules].values.flat_map { |m| m[:instanceMethods] + m[:classMethods] }
+    internal_count = all_methods.count { |m| m[:internal] }
+    public_count = all_methods.length - internal_count
+    puts "  #{pkg}: #{class_count} classes, #{module_count} modules, " \
+         "#{public_count} public methods (#{internal_count} internal)"
   end
 
   output_path = File.join(OUTPUT_DIR, "rails-api.json")
@@ -944,7 +947,7 @@ def tag_internal(methods)
   end
 end
 
-def tag_visibility(info)
+def normalize_class_info(info)
   {
     name: info[:name],
     fqn: info[:fqn],

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -7,7 +7,35 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { resolveRelModule } from "./extract-ts-api.js";
+import * as ts from "typescript";
+import { resolveRelModule, extractClass } from "./extract-ts-api.js";
+import type { ClassInfo } from "./types.js";
+
+function extractFromSource(source: string, className = "Foo"): ClassInfo {
+  const filename = "virtual.ts";
+  const sourceFile = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => (name === filename ? sourceFile : undefined),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => undefined,
+    getCurrentDirectory: () => "/",
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name === filename,
+    readFile: (name) => (name === filename ? source : undefined),
+  };
+  const program = ts.createProgram([filename], { noLib: true, noResolve: true }, host);
+  const checker = program.getTypeChecker();
+  let found: ClassInfo | null = null;
+  ts.forEachChild(program.getSourceFile(filename)!, (node) => {
+    if (ts.isClassDeclaration(node) && node.name?.text === className) {
+      found = extractClass(node, checker, filename);
+    }
+  });
+  if (!found) throw new Error(`class ${className} not found`);
+  return found;
+}
 
 describe("resolveRelModule", () => {
   it("resolves a sibling .js import", () => {
@@ -49,5 +77,67 @@ describe("resolveRelModule", () => {
     const result = resolveRelModule("dir/sub/file.ts", "./sibling.js");
     expect(result).toBe("dir/sub/sibling.ts");
     expect(result).not.toContain("\\");
+  });
+});
+
+describe("extractClass — internal tagging", () => {
+  it("emits public members without the internal flag", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        pubMethod() {}
+        get pubGetter() { return 1; }
+        pubProp = 1;
+      }
+    `);
+    const pub = info.instanceMethods.find((m) => m.name === "pubMethod")!;
+    expect(pub.visibility).toBe("public");
+    expect(pub.internal).toBeUndefined();
+    expect(info.instanceMethods.find((m) => m.name === "pubGetter")!.internal).toBeUndefined();
+    expect(info.instanceMethods.find((m) => m.name === "pubProp")!.internal).toBeUndefined();
+  });
+
+  it("tags `private` and `protected` members with internal: true and matching visibility", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        private privMethod() {}
+        protected protMethod() {}
+        private privProp = 1;
+      }
+    `);
+    const priv = info.instanceMethods.find((m) => m.name === "privMethod")!;
+    expect(priv.visibility).toBe("private");
+    expect(priv.internal).toBe(true);
+
+    const prot = info.instanceMethods.find((m) => m.name === "protMethod")!;
+    expect(prot.visibility).toBe("protected");
+    expect(prot.internal).toBe(true);
+
+    expect(info.instanceMethods.find((m) => m.name === "privProp")!.internal).toBe(true);
+  });
+
+  it("tags `#privateIdentifier` members as internal", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        #hidden() {}
+        #field = 1;
+      }
+    `);
+    const hidden = info.instanceMethods.find((m) => m.name === "#hidden")!;
+    expect(hidden.visibility).toBe("private");
+    expect(hidden.internal).toBe(true);
+    expect(info.instanceMethods.find((m) => m.name === "#field")!.internal).toBe(true);
+  });
+
+  it("tags static private members and keeps them on classMethods", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        static pubStatic() {}
+        private static privStatic() {}
+      }
+    `);
+    expect(info.classMethods.find((m) => m.name === "pubStatic")!.internal).toBeUndefined();
+    const ps = info.classMethods.find((m) => m.name === "privStatic")!;
+    expect(ps.visibility).toBe("private");
+    expect(ps.internal).toBe(true);
   });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -411,7 +411,7 @@ export function resolveRelModule(fromRel: string, spec: string): string | null {
   return path.posix.normalize(path.posix.join(fromDir, withoutExt)) + ".ts";
 }
 
-function extractClass(
+export function extractClass(
   node: ts.ClassDeclaration,
   checker: ts.TypeChecker,
   file: string,

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1702,16 +1702,28 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
         SELECT 1 FROM api_compare_stats acs
         WHERE acs.merge_commit_sha = rjl.merge_commit_sha
       )
-      OR NOT EXISTS (
-        SELECT 1 FROM api_compare_privates_stats acps
-        WHERE acps.merge_commit_sha = rjl.merge_commit_sha
+      OR (
+        -- Only gate on privates stats when the job actually ran the
+        -- --privates step. Historical logs from before the step was
+        -- added would otherwise loop forever on --refresh.
+        rjl.log_output LIKE '%compare.ts --privates%'
+        AND NOT EXISTS (
+          SELECT 1 FROM api_compare_privates_stats acps
+          WHERE acps.merge_commit_sha = rjl.merge_commit_sha
+        )
       )
       OR EXISTS (
-        WITH expected(step_name) AS (VALUES ('api_compare'), ('api_compare_privates'), ('test_compare'))
+        WITH expected(step_name, required) AS (
+          VALUES
+            ('api_compare', 1),
+            ('test_compare', 1),
+            ('api_compare_privates',
+              CASE WHEN rjl.log_output LIKE '%compare.ts --privates%' THEN 1 ELSE 0 END)
+        )
         SELECT 1 FROM expected e
         LEFT JOIN compare_logs cl
           ON cl.merge_commit_sha = rjl.merge_commit_sha AND cl.step_name = e.step_name
-        WHERE cl.step_name IS NULL
+        WHERE e.required = 1 AND cl.step_name IS NULL
       )
     )
     ORDER BY rjl.pr_number DESC


### PR DESCRIPTION
## Summary

- Ruby + TS extractors now emit private/protected (and TS `#`-prefixed) members tagged `internal: true` instead of dropping them.
- `compare.ts` gains a `--privates` flag that runs the comparison against the internal-only surface. Default output and numbers are unchanged (activerecord: 2669/2819, 94.7%). With `--privates`, activerecord reports 113/1421 (8%) on the internal surface — a previously invisible signal.
- CI adds a second `compare.ts --privates` step right after the main API comparison, reusing the already-extracted manifests.
- `stats:sync` persists the privates numbers in a new `api_compare_privates_stats` table so coverage can be tracked historically alongside the public numbers. Step-log extraction now distinguishes the two runs by the presence of `--privates` in the command line.
- Carries a small CLAUDE.md clarification about the `WorktreeCreate` hook that hadn't landed on main yet.

## Test plan

- [ ] `pnpm api:compare` produces identical package totals to pre-change baseline.
- [ ] `pnpm api:compare --privates` prints the "(comparing internal/private API surface ...)" banner and non-zero internal totals for activerecord.
- [ ] CI "Rails API/Test Comparison" job shows both `API comparison` and `API comparison (privates)` steps green.
- [ ] `stats:sync` run against a post-merge commit populates `api_compare_privates_stats` without clobbering `api_compare_stats`.