### PR TITLE
feat(parity): Ruby query runner (PR 3 of 5)

### DIFF
--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -92,11 +92,13 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     #      to_sql(engine) in Rails 8.0 (arel/tree_manager.rb:53, arel/nodes/node.rb:148).
     #    - Binds are extracted via conn.to_sql_and_binds when the result is a manager.
     sql_str, binds = if result.respond_to?(:ast)
-      # Manager (SelectManager, InsertManager, etc.) — use connection for bind extraction
-      raw_sql, raw_binds = conn.to_sql_and_binds(result.ast)
+      # Manager (SelectManager etc.) — pass the whole manager for bind extraction.
+      # connection#to_sql_and_binds accepts an Arel manager or SQL string.
+      raw_sql, raw_binds = conn.to_sql_and_binds(result)
       [raw_sql.strip, raw_binds.map { |b| b.value.to_s }]
     elsif result.respond_to?(:to_sql)
-      # Plain node (Attribute, predicate, etc.)
+      # Plain node (Attribute, predicate, etc.) — Arel::Nodes::Node#to_sql
+      # (arel/nodes/node.rb:148) uses the visitor with the connection's engine.
       [result.to_sql.strip, []]
     else
       raise "query.rb returned #{result.class}: expected an Arel node or manager"
@@ -106,7 +108,7 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     canonical = {
       "version"  => 1,
       "fixture"  => fixture_name,
-      "frozenAt" => frozen_at || Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+      "frozenAt" => frozen_at || Time.now.utc.iso8601(3),
       "sql"      => sql_str,
       "binds"    => binds,
     }

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -4,15 +4,15 @@
 # Usage (from repo root):
 #   bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
 #     ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> \
-#     [--frozen-at ISO8601_UTC]
+#     [--frozen-at ISO8601_UTC_Z]
 #
 # Applies <fixture-dir>/schema.sql to a fresh SQLite database, evaluates
 # <fixture-dir>/query.rb, extracts SQL and binds (via to_sql_and_binds
-# with fallback to to_sql), and writes a
-# CanonicalQuery JSON to <out.json>.
+# with fallback to to_sql), and writes a CanonicalQuery JSON to <out.json>.
 #
-# --frozen-at <iso> freezes time via ActiveSupport::Testing::TimeHelpers for
-# deterministic time-dependent queries (e.g. 1.week.ago).
+# Time is always frozen for deterministic query evaluation. --frozen-at
+# pins the timestamp to a specific ISO 8601 UTC value (trailing Z required,
+# e.g. 2026-01-01T00:00:00.000Z); omitting it uses 2000-01-01T00:00:00.000Z.
 
 require "bundler/setup"
 require "active_record"
@@ -26,7 +26,7 @@ require "fileutils"
 require "time"
 
 def usage
-  warn "Usage: bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> [--frozen-at ISO8601_UTC]"
+  warn "Usage: bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]"
   exit 1
 end
 
@@ -76,7 +76,7 @@ else
   # so both sides use the same timestamp in a parity run.
   Time.utc(2000, 1, 1)
 end
-frozen_ts = frozen_time.iso8601(3)  # e.g. "2026-04-24T00:00:00.000Z"
+frozen_ts = frozen_at || frozen_time.iso8601(3)  # e.g. "2026-04-24T00:00:00.000Z"
 
 # TimeHelper mixin — provides travel_to / travel_back
 module TimeHelper
@@ -118,9 +118,9 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     end
 
     # 5. Get SQL and binds.
-    #    Try conn.to_sql_and_binds first (works for managers, extracts binds Rails-style).
-    #    Plain nodes (no .ast) may only support direct SQL rendering via to_sql;
-    #    fall back to that path if to_sql_and_binds raises.
+    #    conn.to_sql_and_binds accepts a SelectManager directly — it calls .ast internally
+    #    (DatabaseStatements#to_sql_and_binds in AR 8). Plain nodes raise TypeError/
+    #    ArgumentError/NoMethodError; fall back to direct to_sql for those.
     raw_sql, raw_binds = begin
       conn.to_sql_and_binds(result)
     rescue TypeError, ArgumentError, NoMethodError

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -40,7 +40,10 @@ def parse_args(argv)
     when "--frozen-at"
       i += 1
       val = argv[i]
-      (warn "--frozen-at requires a value"; exit 1) unless val
+      if val.nil? || val.start_with?("--")
+        warn "--frozen-at requires a value"
+        exit 1
+      end
       frozen_at = val
     else
       if fixture_dir.nil?
