### PR TITLE
feat(activerecord): Aggregations#initializeDup + reload

### DIFF
--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -427,8 +427,9 @@ describe("AggregationsTest", () => {
     const addr1 = (c as any).address;
     expect(addr1.city).toBe("BOS");
 
-    // Bypass the cache by writing directly to DB, then reload to clear it —
-    // mirrors the Rails test (update_all + reload to flush @aggregation_cache).
+    // Bypass the composed-of setter / aggregation cache invalidation path,
+    // then reload to flush it — mirrors the Rails test's update_all + reload
+    // sequence used to clear @aggregation_cache.
     await c.updateColumn("address_city", "CHI");
     await c.reload();
     const addr2 = (c as any).address;

--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -427,7 +427,10 @@ describe("AggregationsTest", () => {
     const addr1 = (c as any).address;
     expect(addr1.city).toBe("BOS");
 
-    c.address_city = "CHI";
+    // Bypass the cache by writing directly to DB, then reload to clear it —
+    // mirrors the Rails test (update_all + reload to flush @aggregation_cache).
+    await c.updateColumn("address_city", "CHI");
+    await c.reload();
     const addr2 = (c as any).address;
     expect(addr2.city).toBe("CHI");
   });

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -3,7 +3,7 @@ import { reload as persistenceReload } from "./persistence.js";
 
 /**
  * Aggregation cache — memoizes composed-of value objects so repeated reads
- * return the same frozen instance instead of allocating new ones each time.
+ * return the same cached instance instead of allocating new ones each time.
  *
  * Mirrors: ActiveRecord::Aggregations
  */
@@ -19,8 +19,9 @@ export function getAggregationCache(record: Base): Map<string, unknown> {
 }
 
 export function clearAggregationCache(record: Base): void {
-  if (record.isPersisted()) {
-    getAggregationCache(record).clear();
+  const self = record as any;
+  if (self._aggregationCache && record.isPersisted()) {
+    (self._aggregationCache as Map<string, unknown>).clear();
   }
 }
 

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -27,8 +27,8 @@ export function initializeDup(this: Base, _other: unknown): void {
  *
  * Mirrors: ActiveRecord::Aggregations#reload
  */
-export async function reload(this: Base): Promise<Base> {
-  return persistenceReload.call(this);
+export async function reload<T extends Base>(this: T): Promise<T> {
+  return persistenceReload.call(this) as Promise<T>;
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -48,9 +48,9 @@ export function initializeDup(this: Base, _other: unknown): void {
  *
  * Mirrors: ActiveRecord::Aggregations#reload
  */
-export async function reload(this: Base): Promise<Base> {
+export async function reload<T extends Base>(this: T): Promise<T> {
   clearAggregationCache(this);
-  return (persistenceReload as unknown as (this: Base) => Promise<Base>).call(this);
+  return (persistenceReload as unknown as (this: T) => Promise<T>).call(this);
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -2,32 +2,53 @@ import type { Base } from "./base.js";
 import { reload as persistenceReload } from "./persistence.js";
 
 /**
- * Aggregation cache lifecycle hooks mixed into every model.
- *
- * Rails memoizes composed-of value objects in an `@aggregation_cache` hash.
- * Our implementation computes value objects on the fly (no cache), so the
- * cache management methods are no-ops — but the API surface must be present.
+ * Aggregation cache — memoizes composed-of value objects so repeated reads
+ * return the same frozen instance instead of allocating new ones each time.
  *
  * Mirrors: ActiveRecord::Aggregations
  */
 
+// ---------------------------------------------------------------------------
+// Cache accessors used by composed-of.ts
+// ---------------------------------------------------------------------------
+
+export function getAggregationCache(record: Base): Map<string, unknown> {
+  const self = record as any;
+  if (!self._aggregationCache) self._aggregationCache = new Map<string, unknown>();
+  return self._aggregationCache as Map<string, unknown>;
+}
+
+export function clearAggregationCache(record: Base): void {
+  if (record.isPersisted()) {
+    getAggregationCache(record).clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public instance methods
+// ---------------------------------------------------------------------------
+
 /**
- * Dup the aggregation cache when the record is duped.
- * No-op: our composed-of computes on the fly with no cache.
+ * Dup the aggregation cache so the duped record gets independent memoized
+ * value objects.
  *
  * Mirrors: ActiveRecord::Aggregations#initialize_dup
  */
 export function initializeDup(this: Base, _other: unknown): void {
-  // Our composed-of accessors are computed on demand — nothing to dup.
+  const self = this as any;
+  if (self._aggregationCache) {
+    self._aggregationCache = new Map(self._aggregationCache as Map<string, unknown>);
+  }
 }
 
 /**
- * Clear the aggregation cache before reloading from the database.
- * No-op cache clear since we have no cache; delegates to persistence reload.
+ * Clear the aggregation cache before reloading from the database so stale
+ * value objects are not returned after the reload.
  *
  * Mirrors: ActiveRecord::Aggregations#reload
  */
 export async function reload(this: Base): Promise<Base> {
+  clearAggregationCache(this);
   return (persistenceReload as unknown as (this: Base) => Promise<Base>).call(this);
 }
 

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -30,19 +30,15 @@ export function clearAggregationCache(record: Base): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Reset the aggregation cache so the duped record builds independent
- * value objects on demand.
- *
- * Rails dups the cache (sharing frozen value-object references), but since
- * we don't freeze cached objects we clear instead — same result with no
- * shared mutable state risk.
+ * Shallow-copy the aggregation cache into the duped record.
+ * Cached value objects are frozen so sharing references across the dup is safe.
  *
  * Mirrors: ActiveRecord::Aggregations#initialize_dup
  */
 export function initializeDup(this: Base, _other: unknown): void {
   const self = this as any;
   if (self._aggregationCache) {
-    self._aggregationCache = new Map<string, unknown>();
+    self._aggregationCache = new Map(self._aggregationCache as Map<string, unknown>);
   }
 }
 

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -28,7 +28,7 @@ export function initializeDup(this: Base, _other: unknown): void {
  * Mirrors: ActiveRecord::Aggregations#reload
  */
 export async function reload<T extends Base>(this: T): Promise<T> {
-  return persistenceReload.call(this) as Promise<T>;
+  return (persistenceReload as (this: T) => Promise<T>).call(this);
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,0 +1,37 @@
+import type { Base } from "./base.js";
+import { reload as persistenceReload } from "./persistence.js";
+
+/**
+ * Aggregation cache lifecycle hooks mixed into every model.
+ *
+ * Rails memoizes composed-of value objects in an `@aggregation_cache` hash.
+ * Our implementation computes value objects on the fly (no cache), so the
+ * cache management methods are no-ops — but the API surface must be present.
+ *
+ * Mirrors: ActiveRecord::Aggregations
+ */
+
+/**
+ * Dup the aggregation cache when the record is duped.
+ * No-op: our composed-of computes on the fly with no cache.
+ *
+ * Mirrors: ActiveRecord::Aggregations#initialize_dup
+ */
+export function initializeDup(this: Base, _other: unknown): void {
+  // Our composed-of accessors are computed on demand — nothing to dup.
+}
+
+/**
+ * Clear the aggregation cache before reloading from the database.
+ * No-op cache clear since we have no cache; delegates to persistence reload.
+ *
+ * Mirrors: ActiveRecord::Aggregations#reload
+ */
+export async function reload(this: Base): Promise<Base> {
+  return persistenceReload.call(this);
+}
+
+export const InstanceMethods = {
+  initializeDup,
+  reload,
+};

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -30,15 +30,19 @@ export function clearAggregationCache(record: Base): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Dup the aggregation cache so the duped record gets independent memoized
- * value objects.
+ * Reset the aggregation cache so the duped record builds independent
+ * value objects on demand.
+ *
+ * Rails dups the cache (sharing frozen value-object references), but since
+ * we don't freeze cached objects we clear instead — same result with no
+ * shared mutable state risk.
  *
  * Mirrors: ActiveRecord::Aggregations#initialize_dup
  */
 export function initializeDup(this: Base, _other: unknown): void {
   const self = this as any;
   if (self._aggregationCache) {
-    self._aggregationCache = new Map(self._aggregationCache as Map<string, unknown>);
+    self._aggregationCache = new Map<string, unknown>();
   }
 }
 

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -27,8 +27,8 @@ export function initializeDup(this: Base, _other: unknown): void {
  *
  * Mirrors: ActiveRecord::Aggregations#reload
  */
-export async function reload<T extends Base>(this: T): Promise<T> {
-  return (persistenceReload as (this: T) => Promise<T>).call(this);
+export async function reload(this: Base): Promise<Base> {
+  return (persistenceReload as unknown as (this: Base) => Promise<Base>).call(this);
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2790,6 +2790,8 @@ include(Base, LockingPessimistic.InstanceMethods);
 include(Base, Timestamp.InstanceMethods);
 include(Base, TouchLater.InstanceMethods);
 include(Base, _Aggregations.InstanceMethods);
+// Aggregations#reload must override Persistence#reload (include() won't replace).
+(Base.prototype as any).reload = _Aggregations.reload;
 include(Base, AutosaveAssociation);
 include(Base, _AssocInstance.InstanceMethods);
 include(Base, {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -113,6 +113,7 @@ import {
 } from "./core.js";
 import * as _Core from "./core.js";
 import * as _Persistence from "./persistence.js";
+import * as _Aggregations from "./aggregations.js";
 import * as _EnumModule from "./enum.js";
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
@@ -2665,6 +2666,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   updateBang(attrs: Record<string, unknown>): Promise<true>;
   delete(): Promise<this>;
   reload(): Promise<this>;
+  initializeDup(other: unknown): void;
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): void;
@@ -2787,6 +2789,7 @@ include(Base, {
 include(Base, LockingPessimistic.InstanceMethods);
 include(Base, Timestamp.InstanceMethods);
 include(Base, TouchLater.InstanceMethods);
+include(Base, _Aggregations.InstanceMethods);
 include(Base, AutosaveAssociation);
 include(Base, _AssocInstance.InstanceMethods);
 include(Base, {

--- a/packages/activerecord/src/composed-of.ts
+++ b/packages/activerecord/src/composed-of.ts
@@ -59,8 +59,7 @@ export function composedOf(
       const args = options.mapping.map(([modelAttr]) => this.readAttribute(modelAttr));
       if (args.every((a) => a === null || a === undefined)) return null;
 
-      const obj = new options.className(...args);
-      // Rails freezes the cached object; we store it as-is (freeze is opt-in in JS)
+      const obj = Object.freeze(new options.className(...args));
       cache.set(name, obj);
       return obj;
     },
@@ -77,12 +76,16 @@ export function composedOf(
         return;
       }
 
-      // If it's an instance of the class, decompose it and cache
+      // If it's an instance of the class, decompose it and cache frozen copy.
+      // Rails does part.dup.freeze — we freeze a shallow copy via spread.
       if (value instanceof options.className) {
         for (const [modelAttr, valueAttr] of options.mapping) {
           this.writeAttribute(modelAttr, (value as any)[valueAttr]);
         }
-        cache.set(name, value);
+        cache.set(
+          name,
+          Object.freeze(Object.assign(Object.create(Object.getPrototypeOf(value)), value)),
+        );
         return;
       }
 
@@ -93,7 +96,12 @@ export function composedOf(
           for (const [modelAttr, valueAttr] of options.mapping) {
             this.writeAttribute(modelAttr, (converted as any)[valueAttr]);
           }
-          cache.set(name, converted);
+          cache.set(
+            name,
+            Object.freeze(
+              Object.assign(Object.create(Object.getPrototypeOf(converted)), converted),
+            ),
+          );
         }
       }
     },

--- a/packages/activerecord/src/composed-of.ts
+++ b/packages/activerecord/src/composed-of.ts
@@ -71,7 +71,9 @@ export function composedOf(
         for (const [modelAttr] of options.mapping) {
           this.writeAttribute(modelAttr, null);
         }
-        cache.set(name, null);
+        // Don't cache null — let the reader recompute (mirrors Rails where
+        // nil cache entry triggers a rebuild attempt on next read).
+        cache.delete(name);
         return;
       }
 

--- a/packages/activerecord/src/composed-of.ts
+++ b/packages/activerecord/src/composed-of.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
 import { AggregateReflection } from "./reflection.js";
+import { getAggregationCache } from "./aggregations.js";
 
 interface ComposedOfOptions {
   className: new (...args: any[]) => any;
@@ -48,27 +49,38 @@ export function composedOf(
     ),
   );
 
-  // Getter: read mapped attributes and instantiate the value object
+  // Getter: read from aggregation cache or build and cache the value object.
+  // Mirrors: Rails' reader_method — caches in @aggregation_cache[name].freeze
   Object.defineProperty(modelClass.prototype, name, {
     get(this: Base): unknown {
+      const cache = getAggregationCache(this);
+      if (cache.has(name)) return cache.get(name);
+
       const args = options.mapping.map(([modelAttr]) => this.readAttribute(modelAttr));
-      // If all args are null, return null
       if (args.every((a) => a === null || a === undefined)) return null;
-      return new options.className(...args);
+
+      const obj = new options.className(...args);
+      // Rails freezes the cached object; we store it as-is (freeze is opt-in in JS)
+      cache.set(name, obj);
+      return obj;
     },
     set(this: Base, value: unknown): void {
+      const cache = getAggregationCache(this);
+
       if (value === null || value === undefined) {
         for (const [modelAttr] of options.mapping) {
           this.writeAttribute(modelAttr, null);
         }
+        cache.set(name, null);
         return;
       }
 
-      // If it's an instance of the class, decompose it
+      // If it's an instance of the class, decompose it and cache
       if (value instanceof options.className) {
         for (const [modelAttr, valueAttr] of options.mapping) {
           this.writeAttribute(modelAttr, (value as any)[valueAttr]);
         }
+        cache.set(name, value);
         return;
       }
 
@@ -79,6 +91,7 @@ export function composedOf(
           for (const [modelAttr, valueAttr] of options.mapping) {
             this.writeAttribute(modelAttr, (converted as any)[valueAttr]);
           }
+          cache.set(name, converted);
         }
       }
     },


### PR DESCRIPTION
## Summary

- Creates `aggregations.ts` implementing `ActiveRecord::Aggregations` lifecycle hooks
- Adds a real `_aggregationCache` Map per record instance (lazy-initialized)
- Updates `composed-of.ts` reader to cache value objects on first access (mirrors Rails' `@aggregation_cache[name]` memoization)
- Cached objects are `Object.freeze`d — matches Rails' `object.freeze`
- Writer invalidates the cache entry on assignment; null writes delete the key so the reader recomputes naturally
- `initializeDup` shallow-copies the cache Map (safe because values are frozen)
- `reload` clears the cache then delegates to `persistenceReload` — mirrors Rails' `clear_aggregation_cache; super`
- `clearAggregationCache` avoids allocating a new Map if none exists yet

## Rails source
`activerecord/lib/active_record/aggregations.rb`