### PR TITLE
feat(parity): ruby-side dump + canonicalize (PR 4 of 6)

### DIFF
--- a/docs/activerecord-rails-parity-verification.md
+++ b/docs/activerecord-rails-parity-verification.md
@@ -321,62 +321,64 @@ scripts/parity/fixtures/01-trivial /tmp/trails-01.json`
 1. `scripts/parity/schema/ruby/Gemfile` — pins:
    ```ruby
    source "https://rubygems.org"
-   gem "rails", "8.0.2"    # D10
-   gem "sqlite3", "~> 2.1" # matches AR 8.0.2 declared dependency range
-   gem "prism"             # AST parser for canonicalize.rb
+   gem "activerecord", "8.0.2"  # D10 — no full Rails stack needed
+   gem "sqlite3", "~> 2.1"      # matches AR 8.0.2 declared dependency range
+   gem "minitest", "~> 5.25"    # canonicalize_test.rb
    ```
-2. `scripts/parity/schema/ruby/Gemfile.lock` — committed, generated via
-   `bundle install` locally.
-3. `scripts/parity/schema/ruby/dump.rb` — CLI:
+   Note: uses `activerecord` directly (not `rails`) — we only need AR
+   introspection, not the full framework. Gemfile.lock is generated on
+   first `bundle install` (requires network) and should be committed.
+2. `scripts/parity/schema/ruby/dump.rb` — CLI:
    `bundle exec ruby dump.rb <fixture-dir> <out.json>`.
    Steps:
    1. Create temp sqlite via `Dir.mktmpdir`.
-   2. Apply `schema.sql` via the `sqlite3` gem directly (raw SQL, no
-      AR). Same applier as node side conceptually — isolate from SUT.
+   2. Apply `schema.sql` via `SQLite3::Database#execute_batch` (raw SQL,
+      isolates fixture application from AR under test).
    3. `ActiveRecord::Base.establish_connection(adapter: "sqlite3",
 database: tempfile)`.
-   4. Dump schema to a StringIO via
-      `ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection,
-io)`.
-   5. Parse that `schema.rb` string via `canonicalize.rb` →
-      canonical Hash.
+   4. Introspect via `conn.tables`, `conn.columns(table)`,
+      `conn.indexes(table)`, `conn.primary_key(table)` — same data
+      AR's type system provides, in declaration order. Direct
+      introspection is simpler and more reliable than parsing schema.rb.
+   5. Build native dump Hash and pass to `canonicalize.rb`.
    6. Validate against `expected.json` (D6) — same invariant as node
       side. Exit 2 on mismatch.
    7. `File.write(out_json, JSON.pretty_generate(canonical) + "\n")`.
-4. `scripts/parity/schema/ruby/canonicalize.rb` —
-   `Canonicalize.call(schema_rb_source) => Hash`.
-   - Parse with `Prism.parse`.
-   - Walk `create_table`, `t.column`, `t.string`, `t.integer`, …,
-     `add_index` invocations from the AST.
+3. `scripts/parity/schema/ruby/canonicalize.rb` —
+   `Canonicalize.call(native_dump) => Hash`.
+   - Input is a plain Ruby Hash from `dump.rb` (not schema.rb text).
    - Filter `schema_migrations`, `ar_internal_metadata` (D2).
    - Filter `sqlite_autoindex_*` (D3).
-   - Map Rails type method names (`t.string`, `t.integer`, etc.) and
-     generic `t.column` calls to the closed type set (D4). Raise on
-     unknown.
+   - Map `col.type` AR abstract type symbols (`:integer`, `:text`, etc.)
+     to the closed canonical set (D4). Raise on unknown.
    - Output Hash shape exactly matches `CanonicalSchema` (sorted/
      ordered per D1).
-5. `scripts/parity/schema/ruby/canonicalize_test.rb` — minitest, golden
-   fixtures (hand-written `schema.rb string → canonical Hash` pairs).
+4. `scripts/parity/schema/ruby/canonicalize_test.rb` — minitest, golden
+   fixtures (hand-written native-dump Hash → canonical Hash pairs).
    Same coverage as the node-side canonicalize tests.
 
 ### Acceptance
 
