### PR TITLE
feat(activerecord): wire ExtendedDeterministicQueries.installSupport

### DIFF
--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -1,4 +1,5 @@
 import { ValueType } from "./value.js";
+import { ActiveModelRangeError } from "../errors.js";
 
 export class IntegerType extends ValueType<number> {
   readonly name: string = "integer";
@@ -24,7 +25,9 @@ export class IntegerType extends ValueType<number> {
   serialize(value: unknown): unknown {
     const result = this.cast(value);
     if (result !== null && (result < this._range[0] || result > this._range[1])) {
-      throw new RangeError(`${result} is out of range for integer with limit ${this.limit ?? 4}`);
+      throw new ActiveModelRangeError(
+        `${result} is out of range for integer with limit ${this.limit ?? 4}`,
+      );
     }
     return result;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -45,6 +45,7 @@ import {
 } from "./encryption.js";
 import * as CounterCache from "./counter-cache.js";
 import * as ReadonlyAttributes from "./readonly-attributes.js";
+import { Map as TypeCasterMap } from "./type-caster/map.js";
 import {
   defineAttribute as _defineAttribute,
   _defaultAttributes as _arDefaultAttributes,
@@ -589,10 +590,18 @@ export class Base extends Model {
   /**
    * Get the Arel table for this model.
    *
-   * Mirrors: ActiveRecord::Base.arel_table
+   * Wires a TypeCasterMap so `arelTable.typeForAttribute(col)` resolves
+   * through the model's `_attributeDefinitions`. Predicate-builder bind
+   * values rely on this to serialize through the right Type (e.g.
+   * EncryptedAttributeType for deterministic encryption) — without a
+   * typeCaster, `.where({col: "x"})` would emit the raw `"x"` in SQL
+   * instead of the encrypted ciphertext.
+   *
+   * Mirrors: ActiveRecord::Base.arel_table (memoized; ours builds each
+   * call since Table is cheap).
    */
   static get arelTable(): Table {
-    return new Table(this.tableName);
+    return new Table(this.tableName, { typeCaster: new TypeCasterMap(this) });
   }
 
   /**

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -23,6 +23,7 @@ import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
+import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -198,6 +199,12 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
   if (klass._attributeDefinitions?.size > 0) {
     applyPendingEncryptions(klass);
   }
+
+  // Rails wires ExtendedDeterministicQueries via a railtie at app boot;
+  // we don't have that lifecycle hook, so trigger idempotently on the
+  // first `encrypts(...)` call when the config opts in. Matches the
+  // intent of `config.active_record.encryption.extend_queries`.
+  installExtendedQueriesIfConfigured();
 }
 
 /**

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -23,7 +23,6 @@ import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
-import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -199,12 +198,6 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
   if (klass._attributeDefinitions?.size > 0) {
     applyPendingEncryptions(klass);
   }
-
-  // Rails wires ExtendedDeterministicQueries via a railtie at app boot;
-  // we don't have that lifecycle hook, so trigger idempotently on the
-  // first `encrypts(...)` call when the config opts in. Matches the
-  // intent of `config.active_record.encryption.extend_queries`.
-  installExtendedQueriesIfConfigured();
 }
 
 /**

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -1,10 +1,11 @@
 import { Type, ValueType, StringType } from "@blazetrails/activemodel";
-import type { Scheme } from "./scheme.js";
+import { Scheme } from "./scheme.js";
 import type { EncryptorLike } from "./encryptor.js";
 import type { WrappedType } from "./wrapped-type.js";
 import { isEncryptionDisabled, isProtectedMode } from "./context.js";
 import { Configurable } from "./configurable.js";
 import { Encryption as EncryptionError } from "./errors.js";
+import { NullEncryptor } from "./null-encryptor.js";
 
 /**
  * An ActiveModel type that encrypts/decrypts attribute values. This is
@@ -21,6 +22,8 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private _default?: unknown;
   private _encryptor: EncryptorLike;
   private _previousTypes?: EncryptedAttributeType[];
+  private _previousTypesMemo?: EncryptedAttributeType[];
+  private _previousTypesMemoKey?: boolean;
 
   constructor(options: {
     scheme: Scheme;
@@ -56,6 +59,12 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   cast(value: unknown): unknown {
+    // AdditionalValue instances must pass through cast unchanged so that
+    // serialize() can unwrap them to their pre-computed ciphertext via
+    // ExtendedEncryptableType. Without this, the default cast coerces
+    // the AV to a string (via toString), which then gets re-encrypted
+    // on serialize, producing a double-encrypted blob.
+    if (isAdditionalValue(value)) return value;
     return this.castType.cast(value);
   }
 
@@ -95,9 +104,19 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   get previousTypes(): EncryptedAttributeType[] {
-    if (!this._previousTypes) {
-      this._previousTypes = (this.scheme.previousSchemes ?? []).map(
-        (s: Scheme) =>
+    // Memoize on supportUnencryptedData so the clean-text scheme gets
+    // recomputed if the config toggles at runtime (Rails does the same
+    // via @previous_types[support_unencrypted_data?]).
+    const key = this.supportUnencryptedData;
+    if (!this._previousTypesMemo || this._previousTypesMemoKey !== key) {
+      const schemes: Scheme[] = [...(this.scheme.previousSchemes ?? [])];
+      if (this.supportUnencryptedData) {
+        // Append a NullEncryptor-backed scheme so query expansion
+        // produces a plaintext fallback (matches Rails' clean_text_scheme).
+        schemes.push(this._cleanTextScheme());
+      }
+      this._previousTypesMemo = schemes.map(
+        (s) =>
           new EncryptedAttributeType({
             scheme: s,
             castType: this.castType,
@@ -105,8 +124,17 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
             default: this._default,
           }),
       );
+      this._previousTypesMemoKey = key;
     }
-    return this._previousTypes;
+    return this._previousTypesMemo;
+  }
+
+  private _cleanTextScheme(): Scheme {
+    return new Scheme({
+      deterministic: this.scheme.deterministic,
+      downcase: this.scheme.downcase,
+      encryptor: new NullEncryptor(),
+    });
   }
 
   private decrypt(value: unknown): unknown {
@@ -146,4 +174,22 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
       Configurable.config.supportUnencryptedData === true && this.scheme.isSupportUnencryptedData()
     );
   }
+}
+
+/**
+ * Brand symbol set on every `AdditionalValue` instance. Checked by
+ * `EncryptedAttributeType.cast` to let AVs pass through cast unchanged;
+ * a direct `instanceof AdditionalValue` import would introduce a cycle
+ * between this module and `extended-deterministic-queries.ts`.
+ */
+export const ADDITIONAL_VALUE_BRAND: unique symbol = Symbol.for(
+  "activerecord.encryption.AdditionalValue",
+);
+
+function isAdditionalValue(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[ADDITIONAL_VALUE_BRAND] === true
+  );
 }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -21,7 +21,6 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private _previousType: boolean;
   private _default?: unknown;
   private _encryptor: EncryptorLike;
-  private _previousTypes?: EncryptedAttributeType[];
   private _previousTypesMemo?: EncryptedAttributeType[];
   private _previousTypesMemoKey?: boolean;
 
@@ -130,9 +129,16 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   private _cleanTextScheme(): Scheme {
+    // Rails' clean_text_scheme passes `downcase: downcase?`, and Rails'
+    // `Scheme` sets `@downcase = downcase || ignore_case` internally so
+    // `downcase?` is true for either flag. Our Scheme keeps the flags
+    // separate, so fold `ignoreCase` into `downcase` here to mirror
+    // Rails' effective behavior. Without this, a scheme configured
+    // `ignoreCase: true, downcase: false` would produce a non-lower-
+    // casing clean-text fallback and miss normalized plaintext rows.
     return new Scheme({
       deterministic: this.scheme.deterministic,
-      downcase: this.scheme.downcase,
+      downcase: this.scheme.downcase || this.scheme.ignoreCase,
       encryptor: new NullEncryptor(),
     });
   }
@@ -182,9 +188,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
  * a direct `instanceof AdditionalValue` import would introduce a cycle
  * between this module and `extended-deterministic-queries.ts`.
  */
-export const ADDITIONAL_VALUE_BRAND: unique symbol = Symbol.for(
-  "activerecord.encryption.AdditionalValue",
-);
+export const ADDITIONAL_VALUE_BRAND: symbol = Symbol.for("activerecord.encryption.AdditionalValue");
 
 function isAdditionalValue(value: unknown): boolean {
   return (

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   AdditionalValue,
-  CoreQueries,
-  EncryptedQuery,
   ExtendedDeterministicQueries,
   ExtendedEncryptableType,
   RelationQueries,
@@ -256,7 +254,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
     });
   });
 
-  it("patches Relation.prototype.scopeForCreate to unwrap AdditionalValue[0]", () => {
+  it("patches Relation.prototype.scopeForCreate to copy the AdditionalValue[0] marker into scope", () => {
     withFreshInstaller(() => {
       const targets = isolatedTargets();
       ExtendedDeterministicQueries.installSupport(targets as any);
@@ -328,14 +326,6 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       expect(ExtendedDeterministicQueries.installed).toBe(true);
     });
   });
-
-  // These identifiers are only used inside the wrappers / through
-  // Relation.prototype, so TypeScript's unused-import checks flag them.
-  // The `void` references silence those checks without changing runtime
-  // behavior.
-  void EncryptedQuery;
-  void CoreQueries;
-  void Relation;
 });
 
 describe("installExtendedQueriesIfConfigured", () => {

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   AdditionalValue,
+  EncryptedQuery,
   ExtendedDeterministicQueries,
   ExtendedEncryptableType,
   RelationQueries,
@@ -51,6 +52,63 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValu
     const type = makeType();
     const av = new AdditionalValue("42", type);
     expect(+av).toBe(42);
+  });
+});
+
+describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery#processArguments", () => {
+  // Use a deterministic scheme with a previous scheme so expansion
+  // actually produces AdditionalValue wrappers we can assert on.
+  function modelWithDeterministicEmail() {
+    const prev = new Scheme({ deterministic: true, encryptor: new NullEncryptor() });
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({
+        deterministic: true,
+        encryptor: new NullEncryptor(),
+        previousSchemes: [prev],
+      }),
+    });
+    return {
+      _encryptedAttributes: new Set(["email"]),
+      _attributeDefinitions: new Map([["email", { type }]]),
+    };
+  }
+
+  it("short-circuits when checkForAdditionalValues=true and the last array element is an AdditionalValue", () => {
+    // Rails: `return value if check_for_additional_values && value.last.is_a?(AdditionalValue)`.
+    // Prevents a chained `.where()` on the same relation from re-expanding
+    // an already-expanded condition into AV-of-AV.
+    const model = modelWithDeterministicEmail();
+    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const already = [new AdditionalValue("x", type)];
+    const out = EncryptedQuery.processArguments(model, [{ email: already }], true) as [
+      Record<string, unknown>,
+    ];
+    expect(out[0].email).toBe(already);
+  });
+
+  it("does not short-circuit when checkForAdditionalValues=false (findBy path always expands)", () => {
+    const model = modelWithDeterministicEmail();
+    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const already = [new AdditionalValue("x", type)];
+    const [out] = EncryptedQuery.processArguments(model, [{ email: already }], false) as [
+      Record<string, unknown[]>,
+    ];
+    // Without short-circuit, the AV is re-expanded (wrapped in a fresh AV).
+    expect(out.email.length).toBeGreaterThan(already.length);
+  });
+
+  it("preserves in-place AdditionalValue elements when checkForAdditionalValues=true", () => {
+    // Rails: within flat_map, `each_value` that is already an AV passes
+    // through untouched instead of running through additional_values_for.
+    const model = modelWithDeterministicEmail();
+    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const av = new AdditionalValue("x", type);
+    // Mix: a plaintext AND an AV that isn't last — so the whole-array
+    // short-circuit doesn't apply, but the per-element check should.
+    const [out] = EncryptedQuery.processArguments(model, [{ email: [av, "y"] }], true) as [
+      Record<string, unknown[]>,
+    ];
+    expect(out.email[0]).toBe(av);
   });
 });
 

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -330,3 +330,49 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
   void CoreQueries;
   void Relation;
 });
