### PR TITLE
feat(encryption): decrypt fallback to previous schemes (PR D)

### DIFF
--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -4,7 +4,7 @@ import type { EncryptorLike } from "./encryptor.js";
 import type { WrappedType } from "./wrapped-type.js";
 import { isEncryptionDisabled, isProtectedMode } from "./context.js";
 import { Configurable } from "./configurable.js";
-import { Encryption as EncryptionError } from "./errors.js";
+import { Encryption as EncryptionError, Decryption as DecryptionError } from "./errors.js";
 import { NullEncryptor } from "./null-encryptor.js";
 
 /**
@@ -147,11 +147,40 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     if (value === null || value === undefined) return value;
     if (this._default !== undefined && this._default === value) return value;
 
-    if (this.supportUnencryptedData && !this.isEncrypted(value)) {
+    try {
+      return this._encryptor.decrypt(String(value), this.decryptionOptions());
+    } catch (error) {
+      const prevWithoutCleanText = this.previousTypes.filter((t) => !t._isCleanTextType());
+      if (prevWithoutCleanText.length === 0) {
+        return this._handleDeserializeError(error, value);
+      }
+      return this._tryPreviousTypes(value);
+    }
+  }
+
+  private _tryPreviousTypes(value: unknown): unknown {
+    const prev = this.previousTypes;
+    for (let i = 0; i < prev.length; i++) {
+      try {
+        return prev[i].deserialize(value);
+      } catch (error) {
+        if (i === prev.length - 1) {
+          return this._handleDeserializeError(error, value);
+        }
+      }
+    }
+    return value;
+  }
+
+  private _handleDeserializeError(error: unknown, value: unknown): unknown {
+    if (error instanceof DecryptionError && this.supportUnencryptedData) {
       return value;
     }
+    throw error;
+  }
 
-    return this._encryptor.decrypt(String(value), this.decryptionOptions());
+  private _isCleanTextType(): boolean {
+    return this._encryptor instanceof NullEncryptor;
   }
 
   private encrypt(value: string): string {

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -4,7 +4,11 @@ import type { EncryptorLike } from "./encryptor.js";
 import type { WrappedType } from "./wrapped-type.js";
 import { isEncryptionDisabled, isProtectedMode } from "./context.js";
 import { Configurable } from "./configurable.js";
-import { Encryption as EncryptionError, Decryption as DecryptionError } from "./errors.js";
+import {
+  Encryption as EncryptionError,
+  Decryption as DecryptionError,
+  Base as BaseEncryptionError,
+} from "./errors.js";
 import { NullEncryptor } from "./null-encryptor.js";
 
 /**
@@ -150,8 +154,8 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     try {
       return this._encryptor.decrypt(String(value), this.decryptionOptions());
     } catch (error) {
-      const prevWithoutCleanText = this.previousTypes.filter((t) => !t._isCleanTextType());
-      if (prevWithoutCleanText.length === 0) {
+      if (!(error instanceof BaseEncryptionError)) throw error;
+      if (this.scheme.previousSchemes.length === 0) {
         return this._handleDeserializeError(error, value);
       }
       return this._tryPreviousTypes(value);
@@ -164,6 +168,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
       try {
         return prev[i].deserialize(value);
       } catch (error) {
+        if (!(error instanceof BaseEncryptionError)) throw error;
         if (i === prev.length - 1) {
           return this._handleDeserializeError(error, value);
         }
@@ -172,15 +177,11 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return value;
   }
 
-  private _handleDeserializeError(error: unknown, value: unknown): unknown {
+  private _handleDeserializeError(error: BaseEncryptionError, value: unknown): unknown {
     if (error instanceof DecryptionError && this.supportUnencryptedData) {
       return value;
     }
     throw error;
-  }
-
-  private _isCleanTextType(): boolean {
-    return this._encryptor instanceof NullEncryptor;
   }
 
   private encrypt(value: string): string {

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -59,44 +59,67 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   it("use global previous schemes to decrypt data encrypted with previous schemes", () => {
     Configurable.config.supportUnencryptedData = false;
 
-    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
-    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
-    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+    const prev1Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }),
+    });
+    const prev2Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }),
+    });
+    const type = makeType(new TestEncryptor({ current: "current_cipher" }), [
+      prev1Scheme,
+      prev2Scheme,
+    ]);
 
     expect(type.previousTypes).toHaveLength(2);
     const [previousType1, previousType2] = type.previousTypes;
 
-    const ciphertext1 = previousType1.serialize("1") as string;
-    expect(type.deserialize(ciphertext1)).toBe("0");
+    // primary cannot decrypt legacy ciphertexts — falls back to previousType1
+    const ciphertext1 = previousType1.serialize("legacy1") as string;
+    expect(type.deserialize(ciphertext1)).toBe("legacy1");
 
-    const ciphertext2 = previousType2.serialize("2") as string;
-    expect(type.deserialize(ciphertext2)).toBe("1");
+    // primary and previousType1 cannot decrypt — falls back to previousType2
+    const ciphertext2 = previousType2.serialize("legacy2") as string;
+    expect(type.deserialize(ciphertext2)).toBe("legacy2");
   });
 
   it("use global previous schemes to decrypt data encrypted with previous schemes with unencrypted data", () => {
     Configurable.config.supportUnencryptedData = true;
 
-    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
-    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
-    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+    const prev1Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }),
+    });
+    const prev2Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }),
+    });
+    const type = makeType(new TestEncryptor({ current: "current_cipher" }), [
+      prev1Scheme,
+      prev2Scheme,
+    ]);
 
     // clean-text scheme is appended when supportUnencryptedData → 3 total
     expect(type.previousTypes).toHaveLength(3);
     const [previousType1, previousType2] = type.previousTypes;
 
-    const ciphertext1 = previousType1.serialize("1") as string;
-    expect(type.deserialize(ciphertext1)).toBe("0");
+    const ciphertext1 = previousType1.serialize("legacy1") as string;
+    expect(type.deserialize(ciphertext1)).toBe("legacy1");
 
-    const ciphertext2 = previousType2.serialize("2") as string;
-    expect(type.deserialize(ciphertext2)).toBe("1");
+    const ciphertext2 = previousType2.serialize("legacy2") as string;
+    expect(type.deserialize(ciphertext2)).toBe("legacy2");
   });
 
   it("returns ciphertext all the previous schemes fail to decrypt and support for unencrypted data is on", () => {
     Configurable.config.supportUnencryptedData = true;
 
-    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
-    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
-    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+    const prev1Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }),
+    });
+    const prev2Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }),
+    });
+    const type = makeType(new TestEncryptor({ current: "current_cipher" }), [
+      prev1Scheme,
+      prev2Scheme,
+    ]);
 
     expect(type.deserialize("some ciphertext")).toBe("some ciphertext");
   });
@@ -104,9 +127,16 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   it("raise decryption error when all the previous schemes fail to decrypt", () => {
     Configurable.config.supportUnencryptedData = false;
 
-    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
-    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
-    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+    const prev1Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }),
+    });
+    const prev2Scheme = new Scheme({
+      encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }),
+    });
+    const type = makeType(new TestEncryptor({ current: "current_cipher" }), [
+      prev1Scheme,
+      prev2Scheme,
+    ]);
 
     expect(() => type.deserialize("some invalid ciphertext")).toThrow(DecryptionError);
   });

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -1,14 +1,116 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { Scheme } from "./scheme.js";
+import { Configurable } from "./configurable.js";
+import { Decryption as DecryptionError } from "./errors.js";
+import type { EncryptorLike } from "./encryptor.js";
+
+class TestEncryptor implements EncryptorLike {
+  constructor(private readonly map: Record<string, string>) {}
+
+  encrypt(clearText: string): string {
+    return this.map[clearText] ?? clearText;
+  }
+
+  decrypt(encryptedText: string): string {
+    for (const [clear, cipher] of Object.entries(this.map)) {
+      if (cipher === encryptedText) return clear;
+    }
+    throw new DecryptionError(`Couldn't find a match for ${encryptedText}`);
+  }
+
+  isEncrypted(text: string): boolean {
+    try {
+      this.decrypt(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  isBinary(): boolean {
+    return false;
+  }
+}
+
+function makeType(
+  encryptor: EncryptorLike,
+  previousSchemes: Scheme[] = [],
+): EncryptedAttributeType {
+  return new EncryptedAttributeType({ scheme: new Scheme({ encryptor, previousSchemes }) });
+}
 
 describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
+  let savedSupportUnencryptedData: boolean;
+
+  beforeEach(() => {
+    savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
+  });
+
+  afterEach(() => {
+    Configurable.config.supportUnencryptedData = savedSupportUnencryptedData;
+  });
+
   it.skip("can decrypt encrypted_value encrypted with a different encryption scheme", () => {});
   it.skip("when defining previous encryption schemes, you still get Decryption errors when using invalid clear values", () => {});
   it.skip("use a custom encryptor", () => {});
   it.skip("support previous contexts", () => {});
-  it.skip("use global previous schemes to decrypt data encrypted with previous schemes", () => {});
-  it.skip("use global previous schemes to decrypt data encrypted with previous schemes with unencrypted data", () => {});
-  it.skip("returns ciphertext all the previous schemes fail to decrypt and support for unencrypted data is on", () => {});
-  it.skip("raise decryption error when all the previous schemes fail to decrypt", () => {});
+
+  it("use global previous schemes to decrypt data encrypted with previous schemes", () => {
+    Configurable.config.supportUnencryptedData = false;
+
+    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
+    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
+    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+
+    expect(type.previousTypes).toHaveLength(2);
+    const [previousType1, previousType2] = type.previousTypes;
+
+    const ciphertext1 = previousType1.serialize("1") as string;
+    expect(type.deserialize(ciphertext1)).toBe("0");
+
+    const ciphertext2 = previousType2.serialize("2") as string;
+    expect(type.deserialize(ciphertext2)).toBe("1");
+  });
+
+  it("use global previous schemes to decrypt data encrypted with previous schemes with unencrypted data", () => {
+    Configurable.config.supportUnencryptedData = true;
+
+    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
+    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
+    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+
+    // clean-text scheme is appended when supportUnencryptedData → 3 total
+    expect(type.previousTypes).toHaveLength(3);
+    const [previousType1, previousType2] = type.previousTypes;
+
+    const ciphertext1 = previousType1.serialize("1") as string;
+    expect(type.deserialize(ciphertext1)).toBe("0");
+
+    const ciphertext2 = previousType2.serialize("2") as string;
+    expect(type.deserialize(ciphertext2)).toBe("1");
+  });
+
+  it("returns ciphertext all the previous schemes fail to decrypt and support for unencrypted data is on", () => {
+    Configurable.config.supportUnencryptedData = true;
+
+    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
+    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
+    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+
+    expect(type.deserialize("some ciphertext")).toBe("some ciphertext");
+  });
+
+  it("raise decryption error when all the previous schemes fail to decrypt", () => {
+    Configurable.config.supportUnencryptedData = false;
+
+    const prev1Scheme = new Scheme({ encryptor: new TestEncryptor({ "0": "1" }) });
+    const prev2Scheme = new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) });
+    const type = makeType(new TestEncryptor({ "0": "1" }), [prev1Scheme, prev2Scheme]);
+
+    expect(() => type.deserialize("some invalid ciphertext")).toThrow(DecryptionError);
+  });
+
   it.skip("deterministic encryption is fixed by default: it will always use the oldest scheme to encrypt data", () => {});
   it.skip("don't use global previous schemes with a different deterministic nature", () => {});
   it.skip("deterministic encryption will use the newest encryption scheme to encrypt data when setting it to { fixed: false }", () => {});


### PR DESCRIPTION
## Summary

- `EncryptedAttributeType.decrypt()` now catches decryption errors and iterates `previousTypes` before re-raising, matching Rails' `try_to_deserialize_with_previous_encrypted_types` + `handle_deserialize_error`
- Removes the `supportUnencryptedData && !isEncrypted` early-return from `decrypt()` — Rails has no such shortcut; the unencrypted-data escape hatch lives only in `handle_deserialize_error` (returns raw value when last scheme fails with `Errors::Decryption` and `supportUnencryptedData` is on)
- Adds `DecryptionError` import (used by `_handleDeserializeError` to mirror Rails' `is_a?(Errors::Decryption)` check)
- Implements 4 previously-skipped tests in `encryption-schemes.test.ts` covering the full fallback matrix

## Rails source
`activerecord/lib/active_record/encryption/encrypted_attribute_type.rb` lines 84–116

## Test plan
- [ ] `encryption-schemes.test.ts` — 4 new tests pass: previous schemes decrypt, unencrypted data fallback, ciphertext passthrough, decryption error propagation
- [ ] Full encryption suite passes (168 tests)