### PR TITLE
feat(activemodel): ValidationError uses I18n :model_invalid + Model#freeze

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1142,6 +1142,32 @@ export class Model {
     return !this.isValid(context);
   }
 
+  /**
+   * Freeze this model instance. Mirrors Rails
+   * `ActiveModel::Validations#freeze` (activemodel/lib/active_model/validations.rb:372-377):
+   *
+   *   def freeze
+   *     errors
+   *     context_for_validation
+   *     super
+   *   end
+   *
+   * Rails pre-touches `@errors` and `@context_for_validation` so frozen
+   * models can still answer `#errors` and `#validation_context` without
+   * tripping their `||=` lazy-init. Our `errors` is already eager
+   * (`model.ts:954`) and `_validationContext` is eagerly `null`, so the
+   * pre-touch is a no-op — we still expose the method for API parity so
+   * `model.freeze()` works Rails-style and locks the object under
+   * `Object.freeze`.
+   */
+  freeze(): this {
+    // Touch state that Rails lazy-inits so it survives the freeze.
+    void this.errors;
+    void this._validationContext;
+    Object.freeze(this);
+    return this;
+  }
+
   // -- Dirty tracking --
 
   get changed(): boolean {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1154,16 +1154,14 @@ export class Model {
    *
    * Rails pre-touches `@errors` and `@context_for_validation` so frozen
    * models can still answer `#errors` and `#validation_context` without
-   * tripping their `||=` lazy-init. Our `errors` is already eager
-   * (`model.ts:954`) and `_validationContext` is eagerly `null`, so the
-   * pre-touch is a no-op — we still expose the method for API parity so
-   * `model.freeze()` works Rails-style and locks the object under
-   * `Object.freeze`.
+   * tripping their `||=` lazy-init. We mirror that by going through the
+   * public API (`.errors`, `.validationContext`) — that way, if either
+   * becomes lazy in the future, the pre-materialization still runs
+   * without this method coupling to private fields.
    */
   freeze(): this {
-    // Touch state that Rails lazy-inits so it survives the freeze.
     void this.errors;
-    void this._validationContext;
+    void this.validationContext;
     Object.freeze(this);
     return this;
   }

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1038,4 +1038,52 @@ describe("ValidationsTest", () => {
       expect(m.validationContext).toBe(before);
     });
   });
+
+  describe("ValidationError + freeze (Rails fidelity)", () => {
+    class Topic extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { presence: true });
+      }
+    }
+
+    it("ValidationError message comes from I18n :model_invalid", () => {
+      // Default en → "Validation failed: %{errors}"
+      // (activemodel locale/en.yml:9).
+      expect(() => new Topic({}).validateBang()).toThrow(
+        /^Validation failed: Title can't be blank$/,
+      );
+    });
+
+    it("ValidationError message picks up per-scope override", async () => {
+      const { I18n } = await import("./i18n.js");
+      I18n.storeTranslations("en", {
+        activemodel: {
+          errors: {
+            messages: { model_invalid: "Nope: %{errors}" },
+          },
+        },
+      });
+      try {
+        expect(() => new Topic({}).validateBang()).toThrow(/^Nope: /);
+      } finally {
+        I18n.reset();
+      }
+    });
+
+    it("freeze locks the object and returns self", () => {
+      const t = new Topic({ title: "ok" });
+      expect(t.freeze()).toBe(t);
+      expect(Object.isFrozen(t)).toBe(true);
+    });
+
+    it("freeze preserves errors/validationContext access (Rails pre-touch)", () => {
+      const t = new Topic({ title: "ok" });
+      t.freeze();
+      // Rails validations.rb:372-377 ensures these lazy ivars are
+      // materialized so frozen models can still answer.
+      expect(t.errors).toBeDefined();
+      expect(t.validationContext).toBe(null);
+    });
+  });
 });

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -1,5 +1,6 @@
 import type { Errors } from "./errors.js";
 import type { ConditionalOptions } from "./validator.js";
+import { I18n } from "./i18n.js";
 
 /**
  * Validations mixin contract — provides the validation lifecycle.
@@ -61,9 +62,25 @@ export class ValidationError extends globalThis.Error {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly model: any;
 
+  // Mirrors Rails `ActiveModel::ValidationError#initialize`
+  // (activemodel/lib/active_model/validations.rb:496-500):
+  //
+  //   def initialize(model)
+  //     @model = model
+  //     errors = @model.errors.full_messages.join(", ")
+  //     super(I18n.t(:"#{@model.class.i18n_scope}.errors.messages.model_invalid",
+  //                  errors: errors, default: :"errors.messages.model_invalid"))
+  //   end
+  //
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(model: any) {
-    super(`Validation failed: ${model.errors.fullMessages.join(", ")}`);
+    const errors = model.errors.fullMessages.join(", ");
+    const scope: string = model.constructor?.i18nScope ?? "activemodel";
+    const message = I18n.t(`${scope}.errors.messages.model_invalid`, {
+      errors,
+      defaults: [{ key: "errors.messages.model_invalid" }],
+    });
+    super(message);
     this.name = "ValidationError";
     this.model = model;
   }

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -75,7 +75,10 @@ export class ValidationError extends globalThis.Error {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(model: any) {
     const errors = model.errors.fullMessages.join(", ");
-    const scope: string = model.constructor?.i18nScope ?? "activemodel";
+    // Match the guard used by `error.ts`'s I18n lookups — only treat
+    // `i18nScope` as a scope when the class actually exposes a string.
+    const rawScope = model.constructor?.i18nScope;
+    const scope = typeof rawScope === "string" ? rawScope : "activemodel";
     const message = I18n.t(`${scope}.errors.messages.model_invalid`, {
       errors,
       defaults: [{ key: "errors.messages.model_invalid" }],


### PR DESCRIPTION
## Summary

PR 9 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

### 1. `ValidationError` message via I18n

Rails `validations.rb:496-500`:
\`\`\`ruby
def initialize(model)
  @model = model
  errors = @model.errors.full_messages.join(", ")
  super(I18n.t(:"#{@model.class.i18n_scope}.errors.messages.model_invalid",
               errors: errors, default: :"errors.messages.model_invalid"))
end
\`\`\`

Previously hard-coded English. Now:
- primary lookup: `${i18nScope}.errors.messages.model_invalid`
- fallback: `errors.messages.model_invalid`

Default en translation is already in `i18n.ts` at `activemodel.errors.messages.model_invalid: "Validation failed: %{errors}"` (matches `locale/en.yml:9`), so the observable message for default-locale users is unchanged — but subclasses can now override per-scope and apps can swap locales.

### 2. `Model#freeze`

Rails `validations.rb:372-377`:
\`\`\`ruby
def freeze
  errors
  context_for_validation
  super
end
\`\`\`

Ours touches `errors`/`_validationContext` (both eagerly initialized already), then `Object.freeze(this); return self`. Adds the Rails-style instance `.freeze()` API.

## Test plan

- [x] `ValidationError message comes from I18n :model_invalid`
- [x] `ValidationError message picks up per-scope override` (via `I18n.storeTranslations`)
- [x] `freeze locks the object and returns self`
- [x] `freeze preserves errors/validationContext access (Rails pre-touch)`
- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10388/10388
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`