### PR TITLE
feat(activemodel): ModelName uncountables delegate to activesupport Inflector

### DIFF
--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -65,6 +65,24 @@ describe("NamingTest", () => {
     const name = new ModelName("Sheep");
     expect(name.plural).toBe("sheep");
   });
+
+  it("addUncountable writes through to the shared activesupport inflector", async () => {
+    // Rails `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
+    // writes to a shared store every inflection consumer reads. Ours
+    // must do the same so `pluralize` picks up custom uncountables.
+    const { pluralize, Inflections } = await import("@blazetrails/activesupport");
+    const word = "fizzbuzzuncountabletestword";
+    try {
+      ModelName.addUncountable(word);
+      expect(Inflections.instance("en").uncountables.has(word)).toBe(true);
+      expect(pluralize(word)).toBe(word);
+      const mn = new ModelName("Fizzbuzzuncountabletestword");
+      expect(mn.singular).toBe(word);
+      expect(mn.plural).toBe(word);
+    } finally {
+      Inflections.instance("en").uncountables.delete(word);
+    }
+  });
 });
 
 describe("NamingHelpersTest", () => {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -1,4 +1,10 @@
-import { underscore, pluralize, singularize, humanize } from "@blazetrails/activesupport";
+import {
+  underscore,
+  pluralize,
+  singularize,
+  humanize,
+  Inflections,
+} from "@blazetrails/activesupport";
 import { ArgumentError } from "./attribute-assignment.js";
 
 function sameSegments(a: readonly string[] | null, b: readonly string[] | null): boolean {
@@ -94,17 +100,25 @@ export class ModelName {
   private _humanFallback: string;
   private _klass: ModelLike | null;
 
-  private static _uncountables: Set<string> = new Set([
-    "sheep",
-    "fish",
-    "series",
-    "species",
-    "money",
-    "rice",
-  ]);
+  // Uncountable lookup delegates to `@blazetrails/activesupport`'s
+  // `Inflections.instance("en")` — the same store Rails models go
+  // through via `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
+  // (activesupport/lib/active_support/inflections.rb). Previously we
+  // maintained a local 6-word set that ignored user-added inflections
+  // and diverged from activesupport's own pluralize() which uses the
+  // shared store.
+  private static get _uncountables(): Set<string> {
+    return Inflections.instance("en").uncountables;
+  }
 
+  /**
+   * Register an uncountable word. Mirrors Rails
+   * `ActiveSupport::Inflector.inflections.uncountable(word)` — writes
+   * through to the shared inflector store so `pluralize("sheep")`,
+   * `ModelName`, and every other inflection consumer see it.
+   */
   static addUncountable(word: string): void {
-    this._uncountables.add(word.toLowerCase());
+    Inflections.instance("en").uncountable(word);
   }
 
   /**


### PR DESCRIPTION
## Summary

PR 14 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

`ModelName._uncountables` was a hardcoded private Set of six words (`sheep, fish, series, species, money, rice`) that diverged from `@blazetrails/activesupport`'s `Inflections.instance("en")` (10 defaults: `equipment, information, rice, money, species, series, fish, sheep, jeans, police`) and from Rails' global inflector store.

`ModelName.addUncountable("news")` wouldn't affect `pluralize`, and vice versa — silent divergence between ModelName plural behavior and activesupport's.

### Changes

- `ModelName._uncountables` is now a getter into `Inflections.instance("en").uncountables`.
- `ModelName.addUncountable(word)` delegates to `Inflections.instance("en").uncountable(word)` — writes through to the shared store, matching Rails `ActiveSupport::Inflector.inflections { |i| i.uncountable "news" }`.

**Note:** the default uncountables list now contains 10 words instead of 6. `equipment`/`information`/`jeans`/`police` are newly uncountable — matches Rails.

## Test plan

- [x] New test `addUncountable writes through to the shared activesupport inflector` — registers a custom word, verifies it's in the shared store, that `pluralize()` sees it, and that a ModelName from its CamelCase form stays singular. Teardown restores the store.
- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10,489/10,489
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`