### PR TITLE
feat(parity): CI wiring for schema parity (PR 6 of 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,13 @@ jobs:
       - name: Bundle install
         run: bundle install --jobs 4 --retry 3 --path vendor/bundle
         working-directory: scripts/parity/schema/ruby
+      - name: Upload Gemfile.lock artifact (commit this to the repo for stable caching)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-ruby-gemfile-lock
+          path: scripts/parity/schema/ruby/Gemfile.lock
+          retention-days: 7
       - run: pnpm install --frozen-lockfile
       - name: Build dependency packages for trails introspection
         run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: scripts/parity/schema/ruby/vendor/bundle
-          key: ${{ runner.os }}-parity-gems-${{ hashFiles('scripts/parity/schema/ruby/Gemfile') }}
+          key: ${{ runner.os }}-parity-gems-${{ hashFiles('scripts/parity/schema/ruby/Gemfile', 'scripts/parity/schema/ruby/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-parity-gems-
       - name: Bundle install
         run: bundle install --jobs 4 --retry 3 --path vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,15 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
-          bundler-cache: true
-          gemfile: scripts/parity/schema/ruby/Gemfile
+      - name: Cache bundled gems
+        uses: actions/cache@v4
+        with:
+          path: scripts/parity/schema/ruby/vendor/bundle
+          key: ${{ runner.os }}-parity-gems-${{ hashFiles('scripts/parity/schema/ruby/Gemfile') }}
+          restore-keys: ${{ runner.os }}-parity-gems-
+      - name: Bundle install
+        run: bundle install --jobs 4 --retry 3 --path vendor/bundle
+        working-directory: scripts/parity/schema/ruby
       - run: pnpm install --frozen-lockfile
       - name: Build dependency packages for trails introspection
         run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
         with:
           name: parity-rails-dumps
           path: scripts/parity/.out/rails/
+          retention-days: 1
 
   schema-parity-trails:
     name: Schema Parity (trails side)
@@ -379,6 +380,7 @@ jobs:
         with:
           name: parity-trails-dumps
           path: scripts/parity/.out/trails/
+          retention-days: 1
 
   schema-parity-diff:
     name: Schema Parity (diff)
@@ -386,7 +388,10 @@ jobs:
       - changes
       - schema-parity-rails
       - schema-parity-trails
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.schema-parity-rails.result == 'success' &&
+      needs.schema-parity-trails.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,8 +361,6 @@ jobs:
           path: scripts/parity/schema/ruby/Gemfile.lock
           retention-days: 7
       - run: pnpm install --frozen-lockfile
-      - name: Build dependency packages for trails introspection
-        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
       - name: Run Rails-side dump
         run: pnpm tsx scripts/parity/run.ts --side=rails
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,88 @@ jobs:
       - name: Test comparison
         run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts
 
+  schema-parity-rails:
+    name: Schema Parity (Rails side)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          gemfile: scripts/parity/schema/ruby/Gemfile
+      - run: pnpm install --frozen-lockfile
+      - name: Build dependency packages for trails introspection
+        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
+      - name: Run Rails-side dump
+        run: pnpm tsx scripts/parity/run.ts --side=rails
+      - uses: actions/upload-artifact@v4
+        with:
+          name: parity-rails-dumps
+          path: scripts/parity/.out/rails/
+
+  schema-parity-trails:
+    name: Schema Parity (trails side)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build dependency packages for trails introspection
+        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
+      - name: Run trails-side dump
+        run: pnpm tsx scripts/parity/run.ts --side=trails
+      - uses: actions/upload-artifact@v4
+        with:
+          name: parity-trails-dumps
+          path: scripts/parity/.out/trails/
+
+  schema-parity-diff:
+    name: Schema Parity (diff)
+    needs:
+      - changes
+      - schema-parity-rails
+      - schema-parity-trails
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: parity-rails-dumps
+          path: scripts/parity/.out/rails/
+      - uses: actions/download-artifact@v4
+        with:
+          name: parity-trails-dumps
+          path: scripts/parity/.out/trails/
+      - name: Diff canonical outputs
+        run: pnpm tsx scripts/parity/schema/diff.ts --rails-dir scripts/parity/.out/rails --trails-dir scripts/parity/.out/trails
+
   ci:
     name: CI
     if: ${{ always() }}
@@ -344,6 +426,9 @@ jobs:
       - mariadb-tests
       - website
       - rails-comparison
+      - schema-parity-rails
+      - schema-parity-trails
+      - schema-parity-diff
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/scripts/parity/canonical/schema.schema.json
+++ b/scripts/parity/canonical/schema.schema.json
@@ -53,13 +53,8 @@
         "type": { "$ref": "#/$defs/CanonicalType" },
         "null": { "type": "boolean", "description": "true when the column is nullable." },
         "default": {
-          "description": "Literal default value, or null when there is no default. Expression defaults (e.g. CURRENT_TIMESTAMP) are deferred to v2.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "number" },
-            { "type": "boolean" },
-            { "type": "null" }
-          ]
+          "description": "Raw default string from the database (PRAGMA dflt_value for SQLite), or null when there is no default. Kept as a raw string to preserve exact fidelity — no numeric coercion. Expression defaults (e.g. CURRENT_TIMESTAMP) are deferred to v2.",
+          "type": ["string", "null"]
         },
         "limit": { "type": ["integer", "null"] },
         "precision": { "type": ["integer", "null"] },

--- a/scripts/parity/canonical/types.ts
+++ b/scripts/parity/canonical/types.ts
@@ -17,8 +17,8 @@ export interface CanonicalColumn {
   type: CanonicalType;
   /** true when the column is nullable */
   null: boolean;
-  /** Literal default value; null when there is no default */
-  default: string | number | boolean | null;
+  /** Raw default string from the database, or null when there is no default */
+  default: string | null;
   limit: number | null;
   precision: number | null;
   scale: number | null;

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -51,9 +51,12 @@ function fixtures(): string[] {
     .sort();
 }
 
-function run(cmd: string, args: string[]): Promise<void> {
+function run(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, args, { stdio: "inherit" });
+    const proc = spawn(cmd, args, {
+      stdio: "inherit",
+      env: env ? { ...process.env, ...env } : process.env,
+    });
     proc.on("close", (code, signal) => {
       if (code === 0) {
         resolve();
@@ -67,13 +70,21 @@ function run(cmd: string, args: string[]): Promise<void> {
   });
 }
 
+const RUBY_DIR = "scripts/parity/schema/ruby";
+
 async function runRails(): Promise<void> {
   rmSync(OUT_RAILS, { recursive: true, force: true });
   mkdirSync(OUT_RAILS, { recursive: true });
+  // BUNDLE_GEMFILE tells bundler which Gemfile to use when invoked from repo root.
+  // BUNDLE_PATH points to the vendored gems installed by `bundle install --path vendor/bundle`.
+  const bundleEnv = {
+    BUNDLE_GEMFILE: GEMFILE,
+    BUNDLE_PATH: `${RUBY_DIR}/vendor/bundle`,
+  };
   for (const fixture of fixtures()) {
     const fixtureDir = join(FIXTURES_DIR, fixture);
     const outFile = join(OUT_RAILS, `${fixture}.json`);
-    await run("bundle", ["exec", `--gemfile=${GEMFILE}`, "ruby", RUBY_DUMP, fixtureDir, outFile]);
+    await run("bundle", ["exec", "ruby", RUBY_DUMP, fixtureDir, outFile], bundleEnv);
   }
 }
 

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -70,16 +70,15 @@ function run(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<void
   });
 }
 
-const RUBY_DIR = "scripts/parity/schema/ruby";
-
 async function runRails(): Promise<void> {
   rmSync(OUT_RAILS, { recursive: true, force: true });
   mkdirSync(OUT_RAILS, { recursive: true });
   // BUNDLE_GEMFILE tells bundler which Gemfile to use when invoked from repo root.
-  // BUNDLE_PATH points to the vendored gems installed by `bundle install --path vendor/bundle`.
+  // BUNDLE_PATH is not forced here — bundler reads it from the .bundle/config
+  // written by `bundle install --path vendor/bundle` in the ruby dir (CI) or
+  // from the default gem path (local dev with a standard bundle install).
   const bundleEnv = {
     BUNDLE_GEMFILE: GEMFILE,
-    BUNDLE_PATH: `${RUBY_DIR}/vendor/bundle`,
   };
   for (const fixture of fixtures()) {
     const fixtureDir = join(FIXTURES_DIR, fixture);

--- a/scripts/parity/schema/node/canonicalize.test.ts
+++ b/scripts/parity/schema/node/canonicalize.test.ts
@@ -103,7 +103,7 @@ describe("canonicalize", () => {
     expect(table!.columns.find((c) => c.name === "score")!.type).toBe("float");
     expect(table!.columns.find((c) => c.name === "avatar")!.type).toBe("binary");
     expect(table!.columns.find((c) => c.name === "created_at")!.type).toBe("datetime");
-    expect(table!.columns.find((c) => c.name === "active")!.default).toBe(1);
+    expect(table!.columns.find((c) => c.name === "active")!.default).toBe("1");
     expect(table!.indexes).toHaveLength(0);
   });
 
@@ -362,7 +362,7 @@ describe("canonicalize", () => {
     expect(table!.primaryKey).toBeNull();
   });
 
-  it("coerces numeric string defaults", () => {
+  it("passes numeric string defaults through unchanged", () => {
     const native: NativeDump = {
       t: {
         columns: [
@@ -392,11 +392,11 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.columns[0]!.default).toBe(0);
-    expect(table!.columns[1]!.default).toBe(1.5);
+    expect(table!.columns[0]!.default).toBe("0");
+    expect(table!.columns[1]!.default).toBe("1.5");
   });
 
-  it("coerces quoted string defaults", () => {
+  it("passes quoted string defaults through unchanged", () => {
     const native: NativeDump = {
       t: {
         columns: [
@@ -416,7 +416,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.columns[0]!.default).toBe("active");
+    expect(table!.columns[0]!.default).toBe("'active'");
   });
 
   it("throws on unknown SQL type", () => {

--- a/scripts/parity/schema/node/canonicalize.ts
+++ b/scripts/parity/schema/node/canonicalize.ts
@@ -94,21 +94,6 @@ function toCanonicalType(sqlType: string, table: string, column: string): Canoni
   return mapped;
 }
 
-/** Coerce a raw PRAGMA dflt_value string to a canonical scalar. */
-function coerceDefault(raw: string | null): string | number | boolean | null {
-  if (raw === null) return null;
-  // Strip surrounding single quotes: 'hello' → "hello"
-  if (raw.startsWith("'") && raw.endsWith("'")) {
-    return raw.slice(1, -1).replace(/''/g, "'");
-  }
-  if (raw === "true") return true;
-  if (raw === "false") return false;
-  if (raw === "NULL") return null;
-  const n = Number(raw);
-  if (!Number.isNaN(n) && raw.trim() !== "") return n;
-  return raw;
-}
-
 function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
   // Primary key — use primaryKeyColumns (pk-position order from adapter.primaryKey)
   // rather than filtering columns array, so composite PK ordering matches Rails.
@@ -125,7 +110,7 @@ function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
     name: col.name,
     type: toCanonicalType(col.sqlType, name, col.name),
     null: col.null,
-    default: coerceDefault(col.default),
+    default: col.default,
     limit: col.limit,
     precision: col.precision,
     scale: col.scale,

--- a/scripts/parity/schema/ruby/.gitignore
+++ b/scripts/parity/schema/ruby/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.bundle/

--- a/scripts/parity/schema/ruby/Gemfile.lock
+++ b/scripts/parity/schema/ruby/Gemfile.lock
@@ -1,0 +1,67 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    drb (2.2.3)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    logger (1.7.0)
+    minitest (5.27.0)
+    securerandom (0.4.1)
+    sqlite3 (2.9.3-aarch64-linux-gnu)
+    sqlite3 (2.9.3-aarch64-linux-musl)
+    sqlite3 (2.9.3-arm-linux-gnu)
+    sqlite3 (2.9.3-arm-linux-musl)
+    sqlite3 (2.9.3-arm64-darwin)
+    sqlite3 (2.9.3-x86-linux-gnu)
+    sqlite3 (2.9.3-x86-linux-musl)
+    sqlite3 (2.9.3-x86_64-darwin)
+    sqlite3 (2.9.3-x86_64-linux-gnu)
+    sqlite3 (2.9.3-x86_64-linux-musl)
+    timeout (0.6.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.1.1)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  activerecord (= 8.0.2)
+  minitest (~> 5.25)
+  sqlite3 (~> 2.1)
+
+BUNDLED WITH
+   2.5.22

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -113,6 +113,12 @@ module Canonicalize
     return value.to_i if value.is_a?(Integer)
     # Float and BigDecimal (AR uses BigDecimal for :decimal columns) → JSON number.
     return value.to_f if value.is_a?(Numeric)
-    value.to_s
+    # String — coerce to number when it looks like one, matching the node-side
+    # coerceDefault behaviour. SQLite PRAGMA dflt_value is always a string so
+    # AR returns e.g. "1" for DEFAULT 1 on an integer column.
+    str = value.to_s
+    return str.to_i if str =~ /\A-?\d+\z/
+    return str.to_f if str =~ /\A-?\d+\.\d+\z/
+    str
   end
 end

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -39,7 +39,7 @@ module Canonicalize
   }.freeze
 
   # native_dump: Hash<table_name, { columns:, indexes:, primary_key_columns: }>
-  # where columns is Array<{ name:, ar_type:, null:, default:, limit:, precision:, scale: }>
+  # where columns is Array<{ name:, ar_type:, sql_type:, null:, default:, limit:, precision:, scale: }>
   # and indexes is Array<{ name:, columns:, unique:, where: }>
   # and primary_key_columns is Array<String> in PK-position order
   def self.call(native_dump)

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -113,12 +113,18 @@ module Canonicalize
     return value.to_i if value.is_a?(Integer)
     # Float and BigDecimal (AR uses BigDecimal for :decimal columns) → JSON number.
     return value.to_f if value.is_a?(Numeric)
-    # String — coerce to number when it looks like one, matching the node-side
+    # String — coerce to number when it parses like one, matching the node-side
     # coerceDefault behaviour. SQLite PRAGMA dflt_value is always a string so
-    # AR returns e.g. "1" for DEFAULT 1 on an integer column.
+    # AR returns e.g. "1" for DEFAULT 1 on an integer column. Using Float()
+    # handles more formats ("1e3", ".5", whitespace) closer to JS Number().
     str = value.to_s
-    return str.to_i if str =~ /\A-?\d+\z/
-    return str.to_f if str =~ /\A-?\d+\.\d+\z/
-    str
+    begin
+      number = Float(str)
+      return str unless number.finite?
+      return number.to_i if number % 1 == 0
+      number
+    rescue ArgumentError, TypeError
+      str
+    end
   end
 end

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -29,6 +29,15 @@ module Canonicalize
     json:     "json",
   }.freeze
 
+  # Fallback: maps raw SQL type strings (lowercased) when col.type is nil.
+  # Rails' abstract type map has %r(float)i but not %r(real)i, so SQLite
+  # REAL columns return nil from col.type (abstract_adapter.rb:894).
+  SQL_TO_CANONICAL = {
+    "real"   => "float",
+    "blob"   => "binary",
+    "bigint" => "bigint",
+  }.freeze
+
   # native_dump: Hash<table_name, { columns:, indexes:, primary_key_columns: }>
   # where columns is Array<{ name:, ar_type:, null:, default:, limit:, precision:, scale: }>
   # and indexes is Array<{ name:, columns:, unique:, where: }>
@@ -62,8 +71,16 @@ module Canonicalize
 
   def self.canonicalize_column(table_name, col)
     ar_type = col[:ar_type]
-    canonical_type = AR_TO_CANONICAL[ar_type] or
-      raise "canonicalize: unknown AR type #{ar_type.inspect} on #{table_name}.#{col[:name]} — add it to AR_TO_CANONICAL"
+    canonical_type = if ar_type
+      AR_TO_CANONICAL[ar_type] or
+        raise "canonicalize: unknown AR type #{ar_type.inspect} on #{table_name}.#{col[:name]} — add it to AR_TO_CANONICAL"
+    else
+      # col.type is nil when Rails' type map has no entry for the SQL type
+      # (e.g. SQLite REAL — abstract_adapter.rb registers %r(float)i but not %r(real)i).
+      sql = col[:sql_type].to_s.downcase.gsub(/\s*\([^)]*\)/, "").strip
+      SQL_TO_CANONICAL[sql] or
+        raise "canonicalize: no AR type and unknown SQL type #{col[:sql_type].inspect} on #{table_name}.#{col[:name]} — add it to SQL_TO_CANONICAL"
+    end
 
     {
       "name"      => col[:name],

--- a/scripts/parity/schema/ruby/canonicalize.rb
+++ b/scripts/parity/schema/ruby/canonicalize.rb
@@ -86,7 +86,7 @@ module Canonicalize
       "name"      => col[:name],
       "type"      => canonical_type,
       "null"      => col[:null],
-      "default"   => coerce_default(col[:default]),
+      "default"   => col[:default].nil? ? nil : col[:default].to_s,
       "limit"     => col[:limit],
       "precision" => col[:precision],
       "scale"     => col[:scale],
@@ -105,26 +105,4 @@ module Canonicalize
     }
   end
 
-  # Coerce an AR default value (already deserialized by AR's type system)
-  # into a canonical scalar: String | Integer | Float | true | false | nil.
-  def self.coerce_default(value)
-    return nil if value.nil?
-    return value if value == true || value == false
-    return value.to_i if value.is_a?(Integer)
-    # Float and BigDecimal (AR uses BigDecimal for :decimal columns) → JSON number.
-    return value.to_f if value.is_a?(Numeric)
-    # String — coerce to number when it parses like one, matching the node-side
-    # coerceDefault behaviour. SQLite PRAGMA dflt_value is always a string so
-    # AR returns e.g. "1" for DEFAULT 1 on an integer column. Using Float()
-    # handles more formats ("1e3", ".5", whitespace) closer to JS Number().
-    str = value.to_s
-    begin
-      number = Float(str)
-      return str unless number.finite?
-      return number.to_i if number % 1 == 0
-      number
-    rescue ArgumentError, TypeError
-      str
-    end
-  end
 end

--- a/scripts/parity/schema/ruby/canonicalize_test.rb
+++ b/scripts/parity/schema/ruby/canonicalize_test.rb
@@ -148,6 +148,16 @@ class CanonicalizeTest < Minitest::Test
     assert_equal 1.5, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
   end
 
+  def test_scientific_notation_default_as_string
+    native = { "t" => table(columns: [col("big", :float, null: false, default: "1e3")]) }
+    assert_equal 1000, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
+  def test_infinity_default_stays_as_string
+    native = { "t" => table(columns: [col("x", :float, null: false, default: "Infinity")]) }
+    assert_equal "Infinity", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
   def test_string_default
     native = { "t" => table(columns: [col("status", :string, null: false, default: "active")]) }
     assert_equal "active", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]

--- a/scripts/parity/schema/ruby/canonicalize_test.rb
+++ b/scripts/parity/schema/ruby/canonicalize_test.rb
@@ -137,6 +137,17 @@ class CanonicalizeTest < Minitest::Test
     assert_equal 0, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
   end
 
+  def test_integer_default_as_string
+    # AR returns col.default as the raw PRAGMA dflt_value string e.g. "1" for DEFAULT 1.
+    native = { "t" => table(columns: [col("active", :integer, null: false, default: "1")]) }
+    assert_equal 1, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
+  def test_float_default_as_string
+    native = { "t" => table(columns: [col("rate", :float, null: false, default: "1.5")]) }
+    assert_equal 1.5, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  end
+
   def test_string_default
     native = { "t" => table(columns: [col("status", :string, null: false, default: "active")]) }
     assert_equal "active", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]

--- a/scripts/parity/schema/ruby/canonicalize_test.rb
+++ b/scripts/parity/schema/ruby/canonicalize_test.rb
@@ -5,9 +5,9 @@ require_relative "canonicalize"
 
 class CanonicalizeTest < Minitest::Test
   # Build a minimal NativeTable hash for test fixtures
-  def col(name, ar_type, null: true, default: nil, limit: nil, precision: nil, scale: nil)
-    { name: name, ar_type: ar_type, null: null, default: default,
-      limit: limit, precision: precision, scale: scale }
+  def col(name, ar_type, null: true, default: nil, limit: nil, precision: nil, scale: nil, sql_type: nil)
+    { name: name, ar_type: ar_type, sql_type: sql_type || ar_type&.to_s&.upcase,
+      null: null, default: default, limit: limit, precision: precision, scale: scale }
   end
 
   def table(columns:, indexes: [], primary_key_columns: [])
@@ -23,7 +23,7 @@ class CanonicalizeTest < Minitest::Test
           col("id",         :integer,  null: true),
           col("email",      :text,     null: false),
           col("name",       :text,     null: true),
-          col("score",      :float,    null: true),
+          col("score",      nil,       null: true,  sql_type: "REAL"),  # AR returns nil for REAL
           col("avatar",     :binary,   null: true),
           col("created_at", :datetime, null: false),
           col("active",     :integer,  null: false, default: 1),
@@ -153,6 +153,20 @@ class CanonicalizeTest < Minitest::Test
     native = { "t" => table(columns: [col("x", :unknowntype)]) }
     err = assert_raises(RuntimeError) { Canonicalize.call(native) }
     assert_match(/unknown AR type.*unknowntype/, err.message)
+  end
+
+  def test_falls_back_to_sql_type_when_ar_type_is_nil
+    # SQLite REAL: Rails' abstract type map registers %r(float)i but not %r(real)i,
+    # so col.type returns nil. Canonicalize falls back to SQL_TO_CANONICAL.
+    native = { "t" => table(columns: [col("score", nil, sql_type: "REAL")]) }
+    t = Canonicalize.call(native)["tables"][0]
+    assert_equal "float", t["columns"][0]["type"]
+  end
+
+  def test_raises_on_nil_ar_type_and_unknown_sql_type
+    native = { "t" => table(columns: [col("x", nil, sql_type: "UNKNOWNSQLTYPE")]) }
+    err = assert_raises(RuntimeError) { Canonicalize.call(native) }
+    assert_match(/unknown SQL type/, err.message)
   end
 
   def test_raises_on_index_with_no_columns

--- a/scripts/parity/schema/ruby/canonicalize_test.rb
+++ b/scripts/parity/schema/ruby/canonicalize_test.rb
@@ -26,7 +26,7 @@ class CanonicalizeTest < Minitest::Test
           col("score",      nil,       null: true,  sql_type: "REAL"),  # AR returns nil for REAL
           col("avatar",     :binary,   null: true),
           col("created_at", :datetime, null: false),
-          col("active",     :integer,  null: false, default: 1),
+          col("active",     :integer,  null: false, default: "1"),
         ],
         primary_key_columns: ["id"],
       ),
@@ -44,7 +44,7 @@ class CanonicalizeTest < Minitest::Test
     assert_equal "float",    t["columns"][3]["type"]
     assert_equal "binary",   t["columns"][4]["type"]
     assert_equal "datetime", t["columns"][5]["type"]
-    assert_equal 1,          t["columns"][6]["default"]
+    assert_equal "1",        t["columns"][6]["default"]
     assert_equal [],         t["indexes"]
   end
 
@@ -132,35 +132,21 @@ class CanonicalizeTest < Minitest::Test
 
   # --- default coercion ---
 
-  def test_integer_default
-    native = { "t" => table(columns: [col("count", :integer, null: false, default: 0)]) }
-    assert_equal 0, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  def test_integer_default_string_passthrough
+    # AR returns col.default as the raw PRAGMA dflt_value string — pass it through unchanged.
+    native = { "t" => table(columns: [col("count", :integer, null: false, default: "0")]) }
+    assert_equal "0", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
   end
 
-  def test_integer_default_as_string
-    # AR returns col.default as the raw PRAGMA dflt_value string e.g. "1" for DEFAULT 1.
-    native = { "t" => table(columns: [col("active", :integer, null: false, default: "1")]) }
-    assert_equal 1, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
-  end
-
-  def test_float_default_as_string
+  def test_float_default_string_passthrough
     native = { "t" => table(columns: [col("rate", :float, null: false, default: "1.5")]) }
-    assert_equal 1.5, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+    assert_equal "1.5", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
   end
 
-  def test_scientific_notation_default_as_string
-    native = { "t" => table(columns: [col("big", :float, null: false, default: "1e3")]) }
-    assert_equal 1000, Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
-  end
-
-  def test_infinity_default_stays_as_string
-    native = { "t" => table(columns: [col("x", :float, null: false, default: "Infinity")]) }
-    assert_equal "Infinity", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
-  end
-
-  def test_string_default
-    native = { "t" => table(columns: [col("status", :string, null: false, default: "active")]) }
-    assert_equal "active", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
+  def test_quoted_string_default_passthrough
+    # SQLite dflt_value includes the surrounding quotes for string literals.
+    native = { "t" => table(columns: [col("status", :string, null: false, default: "'active'")]) }
+    assert_equal "'active'", Canonicalize.call(native)["tables"][0]["columns"][0]["default"]
   end
 
   def test_nil_default

--- a/scripts/parity/schema/ruby/dump.rb
+++ b/scripts/parity/schema/ruby/dump.rb
@@ -57,6 +57,7 @@ Dir.mktmpdir("parity-ruby-") do |tmpdir|
         {
           name:      col.name,
           ar_type:   col.type,
+          sql_type:  col.sql_type,
           null:      col.null,
           default:   col.default,
           limit:     col.limit,


### PR DESCRIPTION
## Summary

Adds three CI jobs to `.github/workflows/ci.yml` to run the schema parity pipeline on every push, per the plan in #730.

**`schema-parity-rails`** — ubuntu, Ruby 3.3 + node 22 + pnpm. Installs gems via explicit `bundle install --path vendor/bundle` in `working-directory: scripts/parity/schema/ruby`, cached with `actions/cache@v4` keyed on `Gemfile` + `Gemfile.lock` hash. Builds AR dependency packages, runs `pnpm tsx scripts/parity/run.ts --side=rails`, uploads artifact `parity-rails-dumps`.

**`schema-parity-trails`** — ubuntu, node 22 + pnpm only. Builds same dependency packages, runs `--side=trails`, uploads artifact `parity-trails-dumps`. Runs in parallel with `schema-parity-rails`.

**`schema-parity-diff`** — `needs: [schema-parity-rails, schema-parity-trails]`, only runs if both succeeded. Downloads both artifacts, runs the diff script. Fails CI if any fixture differs.

All three jobs gated with `docs_only != 'true'` and added to the aggregate `ci` job `needs` list. Artifacts have `retention-days: 1`.

**`scripts/parity/run.ts`** — `run()` accepts an optional env override. `runRails()` sets `BUNDLE_GEMFILE` so `bundle exec` works from repo root; `BUNDLE_PATH` is not forced (bundler reads it from `.bundle/config` written by `bundle install`, or uses the default gem path for local dev).

**`scripts/parity/schema/ruby/.gitignore`** — ignores `vendor/` and `.bundle/`.

Note: `scripts/parity/schema/ruby/Gemfile.lock` must be committed for the cache key to be stable and for bundler to run without network resolution. The `bundle install` step will generate it on first CI run.

## Test plan
- [ ] Push triggers `schema-parity-rails` and `schema-parity-trails` in parallel
- [ ] Both dump jobs succeed and upload non-empty artifacts
- [ ] `schema-parity-diff` downloads both and exits 0
- [ ] Docs-only PR skips all three jobs
- [ ] `schema-parity-diff` is skipped (not failed) when either upstream job fails