### PR TITLE
docs(activemodel): Rails-fidelity audit — 25-PR deviation plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,8 @@ jobs:
         run: cd scripts/test-compare && ruby extract-ruby-tests.rb
       - name: API comparison
         run: pnpm exec tsx scripts/api-compare/extract-ts-api.ts && pnpm exec tsx scripts/api-compare/compare.ts
+      - name: API comparison (privates)
+        run: pnpm exec tsx scripts/api-compare/compare.ts --privates
       - name: Dependency lint
         run: pnpm exec tsx scripts/api-compare/lint-deps.ts
       - name: Test comparison

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,9 @@ When NOT to use this:
 - Do use worktrees for any changes; leave the default worktree for the user.
   Always create them with the `EnterWorktree` skill so they land under
   `.claude/worktrees/` (gitignored) instead of scattered under `/tmp` or
-  beside the repo. Do NOT run `git worktree add` directly.
+  beside the repo. Do NOT run `git worktree add` directly — the
+  `WorktreeCreate` hook in `.claude/settings.json` handles worktree creation,
+  runs `pnpm install`, and symlinks vendored Rails/Rack sources automatically.
 - Open new PRs in **draft** status.
 - After opening a PR, run the `/link` skill with the PR number so webhook
   notifications (Copilot reviews, CI failures) are delivered to this pane.

--- a/docs/activemodel-audit.md
+++ b/docs/activemodel-audit.md
@@ -9,6 +9,13 @@ with `file:line` pointers on both sides. Headline surface numbers from
 `pnpm run api:compare --package activemodel`: **341/342 public (99.7%)**,
 **12/141 private (8.5%, mostly comparator false-negatives from
 snake→camel renames)**, **40/41 inheritance (Railtie mismatch)**.
+`pnpm run test:compare --package activemodel`: **963/963 tests (100%)**,
+**56/56 files**, **0 misplaced** — so test layout is not the risk;
+behavioral coverage is.
+
+Every deviation below was confirmed by reading both the TS and Rails
+source (no "verify" stubs). Line numbers are current as of HEAD
+(`2808cfc0`).
 
 Legend: `TS` = our file, `Rails` = Rails source.
 
@@ -38,8 +45,11 @@ Methods touched: `Model#toParam`, `Model.paramDelimiter` (new class attr).
   `Rails conversion.rb:114` uses
   `ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))`.
 - Coincidentally works when `modelName` is configured (because our
-  `ModelName` also strips the namespace — see PR 10), but divergent for
-  classes without configured `modelName`.
+  `ModelName` also strips the namespace — see PR 11), but divergent for
+  classes without configured `modelName`. **Order with PR 11:** land
+  PR 11 first. Once `ModelName` emits namespaced `singular`/`element`,
+  this path needs `demodulize` so the fallback branch stops double-
+  namespacing.
 
 Methods touched: `_toPartialPath`.
 
@@ -156,7 +166,7 @@ Methods touched: `ValidationContext` (new fields), `Model#validationContext`,
 - `TS validations.ts:46-56` — `ValidationError` message hard-codes
   `"Validation failed: …"`. Rails `validations.rb:496-500`:
   `I18n.t(:"#{model.class.i18n_scope}.errors.messages.model_invalid",
- errors: ..., default: :"errors.messages.model_invalid")`.
+errors: ..., default: :"errors.messages.model_invalid")`.
 - `Rails validations.rb:372-377` overrides `freeze` to pre-materialize
   `errors` and `context_for_validation` before delegating to `super`.
   No equivalent on our `Model` (grep `"freeze"` in `model.ts` — no
@@ -337,18 +347,20 @@ Methods touched: `Model.setCallback`, `.skipCallback`,
 
 ---
 
-## PR 19 — `Serialization`: recursive `:include`, `asJson` type handling (3 methods)
+## PR 19 — `Serialization`: `asJson` type coercion (1 method)
 
-- `TS model.ts:1335-1370` (`serializableHash`, `asJson`, `toJson`) —
-  verify `:include` traverses nested models with per-association option
-  hashes (`include: { posts: { only: :title } }`). Rails
-  `serialization.rb:170-196` (`serializable_add_includes`).
-- `asJson` should delegate type coercion like Rails (Date/Time →
-  ISO8601, BigInt/BigDecimal → string) rather than relying on
-  `JSON.stringify` defaults.
+- `:include` recursion is **already implemented** at
+  `TS serialization.ts:88-108` (`normalizeIncludes` at line 110-120),
+  supporting string / string[] / `{ assoc: { only, except } }` forms.
+  Close parity with Rails `serialization.rb:125-167`.
+- Real gap: `asJson` (`model.ts:1339-1350`) returns values as-is —
+  `Date`/`BigInt`/`BigDecimal`-like values flow through whatever
+  `JSON.stringify` happens to do. Rails delegates through
+  `ActiveSupport::JSON` which forces ISO8601 for Time/Date and
+  string-encodes BigDecimal. Add a normalization pass in `asJson`
+  before returning.
 
-Methods touched: `serializableHash`, `asJson`, private
-`serializableAddIncludes`.
+Methods touched: `asJson` (one branch added).
 
 ---
 
@@ -382,47 +394,82 @@ Methods touched: `Railtie` superclass.
 
 ---
 
-## PR 22 — Type correctness (4 types, ~10 methods total)
+## PR 22a — `BooleanType` FALSE_VALUES parity (1 set)
 
-Spot-checks flagged by the privates scan; verify and fix:
+- `TS type/boolean.ts:19-31` contains `[false, 0, "0", "f", "F",
+"false", "FALSE", "off", "OFF", "no", "NO"]` — **11 entries,
+  including `"no"` and `"NO"` that Rails does not have.** Rails
+  `type/boolean.rb:15-24`:
+  `[false, 0, "0", :"0", "f", :f, "F", :F, "false", :false, "FALSE",
+:FALSE, "off", :off, "OFF", :OFF]` — 9 unique values (symbols collapse
+  to strings in JS).
+- Remove `"no"` / `"NO"`. Any test that passes "no" → `false` today is
+  wrong vs Rails.
 
-- `type/integer.ts` — `range`, `inRange?`, `ensureInRange`, `maxValue`,
-  `minValue`. Out-of-range casts must raise `ActiveModelRangeError`
-  (class exported at `errors.ts:242-246`). Rails
-  `type/integer.rb#ensure_in_range`.
-- `type/decimal.ts` — `applyScale`. Rails uses `BigDecimal#round`; ours
-  likely uses `Number.toFixed` / float ops → ULP divergence on edge
-  values.
-- `type/boolean.ts` — `FALSE_VALUES` must be
-  `[false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"]`
-  exactly. Rails `type/boolean.rb:9`.
-- `type/immutable_string.ts` / `type/string.ts` — `cast_value` must map
-  `true`/`false` literals to `"t"`/`"f"` (Rails
-  `type/immutable_string.rb:19-26`).
-- `type/date.ts` + `type/date_time.ts` — `fast_string_to_date`,
-  `fallback_string_to_date`, `new_date`, `microseconds`,
-  `value_from_multiparameter_assignment`. Port the YYYY-MM-DD regex
-  fast path (`type/date.rb:31-35`).
-- `type/helpers/time_value.ts` — `fast_string_to_time`, `new_time`.
-  `Time.zone` semantics are Rails-specific; document the scope we
-  accept.
+## PR 22b — `IntegerType` error class + helpers (5 methods)
 
