### PR TITLE
feat(activerecord): Associations.eagerLoadBang (PR N)

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -5,7 +5,7 @@
  * polymorphic, dependent, counterCache, touch, CollectionProxy, reflection,
  * strict loading, inverse_of, and scoped associations.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   loadHabtm,
   Base,
@@ -7993,21 +7993,34 @@ describe("CollectionProxyDelegation", () => {
 });
 
 describe("eagerLoadBang", () => {
-  it("resolves without error and registers CollectionProxy so association() does not throw 'not registered'", async () => {
-    const { eagerLoadBang, association } = await import("./associations.js");
+  it("resolves without error", async () => {
+    const { eagerLoadBang } = await import("./associations.js");
     await expect(eagerLoadBang()).resolves.toBeUndefined();
+  });
 
-    class EagerPost extends Base {
+  it("registers CollectionProxy so association() does not throw 'not registered' after module reset", async () => {
+    // Reset modules to clear the ctor slot, simulating a subpath-only import
+    // (i.e. without going through the full package entry that normally registers CP).
+    vi.resetModules();
+    const { eagerLoadBang, association } = await import("./associations.js");
+
+    // Before calling eagerLoadBang, the slot is cleared — calling association()
+    // with a valid definition would throw "CollectionProxy not registered".
+    // After eagerLoadBang, CP is registered and the error changes to "not found".
+    await eagerLoadBang();
+
+    const { Base: FreshBase } = await import("./base.js");
+    class IsolatedPost extends (FreshBase as typeof Base) {
       static {
         this.attribute("title", "string");
         this.adapter = createTestAdapter();
       }
     }
-    const post = new EagerPost({ title: "hi" });
-    // After eagerLoadBang, CollectionProxy IS registered.
-    // association() throws for a missing definition — not the
-    // "CollectionProxy not registered" error — confirming CP is wired.
+    const post = new IsolatedPost({ title: "hi" });
     expect(() => association(post, "nonexistent")).toThrow(/not found/i);
     expect(() => association(post, "nonexistent")).not.toThrow(/CollectionProxy not registered/);
+
+    // Restore module cache for subsequent tests.
+    vi.resetModules();
   });
 });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -7991,3 +7991,19 @@ describe("CollectionProxyDelegation", () => {
     expect(reflectOnAllAssociations(BtAuthor).map((r) => r.name)).toContain("bt_tags");
   });
 });
+
+describe("eagerLoadBang", () => {
+  it("initializes CollectionProxy and association() without error", async () => {
+    const { eagerLoadBang, association } = await import("./associations.js");
+    await expect(eagerLoadBang()).resolves.toBeUndefined();
+
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = createTestAdapter();
+      }
+    }
+    const post = new Post({ title: "hi" });
+    expect(() => association(post, "nonexistent")).toThrow();
+  });
+});

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -18,6 +18,7 @@ import {
   DeleteRestrictionError,
   touchBelongsToParents,
 } from "./index.js";
