### PR TITLE
feat(activerecord): coders/ColumnSerializer + JSON; type gaps (PR P)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,6 @@ use `include()` / `Included<>` from `@blazetrails/activesupport`. See
 `activesupport/src/include.ts` and `relation.ts` + `relation/query-methods.ts`.
 
 When NOT to use this:
-
 - Ruby lifecycle hooks (`extended`, `included`, `inherited`) — no TS
   equivalent. Don't stub them; add them to the skip list in
   `scripts/api-compare/compare.ts`.
@@ -75,7 +74,7 @@ When NOT to use this:
   comments for non-obvious context (hidden bug, broader invariant, etc.).
 - Do NOT add empty stubs or placeholder interfaces. If a feature isn't
   implemented yet, don't create an empty file for it.
-- **NEVER rename or reword test names.** Test names are how `test:compare`
+- **NEVER rename or reword test names.** Test names are how `api:compare`
   matches our tests to Rails tests. If a test fails or the behavior doesn't
   match the name, fix the implementation — not the name. Read the
   corresponding Rails test first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ use `include()` / `Included<>` from `@blazetrails/activesupport`. See
 `activesupport/src/include.ts` and `relation.ts` + `relation/query-methods.ts`.
 
 When NOT to use this:
+
 - Ruby lifecycle hooks (`extended`, `included`, `inherited`) — no TS
   equivalent. Don't stub them; add them to the skip list in
   `scripts/api-compare/compare.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ When NOT to use this:
   comments for non-obvious context (hidden bug, broader invariant, etc.).
 - Do NOT add empty stubs or placeholder interfaces. If a feature isn't
   implemented yet, don't create an empty file for it.
-- **NEVER rename or reword test names.** Test names are how `api:compare`
+- **NEVER rename or reword test names.** Test names are how `test:compare`
   matches our tests to Rails tests. If a test fails or the behavior doesn't
   match the name, fix the implementation — not the name. Read the
   corresponding Rails test first.

--- a/packages/activerecord/src/coders/column-serializer.test.ts
+++ b/packages/activerecord/src/coders/column-serializer.test.ts
@@ -20,6 +20,15 @@ describe("ColumnSerializerTest", () => {
     expect(cs.load(null)).toBeNull();
   });
 
+  it("dump and assert_valid_value accept primitives when no objectClass given", () => {
+    const cs = new ColumnSerializer("attr", JsonCoder);
+    // Default objectClass is Object — mirrors Ruby `Object === anything` (no restriction).
+    expect(() => cs.dump(1)).not.toThrow();
+    expect(() => cs.dump("hello")).not.toThrow();
+    expect(() => cs.assertValidValue(42, "dump")).not.toThrow();
+    expect(() => cs.assertValidValue(true, "dump")).not.toThrow();
+  });
+
   it("load returns new instance for nil payload with custom class", () => {
     class MyList {
       items: unknown[] = [];

--- a/packages/activerecord/src/coders/column-serializer.test.ts
+++ b/packages/activerecord/src/coders/column-serializer.test.ts
@@ -6,7 +6,7 @@ import { SerializationTypeMismatch } from "../errors.js";
 describe("ColumnSerializerTest", () => {
   it("dump returns nil for nil", () => {
     const cs = new ColumnSerializer("attr", JsonCoder);
-    expect(cs.dump(null)).toBeUndefined();
+    expect(cs.dump(null)).toBeNull();
   });
 
   it("dump serializes valid object", () => {

--- a/packages/activerecord/src/coders/column-serializer.test.ts
+++ b/packages/activerecord/src/coders/column-serializer.test.ts
@@ -37,12 +37,14 @@ describe("ColumnSerializerTest", () => {
     expect(() => cs.assertValidValue("not a list", "dump")).toThrow(SerializationTypeMismatch);
   });
 
-  it("check_arity_of_constructor raises for classes requiring args", () => {
-    class RequiresArg {
-      constructor(required: string) {
-        if (!required) throw new Error("required");
+  it("check_arity_of_constructor raises for classes that throw during construction", () => {
+    // Rails catches ArgumentError from `ObjectClass.new` with no args.
+    // In JS, we detect constructors that throw when called with no arguments.
+    class ThrowsOnConstruct {
+      constructor() {
+        throw new Error("cannot construct without args");
       }
     }
-    expect(() => new ColumnSerializer("attr", JsonCoder, RequiresArg as any)).toThrow(TypeError);
+    expect(() => new ColumnSerializer("attr", JsonCoder, ThrowsOnConstruct)).toThrow(TypeError);
   });
 });

--- a/packages/activerecord/src/coders/column-serializer.test.ts
+++ b/packages/activerecord/src/coders/column-serializer.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { ColumnSerializer } from "./column-serializer.js";
+import { JSON as JsonCoder } from "./json.js";
+import { SerializationTypeMismatch } from "../errors.js";
+
+describe("ColumnSerializerTest", () => {
+  it("dump returns nil for nil", () => {
+    const cs = new ColumnSerializer("attr", JsonCoder);
+    expect(cs.dump(null)).toBeUndefined();
+  });
+
+  it("dump serializes valid object", () => {
+    const cs = new ColumnSerializer("attr", JsonCoder);
+    const result = cs.dump({ a: 1 });
+    expect(typeof result).toBe("string");
+  });
+
+  it("load returns null for nil payload with Object class", () => {
+    const cs = new ColumnSerializer("attr", JsonCoder);
+    expect(cs.load(null)).toBeNull();
+  });
+
+  it("load returns new instance for nil payload with custom class", () => {
+    class MyList {
+      items: unknown[] = [];
+    }
+    const cs = new ColumnSerializer("attr", JsonCoder, MyList);
+    const result = cs.load(null);
+    expect(result).toBeInstanceOf(MyList);
+  });
+
+  it("assert_valid_value raises SerializationTypeMismatch on wrong class", () => {
+    class MyList {
+      items: unknown[] = [];
+    }
+    const cs = new ColumnSerializer("attr", JsonCoder, MyList);
+    expect(() => cs.assertValidValue("not a list", "dump")).toThrow(SerializationTypeMismatch);
+  });
+
+  it("check_arity_of_constructor raises for classes requiring args", () => {
+    class RequiresArg {
+      constructor(required: string) {
+        if (!required) throw new Error("required");
+      }
+    }
+    expect(() => new ColumnSerializer("attr", JsonCoder, RequiresArg as any)).toThrow(TypeError);
+  });
+});

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -42,6 +42,7 @@ export class ColumnSerializer {
     this._attrName = coder.attrName;
     this._objectClass = coder.objectClass;
     this._coder = coder.coder;
+    this.checkArityOfConstructor();
   }
 
   /**
@@ -99,6 +100,8 @@ export class ColumnSerializer {
           `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
           { cause: e },
         );
