### PR TITLE
feat(activerecord): encryption 100% — remaining method gaps (PRs 5–12)

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -22,6 +22,7 @@ import { type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
+import { Cipher } from "./encryption/cipher/aes256-gcm.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -245,4 +246,19 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
     current = Object.getPrototypeOf(current);
   }
   return false;
+}
+
+/** Mirrors: ActiveRecord::Encryption.key_length */
+export function keyLength(): number {
+  return Cipher.keyLength;
+}
+
+/** Mirrors: ActiveRecord::Encryption.iv_length */
+export function ivLength(): number {
+  return Cipher.ivLength;
+}
+
+/** Mirrors: ActiveRecord::Encryption.eager_load! */
+export function eagerLoadBang(): void {
+  // No-op in TS — all encryption classes are statically imported.
 }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -4,6 +4,32 @@
  * Mirrors: ActiveRecord::Encryption::Contexts
  */
 
+/**
+ * Holds the encryption configuration for a single context frame:
+ * key provider, key generator, cipher, message serializer, encryptor,
+ * and whether encryption is frozen (read-only mode).
+ *
+ * Mirrors: ActiveRecord::Encryption::Context
+ */
+export class Context {
+  private _keyProvider?: unknown;
+  keyGenerator?: unknown;
+  cipher?: unknown;
+  messageSerializer?: unknown;
+  encryptor?: unknown;
+  frozenEncryption: boolean = false;
+
+  constructor() {}
+
+  get keyProvider(): unknown {
+    return this._keyProvider;
+  }
+
+  set keyProvider(value: unknown) {
+    this._keyProvider = value;
+  }
+}
+
 export interface EncryptionContext {
   encryptionDisabled?: boolean;
   protectedMode?: boolean;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -2,6 +2,8 @@ import { Scheme, type SchemeOptions } from "./scheme.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 
+const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
+
 /**
  * Provides the `encrypts` declaration for model classes, enabling
  * transparent attribute encryption/decryption. This is wired into
@@ -78,6 +80,12 @@ export class EncryptableRecord {
 
   static encryptedAttributes(modelClass: any): Set<string> {
     return modelClass._encryptedAttributes ?? new Set();
+  }
+
+  static sourceAttributeFromPreservedAttribute(attributeName: string): string | undefined {
+    return attributeName.startsWith(ORIGINAL_ATTRIBUTE_PREFIX)
+      ? attributeName.slice(ORIGINAL_ATTRIBUTE_PREFIX.length)
+      : undefined;
   }
 
   static deterministicEncryptedAttributes(modelClass: any): Set<string> {

--- a/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
+++ b/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
@@ -1,6 +1,47 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { EncryptedFixtures } from "./encrypted-fixtures.js";
+import { Scheme } from "./scheme.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import type { EncryptorLike } from "./encryptor.js";
+
+// Encryptor that produces a distinguishable ciphertext for test assertions.
+const prefixEncryptor: EncryptorLike = {
+  encrypt: (v) => `enc:${v}`,
+  decrypt: (v) => v.replace(/^enc:/, ""),
+  isEncrypted: (v) => v.startsWith("enc:"),
+  isBinary: () => false,
+};
+
+function makeType(): EncryptedAttributeType {
+  return new EncryptedAttributeType({ scheme: new Scheme({ encryptor: prefixEncryptor }) });
+}
 
 describe("ActiveRecord::Encryption::EncryptableFixtureTest", () => {
-  it.skip("fixtures get encrypted automatically", () => {});
-  it.skip("preserved columns due to ignore_case: true gets encrypted automatically", () => {});
+  it("fixtures get encrypted automatically", () => {
+    const type = makeType();
+    const modelClass = {
+      _encryptedAttributes: new Set(["email"]),
+      _attributeDefinitions: new Map([["email", { type }]]),
+    };
+    const ef = new EncryptedFixtures({ email: "user@example.com", name: "Alice" }, modelClass);
+    expect(ef.fixture.email).toBe("enc:user@example.com");
+    expect(ef.fixture.name).toBe("Alice");
+  });
+
+  it("preserved columns due to ignore_case: true gets encrypted automatically", () => {
+    const type = makeType();
+    const modelClass = {
+      _encryptedAttributes: new Set(["email", "original_email"]),
+      _attributeDefinitions: new Map([
+        ["email", { type }],
+        ["original_email", { type }],
+      ]),
+    };
+    const ef = new EncryptedFixtures(
+      { email: "user@example.com", original_email: "user@example.com" },
+      modelClass,
+    );
+    expect(ef.fixture.email).toBe("enc:user@example.com");
+    expect(ef.fixture.original_email).toBe("enc:user@example.com");
+  });
 });

--- a/packages/activerecord/src/encryption/encrypted-fixtures.ts
+++ b/packages/activerecord/src/encryption/encrypted-fixtures.ts
@@ -4,14 +4,60 @@
  * Mirrors: ActiveRecord::Encryption::EncryptedFixtures
  */
 
-export interface EncryptedFixtures {
-  encryptFixtureData(
-    data: Record<string, unknown>,
-    encryptedAttributes: string[],
-    encrypt: (value: unknown) => unknown,
-  ): Record<string, unknown>;
+import { EncryptableRecord } from "./encryptable-record.js";
+
+/**
+ * Encrypts fixture data for model classes that use encrypted attributes.
+ * Iterates all encrypted attributes declared on the model class, encrypts
+ * their values in the fixture, and also processes preserved-original columns.
+ *
+ * Mirrors: ActiveRecord::Encryption::EncryptedFixtures
+ */
+export class EncryptedFixtures {
+  readonly fixture: Record<string, unknown>;
+  private _cleanValues: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+
+  constructor(fixture: Record<string, unknown>, modelClass: any) {
+    this.fixture = { ...fixture };
+    this._encryptFixtureData(this.fixture, modelClass);
+    this._processPreservedOriginalColumns(this.fixture, modelClass);
+  }
+
+  private _encryptFixtureData(fixture: Record<string, unknown>, modelClass: any): void {
+    const encryptedAttrs: Set<string> = modelClass?._encryptedAttributes ?? new Set();
+    for (const attr of encryptedAttrs) {
+      const attrStr = String(attr);
+      if (Object.prototype.hasOwnProperty.call(fixture, attrStr)) {
+        this._cleanValues[attrStr] = fixture[attrStr];
+        const type = modelClass?._attributeDefinitions?.get?.(attrStr)?.type;
+        if (type?.serialize) {
+          fixture[attrStr] = type.serialize(fixture[attrStr]);
+        }
+      }
+    }
+  }
+
+  private _processPreservedOriginalColumns(
+    fixture: Record<string, unknown>,
+    modelClass: any,
+  ): void {
+    const encryptedAttrs: Set<string> = modelClass?._encryptedAttributes ?? new Set();
+    for (const attr of encryptedAttrs) {
+      const sourceAttr = EncryptableRecord.sourceAttributeFromPreservedAttribute(String(attr));
+      if (sourceAttr !== undefined) {
+        const cleanValue = this._cleanValues[sourceAttr];
+        if (cleanValue !== undefined) {
+          const type = modelClass?._attributeDefinitions?.get?.(String(attr))?.type;
+          if (type?.serialize) {
+            fixture[String(attr)] = type.serialize(cleanValue);
+          }
+        }
+      }
+    }
+  }
 }
 
+/** @deprecated Use EncryptedFixtures class instead */
 export function encryptFixtureData(
   data: Record<string, unknown>,
   encryptedAttributes: string[],

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
@@ -51,6 +51,25 @@ describe("ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest", () => {
     expect(decrypted).toBe("hello");
   });
 
+  it("active_primary_key returns and memoizes the primary key", () => {
+    let callCount = 0;
+    const primaryKey = makeKey();
+    const trackingProvider = {
+      encryptionKey() {
+        callCount++;
+        return primaryKey;
+      },
+      decryptionKeys: () => [primaryKey],
+    } as unknown as KeyProvider;
+
+    const provider = new EnvelopeEncryptionKeyProvider(trackingProvider);
+    const k1 = provider.activePrimaryKey;
+    const k2 = provider.activePrimaryKey;
+    expect(k1).toBe(primaryKey);
+    expect(k2).toBe(k1);
+    expect(callCount).toBe(1);
+  });
+
   it("work with multiple keys when config.store_key_references is true", () => {
     const primaryProvider = new KeyProvider([makeKey(), makeKey()]);
     const provider = new EnvelopeEncryptionKeyProvider(primaryProvider);

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -14,6 +14,7 @@ import type { Message } from "./message.js";
 export class EnvelopeEncryptionKeyProvider {
   private _primaryKeyProvider: KeyProvider;
   private _encryptor: Encryptor;
+  private _activePrimaryKey?: Key;
 
   constructor(primaryKeyProvider: KeyProvider) {
     this._primaryKeyProvider = primaryKeyProvider;
@@ -40,6 +41,11 @@ export class EnvelopeEncryptionKeyProvider {
       keyProvider: this._primaryKeyProvider,
     });
     return [new Key(secret)];
+  }
+
+  get activePrimaryKey(): Key {
+    this._activePrimaryKey ??= this._primaryKeyProvider.encryptionKey();
+    return this._activePrimaryKey;
   }
 
   generateRandomEncryptionKey(): string {

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { EncryptedUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { Scheme } from "./scheme.js";
+import { isEncryptionDisabled } from "./context.js";
+import type { EncryptorLike } from "./encryptor.js";
+
+// Encryptors that produce distinguishable ciphertexts so assertions are meaningful.
+const encryptorA: EncryptorLike = {
+  encrypt: (v) => `A:${v}`,
+  decrypt: (v) => v.replace(/^A:/, ""),
+  isEncrypted: (v) => v.startsWith("A:"),
+  isBinary: () => false,
+};
+const encryptorB: EncryptorLike = {
+  encrypt: (v) => `B:${v}`,
+  decrypt: (v) => v.replace(/^B:/, ""),
+  isEncrypted: (v) => v.startsWith("B:"),
+  isBinary: () => false,
+};
+
+describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest", () => {
+  it("validateEach calls originalValidateEach for current and previous scheme ciphertexts", () => {
+    const prevScheme = new Scheme({ deterministic: true, encryptor: encryptorB });
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({
+        deterministic: true,
+        encryptor: encryptorA,
+        previousSchemes: [prevScheme],
+      }),
+    });
+
+    const klass = {
+      _encryptedAttributes: new Set(["email"]),
+      _attributeDefinitions: new Map([["email", { type }]]),
+    };
+    const record = { constructor: klass };
+
+    const calls: Array<{ attribute: string; value: unknown; encryptionDisabled: boolean }> = [];
+    const originalValidateEach = (_record: any, attribute: string, value: unknown) => {
+      calls.push({ attribute, value, encryptionDisabled: isEncryptionDisabled() });
+    };
+
+    new EncryptedUniquenessValidator().validateEach(
+      originalValidateEach,
+      record,
+      "email",
+      "user@example.com",
+    );
+
+    // First call: current value (encryption enabled)
+    expect(calls[0].value).toBe("user@example.com");
+    expect(calls[0].encryptionDisabled).toBe(false);
+
+    // Second call: previous scheme ciphertext (encryption disabled)
+    expect(calls[1]).toBeDefined();
+    expect(calls[1].value).toBe(type.previousTypes[0].serialize("user@example.com"));
+    expect(calls[1].encryptionDisabled).toBe(true);
+  });
+
+  it("validateEach skips non-deterministic attributes", () => {
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({ deterministic: false, encryptor: encryptorA }),
+    });
+    const klass = {
+      _encryptedAttributes: new Set(["body"]),
+      _attributeDefinitions: new Map([["body", { type }]]),
+    };
+    const record = { constructor: klass };
+
+    const calls: unknown[] = [];
+    const originalValidateEach = (_r: any, _a: string, value: unknown) => calls.push(value);
+
+    new EncryptedUniquenessValidator().validateEach(originalValidateEach, record, "body", "hello");
+
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -1,6 +1,7 @@
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
-import { getAttributeType } from "./encryptable-record.js";
+import { EncryptableRecord, getAttributeType } from "./encryptable-record.js";
 import { AdditionalValue } from "./extended-deterministic-queries.js";
+import { withoutEncryption } from "./context.js";
 
 /**
  * Extends uniqueness validation for deterministic encrypted attributes.
@@ -29,6 +30,29 @@ export class ExtendedDeterministicUniquenessValidator {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator::EncryptedUniquenessValidator
  */
 export class EncryptedUniquenessValidator {
+  validateEach(
+    originalValidateEach: (record: any, attribute: string, value: unknown) => void,
+    record: any,
+    attribute: string,
+    value: unknown,
+  ): void {
+    originalValidateEach(record, attribute, value);
+
+    const klass = record.constructor;
+    const deterministicAttrs = EncryptableRecord.deterministicEncryptedAttributes(klass);
+    if (!deterministicAttrs.has(attribute)) return;
+
+    const encryptedType = getAttributeType(klass, attribute);
+    if (!(encryptedType instanceof EncryptedAttributeType)) return;
+
+    for (const prevType of encryptedType.previousTypes) {
+      const encryptedValue = prevType.serialize(value);
+      withoutEncryption(() => {
+        originalValidateEach(record, attribute, encryptedValue);
+      });
+    }
+  }
+
   /**
    * Returns all ciphertext variants for a value across current and
    * previous encryption schemes. Used by uniqueness validation to

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -23,6 +23,7 @@ export { Configurable } from "./configurable.js";
 export { Contexts } from "./contexts.js";
 export { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 export { EncryptableRecord } from "./encryptable-record.js";
+export { EncryptedFixtures } from "./encrypted-fixtures.js";
 export { AutoFilteredParameters } from "./auto-filtered-parameters.js";
 export { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
 export {
@@ -45,5 +46,8 @@ export {
   applyPendingEncryptions,
   isEncryptedAttribute,
   defaultEncryptor,
+  keyLength,
+  ivLength,
+  eagerLoadBang,
 } from "../encryption.js";
 export type { Encryptor as LegacyEncryptor, EncryptsOptions } from "../encryption.js";

--- a/packages/activerecord/src/encryption/key-generator.test.ts
+++ b/packages/activerecord/src/encryption/key-generator.test.ts
@@ -49,4 +49,15 @@ describe("ActiveRecord::Encryption::KeyGeneratorTest", () => {
     const key = gen.deriveKey("password", 16);
     expect(Buffer.from(key, "base64").length).toBe(16);
   });
+
+  it("hash_digest_class reflects the configured digest", () => {
+    expect(new KeyGenerator("SHA256").hashDigestClass).toBe("SHA256");
+    expect(new KeyGenerator("SHA1").hashDigestClass).toBe("SHA1");
+  });
+
+  it("derive_key_from produces the same output as deriveKey", () => {
+    const gen = new KeyGenerator();
+    expect(gen.deriveKeyFrom("password")).toBe(gen.deriveKey("password"));
+    expect(gen.deriveKeyFrom("password", 16)).toBe(gen.deriveKey("password", 16));
+  });
 });

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -15,6 +15,14 @@ export class KeyGenerator {
     this._hashDigestClass = hashDigestClass;
   }
 
+  get hashDigestClass(): string {
+    return this._hashDigestClass;
+  }
+
+  deriveKeyFrom(password: string, length: number = DEFAULT_KEY_LENGTH): string {
+    return this.deriveKey(password, length);
+  }
+
   generateRandomKey(length: number = DEFAULT_KEY_LENGTH): string {
     return getCrypto().randomBytes(length).toString("base64");
   }

--- a/packages/activerecord/src/encryption/properties.test.ts
+++ b/packages/activerecord/src/encryption/properties.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Properties } from "./properties.js";
-import { EncryptedContentIntegrity } from "./errors.js";
+import { EncryptedContentIntegrity, ForbiddenClass } from "./errors.js";
 
 describe("ActiveRecord::EncryptionPropertiesTest", () => {
   it("behaves like a hash", () => {
@@ -33,11 +33,11 @@ describe("ActiveRecord::EncryptionPropertiesTest", () => {
   });
 
   it("validate allowed types on creation", () => {
-    expect(() => new Properties({ a: {} as any })).toThrow(EncryptedContentIntegrity);
+    expect(() => new Properties({ a: {} as any })).toThrow(ForbiddenClass);
   });
 
   it("validate allowed_types setting headers", () => {
     const props = new Properties();
-    expect(() => props.set("a", {} as any)).toThrow(EncryptedContentIntegrity);
+    expect(() => props.set("a", {} as any)).toThrow(ForbiddenClass);
   });
 });

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Properties
  */
 
-import { EncryptedContentIntegrity } from "./errors.js";
+import { EncryptedContentIntegrity, ForbiddenClass } from "./errors.js";
 
 const ALLOWED_TYPES = new Set(["string", "number", "boolean"]);
 
@@ -77,15 +77,29 @@ export class Properties {
     return this.get("at") as string | undefined;
   }
 
-  private _validateType(value: unknown): void {
+  validateValueType(value: unknown): void {
     if (value === null) return;
     if (typeof value === "object" && value !== null && "payload" in value && "headers" in value)
       return;
     const t = typeof value;
     if (!ALLOWED_TYPES.has(t)) {
-      throw new EncryptedContentIntegrity(
-        `Invalid property type: ${t}. Only string, number, boolean, nil are allowed.`,
+      const typeName = _typeNameFor(value);
+      throw new ForbiddenClass(
+        `Can't store a ${typeName}, only properties of type string, number, boolean, null are allowed`,
       );
     }
   }
+
+  private _validateType(value: unknown): void {
+    this.validateValueType(value);
+  }
+}
+
+function _typeNameFor(value: unknown): string {
+  const t = typeof value;
+  if ((t === "object" || t === "function") && value !== null) {
+    const name = (value as { constructor?: { name?: string } }).constructor?.name;
+    if (name) return name;
+  }
+  return t;
 }


### PR DESCRIPTION
## Summary

Closes the remaining 15 method gaps across 8 encryption files to reach 100% api:compare coverage for all encryption files.

| File | Method(s) added |
|------|-----------------|
| `encryption.ts` | `keyLength`, `ivLength`, `eagerLoadBang` |
| `encryption/context.ts` | `Context` class with `constructor` and `keyProvider` |
| `encryption/encryptable-record.ts` | `sourceAttributeFromPreservedAttribute` |
| `encryption/encrypted-fixtures.ts` | `EncryptedFixtures` class with `constructor` |
| `encryption/envelope-encryption-key-provider.ts` | `activePrimaryKey` |
| `encryption/extended-deterministic-uniqueness-validator.ts` | `validateEach` |
| `encryption/key-generator.ts` | `hashDigestClass` getter, `deriveKeyFrom` |
| `encryption/properties.ts` | `validateValueType` (public, raises `ForbiddenClass` per Rails) |

**`properties.ts` error type fix**: `_validateType` now correctly raises `ForbiddenClass` (not `EncryptedContentIntegrity`) for invalid value types, matching Rails' `Errors::ForbiddenClass`.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `key-generator.test.ts`, `properties.test.ts`, `envelope-encryption-key-provider.test.ts` pass
- [ ] `pnpm api:compare -- --package activerecord` shows all encryption files at 100%