### PR TITLE
feat(activemodel): toParam respects isPersisted + configurable paramDelimiter

### DIFF
--- a/packages/activemodel/src/conversion.test.ts
+++ b/packages/activemodel/src/conversion.test.ts
@@ -14,15 +14,18 @@ describe("ConversionTest", () => {
 
   it("#to_param_delimiter allows redefining the delimiter used in #to_param", () => {
     class Person extends Model {
+      static paramDelimiter = "_";
       static {
         this.attribute("id", "integer");
       }
       isPersisted() {
         return true;
       }
+      toKey() {
+        return [1, 2];
+      }
     }
-    const p = new Person({ id: 123 });
-    expect(p.toParam()).toBe("123");
+    expect(new Person({ id: 1 }).toParam()).toBe("1_2");
   });
 
   it("to_key doesn't double-wrap composite `id`s", () => {
@@ -43,10 +46,14 @@ describe("ConversionTest", () => {
       static {
         this.attribute("id", "integer");
       }
+      isPersisted() {
+        return true;
+      }
+      toKey() {
+        return [1, null];
+      }
     }
-    const p = new Person({});
-    // Not persisted, so toParam returns null
-    expect(p.toParam()).toBeNull();
+    expect(new Person({}).toParam()).toBeNull();
   });
 
   it("to_partial_path handles non-standard model_name", () => {
@@ -61,15 +68,30 @@ describe("ConversionTest", () => {
 
   it("#to_param_delimiter is defined per class", () => {
     class Person extends Model {
+      static paramDelimiter = ";";
       static {
         this.attribute("id", "integer");
       }
       isPersisted() {
         return true;
       }
+      toKey() {
+        return [1, 2];
+      }
     }
-    const p = new Person({ id: 1 });
-    expect(p.toParam()).toBe("1");
+    class Other extends Model {
+      static {
+        this.attribute("id", "integer");
+      }
+      isPersisted() {
+        return true;
+      }
+      toKey() {
+        return [3, 4];
+      }
+    }
+    expect(new Person({ id: 1 }).toParam()).toBe("1;2");
+    expect(new Other({ id: 3 }).toParam()).toBe("3-4");
   });
 
   it("to_model default implementation returns self", () => {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -63,6 +63,8 @@ export class Model {
 
   // -- Class-level registries --
   static includeRootInJson: boolean | string = false;
+  // Rails: class_attribute :param_delimiter, instance_reader: false, default: "-"
+  // (activemodel/lib/active_model/conversion.rb:32)
   static paramDelimiter: string = "-";
   static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
   static _attributeMethodPatterns: AttributeMethodPattern[] = [];

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -63,6 +63,7 @@ export class Model {
 
   // -- Class-level registries --
   static includeRootInJson: boolean | string = false;
+  static paramDelimiter: string = "-";
   static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
   static _attributeMethodPatterns: AttributeMethodPattern[] = [];
   static _attributeAliases: Record<string, string> = {};
@@ -1464,9 +1465,11 @@ export class Model {
   }
 
   toParam(): string | null {
+    if (!this.isPersisted()) return null;
     const key = this.toKey();
     if (!key) return null;
-    return key.map(String).join("-");
+    if (!key.every((part) => part !== null && part !== undefined && part !== false)) return null;
+    return key.map(String).join((this.constructor as typeof Model).paramDelimiter);
   }
 
   toPartialPath(): string {


### PR DESCRIPTION
## Summary

PR 1 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

Fixes a silent URL-generation deviation from Rails `ActiveModel::Conversion#to_param`:

```ruby
# Rails conversion.rb:90-92
def to_param
  (persisted? && (key = to_key) && key.all?) ? key.join(self.class.param_delimiter) : nil
end
```

Previously `Model#toParam` (`model.ts:1466`) skipped `isPersisted()`, skipped the `key.all?` check, and hard-coded `"-"`.

- Adds `Model.paramDelimiter: string = "-"` (Rails' `class_attribute :param_delimiter, default: "-"`).
- `#toParam` now returns `null` when `!isPersisted()`, when any key part is nullish/`false`, and joins via `this.constructor.paramDelimiter`.
- Tightened the two existing `#to_param_delimiter` tests to actually exercise the override and per-class isolation. Names unchanged (per CLAUDE.md).
- No ActiveRecord impact — `ActiveRecord::Integration#to_param` overrides this entirely and already matches Rails.

## Test plan

- [x] `pnpm vitest run packages/activemodel` — 1377/1377
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`
- [x] `pnpm run api:compare --package activemodel` — 341/342 (99.7%), unchanged