+import { AssociationNotFoundError } from "./associations/errors.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
@@ -7993,17 +7994,21 @@ describe("CollectionProxyDelegation", () => {
 });
 
 describe("eagerLoadBang", () => {
-  it("initializes CollectionProxy and association() without error", async () => {
+  it("resolves without error and registers CollectionProxy so association() does not throw 'not registered'", async () => {
     const { eagerLoadBang, association } = await import("./associations.js");
     await expect(eagerLoadBang()).resolves.toBeUndefined();
 
-    class Post extends Base {
+    class EagerPost extends Base {
       static {
         this.attribute("title", "string");
         this.adapter = createTestAdapter();
       }
     }
-    const post = new Post({ title: "hi" });
-    expect(() => association(post, "nonexistent")).toThrow();
+    const post = new EagerPost({ title: "hi" });
+    // After eagerLoadBang, CollectionProxy IS registered.
+    // association() throws for a missing definition — not the
+    // "CollectionProxy not registered" error — confirming CP is wired.
+    expect(() => association(post, "nonexistent")).toThrow(/not found/i);
+    expect(() => association(post, "nonexistent")).not.toThrow(/CollectionProxy not registered/);
   });
 });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -8002,25 +8002,27 @@ describe("eagerLoadBang", () => {
     // Reset modules to clear the ctor slot, simulating a subpath-only import
     // (i.e. without going through the full package entry that normally registers CP).
     vi.resetModules();
-    const { eagerLoadBang, association } = await import("./associations.js");
+    try {
+      const { eagerLoadBang, association } = await import("./associations.js");
 
-    // Before calling eagerLoadBang, the slot is cleared — calling association()
-    // with a valid definition would throw "CollectionProxy not registered".
-    // After eagerLoadBang, CP is registered and the error changes to "not found".
-    await eagerLoadBang();
+      // Before calling eagerLoadBang, the slot is cleared — calling association()
+      // with a valid definition would throw "CollectionProxy not registered".
+      // After eagerLoadBang, CP is registered and the error changes to "not found".
+      await eagerLoadBang();
 
-    const { Base: FreshBase } = await import("./base.js");
-    class IsolatedPost extends (FreshBase as typeof Base) {
-      static {
-        this.attribute("title", "string");
-        this.adapter = createTestAdapter();
+      const { Base: FreshBase } = await import("./base.js");
+      class IsolatedPost extends (FreshBase as typeof Base) {
+        static {
+          this.attribute("title", "string");
+          this.adapter = createTestAdapter();
+        }
       }
+      const post = new IsolatedPost({ title: "hi" });
+      expect(() => association(post, "nonexistent")).toThrow(/not found/i);
+      expect(() => association(post, "nonexistent")).not.toThrow(/CollectionProxy not registered/);
+    } finally {
+      // Restore module cache for subsequent tests.
+      vi.resetModules();
     }
-    const post = new IsolatedPost({ title: "hi" });
-    expect(() => association(post, "nonexistent")).toThrow(/not found/i);
-    expect(() => association(post, "nonexistent")).not.toThrow(/CollectionProxy not registered/);
-
-    // Restore module cache for subsequent tests.
-    vi.resetModules();
   });
 });

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -18,7 +18,6 @@ import {
   DeleteRestrictionError,
   touchBelongsToParents,
 } from "./index.js";
-import { AssociationNotFoundError } from "./associations/errors.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -7,10 +7,15 @@ import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 
 /**
- * Forces all association-related modules to load eagerly. Mirrors
- * Rails' `ActiveRecord::Associations.eager_load!` which calls
- * `Preloader.eager_load!` and `JoinDependency.eager_load!` — the
- * Ruby autoload equivalent of our dynamic-import initialization.
+ * Eagerly initializes the association modules needed for the
+ * constructor-slot registration cycle used by `association()` and
+ * `CollectionProxy`. Delegates to `initializeAssociations()` so
+ * subpath consumers don't need to call it directly.
+ *
+ * In Rails, `Associations.eager_load!` forces Ruby autoloaded constants
+ * (`Preloader`, `JoinDependency`) to load immediately. We use dynamic
+ * imports instead of Ruby autoload, so this achieves the equivalent
+ * result for our ctor-slot registration pattern.
  *
  * Mirrors: ActiveRecord::Associations.eager_load!
  */

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -7,6 +7,18 @@ import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 
 /**
+ * Forces all association-related modules to load eagerly. Mirrors
+ * Rails' `ActiveRecord::Associations.eager_load!` which calls
+ * `Preloader.eager_load!` and `JoinDependency.eager_load!` — the
+ * Ruby autoload equivalent of our dynamic-import initialization.
+ *
+ * Mirrors: ActiveRecord::Associations.eager_load!
+ */
+export async function eagerLoadBang(): Promise<void> {
+  await initializeAssociations();
+}
+
+/**
  * Explicit initialization hook for subpath consumers.
  *
  * The package entry (`@blazetrails/activerecord`) loads
@@ -20,18 +32,6 @@ export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js
  * dependency cycle (associations → CP → Relation → Base →
  * associations) that forced the late-binding in the first place.
  */
-/**
- * Forces all association-related modules to load eagerly. Mirrors
- * Rails' `ActiveRecord::Associations.eager_load!` which calls
- * `Preloader.eager_load!` and `JoinDependency.eager_load!` — the
- * Ruby autoload equivalent of our dynamic-import initialization.
- *
- * Mirrors: ActiveRecord::Associations.eager_load!
- */
-export async function eagerLoadBang(): Promise<void> {
-  await initializeAssociations();
-}
-
 export async function initializeAssociations(): Promise<void> {
   // Load both ctor slots. `association-relation.js` imports
   // `collection-proxy.js` for the late-bind ctor setter, so importing

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -20,6 +20,18 @@ export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js
  * dependency cycle (associations → CP → Relation → Base →
  * associations) that forced the late-binding in the first place.
  */
+/**
+ * Forces all association-related modules to load eagerly. Mirrors
+ * Rails' `ActiveRecord::Associations.eager_load!` which calls
+ * `Preloader.eager_load!` and `JoinDependency.eager_load!` — the
+ * Ruby autoload equivalent of our dynamic-import initialization.
+ *
+ * Mirrors: ActiveRecord::Associations.eager_load!
+ */
+export async function eagerLoadBang(): Promise<void> {
+  await initializeAssociations();
+}
+
 export async function initializeAssociations(): Promise<void> {
   // Load both ctor slots. `association-relation.js` imports
   // `collection-proxy.js` for the late-bind ctor setter, so importing

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -9,13 +9,15 @@ export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js
 /**
  * Eagerly initializes the association modules needed for the
  * constructor-slot registration cycle used by `association()` and
- * `CollectionProxy`. Delegates to `initializeAssociations()` so
- * subpath consumers don't need to call it directly.
+ * `CollectionProxy`. Delegates to `initializeAssociations()`.
  *
- * In Rails, `Associations.eager_load!` forces Ruby autoloaded constants
- * (`Preloader`, `JoinDependency`) to load immediately. We use dynamic
- * imports instead of Ruby autoload, so this achieves the equivalent
- * result for our ctor-slot registration pattern.
+ * **Rails parity note:** Rails' `Associations.eager_load!` uses Ruby's
+ * `ActiveSupport::Autoload` to force-load `BelongsToAssociation`,
+ * `HasManyAssociation`, `Preloader`, `JoinDependency`, `AssociationScope`,
+ * etc. In TypeScript/ESM there is no `autoload` — those modules are
+ * already statically imported throughout the codebase and therefore
+ * always present. The only genuinely lazy initialization in our port is
+ * the `CollectionProxy` constructor-slot, which this method resolves.
  *
  * Mirrors: ActiveRecord::Associations.eager_load!
  */

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -51,6 +51,7 @@ export {
   loadHabtm,
   updateCounterCaches,
   touchBelongsToParents,
+  eagerLoadBang,
 } from "./associations.js";
 export { CollectionProxy } from "./associations/collection-proxy.js";
 export type { AssociationProxy } from "./associations/collection-proxy.js";


### PR DESCRIPTION
## Summary

Adds `eagerLoadBang()` to `associations.ts`, mirroring Rails' `ActiveRecord::Associations.eager_load!`. In Rails this calls `Preloader.eager_load!` and `JoinDependency.eager_load!` — the `ActiveSupport::Autoload` hook that forces lazy constants to load. Our equivalent delegates to `initializeAssociations()` which performs the same role via dynamic imports.