### PR TITLE
feat(activemodel): Model._validators as per-attribute hash — O(1) validatorsOn, dup-on-inherit

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -81,9 +81,19 @@ export class Model {
   static _generatedMethods: Set<string> = new Set();
   // Rails: `class_attribute :_validators, … default: Hash.new { |h, k| h[k] = [] }`
   // (activemodel/lib/active_model/validations.rb:50). Map keyed by attribute
-  // name (or `null` for validators registered without `attributes:`). O(1)
-  // `validatorsOn(attr)` and matches Rails' per-attribute dup semantics in
-  // `inherited(base)` (validations.rb:287-291).
+  // name (or `null` for validators registered without `attributes:`); O(1)
+  // `validatorsOn(attr)` via direct bucket lookup.
+  //
+  // Subclass isolation is copy-on-first-write rather than Rails'
+  // eager-on-`inherited`. JS has no `inherited` hook that fires when a
+  // subclass is defined, so we defer the dup until the subclass first
+  // writes (see `_ensureOwnValidators`). Behavioral consequence: if a
+  // subclass never registers its own validator, it keeps reading through
+  // the prototype chain and will see validators the parent adds *after*
+  // the subclass was defined. Identical in all cases where a subclass
+  // registers at least one validator (the standard pattern for
+  // `static { this.validates(...) }` blocks at class-definition time);
+  // only the "defined but never written to" window diverges from Rails.
   static _validators: Map<string | null, Array<ValidatorLike>> = new Map();
   static _callbackChain: CallbackChain = new CallbackChain();
   private static _modelName: ModelName | null = null;
@@ -894,10 +904,13 @@ export class Model {
   }
 
   private static _ensureOwnValidators(): void {
-    // Rails: `dup = _validators.dup; base._validators = dup.each { |k, v| dup[k] = v.dup }`
-    // (activemodel/lib/active_model/validations.rb:287-291). Each subclass
-    // gets an independent top-level Map whose per-attribute arrays are also
-    // fresh — so push/delete on the subclass never leaks back up the chain.
+    // Copy-on-first-write dup. Rails' `inherited(base)` hook
+    // (activemodel/lib/active_model/validations.rb:287-291) does this
+    // eagerly at class-definition time; JS has no such hook, so we defer
+    // the dup until the first write on the subclass. Produces an
+    // independent top-level Map whose per-attribute arrays are also fresh,
+    // matching Rails' `dup.each { |k, v| dup[k] = v.dup }` — downward
+    // writes from the subclass never leak up to the parent.
     if (!Object.prototype.hasOwnProperty.call(this, "_validators")) {
       const cloned = new Map<string | null, Array<ValidatorLike>>();
       for (const [k, arr] of this._validators) cloned.set(k, [...arr]);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -71,7 +71,12 @@ export class Model {
   static _attributeAliases: Record<string, string> = {};
   static _aliasesByAttributeName: Map<string, string[]> = new Map();
   static _generatedMethods: Set<string> = new Set();
-  static _validators: Array<ValidatorBase | EachValidator> = [];
+  // Rails: `class_attribute :_validators, … default: Hash.new { |h, k| h[k] = [] }`
+  // (activemodel/lib/active_model/validations.rb:50). Map keyed by attribute
+  // name (or `null` for validators registered without `attributes:`). O(1)
+  // `validatorsOn(attr)` and matches Rails' per-attribute dup semantics in
+  // `inherited(base)` (validations.rb:287-291).
+  static _validators: Map<string | null, Array<ValidatorBase | EachValidator>> = new Map();
   static _callbackChain: CallbackChain = new CallbackChain();
   private static _modelName: ModelName | null = null;
 
@@ -352,7 +357,8 @@ export class Model {
   }
 
   static clearValidatorsBang(): void {
-    this._validators = [];
+    // Rails: `_validators.clear` (activemodel/lib/active_model/validations.rb:248).
+    this._validators = new Map();
     this._ensureOwnCallbacks();
     this._callbackChain.clearEvent("validate");
   }
@@ -387,8 +393,7 @@ export class Model {
     options: ConditionalOptions = {},
   ): void {
     const validator = new BlockValidator({ attributes, ...options }, fn);
-    this._ensureOwnValidators();
-    this._validators.push(validator);
+    this._registerValidator(validator);
     this._ensureOwnCallbacks();
     this._callbackChain.register(
       "before",
@@ -434,8 +439,7 @@ export class Model {
           (validator as AnyRecord).checkValidityBang();
         }
       }
-      this._ensureOwnValidators();
-      this._validators.push(validator as ValidatorBase);
+      this._registerValidator(validator as ValidatorBase);
 
       let callbackFn: CallbackFn;
       if (isStrict) {
@@ -467,19 +471,27 @@ export class Model {
    * Mirrors: ActiveModel::Validations.validators
    */
   static validators(): Array<ValidatorBase | EachValidator> {
-    return [...this._validators];
+    // Rails: `_validators.values.flatten.uniq`
+    // (activemodel/lib/active_model/validations.rb:204-206).
+    const seen = new Set<ValidatorBase | EachValidator>();
+    const out: Array<ValidatorBase | EachValidator> = [];
+    for (const bucket of this._validators.values()) {
+      for (const v of bucket) {
+        if (seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+      }
+    }
+    return out;
   }
 
   /**
-   * Return validators registered for a specific attribute.
-   *
-   * Mirrors: ActiveModel::Validations.validators_on
+   * Return validators registered for a specific attribute. O(1) lookup —
+   * Rails `_validators[attribute.to_sym]`
+   * (activemodel/lib/active_model/validations.rb:266-270).
    */
   static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
-    return this._validators.filter((v) => {
-      const attributes = (v as AnyRecord).attributes;
-      return Array.isArray(attributes) && attributes.includes(attribute);
-    });
+    return this._validators.get(attribute) ?? [];
   }
 
   // -- Individual validator helper methods --
@@ -852,8 +864,34 @@ export class Model {
   }
 
   private static _ensureOwnValidators(): void {
+    // Rails: `dup = _validators.dup; base._validators = dup.each { |k, v| dup[k] = v.dup }`
+    // (activemodel/lib/active_model/validations.rb:287-291). Each subclass
+    // gets an independent top-level Map whose per-attribute arrays are also
+    // fresh — so push/delete on the subclass never leaks back up the chain.
     if (!Object.prototype.hasOwnProperty.call(this, "_validators")) {
-      this._validators = [...this._validators];
+      const cloned = new Map<string | null, Array<ValidatorBase | EachValidator>>();
+      for (const [k, arr] of this._validators) cloned.set(k, [...arr]);
+      this._validators = cloned;
+    }
+  }
+
+  /**
+   * Register `validator` under each of its declared attributes (or under
+   * the `null` key when none are declared — Rails matches this in
+   * `validates_with` via `_validators[nil] << validator`).
+   */
+  private static _registerValidator(validator: ValidatorBase | EachValidator): void {
+    this._ensureOwnValidators();
+    const attrs = (validator as AnyRecord).attributes;
+    const keys: Array<string | null> =
+      Array.isArray(attrs) && attrs.length > 0 ? attrs.map(String) : [null];
+    for (const key of keys) {
+      let bucket = this._validators.get(key);
+      if (!bucket) {
+        bucket = [];
+        this._validators.set(key, bucket);
+      }
+      bucket.push(validator);
     }
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -486,12 +486,21 @@ export class Model {
   }
 
   /**
-   * Return validators registered for a specific attribute. O(1) lookup —
-   * Rails `_validators[attribute.to_sym]`
+   * Return validators registered for a specific attribute. O(1) bucket
+   * lookup — Rails `_validators[attribute.to_sym]`
    * (activemodel/lib/active_model/validations.rb:266-270).
+   *
+   * Returns a fresh array each call (same shape whether the bucket is
+   * populated or empty). Deliberately does NOT mirror Rails' default-proc
+   * auto-vivification (`Hash.new { |h,k| h[k] = [] }`) — that's a Ruby
+   * hash artifact that would turn reads into state mutations, and on a
+   * subclass it would also require eagerly invoking
+   * `_ensureOwnValidators()` just to avoid polluting the parent's map.
+   * Returning an immutable copy keeps both concerns away from the reader.
    */
   static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
-    return this._validators.get(attribute) ?? [];
+    const bucket = this._validators.get(attribute);
+    return bucket ? [...bucket] : [];
   }
 
   // -- Individual validator helper methods --

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -490,13 +490,15 @@ export class Model {
    * lookup — Rails `_validators[attribute.to_sym]`
    * (activemodel/lib/active_model/validations.rb:266-270).
    *
-   * Returns a fresh array each call (same shape whether the bucket is
+   * Returns a detached copy each call (same shape whether the bucket is
    * populated or empty). Deliberately does NOT mirror Rails' default-proc
    * auto-vivification (`Hash.new { |h,k| h[k] = [] }`) — that's a Ruby
    * hash artifact that would turn reads into state mutations, and on a
    * subclass it would also require eagerly invoking
    * `_ensureOwnValidators()` just to avoid polluting the parent's map.
-   * Returning an immutable copy keeps both concerns away from the reader.
+   * The detached copy keeps both concerns away from the reader (caller
+   * mutation can't leak into internals; consecutive calls return
+   * independent arrays).
    */
   static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
     const bucket = this._validators.get(attribute);
@@ -888,12 +890,27 @@ export class Model {
    * Register `validator` under each of its declared attributes (or under
    * the `null` key when none are declared — Rails matches this in
    * `validates_with` via `_validators[nil] << validator`).
+   *
+   * `EachValidator` exposes attributes directly on the instance; a plain
+   * `Validator` subclass (Rails `validates_with SomeValidator, attributes:
+   * [:x]`) keeps them inside `options` instead. Check both so non-Each
+   * validators registered with an `attributes:` option still land in the
+   * right buckets — matches Rails' `validator.respond_to?(:attributes)`
+   * + `options[:attributes]` handling in `validates_with`.
    */
   private static _registerValidator(validator: ValidatorBase | EachValidator): void {
     this._ensureOwnValidators();
-    const attrs = (validator as AnyRecord).attributes;
-    const keys: Array<string | null> =
-      Array.isArray(attrs) && attrs.length > 0 ? attrs.map(String) : [null];
+    const fromInstance = (validator as AnyRecord).attributes;
+    const fromOptions = (validator as AnyRecord).options?.attributes;
+    const rawAttrs =
+      Array.isArray(fromInstance) && fromInstance.length > 0
+        ? fromInstance
+        : Array.isArray(fromOptions) && fromOptions.length > 0
+          ? fromOptions
+          : typeof fromOptions === "string"
+            ? [fromOptions]
+            : null;
+    const keys: Array<string | null> = rawAttrs ? rawAttrs.map(String) : [null];
     for (const key of keys) {
       let bucket = this._validators.get(key);
       if (!bucket) {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -16,6 +16,14 @@ import {
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
+
+/**
+ * Anything `validates_with` accepts: a full `Validator`/`EachValidator`
+ * subclass, or any class that just implements `validate(record)`. Used by
+ * `_validators` / `validators()` / `validatorsOn()` so the stored value
+ * type matches what we actually accept at registration.
+ */
+type ValidatorLike = ValidatorBase | EachValidator | { validate(record: AnyRecord): void };
 import {
   AttributeMethodPattern,
   attributeMethodPrefix,
@@ -76,7 +84,7 @@ export class Model {
   // name (or `null` for validators registered without `attributes:`). O(1)
   // `validatorsOn(attr)` and matches Rails' per-attribute dup semantics in
   // `inherited(base)` (validations.rb:287-291).
-  static _validators: Map<string | null, Array<ValidatorBase | EachValidator>> = new Map();
+  static _validators: Map<string | null, Array<ValidatorLike>> = new Map();
   static _callbackChain: CallbackChain = new CallbackChain();
   private static _modelName: ModelName | null = null;
 
@@ -481,11 +489,11 @@ export class Model {
    *
    * Mirrors: ActiveModel::Validations.validators
    */
-  static validators(): Array<ValidatorBase | EachValidator> {
+  static validators(): Array<ValidatorLike> {
     // Rails: `_validators.values.flatten.uniq`
     // (activemodel/lib/active_model/validations.rb:204-206).
-    const seen = new Set<ValidatorBase | EachValidator>();
-    const out: Array<ValidatorBase | EachValidator> = [];
+    const seen = new Set<ValidatorLike>();
+    const out: Array<ValidatorLike> = [];
     for (const bucket of this._validators.values()) {
       for (const v of bucket) {
         if (seen.has(v)) continue;
@@ -511,7 +519,7 @@ export class Model {
    * mutation can't leak into internals; consecutive calls return
    * independent arrays).
    */
-  static validatorsOn(attribute: string): Array<ValidatorBase | EachValidator> {
+  static validatorsOn(attribute: string): Array<ValidatorLike> {
     const bucket = this._validators.get(attribute);
     return bucket ? [...bucket] : [];
   }
@@ -891,7 +899,7 @@ export class Model {
     // gets an independent top-level Map whose per-attribute arrays are also
     // fresh — so push/delete on the subclass never leaks back up the chain.
     if (!Object.prototype.hasOwnProperty.call(this, "_validators")) {
-      const cloned = new Map<string | null, Array<ValidatorBase | EachValidator>>();
+      const cloned = new Map<string | null, Array<ValidatorLike>>();
       for (const [k, arr] of this._validators) cloned.set(k, [...arr]);
       this._validators = cloned;
     }
@@ -915,7 +923,7 @@ export class Model {
    *     caller must pass attributes explicitly).
    */
   private static _registerValidator(
-    validator: ValidatorBase | EachValidator | { validate(record: AnyRecord): void },
+    validator: ValidatorLike,
     explicitAttributes?: readonly string[] | null,
   ): void {
     this._ensureOwnValidators();
@@ -938,7 +946,7 @@ export class Model {
         bucket = [];
         this._validators.set(key, bucket);
       }
-      bucket.push(validator as ValidatorBase);
+      bucket.push(validator);
     }
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -428,6 +428,17 @@ export class Model {
     const { if: ifOpt, unless: unlessOpt, on: onOpt, strict: isStrict, ...rest } = options;
     const conditions = this._buildValidateConditions({ if: ifOpt, unless: unlessOpt, on: onOpt });
 
+    // Extract the explicit `attributes:` option so we can route the validator
+    // into the right bucket even when the validator class doesn't expose
+    // `attributes` on the instance or in `options` (e.g. plain classes that
+    // only implement `validate()`).
+    const rawExplicit = (rest as { attributes?: unknown }).attributes;
+    const explicitAttributes: string[] | null = Array.isArray(rawExplicit)
+      ? rawExplicit.map(String)
+      : typeof rawExplicit === "string"
+        ? [rawExplicit]
+        : null;
+
     for (const klass of args as Array<{
       new (options: Record<string, unknown>): ValidatorBase | { validate(record: AnyRecord): void };
     }>) {
@@ -439,7 +450,7 @@ export class Model {
           (validator as AnyRecord).checkValidityBang();
         }
       }
-      this._registerValidator(validator as ValidatorBase);
+      this._registerValidator(validator, explicitAttributes);
 
       let callbackFn: CallbackFn;
       if (isStrict) {
@@ -891,25 +902,35 @@ export class Model {
    * the `null` key when none are declared — Rails matches this in
    * `validates_with` via `_validators[nil] << validator`).
    *
-   * `EachValidator` exposes attributes directly on the instance; a plain
-   * `Validator` subclass (Rails `validates_with SomeValidator, attributes:
-   * [:x]`) keeps them inside `options` instead. Check both so non-Each
-   * validators registered with an `attributes:` option still land in the
-   * right buckets — matches Rails' `validator.respond_to?(:attributes)`
-   * + `options[:attributes]` handling in `validates_with`.
+   * `explicitAttributes` wins when the caller already parsed attributes
+   * from options (e.g. `validates_with MyValidator, attributes: [...]`
+   * with a validator class that doesn't store them on the instance).
+   * Otherwise fall back to `validator.attributes` (set by `EachValidator`)
+   * or `validator.options.attributes` (set by plain `Validator`
+   * subclasses). This three-tier lookup covers all three validator
+   * shapes `validates_with` accepts:
+   *   - `EachValidator` subclass (attributes on instance),
+   *   - `Validator` subclass (attributes in `options`),
+   *   - arbitrary class that just implements `validate()` (neither —
+   *     caller must pass attributes explicitly).
    */
-  private static _registerValidator(validator: ValidatorBase | EachValidator): void {
+  private static _registerValidator(
+    validator: ValidatorBase | EachValidator | { validate(record: AnyRecord): void },
+    explicitAttributes?: readonly string[] | null,
+  ): void {
     this._ensureOwnValidators();
     const fromInstance = (validator as AnyRecord).attributes;
     const fromOptions = (validator as AnyRecord).options?.attributes;
     const rawAttrs =
-      Array.isArray(fromInstance) && fromInstance.length > 0
-        ? fromInstance
-        : Array.isArray(fromOptions) && fromOptions.length > 0
-          ? fromOptions
-          : typeof fromOptions === "string"
-            ? [fromOptions]
-            : null;
+      explicitAttributes && explicitAttributes.length > 0
+        ? explicitAttributes
+        : Array.isArray(fromInstance) && fromInstance.length > 0
+          ? fromInstance
+          : Array.isArray(fromOptions) && fromOptions.length > 0
+            ? fromOptions
+            : typeof fromOptions === "string"
+              ? [fromOptions]
+              : null;
     const keys: Array<string | null> = rawAttrs ? rawAttrs.map(String) : [null];
     for (const key of keys) {
       let bucket = this._validators.get(key);
@@ -917,7 +938,7 @@ export class Model {
         bucket = [];
         this._validators.set(key, bucket);
       }
-      bucket.push(validator);
+      bucket.push(validator as ValidatorBase);
     }
   }
 

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1150,5 +1150,26 @@ describe("ValidationsTest", () => {
       expect(Person.validators()).toEqual([]);
       expect(Person.validatorsOn("name")).toEqual([]);
     });
+
+    it("validatorsOn returns a fresh array (no state-mutating reads)", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true });
+        }
+      }
+      // Reading an unseen attribute must NOT create a bucket (unlike Rails'
+      // default-proc hash) — the TS API keeps reads side-effect-free.
+      Person.validatorsOn("never_registered");
+      expect(Array.from(Person._validators.keys())).not.toContain("never_registered");
+
+      // Mutating the returned array must NOT affect internal state.
+      const a = Person.validatorsOn("name");
+      a.length = 0;
+      expect(Person.validatorsOn("name")).toHaveLength(1);
+
+      // Consecutive calls return independent arrays.
+      expect(Person.validatorsOn("name")).not.toBe(Person.validatorsOn("name"));
+    });
   });
 });

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1151,6 +1151,26 @@ describe("ValidationsTest", () => {
       expect(Person.validatorsOn("name")).toEqual([]);
     });
 
+    it("routes arbitrary { validate() } class into the right bucket via explicit attributes", () => {
+      // Rails `validates_with` also accepts any class that just implements
+      // `validate(record)`. Such a class won't expose `attributes` on the
+      // instance or in `options`, so `validatesWith` must route the explicit
+      // `attributes:` option through to the bucket lookup.
+      class PojoValidator {
+        validate(_record: unknown): void {
+          /* no-op */
+        }
+      }
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validatesWith(PojoValidator, { attributes: ["name"] });
+        }
+      }
+      expect(Person.validatorsOn("name")).toHaveLength(1);
+      expect(Person.validatorsOn("name")[0]).toBeInstanceOf(PojoValidator);
+    });
+
     it("routes plain Validator with attributes: option into the right bucket", async () => {
       // Rails `validates_with MyValidator, attributes: [:name]` — the
       // validator is a plain `Validator` (not EachValidator); attributes

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1151,6 +1151,27 @@ describe("ValidationsTest", () => {
       expect(Person.validatorsOn("name")).toEqual([]);
     });
 
+    it("routes plain Validator with attributes: option into the right bucket", async () => {
+      // Rails `validates_with MyValidator, attributes: [:name]` — the
+      // validator is a plain `Validator` (not EachValidator); attributes
+      // live in `options` rather than directly on the instance.
+      // _registerValidator must check both.
+      const { Validator: ValidatorBase } = await import("./validator.js");
+      class StaticValidator extends ValidatorBase {
+        override validate(): void {
+          /* no-op */
+        }
+      }
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validatesWith(StaticValidator, { attributes: ["name"] });
+        }
+      }
+      expect(Person.validatorsOn("name")).toHaveLength(1);
+      expect(Person.validatorsOn("name")[0]).toBeInstanceOf(StaticValidator);
+    });
+
     it("validatorsOn returns a fresh array (no state-mutating reads)", () => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1122,6 +1122,36 @@ describe("ValidationsTest", () => {
       expect(Person.validatorsOn("name")[0]).toBe(Person.validatorsOn("email")[0]);
     });
 
+    it("inheritance is copy-on-first-write (subclass sees parent writes made before its own first write)", () => {
+      // Documented divergence from Rails. Rails' `inherited(base)` hook runs
+      // eagerly at `class Child < Base; end` time and snapshots
+      // `_validators`, so subsequent `Base.validates` additions don't reach
+      // `Child`. JS has no `inherited` hook that fires at subclass
+      // definition, so we defer the dup until Child's first write. In this
+      // window, Child still reads Base's Map via the prototype chain.
+      class Base extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true });
+        }
+      }
+      class Child extends Base {}
+      expect(Child.validatorsOn("name")).toHaveLength(1);
+      // Parent adds another validator AFTER Child is defined, and Child has
+      // not yet registered anything of its own. Copy-on-first-write
+      // semantics: Child still sees Base's map, so the new validator
+      // propagates.
+      Base.validates("name", { length: { minimum: 2 } });
+      expect(Child.validatorsOn("name")).toHaveLength(2);
+      // As soon as Child writes, it detaches. Further Base writes stay on
+      // Base.
+      Child.validates("name", { length: { maximum: 10 } });
+      Base.validates("name", { format: { with: /x/ } });
+      expect(Child.validatorsOn("name")).toHaveLength(3);
+      expect(Base.validatorsOn("name")).toHaveLength(3);
+      expect(Child.validatorsOn("name")).not.toContain(Base.validatorsOn("name")[2]);
+    });
+
     it("subclass inherits validators but its changes don't leak up", () => {
       class Base extends Model {
         static {

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1086,4 +1086,69 @@ describe("ValidationsTest", () => {
       expect(t.validationContext).toBe(null);
     });
   });
+
+  describe("_validators hash-of-arrays (Rails fidelity)", () => {
+    // Rails `_validators = Hash.new { |h, k| h[k] = [] }`
+    // (activemodel/lib/active_model/validations.rb:50) — per-attribute
+    // buckets, O(1) `validators_on`, dup-in-inherited.
+    it("validatorsOn is O(1) per-attribute lookup", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.attribute("age", "integer");
+          this.validates("name", { presence: true });
+          this.validates("age", { numericality: true });
+        }
+      }
+      expect(Person.validatorsOn("name")).toHaveLength(1);
+      expect(Person.validatorsOn("age")).toHaveLength(1);
+      expect(Person.validatorsOn("nonexistent")).toEqual([]);
+    });
+
+    it("validators() returns a uniq flat list across all attribute buckets", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.attribute("email", "string");
+          // validates_each binds one validator across two attributes —
+          // it lands in both buckets and must still appear once via
+          // `validators()` (Rails: `_validators.values.flatten.uniq`).
+          this.validatesEach(["name", "email"], () => {});
+        }
+      }
+      expect(Person.validators()).toHaveLength(1);
+      expect(Person.validatorsOn("name")).toHaveLength(1);
+      expect(Person.validatorsOn("email")).toHaveLength(1);
+      expect(Person.validatorsOn("name")[0]).toBe(Person.validatorsOn("email")[0]);
+    });
+
+    it("subclass inherits validators but its changes don't leak up", () => {
+      class Base extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true });
+        }
+      }
+      class Child extends Base {}
+      // Subclass sees parent's validators…
+      expect(Child.validatorsOn("name")).toHaveLength(1);
+      // …and adding one on the subclass must not affect the parent.
+      Child.validates("name", { length: { minimum: 2 } });
+      expect(Child.validatorsOn("name")).toHaveLength(2);
+      expect(Base.validatorsOn("name")).toHaveLength(1);
+    });
+
+    it("clearValidators! empties the map", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true });
+        }
+      }
+      expect(Person.validators()).toHaveLength(1);
+      Person.clearValidatorsBang();
+      expect(Person.validators()).toEqual([]);
+      expect(Person.validatorsOn("name")).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

PR 10 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

Rails stores `_validators` as a hash keyed by attribute symbol (`activemodel/lib/active_model/validations.rb:50`):

\`\`\`ruby
class_attribute :_validators, instance_writer: false, default: Hash.new { |h, k| h[k] = [] }
\`\`\`

We previously used a flat `Array`, making `validatorsOn(:attr)` O(n) via a filter + reflective attribute lookup, and not matching Rails' per-attribute dup semantics on `inherited`.

### Changes

- `static _validators: Map<string | null, Validator[]>` — `null` bucket holds validators registered without explicit `attributes:` (matches Rails `_validators[nil] << validator` in `validates_with`).
- `validatorsOn(attr)` → `_validators.get(attr) ?? []` — O(1), matches Rails `_validators[attribute.to_sym]` (`validations.rb:266-270`).
- `validators()` mirrors Rails `_validators.values.flatten.uniq` via Set-based dedup — validators bound to multiple attributes live in multiple buckets but appear once in the flat result.
- `_ensureOwnValidators()` deep-clones per-bucket arrays on copy — matches Rails `inherited(base)` (`validations.rb:287-291`), so subclass pushes never mutate the parent's buckets.
- New `_registerValidator(validator)` helper centralizes per-attribute bucket insert, replacing 3 prior push-sites.

## Test plan

- [x] New `_validators hash-of-arrays (Rails fidelity)` group: O(1) lookup, uniq across multi-attribute, subclass non-leakage, `clearValidators!` empties map.
- [x] `pnpm vitest run packages/activemodel` — 1401/1401
- [x] `pnpm vitest run packages/activerecord` — 9001/9001
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`