@@ -129,13 +132,14 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     end
 
     binds = Array(raw_binds).map do |b|
-      if b.respond_to?(:value_before_type_cast)
-        b.value_before_type_cast.to_s
+      raw = if b.respond_to?(:value_before_type_cast)
+        b.value_before_type_cast
       elsif b.respond_to?(:value)
-        b.value.to_s
+        b.value
       else
-        b.to_s
+        b
       end
+      raw.nil? ? nil : raw.to_s
     end
     sql_str = raw_sql.strip
 

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -60,6 +60,21 @@ end
 fixture_dir, out_path, frozen_at = parse_args(ARGV)
 fixture_name = File.basename(fixture_dir)
 
+# Validate and parse frozen_at — must be ISO 8601 UTC (trailing Z required).
+# Time.parse is too permissive; enforce the format from canonical/query.schema.json.
+frozen_time = if frozen_at
+  unless frozen_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\z/)
+    warn "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)"
+    exit 1
+  end
+  Time.iso8601(frozen_at).utc
+else
+  # Always freeze time so the output is deterministic even when --frozen-at is
+  # omitted. Capture once and use for both travel_to and the frozenAt field.
+  Time.now.utc
+end
+frozen_ts = frozen_time.iso8601(3)  # e.g. "2026-04-24T00:00:00.000Z"
+
 # TimeHelper mixin — provides travel_to / travel_back
 module TimeHelper
   include ActiveSupport::Testing::TimeHelpers
@@ -79,13 +94,16 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_path)
     conn = ActiveRecord::Base.connection
 
-    # 3. Freeze time if requested (activesupport travel_to)
-    time_helper.travel_to(Time.parse(frozen_at)) if frozen_at
+    # 3. Always freeze time so query evaluation is deterministic
+    time_helper.travel_to(frozen_time)
 
-    # 4. Evaluate query.rb — last expression is the Arel node/manager to dump
-    query_source = File.read(File.join(fixture_dir, "query.rb"))
+    # 4. Evaluate query.rb — last expression is the Arel node/manager to dump.
+    # Pass the file path and TOPLEVEL_BINDING so stack traces reference query.rb
+    # line numbers, not "(eval)", and local vars from this script don't leak in.
+    query_path   = File.join(fixture_dir, "query.rb")
+    query_source = File.read(query_path)
     # rubocop:disable Security/Eval
-    result = eval(query_source)
+    result = eval(query_source, TOPLEVEL_BINDING, query_path)
     # rubocop:enable Security/Eval
     raise "[#{fixture_name}] query.rb returned nil" if result.nil?
 
@@ -105,8 +123,6 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     else
       raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager"
     end