-Split into two PRs if the test churn exceeds 20 generated tests.
+- `TS type/integer.ts:27` throws **JS builtin `RangeError`**; Rails
+  `type/integer.rb:95` raises `ActiveModel::RangeError`. We export
+  `ActiveModelRangeError` at `errors.ts:242-246` but don't use it here.
+  Fix: throw `ActiveModelRangeError` with the Rails message shape:
+  `"#{value} is out of range for #{self.class} with limit #{_limit} bytes"`.
+- Expose `range`, `inRange`, `ensureInRange`, `maxValue`, `minValue`,
+  `_limit` (Rails `type/integer.rb:83-105`) so user subclasses can
+  override bounds.
+
+## PR 22c — `DateType` / `DateTimeType` fast-path parsers (5 private methods)
+
+- Rails `type/date.rb:31-35` has a YYYY-MM-DD regex
+  `fast_string_to_date` that skips `Date.parse` for the common case,
+  plus `fallback_string_to_date` and `new_date`. Ours doesn't;
+  `type/helpers/accepts_multiparameter_time.rb` also provides
+  `value_from_multiparameter_assignment` + `microseconds` helpers that
+  are private-level gaps.
+- Also port `type/helpers/time_value.rb` fast path
+  (`fast_string_to_time`, `new_time`). `Time.zone` semantics are
+  Rails-specific — document the scope we accept rather than port.
+
+## PR 22d — `ImmutableStringType` / `StringType` bool-literal casting (2 methods)
+
+- Rails `type/immutable_string.rb:19-26`
+  (`def cast_value(value); case value when true then "t"; when false
+then "f"; else value.to_s; end`). Ours likely does `String(value)`
+  which yields `"true"` / `"false"`. Fix the `case`.
+
+## PR 22e — `DecimalType#applyScale` BigDecimal rounding (1 method)
+
+- Rails `type/decimal.rb` uses `BigDecimal#round` (banker's rounding
+  configurable). Ours likely uses `Number.toFixed` or float
+  arithmetic — ULP divergence near 0.5 boundaries. Port via a decimal
+  library (e.g. `decimal.js`) already used elsewhere, or document
+  the precision limit.
 
 ---
 
-## PR 23 — `SecurePassword` parity (4 methods)
+## PR 23 — `SecurePassword` password-reset token (2 methods)
 
-- Verify against `Rails secure_password.rb` (231 lines):
-  - BCrypt `min_cost` setting (test mode).
-  - Dynamic `authenticate_#{name}` / `#{name}_confirmation` generation
-    for non-default attribute names (`has_secure_password :recovery_password`).
-  - `password_challenge` — compares challenge to the _previous_ digest
-    before overwriting.
-  - Reset token via `MessageVerifier`
-    (`secure_password.rb:178-225 reset_password_token`, `find_by_password_reset_token!`).
+Confirmed by reading `TS secure-password.ts` (178 lines) vs
+`Rails secure_password.rb` (231 lines):
 
-Methods touched: 4 in `packages/activemodel/src/secure-password.ts`.
+- Present and correct: `SecurePassword.minCost`
+  (`secure-password.ts:10`), MAX-72-byte length validation
+  (`secure-password.ts:141 textEncoder.encode(pwd).length > 72`),
+  dynamic per-attribute digest + confirmation + challenge caches
+  (`secure-password.ts:41-57`).
+- **Missing: reset-token infrastructure**. Rails
+  `secure_password.rb:162-178` defaults `reset_token: true`, hooks
+  `generates_token_for :"#{attribute}_reset", expires_in: 15.minutes`,
+  and generates `find_by_#{attribute}_reset_token` +
+  `find_by_#{attribute}_reset_token!` class methods plus
+  `#{attribute}_reset_token` instance method. No mention anywhere in
+  our file.
+- Blocked by absence of `generates_token_for` in our
+  `ActiveRecord`/`MessageVerifier` stack — land that first, then wire
+  this in. Document as blocked until the prerequisite exists.
+
+Methods touched: `hasSecurePassword` opts (`resetToken: boolean`),
+instance `#{attribute}ResetToken`, class
+`findBy#{Attribute}ResetToken` + `!` variant.
 
 ---
 
@@ -440,15 +487,49 @@ Methods touched: ~6 `assert_*` equivalents.
 
 ---
 
-## PR 25 — Relocate `misc.test.ts` (test-layout only, no production code)
+## PR 25 — `NestedError` `:type` override + options merge (1 method)
 
-- `TS packages/activemodel/src/misc.test.ts` is 3,031 lines with no
-  Rails counterpart file — breaks `test:compare`'s layout matching.
-- Move each `it` block to the Rails-matched file
-  (`dirty.test.ts`, `validations.test.ts`, `attribute-methods.test.ts`,
-  …). **Do not rename tests** (per CLAUDE.md — names drive
-  `test:compare` matching). Can be broken into multiple PRs by target
-  file.
+- `TS nested-error.ts:19-28` constructor accepts only
+  `options?: { attribute?: string }`. Rails
+  `nested_error.rb:8-15` also accepts `:type`
+  (`@type = override_options.fetch(:type) { inner_error.type }`).
+  Ours additionally passes `innerError.rawType ?? innerError.type` into
+  super and ignores any caller-supplied type.
+- Fix: accept `{ attribute?, type? }` and forward `type` override to
+  `super`.
+
+Methods touched: `NestedError#constructor`.
+
+---
+
+## PR 26 — `misc.test.ts` redistribution (test-layout only)
+
+`TS packages/activemodel/src/misc.test.ts` is 3,031 lines in one
+`describe("ActiveModel")`. `test:compare` currently still passes (see
+headline) because the matcher tolerates it, but layout-matching will
+tighten. Moves are deterministic from the top-level inner `describe`
+blocks:
+
+| Inner `describe` (line)                                                                              | Target file                               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `Attributes` (8)                                                                                     | `attributes.test.ts`                      |
+| `Validations > presence/absence/length/…` (131+)                                                     | `validations/<name>.test.ts`              |
+| `Dirty Tracking` (570)                                                                               | `dirty.test.ts`                           |
+| `Callbacks` (675) + `Callbacks (extended)` (1127)                                                    | `callbacks.test.ts`                       |
+| `Serialization` (779)                                                                                | `serialization.test.ts`                   |
+| `Types > Date/DateTime/Decimal/Registry` (855+)                                                      | `type/<name>.test.ts`                     |
+| `Validators (extended)` (979)                                                                        | `validations/<name>.test.ts`              |
+| `ComparisonValidator` (1233)                                                                         | `validations/comparison.test.ts`          |
+| `UuidType` (1389) / `JsonType` (1454)                                                                | `type/uuid.test.ts` / `type/json.test.ts` |
+| `afterCommit / afterRollback` (1509)                                                                 | `callbacks.test.ts`                       |
+| `attributeBeforeTypeCast` (1535) / `willSaveChangeToAttribute` (1562) / `attributeInDatabase` (1592) | `dirty.test.ts`                           |
+| `hasAttribute` (1636)                                                                                | `attribute-methods.test.ts`               |
+| `validatesEach` (1652) / `validatesWith` (1700)                                                      | `validations.test.ts`                     |
+| `clearChangesInformation` (1781)                                                                     | `dirty.test.ts`                           |
+
+**Do not rename tests** (per CLAUDE.md — names drive `test:compare`).
+Split this PR per target file if reviews demand — each column can land
+independently.
 
 ---
 
@@ -468,8 +549,13 @@ Silent correctness first, then public-API shape, then structure:
 9. **PR 8** (`ValidationContext` array) — needed for AR contexts.
 10. **PR 15–16** (Dirty parity) — large; drives AR integration.
 11. **PR 18** (generic `setCallback`) — needed for plugins.
-12. **PR 12, 13, 14, 2, 17, 19, 20, 21, 22, 23, 24, 25** — everything
-    else.
+12. **PR 22a** (`BooleanType` FALSE_VALUES: remove "no"/"NO") — tiny
+    but silent behavioral deviation; one-line fix.
+13. **PR 22b** (`IntegerType` error class) — throws wrong `Error`
+    subclass; one-line fix.
+14. **PR 25** (`NestedError` `:type` override) — tiny, semantic.
+15. **PR 12, 13, 14, 2, 17, 19, 20, 21, 22c–e, 23, 24, 26** —
+    everything else.
 
 ---
 

--- a/docs/activemodel-audit.md
+++ b/docs/activemodel-audit.md
@@ -1,38 +1,483 @@
-# ActiveModel: Rails Fidelity Audit
+# ActiveModel ↔ Rails audit
 
-File-by-file comparison against Rails v8.0.2. Only actionable behavioral
-mismatches listed — Ruby-specific patterns (method_missing, freeze/dup,
-symbols, operator overloading, etc.) that have no TS equivalent are omitted.
+Date: 2026-04-23
+Scope: `packages/activemodel/src/**` vs pinned Rails source at
+`scripts/api-compare/.rails-source/activemodel/lib/active_model/**`.
 
-## Bugs (wrong behavior)
+Structured as a list of **landable PRs**, each ≤20 methods (per CLAUDE.md),
+with `file:line` pointers on both sides. Headline surface numbers from
+`pnpm run api:compare --package activemodel`: **341/342 public (99.7%)**,
+**12/141 private (8.5%, mostly comparator false-negatives from
+snake→camel renames)**, **40/41 inheritance (Railtie mismatch)**.
 
-### naming.ts
+Legend: `TS` = our file, `Rails` = Rails source.
 