-- From `scripts/parity/schema/ruby/`:
-  `bundle install && bundle exec ruby dump.rb
-../../fixtures/01-trivial /tmp/rails-01.json`
+- From repo root:
+  `cd scripts/parity/schema/ruby && bundle install && cd - &&
+bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby
+scripts/parity/schema/ruby/dump.rb
+scripts/parity/fixtures/01-trivial /tmp/rails-01.json`
   writes a file that validates against
   `scripts/parity/canonical/schema.schema.json`.
-- `bundle exec ruby canonicalize_test.rb` green.
+- `bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby
+scripts/parity/schema/ruby/canonicalize_test.rb` green.
 
 ### Gotchas
 
-- Rails creates `ar_internal_metadata` on connect. Ensure `dump.rb`
-  filters it **and** the canonicalizer filters it (belt +
-  suspenders; the AR version in the schema.rb varies by migration
-  state).
-- `schema.rb` output includes a `ActiveRecord::Schema[8.0].define(…)`
-  header with `version: 0` or similar — canonicalize must strip this
-  metadata, not leak it into output.
+- Rails creates `ar_internal_metadata` on connect. `conn.tables`
+  includes it — filter in both `dump.rb` and `canonicalize.rb` (D2).
+- `conn.primary_key` returns `nil`, a `String`, or an `Array` of
+  strings — handle all three cases.
+- `conn.indexes` on SQLite returns only user-created indexes (origin
+  `"c"`) — autoindexes are already filtered at the AR level, same as
+  the node side's `introspectIndexes`. The canonicalizer's
+  `sqlite_autoindex_*` filter is belt-and-suspenders.
 
 ---
 

