### PR TITLE
feat(activemodel): BooleanType Rails-policy casting, IntegerType error format, _toPartialPath demodulize

### DIFF
--- a/packages/activemodel/src/attributes.test.ts
+++ b/packages/activemodel/src/attributes.test.ts
@@ -43,10 +43,12 @@ describe("AttributesTest", () => {
   });
 
   it("casts string to boolean", () => {
+    // Rails BooleanType: only FALSE_VALUES coerce to false; "yes"/"no"
+    // are both truthy (not in FALSE_VALUES).
     expect(new User({ active: "false" }).readAttribute("active")).toBe(false);
     expect(new User({ active: "true" }).readAttribute("active")).toBe(true);
     expect(new User({ active: "yes" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "no" }).readAttribute("active")).toBe(false);
+    expect(new User({ active: "no" }).readAttribute("active")).toBe(true);
     expect(new User({ active: "1" }).readAttribute("active")).toBe(true);
     expect(new User({ active: "0" }).readAttribute("active")).toBe(false);
     expect(new User({ active: 1 }).readAttribute("active")).toBe(true);

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -1,4 +1,4 @@
-import { underscore, tableize } from "@blazetrails/activesupport";
+import { underscore, tableize, demodulize } from "@blazetrails/activesupport";
 
 /**
  * Conversion mixin — provides toModel, toKey, toParam, toPartialPath.
@@ -29,7 +29,14 @@ export function _toPartialPath(this: AnyConversionHost): string {
       const mn = this.modelName;
       this._cachedToPartialPath = `${mn.collection}/${mn.element}`;
     } else {
-      const element = underscore(this.name);
+      // Rails `_to_partial_path` fallback
+      // (activemodel/lib/active_model/conversion.rb:110-118):
+      //   element    = underscore(demodulize(name))
+      //   collection = tableize(name)
+      // Using `underscore(this.name)` without `demodulize` would produce
+      // a path-shape element like "blog/post" for a namespaced class name
+      // — keeping the fallback Rails-faithful: demodulize first.
+      const element = underscore(demodulize(this.name));
       const collection = tableize(this.name);
       this._cachedToPartialPath = `${collection}/${element}`;
     }

--- a/packages/activemodel/src/misc.test.ts
+++ b/packages/activemodel/src/misc.test.ts
@@ -44,10 +44,11 @@ describe("ActiveModel", () => {
     });
 
     it("casts string to boolean", () => {
+      // Rails BooleanType: "yes"/"no" both truthy (neither in FALSE_VALUES).
       expect(new User({ active: "false" }).readAttribute("active")).toBe(false);
       expect(new User({ active: "true" }).readAttribute("active")).toBe(true);
       expect(new User({ active: "yes" }).readAttribute("active")).toBe(true);
-      expect(new User({ active: "no" }).readAttribute("active")).toBe(false);
+      expect(new User({ active: "no" }).readAttribute("active")).toBe(true);
       expect(new User({ active: "1" }).readAttribute("active")).toBe(true);
       expect(new User({ active: "0" }).readAttribute("active")).toBe(false);
       expect(new User({ active: 1 }).readAttribute("active")).toBe(true);

--- a/packages/activemodel/src/type/boolean.test.ts
+++ b/packages/activemodel/src/type/boolean.test.ts
@@ -12,8 +12,11 @@ describe("BooleanTest", () => {
     expect(type.cast("0")).toBe(false);
     expect(type.cast(1)).toBe(true);
     expect(type.cast(0)).toBe(false);
+    // Rails: anything not in FALSE_VALUES is true. "yes" and "no" are
+    // BOTH truthy under that policy — the string "no" isn't a Rails
+    // FALSE_VALUE (type/boolean.rb:15-24).
     expect(type.cast("yes")).toBe(true);
-    expect(type.cast("no")).toBe(false);
+    expect(type.cast("no")).toBe(true);
     expect(type.cast(null)).toBe(null);
   });
 });

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -3,19 +3,10 @@ import { ValueType } from "./value.js";
 export class BooleanType extends ValueType<boolean> {
   readonly name = "boolean";
 
-  private static readonly TRUE_VALUES: ReadonlySet<unknown> = new Set([
-    true,
-    1,
-    "1",
-    "t",
-    "T",
-    "true",
-    "TRUE",
-    "on",
-    "ON",
-    "yes",
-    "YES",
-  ]);
+  // Mirrors Rails `ActiveModel::Type::Boolean::FALSE_VALUES`
+  // (activemodel/lib/active_model/type/boolean.rb:15-24). Rails' Symbol
+  // variants (`:"0"`, `:false`, `:FALSE`, `:off`, `:OFF`, …) are omitted
+  // since JS has no symbols for those strings.
   private static readonly FALSE_VALUES: ReadonlySet<unknown> = new Set([
     false,
     0,
@@ -26,16 +17,27 @@ export class BooleanType extends ValueType<boolean> {
     "FALSE",
     "off",
     "OFF",
-    "no",
-    "NO",
   ]);
 
+  /**
+   * Mirrors Rails `cast_value` (type/boolean.rb:40-45):
+   *
+   *   def cast_value(value)
+   *     if value == ""
+   *       nil
+   *     else
+   *       !FALSE_VALUES.include?(value)
+   *     end
+   *   end
+   *
+   * Anything not in `FALSE_VALUES` is `true` — Rails' permissive
+   * policy. "yes", "no", "garbage" all coerce to `true`. Empty string
+   * and `null`/`undefined` map to `null`.
+   */
   cast(value: unknown): boolean | null {
     if (value === null || value === undefined) return null;
     if (value === "") return null;
-    if (BooleanType.TRUE_VALUES.has(value)) return true;
-    if (BooleanType.FALSE_VALUES.has(value)) return false;
-    return null;
+    return !BooleanType.FALSE_VALUES.has(value);
   }
 
   serialize(value: unknown): boolean | null {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -25,8 +25,12 @@ export class IntegerType extends ValueType<number> {
   serialize(value: unknown): unknown {
     const result = this.cast(value);
     if (result !== null && (result < this._range[0] || result > this._range[1])) {
+      // Rails message shape
+      // (activemodel/lib/active_model/type/integer.rb:95):
+      //   "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+      const klass = (this.constructor as { name: string }).name;
       throw new ActiveModelRangeError(
-        `${result} is out of range for integer with limit ${this.limit ?? 4}`,
+        `${result} is out of range for ${klass} with limit ${this.limit ?? 4} bytes`,
       );
     }
     return result;


### PR DESCRIPTION
## Summary

Small correctness batch — three audit items at once.

### 22a — `BooleanType` matches Rails FALSE_VALUES semantics

Rails `cast_value` (`type/boolean.rb:40-45`):
\`\`\`ruby
def cast_value(value)
  if value == ""
    nil
  else
    !FALSE_VALUES.include?(value)
  end
end
\`\`\`

Ours used an explicit TRUE_VALUES ∪ FALSE_VALUES list with "anything else → null" — narrower than Rails AND silently coerced `"no"`/`"NO"` to `false` (neither are in Rails' FALSE_VALUES).

- Dropped TRUE_VALUES.
- FALSE_VALUES: `[false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"]` (exact Rails match).
- `cast(v)`: null/undefined/"" → null; otherwise `!FALSE_VALUES.has(v)`. `"yes"`, `"no"`, `"garbage"` all → `true`.

Test bodies updated (names unchanged) — `casts string to boolean` + `type cast boolean` now assert `"no" → true`.

### 22b — `IntegerType` error message format

Rails (`type/integer.rb:95`):
\`\`\`ruby
raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
\`\`\`

Ours already threw `ActiveModelRangeError` but without the class name or "bytes" suffix. Now matches.

### PR 2 — `Conversion._toPartialPath` demodulizes

Rails (`conversion.rb:110-118`):
\`\`\`ruby
element    = underscore(demodulize(name))
collection = tableize(name)
\`\`\`

Ours used `underscore(this.name)` without `demodulize`. A class without a configured `modelName` with a namespaced `.name` like `"Blog::Post"` would produce `element = "blog/post"` instead of `"post"`.

## Test plan

- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10,477/10,477
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`