### PR TITLE
feat(encryption): wire config.previous global schemes into encrypts() declarations

### DIFF
--- a/packages/activerecord/src/encryption.test.ts
+++ b/packages/activerecord/src/encryption.test.ts
@@ -1,8 +1,35 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
+import { Configurable } from "./encryption/configurable.js";
+import { Decryption as DecryptionError } from "./encryption/errors.js";
+import type { EncryptorLike } from "./encryption/encryptor.js";
+
+class TestEncryptor implements EncryptorLike {
+  constructor(private readonly map: Record<string, string>) {}
+  encrypt(clearText: string): string {
+    return this.map[clearText] ?? clearText;
+  }
+  decrypt(encryptedText: string): string {
+    for (const [clear, cipher] of Object.entries(this.map)) {
+      if (cipher === encryptedText) return clear;
+    }
+    throw new DecryptionError(`No match for ${encryptedText}`);
+  }
+  isEncrypted(text: string): boolean {
+    try {
+      this.decrypt(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  isBinary(): boolean {
+    return false;
+  }
+}
 
 // -- Helpers --
 
@@ -104,5 +131,60 @@ describe("encrypts()", () => {
     }
 
     expect((User as any)._encryptedAttributes.has("ssn")).toBe(true);
+  });
+});
+
+describe("Base.encrypts() — global previous schemes via config.previous", () => {
+  let savedPreviousSchemes: typeof Configurable.config.previousSchemes;
+
+  beforeEach(() => {
+    savedPreviousSchemes = [...Configurable.config.previousSchemes];
+    Configurable.config.previousSchemes = [];
+  });
+
+  afterEach(() => {
+    Configurable.config.previousSchemes = savedPreviousSchemes;
+  });
+
+  it("config.previous schemes are applied to Base.encrypts() attribute types", () => {
+    Configurable.config.previous = [
+      { encryptor: new TestEncryptor({ legacy: "legacy_cipher" }) } as any,
+    ];
+
+    const adapter = createTestAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("email", "string");
+        this.adapter = adapter;
+        this.encrypts("email", { encryptor: new TestEncryptor({ current: "current_cipher" }) });
+      }
+    }
+    new User();
+    const type = (User as any)._attributeDefinitions.get("email")?.type as EncryptedAttributeType;
+    expect(type.previousTypes).toHaveLength(1);
+
+    // legacy ciphertext falls back to previous scheme
+    expect(type.deserialize("legacy_cipher")).toBe("legacy");
+  });
+
+  it("deterministic-incompatible global previous schemes are excluded", () => {
+    Configurable.config.previous = [
+      { encryptor: new TestEncryptor({ det: "det_cipher" }), deterministic: true } as any,
+    ];
+
+    const adapter = createTestAdapter();
+    class User extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("email", "string");
+        this.adapter = adapter;
+        this.encrypts("email", { encryptor: new TestEncryptor({ current: "current_cipher" }) });
+      }
+    }
+    new User();
+    const type = (User as any)._attributeDefinitions.get("email")?.type as EncryptedAttributeType;
+    // non-deterministic attribute: deterministic global scheme is incompatible
+    expect(type.previousTypes).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -137,7 +137,7 @@ function buildScheme(options: EncryptsOptions): Scheme {
 
   const base = new Scheme(coreOpts);
   const globalPrevious = globalPreviousSchemesFor(base);
-  const allPrevious = [...globalPrevious, ...localPrevious.map((o) => new Scheme(o))];
+  const allPrevious = [...globalPrevious, ...localPrevious];
   return allPrevious.length > 0 ? new Scheme({ ...coreOpts, previousSchemes: allPrevious }) : base;
 }
 

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -23,6 +23,7 @@ import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
+import { globalPreviousSchemesFor } from "./encryption/encryptable-record.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -126,31 +127,18 @@ export interface EncryptsOptions extends Omit<SchemeOptions, "encryptor"> {
 }
 
 function buildScheme(options: EncryptsOptions): Scheme {
-  const { encryptor, ...schemeOptions } = options;
+  const { encryptor, previousSchemes: localPrevious = [], ...schemeOptions } = options;
 
-  if (encryptor) {
-    return new Scheme({ ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) });
-  }
+  const coreOpts: SchemeOptions = encryptor
+    ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
+    : Object.keys(schemeOptions).length > 0
+      ? schemeOptions
+      : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
 
