### PR TITLE
fix(activerecord): encryption interop — HMAC IV, config salt, SHA1 default (PR A)

### DIFF
--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
@@ -40,6 +40,26 @@ describe("ActiveRecord::Encryption::Aes256GcmTest", () => {
     expect(r1.iv).toBe(r2.iv);
   });
 
+  it("deterministic IV matches Rails HMAC-SHA256 derivation (fixed vector)", () => {
+    // Fixed key and plaintext — verify the IV equals HMAC-SHA256(key_bytes, plaintext)[0..12].
+    // To verify with Ruby:
+    //   key_bytes = Base64.strict_decode64(key)[0,32]
+    //   iv = OpenSSL::HMAC.digest("SHA256", key_bytes, "hello world")[0, 12]
+    //   puts Base64.strict_encode64(iv)
+    const key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // 32 zero bytes base64
+    const keyBuf = Buffer.from(key, "base64").subarray(0, 32);
+    const expectedIv = crypto
+      .createHmac("sha256", keyBuf)
+      .update("hello world")
+      .digest()
+      .subarray(0, 12)
+      .toString("base64");
+
+    const cipher = new Cipher();
+    const result = cipher.encrypt("hello world", key, { deterministic: true });
+    expect(result.iv).toBe(expectedIv);
+  });
+
   it("it generates different ivs for different ciphertexts", () => {
     const cipher = new Cipher();
     const key = generateKey();

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -33,7 +33,7 @@ export class Cipher {
     const keyBuf = Buffer.from(key, "base64").subarray(0, KEY_LENGTH);
     let iv: Buffer;
     if (options?.deterministic ?? this.deterministic) {
-      iv = crypto.createHash("sha256").update(data).update(key).digest().subarray(0, IV_LENGTH);
+      iv = crypto.createHmac("sha256", keyBuf).update(data).digest().subarray(0, IV_LENGTH);
     } else {
       iv = crypto.randomBytes(IV_LENGTH);
     }

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -18,7 +18,7 @@ export class Config {
   excludeFromFilterParameters: string[] = [];
   previousSchemes: unknown[] = [];
   extendQueries: boolean = false;
-  hashDigestClass: string = "SHA256";
+  hashDigestClass: string = "SHA1";
   keyProviderClass?: string;
   compressor: Compressor = defaultCompressor;
   forcedEncodingForDeterministicEncryption: string = "UTF-8";

--- a/packages/activerecord/src/encryption/key-generator.test.ts
+++ b/packages/activerecord/src/encryption/key-generator.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { KeyGenerator } from "./key-generator.js";
+import { Configurable } from "./configurable.js";
 
 describe("ActiveRecord::Encryption::KeyGeneratorTest", () => {
   it("generate_random_key generates random keys with the cipher key length by default", () => {
@@ -55,9 +56,34 @@ describe("ActiveRecord::Encryption::KeyGeneratorTest", () => {
     expect(new KeyGenerator("SHA1").hashDigestClass).toBe("SHA1");
   });
 
-  it("derive_key_from produces the same output as deriveKey", () => {
-    const gen = new KeyGenerator();
-    expect(gen.deriveKeyFrom("password")).toBe(gen.deriveKey("password"));
-    expect(gen.deriveKeyFrom("password", 16)).toBe(gen.deriveKey("password", 16));
+  it("default hash_digest_class reads from config", () => {
+    expect(new KeyGenerator().hashDigestClass).toBe(Configurable.config.hashDigestClass);
+  });
+
+  describe("derive_key_from", () => {
+    let originalSalt: string | undefined;
+    beforeEach(() => {
+      originalSalt = Configurable.config.keyDerivationSalt;
+      Configurable.config.keyDerivationSalt = "test-salt";
+    });
+    afterEach(() => {
+      Configurable.config.keyDerivationSalt = originalSalt;
+    });
+
+    it("uses config.keyDerivationSalt as the salt", () => {
+      const gen = new KeyGenerator("SHA256");
+      expect(gen.deriveKeyFrom("password")).toBe(gen.deriveKey("password", 32, "test-salt"));
+    });
+
+    it("raises when config.keyDerivationSalt is not set", () => {
+      Configurable.config.keyDerivationSalt = undefined;
+      const gen = new KeyGenerator("SHA256");
+      expect(() => gen.deriveKeyFrom("password")).toThrow();
+    });
+
+    it("produces a different key than empty-salt deriveKey", () => {
+      const gen = new KeyGenerator("SHA256");
+      expect(gen.deriveKeyFrom("password")).not.toBe(gen.deriveKey("password", 32, ""));
+    });
   });
 });

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -5,14 +5,15 @@
  */
 
 import { getCrypto } from "@blazetrails/activesupport";
+import { Configurable } from "./configurable.js";
 
 const DEFAULT_KEY_LENGTH = 32; // AES-256
 
 export class KeyGenerator {
   private _hashDigestClass: string;
 
-  constructor(hashDigestClass: string = "SHA256") {
-    this._hashDigestClass = hashDigestClass;
+  constructor(hashDigestClass?: string) {
+    this._hashDigestClass = hashDigestClass ?? Configurable.config.hashDigestClass;
   }
 
   get hashDigestClass(): string {
@@ -20,7 +21,8 @@ export class KeyGenerator {
   }
 
   deriveKeyFrom(password: string, length: number = DEFAULT_KEY_LENGTH): string {
-    return this.deriveKey(password, length);
+    const salt = Configurable.config.get("keyDerivationSalt") as string;
+    return this.deriveKey(password, length, salt);
   }
 
   generateRandomKey(length: number = DEFAULT_KEY_LENGTH): string {


### PR DESCRIPTION
## Summary

Three changes required for Rails ↔ TS round-trip compatibility. Without these, TS-encrypted deterministic values cannot be decrypted by Rails and vice versa.

### A1 — Deterministic IV: HMAC-SHA256 instead of plain SHA256 (`cipher/aes256-gcm.ts:36`)
Rails uses `OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, @secret, clear_text)` to generate the deterministic IV. TS was using a plain `SHA256(data + key)` hash. HMAC and hash produce different values — deterministic ciphertexts were incompatible across implementations.

### A2 — `deriveKeyFrom` reads `config.keyDerivationSalt` (`key-generator.ts:22–23`)
Rails `derive_key_from` uses `key_derivation_salt` from config as the PBKDF2 salt. TS was defaulting to `""`, producing different derived keys for the same password.

### A3 — `config.hashDigestClass` defaults to `"SHA1"` (`config.ts:21`)
Rails defaults to `OpenSSL::Digest::SHA1`; TS was defaulting to `"SHA256"`. `KeyGenerator` constructor now reads `Configurable.config.hashDigestClass` when no explicit digest is passed, so the default follows config.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `cipher/aes256-gcm.test.ts` — deterministic mode still produces consistent ciphertext (consistency test; round-trip test)
- [x] `key-generator.test.ts` — new tests verify `deriveKeyFrom` uses config salt, default digest class reads config