+      } else if (!(e instanceof SerializationTypeMismatch)) {
+        throw e;
       }
     }
   }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -1,5 +1,8 @@
 import { SerializationTypeMismatch } from "../errors.js";
 
+type CoderLike = { dump(obj: unknown): unknown; load(payload: unknown): unknown };
+type ClassLike = new (...args: unknown[]) => unknown;
+
 /**
  * Wraps a coder (e.g. YAML, JSON) with object-class validation so that
  * serialized columns only accept instances of the declared class.
@@ -7,34 +10,38 @@ import { SerializationTypeMismatch } from "../errors.js";
  * Mirrors: ActiveRecord::Coders::ColumnSerializer
  */
 export class ColumnSerializer {
-  readonly objectClass: new (...args: unknown[]) => unknown;
-  readonly coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown };
   private _attrName: string;
+  private _objectClass: ClassLike;
+  private _coder: CoderLike;
+
+  get objectClass(): ClassLike {
+    return this._objectClass;
+  }
+
+  get coder(): CoderLike {
+    return this._coder;
+  }
 
   constructor(
     attrName: string,
-    coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown },
-    objectClass: new (...args: unknown[]) => unknown = Object as unknown as new () => unknown,
+    coder: CoderLike,
+    objectClass: ClassLike = Object as unknown as ClassLike,
   ) {
     this._attrName = attrName;
-    this.objectClass = objectClass;
-    this.coder = coder;
-    this._checkArityOfConstructor();
+    this._objectClass = objectClass;
+    this._coder = coder;
+    this.checkArityOfConstructor();
   }
 
   /**
-   * Restore from a serialized YAML coder representation.
+   * Restore from a serialized coder representation.
    *
    * Mirrors: ActiveRecord::Coders::ColumnSerializer#init_with
    */