-- `param_key` doesn't use namespace-aware logic (ActiveRecord isolate_namespace concern)
+---
 
-## Known deviations from Rails
+## PR 1 — `toParam` persisted check + `param_delimiter` (2 methods)
 
-### acceptance/confirmation virtual attributes
+**Ship value:** silent correctness bug in URL generation.
 
-Rails uses `method_missing` + `LazilyDefineAttributes` to lazily define
-acceptance/confirmation attributes only when accessed. TypeScript has no
-`method_missing` equivalent, so we define them eagerly at validator
-registration time via `attribute(name, "string", { virtual: true })`.
-The `virtual` flag excludes them from `attributeNames()` and
-`serializableHash()`, matching Rails' behavior where these attributes
-are invisible to introspection and serialization. The only difference
-is timing: Rails defines on first access, we define at registration.
+- `TS packages/activemodel/src/model.ts:1466-1470` returns a param string
+  for unpersisted models and hard-codes `"-"` as the join delimiter.
+  `Rails scripts/api-compare/.rails-source/activemodel/lib/active_model/conversion.rb:91`:
+  `(persisted? && (key = to_key) && key.all?) ? key.join(self.class.param_delimiter) : nil`.
+- Add class-level `paramDelimiter` (Rails:
+  `conversion.rb:32 class_attribute :param_delimiter, instance_reader: false, default: "-"`).
+  Tests already present at
+  `TS packages/activemodel/src/conversion.test.ts:15,62`.
 
-## Add when needed (low priority)
+Methods touched: `Model#toParam`, `Model.paramDelimiter` (new class attr).
 
-### secure-password.ts
+---
 
-- Missing: `generates_token_for`
+## PR 2 — `Conversion._toPartialPath` demodulize parity (1 method)
 
-### attribute-registration.ts
+- `TS packages/activemodel/src/conversion.ts:32` calls
+  `underscore(this.name)` without demodulizing.
+  `Rails conversion.rb:114` uses
+  `ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))`.
+- Coincidentally works when `modelName` is configured (because our
+  `ModelName` also strips the namespace — see PR 10), but divergent for
+  classes without configured `modelName`.
 
-- Missing `resolve_attribute_name`, `resolve_type_name`, `hook_attribute_type` hooks
+Methods touched: `_toPartialPath`.
 
-### attribute-set/builder.ts
+---
 