-
-    frozen_ts = frozen_at || Time.now.utc.iso8601(3)
 
     # 6. Write CanonicalQuery JSON
     canonical = {
@@ -129,7 +145,7 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     puts "  → #{out_path}"
 
   ensure
-    time_helper.travel_back if frozen_at
+    time_helper.travel_back
     begin
       ActiveRecord::Base.remove_connection
     rescue StandardError

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -7,7 +7,8 @@
 #     [--frozen-at ISO8601_UTC]
 #
 # Applies <fixture-dir>/schema.sql to a fresh SQLite database, evaluates
-# <fixture-dir>/query.rb, calls to_sql on the result, and writes a
+# <fixture-dir>/query.rb, extracts SQL and binds (via to_sql_and_binds
+# with fallback to to_sql), and writes a
 # CanonicalQuery JSON to <out.json>.
 #
 # --frozen-at <iso> freezes time via ActiveSupport::Testing::TimeHelpers for
@@ -25,7 +26,7 @@ require "fileutils"
 require "time"
 
 def usage
-  warn "Usage: bundle exec ruby dump.rb <fixture-dir> <out.json> [--frozen-at ISO]"
+  warn "Usage: bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> [--frozen-at ISO8601_UTC]"
   exit 1
 end
 
@@ -119,22 +120,23 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     #    Try conn.to_sql_and_binds first (works for managers and SQL strings, extracts
     #    binds Rails-style). Plain nodes may only support direct SQL rendering via to_sql;
     #    fall back to that path if to_sql_and_binds raises.
-    sql_str, binds = begin
-      raw_sql, raw_binds = conn.to_sql_and_binds(result)
-      coerced = Array(raw_binds).map do |b|
-        if b.respond_to?(:value_before_type_cast)
-          b.value_before_type_cast.to_s
-        elsif b.respond_to?(:value)
-          b.value.to_s
-        else
-          b.to_s
-        end
-      end
-      [raw_sql.strip, coerced]
+    raw_sql, raw_binds = begin
+      conn.to_sql_and_binds(result)
     rescue TypeError, ArgumentError, NoMethodError
       # Plain node — Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148)
       [result.to_sql.strip, []]
     end
+
+    binds = Array(raw_binds).map do |b|
+      if b.respond_to?(:value_before_type_cast)
+        b.value_before_type_cast.to_s
+      elsif b.respond_to?(:value)
+        b.value.to_s
+      else
+        b.to_s
+      end
+    end
+    sql_str = raw_sql.strip
 
     # 6. Write CanonicalQuery JSON
     canonical = {

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -70,9 +70,10 @@ frozen_time = if frozen_at
   end
   Time.iso8601(frozen_at).utc
 else
-  # Fixed default so runs are reproducible without --frozen-at.
-  # The orchestrator (run.ts) always passes --frozen-at; this is only for
-  # direct invocation during development.
+  # Fixed default so direct invocations (e.g. during development) are still
+  # reproducible. The query parity orchestrator (added in PR5 of
+  # docs/query-parity-verification.md) always passes --frozen-at explicitly
+  # so both sides use the same timestamp in a parity run.
   Time.utc(2000, 1, 1)
 end
 frozen_ts = frozen_time.iso8601(3)  # e.g. "2026-04-24T00:00:00.000Z"

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Usage (from repo root):
+#   bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
+#     ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> \
+#     [--frozen-at ISO8601_UTC]
+#
+# Applies <fixture-dir>/schema.sql to a fresh SQLite database, evaluates
+# <fixture-dir>/query.rb, calls to_sql on the result, and writes a
+# CanonicalQuery JSON to <out.json>.
+#
+# --frozen-at <iso> freezes time via ActiveSupport::Testing::TimeHelpers for
+# deterministic time-dependent queries (e.g. 1.week.ago).
+
+require "bundler/setup"
+require "active_record"
+require "active_support"
+require "active_support/core_ext/integer/time"
+require "active_support/testing/time_helpers"
+require "sqlite3"
+require "tmpdir"
+require "json"
+require "fileutils"
+require "time"
+
+def usage
+  warn "Usage: bundle exec ruby dump.rb <fixture-dir> <out.json> [--frozen-at ISO]"
+  exit 1
+end
+
+def parse_args(argv)
+  fixture_dir = nil
+  out_path    = nil
+  frozen_at   = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when "--frozen-at"
+      i += 1
+      val = argv[i]
+      (warn "--frozen-at requires a value"; exit 1) unless val
+      frozen_at = val
+    else
+      if fixture_dir.nil?
+        fixture_dir = argv[i]
+      elsif out_path.nil?
+        out_path = argv[i]
+      else
+        warn "unexpected argument: #{argv[i]}"
+        usage
+      end
+    end
+    i += 1
+  end
+  usage unless fixture_dir && out_path
+  [File.expand_path(fixture_dir), File.expand_path(out_path), frozen_at]
+end
+
+fixture_dir, out_path, frozen_at = parse_args(ARGV)
+fixture_name = File.basename(fixture_dir)
+
+# TimeHelper mixin — provides travel_to / travel_back
+module TimeHelper
+  include ActiveSupport::Testing::TimeHelpers
+end
+time_helper = Object.new.extend(TimeHelper)
+
+Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
+  db_path = File.join(tmpdir, "query.db")
+
+  begin
+    # 1. Apply schema.sql to a fresh temp SQLite file
+    SQLite3::Database.new(db_path) do |db|
+      db.execute_batch(File.read(File.join(fixture_dir, "schema.sql")))
+    end
+
+    # 2. Connect via ActiveRecord
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_path)
+    conn = ActiveRecord::Base.connection
+
+    # 3. Freeze time if requested (activesupport travel_to)
+    time_helper.travel_to(Time.parse(frozen_at)) if frozen_at
+
+    # 4. Evaluate query.rb — last expression is the Arel node/manager to dump
+    # rubocop:disable Security/Eval
+    result = eval(File.read(File.join(fixture_dir, "query.rb")))
+    # rubocop:enable Security/Eval
+
+    # 5. Get SQL and binds.
+    #    - Arel::TreeManager (SelectManager etc.) and Arel::Nodes::Node both expose
+    #      to_sql(engine) in Rails 8.0 (arel/tree_manager.rb:53, arel/nodes/node.rb:148).
+    #    - Binds are extracted via conn.to_sql_and_binds when the result is a manager.
+    sql_str, binds = if result.respond_to?(:ast)
+      # Manager (SelectManager, InsertManager, etc.) — use connection for bind extraction
+      raw_sql, raw_binds = conn.to_sql_and_binds(result.ast)
+      [raw_sql.strip, raw_binds.map { |b| b.value.to_s }]
+    elsif result.respond_to?(:to_sql)
+      # Plain node (Attribute, predicate, etc.)
+      [result.to_sql.strip, []]
+    else
+      raise "query.rb returned #{result.class}: expected an Arel node or manager"
+    end
+
+    # 6. Write CanonicalQuery JSON
+    canonical = {
+      "version"  => 1,
+      "fixture"  => fixture_name,
+      "frozenAt" => frozen_at || Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+      "sql"      => sql_str,
+      "binds"    => binds,
+    }
+
+    FileUtils.mkdir_p(File.dirname(out_path))
+    File.write(out_path, JSON.pretty_generate(canonical) + "\n")
+    puts "parity query dump (rails): wrote #{out_path}"
+
+  ensure
+    time_helper.travel_back if frozen_at
+    begin
+      ActiveRecord::Base.remove_connection
+    rescue StandardError
+      # already removed or never opened
+    end
+  end
+end

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -83,9 +83,11 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     time_helper.travel_to(Time.parse(frozen_at)) if frozen_at
 
     # 4. Evaluate query.rb — last expression is the Arel node/manager to dump
+    query_source = File.read(File.join(fixture_dir, "query.rb"))
     # rubocop:disable Security/Eval
-    result = eval(File.read(File.join(fixture_dir, "query.rb")))
+    result = eval(query_source)
     # rubocop:enable Security/Eval
+    raise "[#{fixture_name}] query.rb returned nil" if result.nil?
 
     # 5. Get SQL and binds.
     #    - Arel::TreeManager (SelectManager etc.) and Arel::Nodes::Node both expose
@@ -101,21 +103,30 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
       # (arel/nodes/node.rb:148) uses the visitor with the connection's engine.
       [result.to_sql.strip, []]
     else
-      raise "query.rb returned #{result.class}: expected an Arel node or manager"
+      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager"
     end
+
+    frozen_ts = frozen_at || Time.now.utc.iso8601(3)
 
     # 6. Write CanonicalQuery JSON
     canonical = {
       "version"  => 1,
       "fixture"  => fixture_name,
-      "frozenAt" => frozen_at || Time.now.utc.iso8601(3),
+      "frozenAt" => frozen_ts,
       "sql"      => sql_str,
       "binds"    => binds,
     }
 
     FileUtils.mkdir_p(File.dirname(out_path))
     File.write(out_path, JSON.pretty_generate(canonical) + "\n")
-    puts "parity query dump (rails): wrote #{out_path}"
+
+    # Verbose output for debugging in CI logs
+    puts "[rails] #{fixture_name}"
+    puts "  result type : #{result.class}"
+    puts "  sql         : #{sql_str}"
+    puts "  binds (#{binds.length})  : #{binds.inspect}" unless binds.empty?
+    puts "  frozenAt    : #{frozen_ts}"
+    puts "  → #{out_path}"
 
   ensure
     time_helper.travel_back if frozen_at

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -69,9 +69,10 @@ frozen_time = if frozen_at
   end
   Time.iso8601(frozen_at).utc
 else
-  # Always freeze time so the output is deterministic even when --frozen-at is
-  # omitted. Capture once and use for both travel_to and the frozenAt field.
-  Time.now.utc
+  # Fixed default so runs are reproducible without --frozen-at.
+  # The orchestrator (run.ts) always passes --frozen-at; this is only for
+  # direct invocation during development.
+  Time.utc(2000, 1, 1)
 end
 frozen_ts = frozen_time.iso8601(3)  # e.g. "2026-04-24T00:00:00.000Z"
 
@@ -98,30 +99,41 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     time_helper.travel_to(frozen_time)
 
     # 4. Evaluate query.rb — last expression is the Arel node/manager to dump.
-    # Pass the file path and TOPLEVEL_BINDING so stack traces reference query.rb
-    # line numbers, not "(eval)", and local vars from this script don't leak in.
-    query_path   = File.join(fixture_dir, "query.rb")
-    query_source = File.read(query_path)
+    # Pass the file path and an isolated binding so:
+    # 1. Stack traces reference query.rb line numbers, not "(eval)".
+    # 2. Runner-local variables (fixture_dir, out_path, etc.) don't leak into
+    #    the fixture's scope and can't be accidentally referenced.
+    query_path    = File.join(fixture_dir, "query.rb")
+    query_source  = File.read(query_path)
+    query_context = Object.new
+    query_binding = query_context.instance_eval { binding }
     # rubocop:disable Security/Eval
-    result = eval(query_source, TOPLEVEL_BINDING, query_path)
+    result = eval(query_source, query_binding, query_path)
     # rubocop:enable Security/Eval
     raise "[#{fixture_name}] query.rb returned nil" if result.nil?
+    unless result.respond_to?(:to_sql) || result.respond_to?(:ast)
+      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager"
+    end
 
     # 5. Get SQL and binds.
-    #    - Arel::TreeManager (SelectManager etc.) and Arel::Nodes::Node both expose
-    #      to_sql(engine) in Rails 8.0 (arel/tree_manager.rb:53, arel/nodes/node.rb:148).
-    #    - Binds are extracted via conn.to_sql_and_binds when the result is a manager.
-    sql_str, binds = if result.respond_to?(:ast)
-      # Manager (SelectManager etc.) — pass the whole manager for bind extraction.
-      # connection#to_sql_and_binds accepts an Arel manager or SQL string.
+    #    Try conn.to_sql_and_binds first (works for managers and SQL strings, extracts
+    #    binds Rails-style). Plain nodes may only support direct SQL rendering via to_sql;
+    #    fall back to that path if to_sql_and_binds raises.
+    sql_str, binds = begin
       raw_sql, raw_binds = conn.to_sql_and_binds(result)
-      [raw_sql.strip, raw_binds.map { |b| b.value.to_s }]
-    elsif result.respond_to?(:to_sql)
-      # Plain node (Attribute, predicate, etc.) — Arel::Nodes::Node#to_sql
-      # (arel/nodes/node.rb:148) uses the visitor with the connection's engine.
+      coerced = Array(raw_binds).map do |b|
+        if b.respond_to?(:value_before_type_cast)
+          b.value_before_type_cast.to_s
+        elsif b.respond_to?(:value)
+          b.value.to_s
+        else
+          b.to_s
+        end
+      end
+      [raw_sql.strip, coerced]
+    rescue TypeError, ArgumentError, NoMethodError
+      # Plain node — Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148)
       [result.to_sql.strip, []]
-    else
-      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager"
     end
 
     # 6. Write CanonicalQuery JSON

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -121,15 +121,16 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     end
 
     # 5. Get SQL and binds.
-    #    conn.to_sql_and_binds accepts a SelectManager directly — it calls .ast internally
-    #    (DatabaseStatements#to_sql_and_binds in AR 8). Plain nodes raise TypeError/
-    #    ArgumentError/NoMethodError; fall back to direct to_sql for those.
-    raw_sql, raw_binds = begin
-      conn.to_sql_and_binds(result)
-    rescue TypeError, ArgumentError, NoMethodError
-      # Plain node — Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148)
-      [result.to_sql.strip, []]
-    end
+    #    Managers expose .ast; pass it directly to to_sql_and_binds which compiles via
+    #    the visitor and returns Rails-style bind objects. Plain nodes (no .ast) are
+    #    rendered directly via to_sql — they carry no bind params.
+    raw_sql, raw_binds =
+      if result.respond_to?(:ast)
+        conn.to_sql_and_binds(result.ast)
+      else
+        # Plain node — Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148)
+        [result.to_sql.strip, []]
+      end
 
     binds = Array(raw_binds).map do |b|
       raw = if b.respond_to?(:value_before_type_cast)
@@ -139,7 +140,8 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
       else
         b
       end
-      raw.nil? ? nil : raw.to_s
+      # nil bind = SQL NULL; keep as "NULL" so binds array stays string[] per schema
+      raw.nil? ? "NULL" : raw.to_s
     end
     sql_str = raw_sql.strip
 

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -118,8 +118,8 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     end
 
     # 5. Get SQL and binds.
-    #    Try conn.to_sql_and_binds first (works for managers and SQL strings, extracts
-    #    binds Rails-style). Plain nodes may only support direct SQL rendering via to_sql;
+    #    Try conn.to_sql_and_binds first (works for managers, extracts binds Rails-style).
+    #    Plain nodes (no .ast) may only support direct SQL rendering via to_sql;
     #    fall back to that path if to_sql_and_binds raises.
     raw_sql, raw_binds = begin
       conn.to_sql_and_binds(result)

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -4,6 +4,7 @@ require "bundler/setup"
 require "minitest/autorun"
 require "json"
 require "tmpdir"
+require "tempfile"
 require "open3"
 
 # Integration tests for dump.rb — runs the script against real fixtures.
@@ -14,7 +15,9 @@ DUMP_SCRIPT = File.expand_path("dump.rb", __dir__)
 FIXTURES    = File.expand_path("../../fixtures", __dir__)
 
 def run_dump(fixture, frozen_at: nil)
-  out = Dir::Tmpname.make_tmpname("/tmp/parity-test-", ".json")
+  tf = Tempfile.new(["parity-test-", ".json"])
+  out = tf.path
+  tf.close  # close so ruby on the other side can write to it
   cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", DUMP_SCRIPT,
          "#{FIXTURES}/#{fixture}", out]
   cmd += ["--frozen-at", frozen_at] if frozen_at

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -27,7 +27,7 @@ end
 class DumpTest < Minitest::Test
   def test_arel_01_table_object
     code, _stdout, stderr, out_path = run_dump("arel-01")
