### PR TITLE
feat(parity): node-side dump + canonicalize (PR 3 of 6)

### DIFF
--- a/packages/activerecord/src/schema-introspection.test.ts
+++ b/packages/activerecord/src/schema-introspection.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { createTestAdapter } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
-import { introspectTables, introspectColumns } from "./schema-introspection.js";
+import {
+  introspectTables,
+  introspectColumns,
+  introspectIndexes,
+  introspectPrimaryKey,
+} from "./schema-introspection.js";
 
 /**
  * Return a proxy over `adapter` that hides the named methods so the
@@ -87,5 +92,89 @@ describe("introspectColumns", () => {
     const names = cols.map((c) => c.name).sort();
 
     expect(names).toEqual(["age", "id", "name"]);
+  });
+});
+
+describe("introspectIndexes", () => {
+  it("uses adapter.indexes() when the adapter implements it", async () => {
+    let calledWith: string | undefined;
+    const fakeIndexes = [{ name: "idx_users_email", columns: ["email"], unique: true }];
+    const adapter = {
+      async indexes(table: string): Promise<unknown[]> {
+        calledWith = table;
+        return fakeIndexes;
+      },
+    } as unknown as Parameters<typeof introspectIndexes>[0];
+
+    const idxs = await introspectIndexes(adapter, "users");
+
+    expect(calledWith).toBe("users");
+    expect(idxs).toBe(fakeIndexes);
+  });
+
+  it("falls back to SchemaStatements when the adapter doesn't implement indexes()", async () => {
+    const realAdapter = createTestAdapter();
+    const ctx = new MigrationContext(realAdapter);
+    await ctx.createTable("widgets", {}, (t) => {
+      t.string("name");
+    });
+    await ctx.addIndex("widgets", ["name"], { name: "idx_widgets_name" });
+
+    const stripped = withoutMethods(realAdapter, ["indexes"]);
+
+    const idxs = await introspectIndexes(stripped, "widgets");
+
+    expect(idxs.some((i) => i.name === "idx_widgets_name")).toBe(true);
+  });
+});
+
+describe("introspectPrimaryKey", () => {
+  it("uses adapter.primaryKey() when the adapter implements it", async () => {
+    let calledWith: string | undefined;
+    const adapter = {
+      async primaryKey(table: string): Promise<string | null> {
+        calledWith = table;
+        return "id";
+      },
+    } as unknown as Parameters<typeof introspectPrimaryKey>[0];
+
+    const pk = await introspectPrimaryKey(adapter, "users");
+
+    expect(calledWith).toBe("users");
+    expect(pk).toEqual(["id"]);
+  });
+
+  it("returns composite PK as ordered array from adapter.primaryKey()", async () => {
+    const adapter = {
+      async primaryKey(_table: string): Promise<string[]> {
+        return ["b", "a"]; // PK constraint order, not declaration order
+      },
+    } as unknown as Parameters<typeof introspectPrimaryKey>[0];
+
+    expect(await introspectPrimaryKey(adapter, "t")).toEqual(["b", "a"]);
+  });
+
+  it("returns empty array when adapter.primaryKey() returns null", async () => {
+    const adapter = {
+      async primaryKey(_table: string): Promise<null> {
+        return null;
+      },
+    } as unknown as Parameters<typeof introspectPrimaryKey>[0];
+
+    expect(await introspectPrimaryKey(adapter, "t")).toEqual([]);
+  });
+
+  it("falls back to columns with primaryKey===true when adapter lacks primaryKey()", async () => {
+    const realAdapter = createTestAdapter();
+    const ctx = new MigrationContext(realAdapter);
+    await ctx.createTable("widgets", {}, (t) => {
+      t.string("name");
+    });
+
+    const stripped = withoutMethods(realAdapter, ["primaryKey"]);
+
+    const pk = await introspectPrimaryKey(stripped, "widgets");
+
+    expect(pk).toEqual(["id"]);
   });
 });

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -19,12 +19,27 @@ import type { Column } from "./connection-adapters/column.js";
 
 type AdapterWithTables = { tables(): Promise<string[]> };
 type AdapterWithColumns = { columns(table: string): Promise<Column[]> };
+type AdapterWithIndexes = {
+  indexes(table: string): Promise<Array<{ name: string; columns: string[]; unique: boolean }>>;
+};
+
+/** Minimal index descriptor shared by all adapters. */
+export interface IntrospectedIndex {
+  name: string;
+  columns: string[];
+  unique: boolean;
+  /** Partial-index predicate; undefined when adapter does not surface it. */
+  where?: string;
+}
 
 function hasTables(a: unknown): a is AdapterWithTables {
   return typeof (a as AdapterWithTables).tables === "function";
 }
 function hasColumns(a: unknown): a is AdapterWithColumns {
   return typeof (a as AdapterWithColumns).columns === "function";
+}
+function hasIndexes(a: unknown): a is AdapterWithIndexes {
+  return typeof (a as AdapterWithIndexes).indexes === "function";
 }
 
 // Memoize `SchemaStatements` per-adapter so the fallback path doesn't