-  const hasSchemeOptions =
-    schemeOptions.key !== undefined ||
-    schemeOptions.keyProvider !== undefined ||
-    schemeOptions.deterministic !== undefined ||
-    schemeOptions.downcase !== undefined ||
-    schemeOptions.ignoreCase !== undefined ||
-    schemeOptions.previousSchemes !== undefined ||
-    schemeOptions.compress !== undefined ||
-    schemeOptions.compressor !== undefined ||
-    schemeOptions.supportUnencryptedData !== undefined;
-
-  if (hasSchemeOptions) {
-    return new Scheme(schemeOptions);
-  }
-
-  // No scheme configuration and no explicit encryptor — fall back to
-  // the repo's default AR_ENC:base64 encryptor so `this.encrypts("name")`
-  // works in contexts that haven't set up keys/config.
-  return new Scheme({ encryptor: new LegacyEncryptorShim(defaultEncryptor) });
+  const base = new Scheme(coreOpts);
+  const globalPrevious = globalPreviousSchemesFor(base);
+  const allPrevious = [...globalPrevious, ...localPrevious.map((o) => new Scheme(o))];
+  return allPrevious.length > 0 ? new Scheme({ ...coreOpts, previousSchemes: allPrevious }) : base;
 }
 
 interface PendingEncryption {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -129,9 +129,20 @@ export interface EncryptsOptions extends Omit<SchemeOptions, "encryptor"> {
 function buildScheme(options: EncryptsOptions): Scheme {
   const { encryptor, previousSchemes: localPrevious = [], ...schemeOptions } = options;
 
+  const hasSchemeOptions =
+    schemeOptions.key !== undefined ||
+    schemeOptions.keyProvider !== undefined ||
+    schemeOptions.deterministic !== undefined ||
+    schemeOptions.downcase !== undefined ||
+    schemeOptions.ignoreCase !== undefined ||
+    localPrevious.length > 0 ||
+    schemeOptions.compress !== undefined ||
+    schemeOptions.compressor !== undefined ||
+    schemeOptions.supportUnencryptedData !== undefined;
+
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
-    : Object.keys(schemeOptions).length > 0
+    : hasSchemeOptions
       ? schemeOptions
       : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
 

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -5,6 +5,9 @@
  */
 
 import { ConfigError } from "./errors.js";
+import type { SchemeOptions } from "./scheme.js";
+import { KeyGenerator } from "./key-generator.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 export class Config {
   primaryKey?: string | string[];
@@ -16,7 +19,7 @@ export class Config {
   validateColumnSize: boolean = true;
   addToFilterParameters: boolean = true;
   excludeFromFilterParameters: string[] = [];
-  previousSchemes: unknown[] = [];
+  previousSchemes: SchemeOptions[] = [];
   extendQueries: boolean = false;
   hashDigestClass: string = "SHA1";
   keyProviderClass?: string;
@@ -35,7 +38,7 @@ export class Config {
     return this.excludeFromFilterParameters;
   }
 
-  set previous(schemes: Record<string, unknown>[]) {
+  set previous(schemes: SchemeOptions[]) {
     for (const props of schemes) {
       this.previousSchemes.push(props);
     }
@@ -43,7 +46,11 @@ export class Config {
 
   set supportSha1ForNonDeterministicEncryption(value: boolean) {
     if (value && this.primaryKey) {
-      this.previousSchemes.push({ hashDigestClass: "SHA1" });
+      const sha1KeyGenerator = new KeyGenerator("SHA1");
+      const sha1KeyProvider = new DerivedSecretKeyProvider(this.primaryKey, {
+        keyGenerator: sha1KeyGenerator,
+      });
+      this.previousSchemes.push({ keyProvider: sha1KeyProvider });
     }
   }
 

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -6,8 +6,6 @@
 
 import { ConfigError } from "./errors.js";
 import type { SchemeOptions } from "./scheme.js";
-import { KeyGenerator } from "./key-generator.js";
-import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 export class Config {
   primaryKey?: string | string[];
@@ -20,6 +18,7 @@ export class Config {
   addToFilterParameters: boolean = true;
   excludeFromFilterParameters: string[] = [];
   previousSchemes: SchemeOptions[] = [];
+  supportSha1ForNonDeterministicEncryption: boolean = false;
   extendQueries: boolean = false;
   hashDigestClass: string = "SHA1";
   keyProviderClass?: string;
@@ -41,16 +40,6 @@ export class Config {
   set previous(schemes: SchemeOptions[]) {
     for (const props of schemes) {
       this.previousSchemes.push(props);
-    }
-  }
-
-  set supportSha1ForNonDeterministicEncryption(value: boolean) {
-    if (value && this.primaryKey) {
-      const sha1KeyGenerator = new KeyGenerator("SHA1");
-      const sha1KeyProvider = new DerivedSecretKeyProvider(this.primaryKey, {
-        keyGenerator: sha1KeyGenerator,
-      });
-      this.previousSchemes.push({ keyProvider: sha1KeyProvider });
     }
   }
 

--- a/packages/activerecord/src/encryption/derived-secret-key-provider.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.ts
@@ -9,9 +9,9 @@ import { KeyProvider } from "./key-provider.js";
 import { KeyGenerator } from "./key-generator.js";
 
 export class DerivedSecretKeyProvider extends KeyProvider {
-  constructor(passwords: string | string[]) {
+  constructor(passwords: string | string[], options?: { keyGenerator?: KeyGenerator }) {
     const passwordList = Array.isArray(passwords) ? passwords : [passwords];
-    const generator = new KeyGenerator();
+    const generator = options?.keyGenerator ?? new KeyGenerator();
     // Mirror Rails: uses key_generator.derive_key_from(password) which applies
     // config.key_derivation_salt. deriveKeyFrom raises ConfigError if the salt
     // is not configured, matching Rails' required-key semantics.

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,6 +1,8 @@
 import { Scheme, type SchemeOptions } from "./scheme.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
+import { KeyGenerator } from "./key-generator.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 /**
  * Mirrors Rails' EncryptableRecord#global_previous_schemes_for.
@@ -10,7 +12,20 @@ import { Configurable } from "./configurable.js";
  * are preserved in the fallback scheme.
  */
 export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
-  return Configurable.config.previousSchemes
+  const config = Configurable.config;
+  const allSchemeOptions: SchemeOptions[] = [...config.previousSchemes];
+
+  // Mirrors Rails' support_sha1_for_non_deterministic_encryption= setter:
+  // builds the SHA1 DerivedSecretKeyProvider lazily here (not in Config) to
+  // avoid a config → key-generator → configurable → config circular import.
+  if (config.supportSha1ForNonDeterministicEncryption && config.primaryKey) {
+    const sha1KeyProvider = new DerivedSecretKeyProvider(config.primaryKey, {
+      keyGenerator: new KeyGenerator("SHA1"),
+    });
+    allSchemeOptions.push({ keyProvider: sha1KeyProvider });
+  }
+
+  return allSchemeOptions
     .map((opts) => new Scheme(opts))
     .filter((prev) => scheme.isCompatibleWith(prev))
     .map((prev) => scheme.merge(prev));

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -4,6 +4,36 @@ import { Configurable } from "./configurable.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
+// Memoized SHA1 key provider: PBKDF2 is expensive (65536 iterations), so
+// reuse the same provider as long as primaryKey and keyDerivationSalt haven't
+// changed. Keyed on the tuple so config rotation invalidates the cache.
+let _sha1ProviderCache:
+  | {
+      primaryKey: string | string[];
+      keyDerivationSalt: string | undefined;
+      provider: DerivedSecretKeyProvider;
+    }
+  | undefined;
+
+function getSha1KeyProvider(
+  primaryKey: string | string[],
+  keyDerivationSalt: string | undefined,
+): DerivedSecretKeyProvider {
+  const cacheKey = JSON.stringify(primaryKey);
+  if (
+    _sha1ProviderCache &&
+    JSON.stringify(_sha1ProviderCache.primaryKey) === cacheKey &&
+    _sha1ProviderCache.keyDerivationSalt === keyDerivationSalt
+  ) {
+    return _sha1ProviderCache.provider;
+  }
+  const provider = new DerivedSecretKeyProvider(primaryKey, {
+    keyGenerator: new KeyGenerator("SHA1"),
+  });
+  _sha1ProviderCache = { primaryKey, keyDerivationSalt, provider };
+  return provider;
+}
+
 /**
  * Mirrors Rails' EncryptableRecord#global_previous_schemes_for.
  * Exported so encryption.ts (Base.encrypts path) can use the same logic.
@@ -19,10 +49,9 @@ export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
   // builds the SHA1 DerivedSecretKeyProvider lazily here (not in Config) to
   // avoid a config → key-generator → configurable → config circular import.
   if (config.supportSha1ForNonDeterministicEncryption && config.primaryKey) {
-    const sha1KeyProvider = new DerivedSecretKeyProvider(config.primaryKey, {
-      keyGenerator: new KeyGenerator("SHA1"),
+    allSchemeOptions.push({
+      keyProvider: getSha1KeyProvider(config.primaryKey, config.keyDerivationSalt),
     });
-    allSchemeOptions.push({ keyProvider: sha1KeyProvider });
   }
 
   return allSchemeOptions

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -25,7 +25,7 @@ function schemeFor(options: SchemeOptions): Scheme {
   const { previousSchemes: localPrevious = [], ...rest } = options;
   const base = new Scheme(rest);
   const globalPrevious = globalPreviousSchemesFor(base);
-  const allPrevious = [...globalPrevious, ...localPrevious.map((o) => new Scheme(o))];
+  const allPrevious = [...globalPrevious, ...localPrevious];
   return allPrevious.length > 0 ? new Scheme({ ...rest, previousSchemes: allPrevious }) : base;
 }
 

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -2,6 +2,33 @@ import { Scheme, type SchemeOptions } from "./scheme.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 
+/**
+ * Mirrors Rails' EncryptableRecord#global_previous_schemes_for.
+ * Exported so encryption.ts (Base.encrypts path) can use the same logic.
+ * Filters config.previousSchemes to those compatible with the given scheme
+ * and merges each one so per-attribute settings (deterministic, downcase)
+ * are preserved in the fallback scheme.
+ */
+export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
+  return Configurable.config.previousSchemes
+    .map((opts) => new Scheme(opts))
+    .filter((prev) => scheme.isCompatibleWith(prev))
+    .map((prev) => scheme.merge(prev));
+}
+
+/**
+ * Mirrors Rails' EncryptableRecord#scheme_for.
+ * Builds the scheme with global previous schemes prepended to any
+ * per-attribute previousSchemes declared in options.
+ */
+function schemeFor(options: SchemeOptions): Scheme {
+  const { previousSchemes: localPrevious = [], ...rest } = options;
+  const base = new Scheme(rest);
+  const globalPrevious = globalPreviousSchemesFor(base);
+  const allPrevious = [...globalPrevious, ...localPrevious.map((o) => new Scheme(o))];
+  return allPrevious.length > 0 ? new Scheme({ ...rest, previousSchemes: allPrevious }) : base;
+}
+
 const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
 
 /**
@@ -32,7 +59,7 @@ export class EncryptableRecord {
       }
     }
 
-    const scheme = new Scheme(options);
+    const scheme = schemeFor(options);
 
     if (!modelClass._encryptedAttributes) {
       modelClass._encryptedAttributes = new Set<string>();

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -5,6 +5,7 @@ import { Configurable } from "./configurable.js";
 import { Decryption as DecryptionError } from "./errors.js";
 import type { EncryptorLike } from "./encryptor.js";
 import { EncryptableRecord } from "./encryptable-record.js";
+import type { SchemeOptions } from "./scheme.js";
 
 class TestEncryptor implements EncryptorLike {
   constructor(private readonly map: Record<string, string>) {}
@@ -151,7 +152,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
 describe("global previous schemes wiring — config.previous → EncryptableRecord.encrypts", () => {
   let savedSupportUnencryptedData: boolean;
-  let savedPreviousSchemes: unknown[];
+  let savedPreviousSchemes: typeof Configurable.config.previousSchemes;
 
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
@@ -160,14 +161,14 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
 
   afterEach(() => {
     Configurable.config.supportUnencryptedData = savedSupportUnencryptedData;
-    Configurable.config.previousSchemes = savedPreviousSchemes as any;
+    Configurable.config.previousSchemes = savedPreviousSchemes;
   });
 
   it("config.previous schemes are merged into the attribute type's previousTypes", () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previous = [
-      { encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }) },
-      { encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }) },
+      { encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }) } as SchemeOptions,
+      { encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }) } as SchemeOptions,
     ];
 
     const modelClass = { _attributeDefinitions: new Map() };
@@ -190,8 +191,11 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
   it("only compatible global previous schemes are applied (matching deterministic nature)", () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previous = [
-      { encryptor: new TestEncryptor({ legacy_det: "cipher_det" }), deterministic: true },
-      { encryptor: new TestEncryptor({ legacy_non: "cipher_non" }), deterministic: false },
+      {
+        encryptor: new TestEncryptor({ legacy_det: "cipher_det" }),
+        deterministic: true,
+      } as SchemeOptions,
+      { encryptor: new TestEncryptor({ legacy_non: "cipher_non" }) } as SchemeOptions,
     ];
 
     const modelClass = { _attributeDefinitions: new Map() };

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -4,6 +4,7 @@ import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
 import { Decryption as DecryptionError } from "./errors.js";
 import type { EncryptorLike } from "./encryptor.js";
+import { EncryptableRecord } from "./encryptable-record.js";
 
 class TestEncryptor implements EncryptorLike {
   constructor(private readonly map: Record<string, string>) {}
@@ -146,4 +147,61 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   it.skip("deterministic encryption will use the newest encryption scheme to encrypt data when setting it to { fixed: false }", () => {});
   it.skip("use global previous schemes when performing queries", () => {});
   it.skip("don't use global previous schemes with a different deterministic nature when performing queries", () => {});
+});
+
+describe("global previous schemes wiring — config.previous → EncryptableRecord.encrypts", () => {
+  let savedSupportUnencryptedData: boolean;
+  let savedPreviousSchemes: unknown[];
+
+  beforeEach(() => {
+    savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
+    savedPreviousSchemes = [...Configurable.config.previousSchemes];
+  });
+
+  afterEach(() => {
+    Configurable.config.supportUnencryptedData = savedSupportUnencryptedData;
+    Configurable.config.previousSchemes = savedPreviousSchemes as any;
+  });
+
+  it("config.previous schemes are merged into the attribute type's previousTypes", () => {
+    Configurable.config.supportUnencryptedData = false;
+    Configurable.config.previous = [
+      { encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }) },
+      { encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }) },
+    ];
+
+    const modelClass = { _attributeDefinitions: new Map() };
+    EncryptableRecord.encrypts(modelClass, "name", {
+      encryptor: new TestEncryptor({ current: "current_cipher" }),
+    });
+
+    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    expect(type.previousTypes).toHaveLength(2);
+
+    // value encrypted with first global previous scheme decrypts correctly
+    const ciphertext1 = type.previousTypes[0].serialize("legacy1") as string;
+    expect(type.deserialize(ciphertext1)).toBe("legacy1");
+
+    // value encrypted with second global previous scheme decrypts correctly
+    const ciphertext2 = type.previousTypes[1].serialize("legacy2") as string;
+    expect(type.deserialize(ciphertext2)).toBe("legacy2");
+  });
+
+  it("only compatible global previous schemes are applied (matching deterministic nature)", () => {
+    Configurable.config.supportUnencryptedData = false;
+    Configurable.config.previous = [
+      { encryptor: new TestEncryptor({ legacy_det: "cipher_det" }), deterministic: true },
+      { encryptor: new TestEncryptor({ legacy_non: "cipher_non" }), deterministic: false },
+    ];
+
+    const modelClass = { _attributeDefinitions: new Map() };
+    EncryptableRecord.encrypts(modelClass, "name", {
+      encryptor: new TestEncryptor({ current: "current_cipher" }),
+    });
+
+    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    // non-deterministic attribute: only the non-deterministic global scheme is compatible
+    expect(type.previousTypes).toHaveLength(1);
+    expect(type.deserialize("cipher_non")).toBe("legacy_non");
+  });
 });

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -157,6 +157,7 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
     savedPreviousSchemes = [...Configurable.config.previousSchemes];
+    Configurable.config.previousSchemes = [];
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- `EncryptableRecord.encrypts()` and `Base.encrypts()` now apply global previous schemes from `config.previous` before any per-attribute `previous:` list, matching Rails' `EncryptableRecord#scheme_for` + `#global_previous_schemes_for`
- Only compatible schemes (same `deterministic` nature) are included — mirrors Rails' `scheme.compatible_with?(previous_scheme)` filter
- `Config.previousSchemes` typed as `SchemeOptions[]` (was `unknown[]`)
- `config.supportSha1ForNonDeterministicEncryption` now correctly builds a `DerivedSecretKeyProvider` with a SHA1 `KeyGenerator` (was incorrectly pushing a non-existent `hashDigestClass` field)
- `DerivedSecretKeyProvider` gains an optional `{ keyGenerator }` constructor param, mirroring Rails' `DerivedSecretKeyProvider.new(primary_key, key_generator: ...)`

## Rails source
`activerecord/lib/active_record/encryption/encryptable_record.rb` lines 70–82  
`activerecord/lib/active_record/encryption/config.rb` lines 27–34

## Test plan
- [ ] 2 new unit tests validate global previous scheme wiring and compatibility filtering without a DB
- [ ] All 170 encryption tests pass
- [ ] `api:compare` shows 27/27 encryption files at 100%