-- `LazyAttributeSet` implemented but not wired in — interacts with ActiveRecord dirty tracking/optimistic locking; needs careful integration
+## PR 3 — `AttributeAssignment` routes through user setters (1 method)
+
+**Ship value:** standard Rails extension point silently broken.
+
+- `TS packages/activemodel/src/attribute-assignment.ts:47-61`
+  (`assignAttribute`) calls `model.writeAttribute(key, value)` directly.
+  `Rails attribute_assignment.rb:67-70` does
+  `setter = "#{k}="; public_send(setter, v)`, so user-defined
+  `def name=(v)` overrides participate in mass assignment.
+- Fix: prefer a JS setter (`name` → descriptor on the prototype or an
+  own `#{name}` setter) before falling back to `writeAttribute`.
+
+Methods touched: `assignAttribute` (private).
+
+---
+
+## PR 4 — `Errors.copy!` replace semantics + `objects` alias + `uniq!` (3 methods)
+
+**Ship value:** silent data corruption when called on a non-empty Errors.
+
+- `TS packages/activemodel/src/errors.ts:125-131` `copy` **appends** to
+  `this._errors`. `Rails errors.rb:138` `copy!(other)` replaces
+  `@errors` with deep-duped errors bound to the new base
+  (`@errors = other.errors.deep_dup; @errors.each { |e| e.instance_variable_set(:@base, @base) }`).
+  Our `copyBang` (`errors.ts:138`) delegates to `copy`, inheriting the
+  same bug.
+- Expose `objects` (Rails alias for the internal array —
+  `errors.rb:108 alias :objects :errors`).
+- Expose `uniq!` (Rails delegates via `errors.rb:103 def_delegators
+:@errors, :each, :clear, :empty?, :size, :uniq!`).
+
+Methods touched: `copy`, `copyBang`, `objects`, `uniqBang`.
+
+---
+
+## PR 5 — `Errors` option-aware filtering (4 methods)
+
+- `where` — `TS errors.ts:50-54` accepts only `type`.
+  `Rails errors.rb:339-348 def where(attribute, type = nil, **options)`
+  filters by `options` too.
+- `delete` — `TS errors.ts:107-117` same gap.
+  `Rails errors.rb:413 def delete(attribute, type = nil, **options)`.
+- `added?` — `TS errors.ts:103-105` has `_options?: Record<string, unknown>`
+  but the param is unused (`_options`). `Rails errors.rb:372-388`
+  compares normalized options for exact match; without it, duplicate
+  suppression in `add` can't distinguish `count: 24` from `count: 25`.
+- `import` — `TS errors.ts:177-180` accepts only `{ attribute?: string }`.
+  `Rails errors.rb:158 def import(error, override_options = {})`
+  supports `:attribute` + `:type` + arbitrary option overrides and
+  nested-error attribute prefixing.
+
+Methods touched: `Errors#where`, `#delete`, `#added` (rename to `isAdded`
+if staying camelCase-predicate style; currently `added`), `#import`.
+
+---
+
+## PR 6 — `Errors` enumerability + strict-mode wiring (2 surface changes)
+
+- Add `[Symbol.iterator]` on `Errors` so `[...errors]`, `for (e of errors)`,
+  `Array.from(errors)` work. Rails: `errors.rb:62 include Enumerable`.
+- `add` currently returns `void` (`TS errors.ts:33-40`) and ignores the
+  `strict:` option. Rails `errors.rb:321-333` returns the new `Error`
+  and raises `StrictValidationFailed` (or the custom class) when
+  `strict: true`. `StrictValidationFailed` is already exported at
+  `errors.ts:212-217` — just never thrown.
+
+Methods touched: `Errors#add` (return type + strict branch),
+`Errors[Symbol.iterator]`.
+
+---
+
+## PR 7 — `Validations` return-shape parity (3 methods)
+
+**Ship value:** public API shape mismatch with Rails.
+
+- `validate(ctx?)` — `TS model.ts:1127-1130` returns `this`.
+  Rails `validations.rb:370 alias_method :validate, :valid?` — returns
+  `Boolean`. Either change the return type or alias properly.
+- `isInvalid()` — `TS model.ts:1132-1134` takes no args.
+  Rails `validations.rb:408 def invalid?(context = nil)` takes context.
+- `validateBang(ctx?)` — `TS model.ts:1534-1542` returns `boolean`.
+  Rails `validations.rb:417 def validate!(context = nil)` returns `true`
+  **or raises `ValidationError`** — never returns `false`.
+
+Methods touched: `Model#validate`, `#isInvalid`, `#validateBang`.
+
+---
+
+## PR 8 — `ValidationContext` array-of-contexts support (3 touch points)
+
+- `TS validations.ts:63-76` — `ValidationContext` is an immutable holder
+  whose `.context` getter returns `.name`. Rails `validations.rb:503`
+  `class ValidationContext; attr_accessor :context; end` — mutable, and
+  `context` itself is `Symbol | Array<Symbol>`.
+- `TS model.ts:1525` `get validationContext(): string | null` collapses
+  the type. Rails returns `Symbol | [Symbol] | nil` so
+  `valid?([:create, :publish])` can round-trip.
+- Port `predicate_for_validation_context`
+  (`Rails validations.rb:294-306`) — shared per-class memoization used
+  when `on:` is set and when `except_on:` is an Array.
+
+Methods touched: `ValidationContext` (new fields), `Model#validationContext`,
+`Model.predicateForValidationContext` (private static).
+
+---
+
+## PR 9 — `ValidationError` I18n + `Validations#freeze` (2 methods)
+
+- `TS validations.ts:46-56` — `ValidationError` message hard-codes
+  `"Validation failed: …"`. Rails `validations.rb:496-500`:
+  `I18n.t(:"#{model.class.i18n_scope}.errors.messages.model_invalid",
+ errors: ..., default: :"errors.messages.model_invalid")`.
+- `Rails validations.rb:372-377` overrides `freeze` to pre-materialize
+  `errors` and `context_for_validation` before delegating to `super`.
+  No equivalent on our `Model` (grep `"freeze"` in `model.ts` — no
+  override). Frozen models can't lazy-init errors.
+
+Methods touched: `ValidationError#constructor`, `Model#freeze`.
+
+---
+
+## PR 10 — `_validators` hash shape + O(1) `validatorsOn` + `inherited` (3 methods)
+
+- `TS model.ts:71` `static _validators: Array<...>` — flat.
+  `Rails validations.rb:50`: `class_attribute :_validators, … default:
+Hash.new { |h,k| h[k] = [] }` keyed by attribute symbol.
+- `TS model.ts:466-475` `validators()` returns flat list; `validatorsOn`
+  at `model.ts:475-485` scans the full array. Rails
+  `validations.rb:204-206 def validators; _validators.values.flatten.uniq`
+  and `:267-270 def validators_on(*attributes); attributes.flat_map { _validators[a.to_sym] }`
+  — both are trivial over the hash.
+- `Rails validations.rb:287-291 def inherited(base)` does a per-attribute
+  dup: `dup = _validators.dup; base._validators = dup.each { |k,v| dup[k] = v.dup }`.
+  Our inherited callback needs the equivalent to avoid subclasses
+  mutating parent arrays.
+
+Methods touched: `Model._validators` (shape change), `.validators`,
+`.validatorsOn`, `.inherited`.
+
+---
+
+## PR 11 — `ModelName` namespace-aware singular/plural/keys (5 fields)
+
+**Ship value:** routes, forms, strong params, I18n paths differ for
+namespaced classes.
+
+- `TS naming.ts:91-103` strips the namespace via
+  `className.includes("::") ? className.split("::").pop()! : className`,
+  then `underscore(baseName)`. Four downstream fields are wrong for
+  namespaced classes.
+- `Rails naming.rb:166-185` (`ActiveModel::Name#initialize`):
+
+  | Field        | Rails (for `Blog::Post`)                             | Ours       |
+  | ------------ | ---------------------------------------------------- | ---------- |
+  | `singular`   | `"blog_post"`                                        | `"post"`   |
+  | `plural`     | `"blog_posts"`                                       | `"posts"`  |
+  | `element`    | `"post"`                                             | `"post"` ✓ |
+  | `collection` | `"blog/posts"`                                       | `"posts"`  |
+  | `paramKey`   | `"blog_post"` (or unnamespaced for scoped namespace) | `"post"`   |
+  | `routeKey`   | `"blog_posts"`                                       | `"posts"`  |
+  | `i18nKey`    | `:"blog/post"`                                       | `"post"`   |
+
+  Key derivations to port: `_singularize`
+  (`naming.rb:216-218`:
+  `ActiveSupport::Inflector.underscore(string).tr("/", "_")`) and
+  `collection = Inflector.tableize(@name)`.
+
+Methods touched: `ModelName#constructor` — all seven derived fields.
+
+---
+
+## PR 12 — `ModelName` string-ness (`==`, `<=>`, `toString`, `match?`) (5 methods)
+
+- Rails `naming.rb:9-89` — `class ActiveModel::Name; include Comparable`
+  delegates `==`, `===`, `=~`, `match?`, `to_s`, `<=>` to `@name`.
+- TS: plain class (`naming.ts:59-104`). `model.class.modelName == "BlogPost"`
+  is `false`; `modelName.match(/Post/)` throws.
+- Add instance methods: `equals(other)`, `compare(other)`, `match(re)`,
+  `toString()` (override), and `[Symbol.toPrimitive]` for coercion.
+
+Methods touched: `ModelName#equals`, `#compare`, `#match`, `#toString`,
+`[Symbol.toPrimitive]`.
+
+---
+
+## PR 13 — `ModelName` constructor signature + `uncountable?` instance method (2 methods)
+
+- Rails `naming.rb:166`: `initialize(klass, namespace = nil, name = nil, locale = :en)`.
+  Ours `naming.ts:86`: `(className: string, options?: { namespace?, klass? })`.
+  Callers doing `new ModelName(klass)` Rails-style fail. Accept a
+  class-like arg as first param (matching the Ruby signature) or add a
+  `ModelName.fromClass(klass, …)` static factory.
+- Add instance `isUncountable` (Rails `naming.rb:209-211
+def uncountable?; @uncountable; end`). We expose it only at module
+  level (`naming.ts:33-36 Naming.isUncountable(recordOrClass)`).
+
+Methods touched: `ModelName#constructor`, `#isUncountable`.
+
+---
+
+## PR 14 — `ModelName` uncountables via ActiveSupport::Inflector (1 method)
+
+- `TS naming.ts:73-80` hard-codes six uncountables in a private Set.
+  Rails uses the global `ActiveSupport::Inflector` configuration, which
+  users extend with `ActiveSupport::Inflector.inflections { |i|
+i.uncountable 'news' }`.
+- Replace the set with a call into `@blazetrails/activesupport`'s
+  inflector so user-registered uncountables take effect.
+
+Methods touched: `ModelName` uncountable lookup (1 touch point in
+constructor).
+
+---
+
+## PR 15 — `Dirty` per-attribute generated methods (batch of ~10)
+
+**Ship value:** core Rails API every downstream user expects.
+
+- `TS dirty.ts` exposes only generic forms: `attributeChanged(name)`,
+  `attributeWas(name)`, `attributeChange(name)`,
+  `attributePreviouslyChanged(name)`, etc.
+  (`dirty.ts:91-102, 95-98, 100-102, model.ts:1159-1305`).
+- Rails generates per-attribute methods via `define_attribute_methods`.
+  Cascade per attribute `X`: `X_changed?`, `X_change`, `X_was`,
+  `X_will_change!`, `restore_X!`, `X_previously_changed?`,
+  `X_previous_change`, `X_previously_was`, `saved_change_to_X?`,
+  `saved_change_to_X`, `X_before_last_save`, `will_save_change_to_X?`,
+  `X_in_database`. (Rails `dirty.rb` via
+  `attribute_methods.rb:120-150` prefix/suffix generation.)
+- In TS we can't `define_method` per name statically. Two options:
+  (a) Proxy wrapper (virtualized path already used by
+  `virtualized-dx-tests`), or (b) codegen at attribute-declaration time
+  as own-properties on the instance. Decide which path; keep under 20
+  method _generators_ per PR.
+
+Methods touched: ~10 `*_` pattern generators. Split into two PRs if
+testing expands.
+
+---
+
+## PR 16 — `Dirty` `mutations_from_database` vs `mutations_before_last_save` split (4 methods)
+
+- Rails `attribute_mutation_tracker.rb:1-189` plus `dirty.rb` tracks two
+  distinct states: pre-save diff (`mutations_from_database`) vs
+  last-commit diff (`mutations_before_last_save`). Our
+  `DirtyTracker` (`dirty.ts:35-161`) conflates them — `_previousChanges`
+  doubles for both.
+- Port: `mutations_from_database`, `mutations_before_last_save`,
+  `forget_attribute_assignments`, `clear_attribute_change`.
+
+Methods touched: `DirtyTracker#mutationsFromDatabase`,
+`#mutationsBeforeLastSave`, `#forgetAttributeAssignments`,
+`#clearAttributeChange`.
+
+---
+
+## PR 17 — `AttributeMethods` `alias_attribute` cascade (3 methods)
+
+- `TS attribute-methods.ts:150-152` `aliasAttribute` just stores
+  `newName → oldName` in `_attributeAliases`.
+- Rails `attribute_methods.rb` `alias_attribute` generates the full
+  method cascade: `X`, `X=`, `X?`, plus all dirty (`X_changed?`,
+  `X_was`, …) and type-cast (`X_before_type_cast`) aliases.
+- `attribute-methods.ts:250` has `aliasAttributeMethodDefinition`; wire
+  it into `aliasAttribute` so dynamic methods resolve through
+  `_attributeAliases` without the caller having to go through
+  `readAttribute`/`writeAttribute`.
+
+Methods touched: `aliasAttribute`, `aliasAttributeMethodDefinition`,
+`resolveAlias`.
+
+---
+
+## PR 18 — `Callbacks` generic `setCallback` / `skipCallback` / `_run_*_callbacks` (3 methods)
+
+- `TS model.ts:571-888` has named convenience registrars
+  (`beforeSave`, `afterCreate`, `aroundUpdate`, …) — covers the common
+  case — but no generic `setCallback(event, kind, fn, options)` /
+  `skipCallback(event, kind, fn)` / public `runCallbacks(event, &block)`
+  entry points. `model.ts:1565` exposes `runCallbacks(event, block)`
+  ✓ (half done).
+- Rails (`ActiveSupport::Callbacks` via
+  `validations/callbacks.rb` + `callbacks.rb`) gives users
+  `set_callback :validate, :before, ...`. Required for any third-party
+  plugin that wants to register callbacks without knowing the event
+  name at compile time.
+
+Methods touched: `Model.setCallback`, `.skipCallback`,
+`.resetCallbacks`.
+
+---
+
+## PR 19 — `Serialization`: recursive `:include`, `asJson` type handling (3 methods)
+
+- `TS model.ts:1335-1370` (`serializableHash`, `asJson`, `toJson`) —
+  verify `:include` traverses nested models with per-association option
+  hashes (`include: { posts: { only: :title } }`). Rails
+  `serialization.rb:170-196` (`serializable_add_includes`).
+- `asJson` should delegate type coercion like Rails (Date/Time →
+  ISO8601, BigInt/BigDecimal → string) rather than relying on
+  `JSON.stringify` defaults.
+
+Methods touched: `serializableHash`, `asJson`, private
+`serializableAddIncludes`.
+
+---
+
+## PR 20 — I18n fallback chain + `%{key}` interpolation (scoped to I18n module)
+
+- `TS packages/activemodel/src/i18n.ts` (170 lines) is a minimal
+  lookup. No pluralization rules (CLDR), no locale fallback, `{key}`
+  instead of `%{key}` with lambda + reserved-key (`count`, `default`)
+  support. Affects `translation.ts:humanAttributeName`, every Rails
+  error-message key, and `ValidationError`'s `:model_invalid` key
+  (PR 9).
+- Rails has no `i18n.rb` in `active_model`; it ships `locale/en.yml`
+  and relies on the global `i18n` gem. Port enough of the gem's
+  interpolation + fallback to match.
+
+Methods touched: `I18n.t`, `I18n.translate` interpolation helper,
+fallback chain walker.
+
+---
+
+## PR 21 — `Railtie` base class (1 change)
+
+- `api:compare` inheritance mismatch — `TS packages/activemodel/src/railtie.ts:33`
+  has no super class. Rails `railtie.rb:12
+class Railtie < ::Rails::Railtie`.
+- Wire up trailties' base `Railtie` and have ActiveModel's extend it
+  (small; but requires a trailties API, which may be scoped
+  separately).
+
+Methods touched: `Railtie` superclass.
+
+---
+
+## PR 22 — Type correctness (4 types, ~10 methods total)
+
+Spot-checks flagged by the privates scan; verify and fix:
+
+- `type/integer.ts` — `range`, `inRange?`, `ensureInRange`, `maxValue`,
+  `minValue`. Out-of-range casts must raise `ActiveModelRangeError`
+  (class exported at `errors.ts:242-246`). Rails
+  `type/integer.rb#ensure_in_range`.
+- `type/decimal.ts` — `applyScale`. Rails uses `BigDecimal#round`; ours
+  likely uses `Number.toFixed` / float ops → ULP divergence on edge
+  values.
+- `type/boolean.ts` — `FALSE_VALUES` must be
+  `[false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"]`
+  exactly. Rails `type/boolean.rb:9`.
+- `type/immutable_string.ts` / `type/string.ts` — `cast_value` must map
+  `true`/`false` literals to `"t"`/`"f"` (Rails
+  `type/immutable_string.rb:19-26`).
+- `type/date.ts` + `type/date_time.ts` — `fast_string_to_date`,
+  `fallback_string_to_date`, `new_date`, `microseconds`,
+  `value_from_multiparameter_assignment`. Port the YYYY-MM-DD regex
+  fast path (`type/date.rb:31-35`).
+- `type/helpers/time_value.ts` — `fast_string_to_time`, `new_time`.
+  `Time.zone` semantics are Rails-specific; document the scope we
+  accept.
+
+Split into two PRs if the test churn exceeds 20 generated tests.
+
+---
+
+## PR 23 — `SecurePassword` parity (4 methods)
+
+- Verify against `Rails secure_password.rb` (231 lines):
+  - BCrypt `min_cost` setting (test mode).
+  - Dynamic `authenticate_#{name}` / `#{name}_confirmation` generation
+    for non-default attribute names (`has_secure_password :recovery_password`).
+  - `password_challenge` — compares challenge to the _previous_ digest
+    before overwriting.
+  - Reset token via `MessageVerifier`
+    (`secure_password.rb:178-225 reset_password_token`, `find_by_password_reset_token!`).
+
+Methods touched: 4 in `packages/activemodel/src/secure-password.ts`.
+
+---
+
+## PR 24 — `Lint` as a MiniTest-style mixin (separate PR, behavioral)
+
+- Rails `lint.rb` exposes `ActiveModel::Lint::Tests` — a module mixed
+  into a MiniTest class; its `test_*` methods become runnable tests
+  (`assert_*` based contract checks).
+- Ours `lint.ts` (97 lines) is a free-function checker. Users can't
+  include the module in their own test class and inherit the suite.
+- Port by exporting a Vitest-friendly `describeLint(ModelClass)` that
+  declares the equivalent `it` blocks.
+
+Methods touched: ~6 `assert_*` equivalents.
+
+---
+
+## PR 25 — Relocate `misc.test.ts` (test-layout only, no production code)
+
+- `TS packages/activemodel/src/misc.test.ts` is 3,031 lines with no
+  Rails counterpart file — breaks `test:compare`'s layout matching.
+- Move each `it` block to the Rails-matched file
+  (`dirty.test.ts`, `validations.test.ts`, `attribute-methods.test.ts`,
+  …). **Do not rename tests** (per CLAUDE.md — names drive
+  `test:compare` matching). Can be broken into multiple PRs by target
+  file.
+
+---
+
+## Triage order (recommended)
+
+Silent correctness first, then public-API shape, then structure:
+
+1. **PR 1** (`toParam`/`paramDelimiter`) — wrong URLs for unpersisted.
+2. **PR 3** (`assignAttributes` → user setter) — extension point broken.
+3. **PR 4** (`Errors.copy!` replace) — data corruption on non-empty.
+4. **PR 7** (`validate`/`invalid?`/`validate!` shapes) — API contract.
+5. **PR 9** (`ValidationError` I18n + `freeze`) — user-visible strings.
+6. **PR 11** (`ModelName` namespace) — forms, routes, I18n keys.
+7. **PR 10** (`_validators` hash shape) — small, perf + parity win.
+8. **PR 5 / PR 6** (`Errors` options filtering + Enumerable) —
+   ergonomic.
+9. **PR 8** (`ValidationContext` array) — needed for AR contexts.
+10. **PR 15–16** (Dirty parity) — large; drives AR integration.
+11. **PR 18** (generic `setCallback`) — needed for plugins.
+12. **PR 12, 13, 14, 2, 17, 19, 20, 21, 22, 23, 24, 25** — everything
+    else.
+
+---
+
+## Appendix — files to read when picking a PR
+
+- Rails pins are under
+  `scripts/api-compare/.rails-source/activemodel/lib/active_model/`.
+- Comparison JSON: `scripts/api-compare/output/api-comparison.json`
+  (public) and `api-comparison-privates.json` (privates).
+- Regenerate with `pnpm run api:compare --package activemodel` (+
+  `--privates`).

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { nameMatches, superclassesMatch, resolveTsClassForRuby } from "./compare.js";
-import type { ClassInfo } from "./types.js";
+import { nameMatches, superclassesMatch, resolveTsClassForRuby, methodInMode } from "./compare.js";
+import type { ClassInfo, MethodInfo } from "./types.js";
 
 function cls(file: string, name: string, superclass?: string): ClassInfo {
   return {
@@ -172,5 +172,32 @@ describe("resolveTsClassForRuby", () => {
 
   it("returns undefined when nothing resolves", () => {
     expect(resolveTsClassForRuby("Nothing", "nowhere.ts", new Map())).toBeUndefined();
+  });
+});
+
+describe("methodInMode", () => {
+  const method = (internal?: boolean): MethodInfo => ({
+    name: "foo",
+    visibility: internal ? "private" : "public",
+    params: [],
+    ...(internal ? { internal: true } : {}),
+  });
+
+  it("keeps public methods when --privates is off", () => {
+    expect(methodInMode(method(false), false)).toBe(true);
+    expect(methodInMode(method(true), false)).toBe(false);
+  });
+
+  it("keeps only internal methods when --privates is on", () => {
+    expect(methodInMode(method(true), true)).toBe(true);
+    expect(methodInMode(method(false), true)).toBe(false);
+  });
+
+  it("treats missing internal flag as public", () => {
+    // Legacy fixture manifests may not set `internal` at all; those
+    // methods must count toward the public surface, not drop out.
+    const bare: MethodInfo = { name: "x", visibility: "public", params: [] };
+    expect(methodInMode(bare, false)).toBe(true);
+    expect(methodInMode(bare, true)).toBe(false);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -278,6 +278,13 @@ function main() {
   const showFiles = args.includes("--files");
   const showIncomplete = args.includes("--incomplete");
   const showInheritance = args.includes("--inheritance");
+  // When --privates is passed, the comparison runs against internal-only
+  // methods (Ruby `private`/`protected`, TS `private`/`protected`,
+  // `#`-prefixed fields). Without it, internal methods are filtered out
+  // and the numbers match the historical public-API coverage.
+  const showPrivates = args.includes("--privates");
+  const methodMatchesMode = (m: MethodInfo): boolean =>
+    showPrivates ? m.internal === true : m.internal !== true;
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-api.json");
@@ -309,6 +316,7 @@ function main() {
         const file = cls.file || "";
         const methods = tsMethodsByFile.get(file) || new Set();
         for (const m of [...cls.instanceMethods, ...cls.classMethods]) {
+          if (!methodMatchesMode(m)) continue;
           methods.add(m.name);
         }
         tsMethodsByFile.set(file, methods);
@@ -322,6 +330,7 @@ function main() {
         for (const [file, fns] of Object.entries(tsPkg.fileFunctions)) {
           const methods = tsMethodsByFile.get(file) || new Set();
           for (const fn of fns) {
+            if (!methodMatchesMode(fn)) continue;
             methods.add(fn.name);
           }
           tsMethodsByFile.set(file, methods);
@@ -378,6 +387,7 @@ function main() {
 
         const methods = new Set<string>();
         for (const m of [...entity.instanceMethods, ...entity.classMethods]) {
+          if (!methodMatchesMode(m)) continue;
           methods.add(m.name);
         }
 
@@ -592,6 +602,7 @@ function main() {
       for (const item of items) {
         const rubyMethods = [...item.info.instanceMethods, ...item.info.classMethods];
         for (const rm of rubyMethods) {
+          if (!methodMatchesMode(rm)) continue;
           const tsCandidates = rubyMethodToTs(rm.name);
           if (tsCandidates === null) continue;
           const key = tsCandidates[0];
@@ -801,7 +812,15 @@ function main() {
     JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2),
   );
 
-  printReport(results, showMissing, showFiles, filterPkg, showIncomplete, showInheritance);
+  printReport(
+    results,
+    showMissing,
+    showFiles,
+    filterPkg,
+    showIncomplete,
+    showInheritance,
+    showPrivates,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -815,7 +834,14 @@ function printReport(
   filterPkg: string | null,
   showIncomplete = false,
   showInheritance = false,
+  showPrivates = false,
 ) {
+  if (showPrivates) {
+    console.log(
+      `\n  (comparing internal/private API surface — ` +
+        `Ruby private/protected, TS private/protected, TS #-prefixed fields)`,
+    );
+  }
   let grandTotal = 0;
   let grandMatched = 0;
   let grandFiles = 0;

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -258,6 +258,16 @@ export function superclassesMatch(
   return tsChain.some((ancestor) => nameMatches(rubySuper, ancestor));
 }
 
+/**
+ * Whether a given method belongs to the current comparison bucket.
+ * Default mode (showPrivates=false) keeps only public API methods; with
+ * `--privates` the comparison runs exclusively against internal methods.
+ * Exported so compare.test.ts can pin the filter semantics.
+ */
+export function methodInMode(m: MethodInfo, showPrivates: boolean): boolean {
+  return showPrivates ? m.internal === true : m.internal !== true;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -283,8 +293,7 @@ function main() {
   // `#`-prefixed fields). Without it, internal methods are filtered out
   // and the numbers match the historical public-API coverage.
   const showPrivates = args.includes("--privates");
-  const methodMatchesMode = (m: MethodInfo): boolean =>
-    showPrivates ? m.internal === true : m.internal !== true;
+  const methodMatchesMode = (m: MethodInfo): boolean => methodInMode(m, showPrivates);
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-api.json");
@@ -805,8 +814,10 @@ function main() {
     });
   }
 
-  // Write JSON
-  const jsonPath = path.join(OUTPUT_DIR, "api-comparison.json");
+  // Write JSON. Separate file for the --privates run so the public artifact
+  // isn't clobbered when both run back-to-back in CI.
+  const jsonFilename = showPrivates ? "api-comparison-privates.json" : "api-comparison.json";
+  const jsonPath = path.join(OUTPUT_DIR, jsonFilename);
   fs.writeFileSync(
     jsonPath,
     JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2),

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -396,13 +396,16 @@ class ApiExtractor
 
     case cmd_name
     when "private", "protected", "public"
-      # Check if it's a visibility modifier with no args (changes default)
-      # or with args (modifies specific methods)
+      # No-args form (`private`) flips the default visibility for the scope.
+      # Symbol-args form (`private :foo, :bar`) retroactively marks those
+      # named methods — without this, methods defined above as public would
+      # stay tagged public, causing them to be misclassified.
       if args.nil? || (args.is_a?(Array) && args[0] == :args_new)
         @visibility_stack[-1] = cmd_name.to_sym
+      else
+        names = extract_symbol_args(args)
+        apply_visibility_to_named(names, cmd_name.to_sym) unless names.empty?
       end
-      # If it has args, it modifies specific methods — we handle this by
-      # not changing default visibility
     when "include"
       process_include(args)
     when "extend"
@@ -444,12 +447,18 @@ class ApiExtractor
       cmd_name = ident_name(node[1][1])
       case cmd_name
       when "private", "protected", "public"
-        # This is the inline form: private def foo; end
-        # The method is already defined, we need to mark it
-        # For simplicity, handle the case where the arg is a def
+        # Either inline `private def foo; end` (recurse so the def is
+        # visited under the adjusted visibility) or the paren symbol form
+        # `private(:foo, :bar)` which retroactively marks named methods.
         args = node[2]
-        if args.is_a?(Array)
-          walk(args)
+        names = args.is_a?(Array) ? extract_symbol_args_from_paren(args) : []
+        if names.empty?
+          prev_vis = @visibility_stack[-1]
+          @visibility_stack[-1] = cmd_name.to_sym
+          walk(args) if args.is_a?(Array)
+          @visibility_stack[-1] = prev_vis
+        else
+          apply_visibility_to_named(names, cmd_name.to_sym)
         end
       when "attr_reader", "attr_writer", "attr_accessor"
         process_attr_from_arg_paren(node[2], cmd_name)
@@ -463,6 +472,17 @@ class ApiExtractor
     else
       walk(node[1]) if node[1].is_a?(Array)
       walk(node[2]) if node[2].is_a?(Array)
+    end
+  end
+
+  def apply_visibility_to_named(names, vis)
+    fqn = current_fqn
+    target = @classes[fqn] || @modules[fqn]
+    return unless target
+
+    bucket = @in_sclass ? :classMethods : :instanceMethods
+    target[bucket].each do |m|
+      m[:visibility] = vis.to_s if names.include?(m[:name])
     end
   end
 

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -913,6 +913,16 @@ def run
   puts "\nWritten to #{output_path}"
 end
 
+def tag_internal(methods)
+  methods.map do |m|
+    if m[:visibility] == "public"
+      m
+    else
+      m.merge(internal: true)
+    end
+  end
+end
+
 def filter_public(info)
   {
     name: info[:name],
@@ -921,8 +931,8 @@ def filter_public(info)
     file: info[:file],
     includes: info[:includes].uniq,
     extends: info[:extends].uniq,
-    instanceMethods: info[:instanceMethods].select { |m| m[:visibility] == "public" },
-    classMethods: info[:classMethods].select { |m| m[:visibility] == "public" },
+    instanceMethods: tag_internal(info[:instanceMethods]),
+    classMethods: tag_internal(info[:classMethods]),
   }
 end
 

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -902,15 +902,16 @@ def run
       extractor.process_file(filepath, pkg_dir)
     end
 
-    # Filter to only public methods
+    # Preserve every method; non-public methods are tagged with
+    # `internal: true` so --privates mode can select them.
     classes = {}
     extractor.classes.each do |fqn, info|
-      classes[fqn] = filter_public(info)
+      classes[fqn] = tag_visibility(info)
     end
 
     modules = {}
     extractor.modules.each do |fqn, info|
-      modules[fqn] = filter_public(info)
+      modules[fqn] = tag_visibility(info)
     end
 
     manifest[:packages][pkg_name] = {
@@ -925,7 +926,7 @@ def run
     module_count = data[:modules].length
     method_count = data[:classes].values.sum { |c| c[:instanceMethods].length + c[:classMethods].length } +
                    data[:modules].values.sum { |m| m[:instanceMethods].length + m[:classMethods].length }
-    puts "  #{pkg}: #{class_count} classes, #{module_count} modules, #{method_count} public methods"
+    puts "  #{pkg}: #{class_count} classes, #{module_count} modules, #{method_count} methods (public + internal)"
   end
 
   output_path = File.join(OUTPUT_DIR, "rails-api.json")
@@ -943,7 +944,7 @@ def tag_internal(methods)
   end
 end
 
-def filter_public(info)
+def tag_visibility(info)
   {
     name: info[:name],
     fqn: info[:fqn],

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -243,7 +243,12 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
         if (prop.flags & ts.SymbolFlags.Prototype) continue;
         const decl = prop.valueDeclaration ?? prop.declarations?.[0];
         if (!decl) continue;
-        const isPrivateField = prop.name.startsWith("#");
+        // `#private` fields surface in the symbol table with their
+        // mangled name, not a literal leading `#`, so derive the flag
+        // from the declaration's name node (same approach as `getVisibility`
+        // below and the top-level class walker at line 707/727).
+        const declNameNode = (decl as ts.NamedDeclaration).name;
+        const isPrivateField = !!declNameNode && ts.isPrivateIdentifier(declNameNode);
         const hasPrivateMod = hasModifier(decl, ts.SyntaxKind.PrivateKeyword);
         const hasProtectedMod = hasModifier(decl, ts.SyntaxKind.ProtectedKeyword);
         const visibility: "public" | "private" | "protected" =

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -240,20 +240,24 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
       const mixinMethods: MethodInfo[] = [];
 
       for (const prop of instanceType.getProperties()) {
-        if (prop.name.startsWith("#")) continue;
         if (prop.flags & ts.SymbolFlags.Prototype) continue;
         const decl = prop.valueDeclaration ?? prop.declarations?.[0];
         if (!decl) continue;
-        if (hasModifier(decl, ts.SyntaxKind.PrivateKeyword)) continue;
-        if (hasModifier(decl, ts.SyntaxKind.ProtectedKeyword)) continue;
+        const isPrivateField = prop.name.startsWith("#");
+        const hasPrivateMod = hasModifier(decl, ts.SyntaxKind.PrivateKeyword);
+        const hasProtectedMod = hasModifier(decl, ts.SyntaxKind.ProtectedKeyword);
+        const visibility: "public" | "private" | "protected" =
+          isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
+        const internal = visibility !== "public";
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
         mixinMethods.push({
           name: prop.name,
-          visibility: "public",
+          visibility,
           params: [],
           isStatic: false,
           line,
           file: relPath,
+          ...(internal ? { internal: true } : {}),
         });
       }
 
@@ -435,9 +439,6 @@ function extractClass(
   }
 
   for (const member of node.members) {
-    // Skip private/protected members
-    if (hasModifier(member, ts.SyntaxKind.PrivateKeyword)) continue;
-    if (hasModifier(member, ts.SyntaxKind.ProtectedKeyword)) continue;
     const memberName = getMemberName(member);
     // Skip _-prefixed non-method members (backing fields), but keep _-prefixed methods
     // since Rails has public methods like _load_from, _reflect_on_association, etc.
@@ -449,6 +450,8 @@ function extractClass(
     )
       continue;
 
+    const visibility = memberVisibility(member);
+    const internal = visibility !== "public";
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);
     const line = member.getSourceFile().getLineAndCharacterOfPosition(member.getStart()).line + 1;
 
@@ -456,11 +459,12 @@ function extractClass(
       const params = extractParameters(member.parameters);
       const method: MethodInfo = {
         name: memberName,
-        visibility: "public",
+        visibility,
         params,
         line,
         file,
         isStatic,
+        ...(internal ? { internal: true } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -471,19 +475,21 @@ function extractClass(
       const params = extractParameters(member.parameters);
       instanceMethods.push({
         name: "constructor",
-        visibility: "public",
+        visibility,
         params,
         line,
         file,
+        ...(internal ? { internal: true } : {}),
       });
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
       const method: MethodInfo = {
         name: memberName,
-        visibility: "public",
+        visibility,
         params: [],
         line,
         file,
         isStatic,
+        ...(internal ? { internal: true } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -494,11 +500,12 @@ function extractClass(
       const params = extractParameters(member.parameters);
       const method: MethodInfo = {
         name: memberName,
-        visibility: "public",
+        visibility,
         params,
         line,
         file,
         isStatic,
+        ...(internal ? { internal: true } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -510,11 +517,12 @@ function extractClass(
       // Only record them if they're not readonly (readonly = getter only conceptually)
       const method: MethodInfo = {
         name: memberName,
-        visibility: "public",
+        visibility,
         params: [],
         line,
         file,
         isStatic,
+        ...(internal ? { internal: true } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -696,6 +704,9 @@ function getMemberName(member: ts.ClassElement): string | undefined {
     if (ts.isIdentifier(member.name)) {
       return member.name.text;
     }
+    if (ts.isPrivateIdentifier(member.name)) {
+      return member.name.text;
+    }
     if (ts.isStringLiteral(member.name)) {
       return member.name.text;
     }
@@ -704,6 +715,17 @@ function getMemberName(member: ts.ClassElement): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Returns the effective visibility of a class member, treating
+ * `#`-prefixed private fields as `private`.
+ */
+function memberVisibility(member: ts.ClassElement): "public" | "private" | "protected" {
+  if (hasModifier(member, ts.SyntaxKind.PrivateKeyword)) return "private";
+  if (hasModifier(member, ts.SyntaxKind.ProtectedKeyword)) return "protected";
+  if (member.name && ts.isPrivateIdentifier(member.name)) return "private";
+  return "public";
 }
 
 function isExported(node: ts.Node): boolean {

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -18,6 +18,13 @@ export interface MethodInfo {
   deps?: string[];
   depRefs?: Record<string, string[]>;
   calls?: string[];
+  /**
+   * True when the method is not part of the public API surface:
+   * Ruby `private`/`protected`, TS `private`/`protected`, or
+   * TS `#`-prefixed private fields. Consumers should filter these
+   * out of normal coverage and only include them behind an opt-in flag.
+   */
+  internal?: boolean;
 }
 
 export interface ClassInfo {

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1815,9 +1815,13 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
       parsed++;
       const totalTests = [...testStats.values()].reduce((sum, s) => sum + s.matched, 0);
       const totalApi = [...apiStats.values()].reduce((sum, s) => sum + s.matched, 0);
+      const totalApiPrivates = [...apiPrivatesStats.values()].reduce(
+        (sum, s) => sum + s.matched,
+        0,
+      );
       const logSteps = [...stepLogs.keys()].join(", ");
       console.log(
-        `  PR #${prNumber}: ${testStats.size} test packages (${totalTests} matched), ${apiStats.size} api packages (${totalApi} matched), logs: [${logSteps}]`,
+        `  PR #${prNumber}: ${testStats.size} test packages (${totalTests} matched), ${apiStats.size} api packages (${totalApi} matched), ${apiPrivatesStats.size} api-privates packages (${totalApiPrivates} matched), logs: [${logSteps}]`,
       );
     }
   }
@@ -1846,6 +1850,7 @@ async function printSummary() {
     stepCount,
     testStatCount,
     apiStatCount,
+    apiPrivatesStatCount,
     logCount,
     rawLogCount,
   ] = await Promise.all([
@@ -1855,6 +1860,7 @@ async function printSummary() {
     count("workflow_steps"),
     countDistinct("test_compare_stats", "merge_commit_sha"),
     countDistinct("api_compare_stats", "merge_commit_sha"),
+    countDistinct("api_compare_privates_stats", "merge_commit_sha"),
     countDistinct("compare_logs", "merge_commit_sha"),
     count("raw_job_logs"),
   ]);
@@ -1903,6 +1909,7 @@ async function printSummary() {
   console.log(`  Workflow steps: ${stepCount}`);
   console.log(`  Commits with test:compare stats: ${testStatCount}`);
   console.log(`  Commits with api:compare stats: ${apiStatCount}`);
+  console.log(`  Commits with api:compare --privates stats: ${apiPrivatesStatCount}`);
   console.log(`  Commits with compare logs: ${logCount}`);
   console.log(`  Database: ${DB_PATH}`);
 
@@ -1940,6 +1947,28 @@ async function printSummary() {
   if (latestApiStats.length > 0) {
     console.log("\n  Latest api:compare:");
     for (const row of latestApiStats) {
+      const pkg = row.readAttribute("package");
+      const matched = row.readAttribute("matched");
+      const total = row.readAttribute("total");
+      const percent = row.readAttribute("percent");
+      const missing = row.readAttribute("missing") as number;
+      const missStr = missing > 0 ? ` (${missing} missing)` : "";
+      console.log(`    ${pkg}: ${matched}/${total} (${percent}%)${missStr}`);
+    }
+  }
+
+  const latestApiPrivatesStats = await ApiComparePrivatesStat.findBySql(`
+    SELECT package, matched, total, percent, missing
+    FROM api_compare_privates_stats
+    WHERE merge_commit_sha = (
+      SELECT merge_commit_sha FROM api_compare_privates_stats ORDER BY pr_number DESC LIMIT 1
+    )
+    ORDER BY package
+  `);
+
+  if (latestApiPrivatesStats.length > 0) {
+    console.log("\n  Latest api:compare --privates:");
+    for (const row of latestApiPrivatesStats) {
       const pkg = row.readAttribute("package");
       const matched = row.readAttribute("matched");
       const total = row.readAttribute("total");

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -235,6 +235,19 @@ class ApiCompareStat extends Base {
   }
 }
 
+class ApiComparePrivatesStat extends Base {
+  static {
+    this.tableName = "api_compare_privates_stats";
+    this.attribute("merge_commit_sha", "string");
+    this.attribute("pr_number", "integer");
+    this.attribute("package", "string");
+    this.attribute("matched", "integer");
+    this.attribute("total", "integer");
+    this.attribute("percent", "float");
+    this.attribute("missing", "integer", { default: 0 });
+  }
+}
+
 class CompareLog extends Base {
   static {
     this.tableName = "compare_logs";
@@ -462,6 +475,19 @@ async function migrateDb(adapter: SQLite3Adapter) {
       });
     }
 
+    if (!(await tableExists(adapter, "api_compare_privates_stats"))) {
+      await ctx.createTable("api_compare_privates_stats", {}, (t) => {
+        t.string("merge_commit_sha");
+        t.integer("pr_number");
+        t.string("package");
+        t.integer("matched");
+        t.integer("total");
+        t.float("percent");
+        t.integer("missing", { default: 0 });
+        t.index(["merge_commit_sha", "package"], { unique: true });
+      });
+    }
+
     return;
   }
 
@@ -649,6 +675,17 @@ async function migrateDb(adapter: SQLite3Adapter) {
       t.integer("total");
       t.float("percent");
       t.integer("misplaced", { default: 0 });
+      t.integer("missing", { default: 0 });
+      t.index(["merge_commit_sha", "package"], { unique: true });
+    });
+
+    await ctx.createTable("api_compare_privates_stats", {}, (t) => {
+      t.string("merge_commit_sha");
+      t.integer("pr_number");
+      t.string("package");
+      t.integer("matched");
+      t.integer("total");
+      t.float("percent");
       t.integer("missing", { default: 0 });
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
@@ -1399,7 +1436,7 @@ function extractStepLogs(rawLog: string): Map<string, string> {
     let stepName: string | null = null;
 
     if (command.includes("api-compare/compare.ts")) {
-      stepName = "api_compare";
+      stepName = command.includes("--privates") ? "api_compare_privates" : "api_compare";
     } else if (
       command.includes("test-compare/test-compare.ts") ||
       command.includes("test-compare/convention-compare.ts")
@@ -1665,8 +1702,12 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
         SELECT 1 FROM api_compare_stats acs
         WHERE acs.merge_commit_sha = rjl.merge_commit_sha
       )
+      OR NOT EXISTS (
+        SELECT 1 FROM api_compare_privates_stats acps
+        WHERE acps.merge_commit_sha = rjl.merge_commit_sha
+      )
       OR EXISTS (
-        WITH expected(step_name) AS (VALUES ('api_compare'), ('test_compare'))
+        WITH expected(step_name) AS (VALUES ('api_compare'), ('api_compare_privates'), ('test_compare'))
         SELECT 1 FROM expected e
         LEFT JOIN compare_logs cl
           ON cl.merge_commit_sha = rjl.merge_commit_sha AND cl.step_name = e.step_name
@@ -1729,7 +1770,12 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
       );
     }
 
-    const apiStats = parseApiCompareFromLogs(logs);
+    // Parse the public-API step in isolation so the privates step (same log
+    // format, appended below it) doesn't overwrite entries.
+    const apiStepLog = stepLogs.get("api_compare") ?? "";
+    const apiStats = apiStepLog
+      ? parseApiCompareFromLogs(apiStepLog)
+      : parseApiCompareFromLogs(logs);
     if (apiStats.size > 0) {
       await ApiCompareStat.upsertAll(
         [...apiStats.entries()].map(([pkg, s]) => ({
@@ -1746,7 +1792,26 @@ async function syncCompareStats(mode: "latest" | "refresh"): Promise<number> {
       );
     }
 
-    if (stepLogs.size > 0 || testStats.size > 0 || apiStats.size > 0) {
+    const apiPrivatesStepLog = stepLogs.get("api_compare_privates") ?? "";
+    const apiPrivatesStats = apiPrivatesStepLog
+      ? parseApiCompareFromLogs(apiPrivatesStepLog)
+      : parseApiCompareFromLogs("");
+    if (apiPrivatesStats.size > 0) {
+      await ApiComparePrivatesStat.upsertAll(
+        [...apiPrivatesStats.entries()].map(([pkg, s]) => ({
+          merge_commit_sha: headSha,
+          pr_number: prNumber,
+          package: pkg,
+          matched: s.matched,
+          total: s.total,
+          percent: s.percent,
+          missing: s.missing,
+        })),
+        { uniqueBy: ["merge_commit_sha", "package"] },
+      );
+    }
+
+    if (stepLogs.size > 0 || testStats.size > 0 || apiStats.size > 0 || apiPrivatesStats.size > 0) {
       parsed++;
       const totalTests = [...testStats.values()].reduce((sum, s) => sum + s.matched, 0);
       const totalApi = [...apiStats.values()].reduce((sum, s) => sum + s.matched, 0);


### PR DESCRIPTION
## Summary

Thorough audit of `packages/activemodel` against the pinned Rails source at `scripts/api-compare/.rails-source/activemodel/`, structured as 25 landable PRs (≤20 methods each, per CLAUDE.md) with \`file:line\` pointers on both the TS and Rails side.

Headline surface from \`pnpm run api:compare --package activemodel\`:
- Public: **341/342 (99.7%)**
- Privates: **12/141 (8.5%)** — mostly comparator false-negatives from snake→camel renames, mixed with real gaps
- Inheritance: **40/41** (Railtie mismatch)

Surface is near-complete; the audit focuses on **behavioral deviations** the comparator doesn't catch.

## Top silent-correctness bugs (triage order)

- **PR 1** — \`Model#toParam\` skips \`isPersisted()\` and hard-codes \`"-"\` (\`model.ts:1466\` vs \`conversion.rb:91\`)
- **PR 3** — \`assignAttributes\` bypasses user-defined \`name=\` setters (\`attribute-assignment.ts:47\` vs \`attribute_assignment.rb:67-70\`)
- **PR 4** — \`Errors#copy\` appends instead of replacing (\`errors.ts:125\` vs \`errors.rb:138\`) — data corruption on non-empty
- **PR 7** — \`validate\`/\`isInvalid\`/\`validateBang\` return shapes diverge from Rails
- **PR 11** — \`ModelName\` strips namespaces (\`Blog::Post\` → \`post\`, Rails → \`blog_post\`); affects routes, forms, I18n paths
- **PR 10** — \`_validators\` is a flat array; Rails uses a hash keyed by attribute (O(1) \`validatorsOn\`)

Full file: [\`docs/activemodel-audit.md\`](../blob/activemodel-audit/docs/activemodel-audit.md).

## Test plan

- [ ] Review the 25 PR groupings and confirm sizing/scope
- [ ] Confirm triage order matches priorities
- [ ] Pick up PR 1 (highest ship value, smallest diff)