### PR TITLE
fix(activerecord): whereValuesHash exposes IN arrays; scope_for_create filters via equality_only

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -65,10 +65,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::ExtendedEncryp
 });
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQueries#scopeForCreate", () => {
-  it("unwraps AdditionalValues from _encryptionExpansion to produce the current-scheme ciphertext", () => {
-    // _encryptionExpansion is set by RelationQueries.where when processArguments expands
-    // the condition. scopeForCreate reads it directly, bypassing WhereClause.toH() which
-    // cannot extract OR chains that ArrayHandler produces for object values.
+  it("unwraps AdditionalValues from whereValuesHash() to produce the current-scheme ciphertext", () => {
     const type = makeType(true);
     const prevType = makeType(true);
     const avCurrent = new AdditionalValue("plain@example.com", type);
@@ -79,25 +76,23 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       _attributeDefinitions: new Map([["email", { type }]]),
     };
     const relation = {
-      _modelClass: model,
-      _encryptionExpansion: { email: [avCurrent, avPrev] },
+      model,
+      whereValuesHash: () => ({ email: [avCurrent, avPrev] }),
     };
 
-    const originalScopeForCreate = () => ({});
-    const result = RelationQueries.scopeForCreate(originalScopeForCreate, relation);
+    const result = RelationQueries.scopeForCreate(() => ({}), relation);
     expect(result.email).toBe(avCurrent.value);
   });
 
-  it("leaves attributes alone when no expansion context is present", () => {
+  it("leaves attributes alone when whereValuesHash has no matching entry", () => {
     const type = makeType(true);
     const model = {
       _encryptedAttributes: new Set(["email"]),
       _attributeDefinitions: new Map([["email", { type }]]),
     };
-    const relation = { _modelClass: model };
+    const relation = { model, whereValuesHash: () => ({}) };
 
-    const originalScopeForCreate = () => ({ email: "plain@example.com" });
-    const result = RelationQueries.scopeForCreate(originalScopeForCreate, relation);
+    const result = RelationQueries.scopeForCreate(() => ({ email: "plain@example.com" }), relation);
     expect(result.email).toBe("plain@example.com");
   });
 
@@ -108,37 +103,23 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       _encryptedAttributes: new Set(["body"]),
       _attributeDefinitions: new Map([["body", { type }]]),
     };
-    const relation = {
-      _modelClass: model,
-      _encryptionExpansion: { body: [av] },
-    };
+    const relation = { model, whereValuesHash: () => ({ body: [av] }) };
 
-    const originalScopeForCreate = () => ({});
-    const result = RelationQueries.scopeForCreate(originalScopeForCreate, relation);
+    const result = RelationQueries.scopeForCreate(() => ({}), relation);
     expect(result.body).toBeUndefined();
   });
 