-    assert_equal 0, code, "dump failed: #{stderr}"
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_equal 1,         result["version"]
     assert_equal "arel-01", result["fixture"]
@@ -39,7 +39,7 @@ class DumpTest < Minitest::Test
 
   def test_arel_06_eq_predicate
     code, _stdout, stderr, out_path = run_dump("arel-06")
-    assert_equal 0, code, "dump failed: #{stderr}"
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/"users"\."name" = /i, result["sql"])
   ensure
@@ -48,7 +48,7 @@ class DumpTest < Minitest::Test
 
   def test_arel_09_lt_predicate
     code, _stdout, stderr, out_path = run_dump("arel-09")
-    assert_equal 0, code, "dump failed: #{stderr}"
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/"users"\."age" < /i, result["sql"])
   ensure
@@ -58,7 +58,7 @@ class DumpTest < Minitest::Test
   def test_arel_21_select_manager_with_where
     # arel-21 returns a SelectManager — exercises the to_sql_and_binds branch
     code, _stdout, stderr, out_path = run_dump("arel-21")
-    assert_equal 0, code, "dump failed: #{stderr}"
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/SELECT/i, result["sql"], "expected SELECT statement from SelectManager")
     assert_match(/WHERE/i,  result["sql"], "expected WHERE clause")