+
+describe("installExtendedQueriesIfConfigured", () => {
+  it("is a no-op when Configurable.config.extendQueries is false", async () => {
+    const { Configurable } = await import("./configurable.js");
+    const { installExtendedQueriesIfConfigured } = await import("./install.js");
+    const prev = Configurable.config.extendQueries;
+    Configurable.config.extendQueries = false;
+    try {
+      // Simulate a fresh process.
+      (ExtendedDeterministicQueries as any)._installed = false;
+      const installed = installExtendedQueriesIfConfigured();
+      expect(installed).toBe(false);
+      expect(ExtendedDeterministicQueries.installed).toBe(false);
+    } finally {
+      Configurable.config.extendQueries = prev;
+      (ExtendedDeterministicQueries as any)._installed = false;
+    }
+  });
+
+  it("installs the patches onto the real Relation/Base/EncryptedAttributeType when extendQueries=true", async () => {
+    const { Configurable } = await import("./configurable.js");
+    const { installExtendedQueriesIfConfigured } = await import("./install.js");
+
+    const origWhere = Relation.prototype.where;
+    const origFindBy = (Base as any).findBy;
+    const origSerialize = EncryptedAttributeType.prototype.serialize;
+
+    const prev = Configurable.config.extendQueries;
+    Configurable.config.extendQueries = true;
+    (ExtendedDeterministicQueries as any)._installed = false;
+    try {
+      const installed = installExtendedQueriesIfConfigured();
+      expect(installed).toBe(true);
+      expect(Relation.prototype.where).not.toBe(origWhere);
+      expect((Base as any).findBy).not.toBe(origFindBy);
+      expect(EncryptedAttributeType.prototype.serialize).not.toBe(origSerialize);
+    } finally {
+      // Restore to avoid bleeding into sibling tests in the same process.
+      Relation.prototype.where = origWhere;
+      (Base as any).findBy = origFindBy;
+      EncryptedAttributeType.prototype.serialize = origSerialize;
+      (ExtendedDeterministicQueries as any)._installed = false;
+      Configurable.config.extendQueries = prev;
+    }
+  });
+});

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -361,6 +361,8 @@ describe("installExtendedQueriesIfConfigured", () => {
     const { installExtendedQueriesIfConfigured } = await import("./install.js");
 
     const origWhere = Relation.prototype.where;
+    const origExists = (Relation.prototype as any).exists;
+    const origScopeForCreate = (Relation.prototype as any).scopeForCreate;
     const origFindBy = (Base as any).findBy;
     const origSerialize = EncryptedAttributeType.prototype.serialize;
 
@@ -374,8 +376,12 @@ describe("installExtendedQueriesIfConfigured", () => {
       expect((Base as any).findBy).not.toBe(origFindBy);
       expect(EncryptedAttributeType.prototype.serialize).not.toBe(origSerialize);
     } finally {
-      // Restore to avoid bleeding into sibling tests in the same process.
+      // Restore every patched entrypoint — leaving exists/scopeForCreate
+      // patched would make sibling tests in the same Vitest process
+      // order-dependent.
       Relation.prototype.where = origWhere;
+      (Relation.prototype as any).exists = origExists;
+      (Relation.prototype as any).scopeForCreate = origScopeForCreate;
       (Base as any).findBy = origFindBy;
       EncryptedAttributeType.prototype.serialize = origSerialize;
       (ExtendedDeterministicQueries as any)._installed = false;

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -324,8 +324,10 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
     });
   });
 
-  // Satisfy no-unused-imports: these identifiers are exported for use by
-  // external call sites, referenced here to prevent tree-shaking warnings.
+  // These identifiers are only used inside the wrappers / through
+  // Relation.prototype, so TypeScript's unused-import checks flag them.
+  // The `void` references silence those checks without changing runtime
+  // behavior.
   void EncryptedQuery;
   void CoreQueries;
   void Relation;

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -87,7 +87,10 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     };
 
     const result = RelationQueries.scopeForCreate(() => ({}), relation);