-  it("RelationQueries.where stores expansion context on the returned relation", () => {
-    // Need a type with previousTypes so processArguments actually expands the condition.
-    const prevScheme = new Scheme({ deterministic: true, encryptor: new NullEncryptor() });
-    const type = new EncryptedAttributeType({
-      scheme: new Scheme({
-        deterministic: true,
-        encryptor: new NullEncryptor(),
-        previousSchemes: [prevScheme],
-      }),
-    });
+  it("ignores scalar (non-array) where values", () => {
+    const type = makeType(true);
     const model = {
       _encryptedAttributes: new Set(["email"]),
       _attributeDefinitions: new Map([["email", { type }]]),
     };
-    const returnedRelation: any = { _modelClass: model };
-    const originalWhere = (_args: unknown) => returnedRelation;
-    const result = RelationQueries.where(originalWhere, { _modelClass: model }, [
-      { email: "x@example.com" },
-    ]) as any;
-    expect(result._encryptionExpansion).toBeDefined();
-    expect(Array.isArray(result._encryptionExpansion.email)).toBe(true);
-    expect(result._encryptionExpansion.email[0]).toBeInstanceOf(AdditionalValue);
+    const relation = {
+      model,
+      whereValuesHash: () => ({ email: "plain@example.com" }),
+    };
+    const result = RelationQueries.scopeForCreate(() => ({}), relation);
+    expect(result.email).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -127,11 +127,6 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
   });
 
   it("reads IN-array values from a real Relation via whereValuesHash() (integration)", () => {
-    // End-to-end check that Relation#whereValuesHash now exposes IN-array
-    // predicates (the Copilot #3 concern on #737). Uses scalar values to
-    // stay orthogonal to PredicateBuilder's ArrayHandler handling of
-    // AdditionalValue objects (tracked separately — ArrayHandler turns
-    // object-arrays into OR chains which whereValuesHash cannot extract).
     const adapter = createTestAdapter();
     class Contact extends Base {
       static {
@@ -145,5 +140,34 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     expect(rel.whereValuesHash()).toEqual({ email: ["a@x", "b@x"] });
     // scope_for_create filters the IN array out (Rails: equality_only=true).
     expect(rel.scopeForCreate()).toEqual({});
+  });
+
+  it("unwraps AdditionalValue trailers end-to-end on a real Relation", () => {
+    const adapter = createTestAdapter();
+    const type = makeType(true);
+    const prevType = makeType(true);
+
+    class Contact extends Base {
+      static {
+        this._tableName = "contacts";
+        this.attribute("id", "integer");
+        this.attribute("email", "string");
+        this.adapter = adapter;
+      }
+    }
+    (Contact as any)._encryptedAttributes = new Set(["email"]);
+    const defs = (Contact as any)._attributeDefinitions as Map<string, { type: unknown }>;
+    defs.set("email", { type });
+
+    const avCurrent = new AdditionalValue("plain@example.com", type);
+    const avPrev = new AdditionalValue("plain@example.com", prevType);
+    const rel = Contact.all().where({ email: [avCurrent, avPrev] });
+
+    const hash = rel.whereValuesHash();
+    expect(Array.isArray(hash.email)).toBe(true);
+    expect((hash.email as unknown[])[0]).toBe(avCurrent);
+
+    const scope = RelationQueries.scopeForCreate(() => ({}), rel);
+    expect(scope.email).toBe(avCurrent.value);
   });
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -7,6 +7,9 @@ import {
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { NullEncryptor } from "./null-encryptor.js";
+import { Base } from "../base.js";
+import { createTestAdapter } from "../test-adapter.js";
+import "../relation.js";
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
   it.skip("Finds records when data is unencrypted", () => {});
@@ -121,5 +124,26 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     };
     const result = RelationQueries.scopeForCreate(() => ({}), relation);
     expect(result.email).toBeUndefined();
+  });
+
+  it("reads IN-array values from a real Relation via whereValuesHash() (integration)", () => {
+    // End-to-end check that Relation#whereValuesHash now exposes IN-array
+    // predicates (the Copilot #3 concern on #737). Uses scalar values to
+    // stay orthogonal to PredicateBuilder's ArrayHandler handling of
+    // AdditionalValue objects (tracked separately — ArrayHandler turns
+    // object-arrays into OR chains which whereValuesHash cannot extract).
+    const adapter = createTestAdapter();
+    class Contact extends Base {
+      static {
+        this._tableName = "contacts";
+        this.attribute("id", "integer");
+        this.attribute("email", "string");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Contact.all().where({ email: ["a@x", "b@x"] });
+    expect(rel.whereValuesHash()).toEqual({ email: ["a@x", "b@x"] });
+    // scope_for_create filters the IN array out (Rails: equality_only=true).
+    expect(rel.scopeForCreate()).toEqual({});
   });
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -100,18 +100,7 @@ export class EncryptedQuery {
  */
 export class RelationQueries {
   static where(originalWhere: Function, relation: any, args: unknown[]): unknown {
-    const processed = EncryptedQuery.processArguments(relation, args, true);
-    const result = originalWhere.call(relation, ...processed) as any;
-    // Store the expanded conditions on the returned relation so scopeForCreate
-    // can access the AdditionalValue arrays directly, bypassing WhereClause.toH()
-    // which cannot extract OR chains produced by ArrayHandler for object values.
-    if (processed !== args && processed.length > 0 && typeof processed[0] === "object") {
-      result._encryptionExpansion = {
-        ...(relation._encryptionExpansion ?? {}),
-        ...(processed[0] as Record<string, unknown>),
-      };
-    }
-    return result;
+    return originalWhere.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
   }
 
   static isExists(originalExists: Function, relation: any, args: unknown[]): unknown {
@@ -122,19 +111,20 @@ export class RelationQueries {
     originalScopeForCreate: () => Record<string, unknown>,
     relation: any,
   ): Record<string, unknown> {
-    const model = relation._modelClass ?? relation;
+    const model = relation.model ?? relation;
     const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
     if (!encryptedAttrs?.size) return originalScopeForCreate.call(relation);
 
     const scopeAttrs = originalScopeForCreate.call(relation);
-    const wheres: Record<string, unknown> = relation._encryptionExpansion ?? {};
+    const wheres = relation.whereValuesHash();
     for (const attrName of encryptedAttrs) {
       const type = getAttributeType(model, attrName);
       if (!(type instanceof EncryptedAttributeType) || !type.deterministic) continue;
       const values = wheres[attrName];
       if (Array.isArray(values) && values[0] instanceof AdditionalValue) {
-        // values[0] is AdditionalValue for the current scheme — unwrap to ciphertext
-        // so the created record stores the correct encrypted value directly.
+        // Our expansion stores AdditionalValue(current) at index 0 (see
+        // allCiphertextsFor). Unwrap to the ciphertext so the created
+        // record stores the current-scheme-encrypted value directly.
         scopeAttrs[attrName] = (values[0] as AdditionalValue).value;
       }
     }

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -252,13 +252,21 @@ describe("RelationTest", () => {
   it("empty where values hash", () => {
     class Post extends Base {
       static {
+        this._tableName = "posts";
+        this.attribute("id", "integer");
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    const rel = Post.all();
-    const hash = (rel as any)._scopeAttributes ? (rel as any)._scopeAttributes() : {};
-    expect(Object.keys(hash).length).toBe(0);
+    expect(Post.all().whereValuesHash()).toEqual({});
+
+    const notEq = Post.all().where(Post.arelTable.get("id").notEq(10)).whereValuesHash();
+    expect(notEq).toEqual({});
+
+    const distinctFrom = Post.all()
+      .where(Post.arelTable.get("id").isDistinctFrom(10))
+      .whereValuesHash();
+    expect(distinctFrom).toEqual({});
   });
 
   it("create with value", async () => {
@@ -416,21 +424,29 @@ describe("RelationTest", () => {
 
   it("has values", () => {
     const Post = makePost();
-    const rel = Post.where({ title: "test" }).limit(5);
-    expect(rel.toSql()).toContain("test");
-    expect(rel.toSql()).toContain("5");
+    const rel = Post.where({ title: "test" });
+    expect(rel.whereValuesHash()).toEqual({ title: "test" });
   });
 
   it("values wrong table", () => {
     const Post = makePost();
-    const sql = Post.where({ title: "test" }).toSql();
-    expect(sql).toContain("posts");
+    class Comment extends Base {
+      static {
+        this._tableName = "comments";
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Post.all().where(Comment.arelTable.get("id").eq(10));
+    expect(rel.whereValuesHash()).toEqual({});
   });
 
   it("tree is not traversed", () => {
     const Post = makePost();
-    const rel = Post.all();
-    expect(rel.isLoaded).toBe(false);
+    const left = Post.arelTable.get("id").eq(10);
+    const right = Post.arelTable.get("id").eq(10);
+    const rel = Post.all().where(left.or(right));
+    expect(rel.whereValuesHash()).toEqual({});
   });
 
   it("create with value with wheres", async () => {
@@ -646,9 +662,8 @@ describe("RelationTest", () => {
 
   it("where values hash with in clause", () => {
     const Post = makePost();
-    const rel = Post.where({ title: "test" });
-    const hash = rel.whereValuesHash();
-    expect(hash.title).toBe("test");
+    const rel = Post.where({ title: ["foo", "bar", "hello"] });
+    expect(rel.whereValuesHash()).toEqual({ title: ["foo", "bar", "hello"] });
   });
 
   it("#values returns a dup of the values", () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2444,7 +2444,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#where_values_hash
    */
   whereValuesHash(): Record<string, unknown> {
-    return this._scopeAttributes();
+    return this._whereClause.toH(this._modelClass.tableName);
   }
 
   // -- Value accessors (for introspection) --
@@ -2554,14 +2554,7 @@ export class Relation<T extends Base> {
 
   /** @internal */
   protected _scopeAttributes(): Record<string, unknown> {
-    const h = this._whereClause.toH(this._modelClass.tableName);
-    const attrs: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(h)) {
-      if (value !== null && !Array.isArray(value) && !(value instanceof Range)) {
-        attrs[key] = value;
-      }
-    }
-    return attrs;
+    return this._whereClause.toH(this._modelClass.tableName, { equalityOnly: true });
   }
 
   // -- Batches --

--- a/packages/activerecord/src/relation/predicate-builder/array-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/array-handler.ts
@@ -37,9 +37,14 @@ export class ArrayHandler {
     //   values = value.map { |x| x.is_a?(Base) ? x.id : x }
     //   nils = values.compact!
     //   ranges = values.extract! { |v| v.is_a?(Range) }
-    // Everything that isn't a Base record, nil, or Range stays in `values`
-    // and lands in the In/HomogeneousIn branch — including arbitrary
-    // objects like AdditionalValue (for encrypted deterministic queries).
+    // Everything that isn't a Base record, nil, or Range stays in `values`,
+    // including arbitrary objects like AdditionalValue (for encrypted
+    // deterministic queries). A single remaining value is routed through
+    // `predicateBuilder.build(...)` (typically producing an Equality);
+    // multiple values use the In/HomogeneousIn branch. Passing Relations
+    // inside the array is unsupported here — Rails would likewise fail
+    // to serialize them inside HomogeneousIn; use `where(col: relation)`
+    // for subqueries instead.
     const scalarValues: unknown[] = [];
     let hasNull = false;
     const ranges: Range[] = [];

--- a/packages/activerecord/src/relation/predicate-builder/array-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/array-handler.ts
@@ -33,10 +33,16 @@ export class ArrayHandler {
       return attribute.in([]);
     }
 
+    // Mirrors Rails' ArrayHandler#call:
+    //   values = value.map { |x| x.is_a?(Base) ? x.id : x }
+    //   nils = values.compact!
+    //   ranges = values.extract! { |v| v.is_a?(Range) }
+    // Everything that isn't a Base record, nil, or Range stays in `values`
+    // and lands in the In/HomogeneousIn branch — including arbitrary
+    // objects like AdditionalValue (for encrypted deterministic queries).
     const scalarValues: unknown[] = [];
     let hasNull = false;
     const ranges: Range[] = [];
-    const nonScalarValues: unknown[] = [];
 
     for (const item of value) {
       if (item === null || item === undefined) {
@@ -44,15 +50,14 @@ export class ArrayHandler {
       } else if (item instanceof Range) {
         ranges.push(item);
       } else if (typeof item === "object" && item !== null && "id" in item) {
-        scalarValues.push((item as any).id);
-      } else if (typeof item === "object" || typeof item === "function") {
-        nonScalarValues.push(item);
+        // Rails: `x.is_a?(Base) ? x.id : x` — flatten AR records to their PK.
+        // Duck-typed on `id` presence to avoid a circular import on Base.
+        scalarValues.push((item as { id: unknown }).id);
       } else {
         scalarValues.push(item);
       }
     }
 
-    // Build the scalar values predicate, using NullPredicate as sentinel
     let valuesPredicate: Nodes.Node | typeof NullPredicate;
     if (scalarValues.length === 0) {
       valuesPredicate = NullPredicate;
@@ -62,14 +67,6 @@ export class ArrayHandler {
       valuesPredicate = attribute.in(scalarValues);
     }
 
-    // Fold in non-scalar values (e.g. Relations → subqueries) via PredicateBuilder
-    for (const v of nonScalarValues) {
-      const pred = this.predicateBuilder.build(attribute, v);
-      valuesPredicate =
-        valuesPredicate === NullPredicate ? pred : groupedOr(valuesPredicate as Nodes.Node, pred);
-    }
-
-    // Fold in NULL with Grouping to preserve precedence
     if (hasNull) {
       valuesPredicate =
         valuesPredicate === NullPredicate
@@ -77,7 +74,6 @@ export class ArrayHandler {
           : groupedOr(valuesPredicate as Nodes.Node, attribute.isNull());
     }
 
-    // Fold in ranges with Grouping to preserve precedence
     if (ranges.length === 0) {
       return valuesPredicate === NullPredicate ? attribute.in([]) : (valuesPredicate as Nodes.Node);
     }

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -119,9 +119,9 @@ export class WhereClause {
     return attrs;
   }
 
-  toH(tableName?: string): Record<string, unknown> {
+  toH(tableName?: string, opts: { equalityOnly?: boolean } = {}): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const node of equalities(this.predicates)) {
+    for (const node of equalities(this.predicates, opts.equalityOnly ?? false)) {
       const attr = fetchAttributeNode(node);
       if (attr === null) continue;
       if (tableName !== undefined && attr.relation.name !== tableName) continue;
@@ -169,13 +169,16 @@ function fetchAttributeNode(node: Nodes.Node): Nodes.Attribute | null {
   return null;
 }
 
-function equalities(predicates: Nodes.Node[]): Nodes.Node[] {
+function equalities(predicates: Nodes.Node[], equalityOnly: boolean): Nodes.Node[] {
   const result: Nodes.Node[] = [];
   for (const node of predicates) {
-    if (typeof (node as any).isEquality === "function" && (node as any).isEquality()) {
+    const matches = equalityOnly
+      ? node instanceof Nodes.Equality
+      : typeof (node as any).isEquality === "function" && (node as any).isEquality();
+    if (matches) {
       result.push(node);
     } else if (node instanceof Nodes.And) {
-      result.push(...equalities((node as any).children));
+      result.push(...equalities((node as any).children, equalityOnly));
     }
   }
   return result;

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -667,6 +667,32 @@ describe("scopeForCreate / whereValuesHash", () => {
     expect(hash.author).toBe("Alice");
     expect(hash.title).toBe("Test");
   });
+
+  it("whereValuesHash exposes IN-array values (Rails: equality_only=false)", () => {
+    class Post extends Base {
+      static {
+        this.attribute("author", "string");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Post.where({ author: ["Alice", "Bob"] });
+    const hash = rel.whereValuesHash();
+    expect(hash.author).toEqual(["Alice", "Bob"]);
+  });
+
+  it("scopeForCreate filters out IN-array values (Rails: equality_only=true)", () => {
+    class Post extends Base {
+      static {
+        this.attribute("author", "string");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Post.where({ author: ["Alice", "Bob"], title: "Fixed" });
+    const scope = rel.scopeForCreate();
+    expect(scope.title).toBe("Fixed");
+    expect(scope.author).toBeUndefined();
+  });
 });
 
 describe("Scoping block (Rails-guided)", () => {


### PR DESCRIPTION
## Summary

Follow-up to #737 (Copilot comment about `whereValuesHash()` filtering arrays, deferred from that PR).

Rails' `WhereClause#to_h` takes an `equality_only:` flag:

- `where_values_hash` calls `to_h(relation_table_name)` with `equality_only=false` — includes `Equality`, `In`, `HomogeneousIn` (anything where `equality?` is true). IN-array predicates surface as arrays in the hash.
- `scope_for_create` calls `to_h(model.table_name, equality_only: true)` — restricts to `Arel::Nodes::Equality`, naturally excluding IN arrays.

Our code diverged: `WhereClause#toH` had no flag, and `Relation#_scopeAttributes` post-filtered arrays out of the combined result. That made `whereValuesHash()` (which delegated to `_scopeAttributes`) drop IN arrays, which broke `ExtendedDeterministicQueries::RelationQueries#scope_for_create` — the expanded `[AdditionalValue(current), AdditionalValue(prev)]` was invisible, so the override was a no-op. A `_encryptionExpansion` stash on the relation had been added as a workaround.

## Changes

- `WhereClause#toH` takes `{ equalityOnly }`; threaded into the `equalities()` helper, matching Rails' `Equality === node` branch when the flag is set.
- `Relation#_scopeAttributes` now calls `toH(tableName, { equalityOnly: true })` — equivalent to Rails' `scope_for_create` filter. No longer post-strips `null`/`Range` (Rails keeps nulls; Ranges become `Between` nodes which the `Equality`-only branch rejects naturally).
- `Relation#whereValuesHash` now calls `toH(tableName)` directly (equality_only=false), returning IN arrays like Rails.
- `RelationQueries.where` drops the `_encryptionExpansion` stash and is a straight delegate again.
- `RelationQueries.scopeForCreate` reads `whereValuesHash()` and unwraps the leading `AdditionalValue` to its current-scheme ciphertext.

## Test plan

- [x] `whereValuesHash` exposes IN arrays (new test in `relation-scoping.test.ts`)
- [x] `scopeForCreate` filters IN arrays (new test in `relation-scoping.test.ts`)
- [x] Encryption override unwraps `AdditionalValue[0].value` via `whereValuesHash()` (4 updated scopeForCreate tests)
- [x] Full activerecord suite: 8981 passed, 3854 skipped