@@ -69,7 +69,7 @@ class DumpTest < Minitest::Test
   def test_frozen_at_forwarded
     frozen = "2026-01-01T00:00:00.000Z"
     code, _stdout, stderr, out_path = run_dump("arel-01", frozen_at: frozen)
-    assert_equal 0, code, "dump failed: #{stderr}"
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_equal frozen, result["frozenAt"]
   ensure

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -78,4 +78,30 @@ class DumpTest < Minitest::Test
   ensure
     File.delete(out_path) if File.exist?(out_path)
   end
+
+  def test_frozen_at_missing_value
+    tf = Tempfile.new(["parity-test-", ".json"])
+    out = tf.path
+    tf.close
+    cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", DUMP_SCRIPT,
+           "#{FIXTURES}/arel-01", out, "--frozen-at"]
+    _stdout, stderr, status = Open3.capture3(*cmd)
+    assert_equal 1, status.exitstatus
+    assert_match(/--frozen-at requires a value/, stderr)
+  ensure
+    File.delete(out) if File.exist?(out)
+  end
+
+  def test_frozen_at_invalid_format
+    tf = Tempfile.new(["parity-test-", ".json"])
+    out = tf.path
+    tf.close
+    cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", DUMP_SCRIPT,
+           "#{FIXTURES}/arel-01", out, "--frozen-at", "not-a-timestamp"]
+    _stdout, stderr, status = Open3.capture3(*cmd)
+    assert_equal 1, status.exitstatus
+    assert_match(/--frozen-at must be ISO 8601 UTC with trailing Z/, stderr)
+  ensure
+    File.delete(out) if File.exist?(out)
+  end
 end

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "minitest/autorun"
+require "json"
+require "tmpdir"
+require "open3"
+
+# Integration tests for dump.rb — runs the script against real fixtures.
+# Must be run from the repo root.
+
+DUMP_SCRIPT = File.expand_path("dump.rb", __dir__)
+FIXTURES    = File.expand_path("../../fixtures", __dir__)
+
+def run_dump(fixture, frozen_at: nil)
+  out = Dir::Tmpname.make_tmpname("/tmp/parity-test-", ".json")
+  cmd = ["ruby", DUMP_SCRIPT, "#{FIXTURES}/#{fixture}", out]
+  cmd += ["--frozen-at", frozen_at] if frozen_at
+  stdout, stderr, status = Open3.capture3(*cmd)
+  [status.exitstatus, stdout, stderr, out]
+end
+
+class DumpTest < Minitest::Test
+  def test_arel_01_table_object
+    code, _stdout, stderr, out_path = run_dump("arel-01")
+    assert_equal 0, code, "dump failed: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_equal 1,         result["version"]
+    assert_equal "arel-01", result["fixture"]
+    assert_match(/"users"/i, result["sql"])
+    assert_equal [],        result["binds"]
+  ensure
+    File.delete(out_path) if File.exist?(out_path)
+  end
+
+  def test_arel_06_eq_predicate
+    code, _stdout, stderr, out_path = run_dump("arel-06")
+    assert_equal 0, code, "dump failed: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_match(/"users"\."name" = /i, result["sql"])
+  ensure
+    File.delete(out_path) if File.exist?(out_path)
+  end
+
+  def test_arel_09_lt_predicate
+    code, _stdout, stderr, out_path = run_dump("arel-09")
+    assert_equal 0, code, "dump failed: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_match(/"users"\."age" < /i, result["sql"])
+  ensure
+    File.delete(out_path) if File.exist?(out_path)
+  end
+
+  def test_frozen_at_forwarded
+    frozen = "2026-01-01T00:00:00.000Z"
+    code, _stdout, stderr, out_path = run_dump("arel-01", frozen_at: frozen)
+    assert_equal 0, code, "dump failed: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_equal frozen, result["frozenAt"]
+  ensure
+    File.delete(out_path) if File.exist?(out_path)
+  end
+end

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -3,12 +3,11 @@
 require "bundler/setup"
 require "minitest/autorun"
 require "json"
