### PR TITLE
feat(activemodel,activerecord): validate/invalid?/validate! return-shape parity

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1123,17 +1123,23 @@ export class Model {
   }
 
   /**
-   * Run validations and return self.
+   * Run validations and return whether the record is valid.
    *
-   * Mirrors: ActiveModel::Validations#validate
+   * Mirrors Rails `alias_method :validate, :valid?`
+   * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string | ValidationContext): this {
-    this.isValid(context);
-    return this;
+  validate(context?: string | ValidationContext): boolean {
+    return this.isValid(context);
   }
 
-  isInvalid(): boolean {
-    return !this.isValid();
+  /**
+   * Opposite of `isValid`. Accepts an optional context.
+   *
+   * Mirrors Rails `def invalid?(context = nil); !valid?(context); end`
+   * (activemodel/lib/active_model/validations.rb:408-410).
+   */
+  isInvalid(context?: string | ValidationContext): boolean {
+    return !this.isValid(context);
   }
 
   // -- Dirty tracking --
@@ -1532,11 +1538,13 @@ export class Model {
   }
 
   /**
-   * Run validations, throw if invalid.
+   * Run validations. Returns `true` when valid; raises `ValidationError`
+   * otherwise — never returns `false`.
    *
-   * Mirrors: ActiveModel::Validations#validate!
+   * Mirrors Rails `def validate!(context = nil); valid?(context) || raise_validation_error; end`
+   * (activemodel/lib/active_model/validations.rb:417-419).
    */
-  validateBang(context?: string): boolean {
+  validateBang(context?: string | ValidationContext): true {
     if (!this.isValid(context)) {
       throw new ValidationError(this);
     }

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -979,4 +979,35 @@ describe("ValidationsTest", () => {
     }
     expect(() => new Topic({}).isValid()).toThrow(/title/i);
   });
+
+  describe("return-shape parity", () => {
+    class Topic extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { presence: true });
+      }
+    }
+
+    it("validate returns boolean (Rails alias_method :validate, :valid?)", () => {
+      expect(new Topic({ title: "ok" }).validate()).toBe(true);
+      expect(new Topic({}).validate()).toBe(false);
+    });
+
+    it("invalid? accepts a context argument", () => {
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true, on: "create" });
+        }
+      }
+      const s = new Scoped({});
+      expect(s.isInvalid()).toBe(false);
+      expect(s.isInvalid("create")).toBe(true);
+    });
+
+    it("validate! returns true and raises otherwise (never returns false)", () => {
+      expect(new Topic({ title: "ok" }).validateBang()).toBe(true);
+      expect(() => new Topic({}).validateBang()).toThrow(/Validation failed/);
+    });
+  });
 });

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1009,5 +1009,33 @@ describe("ValidationsTest", () => {
       expect(new Topic({ title: "ok" }).validateBang()).toBe(true);
       expect(() => new Topic({}).validateBang()).toThrow(/Validation failed/);
     });
+
+    it("validate! forwards context to valid?", () => {
+      // Rails validations.rb:417-419 — `valid?(context) || raise_validation_error`.
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true, on: "create" });
+        }
+      }
+      // No context → default context → no validators active → passes.
+      expect(new Scoped({}).validateBang()).toBe(true);
+      // :create context → presence validator active → raises.
+      expect(() => new Scoped({}).validateBang("create")).toThrow(/Validation failed/);
+    });
+
+    it("valid? restores previous context in ensure/finally even on failure", () => {
+      // Rails validations.rb:361-368 uses `ensure` to restore context.
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true });
+        }
+      }
+      const m = new Scoped({});
+      const before = m.validationContext;
+      m.isValid("custom");
+      expect(m.validationContext).toBe(before);
+    });
   });
 });

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -12,9 +12,23 @@ import type { ConditionalOptions } from "./validator.js";
 export interface Validations {
   errors: Errors;
   isValid(context?: string | ValidationContext): boolean;
-  validate(context?: string | ValidationContext): this;
-  isInvalid(): boolean;
-  validateBang(context?: string | ValidationContext): boolean;
+  /**
+   * Run validations and return whether the record is valid.
+   * Mirrors Rails `alias_method :validate, :valid?`
+   * (activemodel/lib/active_model/validations.rb:370).
+   */
+  validate(context?: string | ValidationContext): boolean;
+  /**
+   * Opposite of `isValid`. Mirrors Rails `def invalid?(context = nil)`
+   * (activemodel/lib/active_model/validations.rb:408-410).
+   */
+  isInvalid(context?: string | ValidationContext): boolean;
+  /**
+   * Run validations; return `true` or raise `ValidationError`. Mirrors Rails
+   * `def validate!(context = nil); valid?(context) || raise_validation_error; end`
+   * (activemodel/lib/active_model/validations.rb:417-419) — never returns false.
+   */
+  validateBang(context?: string | ValidationContext): true;
   readonly validationContext: string | ValidationContext | null;
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2629,7 +2629,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   loadBelongsTo(name: string): Promise<Base | null>;
   loadHasOne(name: string): Promise<Base | null>;
   readAttributeForValidation(attribute: string): unknown;
-  validate(context?: string): this;
+  validate(context?: string): boolean;
   customValidationContext(): boolean;
   increment(attribute: string, by?: number): this;
   decrement(attribute: string, by?: number): this;

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -52,7 +52,12 @@ export class RecordInvalid extends ActiveRecordError {
  * Mirrors: ActiveRecord::Validations (module instance methods)
  */
 export interface Validations {
-  validate(context?: string): this;
+  /**
+   * Run validations and return whether the record is valid. AR inherits
+   * AM's alias `validate → valid?`
+   * (activemodel/lib/active_model/validations.rb:370).
+   */
+  validate(context?: string): boolean;
   isValid(context?: string): boolean;
 }
 
@@ -104,11 +109,11 @@ export function isValid(this: any, context?: string): boolean {
 }
 
 /**
- * Mirrors: ActiveRecord::Validations#validate (alias of valid?)
+ * Mirrors: ActiveRecord::Validations#validate — inherited alias of `valid?`
+ * (activemodel/lib/active_model/validations.rb:370).
  */
-export function validate(this: any, context?: string): any {
-  isValid.call(this, context);
-  return this;
+export function validate(this: any, context?: string): boolean {
+  return isValid.call(this, context);
 }
 
 /**


### PR DESCRIPTION
## Summary

PR 7 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md). Three Rails-API shape mismatches around validation.

| Rails | Before | After |
|---|---|---|
| `alias :validate, :valid?` (validations.rb:370) → `Boolean` | returned `this` | returns `boolean` |
| `def invalid?(context = nil)` (validations.rb:408) | took no args | accepts `context?` |
| `def validate!(context = nil)` → `true` or raises (validations.rb:417) | typed `boolean` | typed `true` |

`validate!` runtime already raised on failure; tightening the type stops consumers from writing `if (model.validateBang())` as if it could return `false`.

ActiveRecord::Validations also updated — AR inherits AM's `validate → valid?` alias, so `AR::Validations#validate` gets the same boolean return.

No existing callers relied on the old `this` return (grep-confirmed: only test-local invocations and arel's unrelated `.validate()`).

## Test plan

- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10374/10374
- [x] Added `return-shape parity` suite (`validations.test.ts`) exercising all three changes.
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`