@@ -64,4 +79,18 @@ export async function introspectColumns(
 ): Promise<Column[]> {
   if (hasColumns(adapter)) return adapter.columns(table);
   return schemaStatementsFor(adapter).columns(table);
+}
+
+/**
+ * Return index descriptors for `table`. Uses `adapter.indexes()` when
+ * implemented (preferred — adapter-specific semantics like SQLite's
+ * `origin === "c"` filter that excludes constraint-generated autoindexes
+ * are applied), else falls back to `SchemaStatements.indexes()`.
+ */
+export async function introspectIndexes(
+  adapter: DatabaseAdapter,
+  table: string,
+): Promise<IntrospectedIndex[]> {
+  if (hasIndexes(adapter)) return adapter.indexes(table);
+  return schemaStatementsFor(adapter).indexes(table);
 }

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -22,6 +22,9 @@ type AdapterWithColumns = { columns(table: string): Promise<Column[]> };
 type AdapterWithIndexes = {
   indexes(table: string): Promise<Array<{ name: string; columns: string[]; unique: boolean }>>;
 };
+type AdapterWithPrimaryKey = {
+  primaryKey(table: string): Promise<string | string[] | null>;
+};
 
 /** Minimal index descriptor shared by all adapters. */
 export interface IntrospectedIndex {
@@ -40,6 +43,9 @@ function hasColumns(a: unknown): a is AdapterWithColumns {
 }
 function hasIndexes(a: unknown): a is AdapterWithIndexes {
   return typeof (a as AdapterWithIndexes).indexes === "function";
+}
+function hasPrimaryKey(a: unknown): a is AdapterWithPrimaryKey {
+  return typeof (a as AdapterWithPrimaryKey).primaryKey === "function";
 }
 
 // Memoize `SchemaStatements` per-adapter so the fallback path doesn't
@@ -93,4 +99,26 @@ export async function introspectIndexes(
 ): Promise<IntrospectedIndex[]> {
   if (hasIndexes(adapter)) return adapter.indexes(table);
   return schemaStatementsFor(adapter).indexes(table);
+}
+
+/**
+ * Return primary key column names for `table` in PK-position order (matching
+ * Rails' `PRAGMA table_info` pk-field sort). Uses `adapter.primaryKey()` when
+ * implemented, else derives from `columns()` filtered to primaryKey===true —
+ * which preserves declaration order but loses composite PK position.
+ *
+ * Returns an empty array when the table has no primary key.
+ */
+export async function introspectPrimaryKey(
+  adapter: DatabaseAdapter,
+  table: string,
+): Promise<string[]> {
+  if (hasPrimaryKey(adapter)) {
+    const pk = await adapter.primaryKey(table);
+    if (pk === null) return [];
+    return Array.isArray(pk) ? pk : [pk];
+  }
+  // Fallback: columns with primaryKey=true in declaration order.
+  const cols = await introspectColumns(adapter, table);
+  return cols.filter((c) => c.primaryKey).map((c) => c.name);
 }

--- a/scripts/parity/schema/node/canonicalize.test.ts
+++ b/scripts/parity/schema/node/canonicalize.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from "vitest";
+import { canonicalize } from "./canonicalize.js";
+import type { NativeDump } from "./canonicalize.js";
+
+describe("canonicalize", () => {
+  it("maps a trivial fixture to canonical form", () => {
+    const native: NativeDump = {
+      users: {
+        columns: [
+          {
+            name: "id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "email",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "name",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "score",
+            sqlType: "REAL",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "avatar",
+            sqlType: "BLOB",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "created_at",
+            sqlType: "DATETIME",
+            primaryKey: false,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "active",
+            sqlType: "INTEGER",
+            primaryKey: false,
+            null: false,
+            default: "1",
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+
+    const result = canonicalize(native);
+
+    expect(result.version).toBe(1);
+    expect(result.tables).toHaveLength(1);
+    const [table] = result.tables;
+    expect(table!.name).toBe("users");
+    expect(table!.primaryKey).toBe("id");
+    expect(table!.columns.map((c) => c.name)).toEqual([
+      "id",
+      "email",
+      "name",
+      "score",
+      "avatar",
+      "created_at",
+      "active",
+    ]);
+    expect(table!.columns.find((c) => c.name === "id")!.type).toBe("integer");
+    expect(table!.columns.find((c) => c.name === "score")!.type).toBe("float");
+    expect(table!.columns.find((c) => c.name === "avatar")!.type).toBe("binary");
+    expect(table!.columns.find((c) => c.name === "created_at")!.type).toBe("datetime");
+    expect(table!.columns.find((c) => c.name === "active")!.default).toBe(1);
+    expect(table!.indexes).toHaveLength(0);
+  });
+
+  it("preserves column declaration order", () => {
+    const native: NativeDump = {
+      things: {
+        columns: [
+          {
+            name: "z",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "a",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "m",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.columns.map((c) => c.name)).toEqual(["z", "a", "m"]);
+  });
+
+  it("sorts tables by name", () => {
+    const native: NativeDump = {
+      zebra: {
+        columns: [
+          {
+            name: "id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+      apple: {
+        columns: [
+          {
+            name: "id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const result = canonicalize(native);
+    expect(result.tables.map((t) => t.name)).toEqual(["apple", "zebra"]);
+  });
+
+  it("filters schema_migrations and ar_internal_metadata", () => {
+    const native: NativeDump = {
+      users: {
+        columns: [
+          {
+            name: "id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+      schema_migrations: {
+        columns: [
+          {
+            name: "version",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+      ar_internal_metadata: {
+        columns: [
+          {
+            name: "key",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const result = canonicalize(native);
+    expect(result.tables.map((t) => t.name)).toEqual(["users"]);
+  });
+
+  it("filters sqlite_autoindex_* and sorts remaining indexes by name", () => {
+    const native: NativeDump = {
+      posts: {
+        columns: [
+          {
+            name: "id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [
+          { name: "sqlite_autoindex_posts_1", columns: ["title"], unique: true },
+          { name: "idx_posts_z", columns: ["created_at"], unique: false },
+          { name: "idx_posts_a", columns: ["author_id"], unique: false },
+        ],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.indexes.map((i) => i.name)).toEqual(["idx_posts_a", "idx_posts_z"]);
+  });
+
+  it("represents composite PK as tuple", () => {
+    const native: NativeDump = {
+      taggings: {
+        columns: [
+          {
+            name: "tag_id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "taggable_id",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.primaryKey).toEqual(["tag_id", "taggable_id"]);
+  });
+
+  it("represents no-PK table", () => {
+    const native: NativeDump = {
+      logs: {
+        columns: [
+          {
+            name: "message",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.primaryKey).toBeNull();
+  });
+
+  it("coerces numeric string defaults", () => {
+    const native: NativeDump = {
+      t: {
+        columns: [
+          {
+            name: "count",
+            sqlType: "INTEGER",
+            primaryKey: false,
+            null: false,
+            default: "0",
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "rate",
+            sqlType: "REAL",
+            primaryKey: false,
+            null: false,
+            default: "1.5",
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.columns[0]!.default).toBe(0);
+    expect(table!.columns[1]!.default).toBe(1.5);
+  });
+
+  it("coerces quoted string defaults", () => {
+    const native: NativeDump = {
+      t: {
+        columns: [
+          {
+            name: "status",
+            sqlType: "TEXT",
+            primaryKey: false,
+            null: false,
+            default: "'active'",
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.columns[0]!.default).toBe("active");
+  });
+
+  it("throws on unknown SQL type", () => {
+    const native: NativeDump = {
+      t: {
+        columns: [
+          {
+            name: "x",
+            sqlType: "UNKNOWNTYPE",
+            primaryKey: false,
+            null: true,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+      },
+    };
+    expect(() => canonicalize(native)).toThrow(/unknown SQL type "UNKNOWNTYPE"/);
+  });
+});

--- a/scripts/parity/schema/node/canonicalize.test.ts
+++ b/scripts/parity/schema/node/canonicalize.test.ts
@@ -79,6 +79,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: ["id"],
       },
     };
 
@@ -142,6 +143,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     const [table] = canonicalize(native).tables;
@@ -164,6 +166,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: ["id"],
       },
       apple: {
         columns: [
@@ -179,6 +182,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: ["id"],
       },
     };
     const result = canonicalize(native);
@@ -201,6 +205,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: ["id"],
       },
       schema_migrations: {
         columns: [
@@ -216,6 +221,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
       ar_internal_metadata: {
         columns: [
@@ -231,6 +237,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     const result = canonicalize(native);
@@ -257,6 +264,7 @@ describe("canonicalize", () => {
           { name: "idx_posts_z", columns: ["created_at"], unique: false },
           { name: "idx_posts_a", columns: ["author_id"], unique: false },
         ],
+        primaryKeyColumns: ["id"],
       },
     };
     const [table] = canonicalize(native).tables;
@@ -289,10 +297,46 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: ["tag_id", "taggable_id"],
       },
     };
     const [table] = canonicalize(native).tables;
     expect(table!.primaryKey).toEqual(["tag_id", "taggable_id"]);
+  });
+
+  it("uses primaryKeyColumns order, not column declaration order, for composite PK", () => {
+    // Simulates PRIMARY KEY (b, a) where a appears first in the table definition.
+    // Rails preserves the PK constraint order via PRAGMA table_info `pk` position.
+    const native: NativeDump = {
+      items: {
+        columns: [
+          {
+            name: "a",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+          {
+            name: "b",
+            sqlType: "INTEGER",
+            primaryKey: true,
+            null: false,
+            default: null,
+            limit: null,
+            precision: null,
+            scale: null,
+          },
+        ],
+        indexes: [],
+        primaryKeyColumns: ["b", "a"], // PK constraint order: b first, then a
+      },
+    };
+    const [table] = canonicalize(native).tables;
+    expect(table!.primaryKey).toEqual(["b", "a"]);
   });
 
   it("represents no-PK table", () => {
@@ -311,6 +355,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     const [table] = canonicalize(native).tables;
@@ -343,6 +388,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     const [table] = canonicalize(native).tables;
@@ -366,6 +412,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     const [table] = canonicalize(native).tables;
@@ -388,6 +435,7 @@ describe("canonicalize", () => {
           },
         ],
         indexes: [],
+        primaryKeyColumns: [],
       },
     };
     expect(() => canonicalize(native)).toThrow(/unknown SQL type "UNKNOWNTYPE"/);

--- a/scripts/parity/schema/node/canonicalize.ts
+++ b/scripts/parity/schema/node/canonicalize.ts
@@ -1,0 +1,158 @@
+/**
+ * Lowers a native dump (raw adapter introspection data) into the neutral
+ * CanonicalSchema format defined in scripts/parity/canonical/schema.schema.json.
+ *
+ * Pure function — no I/O, no side effects.
+ */
+
+import type {
+  CanonicalColumn,
+  CanonicalIndex,
+  CanonicalSchema,
+  CanonicalTable,
+  CanonicalType,
+} from "../../canonical/types.js";
+
+export interface NativeColumn {
+  name: string;
+  /** Raw SQL type string as returned by PRAGMA table_info (e.g. "INTEGER", "TEXT"). */
+  sqlType: string;
+  primaryKey: boolean;
+  /** true = nullable */
+  null: boolean;
+  /** Raw default string from PRAGMA table_info dflt_value, or null. */
+  default: string | null;
+  limit: number | null;
+  precision: number | null;
+  scale: number | null;
+}
+
+export interface NativeIndex {
+  name: string;
+  columns: string[];
+  unique: boolean;
+  where?: string | null;
+}
+
+export interface NativeTable {
+  /** Columns in declaration order (as returned by introspectColumns). */
+  columns: NativeColumn[];
+  indexes: NativeIndex[];
+}
+
+/** Output shape of dump.ts — keyed by table name. */
+export type NativeDump = Record<string, NativeTable>;
+
+// SQLite PRAGMA type strings → canonical CanonicalType.
+// Keys are lowercased. Only types that appear in SQLite fixtures are
+// required here; extend when adding PG/MySQL fixtures.
+const SQL_TO_CANONICAL: Record<string, CanonicalType> = {
+  integer: "integer",
+  int: "integer",
+  bigint: "bigint",
+  text: "text",
+  varchar: "string",
+  "character varying": "string",
+  real: "float",
+  float: "float",
+  double: "float",
+  "double precision": "float",
+  numeric: "decimal",
+  decimal: "decimal",
+  blob: "binary",
+  binary: "binary",
+  bytea: "binary",
+  boolean: "boolean",
+  bool: "boolean",
+  datetime: "datetime",
+  timestamp: "datetime",
+  date: "date",
+  time: "time",
+  json: "json",
+  jsonb: "json",
+};
+
+const FILTERED_TABLES = new Set(["schema_migrations", "ar_internal_metadata"]);
+const AUTOINDEX_PREFIX = "sqlite_autoindex_";
+
+function toCanonicalType(sqlType: string, table: string, column: string): CanonicalType {
+  const base = sqlType
+    .toLowerCase()
+    .trim()
+    .replace(/\s*\([^)]*\)/, "");
+  const mapped = SQL_TO_CANONICAL[base];
+  if (!mapped) {
+    throw new Error(
+      `canonicalize: unknown SQL type "${sqlType}" on ${table}.${column} — add it to SQL_TO_CANONICAL`,
+    );
+  }
+  return mapped;
+}
+
+/** Coerce a raw PRAGMA dflt_value string to a canonical scalar. */
+function coerceDefault(raw: string | null): string | number | boolean | null {
+  if (raw === null) return null;
+  // Strip surrounding single quotes: 'hello' → "hello"
+  if (raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1).replace(/''/g, "'");
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "NULL") return null;
+  const n = Number(raw);
+  if (!Number.isNaN(n) && raw.trim() !== "") return n;
+  return raw;
+}
+
+function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
+  // Primary key
+  const pkCols = native.columns.filter((c) => c.primaryKey).map((c) => c.name);
+  const primaryKey: CanonicalTable["primaryKey"] =
+    pkCols.length === 0
+      ? null
+      : pkCols.length === 1
+        ? pkCols[0]!
+        : (pkCols as [string, string, ...string[]]);
+
+  // Columns in declaration order (D1)
+  const columns: CanonicalColumn[] = native.columns.map((col) => ({
+    name: col.name,
+    type: toCanonicalType(col.sqlType, name, col.name),
+    null: col.null,
+    default: coerceDefault(col.default),
+    limit: col.limit,
+    precision: col.precision,
+    scale: col.scale,
+  }));
+
+  // Indexes: filter autoindexes (D3), sort by name (D1)
+  const indexes: CanonicalIndex[] = native.indexes
+    .filter((idx) => !idx.name.startsWith(AUTOINDEX_PREFIX))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((idx) => ({
+      name: idx.name,
+      columns: idx.columns as [string, ...string[]],
+      unique: idx.unique,
+      where: idx.where ?? null,
+    }));
+
+  return { name, primaryKey, columns, indexes };
+}
+
+/**
+ * Lower a NativeDump into a CanonicalSchema.
+ *
+ * - Filters schema_migrations / ar_internal_metadata (D2).
+ * - Sorts tables by name (D1).
+ * - Preserves column declaration order (D1).
+ * - Filters sqlite_autoindex_* (D3).
+ * - Throws on unknown SQL types (D4).
+ */
+export function canonicalize(native: NativeDump): CanonicalSchema {
+  const tables: CanonicalTable[] = Object.keys(native)
+    .filter((name) => !FILTERED_TABLES.has(name))
+    .sort()
+    .map((name) => canonicalizeTable(name, native[name]!));
+
+  return { version: 1, tables };
+}

--- a/scripts/parity/schema/node/canonicalize.ts
+++ b/scripts/parity/schema/node/canonicalize.ts
@@ -129,12 +129,17 @@ function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
   const indexes: CanonicalIndex[] = native.indexes
     .filter((idx) => !idx.name.startsWith(AUTOINDEX_PREFIX))
     .sort((a, b) => a.name.localeCompare(b.name))
-    .map((idx) => ({
-      name: idx.name,
-      columns: idx.columns as [string, ...string[]],
-      unique: idx.unique,
-      where: idx.where ?? null,
-    }));
+    .map((idx) => {
+      if (idx.columns.length === 0) {
+        throw new Error(`canonicalize: index "${idx.name}" on table "${name}" has no columns`);
+      }
+      return {
+        name: idx.name,
+        columns: idx.columns as [string, ...string[]],
+        unique: idx.unique,
+        where: idx.where ?? null,
+      };
+    });
 
   return { name, primaryKey, columns, indexes };
 }

--- a/scripts/parity/schema/node/canonicalize.ts
+++ b/scripts/parity/schema/node/canonicalize.ts
@@ -38,6 +38,11 @@ export interface NativeTable {
   /** Columns in declaration order (as returned by introspectColumns). */
   columns: NativeColumn[];
   indexes: NativeIndex[];
+  /**
+   * Primary key column names in PK-position order (from adapter.primaryKey,
+   * which sorts by PRAGMA table_info `pk` field). Empty array = no PK.
+   */
+  primaryKeyColumns: string[];
 }
 
 /** Output shape of dump.ts — keyed by table name. */
@@ -105,8 +110,9 @@ function coerceDefault(raw: string | null): string | number | boolean | null {
 }
 
 function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
-  // Primary key
-  const pkCols = native.columns.filter((c) => c.primaryKey).map((c) => c.name);
+  // Primary key — use primaryKeyColumns (pk-position order from adapter.primaryKey)
+  // rather than filtering columns array, so composite PK ordering matches Rails.
+  const pkCols = native.primaryKeyColumns;
   const primaryKey: CanonicalTable["primaryKey"] =
     pkCols.length === 0
       ? null

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -127,7 +127,8 @@ async function main(): Promise<void> {
       process.stderr.write(
         `parity dump: table mismatch\n  expected: ${JSON.stringify(expectedTableNames)}\n  actual:   ${JSON.stringify(actualTableNames)}\n`,
       );
-      process.exit(2);
+      process.exitCode = 2;
+      return;
     }
 
     const actualIndexCount = canonical.tables.reduce((n, t) => n + t.indexes.length, 0);
@@ -135,15 +136,23 @@ async function main(): Promise<void> {
       process.stderr.write(
         `parity dump: index count mismatch\n  expected: ${expected.indexCount}\n  actual:   ${actualIndexCount}\n`,
       );
-      process.exit(2);
+      process.exitCode = 2;
+      return;
     }
 
     // 6. Write canonical JSON
     writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n");
     process.stdout.write(`parity dump (trails): wrote ${outPathAbs}\n`);
   } finally {
-    // Close the connection before deleting the temp file to avoid EBUSY on
-    // some platforms when better-sqlite3 holds the file open.
+    // Explicitly close the adapter's DB handle before removing the temp file.
+    // Base.removeConnection() only drops the pool reference; the adapter (and
+    // its better-sqlite3 handle) may still be open, causing EBUSY on Windows.
+    try {
+      const a = Base.adapter as { close?: () => void };
+      if (typeof a.close === "function") a.close();
+    } catch {
+      /* adapter unavailable or already closed */
+    }
     try {
       Base.removeConnection();
     } catch {

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -12,7 +12,7 @@
  */
 
 import Database from "better-sqlite3";
-import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 // Relative imports so tsx can resolve from source without a prior build.
@@ -36,9 +36,21 @@ function usage(): never {
   process.exit(1);
 }
 
+function assertRepoRoot(): void {
+  // Relative imports in this file resolve from CWD. Fail fast with a clear
+  // message rather than a cryptic "Cannot find module" error at import time.
+  if (!existsSync("packages/activerecord/src/base.ts")) {
+    process.stderr.write(
+      "parity dump: must be run from the repo root (packages/activerecord/src/base.ts not found)\n",
+    );
+    process.exit(1);
+  }
+}
+
 const FILTERED_TABLES = new Set(["schema_migrations", "ar_internal_metadata"]);
 
 async function main(): Promise<void> {
+  assertRepoRoot();
   const [fixtureDir, outPath] = process.argv.slice(2);
   if (!fixtureDir || !outPath) usage();
 
@@ -119,6 +131,13 @@ async function main(): Promise<void> {
     writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n");
     process.stdout.write(`parity dump (trails): wrote ${outPathAbs}\n`);
   } finally {
+    // Close the connection before deleting the temp file to avoid EBUSY on
+    // some platforms when better-sqlite3 holds the file open.
+    try {
+      Base.removeConnection();
+    } catch {
+      /* already removed or never opened */
+    }
     rmSync(tmpDir, { recursive: true, force: true });
   }
 }

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -72,7 +72,8 @@ async function main(): Promise<void> {
     }
 
     // 2. Connect via trails adapter
-    await Base.establishConnection(`sqlite3://${dbPath}`);
+    // Pass dbPath directly — adapterNameFromUrl recognises .db extension as sqlite.
+    await Base.establishConnection(dbPath);
     const adapter = Base.adapter;
 
     // 3. Introspect tables, columns, indexes
@@ -158,7 +159,13 @@ async function main(): Promise<void> {
     } catch {
       /* already removed or never opened */
     }
-    rmSync(tmpDir, { recursive: true, force: true });
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch (err) {
+      process.stderr.write(
+        `parity dump: warning: failed to remove temp dir ${tmpDir}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
   }
 }
 

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -91,12 +91,19 @@ async function main(): Promise<void> {
         scale: col.scale,
       }));
 
-      const indexes: NativeIndex[] = idxDefs.map((idx) => ({
-        name: idx.name ?? "",
-        columns: idx.columns,
-        unique: idx.unique,
-        where: idx.where ?? null,
-      }));
+      const indexes: NativeIndex[] = idxDefs.map((idx) => {
+        if (!idx.name || idx.name.trim() === "") {
+          throw new Error(
+            `parity dump: index on "${tableName}" has no name (columns: ${JSON.stringify(idx.columns)})`,
+          );
+        }
+        return {
+          name: idx.name,
+          columns: idx.columns,
+          unique: idx.unique,
+          where: idx.where ?? null,
+        };
+      });
 
       nativeDump[tableName] = { columns, indexes };
     }

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env tsx
+/**
+ * Usage: tsx scripts/parity/schema/node/dump.ts <fixture-dir> <out.json>
+ *
+ * Must be run from the repo root so relative imports to packages/ resolve.
+ *
+ * Applies <fixture-dir>/schema.sql to a fresh SQLite database, introspects
+ * it using the trails ActiveRecord adapter, canonicalizes the result, and
+ * writes canonical JSON to <out.json>.
+ *
+ * Validates against <fixture-dir>/expected.json (D6) and exits 2 on mismatch.
+ */
+
+import Database from "better-sqlite3";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+// Relative imports so tsx can resolve from source without a prior build.
+// These paths resolve from the repo root (CWD when the script is run).
+import { Base } from "../../../../packages/activerecord/src/base.js";
+import {
+  introspectTables,
+  introspectColumns,
+} from "../../../../packages/activerecord/src/schema-introspection.js";
+import { SchemaStatements } from "../../../../packages/activerecord/src/connection-adapters/abstract/schema-statements.js";
+import { canonicalize } from "./canonicalize.js";
+import type { NativeDump, NativeColumn, NativeIndex } from "./canonicalize.js";
+
+interface ExpectedManifest {
+  tables: string[];
+  indexCount: number;
+}
+
+function usage(): never {
+  process.stderr.write("Usage: tsx scripts/parity/schema/node/dump.ts <fixture-dir> <out.json>\n");
+  process.exit(1);
+}
+
+const FILTERED_TABLES = new Set(["schema_migrations", "ar_internal_metadata"]);
+
+async function main(): Promise<void> {
+  const [fixtureDir, outPath] = process.argv.slice(2);
+  if (!fixtureDir || !outPath) usage();
+
+  const fixtureDirAbs = resolve(fixtureDir);
+  const outPathAbs = resolve(outPath);
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "parity-node-"));
+  const dbPath = join(tmpDir, "schema.db");
+
+  try {
+    // 1. Apply schema.sql to a fresh temp SQLite file via better-sqlite3
+    const sql = readFileSync(join(fixtureDirAbs, "schema.sql"), "utf8");
+    const db = new Database(dbPath);
+    db.exec(sql);
+    db.close();
+
+    // 2. Connect via trails adapter
+    await Base.establishConnection(`sqlite3://${dbPath}`);
+    const adapter = Base.adapter;
+    const schemaStatements = new SchemaStatements(adapter);
+
+    // 3. Introspect tables, columns, indexes
+    const tables = (await introspectTables(adapter)).filter((t) => !FILTERED_TABLES.has(t)).sort();
+
+    const nativeDump: NativeDump = {};
+
+    for (const tableName of tables) {
+      const cols = await introspectColumns(adapter, tableName);
+      const idxDefs = await schemaStatements.indexes(tableName);
+
+      const columns: NativeColumn[] = cols.map((col) => ({
+        name: col.name,
+        sqlType: col.sqlType ?? col.type ?? "",
+        primaryKey: col.primaryKey,
+        null: col.null,
+        default: col.default !== null && col.default !== undefined ? String(col.default) : null,
+        limit: col.limit,
+        precision: col.precision,
+        scale: col.scale,
+      }));
+
+      const indexes: NativeIndex[] = idxDefs.map((idx) => ({
+        name: idx.name ?? "",
+        columns: idx.columns,
+        unique: idx.unique,
+        where: idx.where ?? null,
+      }));
+
+      nativeDump[tableName] = { columns, indexes };
+    }
+
+    // 4. Canonicalize
+    const canonical = canonicalize(nativeDump);
+
+    // 5. Validate against expected.json (D6)
+    const expected = JSON.parse(
+      readFileSync(join(fixtureDirAbs, "expected.json"), "utf8"),
+    ) as ExpectedManifest;
+
+    const actualTableNames = canonical.tables.map((t) => t.name).sort();
+    const expectedTableNames = [...expected.tables].sort();
+    if (JSON.stringify(actualTableNames) !== JSON.stringify(expectedTableNames)) {
+      process.stderr.write(
+        `parity dump: table mismatch\n  expected: ${JSON.stringify(expectedTableNames)}\n  actual:   ${JSON.stringify(actualTableNames)}\n`,
+      );
+      process.exit(2);
+    }
+
+    const actualIndexCount = canonical.tables.reduce((n, t) => n + t.indexes.length, 0);
+    if (actualIndexCount !== expected.indexCount) {
+      process.stderr.write(
+        `parity dump: index count mismatch\n  expected: ${expected.indexCount}\n  actual:   ${actualIndexCount}\n`,
+      );
+      process.exit(2);
+    }
+
+    // 6. Write canonical JSON
+    writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n");
+    process.stdout.write(`parity dump (trails): wrote ${outPathAbs}\n`);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`parity dump: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -2,7 +2,7 @@
 /**
  * Usage: tsx scripts/parity/schema/node/dump.ts <fixture-dir> <out.json>
  *
- * Must be run from the repo root so relative imports to packages/ resolve.
+ * Must be run from the repo root so fixture paths and output paths resolve correctly.
  *
  * Applies <fixture-dir>/schema.sql to a fresh SQLite database, introspects
  * it using the trails ActiveRecord adapter, canonicalizes the result, and
@@ -16,12 +16,13 @@ import { readFileSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "no
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 // Relative imports so tsx can resolve from source without a prior build.
-// These paths resolve from the repo root (CWD when the script is run).
+// These paths are resolved relative to this file's location by the module system.
 import { Base } from "../../../../packages/activerecord/src/base.js";
 import {
   introspectTables,
   introspectColumns,
   introspectIndexes,
+  introspectPrimaryKey,
 } from "../../../../packages/activerecord/src/schema-introspection.js";
 import { canonicalize } from "./canonicalize.js";
 import type { NativeDump, NativeColumn, NativeIndex } from "./canonicalize.js";
@@ -64,8 +65,11 @@ async function main(): Promise<void> {
     // 1. Apply schema.sql to a fresh temp SQLite file via better-sqlite3
     const sql = readFileSync(join(fixtureDirAbs, "schema.sql"), "utf8");
     const db = new Database(dbPath);
-    db.exec(sql);
-    db.close();
+    try {
+      db.exec(sql);
+    } finally {
+      db.close();
+    }
 
     // 2. Connect via trails adapter
     await Base.establishConnection(`sqlite3://${dbPath}`);
@@ -105,7 +109,8 @@ async function main(): Promise<void> {
         };
       });
 
-      nativeDump[tableName] = { columns, indexes };
+      const primaryKeyColumns = await introspectPrimaryKey(adapter, tableName);
+      nativeDump[tableName] = { columns, indexes, primaryKeyColumns };
     }
 
     // 4. Canonicalize

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -21,8 +21,8 @@ import { Base } from "../../../../packages/activerecord/src/base.js";
 import {
   introspectTables,
   introspectColumns,
+  introspectIndexes,
 } from "../../../../packages/activerecord/src/schema-introspection.js";
-import { SchemaStatements } from "../../../../packages/activerecord/src/connection-adapters/abstract/schema-statements.js";
 import { canonicalize } from "./canonicalize.js";
 import type { NativeDump, NativeColumn, NativeIndex } from "./canonicalize.js";
 
@@ -37,8 +37,8 @@ function usage(): never {
 }
 
 function assertRepoRoot(): void {
-  // Relative imports in this file resolve from CWD. Fail fast with a clear
-  // message rather than a cryptic "Cannot find module" error at import time.
+  // Fixture arguments (argv[2], argv[3]) are resolved relative to CWD.
+  // Fail fast with a clear message rather than a cryptic path error later.
   if (!existsSync("packages/activerecord/src/base.ts")) {
     process.stderr.write(
       "parity dump: must be run from the repo root (packages/activerecord/src/base.ts not found)\n",
@@ -70,7 +70,6 @@ async function main(): Promise<void> {
     // 2. Connect via trails adapter
     await Base.establishConnection(`sqlite3://${dbPath}`);
     const adapter = Base.adapter;
-    const schemaStatements = new SchemaStatements(adapter);
 
     // 3. Introspect tables, columns, indexes
     const tables = (await introspectTables(adapter)).filter((t) => !FILTERED_TABLES.has(t)).sort();
@@ -79,7 +78,7 @@ async function main(): Promise<void> {
 
     for (const tableName of tables) {
       const cols = await introspectColumns(adapter, tableName);
-      const idxDefs = await schemaStatements.indexes(tableName);
+      const idxDefs = await introspectIndexes(adapter, tableName);
 
       const columns: NativeColumn[] = cols.map((col) => ({
         name: col.name,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       "packages/*/src/**/*.test.ts",
       "scripts/guides-typecheck/*.test.ts",
       "scripts/api-compare/*.test.ts",
+      "scripts/parity/**/*.test.ts",
     ],
     exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**", "packages/*/dx-tests/**"],
     setupFiles: process.env.MYSQL_TEST_URL


### PR DESCRIPTION
## Summary

Adds the node-side schema dump + canonicalize pipeline per the plan in #730.

**`scripts/parity/schema/node/canonicalize.ts`** — pure function `canonicalize(NativeDump): CanonicalSchema`. Applies all decisions: column declaration order preserved (D1), tables/indexes sorted by name (D1), `schema_migrations`/`ar_internal_metadata` filtered (D2), `sqlite_autoindex_*` filtered (D3), closed type enum enforced with throw on unknown types (D4). `SQL_TO_CANONICAL` maps SQLite PRAGMA type strings to canonical types.

**`scripts/parity/schema/node/dump.ts`** — CLI: `tsx scripts/parity/schema/node/dump.ts <fixture-dir> <out.json>`. Must run from repo root. Applies `schema.sql` via `better-sqlite3`, connects via `Base.establishConnection`, introspects with `introspectColumns`/`SchemaStatements.indexes` (declaration order preserved), canonicalizes, validates against `expected.json` (D6, exits 2 on mismatch), writes canonical JSON.

Uses relative imports to `packages/activerecord/src/` so tsx can run from source without a prior build. Dependency packages (arel, activemodel, activesupport) must be built first — `pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build`.

**`vitest.config.ts`** — adds `scripts/parity/**/*.test.ts` to the include pattern.

**`scripts/parity/schema/node/canonicalize.test.ts`** — 10 vitest golden tests: trivial fixture mapping, column order preservation, table sort, schema_migrations filter, autoindex filter, composite PK tuple, no-PK null, numeric default coercion, quoted string default, unknown-type throw.

## Verified locally
- `pnpm exec vitest run scripts/parity/schema/node/canonicalize.test.ts` → 10/10 pass
- `tsx scripts/parity/schema/node/dump.ts scripts/parity/fixtures/01-trivial /tmp/out.json` → canonical JSON, expected.json validation passes
- `tsx scripts/parity/schema/node/dump.ts scripts/parity/fixtures/02-moderate /tmp/out.json` → 2 tables, 1 index (autoindex filtered), expected.json validation passes

## Test plan
- [ ] `pnpm exec vitest run scripts/parity/schema/node/canonicalize.test.ts` passes (10 tests)
- [ ] `tsx scripts/parity/schema/node/dump.ts scripts/parity/fixtures/01-trivial /tmp/t.json` exits 0 and writes valid canonical JSON
- [ ] `tsx scripts/parity/schema/node/dump.ts scripts/parity/fixtures/02-moderate /tmp/t.json` exits 0 with `indexCount: 1`