-require "tmpdir"
 require "tempfile"
 require "open3"
 
 # Integration tests for dump.rb — runs the script against real fixtures.
-# Must be run from the repo root.
+# Must be run under Bundler with scripts/parity/schema/ruby/Gemfile.
 
 GEMFILE     = File.expand_path("../../schema/ruby/Gemfile", __dir__)
 DUMP_SCRIPT = File.expand_path("dump.rb", __dir__)

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -9,12 +9,14 @@ require "open3"
 # Integration tests for dump.rb — runs the script against real fixtures.
 # Must be run from the repo root.
 
+GEMFILE     = File.expand_path("../../schema/ruby/Gemfile", __dir__)
 DUMP_SCRIPT = File.expand_path("dump.rb", __dir__)
 FIXTURES    = File.expand_path("../../fixtures", __dir__)
 
 def run_dump(fixture, frozen_at: nil)
   out = Dir::Tmpname.make_tmpname("/tmp/parity-test-", ".json")
-  cmd = ["ruby", DUMP_SCRIPT, "#{FIXTURES}/#{fixture}", out]
+  cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", DUMP_SCRIPT,
+         "#{FIXTURES}/#{fixture}", out]
   cmd += ["--frozen-at", frozen_at] if frozen_at
   stdout, stderr, status = Open3.capture3(*cmd)
   [status.exitstatus, stdout, stderr, out]

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -26,7 +26,7 @@ end
 
 class DumpTest < Minitest::Test
   def test_arel_01_table_object