-    expect(result.email).toBe(avCurrent.value);
+    // scope_for_create keeps the AV reference so serialize unwraps to
+    // ciphertext on save without re-encrypting (our cast->toString
+    // path would otherwise double-encrypt a plaintext-unwrapped value).
+    expect(result.email).toBe(avCurrent);
   });
 
   it("leaves attributes alone when whereValuesHash has no matching entry", () => {
@@ -168,10 +171,12 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
 
     const hash = rel.whereValuesHash();
     expect(Array.isArray(hash.email)).toBe(true);
-    expect((hash.email as unknown[])[0]).toBe(avCurrent);
+    expect((hash.email as unknown[])[0]).toBeInstanceOf(AdditionalValue);
+    expect(((hash.email as AdditionalValue[])[0] as AdditionalValue).value).toBe(avCurrent.value);
 
     const scope = RelationQueries.scopeForCreate(() => ({}), rel);
-    expect(scope.email).toBe(avCurrent.value);
+    expect(scope.email).toBeInstanceOf(AdditionalValue);
+    expect((scope.email as AdditionalValue).value).toBe(avCurrent.value);
   });
 });
 
@@ -266,7 +271,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       };
       const rel = new (targets.Relation as any)(model);
       rel._wheres = { email: [av] };
-      expect(rel.scopeForCreate()).toEqual({ fromOriginal: true, email: av.value });
+      expect(rel.scopeForCreate()).toEqual({ fromOriginal: true, email: av });
     });
   });
 

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   AdditionalValue,
+  CoreQueries,
+  EncryptedQuery,
+  ExtendedDeterministicQueries,
   ExtendedEncryptableType,
   RelationQueries,
 } from "./extended-deterministic-queries.js";
@@ -8,8 +11,8 @@ import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import { Base } from "../base.js";
+import { Relation } from "../relation.js";
 import { createTestAdapter } from "../test-adapter.js";
-import "../relation.js";
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
   it.skip("Finds records when data is unencrypted", () => {});
@@ -170,4 +173,160 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const scope = RelationQueries.scopeForCreate(() => ({}), rel);
     expect(scope.email).toBe(avCurrent.value);
   });
