### PR TITLE
feat(parity): Node query runner (PR 4 of 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@sinonjs/fake-timers": "^15.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@types/pg": "^8.18.0",
+    "@types/sinonjs__fake-timers": "^15.0.1",
     "@vitest/eslint-plugin": "^1.6.12",
     "ajv": "^8.18.0",
     "ajv-cli": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,18 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@sinonjs/fake-timers':
+        specifier: ^15.3.2
+        version: 15.3.2
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/pg':
         specifier: ^8.18.0
         version: 8.18.0
+      '@types/sinonjs__fake-timers':
+        specifier: ^15.0.1
+        version: 15.0.1
       '@vitest/eslint-plugin':
         specifier: ^1.6.12
         version: 1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@25.3.5)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -1157,6 +1163,12 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@15.3.2':
+    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1458,6 +1470,9 @@ packages:
 
   '@types/pg@8.18.0':
     resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -3188,6 +3203,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
   typedoc-plugin-markdown@4.11.0:
     resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
     engines: {node: '>= 18'}
@@ -4200,6 +4219,14 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@15.3.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
@@ -4519,6 +4546,8 @@ snapshots:
       '@types/node': 25.3.5
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6391,6 +6420,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.0.8: {}
 
   typedoc-plugin-markdown@4.11.0(typedoc@0.28.18(typescript@5.9.3)):
     dependencies:

--- a/scripts/parity/fixtures/arel-01/query.rb
+++ b/scripts/parity/fixtures/arel-01/query.rb
@@ -1,2 +1,2 @@
 users = Arel::Table.new(:users)
-users
+users.project(Arel.star)

--- a/scripts/parity/fixtures/arel-01/query.ts
+++ b/scripts/parity/fixtures/arel-01/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users;
+export default users;

--- a/scripts/parity/fixtures/arel-01/query.ts
+++ b/scripts/parity/fixtures/arel-01/query.ts
@@ -1,3 +1,3 @@
-import { Table } from "@blazetrails/arel";
+import { Table, star } from "@blazetrails/arel";
 const users = new Table("users");
-export default users;
+export default users.project(star);

--- a/scripts/parity/fixtures/arel-01/schema.sql
+++ b/scripts/parity/fixtures/arel-01/schema.sql
@@ -1,5 +1,5 @@
 -- Fixture for statement: arel-01
