### PR TITLE
feat(encryption): Configurable.keyProvider delegation + 4 unskipped tests

### DIFF
--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
@@ -81,7 +81,8 @@ describe("ActiveRecord::Encryption::Aes256GcmTest", () => {
   it("inspect_does not show secrets", () => {
     const secret = generateKey();
     const cipher = new Cipher(secret);
-    const inspected = inspect(cipher);
-    expect(inspected).not.toContain(secret);
+    expect(inspect(cipher)).not.toContain(secret);
+    expect(JSON.stringify(cipher)).not.toContain(secret);
+    expect(Object.keys(cipher)).not.toContain("secret");
   });
 });

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
@@ -77,7 +77,10 @@ describe("ActiveRecord::Encryption::Aes256GcmTest", () => {
     expect(r1.iv).not.toBe(r2.iv);
   });
 
-  it.skip("inspect_does not show secrets", () => {
-    /* needs custom inspect/toString */
+  it("inspect_does not show secrets", () => {
+    const secret = generateKey();
+    const cipher = new Cipher(secret);
+    const inspected = String(cipher);
+    expect(inspected).not.toContain(secret);
   });
 });

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Cipher } from "./aes256-gcm.js";
 import * as crypto from "crypto";
+import { inspect } from "util";
 
 function generateKey(): string {
   return crypto.randomBytes(32).toString("base64");
@@ -80,7 +81,7 @@ describe("ActiveRecord::Encryption::Aes256GcmTest", () => {
   it("inspect_does not show secrets", () => {
     const secret = generateKey();
     const cipher = new Cipher(secret);
-    const inspected = String(cipher);
+    const inspected = inspect(cipher);
     expect(inspected).not.toContain(secret);
   });
 });

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -23,6 +23,13 @@ export class Cipher {
     this.deterministic = options?.deterministic ?? false;
   }
 
+  // Mirrors Rails' inspect override — never expose the secret in debug output.
+  // Symbol.for("nodejs.util.inspect.custom") is the stable public symbol
+  // used by Node's util.inspect without importing "util" directly.
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
+    return `Cipher {}`;
+  }
+
   encrypt(
     data: string | Buffer,
     key: string,

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -15,11 +15,18 @@ export class Cipher {
   static keyLength = KEY_LENGTH;
   static ivLength = IV_LENGTH;
 
-  readonly secret?: string;
+  // Declared for TypeScript type-checking only; defined as non-enumerable
+  // in the constructor so it doesn't appear in JSON.stringify / object spreads.
+  declare readonly secret?: string;
   readonly deterministic: boolean;
 
   constructor(secret?: string, options?: { deterministic?: boolean }) {
-    this.secret = secret;
+    Object.defineProperty(this, "secret", {
+      value: secret,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
     this.deterministic = options?.deterministic ?? false;
   }
 
@@ -28,6 +35,10 @@ export class Cipher {
   // used by Node's util.inspect without importing "util" directly.
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return `Cipher {}`;
+  }
+
+  toJSON(): Record<string, unknown> {
+    return { deterministic: this.deterministic };
   }
 
   encrypt(

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -32,7 +32,17 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
   });
 
   it("can access context properties with top level getters", () => {
-    expect(Configurable.keyProvider).toBe(Contexts.context.keyProvider);
+    // Set salt so DerivedSecretKeyProvider can run PBKDF2.
+    Configurable.config.keyDerivationSalt = "the salt";
+    const keyProvider = new DerivedSecretKeyProvider("some secret");
+
+    expect(Configurable.keyProvider).toBeUndefined();
+
+    Contexts.withEncryptionContext({ keyProvider }, () => {
+      expect(Configurable.keyProvider).toBe(keyProvider);
+    });
+
+    expect(Configurable.keyProvider).toBeUndefined();
   });
 
   it(".configure configures initial config properties", () => {

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -1,9 +1,75 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Configurable } from "./configurable.js";
+import { Contexts } from "./contexts.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { EncryptableRecord } from "./encryptable-record.js";
+import type { SchemeOptions } from "./scheme.js";
 
 describe("ActiveRecord::Encryption::ConfigurableTest", () => {
-  it.skip("can access context properties with top level getters", () => {});
-  it.skip(".configure configures initial config properties", () => {});
-  it.skip("can add listeners that will get invoked when declaring encrypted attributes", () => {});
+  let savedConfig: ReturnType<typeof snapshotConfig>;
+
+  function snapshotConfig() {
+    const c = Configurable.config;
+    return {
+      primaryKey: c.primaryKey,
+      deterministicKey: c.deterministicKey,
+      keyDerivationSalt: c.keyDerivationSalt,
+      previousSchemes: [...c.previousSchemes],
+    };
+  }
+
+  beforeEach(() => {
+    savedConfig = snapshotConfig();
+  });
+
+  afterEach(() => {
+    const c = Configurable.config;
+    c.primaryKey = savedConfig.primaryKey;
+    c.deterministicKey = savedConfig.deterministicKey;
+    c.keyDerivationSalt = savedConfig.keyDerivationSalt;
+    c.previousSchemes = savedConfig.previousSchemes;
+    Contexts.resetDefaultContext();
+  });
+
+  it("can access context properties with top level getters", () => {
+    expect(Configurable.keyProvider).toBe(Contexts.context.keyProvider);
+  });
+
+  it(".configure configures initial config properties", () => {
+    // Set salt first so DerivedSecretKeyProvider can run PBKDF2 in its constructor.
+    Configurable.config.keyDerivationSalt = "the salt";
+    const previousKeyProvider = new DerivedSecretKeyProvider("some secret");
+
+    Configurable.configure({
+      primaryKey: "the primary key",
+      deterministicKey: "the deterministic key",
+      keyDerivationSalt: "the salt",
+      previous: [{ keyProvider: previousKeyProvider } as SchemeOptions],
+    });
+
+    const config = Configurable.config;
+    expect(config.primaryKey).toBe("the primary key");
+    expect(config.deterministicKey).toBe("the deterministic key");
+    expect(config.keyDerivationSalt).toBe("the salt");
+    expect(config.previousSchemes[0]).toMatchObject({ keyProvider: previousKeyProvider });
+  });
+
+  it("can add listeners that will get invoked when declaring encrypted attributes", () => {
+    let capturedKlass: any = null;
+    let capturedName: string | null = null;
+
+    Configurable.onEncryptedAttributeDeclared((klass, name) => {
+      capturedKlass = klass;
+      capturedName = name;
+    });
+
+    const modelClass = { _attributeDefinitions: new Map() };
+    EncryptableRecord.encrypts(modelClass, "isbn");
+
+    expect(capturedKlass).toBe(modelClass);
+    expect(capturedName).toBe("isbn");
+  });
+
   it.skip("installing autofiltered parameters will add the encrypted attribute as a filter parameter using the dot notation", () => {});
   it.skip("installing autofiltered parameters will work with unnamed classes", () => {});
   it.skip("exclude the installation of autofiltered params", () => {});

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -58,16 +58,20 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     let capturedKlass: any = null;
     let capturedName: string | null = null;
 
-    Configurable.onEncryptedAttributeDeclared((klass, name) => {
+    const dispose = Configurable.onEncryptedAttributeDeclared((klass, name) => {
       capturedKlass = klass;
       capturedName = name;
     });
 
-    const modelClass = { _attributeDefinitions: new Map() };
-    EncryptableRecord.encrypts(modelClass, "isbn");
+    try {
+      const modelClass = { _attributeDefinitions: new Map() };
+      EncryptableRecord.encrypts(modelClass, "isbn");
 
-    expect(capturedKlass).toBe(modelClass);
-    expect(capturedName).toBe("isbn");
+      expect(capturedKlass).toBe(modelClass);
+      expect(capturedName).toBe("isbn");
+    } finally {
+      dispose();
+    }
   });
 
   it.skip("installing autofiltered parameters will add the encrypted attribute as a filter parameter using the dot notation", () => {});

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -61,7 +61,9 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     expect(config.primaryKey).toBe("the primary key");
     expect(config.deterministicKey).toBe("the deterministic key");
     expect(config.keyDerivationSalt).toBe("the salt");
-    expect(config.previousSchemes[0]).toMatchObject({ keyProvider: previousKeyProvider });
+    expect(config.previousSchemes[config.previousSchemes.length - 1]).toMatchObject({
+      keyProvider: previousKeyProvider,
+    });
   });
 
   it("can add listeners that will get invoked when declaring encrypted attributes", () => {

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -1,4 +1,5 @@
 import { Config } from "./config.js";
+import { Contexts } from "./contexts.js";
 
 let _sharedConfig: Config | null = null;
 const _listeners: Array<(klass: any, name: string) => void> = [];
@@ -17,10 +18,16 @@ export class Configurable {
     return _sharedConfig;
   }
 
+  // Mirrors Rails' delegation of Context::PROPERTIES to context.
+  static get keyProvider(): unknown {
+    return Contexts.context.keyProvider;
+  }
+
   static configure(options: {
     primaryKey?: string | string[];
     deterministicKey?: string;
     keyDerivationSalt?: string;
+    previous?: Config["previousSchemes"];
     [key: string]: unknown;
   }): void {
     const config = this.config;
@@ -37,6 +44,10 @@ export class Configurable {
         (config as any)[key] = value;
       }
     }
+
+    // Mirror Rails: reset_default_context after setting config so context
+    // properties derived from config (e.g. key_provider) are re-evaluated.
+    Contexts.resetDefaultContext();
   }
 
   static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): void {

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -40,6 +40,7 @@ export class Configurable {
       if (key === "primaryKey" || key === "deterministicKey" || key === "keyDerivationSalt") {
         continue;
       }
+      if (value === undefined) continue;
       if (key in config) {
         (config as any)[key] = value;
       }
@@ -59,7 +60,7 @@ export class Configurable {
   }
 
   static encryptedAttributeWasDeclared(klass: any, name: string): void {
-    for (const listener of _listeners) {
+    for (const listener of [..._listeners]) {
       listener(klass, name);
     }
   }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -50,8 +50,12 @@ export class Configurable {
     Contexts.resetDefaultContext();
   }
 
-  static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): void {
+  static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): () => void {
     _listeners.push(callback);
+    return () => {
+      const idx = _listeners.indexOf(callback);
+      if (idx !== -1) _listeners.splice(idx, 1);
+    };
   }
 
   static encryptedAttributeWasDeclared(klass: any, name: string): void {

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -91,6 +91,10 @@ export function getEncryptionContext(): EncryptionContext {
   return currentContext();
 }
 
+export function getCurrentCustomContext(): EncryptionContext | null {
+  return contextStack.length > 0 ? contextStack[contextStack.length - 1] : null;
+}
+
 export function isEncryptionDisabled(): boolean {
   return currentContext().encryptionDisabled === true;
 }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -38,9 +38,18 @@ export interface EncryptionContext {
 }
 
 const contextStack: EncryptionContext[] = [];
+let _defaultContext: EncryptionContext = {};
+
+export function getDefaultContext(): EncryptionContext {
+  return _defaultContext;
+}
+
+export function resetDefaultContext(): void {
+  _defaultContext = {};
+}
 
 function currentContext(): EncryptionContext {
-  return contextStack.length > 0 ? contextStack[contextStack.length - 1] : {};
+  return contextStack.length > 0 ? contextStack[contextStack.length - 1] : _defaultContext;
 }
 
 export function withEncryptionContext<T>(overrides: EncryptionContext, fn: () => T): T {

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -1,14 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   withEncryptionContext,
   withoutEncryption,
   protectingEncryptedData,
   getEncryptionContext,
+  getDefaultContext,
+  resetDefaultContext,
   isEncryptionDisabled,
   isProtectedMode,
 } from "./context.js";
 
 describe("ActiveRecord::Encryption::ContextsTest", () => {
+  afterEach(() => {
+    resetDefaultContext();
+  });
+
+  it("defaultContext is visible via getEncryptionContext when no custom context is active", () => {
+    expect(getEncryptionContext().keyProvider).toBeUndefined();
+
+    getDefaultContext().keyProvider = "default-provider";
+    expect(getEncryptionContext().keyProvider).toBe("default-provider");
+
+    // custom context overrides default
+    withEncryptionContext({ keyProvider: "custom" }, () => {
+      expect(getEncryptionContext().keyProvider).toBe("custom");
+    });
+
+    // default is restored after custom context exits
+    expect(getEncryptionContext().keyProvider).toBe("default-provider");
+
+    resetDefaultContext();
+    expect(getEncryptionContext().keyProvider).toBeUndefined();
+  });
+
   it(".with_encryption_context lets you override properties", () => {
     withEncryptionContext({ keyProvider: "custom" }, () => {
       expect(getEncryptionContext().keyProvider).toBe("custom");

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -4,6 +4,7 @@ import {
   protectingEncryptedData as _protecting,
   getEncryptionContext,
   getDefaultContext,
+  getCurrentCustomContext,
   resetDefaultContext as _resetDefaultContext,
   type EncryptionContext,
 } from "./context.js";
@@ -32,8 +33,7 @@ export class Contexts {
   }
 
   static get currentCustomContext(): EncryptionContext | null {
-    const ctx = getEncryptionContext();
-    return ctx ?? null;
+    return getCurrentCustomContext();
   }
 
   static get defaultContext(): EncryptionContext {

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * Class-based API for managing encryption contexts. Delegates to the
- * existing AsyncLocalStorage-based context system in context.ts.
+ * manual-stack context system in context.ts (Promise-aware push/pop).
  *
  * Mirrors: ActiveRecord::Encryption::Contexts
  */

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -3,10 +3,10 @@ import {
   withoutEncryption as _withoutEnc,
   protectingEncryptedData as _protecting,
   getEncryptionContext,
+  getDefaultContext,
+  resetDefaultContext as _resetDefaultContext,
   type EncryptionContext,
 } from "./context.js";
-
-let _defaultContext: EncryptionContext = {};
 
 /**
  * Class-based API for managing encryption contexts. Delegates to the
@@ -37,10 +37,10 @@ export class Contexts {
   }
 
   static get defaultContext(): EncryptionContext {
-    return _defaultContext;
+    return getDefaultContext();
   }
 
   static resetDefaultContext(): void {
-    _defaultContext = {};
+    _resetDefaultContext();
   }
 }


### PR DESCRIPTION
## Summary

- `Configurable.keyProvider` getter delegates to `Contexts.context.keyProvider`, mirroring Rails' `delegate :key_provider, to: :context` via `Context::PROPERTIES`
- `Configurable.configure()` now calls `Contexts.resetDefaultContext()` after applying settings, matching Rails' `reset_default_context` call
- Unskips 4 previously-skipped Rails tests: context property getter, configure, listeners, and cipher inspect

## Rails source
- `activerecord/lib/active_record/encryption/configurable.rb` lines 14–37
- `activerecord/test/cases/encryption/configurable_test.rb`
- `activerecord/test/cases/encryption/cipher/aes256_gcm_test.rb`

## Test plan
- [ ] 3 new `ConfigurableTest` tests pass
- [ ] 1 new `Aes256GcmTest` test passes  
- [ ] Full encryption suite: 183 pass, 96 skipped