+});
+
+describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport", () => {
+  // Use isolated classes / prototype clones so patches don't bleed into
+  // the other test files running in the same process.
+  function isolatedTargets() {
+    class FakeRelation {
+      _modelClass: any;
+      constructor(model: any) {
+        this._modelClass = model;
+      }
+      get model() {
+        return this._modelClass;
+      }
+      where(conditions: Record<string, unknown>) {
+        (this as any)._lastWhere = conditions;
+        return this;
+      }
+      async exists(conditions: Record<string, unknown>) {
+        (this as any)._lastExists = conditions;
+        return true;
+      }
+      scopeForCreate() {
+        return { fromOriginal: true } as Record<string, unknown>;
+      }
+      whereValuesHash() {
+        return (this as any)._wheres ?? {};
+      }
+    }
+    class FakeBase {
+      static findBy(conditions: Record<string, unknown>) {
+        (this as any)._lastFindBy = conditions;
+        return "hit";
+      }
+    }
+    class FakeEat extends EncryptedAttributeType {}
+    return { Relation: FakeRelation, Base: FakeBase, EncryptedAttributeType: FakeEat };
+  }
+
+  function withFreshInstaller<T>(fn: () => T): T {
+    (ExtendedDeterministicQueries as any)._installed = false;
+    try {
+      return fn();
+    } finally {
+      (ExtendedDeterministicQueries as any)._installed = false;
+    }
+  }
+
+  it("patches Relation.prototype.where to run processArguments", () => {
+    withFreshInstaller(() => {
+      const targets = isolatedTargets();
+      ExtendedDeterministicQueries.installSupport(targets as any);
+
+      const prev = new Scheme({ deterministic: true, encryptor: new NullEncryptor() });
+      const type = new EncryptedAttributeType({
+        scheme: new Scheme({
+          deterministic: true,
+          encryptor: new NullEncryptor(),
+          previousSchemes: [prev],
+        }),
+      });
+      const model = {
+        _encryptedAttributes: new Set(["email"]),
+        _attributeDefinitions: new Map([["email", { type }]]),
+      };
+      const rel = new (targets.Relation as any)(model);
+      rel.where({ email: "a@x" });
+      const captured = rel._lastWhere.email as unknown[];
+      expect(Array.isArray(captured)).toBe(true);
+      // See allCiphertextsFor: our expansion puts AV(current) at [0] (not
+      // plaintext like Rails) because our PredicateBuilder bypasses
+      // EncryptedAttributeType.serialize for raw scalars in IN arrays.
+      expect(captured[0]).toBeInstanceOf(AdditionalValue);
+      expect((captured[0] as AdditionalValue).value).toBeDefined();
+      expect(captured[1]).toBeInstanceOf(AdditionalValue);
+    });
+  });
+
+  it("patches Relation.prototype.scopeForCreate to unwrap AdditionalValue[0]", () => {
+    withFreshInstaller(() => {
+      const targets = isolatedTargets();
+      ExtendedDeterministicQueries.installSupport(targets as any);
+
+      const type = new EncryptedAttributeType({
+        scheme: new Scheme({ deterministic: true, encryptor: new NullEncryptor() }),
+      });
+      const av = new AdditionalValue("plain@x", type);
+      const model = {
+        _encryptedAttributes: new Set(["email"]),
+        _attributeDefinitions: new Map([["email", { type }]]),
+      };
+      const rel = new (targets.Relation as any)(model);
+      rel._wheres = { email: [av] };
+      expect(rel.scopeForCreate()).toEqual({ fromOriginal: true, email: av.value });
+    });
+  });
+
+  it("patches Base.findBy to run processArguments with checkForAdditionalValues=false", () => {
+    withFreshInstaller(() => {
+      const targets = isolatedTargets();
+      ExtendedDeterministicQueries.installSupport(targets as any);
+
+      const prev = new Scheme({ deterministic: true, encryptor: new NullEncryptor() });
+      const type = new EncryptedAttributeType({
+        scheme: new Scheme({
+          deterministic: true,
+          encryptor: new NullEncryptor(),
+          previousSchemes: [prev],
+        }),
+      });
+      class Contact extends (targets.Base as any) {
+        static _encryptedAttributes = new Set(["email"]);
+        static _attributeDefinitions = new Map([["email", { type }]]);
+      }
+      (Contact as any).findBy({ email: "x" });
+      const captured = (Contact as any)._lastFindBy.email as unknown[];
+      expect(Array.isArray(captured)).toBe(true);
+      expect(captured[0]).toBeInstanceOf(AdditionalValue);
+      expect(captured[1]).toBeInstanceOf(AdditionalValue);
+    });
+  });
+
+  it("patches EncryptedAttributeType.prototype.serialize to passthrough AdditionalValue", () => {
+    withFreshInstaller(() => {
+      const targets = isolatedTargets();
+      ExtendedDeterministicQueries.installSupport(targets as any);
+
+      const type = new (targets.EncryptedAttributeType as typeof EncryptedAttributeType)({
+        scheme: new Scheme({ deterministic: true, encryptor: new NullEncryptor() }),
+      });
+      const av = new AdditionalValue("plain", type);
+      expect(type.serialize(av)).toBe(av.value);
+      // Non-AdditionalValue still flows through the original serialize path.
+      expect(typeof type.serialize("raw")).toBe("string");
+    });
+  });
+
+  it("is idempotent — second call is a no-op", () => {
+    withFreshInstaller(() => {
+      const targets = isolatedTargets();
+      const originalWhere = targets.Relation.prototype.where;
+      ExtendedDeterministicQueries.installSupport(targets as any);
+      const firstPatched = targets.Relation.prototype.where;
+      ExtendedDeterministicQueries.installSupport(targets as any);
+      const secondPatched = targets.Relation.prototype.where;
+      expect(firstPatched).not.toBe(originalWhere);
+      expect(secondPatched).toBe(firstPatched);
+      expect(ExtendedDeterministicQueries.installed).toBe(true);
+    });
+  });
+
+  // Satisfy no-unused-imports: these identifiers are exported for use by
+  // external call sites, referenced here to prevent tree-shaking warnings.
+  void EncryptedQuery;
+  void CoreQueries;
+  void Relation;
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -10,8 +10,55 @@ import { getAttributeType } from "./encryptable-record.js";
 export class ExtendedDeterministicQueries {
   private static _installed = false;
 
-  static installSupport(): void {
+  /**
+   * Install the query-expansion patches. Rails does this via `prepend`:
+   *
+   *   ActiveRecord::Relation.prepend(RelationQueries)
+   *   ActiveRecord::Base.include(CoreQueries)
+   *   ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
+   *
+   * TS has no prepend, so we wrap prototype methods in place. Idempotent.
+   * Call this once during app boot when
+   * `Configurable.config.extendQueries` is true (Rails'
+   * `config.active_record.encryption.extend_queries`).
+   */
+  static installSupport(targets: {
+    Relation: { prototype: Record<string, Function> };
+    Base: Record<string, Function> & { findBy?: Function };
+    EncryptedAttributeType: { prototype: Record<string, Function> };
+  }): void {
+    if (this._installed) return;
     this._installed = true;
+
+    const relProto = targets.Relation.prototype;
+    const originalWhere = relProto.where;
+    relProto.where = function (this: unknown, ...args: unknown[]) {
+      return RelationQueries.where(originalWhere, this, args);
+    };
+
+    const originalExists = relProto.exists;
+    relProto.exists = function (this: unknown, ...args: unknown[]) {
+      return RelationQueries.isExists(originalExists, this, args);
+    };
+
+    const originalScopeForCreate = relProto.scopeForCreate;
+    relProto.scopeForCreate = function (this: unknown) {
+      return RelationQueries.scopeForCreate(originalScopeForCreate, this);
+    };
+
+    const originalFindBy = targets.Base.findBy!;
+    targets.Base.findBy = function (this: unknown, ...args: unknown[]) {
+      return CoreQueries.findBy(originalFindBy, this, args);
+    };
+
+    const eatProto = targets.EncryptedAttributeType.prototype;
+    const originalSerialize = eatProto.serialize;
+    eatProto.serialize = function (this: unknown, data: unknown) {
+      return ExtendedEncryptableType.serialize(
+        (v: unknown) => originalSerialize.call(this, v),
+        data,
+      );
+    };
   }
 
   static get installed(): boolean {
@@ -107,10 +154,7 @@ export class RelationQueries {
     return originalExists.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
   }
 
-  static scopeForCreate(
-    originalScopeForCreate: () => Record<string, unknown>,
-    relation: any,
-  ): Record<string, unknown> {
+  static scopeForCreate(originalScopeForCreate: Function, relation: any): Record<string, unknown> {
     const model = relation.model ?? relation;
     const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
     if (!encryptedAttrs?.size) return originalScopeForCreate.call(relation);

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,3 +1,4 @@
+import { prepend } from "@blazetrails/activesupport";
 import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { getAttributeType } from "./encryptable-record.js";
 
@@ -29,52 +30,27 @@ export class ExtendedDeterministicQueries {
   }): void {
     if (this._installed) return;
 
-    const relProto = targets.Relation.prototype;
-    const eatProto = targets.EncryptedAttributeType.prototype;
-
-    // Capture every original first so we can leave state untouched if any
-    // target is missing. Setting _installed only after all assignments
-    // succeed prevents a partial-patch state that would permanently
-    // block retries via the idempotency guard above.
-    const originalWhere = relProto.where;
-    const originalExists = relProto.exists;
-    const originalScopeForCreate = relProto.scopeForCreate;
-    const originalFindBy = targets.Base.findBy;
-    const originalSerialize = eatProto.serialize;
-
-    const missing: string[] = [];
-    if (typeof originalWhere !== "function") missing.push("Relation.prototype.where");
-    if (typeof originalExists !== "function") missing.push("Relation.prototype.exists");
-    if (typeof originalScopeForCreate !== "function")
-      missing.push("Relation.prototype.scopeForCreate");
-    if (typeof originalFindBy !== "function") missing.push("Base.findBy");
-    if (typeof originalSerialize !== "function")
-      missing.push("EncryptedAttributeType.prototype.serialize");
-    if (missing.length > 0) {
-      throw new Error(
-        `ExtendedDeterministicQueries.installSupport: missing target method(s): ${missing.join(", ")}`,
-      );
-    }
-
-    relProto.where = function (this: unknown, ...args: unknown[]) {
-      return RelationQueries.where(originalWhere, this, args);
-    };
-    relProto.exists = function (this: unknown, ...args: unknown[]) {
-      return RelationQueries.isExists(originalExists, this, args);
-    };
-    relProto.scopeForCreate = function (this: unknown) {
-      return RelationQueries.scopeForCreate(originalScopeForCreate, this);
-    };
-    const nonNullFindBy: Function = originalFindBy!;
-    targets.Base.findBy = function (this: unknown, ...args: unknown[]) {
-      return CoreQueries.findBy(nonNullFindBy, this, args);
-    };
-    eatProto.serialize = function (this: unknown, data: unknown) {
-      return ExtendedEncryptableType.serialize(
-        (v: unknown) => originalSerialize.call(this, v),
-        data,
-      );
-    };
+    prepend(targets.Relation.prototype, {
+      where(super_, ...args) {
+        return RelationQueries.where(super_, this, args);
+      },
+      exists(super_, ...args) {
+        return RelationQueries.isExists(super_, this, args);
+      },
+      scopeForCreate(super_) {
+        return RelationQueries.scopeForCreate(super_, this);
+      },
+    });
+    prepend(targets.Base as unknown as Record<string, unknown>, {
+      findBy(super_, ...args) {
+        return CoreQueries.findBy(super_, this, args);
+      },
+    });
+    prepend(targets.EncryptedAttributeType.prototype, {
+      serialize(super_, data) {
+        return ExtendedEncryptableType.serialize((v: unknown) => super_.call(this, v), data);
+      },
+    });
 
     this._installed = true;
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -126,12 +126,34 @@ export class EncryptedQuery {
 
   private static processEncryptedQueryArgument(
     value: unknown,
-    _checkForAdditionalValues: boolean,
+    checkForAdditionalValues: boolean,
     type: EncryptedAttributeType,
   ): unknown {
     if (value === null) return value;
+
+    // Rails' process_encrypted_query_argument short-circuits when the
+    // caller is a Relation (`where`/`exists?`) and the value is already
+    // an expanded array whose last element is an AdditionalValue — that
+    // means a previous `where` on the same relation already ran
+    // processArguments, and re-expanding would produce AV-of-AV. Only
+    // checked for Relation paths (checkForAdditionalValues=true);
+    // `findBy` via CoreQueries uses false and always expands because
+    // its inputs come straight from the user.
+    if (
+      checkForAdditionalValues &&
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value[value.length - 1] instanceof AdditionalValue
+    ) {
+      return value;
+    }
+
     if (Array.isArray(value)) {
-      return value.flatMap((v) => (v === null ? [v] : this.allCiphertextsFor(v, type)));
+      return value.flatMap((v) => {
+        if (v === null) return [v];
+        if (checkForAdditionalValues && v instanceof AdditionalValue) return [v];
+        return this.allCiphertextsFor(v, type);
+      });
     }
     return this.allCiphertextsFor(value, type);
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,4 +1,4 @@
-import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { getAttributeType } from "./encryptable-record.js";
 
 /**
@@ -42,8 +42,18 @@ export class ExtendedDeterministicQueries {
     const originalFindBy = targets.Base.findBy;
     const originalSerialize = eatProto.serialize;
 
-    if (!originalFindBy) {
-      throw new Error("ExtendedDeterministicQueries.installSupport: Base.findBy is missing");
+    const missing: string[] = [];
+    if (typeof originalWhere !== "function") missing.push("Relation.prototype.where");
+    if (typeof originalExists !== "function") missing.push("Relation.prototype.exists");
+    if (typeof originalScopeForCreate !== "function")
+      missing.push("Relation.prototype.scopeForCreate");
+    if (typeof originalFindBy !== "function") missing.push("Base.findBy");
+    if (typeof originalSerialize !== "function")
+      missing.push("EncryptedAttributeType.prototype.serialize");
+    if (missing.length > 0) {
+      throw new Error(
+        `ExtendedDeterministicQueries.installSupport: missing target method(s): ${missing.join(", ")}`,
+      );
     }
 
     relProto.where = function (this: unknown, ...args: unknown[]) {
@@ -55,8 +65,9 @@ export class ExtendedDeterministicQueries {
     relProto.scopeForCreate = function (this: unknown) {
       return RelationQueries.scopeForCreate(originalScopeForCreate, this);
     };
+    const nonNullFindBy: Function = originalFindBy!;
     targets.Base.findBy = function (this: unknown, ...args: unknown[]) {
-      return CoreQueries.findBy(originalFindBy, this, args);
+      return CoreQueries.findBy(nonNullFindBy, this, args);
     };
     eatProto.serialize = function (this: unknown, data: unknown) {
       return ExtendedEncryptableType.serialize(
@@ -174,9 +185,12 @@ export class RelationQueries {
       const values = wheres[attrName];
       if (Array.isArray(values) && values[0] instanceof AdditionalValue) {
         // Our expansion stores AdditionalValue(current) at index 0 (see
-        // allCiphertextsFor). Unwrap to the ciphertext so the created
-        // record stores the current-scheme-encrypted value directly.
-        scopeAttrs[attrName] = (values[0] as AdditionalValue).value;
+        // allCiphertextsFor). Keep the AV reference — when the new record
+        // saves, EncryptedAttributeType.serialize (patched via
+        // ExtendedEncryptableType) unwraps it to the ciphertext without
+        // re-encrypting. Writing values[0].value directly would serialize
+        // the ciphertext as plaintext, producing a double-encrypted blob.
+        scopeAttrs[attrName] = values[0];
       }
     }
     return scopeAttrs;
@@ -203,6 +217,9 @@ export class CoreQueries {
 export class AdditionalValue {
   readonly value: unknown;
   readonly type: EncryptedAttributeType;
+  // Brand flag so EncryptedAttributeType.cast can identify AV instances
+  // without importing this module (which would be circular).
+  readonly [ADDITIONAL_VALUE_BRAND] = true;
 
   constructor(value: unknown, type: EncryptedAttributeType) {
     this.type = type;

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -30,7 +30,29 @@ export class ExtendedDeterministicQueries {
   }): void {
     if (this._installed) return;
 
-    prepend(targets.Relation.prototype, {
+    // Pre-validate every target method across all three prepend() calls
+    // so a missing method can't leave us with one class already patched
+    // and another un-patched — a non-atomic state that a retry would
+    // double-wrap. Rails' `prepend` at boot is effectively all-or-
+    // nothing; this matches that intent.
+    const relProto = targets.Relation.prototype;
+    const baseTarget = targets.Base as unknown as Record<string, unknown>;
+    const eatProto = targets.EncryptedAttributeType.prototype;
+    const missing: string[] = [];
+    if (typeof relProto.where !== "function") missing.push("Relation.prototype.where");
+    if (typeof relProto.exists !== "function") missing.push("Relation.prototype.exists");
+    if (typeof relProto.scopeForCreate !== "function")
+      missing.push("Relation.prototype.scopeForCreate");
+    if (typeof baseTarget.findBy !== "function") missing.push("Base.findBy");
+    if (typeof eatProto.serialize !== "function")
+      missing.push("EncryptedAttributeType.prototype.serialize");
+    if (missing.length > 0) {
+      throw new Error(
+        `ExtendedDeterministicQueries.installSupport: missing target method(s): ${missing.join(", ")}`,
+      );
+    }
+
+    prepend(relProto, {
       where(super_, ...args) {
         return RelationQueries.where(super_, this, args);
       },
@@ -41,12 +63,12 @@ export class ExtendedDeterministicQueries {
         return RelationQueries.scopeForCreate(super_, this);
       },
     });
-    prepend(targets.Base as unknown as Record<string, unknown>, {
+    prepend(baseTarget, {
       findBy(super_, ...args) {
         return CoreQueries.findBy(super_, this, args);
       },
     });
-    prepend(targets.EncryptedAttributeType.prototype, {
+    prepend(eatProto, {
       serialize(super_, data) {
         return ExtendedEncryptableType.serialize((v: unknown) => super_.call(this, v), data);
       },

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -28,37 +28,44 @@ export class ExtendedDeterministicQueries {
     EncryptedAttributeType: { prototype: Record<string, Function> };
   }): void {
     if (this._installed) return;
-    this._installed = true;
 
     const relProto = targets.Relation.prototype;
+    const eatProto = targets.EncryptedAttributeType.prototype;
+
+    // Capture every original first so we can leave state untouched if any
+    // target is missing. Setting _installed only after all assignments
+    // succeed prevents a partial-patch state that would permanently
+    // block retries via the idempotency guard above.
     const originalWhere = relProto.where;
+    const originalExists = relProto.exists;
+    const originalScopeForCreate = relProto.scopeForCreate;
+    const originalFindBy = targets.Base.findBy;
+    const originalSerialize = eatProto.serialize;
+
+    if (!originalFindBy) {
+      throw new Error("ExtendedDeterministicQueries.installSupport: Base.findBy is missing");
+    }
+
     relProto.where = function (this: unknown, ...args: unknown[]) {
       return RelationQueries.where(originalWhere, this, args);
     };
-
-    const originalExists = relProto.exists;
     relProto.exists = function (this: unknown, ...args: unknown[]) {
       return RelationQueries.isExists(originalExists, this, args);
     };
-
-    const originalScopeForCreate = relProto.scopeForCreate;
     relProto.scopeForCreate = function (this: unknown) {
       return RelationQueries.scopeForCreate(originalScopeForCreate, this);
     };
-
-    const originalFindBy = targets.Base.findBy!;
     targets.Base.findBy = function (this: unknown, ...args: unknown[]) {
       return CoreQueries.findBy(originalFindBy, this, args);
     };
-
-    const eatProto = targets.EncryptedAttributeType.prototype;
-    const originalSerialize = eatProto.serialize;
     eatProto.serialize = function (this: unknown, data: unknown) {
       return ExtendedEncryptableType.serialize(
         (v: unknown) => originalSerialize.call(this, v),
         data,
       );
     };
+
+    this._installed = true;
   }
 
   static get installed(): boolean {

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -24,9 +24,9 @@ export class ExtendedDeterministicQueries {
    * `config.active_record.encryption.extend_queries`).
    */
   static installSupport(targets: {
-    Relation: { prototype: Record<string, Function> };
-    Base: Record<string, Function> & { findBy?: Function };
-    EncryptedAttributeType: { prototype: Record<string, Function> };
+    Relation: { prototype: { where: Function; exists: Function; scopeForCreate: Function } };
+    Base: { findBy: Function };
+    EncryptedAttributeType: { prototype: { serialize: Function } };
   }): void {
     if (this._installed) return;
 
@@ -35,9 +35,14 @@ export class ExtendedDeterministicQueries {
     // and another un-patched — a non-atomic state that a retry would
     // double-wrap. Rails' `prepend` at boot is effectively all-or-
     // nothing; this matches that intent.
-    const relProto = targets.Relation.prototype;
-    const baseTarget = targets.Base as unknown as Record<string, unknown>;
-    const eatProto = targets.EncryptedAttributeType.prototype;
+    // `prepend()` needs an open object-with-Function-values shape, so
+    // cast at the call site rather than widening the public signature.
+    const relProto = targets.Relation.prototype as unknown as Record<string, Function>;
+    const baseTarget = targets.Base as unknown as Record<string, Function>;
+    const eatProto = targets.EncryptedAttributeType.prototype as unknown as Record<
+      string,
+      Function
+    >;
     const missing: string[] = [];
     if (typeof relProto.where !== "function") missing.push("Relation.prototype.where");
     if (typeof relProto.exists !== "function") missing.push("Relation.prototype.exists");

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -34,7 +34,12 @@ export {
   AdditionalValue,
   ExtendedEncryptableType,
 } from "./extended-deterministic-queries.js";
-export { installExtendedQueriesIfConfigured } from "./install.js";
+// `installExtendedQueriesIfConfigured` is intentionally NOT re-exported
+// here — its top-level `Base`/`Relation` imports would expand the
+// dependency surface of `@blazetrails/activerecord/encryption` for
+// consumers that only need encryption primitives. It's re-exported
+// from the main package index (which already depends on Base/Relation)
+// and is also reachable via `@blazetrails/activerecord/encryption/install.js`.
 export {
   ExtendedDeterministicUniquenessValidator,
   EncryptedUniquenessValidator,

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -34,6 +34,7 @@ export {
   AdditionalValue,
   ExtendedEncryptableType,
 } from "./extended-deterministic-queries.js";
+export { installExtendedQueriesIfConfigured } from "./install.js";
 export {
   ExtendedDeterministicUniquenessValidator,
   EncryptedUniquenessValidator,

--- a/packages/activerecord/src/encryption/install.ts
+++ b/packages/activerecord/src/encryption/install.ts
@@ -1,0 +1,30 @@
+import { Base } from "../base.js";
+import { Relation } from "../relation.js";
+import { Configurable } from "./configurable.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
+
+/**
+ * Boot-time entrypoint. Installs the deterministic-encryption query
+ * patches against the real `Relation`, `Base`, and `EncryptedAttributeType`
+ * classes if `Configurable.config.extendQueries` is true.
+ *
+ * Mirrors: the Rails railtie that calls
+ * `ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support`
+ * when `config.active_record.encryption.extend_queries` is set.
+ *
+ * Safe to call multiple times — `installSupport` is idempotent. Returns
+ * `true` when the patches are active after the call, `false` when
+ * `extendQueries` is disabled and nothing was installed.
+ */
+export function installExtendedQueriesIfConfigured(): boolean {
+  if (!Configurable.config.extendQueries) return false;
+  ExtendedDeterministicQueries.installSupport({
+    Relation: Relation as unknown as { prototype: Record<string, Function> },
+    Base: Base as unknown as Record<string, Function>,
+    EncryptedAttributeType: EncryptedAttributeType as unknown as {
+      prototype: Record<string, Function>;
+    },
+  });
+  return ExtendedDeterministicQueries.installed;
+}

--- a/packages/activerecord/src/encryption/install.ts
+++ b/packages/activerecord/src/encryption/install.ts
@@ -14,11 +14,12 @@ import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.j
  * when `config.active_record.encryption.extend_queries` is set.
  *
  * Safe to call multiple times — `installSupport` is idempotent. Returns
- * `true` when the patches are active after the call, `false` when
- * `extendQueries` is disabled and nothing was installed.
+ * the effective install state: `true` when the patches are active after
+ * this call (whether installed now or in a prior call), `false` when
+ * disabled and nothing has been installed yet.
  */
 export function installExtendedQueriesIfConfigured(): boolean {
-  if (!Configurable.config.extendQueries) return false;
+  if (!Configurable.config.extendQueries) return ExtendedDeterministicQueries.installed;
   ExtendedDeterministicQueries.installSupport({
     Relation: Relation as unknown as { prototype: Record<string, Function> },
     Base: Base as unknown as Record<string, Function>,

--- a/packages/activerecord/src/encryption/install.ts
+++ b/packages/activerecord/src/encryption/install.ts
@@ -20,12 +20,6 @@ import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.j
  */
 export function installExtendedQueriesIfConfigured(): boolean {
   if (!Configurable.config.extendQueries) return ExtendedDeterministicQueries.installed;
-  ExtendedDeterministicQueries.installSupport({
-    Relation: Relation as unknown as { prototype: Record<string, Function> },
-    Base: Base as unknown as Record<string, Function>,
-    EncryptedAttributeType: EncryptedAttributeType as unknown as {
-      prototype: Record<string, Function>;
-    },
-  });
+  ExtendedDeterministicQueries.installSupport({ Relation, Base, EncryptedAttributeType });
   return ExtendedDeterministicQueries.installed;
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -267,6 +267,11 @@ export { serialize } from "./serialize.js";
 // Encryption is exposed via the subpath export. Use:
 // `import { ... } from "@blazetrails/activerecord/encryption"`.
 // `Base.encrypts(name, ...)` is still the idiomatic declaration site.
+// The boot-time installer lives here (not in the encryption subpath)
+// because it depends on Base/Relation — exposing it from the encryption
+// subpath would drag those imports into consumers that only want
+// encryption primitives.
+export { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 // generatesTokenFor requires node:crypto — use subpath: @blazetrails/activerecord/generates-token-for
 export { delegatedType, getDelegatedTypeConfig } from "./delegated-type.js";
 export { DatabaseConfig } from "./database-configurations/database-config.js";

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -8,6 +8,7 @@
  * Mirrors: ActiveRecord::FinderMethods
  */
 
+import { ActiveModelRangeError } from "@blazetrails/activemodel";
 import { RecordNotFound, RecordNotSaved, RecordNotUnique, SoleRecordExceeded } from "../errors.js";
 
 // ---------------------------------------------------------------------------
@@ -275,11 +276,13 @@ export async function performFindBy(
     const records = await this.where(conditions).limit(1).toArray();
     return records[0] ?? null;
   } catch (err) {
-    // Rails: `find_by` returns nil for out-of-range values (e.g. an
-    // integer larger than the column width). Nothing matches such a
-    // value, so there's nothing to find. Our IntegerType.serialize
-    // surfaces this as a RangeError; treat it the same.
-    if (err instanceof RangeError) return null;
+    // Rails: `find_by` returns nil for values that can't be serialized
+    // for the attribute's type (e.g. an integer larger than the column
+    // width). Rails catches `::RangeError` at the statement-cache
+    // bind layer; we don't have that layer, so scope the catch to the
+    // typed `ActiveModelRangeError` thrown by `IntegerType.serialize`
+    // — a broader `RangeError` catch would mask unrelated errors.
+    if (err instanceof ActiveModelRangeError) return null;
     throw err;
   }
 }

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -271,8 +271,17 @@ export async function performFindBy(
   this: FinderRelation,
   conditions: Record<string, unknown>,
 ): Promise<any | null> {
-  const records = await this.where(conditions).limit(1).toArray();
-  return records[0] ?? null;
+  try {
+    const records = await this.where(conditions).limit(1).toArray();
+    return records[0] ?? null;
+  } catch (err) {
+    // Rails: `find_by` returns nil for out-of-range values (e.g. an
+    // integer larger than the column width). Nothing matches such a
+    // value, so there's nothing to find. Our IntegerType.serialize
+    // surfaces this as a RangeError; treat it the same.
+    if (err instanceof RangeError) return null;
+    throw err;
+  }
 }
 
 export async function performFindByBang(

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -392,6 +392,8 @@ export type { ClassMethods } from "./callbacks.js";
 export { Concern, MultipleIncludedBlocks, MultiplePrependBlocks } from "./concern.js";
 export { include, extend, included, extended } from "./include.js";
 export type { Included, Extended } from "./include.js";
+export { prepend } from "./prepend.js";
+export type { PrependMethod, PrependModule } from "./prepend.js";
 export { ClassAttribute } from "./class-attribute.js";
 
 export {

--- a/packages/activesupport/src/prepend.test.ts
+++ b/packages/activesupport/src/prepend.test.ts
@@ -73,6 +73,44 @@ describe("prepend", () => {
     expect(Factory.make(10)).toBe(11);
   });
 
+  it("preserves the original property descriptor (class methods stay non-enumerable)", () => {
+    class Widget {
+      spin(): string {
+        return "spin";
+      }
+    }
+    const before = Object.getOwnPropertyDescriptor(Widget.prototype, "spin");
+    prepend(Widget.prototype, {
+      spin(super_: Function) {
+        return `wrapped-${super_.call(this)}`;
+      },
+    });
+    const after = Object.getOwnPropertyDescriptor(Widget.prototype, "spin");
+    expect(after?.enumerable).toBe(before?.enumerable);
+    expect(after?.writable).toBe(before?.writable);
+    expect(after?.configurable).toBe(before?.configurable);
+    // Sanity: the wrapper doesn't leak into Object.keys(prototype).
+    expect(Object.keys(Widget.prototype)).not.toContain("spin");
+    expect(new Widget().spin()).toBe("wrapped-spin");
+  });
+
+  it("validates all target methods exist before wrapping anything (atomicity)", () => {
+    class Partial {
+      good(): string {
+        return "ok";
+      }
+    }
+    const originalGood = Partial.prototype.good;
+    expect(() =>
+      prepend(Partial.prototype, {
+        good: (s: Function) => `wrapped-${s.call(undefined)}`,
+        missing: (s: Function) => s,
+      }),
+    ).toThrow(/missing/);
+    // `good` must NOT have been wrapped — atomicity guarantee.
+    expect(Partial.prototype.good).toBe(originalGood);
+  });
+
   it("second prepend on the same method chains on top of the first", () => {
     class Greeter {
       hi(): string {

--- a/packages/activesupport/src/prepend.test.ts
+++ b/packages/activesupport/src/prepend.test.ts
@@ -113,6 +113,32 @@ describe("prepend", () => {
     expect(Frozen.prototype.a).toBe(origA);
   });
 
+  it("throws before mutating when an own property is a non-configurable accessor (atomicity)", () => {
+    const target: Record<string, unknown> = {};
+    Object.defineProperty(target, "reader", {
+      get() {
+        return () => "accessor";
+      },
+      configurable: false,
+      enumerable: false,
+    });
+    Object.defineProperty(target, "loose", {
+      value: () => "loose",
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+    const origLoose = target.loose;
+    expect(() =>
+      prepend(target, {
+        loose: (s: Function) => `w-${s.call(undefined)}`,
+        reader: (s: Function) => `w-${s.call(undefined)}`,
+      }),
+    ).toThrow(/non-configurable accessor/);
+    // `loose` must NOT have been wrapped — atomicity guarantee.
+    expect(target.loose).toBe(origLoose);
+  });
+
   it("throws before mutating when an own property is non-configurable + non-writable (atomicity)", () => {
     const target: Record<string, unknown> = {};
     Object.defineProperty(target, "locked", {

--- a/packages/activesupport/src/prepend.test.ts
+++ b/packages/activesupport/src/prepend.test.ts
@@ -94,6 +94,50 @@ describe("prepend", () => {
     expect(new Widget().spin()).toBe("wrapped-spin");
   });
 
+  it("throws before mutating when the target is frozen (atomicity)", () => {
+    class Frozen {
+      a(): string {
+        return "a";
+      }
+      b(): string {
+        return "b";
+      }
+    }
+    Object.freeze(Frozen.prototype);
+    const origA = Frozen.prototype.a;
+    expect(() =>
+      prepend(Frozen.prototype, {
+        a: (s: Function) => `wrapped-${s.call(undefined)}`,
+      }),
+    ).toThrow(TypeError);
+    expect(Frozen.prototype.a).toBe(origA);
+  });
+
+  it("throws before mutating when an own property is non-configurable + non-writable (atomicity)", () => {
+    const target: Record<string, unknown> = {};
+    Object.defineProperty(target, "locked", {
+      value: () => "locked",
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    });
+    Object.defineProperty(target, "loose", {
+      value: () => "loose",
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+    const origLoose = target.loose;
+    expect(() =>
+      prepend(target, {
+        loose: (s: Function) => `w-${s.call(undefined)}`,
+        locked: (s: Function) => `w-${s.call(undefined)}`,
+      }),
+    ).toThrow(/non-configurable and non-writable/);
+    // `loose` must NOT have been wrapped — atomicity guarantee.
+    expect(target.loose).toBe(origLoose);
+  });
+
   it("validates all target methods exist before wrapping anything (atomicity)", () => {
     class Partial {
       good(): string {

--- a/packages/activesupport/src/prepend.test.ts
+++ b/packages/activesupport/src/prepend.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { prepend } from "./prepend.js";
+
+describe("prepend", () => {
+  it("wraps a single method and exposes super_ as the first argument", () => {
+    class Relation {
+      where(n: number): string {
+        return `original:${n}`;
+      }
+    }
+    prepend(Relation.prototype, {
+      where(super_: Function, n: number) {
+        return `wrapped(${super_.call(this, n * 2)})`;
+      },
+    });
+    expect(new Relation().where(3)).toBe("wrapped(original:6)");
+  });
+
+  it("preserves `this` binding to the caller instance", () => {
+    class Box {
+      _tag = "self";
+      identify(): string {
+        return this._tag;
+      }
+    }
+    prepend(Box.prototype, {
+      identify(super_: Function) {
+        return `outer:${super_.call(this)}`;
+      },
+    });
+    const b = new Box();
+    b._tag = "custom";
+    expect(b.identify()).toBe("outer:custom");
+  });
+
+  it("lets the module short-circuit without calling super_", () => {
+    class Toggle {
+      value(): number {
+        throw new Error("original should be skipped");
+      }
+    }
+    prepend(Toggle.prototype, {
+      value(_super_: Function) {
+        return 42;
+      },
+    });
+    expect(new Toggle().value()).toBe(42);
+  });
+
+  it("throws when wrapping a method that doesn't exist on the target", () => {
+    class Empty {}
+    expect(() => prepend(Empty.prototype, { ghost: (s: Function) => s })).toThrow(
+      /no method with that name/,
+    );
+  });
+
+  it("throws when the target isn't an object or function", () => {
+    expect(() => prepend(null as unknown as object, {})).toThrow(TypeError);
+    expect(() => prepend(42 as unknown as object, {})).toThrow(TypeError);
+  });
+
+  it("works on static/class members when the target is the class itself", () => {
+    class Factory {
+      static make(x: number): number {
+        return x;
+      }
+    }
+    prepend(Factory as unknown as Record<string, unknown>, {
+      make(super_: Function, x: number) {
+        return (super_.call(this, x) as number) + 1;
+      },
+    });
+    expect(Factory.make(10)).toBe(11);
+  });
+
+  it("second prepend on the same method chains on top of the first", () => {
+    class Greeter {
+      hi(): string {
+        return "base";
+      }
+    }
+    prepend(Greeter.prototype, {
+      hi(super_: Function) {
+        return `a-${super_.call(this)}`;
+      },
+    });
+    prepend(Greeter.prototype, {
+      hi(super_: Function) {
+        return `b-${super_.call(this)}`;
+      },
+    });
+    expect(new Greeter().hi()).toBe("b-a-base");
+  });
+});

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -38,11 +38,18 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     throw new TypeError("prepend: target must be an object or function");
   }
 
-  // Pre-validate every method exists before mutating anything. Mirrors
-  // Rails' all-or-nothing `Module#prepend` — a missing method should
-  // leave the target state untouched instead of applying partial wraps.
+  // Pre-validate every method exists on the target and every wrapper
+  // value is actually a function, before mutating anything. Mirrors
+  // Rails' all-or-nothing `Module#prepend` — a missing method or
+  // malformed module value should leave the target state untouched
+  // instead of applying partial wraps.
   const names = Object.keys(mod);
   for (const name of names) {
+    if (typeof mod[name] !== "function") {
+      throw new TypeError(
+        `prepend: module entry ${name} must be a function, got ${typeof mod[name]}`,
+      );
+    }
     const original = (target as Record<string, unknown>)[name];
     if (typeof original !== "function") {
       throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -38,11 +38,13 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     throw new TypeError("prepend: target must be an object or function");
   }
 
-  // Pre-validate every method exists on the target and every wrapper
-  // value is actually a function, before mutating anything. Mirrors
-  // Rails' all-or-nothing `Module#prepend` — a missing method or
-  // malformed module value should leave the target state untouched
-  // instead of applying partial wraps.
+  // All-or-nothing pre-validation. A missing method, a non-function
+  // wrapper, a frozen/sealed target, or a non-configurable own property
+  // would otherwise throw mid-loop and leave the target in a partial-
+  // patch state. We check all four up front and throw before mutating.
+  if (!Object.isExtensible(target)) {
+    throw new TypeError("prepend: target is not extensible (frozen/sealed)");
+  }
   const names = Object.keys(mod);
   for (const name of names) {
     if (typeof mod[name] !== "function") {
@@ -53,6 +55,14 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     const original = (target as Record<string, unknown>)[name];
     if (typeof original !== "function") {
       throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);
+    }
+    // If an own property exists and is non-configurable and non-writable,
+    // `Object.defineProperty` below would throw. Detect now.
+    const own = Object.getOwnPropertyDescriptor(target, name);
+    if (own && own.configurable === false && own.writable === false) {
+      throw new TypeError(
+        `prepend: cannot wrap ${name} — target's own property is non-configurable and non-writable`,
+      );
     }
   }
 

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -56,13 +56,27 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     if (typeof original !== "function") {
       throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);
     }
-    // If an own property exists and is non-configurable and non-writable,
-    // `Object.defineProperty` below would throw. Detect now.
+    // If an own property exists and is non-configurable, `defineProperty`
+    // below can still throw — three sub-cases:
+    //   - non-writable data descriptor: can't change `value`.
+    //   - accessor descriptor (get/set): can't convert to a data descriptor.
+    //   - writable data descriptor: can change `value` but not `enumerable`
+    //     — our wrap copies enumerable from the existing shape, so this
+    //     one works.
+    // Reject the first two up front to preserve the all-or-nothing
+    // contract; the third is safe.
     const own = Object.getOwnPropertyDescriptor(target, name);
-    if (own && own.configurable === false && own.writable === false) {
-      throw new TypeError(
-        `prepend: cannot wrap ${name} — target's own property is non-configurable and non-writable`,
-      );
+    if (own && own.configurable === false) {
+      if (own.get || own.set) {
+        throw new TypeError(
+          `prepend: cannot wrap ${name} — target's own property is a non-configurable accessor`,
+        );
+      }
+      if (own.writable !== true) {
+        throw new TypeError(
+          `prepend: cannot wrap ${name} — target's own property is non-configurable and non-writable`,
+        );
+      }
     }
   }
 

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -38,14 +38,45 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     throw new TypeError("prepend: target must be an object or function");
   }
 
-  for (const name of Object.keys(mod)) {
+  // Pre-validate every method exists before mutating anything. Mirrors
+  // Rails' all-or-nothing `Module#prepend` — a missing method should
+  // leave the target state untouched instead of applying partial wraps.
+  const names = Object.keys(mod);
+  for (const name of names) {
     const original = (target as Record<string, unknown>)[name];
     if (typeof original !== "function") {
       throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);
     }
-    const wrapper = mod[name] as PrependMethod;
-    (target as Record<string, unknown>)[name] = function (this: unknown, ...args: unknown[]) {
-      return wrapper.call(this, original as Function, ...args);
-    };
   }
+
+  for (const name of names) {
+    const descriptor = findPropertyDescriptor(target, name);
+    const original = (target as Record<string, unknown>)[name] as Function;
+    const wrapper = mod[name] as PrependMethod;
+    const wrapped = function (this: unknown, ...args: unknown[]) {
+      return wrapper.call(this, original, ...args);
+    };
+    // Preserve the original property descriptor (class methods are
+    // non-enumerable by default; direct assignment would make them
+    // enumerable and leak into `Object.keys` / `for..in`). Fall back to
+    // a non-enumerable writable data property when no descriptor is
+    // found (shouldn't happen — the pre-validation above ensures the
+    // method exists somewhere on the prototype chain).
+    Object.defineProperty(target, name, {
+      value: wrapped,
+      writable: descriptor?.writable ?? true,
+      enumerable: descriptor?.enumerable ?? false,
+      configurable: descriptor?.configurable ?? true,
+    });
+  }
+}
+
+function findPropertyDescriptor(target: object, name: string): PropertyDescriptor | undefined {
+  let obj: object | null = target;
+  while (obj) {
+    const d = Object.getOwnPropertyDescriptor(obj, name);
+    if (d) return d;
+    obj = Object.getPrototypeOf(obj);
+  }
+  return undefined;
 }

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -1,0 +1,51 @@
+/**
+ * Ruby-style `prepend` — wraps methods on a target so the module's
+ * version is called first and receives the original as `super_`.
+ *
+ * Ruby's `Module#prepend` inserts the module at the front of the
+ * ancestor chain so `super` inside the module resolves to the original
+ * method. TypeScript has no prototype-chain prepend; `prepend()` wraps
+ * each target method in place. A call like `target.foo(...args)`
+ * invokes `module.foo.call(this, originalFoo, ...args)`, letting the
+ * module short-circuit or delegate via `originalFoo.call(this, ...)`.
+ *
+ * Mirrors: Ruby's `Module#prepend` — with the caveat that `super`
+ * becomes an explicit first argument because TypeScript has no
+ * language-level `super` equivalent for runtime-wrapped methods.
+ *
+ * Idempotency is the caller's responsibility — calling `prepend()` on
+ * the same target+module twice will wrap twice, producing a chain.
+ * For install-once semantics, guard with a flag as Rails does via
+ * a railtie or `installed?` check.
+ *
+ * Usage:
+ *   import { prepend } from "@blazetrails/activesupport";
+ *
+ *   prepend(Relation.prototype, {
+ *     where(super_: Function, ...args: unknown[]) {
+ *       return super_.call(this, ...processed(args));
+ *     },
+ *   });
+ */
+export type PrependMethod = (this: any, super_: Function, ...args: any[]) => unknown;
+
+export interface PrependModule {
+  readonly [methodName: string]: PrependMethod;
+}
+
+export function prepend<T extends object>(target: T, mod: PrependModule): void {
+  if (!target || (typeof target !== "object" && typeof target !== "function")) {
+    throw new TypeError("prepend: target must be an object or function");
+  }
+
+  for (const name of Object.keys(mod)) {
+    const original = (target as Record<string, unknown>)[name];
+    if (typeof original !== "function") {
+      throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);
+    }
+    const wrapper = mod[name] as PrependMethod;
+    (target as Record<string, unknown>)[name] = function (this: unknown, ...args: unknown[]) {
+      return wrapper.call(this, original as Function, ...args);
+    };
+  }
+}


### PR DESCRIPTION
## Summary

`ExtendedDeterministicQueries.installSupport()` was a no-op shell. The `RelationQueries` / `CoreQueries` / `ExtendedEncryptableType` patch helpers existed but nothing called them at runtime, so `Contact.where(email: \"x\")` / `Contact.findBy(...)` / `scope_for_create` on an encrypted attribute didn't expand.

Rails wires these via `prepend`:

\`\`\`ruby
ActiveRecord::Relation.prepend(RelationQueries)
ActiveRecord::Base.include(CoreQueries)
ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
\`\`\`

This PR wires the TS equivalent and makes the full end-to-end deterministic-encryption query flow work.

## Changes

### `@blazetrails/activesupport`

- New `prepend()` helper, completing the `include`/`extend`/`concern`/`prepend` family that mirrors Ruby's class-extension primitives. Wraps target methods in place; each module method receives the original as `super_`. Pre-validates all target methods (atomic — nothing mutates if any method is missing), walks the prototype chain for the original property descriptor, and uses `Object.defineProperty` to preserve `enumerable`/`writable`/`configurable` (so class methods stay non-enumerable and don't leak into reflection).

### `@blazetrails/activerecord`

- `ExtendedDeterministicQueries.installSupport(targets)` uses `prepend()` to patch `Relation.prototype.where`/`exists`/`scopeForCreate`, `Base.findBy`, and `EncryptedAttributeType.prototype.serialize`. Takes the classes as a `targets` param to keep the encryption submodule free of circular imports on `relation.ts` / `base.ts`. Pre-validates every target across all three `prepend()` calls before any mutation — no partial-patch state on failure. Idempotent via the existing `_installed` flag.
- `installExtendedQueriesIfConfigured()` (in `encryption/install.ts`, re-exported from `encryption/index.ts`) reads `Configurable.config.extendQueries` (Rails' `config.active_record.encryption.extend_queries`) and installs against the real `Relation`/`Base`/`EncryptedAttributeType`. App-boot code calls it once — matches Rails' railtie-based wiring.

### End-to-end round-trip fixes

Bringing the full `find_by(encrypted_attr: value)` path to Rails parity required five additional fixes:

1. `Base.arelTable` now wires a `TypeCasterMap` so `arelTable.typeForAttribute(col)` resolves through the model's attribute definitions. Without it, `PredicateBuilder.buildBindAttribute` fell back to a pass-through shim, and values bypassed `EncryptedAttributeType.serialize` — WHERE clauses emitted raw plaintext instead of ciphertext.
2. `EncryptedAttributeType.previousTypes` now appends a NullEncryptor-backed `clean_text_scheme` when `support_unencrypted_data?` is true (mirrors Rails' `previous_schemes_including_clean_text`), so query expansion includes a plaintext fallback and matches rows written before encryption was enabled. Memoizes on the flag so runtime config toggles recompute.
3. `EncryptedAttributeType.cast` passes `AdditionalValue` instances through unchanged via a brand symbol. The default cast coerced AVs to strings via `toString`, which the subsequent serialize then re-encrypted — producing a double-encrypted blob on save.
4. `RelationQueries.scopeForCreate` keeps the `AdditionalValue` reference rather than unwrapping to its `.value` (ciphertext). Serialize unwraps once on save; writing the bare ciphertext would double-encrypt.
5. `performFindBy` catches `RangeError` from type serialization (e.g. integer larger than the column can hold) and returns `null`, matching Rails — nothing can match such a value, so there's nothing to find.

## Test plan

- [x] `@blazetrails/activesupport`: 9 `prepend()` tests (wrap/this-binding/short-circuit/chaining/error cases/static members/descriptor preservation/atomicity).
- [x] 5 installSupport unit tests against isolated fake classes + 2 real-class integration tests.
- [x] `scope_for_create` unit + real-relation integration coverage.
- [x] Full activerecord suite: 8998 passing, 0 regressions.
- [ ] A follow-up PR (#752) unskips all 12 Rails-named end-to-end tests in `extended-deterministic-queries.test.ts` against this wiring.