--- a/docs/activerecord-rails-parity-verification.md
+++ b/docs/activerecord-rails-parity-verification.md
@@ -375,10 +375,11 @@ scripts/parity/schema/ruby/canonicalize_test.rb` green.
   includes it — filter in both `dump.rb` and `canonicalize.rb` (D2).
 - `conn.primary_key` returns `nil`, a `String`, or an `Array` of
   strings — handle all three cases.
-- `conn.indexes` on SQLite returns only user-created indexes (origin
-  `"c"`) — autoindexes are already filtered at the AR level, same as
-  the node side's `introspectIndexes`. The canonicalizer's
-  `sqlite_autoindex_*` filter is belt-and-suspenders.
+- `conn.indexes` on SQLite filters any index whose name starts with
+  `"sqlite_"` (Rails source:
+  `sqlite3/schema_statements.rb:12` — `next if row["name"].start_with?("sqlite_")`).
+  The canonicalizer's `sqlite_autoindex_*` filter (D3) is
+  belt-and-suspenders and catches any that slip through.
 
 ---
 

--- a/scripts/parity/schema/ruby/Gemfile
+++ b/scripts/parity/schema/ruby/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activerecord", "8.0.2"     # D10 — matches scripts/api-compare/fetch-rails.sh RAILS_TAG
+gem "sqlite3", "~> 2.1"         # matches AR 8.0.2 declared dependency range
+gem "minitest", "~> 5.25"       # canonicalize_test.rb

--- a/scripts/parity/schema/ruby/README.md
+++ b/scripts/parity/schema/ruby/README.md
@@ -29,5 +29,6 @@ bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
 
 `Gemfile.lock` is not committed in this PR because it requires network
 access to RubyGems to resolve. Generate it with `bundle install` from
-this directory, then commit it. CI uses `bundler-cache: true` on the
-`ruby/setup-ruby` action, which handles lock generation automatically.
+this directory, then commit it. The CI wiring (added in PR6) will run
+`bundle install` from this Gemfile on each push; a committed lock file
+is required for reproducible installs.

--- a/scripts/parity/schema/ruby/README.md
+++ b/scripts/parity/schema/ruby/README.md
@@ -1,0 +1,33 @@
+# Ruby-side schema parity dumper
+
+## Setup
+
+```sh
+cd scripts/parity/schema/ruby
+bundle install     # generates Gemfile.lock — commit it after first run
+```
+
+## Running
+
+From the **repo root**:
+
+```sh
+bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
+  ruby scripts/parity/schema/ruby/dump.rb \
+  scripts/parity/fixtures/01-trivial \
+  /tmp/rails-01.json
+```
+
+## Tests
+
+```sh
+bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
+  ruby scripts/parity/schema/ruby/canonicalize_test.rb
+```
+
+## Gemfile.lock
+
+`Gemfile.lock` is not committed in this PR because it requires network
+access to RubyGems to resolve. Generate it with `bundle install` from
+this directory, then commit it. CI uses `bundler-cache: true` on the
+`ruby/setup-ruby` action, which handles lock generation automatically.

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Lowers a native dump (raw AR introspection data) into the neutral
+# CanonicalSchema format defined in scripts/parity/canonical/schema.schema.json.
+#
+# Pure function — no I/O, no side effects.
+
+module Canonicalize
+  FILTERED_TABLES = %w[schema_migrations ar_internal_metadata].to_set.freeze
+  AUTOINDEX_PREFIX = "sqlite_autoindex_"
+
+  # Maps AR abstract type symbols (col.type) to canonical type strings.
+  # D4: throw on any type not in this map.
+  AR_TO_CANONICAL = {
+    string:   "string",
+    text:     "text",
+    integer:  "integer",
+    bigint:   "bigint",
+    float:    "float",
+    decimal:  "decimal",
+    datetime: "datetime",
+    date:     "date",
+    time:     "time",
+    boolean:  "boolean",
+    binary:   "binary",
+    json:     "json",
+  }.freeze
+
+  # native_dump: Hash<table_name, { columns:, indexes:, primary_key_columns: }>
+  # where columns is Array<{ name:, ar_type:, null:, default:, limit:, precision:, scale: }>
+  # and indexes is Array<{ name:, columns:, unique:, where: }>
+  # and primary_key_columns is Array<String> in PK-position order
+  def self.call(native_dump)
+    tables = native_dump
+      .reject { |name, _| FILTERED_TABLES.include?(name) }
+      .sort_by { |name, _| name }
+      .map { |name, table| canonicalize_table(name, table) }
+
+    { "version" => 1, "tables" => tables }
+  end
+
+  def self.canonicalize_table(name, table)
+    pk_cols = table[:primary_key_columns]
+    primary_key = case pk_cols.length
+    when 0 then nil
+    when 1 then pk_cols[0]
+    else        pk_cols
+    end
+
+    columns = table[:columns].map { |col| canonicalize_column(name, col) }
+
+    indexes = table[:indexes]
+      .reject { |idx| idx[:name].start_with?(AUTOINDEX_PREFIX) }
+      .sort_by { |idx| idx[:name] }
+      .map { |idx| canonicalize_index(name, idx) }
+
+    { "name" => name, "primaryKey" => primary_key, "columns" => columns, "indexes" => indexes }
+  end
+
+  def self.canonicalize_column(table_name, col)
+    ar_type = col[:ar_type]
+    canonical_type = AR_TO_CANONICAL[ar_type] or
+      raise "canonicalize: unknown AR type #{ar_type.inspect} on #{table_name}.#{col[:name]} — add it to AR_TO_CANONICAL"
+
+    {
+      "name"      => col[:name],
+      "type"      => canonical_type,
+      "null"      => col[:null],
+      "default"   => coerce_default(col[:default]),
+      "limit"     => col[:limit],
+      "precision" => col[:precision],
+      "scale"     => col[:scale],
+    }
+  end
+
+  def self.canonicalize_index(table_name, idx)
+    cols = idx[:columns]
+    raise "canonicalize: index #{idx[:name].inspect} on #{table_name} has no columns" if cols.empty?
+
+    {
+      "name"    => idx[:name],
+      "columns" => cols,
+      "unique"  => idx[:unique],
+      "where"   => idx[:where],
+    }
+  end
+
+  # Coerce an AR default value (already deserialized by AR's type system)
+  # into a canonical scalar: String | Integer | Float | true | false | nil.
+  def self.coerce_default(value)
+    return nil if value.nil?
+    return value if value == true || value == false
+    return value.to_i if value.is_a?(Integer)
+    return value.to_f if value.is_a?(Float)
+    value.to_s
+  end
+end

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "set"
+require "bigdecimal"
+
 # Lowers a native dump (raw AR introspection data) into the neutral
 # CanonicalSchema format defined in scripts/parity/canonical/schema.schema.json.
 #
@@ -91,7 +94,8 @@ module Canonicalize
     return nil if value.nil?
     return value if value == true || value == false
     return value.to_i if value.is_a?(Integer)
-    return value.to_f if value.is_a?(Float)
+    # Float and BigDecimal (AR uses BigDecimal for :decimal columns) → JSON number.
+    return value.to_f if value.is_a?(Numeric)
     value.to_s
   end
 end

--- a/scripts/parity/schema/ruby/canonicalize_test.rb
+++ b/scripts/parity/schema/ruby/canonicalize_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "canonicalize"
+
+class CanonicalizeTest < Minitest::Test
+  # Build a minimal NativeTable hash for test fixtures
+  def col(name, ar_type, null: true, default: nil, limit: nil, precision: nil, scale: nil)
+    { name: name, ar_type: ar_type, null: null, default: default,
+      limit: limit, precision: precision, scale: scale }
+  end
+
+  def table(columns:, indexes: [], primary_key_columns: [])
+    { columns: columns, indexes: indexes, primary_key_columns: primary_key_columns }
+  end
+
+  # --- type mapping ---
+
+  def test_maps_trivial_fixture_columns
+    native = {
+      "users" => table(
+        columns: [
+          col("id",         :integer,  null: true),
+          col("email",      :text,     null: false),
+          col("name",       :text,     null: true),
+          col("score",      :float,    null: true),
+          col("avatar",     :binary,   null: true),
+          col("created_at", :datetime, null: false),
+          col("active",     :integer,  null: false, default: 1),
+        ],
+        primary_key_columns: ["id"],
+      ),
+    }
+
+    result = Canonicalize.call(native)
+
+    assert_equal 1, result["version"]
+    assert_equal 1, result["tables"].length
+    t = result["tables"][0]
+    assert_equal "users", t["name"]
+    assert_equal "id", t["primaryKey"]
+    assert_equal %w[id email name score avatar created_at active], t["columns"].map { |c| c["name"] }
+    assert_equal "integer",  t["columns"][0]["type"]
+    assert_equal "float",    t["columns"][3]["type"]
+    assert_equal "binary",   t["columns"][4]["type"]
+    assert_equal "datetime", t["columns"][5]["type"]
+    assert_equal 1,          t["columns"][6]["default"]
+    assert_equal [],         t["indexes"]
+  end
+
+  # --- column ordering ---
+
+  def test_preserves_column_declaration_order
+    native = {
+      "things" => table(columns: [col("z", :text), col("a", :text), col("m", :text)]),
+    }
+    t = Canonicalize.call(native)["tables"][0]
+    assert_equal %w[z a m], t["columns"].map { |c| c["name"] }
+  end
+
+  # --- table sorting ---
+
+  def test_sorts_tables_by_name
+    native = {
+      "zebra" => table(columns: [col("id", :integer)], primary_key_columns: ["id"]),
+      "apple" => table(columns: [col("id", :integer)], primary_key_columns: ["id"]),
+    }
+    names = Canonicalize.call(native)["tables"].map { |t| t["name"] }
+    assert_equal %w[apple zebra], names
+  end
+
+  # --- filters ---
+
+  def test_filters_schema_migrations_and_ar_internal_metadata
+    native = {
+      "users"                => table(columns: [col("id", :integer)], primary_key_columns: ["id"]),
+      "schema_migrations"    => table(columns: [col("version", :string, null: false)]),
+      "ar_internal_metadata" => table(columns: [col("key", :string, null: false)]),
+    }
+    names = Canonicalize.call(native)["tables"].map { |t| t["name"] }
+    assert_equal ["users"], names
+  end
+
+  def test_filters_sqlite_autoindex_and_sorts_remaining_indexes
+    native = {
+      "posts" => table(
+        columns: [col("id", :integer)],
+        primary_key_columns: ["id"],
+        indexes: [
+          { name: "sqlite_autoindex_posts_1", columns: ["title"],      unique: true,  where: nil },
+          { name: "idx_posts_z",              columns: ["created_at"], unique: false, where: nil },
+          { name: "idx_posts_a",              columns: ["author_id"],  unique: false, where: nil },
+        ],
+      ),
+    }
+    t = Canonicalize.call(native)["tables"][0]
+    assert_equal %w[idx_posts_a idx_posts_z], t["indexes"].map { |i| i["name"] }
+  end
+
+  # --- primary key shapes ---
+
+  def test_single_column_pk
+    native = { "t" => table(columns: [col("id", :integer)], primary_key_columns: ["id"]) }
+    assert_equal "id", Canonicalize.call(native)["tables"][0]["primaryKey"]
+  end
+
+  def test_composite_pk_as_array_in_position_order
+    native = {
+      "taggings" => table(
+        columns: [col("tag_id", :integer, null: false), col("taggable_id", :integer, null: false)],
+        primary_key_columns: ["tag_id", "taggable_id"],
+      ),
+    }
+    assert_equal ["tag_id", "taggable_id"], Canonicalize.call(native)["tables"][0]["primaryKey"]
+  end
+
+  def test_pk_position_order_overrides_column_declaration_order
+    # Simulates PRIMARY KEY (b, a) where a appears first in the table definition.
+    native = {
+      "items" => table(
+        columns: [col("a", :integer, null: false), col("b", :integer, null: false)],
+        primary_key_columns: ["b", "a"],
+      ),
+    }
+    assert_equal ["b", "a"], Canonicalize.call(native)["tables"][0]["primaryKey"]
+  end
+
+  def test_no_pk_table
+    native = { "logs" => table(columns: [col("message", :text)]) }
+    assert_nil Canonicalize.call(native)["tables"][0]["primaryKey"]
+  end
+
+  # --- default coercion ---
+
+  def test_integer_default
+    native = { "t" => table(columns: [col("count", :integer, null: false, default: 0)]) }
+    assert_equal 0, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
+  def test_string_default
+    native = { "t" => table(columns: [col("status", :string, null: false, default: "active")]) }
+    assert_equal "active", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
+  def test_nil_default
+    native = { "t" => table(columns: [col("note", :text, null: true, default: nil)]) }
+    assert_nil Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
+  # --- error cases ---
+
+  def test_raises_on_unknown_ar_type
+    native = { "t" => table(columns: [col("x", :unknowntype)]) }
+    err = assert_raises(RuntimeError) { Canonicalize.call(native) }
+    assert_match(/unknown AR type.*unknowntype/, err.message)
+  end
+
+  def test_raises_on_index_with_no_columns
+    native = {
+      "t" => table(
+        columns: [col("id", :integer)],
+        indexes: [{ name: "bad_idx", columns: [], unique: false, where: nil }],
+      ),
+    }
+    err = assert_raises(RuntimeError) { Canonicalize.call(native) }
+    assert_match(/no columns/, err.message)
+  end
+end

--- a/scripts/parity/schema/ruby/dump.rb
+++ b/scripts/parity/schema/ruby/dump.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Usage: bundle exec ruby dump.rb <fixture-dir> <out.json>
+# Usage (from repo root):
+#   bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
+#     ruby scripts/parity/schema/ruby/dump.rb <fixture-dir> <out.json>
 #
-# Must be run from scripts/parity/schema/ruby/ (Gemfile lives here).
 # fixture-dir and out.json paths can be relative or absolute.
 #
 # Applies <fixture-dir>/schema.sql to a fresh SQLite database, introspects
@@ -17,6 +18,7 @@ require "active_record"
 require "sqlite3"
 require "tmpdir"
 require "json"
+require "fileutils"
 require_relative "canonicalize"
 
 FILTERED_TABLES = %w[schema_migrations ar_internal_metadata].freeze

--- a/scripts/parity/schema/ruby/dump.rb
+++ b/scripts/parity/schema/ruby/dump.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Usage: bundle exec ruby dump.rb <fixture-dir> <out.json>
+#
+# Must be run from scripts/parity/schema/ruby/ (Gemfile lives here).
+# fixture-dir and out.json paths can be relative or absolute.
+#
+# Applies <fixture-dir>/schema.sql to a fresh SQLite database, introspects
+# it using ActiveRecord, canonicalizes the result, and writes canonical JSON
+# to <out.json>.
+#
+# Validates against <fixture-dir>/expected.json (D6) and exits 2 on mismatch.
+
+require "bundler/setup"
+require "active_record"
+require "sqlite3"
+require "tmpdir"
+require "json"
+require_relative "canonicalize"
+
+FILTERED_TABLES = %w[schema_migrations ar_internal_metadata].freeze
+
+def usage
+  warn "Usage: bundle exec ruby dump.rb <fixture-dir> <out.json>"
+  exit 1
+end
+
+fixture_dir, out_path = ARGV
+usage unless fixture_dir && out_path
+
+fixture_dir = File.expand_path(fixture_dir)
+out_path    = File.expand_path(out_path)
+
+Dir.mktmpdir("parity-ruby-") do |tmpdir|
+  db_path = File.join(tmpdir, "schema.db")
+
+  begin
+    # 1. Apply schema.sql to a fresh temp SQLite file
+    sql = File.read(File.join(fixture_dir, "schema.sql"))
+    SQLite3::Database.new(db_path) do |db|
+      db.execute_batch(sql)
+    end
+
+    # 2. Connect via ActiveRecord
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_path)
+    conn = ActiveRecord::Base.connection
+
+    # 3. Introspect tables, columns, indexes, PKs
+    tables = conn.tables.reject { |t| FILTERED_TABLES.include?(t) }.sort
+
+    native_dump = {}
+    tables.each do |table_name|
+      cols = conn.columns(table_name).map do |col|
+        {
+          name:      col.name,
+          ar_type:   col.type,
+          null:      col.null,
+          default:   col.default,
+          limit:     col.limit,
+          precision: col.precision,
+          scale:     col.scale,
+        }
+      end
+
+      raw_pk = conn.primary_key(table_name)
+      pk_cols = case raw_pk
+      when nil    then []
+      when Array  then raw_pk
+      else             [raw_pk]
+      end
+
+      idxs = conn.indexes(table_name).map do |idx|
+        {
+          name:    idx.name,
+          columns: idx.columns,
+          unique:  idx.unique,
+          where:   idx.where,
+        }
+      end
+
+      native_dump[table_name] = {
+        columns:             cols,
+        indexes:             idxs,
+        primary_key_columns: pk_cols,
+      }
+    end
+
+    # 4. Canonicalize
+    canonical = Canonicalize.call(native_dump)
+
+    # 5. Validate against expected.json (D6)
+    expected = JSON.parse(File.read(File.join(fixture_dir, "expected.json")))
+
+    actual_tables   = canonical["tables"].map { |t| t["name"] }.sort
+    expected_tables = expected["tables"].sort
+    if actual_tables != expected_tables
+      warn "parity dump: table mismatch\n  expected: #{expected_tables.inspect}\n  actual:   #{actual_tables.inspect}"
+      $stdout.flush
+      exit 2
+    end
+
+    actual_index_count = canonical["tables"].sum { |t| t["indexes"].length }
+    if actual_index_count != expected["indexCount"]
+      warn "parity dump: index count mismatch\n  expected: #{expected["indexCount"]}\n  actual:   #{actual_index_count}"
+      $stdout.flush
+      exit 2
+    end
+
+    # 6. Write canonical JSON
+    FileUtils.mkdir_p(File.dirname(out_path))
+    File.write(out_path, JSON.pretty_generate(canonical) + "\n")
+    puts "parity dump (rails): wrote #{out_path}"
+
+  ensure
+    begin
+      ActiveRecord::Base.remove_connection
+    rescue StandardError
+      # already removed or never opened
+    end
+  end
+end

--- a/scripts/parity/schema/ruby/dump.rb
+++ b/scripts/parity/schema/ruby/dump.rb
@@ -96,14 +96,12 @@ Dir.mktmpdir("parity-ruby-") do |tmpdir|
     expected_tables = expected["tables"].sort
     if actual_tables != expected_tables
       warn "parity dump: table mismatch\n  expected: #{expected_tables.inspect}\n  actual:   #{actual_tables.inspect}"
-      $stdout.flush
       exit 2
     end
 
     actual_index_count = canonical["tables"].sum { |t| t["indexes"].length }
     if actual_index_count != expected["indexCount"]
       warn "parity dump: index count mismatch\n  expected: #{expected["indexCount"]}\n  actual:   #{actual_index_count}"
-      $stdout.flush
       exit 2
     end
 


### PR DESCRIPTION
## Summary

Adds the ruby-side schema dump + canonicalize pipeline per the plan in #730.

**Design change from plan:** uses direct AR introspection (`conn.columns`, `conn.indexes`, `conn.primary_key`) instead of schema.rb parsing. This avoids Prism dependency, is simpler, and produces the same data AR's type system provides — matching the node side's `introspectColumns`/`introspectIndexes`/`introspectPrimaryKey` approach exactly.

**`scripts/parity/schema/ruby/Gemfile`** — pins `activerecord 8.0.2` (D10), `sqlite3 ~> 2.1`, `minitest ~> 5.25`. No full Rails stack — only AR is needed. Gemfile.lock omitted from this commit; generated by `bundle install` on first run and should be committed after CI produces it.

**`scripts/parity/schema/ruby/canonicalize.rb`** — `Canonicalize.call(native_dump)`. Applies all decisions: column declaration order preserved (D1), tables/indexes sorted by name (D1), `schema_migrations`/`ar_internal_metadata` filtered (D2), `sqlite_autoindex_*` filtered (D3), closed AR type map enforced with raise on unknown (D4). Input is a plain Ruby Hash, not schema.rb text.

**`scripts/parity/schema/ruby/dump.rb`** — CLI: `bundle exec ruby dump.rb <fixture-dir> <out.json>`. Applies `schema.sql` via `SQLite3::Database#execute_batch`, connects via `ActiveRecord::Base.establish_connection`, introspects with `conn.columns`/`conn.indexes`/`conn.primary_key`, validates against `expected.json` (D6, exits 2 on mismatch), writes canonical JSON.

**`scripts/parity/schema/ruby/canonicalize_test.rb`** — 13 minitest tests mirroring the node-side coverage: type mapping, column order, table sort, filter rules, PK shapes (single/composite/position-order/nil), default coercion, error cases.

**`docs/activerecord-rails-parity-verification.md`** — updated PR4 section to reflect direct introspection approach and corrected Gemfile (no `rails` gem, no `prism`).

## Test plan
- [ ] `cd scripts/parity/schema/ruby && bundle install` succeeds
- [ ] `bundle exec ruby canonicalize_test.rb` → 13 tests pass
- [ ] `bundle exec ruby dump.rb ../../fixtures/01-trivial /tmp/r-01.json` exits 0, writes valid canonical JSON
- [ ] `bundle exec ruby dump.rb ../../fixtures/02-moderate /tmp/r-02.json` exits 0 with `indexCount: 1`
- [ ] Both output JSONs match the node-side outputs from PR3