### PR TITLE
feat(activemodel): ModelName gains Rails String-inheritance analog (toString, equals, compare, match)

### DIFF
--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -426,6 +426,45 @@ describe("ModelName namespace accepts Module-like {name}", () => {
   });
 });
 
+// Rails `ActiveModel::Name` includes Comparable and delegates ==/<=>/
+// =~/match?/to_s/to_str/as_json to @name (naming.rb:10, :151-152). JS
+// can't overload those operators, so we expose methods + Symbol.toPrimitive.
+describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
+  it("toString returns the class name", () => {
+    expect(new ModelName("Post").toString()).toBe("Post");
+    expect(String(new ModelName("Post"))).toBe("Post");
+    expect(`${new ModelName("Post")}`).toBe("Post");
+  });
+
+  it("Symbol.toPrimitive coerces to the class name in string concatenation", () => {
+    const mn = new ModelName("Post");
+    expect("Model: " + mn).toBe("Model: Post");
+  });
+
+  it("equals compares against strings and other ModelName instances", () => {
+    const mn = new ModelName("Post");
+    expect(mn.equals("Post")).toBe(true);
+    expect(mn.equals("Other")).toBe(false);
+    expect(mn.equals(new ModelName("Post"))).toBe(true);
+    expect(mn.equals(new ModelName("Other"))).toBe(false);
+    expect(mn.equals(42)).toBe(false);
+  });
+
+  it("compare returns -1/0/1 matching String#<=>", () => {
+    const mn = new ModelName("BlogPost");
+    expect(mn.compare("BlogPost")).toBe(0);
+    expect(mn.compare("Blog")).toBe(1);
+    expect(mn.compare("BlogPosts")).toBe(-1);
+    expect(mn.compare(new ModelName("BlogPost"))).toBe(0);
+  });
+
+  it("match tests a regexp against the class name", () => {
+    const mn = new ModelName("BlogPost");
+    expect(mn.match(/Post/)).toBe(true);
+    expect(mn.match(/\d/)).toBe(false);
+  });
+});
+
 describe("OverridingAccessorsTest", () => {
   it("overriding accessors keys", () => {
     class Person extends Model {

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -482,9 +482,40 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
 
   it("compare throws ArgumentError on non-string/non-ModelName input", () => {
     const mn = new ModelName("Post");
-    expect(() => mn.compare(42 as unknown as string)).toThrow(ArgumentError);
-    expect(() => mn.compare(null as unknown as string)).toThrow(ArgumentError);
-    expect(() => mn.compare(undefined as unknown as string)).toThrow(ArgumentError);
+    expect(() => mn.compare(42)).toThrow(ArgumentError);
+    expect(() => mn.compare(null)).toThrow(ArgumentError);
+    expect(() => mn.compare(undefined)).toThrow(ArgumentError);
+  });
+
+  it("match throws ArgumentError on non-RegExp input", () => {
+    const mn = new ModelName("Post");
+    expect(() => mn.match("Post")).toThrow(ArgumentError);
+    expect(() => mn.match(null)).toThrow(ArgumentError);
+    expect(() => mn.match(undefined)).toThrow(ArgumentError);
+  });
+
+  it("equals / compare distinguish namespaced models with the same bare name", () => {
+    // Two ModelName instances share the same `name: "Post"` but differ
+    // in namespace — must not compare equal, must sort deterministically.
+    const blogPost = new ModelName("Post", { namespace: "Blog" });
+    const adminPost = new ModelName("Post", { namespace: "Admin" });
+    const blogPost2 = new ModelName("Post", { namespace: "Blog" });
+    const barePost = new ModelName("Post");
+
+    expect(blogPost.equals(adminPost)).toBe(false);
+    expect(blogPost.equals(blogPost2)).toBe(true);
+    expect(blogPost.equals(barePost)).toBe(false);
+    // Admin < Blog lexicographically on the namespace segment.
+    expect(blogPost.compare(adminPost)).toBe(1);
+    expect(adminPost.compare(blogPost)).toBe(-1);
+    expect(blogPost.compare(blogPost2)).toBe(0);
+
+    // String coercion still yields just the bare name (user-enforced:
+    // no Ruby "::" in TS output). Callers that need namespace-aware
+    // identity use `.equals` / `.namespace`.
+    expect(String(blogPost)).toBe("Post");
+    expect(String(adminPost)).toBe("Post");
+    expect(blogPost.equals("Post")).toBe(true);
   });
 
   it("== operator coerces via Symbol.toPrimitive to the class name", () => {

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -464,6 +464,29 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(mn.match(/\d/)).toBe(false);
   });
 
+  it("match stays stable when reusing global and sticky regexps", () => {
+    // RegExp.prototype.test advances `lastIndex` on /g and /y flags, so a
+    // second call on the same regex can flip false without care. Our
+    // `match` saves/restores `lastIndex` so repeated calls are stable
+    // (Ruby `match?` is stateless).
+    const mn = new ModelName("BlogPost");
+    const globalRe = /Post/g;
+    const stickyRe = /Blog/y;
+    expect(mn.match(globalRe)).toBe(true);
+    expect(mn.match(globalRe)).toBe(true);
+    expect(mn.match(stickyRe)).toBe(true);
+    expect(mn.match(stickyRe)).toBe(true);
+    expect(globalRe.lastIndex).toBe(0);
+    expect(stickyRe.lastIndex).toBe(0);
+  });
+
+  it("compare throws ArgumentError on non-string/non-ModelName input", () => {
+    const mn = new ModelName("Post");
+    expect(() => mn.compare(42 as unknown as string)).toThrow(ArgumentError);
+    expect(() => mn.compare(null as unknown as string)).toThrow(ArgumentError);
+    expect(() => mn.compare(undefined as unknown as string)).toThrow(ArgumentError);
+  });
+
   it("== operator coerces via Symbol.toPrimitive to the class name", () => {
     // Rails `model_name == "Post"` is true because Name < String.
     // JS `==` between object and string triggers primitive coercion,

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -505,7 +505,8 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(blogPost.equals(adminPost)).toBe(false);
     expect(blogPost.equals(blogPost2)).toBe(true);
     expect(blogPost.equals(barePost)).toBe(false);
-    // Admin < Blog lexicographically on the namespace segment.
+    // `compare` compares the full qualified path ("Admin/Post" vs
+    // "Blog/Post"), so Admin < Blog.
     expect(blogPost.compare(adminPost)).toBe(1);
     expect(adminPost.compare(blogPost)).toBe(-1);
     expect(blogPost.compare(blogPost2)).toBe(0);
@@ -516,6 +517,24 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(String(blogPost)).toBe("Post");
     expect(String(adminPost)).toBe("Post");
     expect(blogPost.equals("Post")).toBe(true);
+  });
+
+  it("compare sorts by full qualified path, not bare name first", () => {
+    // Covers the Rails `String#<=>` parity: ordering is determined by
+    // the full namespace+name path as a single string — so a model
+    // under an earlier-sorting namespace outranks a later-sorting
+    // namespace even when its bare name comes later alphabetically.
+    const adminOther = new ModelName("Other", { namespace: "Admin" });
+    const blogPost = new ModelName("Post", { namespace: "Blog" });
+    // "Admin/Other" < "Blog/Post"
+    expect(adminOther.compare(blogPost)).toBe(-1);
+    expect(blogPost.compare(adminOther)).toBe(1);
+    // Bare name ("Post") > a qualified name starting with earlier letters
+    // ("Admin/Other")? No — bare comparison uses the raw qualified path,
+    // so "Admin/Other" < "Post".
+    const barePost = new ModelName("Post");
+    expect(adminOther.compare(barePost)).toBe(-1);
+    expect(barePost.compare(adminOther)).toBe(1);
   });
 
   it("== operator coerces via Symbol.toPrimitive to the class name", () => {

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -463,6 +463,27 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(mn.match(/Post/)).toBe(true);
     expect(mn.match(/\d/)).toBe(false);
   });
+
+  it("== operator coerces via Symbol.toPrimitive to the class name", () => {
+    // Rails `model_name == "Post"` is true because Name < String.
+    // JS `==` between object and string triggers primitive coercion,
+    // which Symbol.toPrimitive steers at the class name — so the
+    // Rails-shaped comparison works verbatim.
+    const mn: unknown = new ModelName("Post");
+
+    expect(mn == "Post").toBe(true);
+
+    expect(mn == "Other").toBe(false);
+  });
+
+  it("asJson / JSON.stringify emits the plain class name", () => {
+    // Rails `String#as_json` returns the string; `Name.new(BlogPost).to_json`
+    // emits '"BlogPost"', not a hash form.
+    const mn = new ModelName("BlogPost");
+    expect(mn.asJson()).toBe("BlogPost");
+    expect(JSON.stringify(mn)).toBe('"BlogPost"');
+    expect(JSON.stringify({ model: mn })).toBe('{"model":"BlogPost"}');
+  });
 });
 
 describe("OverridingAccessorsTest", () => {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -216,6 +216,62 @@ export class ModelName {
     return this.collection;
   }
 
+  // ---------------------------------------------------------------------------
+  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
+  //   include Comparable
+  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
+  //            :to_str, :as_json, to: :name
+  //
+  // JS can't overload `==`/`<=>`/`=~`, so we expose each as a method and
+  // install `Symbol.toPrimitive` so `String(modelName)`,
+  // `` `${modelName}` ``, and `modelName + ""` all coerce to the class
+  // name — enough for route helpers, form keys, and Jest/Vitest
+  // equality when comparing to plain strings.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
+   * (naming.rb:131-152). `name` is Ruby's full constant path
+   * (`"Blog::Post"`); in TS we keep `name` as the bare identifier
+   * (`"Post"`) and let namespace segments live on `.namespace`.
+   */
+  toString(): string {
+    return this.name;
+  }
+
+  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
+  [Symbol.toPrimitive](_hint: string): string {
+    return this.name;
+  }
+
+  /**
+   * Mirrors Rails `@name == other` (String#==). Accepts another
+   * `ModelName` (compared by `.name`) or any string.
+   */
+  equals(other: unknown): boolean {
+    if (other instanceof ModelName) return this.name === other.name;
+    return typeof other === "string" && this.name === other;
+  }
+
+  /**
+   * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
+   * or `1`. Throws for non-string/non-ModelName arguments — matches
+   * Ruby's `nil` Spaceship result being an error in a TS context.
+   */
+  compare(other: ModelName | string): -1 | 0 | 1 {
+    const rhs = other instanceof ModelName ? other.name : other;
+    if (this.name === rhs) return 0;
+    return this.name < rhs ? -1 : 1;
+  }
+
+  /**
+   * Mirrors Rails `@name.match?(regexp)` / `=~`. Returns whether the
+   * class name matches the given regex.
+   */
+  match(pattern: RegExp): boolean {
+    return pattern.test(this.name);
+  }
+
   get human(): string {
     if (!this._klass) return this._humanFallback;
 

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -1,6 +1,14 @@
 import { underscore, pluralize, singularize, humanize } from "@blazetrails/activesupport";
 import { ArgumentError } from "./attribute-assignment.js";
 
+function sameSegments(a: readonly string[] | null, b: readonly string[] | null): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 /**
  * Naming mixin — provides model_name on classes and naming helpers.
  *
@@ -232,9 +240,15 @@ export class ModelName {
 
   /**
    * Mirrors Rails `to_s` / `to_str` delegated to `@name`
-   * (naming.rb:131-152). `name` is Ruby's full constant path
-   * (`"Blog::Post"`); in TS we keep `name` as the bare identifier
-   * (`"Post"`) and let namespace segments live on `.namespace`.
+   * (naming.rb:131-152). Rails' `@name` is the full constant path
+   * (`"Blog::Post"`). TS has no `::` constant syntax and we
+   * deliberately reject `::` at the input boundary (see constructor),
+   * so `toString` returns the bare identifier (`"Post"`). Two
+   * instances with the same bare name but different namespaces will
+   * coerce to the same string — callers that care about namespaced
+   * identity should use `.equals(other)` / `.compare(other)` (which
+   * compare the full name + namespace identity) or read `.namespace`
+   * directly.
    */
   toString(): string {
     return this.name;
@@ -246,30 +260,41 @@ export class ModelName {
   }
 
   /**
-   * Mirrors Rails `@name == other` (String#==). Accepts another
-   * `ModelName` (compared by `.name`) or any string.
+   * Mirrors Rails `@name == other` (String#==). When comparing to
+   * another `ModelName`, both the bare name AND namespace segments
+   * must match — so `ModelName("Post")` and
+   * `ModelName("Post", { namespace: "Blog" })` are NOT equal. When
+   * comparing to a string, only `.name` is matched (a plain string
+   * can't express a namespace).
    */
   equals(other: unknown): boolean {
-    if (other instanceof ModelName) return this.name === other.name;
+    if (other instanceof ModelName) {
+      if (this.name !== other.name) return false;
+      return sameSegments(this.namespace, other.namespace);
+    }
     return typeof other === "string" && this.name === other;
   }
 
   /**
    * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
    * or `1`. Throws `ArgumentError` for non-string / non-ModelName
-   * arguments — Ruby's `nil` Spaceship result is an error in TS.
+   * arguments. For ModelName-to-ModelName, compares the full
+   * identity (name + namespace) so namespace-differing models sort
+   * distinctly; for ModelName-to-string, compares `.name` only.
    */
   compare(other: unknown): -1 | 0 | 1 {
-    let rhs: string;
     if (other instanceof ModelName) {
-      rhs = other.name;
-    } else if (typeof other === "string") {
-      rhs = other;
-    } else {
-      throw new ArgumentError("comparison of ModelName with non-string failed");
+      if (this.name !== other.name) return this.name < other.name ? -1 : 1;
+      if (sameSegments(this.namespace, other.namespace)) return 0;
+      const l = (this.namespace ?? []).join("/");
+      const r = (other.namespace ?? []).join("/");
+      return l < r ? -1 : 1;
     }
-    if (this.name === rhs) return 0;
-    return this.name < rhs ? -1 : 1;
+    if (typeof other === "string") {
+      if (this.name === other) return 0;
+      return this.name < other ? -1 : 1;
+    }
+    throw new ArgumentError("comparison of ModelName with non-string failed");
   }
 
   /**
@@ -281,7 +306,10 @@ export class ModelName {
    * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
    * on stateful flags, but Ruby `match?` is stateless.
    */
-  match(pattern: RegExp): boolean {
+  match(pattern: unknown): boolean {
+    if (!(pattern instanceof RegExp)) {
+      throw new ArgumentError("ModelName#match requires a RegExp");
+    }
     const savedLastIndex = pattern.lastIndex;
     try {
       return pattern.test(this.name);

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -265,11 +265,26 @@ export class ModelName {
   }
 
   /**
-   * Mirrors Rails `@name.match?(regexp)` / `=~`. Returns whether the
-   * class name matches the given regex.
+   * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
+   * name matches the given regex (boolean — this is `match?` semantic,
+   * not the integer position that Ruby `=~` returns).
    */
   match(pattern: RegExp): boolean {
     return pattern.test(this.name);
+  }
+
+  /**
+   * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
+   * string, so we return `this.name` as-is. Lets `JSON.stringify(mn)`
+   * emit the plain class name rather than `{}` / the object form.
+   */
+  asJson(): string {
+    return this.name;
+  }
+
+  /** JSON.stringify hook — delegates to `asJson`. */
+  toJSON(): string {
+    return this.asJson();
   }
 
   get human(): string {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -284,10 +284,13 @@ export class ModelName {
    */
   compare(other: unknown): -1 | 0 | 1 {
     if (other instanceof ModelName) {
-      if (this.name !== other.name) return this.name < other.name ? -1 : 1;
-      if (sameSegments(this.namespace, other.namespace)) return 0;
-      const l = (this.namespace ?? []).join("/");
-      const r = (other.namespace ?? []).join("/");
+      // Single string compare over the full constant path — matches
+      // Rails' `String#<=>` on `@name` (e.g. "Admin::Other" < "Blog::Post"
+      // by first segment, regardless of bare-name ordering). We join
+      // with `/` (not `::`) to keep Ruby syntax out of TS code.
+      const l = ModelName._qualified(this);
+      const r = ModelName._qualified(other);
+      if (l === r) return 0;
       return l < r ? -1 : 1;
     }
     if (typeof other === "string") {
@@ -295,6 +298,10 @@ export class ModelName {
       return this.name < other ? -1 : 1;
     }
     throw new ArgumentError("comparison of ModelName with non-string failed");
+  }
+
+  private static _qualified(mn: ModelName): string {
+    return [...(mn.namespace ?? []), mn.name].join("/");
   }
 
   /**

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -327,10 +327,13 @@ export class ModelName {
 
   /**
    * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
-   * string, so we return `this.name` as-is. Lets `JSON.stringify(mn)`
-   * emit the plain class name rather than `{}` / the object form.
+   * string (and accepts an ignored `options` Hash). Returns `this.name`
+   * as-is; accepts (but ignores) an options argument so callers match
+   * Rails' signature and the rest of this codebase's `asJson(options?)`
+   * conventions. Lets `JSON.stringify(mn)` emit the plain class name
+   * rather than `{}` / the object form.
    */
-  asJson(): string {
+  asJson(_options?: unknown): string {
     return this.name;
   }
 

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -222,11 +222,12 @@ export class ModelName {
   //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
   //            :to_str, :as_json, to: :name
   //
-  // JS can't overload `==`/`<=>`/`=~`, so we expose each as a method and
-  // install `Symbol.toPrimitive` so `String(modelName)`,
-  // `` `${modelName}` ``, and `modelName + ""` all coerce to the class
-  // name — enough for route helpers, form keys, and Jest/Vitest
-  // equality when comparing to plain strings.
+  // JS can't overload operators, so we expose methods + the one coercion
+  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
+  // coercion only — `String(modelName)`, template literals, `modelName +
+  // ""`, and loose `==` against a string. It does NOT trigger on strict
+  // `===` / `Object.is` / Jest's `toBe` (those compare identity without
+  // coercion); for those, callers use `mn.name` or `mn.equals(other)`.
   // ---------------------------------------------------------------------------
 
   /**
@@ -255,11 +256,18 @@ export class ModelName {
 
   /**
    * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
-   * or `1`. Throws for non-string/non-ModelName arguments — matches
-   * Ruby's `nil` Spaceship result being an error in a TS context.
+   * or `1`. Throws `ArgumentError` for non-string / non-ModelName
+   * arguments — Ruby's `nil` Spaceship result is an error in TS.
    */
-  compare(other: ModelName | string): -1 | 0 | 1 {
-    const rhs = other instanceof ModelName ? other.name : other;
+  compare(other: unknown): -1 | 0 | 1 {
+    let rhs: string;
+    if (other instanceof ModelName) {
+      rhs = other.name;
+    } else if (typeof other === "string") {
+      rhs = other;
+    } else {
+      throw new ArgumentError("comparison of ModelName with non-string failed");
+    }
     if (this.name === rhs) return 0;
     return this.name < rhs ? -1 : 1;
   }
@@ -268,9 +276,18 @@ export class ModelName {
    * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
    * name matches the given regex (boolean — this is `match?` semantic,
    * not the integer position that Ruby `=~` returns).
+   *
+   * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
+   * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
+   * on stateful flags, but Ruby `match?` is stateless.
    */
   match(pattern: RegExp): boolean {
-    return pattern.test(this.name);
+    const savedLastIndex = pattern.lastIndex;
+    try {
+      return pattern.test(this.name);
+    } finally {
+      pattern.lastIndex = savedLastIndex;
+    }
   }
 
   /**

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -234,8 +234,8 @@ export class ModelName {
   // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
   // coercion only — `String(modelName)`, template literals, `modelName +
   // ""`, and loose `==` against a string. It does NOT trigger on strict
-  // `===` / `Object.is` / Jest's `toBe` (those compare identity without
-  // coercion); for those, callers use `mn.name` or `mn.equals(other)`.
+  // `===` / `Object.is` / matchers that use strict identity without
+  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
   // ---------------------------------------------------------------------------
 
   /**


### PR DESCRIPTION
## Summary

PR 12 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

Rails' `ActiveModel::Name < String; include Comparable` and delegates `==`/`===`/`<=>`/`=~`/`match?`/`to_s`/`to_str`/`as_json` to `@name` (`naming.rb:10, :151-152`). Our `ModelName` had none of that, so:
- `modelName == "Post"` returned `false`.
- `modelName.match(/Post/)` threw.
- Passing a `ModelName` where a string was expected required explicit `.name`.

JS can't overload operators, so added the method + coercion hook equivalents:

| Rails | Ours |
|---|---|
| `to_s` / `to_str` | `toString()` |
| (implicit string coercion) | `[Symbol.toPrimitive]` — `String(mn)`, `` `${mn}` ``, `mn + ""` all work |
| `==` | `equals(other)` — accepts `ModelName` or string |
| `<=>` | `compare(other)` → `-1 \| 0 \| 1` |
| `match?` / `=~`-truthy | `match(regexp)` → boolean |

## Test plan

- [x] 5 new cases under `ModelName is string-ish (Rails String-inheritance analog)`.
- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10,482/10,482
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`