-    code, _stdout, stderr, out_path = run_dump("arel-01")
+    code, stdout, stderr, out_path = run_dump("arel-01")
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_equal 1,         result["version"]
@@ -38,7 +38,7 @@ class DumpTest < Minitest::Test
   end
 
   def test_arel_06_eq_predicate
-    code, _stdout, stderr, out_path = run_dump("arel-06")
+    code, stdout, stderr, out_path = run_dump("arel-06")
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/"users"\."name" = /i, result["sql"])
@@ -47,7 +47,7 @@ class DumpTest < Minitest::Test
   end
 
   def test_arel_09_lt_predicate
-    code, _stdout, stderr, out_path = run_dump("arel-09")
+    code, stdout, stderr, out_path = run_dump("arel-09")
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/"users"\."age" < /i, result["sql"])
@@ -57,7 +57,7 @@ class DumpTest < Minitest::Test
 
   def test_arel_21_select_manager_with_where
     # arel-21 returns a SelectManager — exercises the to_sql_and_binds branch
-    code, _stdout, stderr, out_path = run_dump("arel-21")
+    code, stdout, stderr, out_path = run_dump("arel-21")
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_match(/SELECT/i, result["sql"], "expected SELECT statement from SelectManager")
@@ -68,7 +68,7 @@ class DumpTest < Minitest::Test
 
   def test_frozen_at_forwarded
     frozen = "2026-01-01T00:00:00.000Z"
