### PR TITLE
feat(activemodel): ValidationContext accepts array contexts (Rails parity)

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1217,23 +1217,30 @@ export class Model {
   // validators all fire. See `validations.rb:361-368` and `:294-306`.
   _validationContext: string | string[] | null = null;
 
-  isValid(context?: string | string[] | ValidationContext): boolean {
+  isValid(context?: string | string[] | ValidationContext | null): boolean {
     this.errors.clear();
     const ctor = this.constructor as typeof Model;
-    // Accept string, string[], or ValidationContext. A ValidationContext
-    // exposes `.context` (possibly array) which we copy so downstream
-    // mutations on the instance can't leak into our frame.
-    let normalized: string | string[] | undefined;
-    if (context instanceof ValidationContext) {
+    // Rails `valid?(context = nil)` (validations.rb:361-368) always
+    // assigns `context_for_validation.context = context` on entry,
+    // restoring in `ensure`. So an explicit `null` is a clear, not a
+    // no-op. We distinguish `undefined` (argument omitted — Rails'
+    // default → nil) from `null` (explicit clear — also nil) by
+    // collapsing both to `null`. For `ValidationContext` / Array we
+    // deep-copy to prevent caller-side mutation from leaking into
+    // our frame.
+    let normalized: string | string[] | null;
+    if (context === undefined || context === null) {
+      normalized = null;
+    } else if (context instanceof ValidationContext) {
       const inner = context.context;
-      normalized = Array.isArray(inner) ? [...inner] : (inner ?? undefined);
+      normalized = Array.isArray(inner) ? [...inner] : inner;
     } else if (Array.isArray(context)) {
       normalized = [...context];
     } else {
       normalized = context;
     }
     const prevContext = this._validationContext;
-    this._validationContext = normalized ?? this._validationContext;
+    this._validationContext = normalized;
 
     try {
       const completed = ctor._callbackChain.runCallbacks("validation", this, () => {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -981,7 +981,7 @@ export class Model {
         const ctx = record._validationContext;
         if (ctx == null) return false;
         const current = Array.isArray(ctx) ? ctx : [ctx];
-        return current.some((c: unknown) => registeredSet.has(c));
+        return current.some((c: unknown) => registeredSet.has(c as string));
       });
     }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1222,12 +1222,10 @@ export class Model {
     const ctor = this.constructor as typeof Model;
     // Rails `valid?(context = nil)` (validations.rb:361-368) always
     // assigns `context_for_validation.context = context` on entry,
-    // restoring in `ensure`. So an explicit `null` is a clear, not a
-    // no-op. We distinguish `undefined` (argument omitted — Rails'
-    // default → nil) from `null` (explicit clear — also nil) by
-    // collapsing both to `null`. For `ValidationContext` / Array we
-    // deep-copy to prevent caller-side mutation from leaking into
-    // our frame.
+    // restoring in `ensure`. An omitted argument and an explicit
+    // `null` both map to Rails' `nil` — so we collapse both to
+    // `null` here. For `ValidationContext` / Array we deep-copy to
+    // prevent caller-side mutation from leaking into our frame.
     let normalized: string | string[] | null;
     if (context === undefined || context === null) {
       normalized = null;
@@ -1264,7 +1262,7 @@ export class Model {
    * Mirrors Rails `alias_method :validate, :valid?`
    * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string | string[] | ValidationContext): boolean {
+  validate(context?: string | string[] | ValidationContext | null): boolean {
     return this.isValid(context);
   }
 
@@ -1274,7 +1272,7 @@ export class Model {
    * Mirrors Rails `def invalid?(context = nil); !valid?(context); end`
    * (activemodel/lib/active_model/validations.rb:408-410).
    */
-  isInvalid(context?: string | string[] | ValidationContext): boolean {
+  isInvalid(context?: string | string[] | ValidationContext | null): boolean {
     return !this.isValid(context);
   }
 
@@ -1704,7 +1702,7 @@ export class Model {
    * Mirrors Rails `def validate!(context = nil); valid?(context) || raise_validation_error; end`
    * (activemodel/lib/active_model/validations.rb:417-419).
    */
-  validateBang(context?: string | string[] | ValidationContext): true {
+  validateBang(context?: string | string[] | ValidationContext | null): true {
     if (!this.isValid(context)) {
       throw new ValidationError(this);
     }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -969,11 +969,19 @@ export class Model {
     const parts: Array<(record: AnyRecord) => boolean> = [];
 
     if (options.on !== undefined) {
-      const onContext = options.on;
+      // Rails `predicate_for_validation_context` (validations.rb:294-306):
+      // both the registered `on:` and the model's current
+      // `validation_context` may be Symbols or Arrays of Symbols. A
+      // validator with `on: [:create, :publish]` fires when the model's
+      // context is `:create`, `[:create]`, `[:publish, :foo]`, etc. —
+      // intersection, not equality.
+      const registered = Array.isArray(options.on) ? options.on : [options.on];
+      const registeredSet = new Set(registered);
       parts.push((record: AnyRecord) => {
         const ctx = record._validationContext;
-        if (!ctx) return false;
-        return ctx === onContext;
+        if (ctx == null) return false;
+        const current = Array.isArray(ctx) ? ctx : [ctx];
+        return current.some((c: unknown) => registeredSet.has(c));
       });
     }
 
@@ -1203,14 +1211,29 @@ export class Model {
 
   // -- Validations --
 
-  _validationContext: string | null = null;
+  // Rails `validation_context` holds either a single Symbol or an
+  // Array<Symbol> (or nil). `valid?([:create, :publish])` round-trips
+  // the array so `on: :create` / `on: [:create]` / `on: [:create, :other]`
+  // validators all fire. See `validations.rb:361-368` and `:294-306`.
+  _validationContext: string | string[] | null = null;
 
-  isValid(context?: string | ValidationContext): boolean {
+  isValid(context?: string | string[] | ValidationContext): boolean {
     this.errors.clear();
     const ctor = this.constructor as typeof Model;
-    const contextStr = context instanceof ValidationContext ? context.name : context;
+    // Accept string, string[], or ValidationContext. A ValidationContext
+    // exposes `.context` (possibly array) which we copy so downstream
+    // mutations on the instance can't leak into our frame.
+    let normalized: string | string[] | undefined;
+    if (context instanceof ValidationContext) {
+      const inner = context.context;
+      normalized = Array.isArray(inner) ? [...inner] : (inner ?? undefined);
+    } else if (Array.isArray(context)) {
+      normalized = [...context];
+    } else {
+      normalized = context;
+    }
     const prevContext = this._validationContext;
-    this._validationContext = contextStr ?? this._validationContext;
+    this._validationContext = normalized ?? this._validationContext;
 
     try {
       const completed = ctor._callbackChain.runCallbacks("validation", this, () => {
@@ -1234,7 +1257,7 @@ export class Model {
    * Mirrors Rails `alias_method :validate, :valid?`
    * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string | ValidationContext): boolean {
+  validate(context?: string | string[] | ValidationContext): boolean {
     return this.isValid(context);
   }
 
@@ -1244,7 +1267,7 @@ export class Model {
    * Mirrors Rails `def invalid?(context = nil); !valid?(context); end`
    * (activemodel/lib/active_model/validations.rb:408-410).
    */
-  isInvalid(context?: string | ValidationContext): boolean {
+  isInvalid(context?: string | string[] | ValidationContext): boolean {
     return !this.isValid(context);
   }
 
@@ -1663,7 +1686,7 @@ export class Model {
    *
    * Mirrors: ActiveModel::Validations#validation_context
    */
-  get validationContext(): string | null {
+  get validationContext(): string | string[] | null {
     return this._validationContext;
   }
 
@@ -1674,7 +1697,7 @@ export class Model {
    * Mirrors Rails `def validate!(context = nil); valid?(context) || raise_validation_error; end`
    * (activemodel/lib/active_model/validations.rb:417-419).
    */
-  validateBang(context?: string | ValidationContext): true {
+  validateBang(context?: string | string[] | ValidationContext): true {
     if (!this.isValid(context)) {
       throw new ValidationError(this);
     }

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1081,6 +1081,26 @@ describe("ValidationsTest", () => {
       expect(captured).toEqual([["create", "publish"]]);
     });
 
+    it("valid?(null) clears the context (Rails sets it to nil on entry)", () => {
+      // Rails `valid?(context = nil)` always assigns
+      // `context_for_validation.context = context` — passing nil clears.
+      const captured: Array<string | string[] | null> = [];
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validate((r: InstanceType<typeof Scoped>) => {
+            captured.push(r.validationContext);
+          });
+        }
+      }
+      const m = new Scoped({});
+      m.isValid("previous");
+      m.isValid(null);
+      // First call saw "previous"; second call saw null (explicit clear),
+      // not "previous" carried over.
+      expect(captured).toEqual(["previous", null]);
+    });
+
     it("valid? restores previous context in ensure/finally even on failure", () => {
       // Rails validations.rb:361-368 uses `ensure` to restore context.
       class Scoped extends Model {

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1024,6 +1024,63 @@ describe("ValidationsTest", () => {
       expect(() => new Scoped({}).validateBang("create")).toThrow(/Validation failed/);
     });
 
+    it("valid? accepts an array context that matches :on-registered validators", () => {
+      // Rails `predicate_for_validation_context` (validations.rb:294-306)
+      // intersects the registered `on:` set with the model's current
+      // context — either side may be a single symbol or an array.
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.attribute("title", "string");
+          this.validates("name", { presence: true, on: "create" });
+          this.validates("title", { presence: true, on: ["publish"] });
+        }
+      }
+      // Single-symbol context → only the `on: :create` validator fires.
+      const a = new Scoped({});
+      expect(a.isValid("create")).toBe(false);
+      expect(a.errors.attributeNames).toEqual(["name"]);
+
+      // Array context → both validators fire (Rails: intersection).
+      const b = new Scoped({});
+      expect(b.isValid(["create", "publish"])).toBe(false);
+      expect(b.errors.attributeNames.sort()).toEqual(["name", "title"]);
+
+      // Array context matching only one registered value fires that one.
+      const c = new Scoped({});
+      expect(c.isValid(["publish"])).toBe(false);
+      expect(c.errors.attributeNames).toEqual(["title"]);
+    });
+
+    it("on: [array] validator fires when current context is a single symbol in the set", () => {
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { presence: true, on: ["create", "publish"] });
+        }
+      }
+      expect(new Scoped({}).isValid("create")).toBe(false);
+      expect(new Scoped({}).isValid("publish")).toBe(false);
+      expect(new Scoped({}).isValid("unrelated")).toBe(true);
+    });
+
+    it("validationContext round-trips array contexts while a validation is in flight", () => {
+      // Rails `validation_context` surfaces whatever context is currently
+      // set — when called inside a validator with an array context, it
+      // returns the array.
+      const captured: Array<string | string[] | null> = [];
+      class Scoped extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validate((record: InstanceType<typeof Scoped>) => {
+            captured.push(record.validationContext);
+          });
+        }
+      }
+      new Scoped({}).isValid(["create", "publish"]);
+      expect(captured).toEqual([["create", "publish"]]);
+    });
+
     it("valid? restores previous context in ensure/finally even on failure", () => {
       // Rails validations.rb:361-368 uses `ensure` to restore context.
       class Scoped extends Model {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -39,7 +39,7 @@ export interface Validations {
    * `validation_context` surfaces `context_for_validation.context`
    * directly (Symbol or Array of Symbols).
    */
-  readonly validationContext: string | string[] | ValidationContext | null;
+  readonly validationContext: string | string[] | null;
 }
 
 /**
@@ -110,12 +110,10 @@ export class ValidationError extends globalThis.Error {
  * segment as a string. `.context` is now `string | string[] | null`.
  */
 export class ValidationContext {
-  readonly name: string;
   private _context: string | string[] | null;
 
   constructor(context: string | string[] | null = null) {
     this._context = context;
-    this.name = Array.isArray(context) ? (context[0] ?? "") : (context ?? "");
   }
 
   get context(): string | string[] | null {
@@ -124,6 +122,16 @@ export class ValidationContext {
 
   set context(value: string | string[] | null) {
     this._context = value;
+  }
+
+  /**
+   * First-segment string form of the current context — live getter so it
+   * stays consistent with `.context` after mutation via the setter.
+   * `""` when the context is null.
+   */
+  get name(): string {
+    const c = this._context;
+    return Array.isArray(c) ? (c[0] ?? "") : (c ?? "");
   }
 
   toString(): string {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -12,25 +12,34 @@ import { I18n } from "./i18n.js";
  */
 export interface Validations {
   errors: Errors;
-  isValid(context?: string | ValidationContext): boolean;
+  isValid(context?: string | string[] | ValidationContext): boolean;
   /**
    * Run validations and return whether the record is valid.
    * Mirrors Rails `alias_method :validate, :valid?`
-   * (activemodel/lib/active_model/validations.rb:370).
+   * (activemodel/lib/active_model/validations.rb:370). Context may be a
+   * single symbol or an array — Rails supports e.g.
+   * `valid?([:create, :publish])` so a validator with `on: :publish`
+   * fires alongside the usual `:create` context.
    */
-  validate(context?: string | ValidationContext): boolean;
+  validate(context?: string | string[] | ValidationContext): boolean;
   /**
    * Opposite of `isValid`. Mirrors Rails `def invalid?(context = nil)`
    * (activemodel/lib/active_model/validations.rb:408-410).
    */
-  isInvalid(context?: string | ValidationContext): boolean;
+  isInvalid(context?: string | string[] | ValidationContext): boolean;
   /**
    * Run validations; return `true` or raise `ValidationError`. Mirrors Rails
    * `def validate!(context = nil); valid?(context) || raise_validation_error; end`
    * (activemodel/lib/active_model/validations.rb:417-419) — never returns false.
    */
-  validateBang(context?: string | ValidationContext): true;
-  readonly validationContext: string | ValidationContext | null;
+  validateBang(context?: string | string[] | ValidationContext): true;
+  /**
+   * The active validation context — a single symbol, an array of
+   * symbols, or `null`. Mirrors Rails `validations.rb:454-456` where
+   * `validation_context` surfaces `context_for_validation.context`
+   * directly (Symbol or Array of Symbols).
+   */
+  readonly validationContext: string | string[] | ValidationContext | null;
 }
 
 /**
@@ -90,18 +99,31 @@ export class ValidationError extends globalThis.Error {
 }
 
 /**
- * Represents a named validation context (e.g., :create, :update).
+ * Holds the active validation context for a model. Mirrors Rails
+ * `class ValidationContext; attr_accessor :context; end`
+ * (activemodel/lib/active_model/validations.rb:503-505) — a thin
+ * mutable holder whose `context` can be a single symbol or an Array
+ * of symbols (see `predicate_for_validation_context`, :294-306).
  *
- * Mirrors: ActiveModel::ValidationContext
+ * Kept backward-compatible: the old `new ValidationContext("create")`
+ * still works and `.name` + `.toString()` continue to return the first
+ * segment as a string. `.context` is now `string | string[] | null`.
  */
 export class ValidationContext {
   readonly name: string;
-  constructor(name: string) {
-    this.name = name;
+  private _context: string | string[] | null;
+
+  constructor(context: string | string[] | null = null) {
+    this._context = context;
+    this.name = Array.isArray(context) ? (context[0] ?? "") : (context ?? "");
   }
 
-  get context(): string {
-    return this.name;
+  get context(): string | string[] | null {
+    return this._context;
+  }
+
+  set context(value: string | string[] | null) {
+    this._context = value;
   }
 
   toString(): string {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -12,7 +12,7 @@ import { I18n } from "./i18n.js";
  */
 export interface Validations {
   errors: Errors;
-  isValid(context?: string | string[] | ValidationContext): boolean;
+  isValid(context?: string | string[] | ValidationContext | null): boolean;
   /**
    * Run validations and return whether the record is valid.
    * Mirrors Rails `alias_method :validate, :valid?`
@@ -21,18 +21,18 @@ export interface Validations {
    * `valid?([:create, :publish])` so a validator with `on: :publish`
    * fires alongside the usual `:create` context.
    */
-  validate(context?: string | string[] | ValidationContext): boolean;
+  validate(context?: string | string[] | ValidationContext | null): boolean;
   /**
    * Opposite of `isValid`. Mirrors Rails `def invalid?(context = nil)`
    * (activemodel/lib/active_model/validations.rb:408-410).
    */
-  isInvalid(context?: string | string[] | ValidationContext): boolean;
+  isInvalid(context?: string | string[] | ValidationContext | null): boolean;
   /**
    * Run validations; return `true` or raise `ValidationError`. Mirrors Rails
    * `def validate!(context = nil); valid?(context) || raise_validation_error; end`
    * (activemodel/lib/active_model/validations.rb:417-419) — never returns false.
    */
-  validateBang(context?: string | string[] | ValidationContext): true;
+  validateBang(context?: string | string[] | ValidationContext | null): true;
   /**
    * The active validation context — a single symbol, an array of
    * symbols, or `null`. Mirrors Rails `validations.rb:454-456` where

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -8,7 +8,14 @@ export type ConditionFn = ((record: AnyRecord) => boolean) | string;
 export interface ConditionalOptions {
   if?: ConditionFn | ConditionFn[];
   unless?: ConditionFn | ConditionFn[];
-  on?: string;
+  /**
+   * Validation context(s) under which this condition fires — a single
+   * context name or an array. Mirrors Rails `on:` which accepts
+   * `Symbol | Array<Symbol>` and intersects with the model's current
+   * `validation_context` via `predicate_for_validation_context`
+   * (activemodel/lib/active_model/validations.rb:294-306).
+   */
+  on?: string | string[];
 }
 
 export function evaluateCondition(record: AnyRecord, cond: ConditionFn): boolean {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -6,6 +6,7 @@
  * The [included] hook registers validateAssociations onto the class.
  */
 import type { Base } from "./base.js";
+import type { ValidationContextArg } from "./validations.js";
 import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
 import type { AssociationDefinition } from "./associations.js";
 import { underscore } from "@blazetrails/activesupport";
@@ -173,7 +174,7 @@ export function clearAutosaveState(record: Base): void {
 const _validatingRecords = new WeakSet<object>();
 const _autosavingRecords = new WeakSet<object>();
 
-export function validateAssociations(record: Base, context?: string): void {
+export function validateAssociations(record: Base, context?: ValidationContextArg): void {
   if (_validatingRecords.has(record)) return;
   _validatingRecords.add(record);
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2596,7 +2596,7 @@ export class Base extends Model {
    * Delegates to validations module for context resolution, then runs
    * autosave association validations.
    */
-  override isValid(context?: string): boolean {
+  override isValid(context?: string | string[]): boolean {
     const effectiveContext =
       context ?? this._validationContext ?? defaultValidationContext.call(this);
     const result = validationsIsValid.call(this, effectiveContext);
@@ -2641,7 +2641,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   loadBelongsTo(name: string): Promise<Base | null>;
   loadHasOne(name: string): Promise<Base | null>;
   readAttributeForValidation(attribute: string): unknown;
-  validate(context?: string): boolean;
+  validate(context?: string | string[]): boolean;
   customValidationContext(): boolean;
   increment(attribute: string, by?: number): this;
   decrement(attribute: string, by?: number): this;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -36,6 +36,7 @@ import {
   defaultValidationContext,
   _setSuperIsValid,
   _setSuperValidates,
+  type ValidationContextArg,
 } from "./validations.js";
 import * as _Validations from "./validations.js";
 import {
@@ -2596,7 +2597,7 @@ export class Base extends Model {
    * Delegates to validations module for context resolution, then runs
    * autosave association validations.
    */
-  override isValid(context?: string | string[] | null): boolean {
+  override isValid(context?: ValidationContextArg): boolean {
     const effectiveContext =
       context ?? this._validationContext ?? defaultValidationContext.call(this);
     const result = validationsIsValid.call(this, effectiveContext);
@@ -2641,7 +2642,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   loadBelongsTo(name: string): Promise<Base | null>;
   loadHasOne(name: string): Promise<Base | null>;
   readAttributeForValidation(attribute: string): unknown;
-  validate(context?: string | string[] | null): boolean;
+  validate(context?: ValidationContextArg): boolean;
   customValidationContext(): boolean;
   increment(attribute: string, by?: number): this;
   decrement(attribute: string, by?: number): this;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2596,7 +2596,7 @@ export class Base extends Model {
    * Delegates to validations module for context resolution, then runs
    * autosave association validations.
    */
-  override isValid(context?: string | string[]): boolean {
+  override isValid(context?: string | string[] | null): boolean {
     const effectiveContext =
       context ?? this._validationContext ?? defaultValidationContext.call(this);
     const result = validationsIsValid.call(this, effectiveContext);
@@ -2641,7 +2641,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   loadBelongsTo(name: string): Promise<Base | null>;
   loadHasOne(name: string): Promise<Base | null>;
   readAttributeForValidation(attribute: string): unknown;
-  validate(context?: string | string[]): boolean;
+  validate(context?: string | string[] | null): boolean;
   customValidationContext(): boolean;
   increment(attribute: string, by?: number): this;
   decrement(attribute: string, by?: number): this;

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -5,7 +5,15 @@
  * database-aware validators (uniqueness, association validity, etc.)
  * and overrides save/valid? to run validations with context awareness.
  */
+import type { ValidationContext } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
+
+/**
+ * Anything Rails' `valid?(context = nil)` accepts — shared between
+ * AM's `Model.isValid` and AR's `valid?` override so the signatures
+ * stay substitutable.
+ */
+export type ValidationContextArg = string | string[] | ValidationContext | null;
 import { AbsenceValidator } from "./validations/absence.js";
 import { AssociatedValidator, validatesAssociated } from "./validations/associated.js";
 import { LengthValidator } from "./validations/length.js";
@@ -57,8 +65,8 @@ export interface Validations {
    * AM's alias `validate → valid?`
    * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string | string[] | null): boolean;
-  isValid(context?: string | string[] | null): boolean;
+  validate(context?: ValidationContextArg): boolean;
+  isValid(context?: ValidationContextArg): boolean;
 }
 
 /**
@@ -76,10 +84,10 @@ export interface ValidationsClassMethods {
 
 // Reference to the parent class's isValid (Model.prototype.isValid).
 // Set by Base at module load via _setSuperIsValid to avoid circular imports.
-let _superIsValid: ((context?: string | string[] | null) => boolean) | null = null;
+let _superIsValid: ((context?: ValidationContextArg) => boolean) | null = null;
 
 /** @internal Called by Base to register the super isValid for delegation. */
-export function _setSuperIsValid(fn: (context?: string | string[] | null) => boolean): void {
+export function _setSuperIsValid(fn: (context?: ValidationContextArg) => boolean): void {
   _superIsValid = fn;
 }
 
@@ -90,7 +98,7 @@ export function _setSuperIsValid(fn: (context?: string | string[] | null) => boo
  * :update for persisted). Sets _validationContext for the duration
  * matching Rails' with_validation_context.
  */
-export function isValid(this: any, context?: string | string[] | null): boolean {
+export function isValid(this: any, context?: ValidationContextArg): boolean {
   const effectiveContext =
     context ?? this._validationContext ?? defaultValidationContext.call(this);
   if (_superIsValid == null) {
@@ -112,7 +120,7 @@ export function isValid(this: any, context?: string | string[] | null): boolean 
  * Mirrors: ActiveRecord::Validations#validate — inherited alias of `valid?`
  * (activemodel/lib/active_model/validations.rb:370).
  */
-export function validate(this: any, context?: string | string[] | null): boolean {
+export function validate(this: any, context?: ValidationContextArg): boolean {
   return isValid.call(this, context);
 }
 

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -57,8 +57,8 @@ export interface Validations {
    * AM's alias `validate → valid?`
    * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string): boolean;
-  isValid(context?: string): boolean;
+  validate(context?: string | string[]): boolean;
+  isValid(context?: string | string[]): boolean;
 }
 
 /**
@@ -76,10 +76,10 @@ export interface ValidationsClassMethods {
 
 // Reference to the parent class's isValid (Model.prototype.isValid).
 // Set by Base at module load via _setSuperIsValid to avoid circular imports.
-let _superIsValid: ((context?: string) => boolean) | null = null;
+let _superIsValid: ((context?: string | string[]) => boolean) | null = null;
 
 /** @internal Called by Base to register the super isValid for delegation. */
-export function _setSuperIsValid(fn: (context?: string) => boolean): void {
+export function _setSuperIsValid(fn: (context?: string | string[]) => boolean): void {
   _superIsValid = fn;
 }
 
@@ -90,7 +90,7 @@ export function _setSuperIsValid(fn: (context?: string) => boolean): void {
  * :update for persisted). Sets _validationContext for the duration
  * matching Rails' with_validation_context.
  */
-export function isValid(this: any, context?: string): boolean {
+export function isValid(this: any, context?: string | string[]): boolean {
   const effectiveContext =
     context ?? this._validationContext ?? defaultValidationContext.call(this);
   if (_superIsValid == null) {
@@ -112,7 +112,7 @@ export function isValid(this: any, context?: string): boolean {
  * Mirrors: ActiveRecord::Validations#validate — inherited alias of `valid?`
  * (activemodel/lib/active_model/validations.rb:370).
  */
-export function validate(this: any, context?: string): boolean {
+export function validate(this: any, context?: string | string[]): boolean {
   return isValid.call(this, context);
 }
 

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -90,7 +90,7 @@ export function _setSuperIsValid(fn: (context?: string | string[] | null) => boo
  * :update for persisted). Sets _validationContext for the duration
  * matching Rails' with_validation_context.
  */
-export function isValid(this: any, context?: string | string[]): boolean {
+export function isValid(this: any, context?: string | string[] | null): boolean {
   const effectiveContext =
     context ?? this._validationContext ?? defaultValidationContext.call(this);
   if (_superIsValid == null) {
@@ -112,7 +112,7 @@ export function isValid(this: any, context?: string | string[]): boolean {
  * Mirrors: ActiveRecord::Validations#validate — inherited alias of `valid?`
  * (activemodel/lib/active_model/validations.rb:370).
  */
-export function validate(this: any, context?: string | string[]): boolean {
+export function validate(this: any, context?: string | string[] | null): boolean {
   return isValid.call(this, context);
 }
 

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -57,8 +57,8 @@ export interface Validations {
    * AM's alias `validate → valid?`
    * (activemodel/lib/active_model/validations.rb:370).
    */
-  validate(context?: string | string[]): boolean;
-  isValid(context?: string | string[]): boolean;
+  validate(context?: string | string[] | null): boolean;
+  isValid(context?: string | string[] | null): boolean;
 }
 
 /**
@@ -76,10 +76,10 @@ export interface ValidationsClassMethods {
 
 // Reference to the parent class's isValid (Model.prototype.isValid).
 // Set by Base at module load via _setSuperIsValid to avoid circular imports.
-let _superIsValid: ((context?: string | string[]) => boolean) | null = null;
+let _superIsValid: ((context?: string | string[] | null) => boolean) | null = null;
 
 /** @internal Called by Base to register the super isValid for delegation. */
-export function _setSuperIsValid(fn: (context?: string | string[]) => boolean): void {
+export function _setSuperIsValid(fn: (context?: string | string[] | null) => boolean): void {
   _superIsValid = fn;
 }
 


### PR DESCRIPTION
## Summary

PR 8 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

Rails' `validation_context` is `Symbol | Array<Symbol>` — `valid?([:create, :publish])` intersects the current context with each validator's `on:` registration (either side may be scalar or array). See `validations.rb:294-306`.

Previously we collapsed to `string | null`:
- `valid?([:a, :b])` lost the array.
- `record.validationContext` inside a validator couldn't return the array the caller passed.
- Scalar `on: :create` against an array context `[:create]` didn't fire.

### Changes

- `Model._validationContext: string | string[] | null`.
- `isValid` / `validate` / `isInvalid` / `validateBang` accept `string | string[] | ValidationContext`.
- `get validationContext(): string | string[] | null`.
- `_buildValidateConditions` `on:` predicate now intersects (registered ∩ current) matching Rails `predicate_for_validation_context`.
- `ValidationContext` class mirrors Rails `attr_accessor :context`: mutable `.context: string | string[] | null` via getter/setter; `.name` kept as read-only first-segment string for backward compat.
- ActiveRecord `isValid`/`validate` signatures widened to match.

## Test plan

- [x] `valid? accepts an array context that matches :on-registered validators` — all three intersection cases.
- [x] `on: [array] validator fires when current context is a single symbol in the set`.
- [x] `validationContext round-trips array contexts while a validation is in flight`.
- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10,463/10,463.
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`.