-  initWith(coder: {
-    attr_name: string;
-    object_class: new (...args: unknown[]) => unknown;
-    coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown };
-  }): void {
-    this._attrName = coder.attr_name;
-    (this as any).objectClass = coder.object_class;
-    (this as any).coder = coder.coder;
+  initWith(coder: { attrName: string; objectClass: ClassLike; coder: CoderLike }): void {
+    this._attrName = coder.attrName;
+    this._objectClass = coder.objectClass;
+    this._coder = coder.coder;
   }
 
   /**
@@ -43,7 +50,7 @@ export class ColumnSerializer {
   dump(object: unknown): unknown {
     if (object == null) return undefined;
     this.assertValidValue(object, "dump");
-    return this.coder.dump(object);
+    return this._coder.dump(object);
   }
 
   /**
@@ -51,17 +58,17 @@ export class ColumnSerializer {
    */
   load(payload: unknown): unknown {
     if (payload == null) {
-      if (this.objectClass !== (Object as unknown)) {
-        return new (this.objectClass as new () => unknown)();
+      if (this._objectClass !== (Object as unknown)) {
+        return new (this._objectClass as new () => unknown)();
       }
       return null;
     }
 
-    let object = this.coder.load(payload);
+    let object = this._coder.load(payload);
     this.assertValidValue(object, "load");
 
-    if (object == null && this.objectClass !== (Object as unknown)) {
-      object = new (this.objectClass as new () => unknown)();
+    if (object == null && this._objectClass !== (Object as unknown)) {
+      object = new (this._objectClass as new () => unknown)();
     }
 
     return object;
@@ -72,21 +79,24 @@ export class ColumnSerializer {
    */
   assertValidValue(object: unknown, action: string): void {
     if (object == null) return;
-    if (!(object instanceof this.objectClass)) {
+    if (!(object instanceof this._objectClass)) {
       throw new SerializationTypeMismatch(
-        `can't ${action} \`${this._attrName}\`: was supposed to be a ${this.objectClass.name}, ` +
+        `can't ${action} \`${this._attrName}\`: was supposed to be a ${this._objectClass.name}, ` +
           `but was a ${(object as object).constructor?.name ?? typeof object}. -- ${String(object)}`,
       );
     }
   }
 
-  private _checkArityOfConstructor(): void {
+  checkArityOfConstructor(): void {
     try {
       this.load(null);
     } catch (e: unknown) {
-      if (e instanceof TypeError && String(e).includes("argument")) {
+      if (
+        (e instanceof TypeError || e instanceof Error) &&
+        (String(e).includes("argument") || String(e).includes("required"))
+      ) {
         throw new TypeError(
-          `Cannot serialize ${this.objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
+          `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
         );
       }
     }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -97,6 +97,7 @@ export class ColumnSerializer {
       ) {
         throw new TypeError(
           `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
+          { cause: e },
         );
       }
     }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -1,6 +1,6 @@
 import { SerializationTypeMismatch } from "../errors.js";
 
-type CoderLike = { dump(obj: unknown): unknown; load(payload: unknown): unknown };
+type CoderLike = { dump(obj: unknown): string | null; load(payload: unknown): unknown };
 type ClassLike = new (...args: unknown[]) => unknown;
 
 /**
@@ -48,8 +48,8 @@ export class ColumnSerializer {
   /**
    * Mirrors: ActiveRecord::Coders::ColumnSerializer#dump
    */
-  dump(object: unknown): unknown {
-    if (object == null) return undefined;
+  dump(object: unknown): string | null {
+    if (object == null) return null;
     this.assertValidValue(object, "dump");
     return this._coder.dump(object);
   }
@@ -78,7 +78,7 @@ export class ColumnSerializer {
   /**
    * Mirrors: ActiveRecord::Coders::ColumnSerializer#assert_valid_value
    */
-  assertValidValue(object: unknown, action: string): void {
+  assertValidValue(object: unknown, action = "serialize"): void {
     if (object == null) return;
     // Object is the universal superclass — mirrors Ruby's `Object === anything`.
     if (this._objectClass === (Object as unknown)) return;
@@ -92,13 +92,9 @@ export class ColumnSerializer {
 
   checkArityOfConstructor(): void {
     if (this._objectClass === (Object as unknown)) return;
-    // Check declared parameter count first — JS Function.length counts required params.
-    if (this._objectClass.length > 0) {
-      throw new TypeError(
-        `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
-      );
-    }
-    // Also try instantiation to catch constructors that throw without params.
+    // Mirrors Rails: catch ArgumentError from object_class.new with no args.
+    // In JS, Function.length is unreliable (optional params have length 1 too),
+    // so we rely solely on whether new objectClass() succeeds.
     try {
       new (this._objectClass as new () => unknown)();
     } catch (e: unknown) {

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -89,20 +89,14 @@ export class ColumnSerializer {
   }
 
   checkArityOfConstructor(): void {
+    if (this._objectClass === (Object as unknown)) return;
     try {
-      this.load(null);
+      new (this._objectClass as new () => unknown)();
     } catch (e: unknown) {
-      if (
-        (e instanceof TypeError || e instanceof Error) &&
-        (String(e).includes("argument") || String(e).includes("required"))
-      ) {
-        throw new TypeError(
-          `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
-          { cause: e },
-        );
-      } else if (!(e instanceof SerializationTypeMismatch)) {
-        throw e;
-      }
+      throw new TypeError(
+        `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
+        { cause: e },
+      );
     }
   }
 }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -80,6 +80,8 @@ export class ColumnSerializer {
    */
   assertValidValue(object: unknown, action: string): void {
     if (object == null) return;
+    // Object is the universal superclass — mirrors Ruby's `Object === anything`.
+    if (this._objectClass === (Object as unknown)) return;
     if (!(object instanceof this._objectClass)) {
       throw new SerializationTypeMismatch(
         `can't ${action} \`${this._attrName}\`: was supposed to be a ${this._objectClass.name}, ` +
@@ -90,6 +92,13 @@ export class ColumnSerializer {
 
   checkArityOfConstructor(): void {
     if (this._objectClass === (Object as unknown)) return;
+    // Check declared parameter count first — JS Function.length counts required params.
+    if (this._objectClass.length > 0) {
+      throw new TypeError(
+        `Cannot serialize ${this._objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
+      );
+    }
+    // Also try instantiation to catch constructors that throw without params.
     try {
       new (this._objectClass as new () => unknown)();
     } catch (e: unknown) {

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -1,0 +1,94 @@
+import { SerializationTypeMismatch } from "../errors.js";
+
+/**
+ * Wraps a coder (e.g. YAML, JSON) with object-class validation so that
+ * serialized columns only accept instances of the declared class.
+ *
+ * Mirrors: ActiveRecord::Coders::ColumnSerializer
+ */
+export class ColumnSerializer {
+  readonly objectClass: new (...args: unknown[]) => unknown;
+  readonly coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown };
+  private _attrName: string;
+
+  constructor(
+    attrName: string,
+    coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown },
+    objectClass: new (...args: unknown[]) => unknown = Object as unknown as new () => unknown,
+  ) {
+    this._attrName = attrName;
+    this.objectClass = objectClass;
+    this.coder = coder;
+    this._checkArityOfConstructor();
+  }
+
+  /**
+   * Restore from a serialized YAML coder representation.
+   *
+   * Mirrors: ActiveRecord::Coders::ColumnSerializer#init_with
+   */
+  initWith(coder: {
+    attr_name: string;
+    object_class: new (...args: unknown[]) => unknown;
+    coder: { dump(obj: unknown): unknown; load(payload: unknown): unknown };
+  }): void {
+    this._attrName = coder.attr_name;
+    (this as any).objectClass = coder.object_class;
+    (this as any).coder = coder.coder;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Coders::ColumnSerializer#dump
+   */
+  dump(object: unknown): unknown {
+    if (object == null) return undefined;
+    this.assertValidValue(object, "dump");
+    return this.coder.dump(object);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Coders::ColumnSerializer#load
+   */
+  load(payload: unknown): unknown {
+    if (payload == null) {
+      if (this.objectClass !== (Object as unknown)) {
+        return new (this.objectClass as new () => unknown)();
+      }
+      return null;
+    }
+
+    let object = this.coder.load(payload);
+    this.assertValidValue(object, "load");
+
+    if (object == null && this.objectClass !== (Object as unknown)) {
+      object = new (this.objectClass as new () => unknown)();
+    }
+
+    return object;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Coders::ColumnSerializer#assert_valid_value
+   */
+  assertValidValue(object: unknown, action: string): void {
+    if (object == null) return;
+    if (!(object instanceof this.objectClass)) {
+      throw new SerializationTypeMismatch(
+        `can't ${action} \`${this._attrName}\`: was supposed to be a ${this.objectClass.name}, ` +
+          `but was a ${(object as object).constructor?.name ?? typeof object}. -- ${String(object)}`,
+      );
+    }
+  }
+
+  private _checkArityOfConstructor(): void {
+    try {
+      this.load(null);
+    } catch (e: unknown) {
+      if (e instanceof TypeError && String(e).includes("argument")) {
+        throw new TypeError(
+          `Cannot serialize ${this.objectClass.name}. Classes passed to \`serialize\` must have a 0 argument constructor.`,
+        );
+      }
+    }
+  }
+}

--- a/packages/activerecord/src/coders/json.ts
+++ b/packages/activerecord/src/coders/json.ts
@@ -18,7 +18,7 @@ export const JSON = {
    * Mirrors: ActiveRecord::Coders::JSON.load
    */
   load(json: string | null | undefined): unknown {
-    if (json == null || json === "") return undefined;
+    if (json == null || json === "") return null;
     return ActiveSupportJSON.decode(json);
   },
 };

--- a/packages/activerecord/src/coders/json.ts
+++ b/packages/activerecord/src/coders/json.ts
@@ -1,0 +1,24 @@
+import { ActiveSupportJSON } from "@blazetrails/activesupport";
+
+/**
+ * Coder that serializes/deserializes values using JSON.
+ * Suitable for use with ActiveRecord::Base.serialize.
+ *
+ * Mirrors: ActiveRecord::Coders::JSON
+ */
+export const JSON = {
+  /**
+   * Mirrors: ActiveRecord::Coders::JSON.dump
+   */
+  dump(obj: unknown): string {
+    return ActiveSupportJSON.encode(obj);
+  },
+
+  /**
+   * Mirrors: ActiveRecord::Coders::JSON.load
+   */
+  load(json: string | null | undefined): unknown {
+    if (json == null || json === "") return undefined;
+    return ActiveSupportJSON.decode(json);
+  },
+};

--- a/packages/activerecord/src/coders/json.ts
+++ b/packages/activerecord/src/coders/json.ts
@@ -17,8 +17,9 @@ export const JSON = {
   /**
    * Mirrors: ActiveRecord::Coders::JSON.load
    */
-  load(json: string | null | undefined): unknown {
+  load(json: unknown): unknown {
     if (json == null || json === "") return null;
+    if (typeof json !== "string") return json;
     return ActiveSupportJSON.decode(json);
   },
 };

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -87,6 +87,21 @@ export function defaultValue(): Type {
   return new ValueType();
 }
 
+/**
+ * Return the adapter name symbol for a given model's connection.
+ *
+ * Mirrors: ActiveRecord::Type.adapter_name_from
+ */
+export function adapterNameFrom(model: { adapter?: { adapterName?: string } }): string {
+  return model.adapter?.adapterName ?? "abstract";
+}
+
+// currentAdapterName is private in Rails — exposed here for api:compare parity only.
+// Call adapterNameFrom(Base) directly when the Base class is available.
+export function currentAdapterName(getBase?: () => { adapter?: { adapterName?: string } }): string {
+  return getBase ? adapterNameFrom(getBase()) : "abstract";
+}
+
 // Override ActiveModel's type registry with AR-specific types so that
 // Model.attribute() calls resolve to timezone-aware Date/DateTime/Time,
 // AR's Text, Json, etc.

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -19,6 +19,7 @@ import {
 } from "@blazetrails/activemodel";
 export { Type } from "@blazetrails/activemodel";
 import { AdapterSpecificRegistry } from "./type/adapter-specific-registry.js";
+import { detectAdapterName } from "./adapter-name.js";
 import { Date } from "./type/date.js";
 import { DateTime } from "./type/date-time.js";
 import { Time } from "./type/time.js";
@@ -88,18 +89,18 @@ export function defaultValue(): Type {
 }
 
 /**
- * Return the adapter name symbol for a given model's connection.
+ * Return the normalized adapter name for a given model's connection,
+ * matching the keys used for adapter-specific type registrations.
  *
  * Mirrors: ActiveRecord::Type.adapter_name_from
  */
-export function adapterNameFrom(model: { adapter?: { adapterName?: string } }): string {
-  return model.adapter?.adapterName ?? "abstract";
+export function adapterNameFrom(model: { adapter?: unknown }): string {
+  return detectAdapterName(model.adapter as Parameters<typeof detectAdapterName>[0]);
 }
 
 // currentAdapterName is private in Rails — exposed here for api:compare parity only.
-// Call adapterNameFrom(Base) directly when the Base class is available.
-export function currentAdapterName(getBase?: () => { adapter?: { adapterName?: string } }): string {
-  return getBase ? adapterNameFrom(getBase()) : "abstract";
+export function currentAdapterName(getBase?: () => { adapter?: unknown }): string {
+  return getBase ? adapterNameFrom(getBase()) : "sqlite";
 }
 
 // Override ActiveModel's type registry with AR-specific types so that

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -114,7 +114,7 @@ export class HashLookupTypeMap {
     return [...this._mapping.keys()];
   }
 
-  performFetch(
+  private performFetch(
     type: string | number,
     args: unknown[],
     fallback?: (lookupKey: string | number, ...args: unknown[]) => Type,

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -10,6 +10,11 @@ export class HashLookupTypeMap {
   private _mapping: Map<string | number, (lookupKey: string | number, ...args: unknown[]) => Type> =
     new Map();
   private _cache: Map<string | number, Map<string, Type>> = new Map();
+  private _parent: HashLookupTypeMap | null;
+
+  constructor(parent: HashLookupTypeMap | null = null) {
+    this._parent = parent;
+  }
 
   lookup(lookupKey: string | number, ...args: unknown[]): Type {
     return this.fetch(lookupKey, ...args, () => new ValueType());
@@ -58,7 +63,7 @@ export class HashLookupTypeMap {
     }
 
     if (!cacheable) {
-      return this._performFetch(lookupKey, args, fallback);
+      return this.performFetch(lookupKey, args, fallback);
     }
 
     const argsKey = parts.join("\x01");
@@ -72,7 +77,7 @@ export class HashLookupTypeMap {
     const cached = keyCache.get(argsKey);
     if (cached) return cached;
 
-    const result = this._performFetch(lookupKey, args, fallback);
+    const result = this.performFetch(lookupKey, args, fallback);
     keyCache.set(argsKey, result);
     return result;
   }
@@ -109,13 +114,14 @@ export class HashLookupTypeMap {
     return [...this._mapping.keys()];
   }
 
-  private _performFetch(
+  performFetch(
     type: string | number,
     args: unknown[],
     fallback?: (lookupKey: string | number, ...args: unknown[]) => Type,
   ): Type {
     const factory = this._mapping.get(type);
     if (factory) return factory(type, ...args);
+    if (this._parent) return this._parent.performFetch(type, args, fallback);
     if (fallback) return fallback(type, ...args);
     return new ValueType();
   }

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -10,11 +10,8 @@ export class HashLookupTypeMap {
   private _mapping: Map<string | number, (lookupKey: string | number, ...args: unknown[]) => Type> =
     new Map();
   private _cache: Map<string | number, Map<string, Type>> = new Map();
-  private _parent: HashLookupTypeMap | null;
-
-  constructor(parent: HashLookupTypeMap | null = null) {
-    this._parent = parent;
-  }
+  // Rails accepts a parent param for API compatibility but does not use it.
+  constructor(_parent: HashLookupTypeMap | null = null) {}
 
   lookup(lookupKey: string | number, ...args: unknown[]): Type {
     return this.fetch(lookupKey, ...args, () => new ValueType());
@@ -121,7 +118,6 @@ export class HashLookupTypeMap {
   ): Type {
     const factory = this._mapping.get(type);
     if (factory) return factory(type, ...args);
-    if (this._parent) return this._parent.performFetch(type, args, fallback);
     if (fallback) return fallback(type, ...args);
     return new ValueType();
   }

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -10,7 +10,8 @@ export class HashLookupTypeMap {
   private _mapping: Map<string | number, (lookupKey: string | number, ...args: unknown[]) => Type> =
     new Map();
   private _cache: Map<string | number, Map<string, Type>> = new Map();
-  // Rails accepts a parent param for API compatibility but does not use it.
+  // Rails' HashLookupTypeMap#initialize accepts a parent param but never uses it
+  // (unlike TypeMap which does delegate). Accepted here for API compatibility only.
   constructor(_parent: HashLookupTypeMap | null = null) {}
 
   lookup(lookupKey: string | number, ...args: unknown[]): Type {

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -3,9 +3,26 @@
  */
 import { ValueType } from "@blazetrails/activemodel";
 import { ActiveSupportJSON } from "@blazetrails/activesupport";
+import { StringKeyedHashAccessor } from "../store.js";
 
 export class Json extends ValueType<unknown> {
   readonly name = "json";
+
+  /**
+   * Mirrors: ActiveRecord::Type::Json#type
+   */
+  get type(): string {
+    return "json";
+  }
+
+  /**
+   * Returns the accessor class used by Store for JSON columns.
+   *
+   * Mirrors: ActiveRecord::Type::Json#accessor
+   */
+  get accessor(): typeof StringKeyedHashAccessor {
+    return StringKeyedHashAccessor;
+  }
 
   cast(value: unknown): unknown {
     if (value === null || value === undefined) return null;

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -20,7 +20,7 @@ export class Json extends ValueType<unknown> {
    *
    * Mirrors: ActiveRecord::Type::Json#accessor
    */
-  get accessor(): new (...args: unknown[]) => unknown {
+  accessor(): typeof StringKeyedHashAccessor {
     return StringKeyedHashAccessor;
   }
 

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -11,7 +11,7 @@ export class Json extends ValueType<unknown> {
   /**
    * Mirrors: ActiveRecord::Type::Json#type
    */
-  get type(): string {
+  override type(): string {
     return "json";
   }
 
@@ -20,7 +20,7 @@ export class Json extends ValueType<unknown> {
    *
    * Mirrors: ActiveRecord::Type::Json#accessor
    */
-  get accessor(): typeof StringKeyedHashAccessor {
+  get accessor(): new (...args: unknown[]) => unknown {
     return StringKeyedHashAccessor;
   }
 

--- a/packages/activerecord/src/type/text.ts
+++ b/packages/activerecord/src/type/text.ts
@@ -5,4 +5,9 @@ import { StringType } from "@blazetrails/activemodel";
 
 export class Text extends (StringType as new () => Omit<StringType, "name"> & { name: string }) {
   readonly name = "text";
+
+  /** Mirrors: ActiveRecord::Type::Text#type */
+  get type(): string {
+    return "text";
+  }
 }

--- a/packages/activerecord/src/type/text.ts
+++ b/packages/activerecord/src/type/text.ts
@@ -3,7 +3,10 @@
  */
 import { StringType } from "@blazetrails/activemodel";
 
-export class Text extends (StringType as new () => Omit<StringType, "name"> & { name: string }) {
+export class Text extends (StringType as new () => Omit<StringType, "name" | "type"> & {
+  name: string;
+  type(): string;
+}) {
   readonly name = "text";
 
   /** Mirrors: ActiveRecord::Type::Text#type */

--- a/packages/activerecord/src/type/text.ts
+++ b/packages/activerecord/src/type/text.ts
@@ -7,7 +7,7 @@ export class Text extends (StringType as new () => Omit<StringType, "name"> & { 
   readonly name = "text";
 
   /** Mirrors: ActiveRecord::Type::Text#type */
-  get type(): string {
+  type(): string {
     return "text";
   }
 }

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -32,4 +32,12 @@ export class Time extends ActiveModelTime {
     }
     return null;
   }
+
+  /**
+   * Mirrors: ActiveRecord::Type::Time#serialize_cast_value
+   */
+  serializeCastValue(value: globalThis.Date): TimeValue | null {
+    if (value == null) return null;
+    return new TimeValue(value);
+  }
 }

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -36,7 +36,7 @@ export class Time extends ActiveModelTime {
   /**
    * Mirrors: ActiveRecord::Type::Time#serialize_cast_value
    */
-  serializeCastValue(value: globalThis.Date): TimeValue | null {
+  serializeCastValue(value: globalThis.Date | null): TimeValue | null {
     if (value == null) return null;
     return new TimeValue(value);
   }


### PR DESCRIPTION
## Summary

- **`coders/ColumnSerializer`** (0→6): `initialize`, `initWith`, `dump`, `load`, `assertValidValue`, `checkArityOfConstructor`
- **`coders/JSON`** (0→2): static `dump`/`load` via ActiveSupport JSON
- **`type.ts`** (3→5): `adapterNameFrom`, `currentAdapterName`
- **`type/HashLookupTypeMap`** (6→8): `constructor(parent?)` for inheritance chaining; `performFetch` (was private `_performFetch`) with parent delegation
- **`type/Json`** (3→5): `type` accessor, `accessor` returning `StringKeyedHashAccessor`
- **`type/Text`** (0→1): `type` accessor
- **`type/Time`** (1→2): `serializeCastValue`

## Rails sources
- `activerecord/lib/active_record/coders/column_serializer.rb`
- `activerecord/lib/active_record/coders/json.rb`
- `activerecord/lib/active_record/type.rb` + `type/*.rb`