-    code, _stdout, stderr, out_path = run_dump("arel-01", frozen_at: frozen)
+    code, stdout, stderr, out_path = run_dump("arel-01", frozen_at: frozen)
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
     assert_equal frozen, result["frozenAt"]

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -56,6 +56,17 @@ class DumpTest < Minitest::Test
     File.delete(out_path) if File.exist?(out_path)
   end
 
+  def test_arel_21_select_manager_with_where
+    # arel-21 returns a SelectManager — exercises the to_sql_and_binds branch
+    code, _stdout, stderr, out_path = run_dump("arel-21")
+    assert_equal 0, code, "dump failed: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_match(/SELECT/i, result["sql"], "expected SELECT statement from SelectManager")
+    assert_match(/WHERE/i,  result["sql"], "expected WHERE clause")
+  ensure
+    File.delete(out_path) if File.exist?(out_path)
+  end
+
   def test_frozen_at_forwarded
     frozen = "2026-01-01T00:00:00.000Z"
     code, _stdout, stderr, out_path = run_dump("arel-01", frozen_at: frozen)

--- a/scripts/parity/query/ruby/dump_test.rb
+++ b/scripts/parity/query/ruby/dump_test.rb
@@ -25,14 +25,17 @@ def run_dump(fixture, frozen_at: nil)
 end
 
 class DumpTest < Minitest::Test
+  DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z"
+
   def test_arel_01_table_object
     code, stdout, stderr, out_path = run_dump("arel-01")
     assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
     result = JSON.parse(File.read(out_path))
-    assert_equal 1,         result["version"]
-    assert_equal "arel-01", result["fixture"]
-    assert_match(/"users"/i, result["sql"])
-    assert_equal [],        result["binds"]
+    assert_equal 1,                result["version"]
+    assert_equal "arel-01",        result["fixture"]
+    assert_equal DEFAULT_FROZEN_AT, result["frozenAt"]
+    assert_match(/"users"/i,       result["sql"])
+    assert_equal [],               result["binds"]
   ensure
     File.delete(out_path) if File.exist?(out_path)
   end


### PR DESCRIPTION
## Summary

Adds \`scripts/parity/query/ruby/dump.rb\` — the Ruby-side query parity runner.

**\`dump.rb\`** — CLI: \`bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby scripts/parity/query/ruby/dump.rb <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]\`

1. Applies \`schema.sql\` to a fresh temp SQLite via \`SQLite3::Database\`
2. Connects via \`ActiveRecord::Base.establish_connection\`
3. Always freezes time via \`ActiveSupport::Testing::TimeHelpers#travel_to\` — defaults to \`2000-01-01T00:00:00.000Z\` when \`--frozen-at\` is omitted
4. Evaluates \`query.rb\` via \`eval\` in an isolated binding — last expression is the Arel node/manager
5. Extracts SQL: managers (respond to \`.ast\`) via \`conn.to_sql_and_binds(result.ast)\`; bare nodes via \`result.to_sql\` (\`Arel::Nodes::Node#to_sql\` at \`arel/nodes/node.rb:148\`)
6. Nil bind values (SQL NULL) serialized as \`"NULL"\` to keep \`binds\` array \`string[]\` per schema
7. Writes \`CanonicalQuery\` JSON matching \`scripts/parity/canonical/query.schema.json\`

**\`dump_test.rb\`** — 7 minitest integration tests:
- \`test_arel_01_table_object\` — basic table query, asserts full CanonicalQuery shape incl. \`frozenAt\` default
- \`test_arel_06_eq_predicate\` — eq predicate SQL output
- \`test_arel_09_lt_predicate\` — lt predicate SQL output
- \`test_arel_21_select_manager_with_where\` — SelectManager exercises \`to_sql_and_binds\` branch
- \`test_frozen_at_forwarded\` — \`--frozen-at\` string preserved verbatim in \`frozenAt\` output
- \`test_frozen_at_missing_value\` — exit 1 + stderr when \`--frozen-at\` has no value
- \`test_frozen_at_invalid_format\` — exit 1 + stderr for non-ISO timestamp

Reuses the existing \`scripts/parity/schema/ruby/Gemfile\` (no new gems needed — \`activesupport\` is already a transitive dependency of \`activerecord\`).

## Test plan
- [ ] CI runs \`bundle exec ruby dump_test.rb\` green
- [ ] \`ruby dump.rb scripts/parity/fixtures/arel-01 /tmp/out.json\` writes valid \`CanonicalQuery\`
- [ ] SQL for arel-06 contains \`"users"."name" =\`