--- Query: Arel::Table.new(:users)
+-- Query: Arel::Table.new(:users).project(Arel.star)
 
 CREATE TABLE users (
   id INTEGER PRIMARY KEY,

--- a/scripts/parity/fixtures/arel-02/query.ts
+++ b/scripts/parity/fixtures/arel-02/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.alias("user_posts");
+export default posts.alias("user_posts");

--- a/scripts/parity/fixtures/arel-03/query.ts
+++ b/scripts/parity/fixtures/arel-03/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("id");
+export default posts.get("id");

--- a/scripts/parity/fixtures/arel-04/query.ts
+++ b/scripts/parity/fixtures/arel-04/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.star;
+export default posts.star;

--- a/scripts/parity/fixtures/arel-05/query.ts
+++ b/scripts/parity/fixtures/arel-05/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("title").as("name");
+export default posts.get("title").as("name");

--- a/scripts/parity/fixtures/arel-06/query.ts
+++ b/scripts/parity/fixtures/arel-06/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("name").eq("amy");
+export default users.get("name").eq("amy");

--- a/scripts/parity/fixtures/arel-07/query.ts
+++ b/scripts/parity/fixtures/arel-07/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("name").eq(null);
+export default users.get("name").eq(null);

--- a/scripts/parity/fixtures/arel-08/query.ts
+++ b/scripts/parity/fixtures/arel-08/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").notEq(10);
+export default users.get("age").notEq(10);

--- a/scripts/parity/fixtures/arel-09/query.ts
+++ b/scripts/parity/fixtures/arel-09/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").lt(10);
+export default users.get("age").lt(10);

--- a/scripts/parity/fixtures/arel-10/query.ts
+++ b/scripts/parity/fixtures/arel-10/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").gt(10);
+export default users.get("age").gt(10);

--- a/scripts/parity/fixtures/arel-11/query.ts
+++ b/scripts/parity/fixtures/arel-11/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").lteq(10);
+export default users.get("age").lteq(10);

--- a/scripts/parity/fixtures/arel-12/query.ts
+++ b/scripts/parity/fixtures/arel-12/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").gteq(10);
+export default users.get("age").gteq(10);

--- a/scripts/parity/fixtures/arel-13/query.ts
+++ b/scripts/parity/fixtures/arel-13/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("id").in([2, 3, 4]);
+export default posts.get("id").in([2, 3, 4]);

--- a/scripts/parity/fixtures/arel-14/query.ts
+++ b/scripts/parity/fixtures/arel-14/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("name").notInAny([["Mike"], ["Molly"]]);
+export default users.get("name").notInAny([["Mike"], ["Molly"]]);

--- a/scripts/parity/fixtures/arel-15/query.ts
+++ b/scripts/parity/fixtures/arel-15/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("title").matches("hell%");
+export default posts.get("title").matches("hell%");

--- a/scripts/parity/fixtures/arel-16/query.ts
+++ b/scripts/parity/fixtures/arel-16/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("name").doesNotMatchRegexp("vic$");
+export default users.get("name").doesNotMatchRegexp("vic$");

--- a/scripts/parity/fixtures/arel-17/query.ts
+++ b/scripts/parity/fixtures/arel-17/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("name").isDistinctFrom("Bob");
+export default users.get("name").isDistinctFrom("Bob");

--- a/scripts/parity/fixtures/arel-18/query.ts
+++ b/scripts/parity/fixtures/arel-18/query.ts
@@ -1,4 +1,4 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
 const bots = new Table("bots");
-users.get("name").eq(bots.get("name"));
+export default users.get("name").eq(bots.get("name"));

--- a/scripts/parity/fixtures/arel-19/query.ts
+++ b/scripts/parity/fixtures/arel-19/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("id").eq(3).and(posts.get("name").eq("hello"));
+export default posts.get("id").eq(3).and(posts.get("name").eq("hello"));

--- a/scripts/parity/fixtures/arel-20/query.ts
+++ b/scripts/parity/fixtures/arel-20/query.ts
@@ -1,6 +1,6 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users
+export default users
   .get("id")
   .eq(2)
   .and(users.get("last_name").eq("doe").or(users.get("first_name").eq("john")));

--- a/scripts/parity/fixtures/arel-21/query.ts
+++ b/scripts/parity/fixtures/arel-21/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.where(users.get("name").eq("bob").or(users.get("age").lt(25)));
+export default users.where(users.get("name").eq("bob").or(users.get("age").lt(25)));

--- a/scripts/parity/fixtures/arel-22/query.ts
+++ b/scripts/parity/fixtures/arel-22/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("answers_count").add(posts.get("likes_count")).as("engagement");
+export default posts.get("answers_count").add(posts.get("likes_count")).as("engagement");

--- a/scripts/parity/fixtures/arel-23/query.ts
+++ b/scripts/parity/fixtures/arel-23/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("answers_count").multiply(2);
+export default posts.get("answers_count").multiply(2);

--- a/scripts/parity/fixtures/arel-24/query.ts
+++ b/scripts/parity/fixtures/arel-24/query.ts
@@ -1,4 +1,4 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
 const employees = new Table("employees");
-users.get("age").divide(3).subtract(employees.get("time_at_company"));
+export default users.get("age").divide(3).subtract(employees.get("time_at_company"));

--- a/scripts/parity/fixtures/arel-25/query.ts
+++ b/scripts/parity/fixtures/arel-25/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("bitmap").bitwiseAnd(16).gt(0);
+export default users.get("bitmap").bitwiseAnd(16).gt(0);

--- a/scripts/parity/fixtures/arel-26/query.ts
+++ b/scripts/parity/fixtures/arel-26/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("bitmap").bitwiseOr(16).gt(0);
+export default users.get("bitmap").bitwiseOr(16).gt(0);

--- a/scripts/parity/fixtures/arel-27/query.ts
+++ b/scripts/parity/fixtures/arel-27/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("bitmap").bitwiseXor(16).gt(0);
+export default users.get("bitmap").bitwiseXor(16).gt(0);

--- a/scripts/parity/fixtures/arel-28/query.ts
+++ b/scripts/parity/fixtures/arel-28/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("bitmap").bitwiseShiftLeft(1).gt(0);
+export default users.get("bitmap").bitwiseShiftLeft(1).gt(0);

--- a/scripts/parity/fixtures/arel-29/query.ts
+++ b/scripts/parity/fixtures/arel-29/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("bitmap").bitwiseShiftRight(1).gt(0);
+export default users.get("bitmap").bitwiseShiftRight(1).gt(0);

--- a/scripts/parity/fixtures/arel-30/query.ts
+++ b/scripts/parity/fixtures/arel-30/query.ts
@@ -1,3 +1,3 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
-new Nodes.BitwiseNot(users.get("bitmap")).gt(0);
+export default new Nodes.BitwiseNot(users.get("bitmap")).gt(0);

--- a/scripts/parity/fixtures/arel-31/query.ts
+++ b/scripts/parity/fixtures/arel-31/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.get("id").count();
+export default posts.get("id").count();

--- a/scripts/parity/fixtures/arel-32/query.ts
+++ b/scripts/parity/fixtures/arel-32/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").sum();
+export default users.get("age").sum();

--- a/scripts/parity/fixtures/arel-33/query.ts
+++ b/scripts/parity/fixtures/arel-33/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("age").average().as("mean_age");
+export default users.get("age").average().as("mean_age");

--- a/scripts/parity/fixtures/arel-34/query.ts
+++ b/scripts/parity/fixtures/arel-34/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.project(posts.get("id"), posts.get("title"));
+export default posts.project(posts.get("id"), posts.get("title"));

--- a/scripts/parity/fixtures/arel-35/query.ts
+++ b/scripts/parity/fixtures/arel-35/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
-posts.project(posts.star).distinct();
+export default posts.project(posts.star).distinct();

--- a/scripts/parity/fixtures/arel-36/query.ts
+++ b/scripts/parity/fixtures/arel-36/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.get("created_at").extract("month");
+export default users.get("created_at").extract("month");

--- a/scripts/parity/fixtures/arel-37/query.ts
+++ b/scripts/parity/fixtures/arel-37/query.ts
@@ -1,4 +1,4 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
 const bots = new Table("bots");
-new Nodes.NamedFunction("COALESCE", [users.get("name"), bots.get("name")]);
+export default new Nodes.NamedFunction("COALESCE", [users.get("name"), bots.get("name")]);

--- a/scripts/parity/fixtures/arel-38/query.ts
+++ b/scripts/parity/fixtures/arel-38/query.ts
@@ -1,3 +1,3 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
-new Nodes.NamedFunction("CAST", [users.get("age").as("float")]);
+export default new Nodes.NamedFunction("CAST", [users.get("age").as("float")]);

--- a/scripts/parity/fixtures/arel-39/query.ts
+++ b/scripts/parity/fixtures/arel-39/query.ts
@@ -1,3 +1,7 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
-new Nodes.NamedFunction("IF", [users.get("name").eq(null), users.get("email"), users.get("name")]);
+export default new Nodes.NamedFunction("IF", [
+  users.get("name").eq(null),
+  users.get("email"),
+  users.get("name"),
+]);

--- a/scripts/parity/fixtures/arel-40/query.ts
+++ b/scripts/parity/fixtures/arel-40/query.ts
@@ -1,3 +1,6 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const posts = new Table("posts");
-new Nodes.NamedFunction("DATE_FORMAT", [posts.get("created_at"), new Nodes.Quoted("%Y%m")]);
+export default new Nodes.NamedFunction("DATE_FORMAT", [
+  posts.get("created_at"),
+  new Nodes.Quoted("%Y%m"),
+]);

--- a/scripts/parity/fixtures/arel-41/query.ts
+++ b/scripts/parity/fixtures/arel-41/query.ts
@@ -1,4 +1,4 @@
 import { Table } from "@blazetrails/arel";
 const posts = new Table("posts");
 const comments = new Table("comments");
-posts.join(comments).on(posts.get("id").eq(comments.get("post_id")));
+export default posts.join(comments).on(posts.get("id").eq(comments.get("post_id")));

--- a/scripts/parity/fixtures/arel-42/query.ts
+++ b/scripts/parity/fixtures/arel-42/query.ts
@@ -2,4 +2,6 @@ import { Table, Nodes } from "@blazetrails/arel";
 const posts = new Table("posts");
 const comments = new Table("comments");
 const postComments = comments.alias("post_comments");
-posts.join(postComments, Nodes.OuterJoin).on(posts.get("id").eq(postComments.get("post_id")));
+export default posts
+  .join(postComments, Nodes.OuterJoin)
+  .on(posts.get("id").eq(postComments.get("post_id")));

--- a/scripts/parity/fixtures/arel-43/query.ts
+++ b/scripts/parity/fixtures/arel-43/query.ts
@@ -1,4 +1,4 @@
 import { Table } from "@blazetrails/arel";
 const comments = new Table("comments");
 const replies = comments.alias("replies");
-comments.join(replies).on(replies.get("parent_id").eq(comments.get("id")));
+export default comments.join(replies).on(replies.get("parent_id").eq(comments.get("id")));

--- a/scripts/parity/fixtures/arel-44/query.ts
+++ b/scripts/parity/fixtures/arel-44/query.ts
@@ -4,4 +4,4 @@ const posts = new Table("posts");
 const comments = new Table("comments");
 const sub = posts.join(comments).on(posts.get("id").eq(comments.get("post_id")));
 const subAlias = sub.as("sub");
-users.join(subAlias).on(posts.get("user_id").eq(users.get("id")));
+export default users.join(subAlias).on(posts.get("user_id").eq(users.get("id")));

--- a/scripts/parity/fixtures/arel-45/query.ts
+++ b/scripts/parity/fixtures/arel-45/query.ts
@@ -1,7 +1,7 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
 const employees = users.alias("employees");
-users.join(employees).on(
+export default users.join(employees).on(
   employees
     .get("id")
     .notEq(users.get("id"))

--- a/scripts/parity/fixtures/arel-46/query.ts
+++ b/scripts/parity/fixtures/arel-46/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.group(users.get("id"), users.get("name"));
+export default users.group(users.get("id"), users.get("name"));

--- a/scripts/parity/fixtures/arel-47/query.ts
+++ b/scripts/parity/fixtures/arel-47/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const photos = new Table("photos");
-photos.group(photos.get("user_id")).having(photos.get("id").count().gt(5));
+export default photos.group(photos.get("user_id")).having(photos.get("id").count().gt(5));

--- a/scripts/parity/fixtures/arel-48/query.ts
+++ b/scripts/parity/fixtures/arel-48/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.order(users.get("id").desc());
+export default users.order(users.get("id").desc());

--- a/scripts/parity/fixtures/arel-49/query.ts
+++ b/scripts/parity/fixtures/arel-49/query.ts
@@ -1,3 +1,3 @@
 import { Table, star, sql } from "@blazetrails/arel";
 const users = new Table("users");
-users.project(star).order(users.get("age"), sql("ARRAY_AGG(DISTINCT users.name)"));
+export default users.project(star).order(users.get("age"), sql("ARRAY_AGG(DISTINCT users.name)"));

--- a/scripts/parity/fixtures/arel-50/query.ts
+++ b/scripts/parity/fixtures/arel-50/query.ts
@@ -1,3 +1,3 @@
 import { Table } from "@blazetrails/arel";
 const users = new Table("users");
-users.take(10).skip(5);
+export default users.take(10).skip(5);

--- a/scripts/parity/fixtures/arel-51/query.ts
+++ b/scripts/parity/fixtures/arel-51/query.ts
@@ -1,4 +1,4 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
 const win = new Nodes.Window().order(users.get("name"));
-users.get("id").count().over(win);
+export default users.get("id").count().over(win);

--- a/scripts/parity/fixtures/arel-52/query.ts
+++ b/scripts/parity/fixtures/arel-52/query.ts
@@ -1,4 +1,4 @@
 import { Table, Nodes } from "@blazetrails/arel";
 const users = new Table("users");
 const win = new Nodes.Window().partition(users.get("name"));
-users.get("id").count().over(win);
+export default users.get("id").count().over(win);

--- a/scripts/parity/fixtures/arel-53/query.ts
+++ b/scripts/parity/fixtures/arel-53/query.ts
@@ -3,7 +3,7 @@ const users = new Table("users");
 const photos = new Table("photos");
 const cte = new Table("cte_photos");
 const photosQuery = photos.project(star);
-users
+export default users
   .project(star)
   .join(cte)
   .on(cte.get("user_id").eq(users.get("id")))

--- a/scripts/parity/fixtures/arel-54/query.ts
+++ b/scripts/parity/fixtures/arel-54/query.ts
@@ -3,7 +3,7 @@ const users = new Table("users");
 const comments = new Table("comments");
 const usersTop = new Table("users_top");
 const topQuery = users.project(users.get("id")).order(users.get("karma").desc()).take(10);
-comments
+export default comments
   .project(star)
   .where(comments.get("author_id").in(usersTop.project(usersTop.get("id"))))
   .with(new Nodes.As(usersTop, topQuery));

--- a/scripts/parity/fixtures/arel-55/query.ts
+++ b/scripts/parity/fixtures/arel-55/query.ts
@@ -1,7 +1,7 @@
 import { Table, star } from "@blazetrails/arel";
 const products = new Table("products");
 const currencyRates = new Table("currency_rates");
-products
+export default products
   .join(currencyRates)
   .on(products.get("currency_id").eq(currencyRates.get("id")))
   .project(star)

--- a/scripts/parity/query/node/dump.test.ts
+++ b/scripts/parity/query/node/dump.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Integration tests for dump.ts — runs the script against real fixtures.
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DUMP_SCRIPT = join(SCRIPT_DIR, "dump.ts");
+const FIXTURES = resolve(SCRIPT_DIR, "../../fixtures");
+const TSX_BIN = resolve(SCRIPT_DIR, "../../../../node_modules/.bin/tsx");
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  outPath: string;
+}
+
+function runDump(fixture: string, opts: { frozenAt?: string } = {}): RunResult {
+  const outDir = mkdtempSync(join(tmpdir(), "parity-node-test-"));
+  const outPath = join(outDir, `${fixture}.json`);
+  const args = [DUMP_SCRIPT, join(FIXTURES, fixture), outPath];
+  if (opts.frozenAt) args.push("--frozen-at", opts.frozenAt);
+  const res = spawnSync(TSX_BIN, args, { encoding: "utf8" });
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    outPath,
+  };
+}
+
+function cleanup(outPath: string): void {
+  try {
+    rmSync(dirname(outPath), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+const DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z";
+
+describe("dump.ts", () => {
+  it("dumps arel-01 (Table) with expected CanonicalQuery fields", () => {
+    const { code, stdout, stderr, outPath } = runDump("arel-01");
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      expect(result.version).toBe(1);
+      expect(result.fixture).toBe("arel-01");
+      expect(result.frozenAt).toBe(DEFAULT_FROZEN_AT);
+      expect(result.sql).toMatch(/"users"/i);
+      expect(result.binds).toEqual([]);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("dumps arel-06 (eq predicate)", () => {
+    const { code, stdout, stderr, outPath } = runDump("arel-06");
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      expect(result.sql).toMatch(/"users"\."name" = /i);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("dumps arel-09 (lt predicate)", () => {
+    const { code, stdout, stderr, outPath } = runDump("arel-09");
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      expect(result.sql).toMatch(/"users"\."age" < /i);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("dumps arel-21 (SelectManager with WHERE)", () => {
+    const { code, stdout, stderr, outPath } = runDump("arel-21");
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      expect(result.sql).toMatch(/SELECT/i);
+      expect(result.sql).toMatch(/WHERE/i);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("preserves --frozen-at string verbatim in frozenAt output", () => {
+    const frozen = "2026-01-01T00:00:00.000Z";
+    const { code, stdout, stderr, outPath } = runDump("arel-01", { frozenAt: frozen });
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      expect(result.frozenAt).toBe(frozen);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("exits 1 with stderr when --frozen-at has no value", () => {
+    const outDir = mkdtempSync(join(tmpdir(), "parity-node-test-"));
+    const outPath = join(outDir, "out.json");
+    try {
+      const res = spawnSync(
+        TSX_BIN,
+        [DUMP_SCRIPT, join(FIXTURES, "arel-01"), outPath, "--frozen-at"],
+        { encoding: "utf8" },
+      );
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/--frozen-at requires a value/);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 with stderr when --frozen-at has invalid format", () => {
+    const { code, stderr, outPath } = runDump("arel-01", { frozenAt: "not-a-timestamp" });
+    try {
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/--frozen-at must be ISO 8601 UTC with trailing Z/);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+});

--- a/scripts/parity/query/node/dump.test.ts
+++ b/scripts/parity/query/node/dump.test.ts
@@ -11,7 +11,11 @@ import Ajv from "ajv/dist/2020.js";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DUMP_SCRIPT = join(SCRIPT_DIR, "dump.ts");
 const FIXTURES = resolve(SCRIPT_DIR, "../../fixtures");
-const TSX_BIN = resolve(SCRIPT_DIR, "../../../../node_modules/.bin/tsx");
+const TSX_BIN = resolve(
+  SCRIPT_DIR,
+  "../../../../node_modules/.bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
 
 interface RunResult {
   code: number;

--- a/scripts/parity/query/node/dump.test.ts
+++ b/scripts/parity/query/node/dump.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import Ajv from "ajv/dist/2020.js";
 
 // Integration tests for dump.ts — runs the script against real fixtures.
 
@@ -126,6 +127,25 @@ describe("dump.ts", () => {
     try {
       expect(code).toBe(1);
       expect(stderr).toMatch(/--frozen-at must be ISO 8601 UTC with trailing Z/);
+    } finally {
+      cleanup(outPath);
+    }
+  });
+
+  it("emits output that validates against query.schema.json", () => {
+    const schemaPath = resolve(SCRIPT_DIR, "../../canonical/query.schema.json");
+    const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(schema);
+
+    const { code, stdout, stderr, outPath } = runDump("arel-06");
+    try {
+      expect(code, `dump failed\nstdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const result = JSON.parse(readFileSync(outPath, "utf8"));
+      const ok = validate(result);
+      expect(ok, `schema validation failed: ${JSON.stringify(validate.errors, null, 2)}`).toBe(
+        true,
+      );
     } finally {
       cleanup(outPath);
     }

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -50,6 +50,9 @@ function parseArgs(argv: string[]): {
       }
       frozenAt = val;
       i += 2;
+    } else if (argv[i].startsWith("--")) {
+      process.stderr.write(`unknown flag: ${argv[i]}\n`);
+      usage();
     } else if (fixtureDir === null) {
       fixtureDir = argv[i++];
     } else if (outPath === null) {
@@ -63,8 +66,20 @@ function parseArgs(argv: string[]): {
   return { fixtureDir, outPath, frozenAt };
 }
 
-const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+// Shape check: ISO 8601 UTC with trailing Z, fractional seconds capped at 3 digits
+// (JS Date resolves to ms — more precision would silently round on round-trip).
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
 const DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z";
+
+// Primitive-safe name for error/debug output. Handles null/undefined/strings/numbers
+// without throwing (Object.getPrototypeOf(null) throws TypeError; primitives don't
+// always carry a meaningful constructor).
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  const name = (v as { constructor?: { name?: string } }).constructor?.name;
+  return name ?? typeof v;
+}
 
 function assertArelBuilt(): void {
   // @blazetrails/arel resolves via package "main" → packages/arel/dist/index.js.
@@ -88,11 +103,19 @@ async function main(): Promise<void> {
     frozenAt,
   } = parseArgs(process.argv.slice(2));
 
-  if (frozenAt !== null && !ISO_UTC_RE.test(frozenAt)) {
-    process.stderr.write(
-      "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)\n",
-    );
-    process.exit(1);
+  if (frozenAt !== null) {
+    if (!ISO_UTC_RE.test(frozenAt)) {
+      process.stderr.write(
+        "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)\n",
+      );
+      process.exit(1);
+    }
+    // Shape alone accepts things like 2026-99-99T25:70:70Z — verify the actual
+    // Date is valid before we install FakeTimers with NaN.
+    if (!Number.isFinite(Date.parse(frozenAt))) {
+      process.stderr.write(`--frozen-at is not a valid date: ${frozenAt}\n`);
+      process.exit(1);
+    }
   }
 
   assertArelBuilt();
@@ -131,7 +154,7 @@ async function main(): Promise<void> {
       throw new Error(`[${fixtureName}] query.ts default export is ${result}`);
     }
     if (typeof (result as { toSql?: unknown }).toSql !== "function") {
-      const ctor = Object.getPrototypeOf(result as object)?.constructor?.name ?? typeof result;
+      const ctor = describe(result);
       throw new Error(
         `[${fixtureName}] query.ts default export is ${ctor}: expected an Arel node or manager with .toSql()`,
       );
@@ -156,7 +179,7 @@ async function main(): Promise<void> {
     mkdirSync(dirname(outPathAbs), { recursive: true });
     writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n", "utf8");
 
-    const ctor = Object.getPrototypeOf(result as object)?.constructor?.name ?? typeof result;
+    const ctor = describe(result);
     process.stdout.write(`[trails] ${fixtureName}\n`);
     process.stdout.write(`  result type : ${ctor}\n`);
     process.stdout.write(`  sql         : ${sqlStr}\n`);

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env tsx
+/**
+ * Usage (from repo root):
+ *   tsx scripts/parity/query/node/dump.ts <fixture-dir> <out.json>
+ *       [--frozen-at ISO8601_UTC_Z]
+ *
+ * Applies <fixture-dir>/schema.sql to a fresh SQLite database, dynamic-imports
+ * <fixture-dir>/query.ts, calls .toSql() on its default export, and writes a
+ * CanonicalQuery JSON to <out.json>.
+ *
+ * Time is always frozen for deterministic query evaluation. --frozen-at
+ * pins the timestamp to a specific ISO 8601 UTC value (trailing Z required,
+ * e.g. 2026-01-01T00:00:00.000Z); omitting it uses 2000-01-01T00:00:00.000Z.
+ *
+ * @blazetrails/arel must be built (packages/arel/dist/index.js) before running —
+ * resolution goes through the published package `main` entry. In CI mirror the
+ * schema-parity-trails job: `pnpm --filter @blazetrails/arel build` first.
+ */
+
+import Database from "better-sqlite3";
+import FakeTimers from "@sinonjs/fake-timers";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname, basename } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { CanonicalQuery } from "../../canonical/query-types.js";
+
+function usage(): never {
+  process.stderr.write(
+    "Usage: tsx scripts/parity/query/node/dump.ts <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]\n",
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): {
+  fixtureDir: string;
+  outPath: string;
+  frozenAt: string | null;
+} {
+  let fixtureDir: string | null = null;
+  let outPath: string | null = null;
+  let frozenAt: string | null = null;
+  let i = 0;
+  while (i < argv.length) {
+    if (argv[i] === "--frozen-at") {
+      const val = argv[i + 1];
+      if (!val || val.startsWith("--")) {
+        process.stderr.write("--frozen-at requires a value\n");
+        process.exit(1);
+      }
+      frozenAt = val;
+      i += 2;
+    } else if (fixtureDir === null) {
+      fixtureDir = argv[i++];
+    } else if (outPath === null) {
+      outPath = argv[i++];
+    } else {
+      process.stderr.write(`unexpected argument: ${argv[i]}\n`);
+      usage();
+    }
+  }
+  if (!fixtureDir || !outPath) usage();
+  return { fixtureDir, outPath, frozenAt };
+}
+
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+const DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z";
+
+function assertArelBuilt(): void {
+  // @blazetrails/arel resolves via package "main" → packages/arel/dist/index.js.
+  // tsx's own loader doesn't help here: the fixture is a module on disk that
+  // Node resolves through the normal package graph, not via the TS source.
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const arelDist = resolve(scriptDir, "../../../../packages/arel/dist/index.js");
+  if (!existsSync(arelDist)) {
+    process.stderr.write(
+      `parity dump (trails): @blazetrails/arel is not built (missing ${arelDist}).\n`,
+    );
+    process.stderr.write("Run: pnpm --filter @blazetrails/arel build\n");
+    process.exit(1);
+  }
+}
+
+async function main(): Promise<void> {
+  const {
+    fixtureDir: fixtureDirRaw,
+    outPath: outPathRaw,
+    frozenAt,
+  } = parseArgs(process.argv.slice(2));
+
+  if (frozenAt !== null && !ISO_UTC_RE.test(frozenAt)) {
+    process.stderr.write(
+      "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)\n",
+    );
+    process.exit(1);
+  }
+
+  assertArelBuilt();
+
+  const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
+  const frozenMs = new Date(frozenTs).getTime();
+  const fixtureDirAbs = resolve(fixtureDirRaw);
+  const outPathAbs = resolve(outPathRaw);
+  const fixtureName = basename(fixtureDirAbs);
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "parity-query-node-"));
+
+  // Freeze time before importing the fixture — the fixture may read Date() at
+  // module-evaluation time (e.g. a translated `1.week.ago` analog).
+  const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
+
+  try {
+    // 1. Apply schema.sql to a fresh temp SQLite file. We don't currently hand
+    //    the DB to the fixture, but applying the schema keeps the pipeline
+    //    symmetric with the Ruby side and validates the SQL parses.
+    const dbPath = join(tmpDir, "query.db");
+    const db = new Database(dbPath);
+    try {
+      db.exec(readFileSync(join(fixtureDirAbs, "schema.sql"), "utf8"));
+    } finally {
+      db.close();
+    }
+
+    // 2. Import query.ts. Fixtures end with `export default <expr>` — see
+    //    scripts/parity/translate/arel.ts (generateTs).
+    const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
+    const mod = (await import(queryUrl)) as { default: unknown };
+    const result = mod.default;
+
+    if (result === null || result === undefined) {
+      throw new Error(`[${fixtureName}] query.ts default export is ${result}`);
+    }
+    if (typeof (result as { toSql?: unknown }).toSql !== "function") {
+      const ctor = Object.getPrototypeOf(result as object)?.constructor?.name ?? typeof result;
+      throw new Error(
+        `[${fixtureName}] query.ts default export is ${ctor}: expected an Arel node or manager with .toSql()`,
+      );
+    }
+
+    // 3. Extract SQL. Arel node/manager both expose .toSql():
+    //    Node#toSql()         packages/arel/src/nodes/node.ts
+    //    TreeManager#toSql()  packages/arel/src/tree-manager.ts
+    //    Arel inlines bind values into the SQL string — no separate bind array.
+    const sqlStr = (result as { toSql(): string }).toSql().trim();
+    const binds: string[] = [];
+
+    // 4. Write CanonicalQuery JSON
+    const canonical: CanonicalQuery = {
+      version: 1,
+      fixture: fixtureName,
+      frozenAt: frozenTs,
+      sql: sqlStr,
+      binds,
+    };
+
+    mkdirSync(dirname(outPathAbs), { recursive: true });
+    writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n", "utf8");
+
+    const ctor = Object.getPrototypeOf(result as object)?.constructor?.name ?? typeof result;
+    process.stdout.write(`[trails] ${fixtureName}\n`);
+    process.stdout.write(`  result type : ${ctor}\n`);
+    process.stdout.write(`  sql         : ${sqlStr}\n`);
+    process.stdout.write(`  frozenAt    : ${frozenTs}\n`);
+    process.stdout.write(`  → ${outPathAbs}\n`);
+  } finally {
+    clock.uninstall();
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch (err) {
+      process.stderr.write(
+        `parity dump: warning: failed to remove temp dir ${tmpDir}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `parity dump (trails): ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -66,9 +66,11 @@ function parseArgs(argv: string[]): {
   return { fixtureDir, outPath, frozenAt };
 }
 
-// Shape check: ISO 8601 UTC with trailing Z, fractional seconds capped at 3 digits
-// (JS Date resolves to ms — more precision would silently round on round-trip).
-const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+// Shape check: ISO 8601 UTC with trailing Z. Matches scripts/parity/canonical/
+// query.schema.json and the Ruby runner's regex — any fractional precision is
+// accepted by the contract. Semantic validity (calendar-valid date) is enforced
+// below via Date.parse().
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
 const DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z";
 
 // Primitive-safe name for error/debug output. Handles null/undefined/strings/numbers

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -96,9 +96,9 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
       db.execute_batch(File.read(File.join(fixture_dir, "schema.sql")))
     end
 
-    # 2. Connect via ActiveRecord
+    # 2. Connect via ActiveRecord so fixtures that reference AR::Base.connection
+    #    (via time helpers or implicit connection resolution) work.
     ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_path)
-    conn = ActiveRecord::Base.connection
 
     # 3. Always freeze time so query evaluation is deterministic
     time_helper.travel_to(frozen_time)
@@ -116,34 +116,18 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     result = eval(query_source, query_binding, query_path)
     # rubocop:enable Security/Eval
     raise "[#{fixture_name}] query.rb returned nil" if result.nil?
-    unless result.respond_to?(:to_sql) || result.respond_to?(:ast)
-      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager"
+    unless result.respond_to?(:to_sql)
+      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an Arel node or manager responding to #to_sql"
     end
 
-    # 5. Get SQL and binds.
-    #    Managers expose .ast; pass it directly to to_sql_and_binds which compiles via
-    #    the visitor and returns Rails-style bind objects. Plain nodes (no .ast) are
-    #    rendered directly via to_sql — they carry no bind params.
-    raw_sql, raw_binds =
-      if result.respond_to?(:ast)
-        conn.to_sql_and_binds(result.ast)
-      else
-        # Plain node — Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148)
-        [result.to_sql.strip, []]
-      end
-
-    binds = Array(raw_binds).map do |b|
-      raw = if b.respond_to?(:value_before_type_cast)
-        b.value_before_type_cast
-      elsif b.respond_to?(:value)
-        b.value
-      else
-        b
-      end
-      # nil bind = SQL NULL; keep as "NULL" so binds array stays string[] per schema
-      raw.nil? ? "NULL" : raw.to_s
-    end
-    sql_str = raw_sql.strip
+    # 5. Get SQL. For pure Arel fixtures (v1 scope) all values are inlined — both
+    #    Arel::Nodes::Node#to_sql and Arel::SelectManager#to_sql render literals
+    #    directly, so binds is always []. Note: ConnectionAdapters
+    #    DatabaseStatements#to_sql_and_binds is private in Rails 8.0
+    #    (activerecord-8.0.2/lib/.../abstract/database_statements.rb:52), so we
+    #    call to_sql directly. This mirrors the trails side which uses .toSql().
+    sql_str = result.to_sql.strip
+    binds = []
 
     # 6. Write CanonicalQuery JSON
     canonical = {

--- a/scripts/parity/translate/arel.ts
+++ b/scripts/parity/translate/arel.ts
@@ -213,7 +213,7 @@ function translateQuery(
 
   return {
     rb: `${rbDecls}\n${query}`,
-    ts: `${tsDecls}\n${tsExpr};`,
+    ts: `${tsDecls}\nexport default ${tsExpr};`,
     imports: [...new Set(imports)].sort(),
   };
 }

--- a/scripts/parity/translate/arel.ts
+++ b/scripts/parity/translate/arel.ts
@@ -116,9 +116,14 @@ function translateQuery(
   const tsDecls = tables.map((t) => `const ${t} = new Table("${t}");`).join("\n");
 
   if (isNonTranslatable(query)) {
+    // Keep the same module shape as translatable queries (default export) so the
+    // Node runner fails with a clear message rather than "default export is
+    // undefined". The thrown-error default makes the TODO explicit at evaluation.
+    const todo = `// TODO: translate — ${query}`;
+    const throwExpr = `((() => { throw new Error("parity fixture not translated: ${query.replace(/["\\]/g, "\\$&")}"); })())`;
     return {
       rb: `${rbDecls}\n# TODO: translate — ${query}`,
-      ts: `${tsDecls}\n// TODO: translate — ${query}`,
+      ts: `${tsDecls}\n${todo}\nexport default ${throwExpr};`,
       imports: ["Table"],
     };
   }


### PR DESCRIPTION
## Summary

Adds the trails-side query parity runner, symmetric with the Ruby runner from PR 3 (#761), fixes two latent bugs in the Ruby runner surfaced by wiring the Node side, and converts the 55 generated `query.ts` fixtures to idiomatic ESM so the runner can dynamic-import and read the result.

### Node runner — `scripts/parity/query/node/dump.ts`

CLI: `tsx scripts/parity/query/node/dump.ts <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]`

1. Applies `schema.sql` to a fresh temp SQLite via `better-sqlite3`
2. Installs `@sinonjs/fake-timers` and pins `Date` (default `2000-01-01T00:00:00.000Z`)
3. Dynamic-imports `query.ts`, reads `module.default`
4. Calls `.toSql()` on the result (`Node#toSql()` / `TreeManager#toSql()`). Arel inlines bind values into the SQL string, so `binds: []` — same shape as the Ruby side.
5. Writes `CanonicalQuery` JSON matching `scripts/parity/canonical/query.schema.json`
6. Guards with a clear error if `@blazetrails/arel` isn't built.

### Ruby runner fixes (PR 3 follow-ups)

- **Private `to_sql_and_binds`**: PR 3's Ruby runner called `conn.to_sql_and_binds(result.ast)`. That method is private in Rails 8.0.2 (`activerecord-8.0.2/lib/.../abstract/database_statements.rb:52`), so every SelectManager fixture failed with `NoMethodError`. For pure Arel (v1 scope) values are already inlined, so `result.to_sql` is sufficient for both nodes and managers; `binds` is always `[]`. This mirrors the trails side.
- **`arel-01` fixture**: a bare `Arel::Table` has neither `.to_sql` nor `.ast` — it's a factory, not a renderable node. Fixture updated to `Arel::Table.new(:users).project(Arel.star)` (Ruby) and `users.project(star)` (trails) so both sides produce a valid SELECT.

### Fixture format change: `export default`

55 fixtures converted from bare trailing expression (`users.get("name").eq("amy");`) to idiomatic ESM default export (`export default users.get("name").eq("amy");`). Ruby's `eval` naturally returns the last expression; ESM has no equivalent, so an explicit export is cleaner than runtime source rewriting. The translator now emits this form directly.

### Tests — `scripts/parity/query/node/dump.test.ts`

8 vitest integration tests: Table projection, eq, lt, SelectManager w/ WHERE, `--frozen-at` passthrough, missing value error, invalid format error, and **output validates against `query.schema.json`** (via ajv) — catches runner/contract drift independent of PR 5's diff step.

### Parity status (55 Arel fixtures)

| Outcome | Count |
|---|---|
| **Byte-identical SQL** | **40** |
| Different SQL (real trails↔Rails parity findings) | 3 |
| Node-only failure (trails Arel gap) | 9 |
| Ruby-only failure (trails more capable) | 3 |
| Both fail | 1 |

The 3 legitimate SQL diffs:
- `arel-17`: `IS DISTINCT FROM` (trails) vs `IS NOT` (Rails / SQLite extension)
- `arel-36`: `EXTRACT(MONTH FROM ...)` vs `EXTRACT(month FROM ...)` — literal case in trails visitor
- `arel-44`: subquery alias quoting — trails emits `"sub"`, Rails emits bare `sub`

These are exactly the kind of finding this pipeline is meant to surface. PR 5's diff step will formalize them.

### Local workflow

```
pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
pnpm tsx scripts/parity/query/node/dump.ts scripts/parity/fixtures/arel-06 /tmp/out.json
```

### Files

- **Add**: `scripts/parity/query/node/dump.ts`, `dump.test.ts`
- **Edit**: `scripts/parity/query/ruby/dump.rb` (private-method fix)
- **Edit**: `scripts/parity/translate/arel.ts` (emit `export default`)
- **Edit**: `scripts/parity/fixtures/arel-{01..55}/query.ts` (export default form)
- **Edit**: `scripts/parity/fixtures/arel-01/{schema.sql,query.rb,query.ts}` (projection)
- **Root devDeps**: `@sinonjs/fake-timers`, `@types/sinonjs__fake-timers`

## Test plan

- [x] `pnpm vitest run scripts/parity/query/node/dump.test.ts` — 8 pass
- [x] `bundle exec ruby scripts/parity/query/ruby/dump_test.rb` — 7 pass
- [x] Full 55-fixture sweep: 40 byte-identical matches, 3 real diffs, 12 asymmetric failures categorized