### PR TITLE
feat(activerecord): SQLite3 collation + JSON column default; test:compare 338/338 (100%)

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/sqlite3/collation_test.rb
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SchemaDumper } from "../../schema-dumper.js";
+
+let adapter: SQLite3Adapter;
+
+beforeEach(() => {
+  adapter = new SQLite3Adapter(":memory:");
+  adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "string_nocase" VARCHAR(255) COLLATE "NOCASE",
+    "text_rtrim" TEXT COLLATE "RTRIM",
+    "decimal_col" DECIMAL(6, 2),
+    "string_after_decimal_nocase" VARCHAR(255) COLLATE "NOCASE"
+  )`);
+});
+
+afterEach(() => {
+  adapter.close();
+});
+
+describe("SQLite3CollationTest", () => {
+  it("string column with collation", async () => {
+    const columns = await adapter.columns("collation_table_sqlite3");
+
+    const stringNocase = columns.find((c) => c.name === "string_nocase")!;
+    expect(stringNocase.sqlType?.toLowerCase()).toMatch(/varchar|char/);
+    expect(stringNocase.collation).toBe("NOCASE");
+
+    const stringAfterDecimal = columns.find((c) => c.name === "string_after_decimal_nocase")!;
+    expect(stringAfterDecimal.sqlType?.toLowerCase()).toMatch(/varchar|char/);
+    expect(stringAfterDecimal.collation).toBe("NOCASE");
+  });
+
+  it("text column with collation", async () => {
+    const columns = await adapter.columns("collation_table_sqlite3");
+    const textRtrim = columns.find((c) => c.name === "text_rtrim")!;
+    expect(textRtrim.sqlType?.toLowerCase()).toBe("text");
+    expect(textRtrim.collation).toBe("RTRIM");
+  });
+
+  it("add column with collation", async () => {
+    await adapter.addColumn("collation_table_sqlite3", "title", "string", { collation: "RTRIM" });
+
+    const columns = await adapter.columns("collation_table_sqlite3");
+    const title = columns.find((c) => c.name === "title")!;
+    expect(title.sqlType?.toLowerCase()).toMatch(/varchar|char/);
+    expect(title.collation).toBe("RTRIM");
+  });
+
+  it("change column with collation", async () => {
+    await adapter.addColumn("collation_table_sqlite3", "description", "string");
+    await adapter.changeColumn("collation_table_sqlite3", "description", "text", {
+      collation: "RTRIM",
+    });
+
+    const columns = await adapter.columns("collation_table_sqlite3");
+    const desc = columns.find((c) => c.name === "description")!;
+    expect(desc.sqlType?.toLowerCase()).toBe("text");
+    expect(desc.collation).toBe("RTRIM");
+  });
+
+  it("schema dump includes collation", async () => {
+    const output = await SchemaDumper.dump(adapter);
+    expect(output).toMatch(/t\.string\("string_nocase",[^)]*collation: "NOCASE"/);
+    expect(output).toMatch(/t\.text\("text_rtrim",[^)]*collation: "RTRIM"/);
+  });
+});

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/sqlite3/json_test.rb
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { Base } from "../../index.js";
+
+let adapter: SQLite3Adapter;
+
+beforeEach(() => {
+  adapter = new SQLite3Adapter(":memory:");
+});
+
+afterEach(() => {
+  adapter.close();
+});
+
+describe("SQLite3JSONTest", () => {
+  it("test_default", async () => {
+    adapter.exec(`CREATE TABLE "json_data_type" (
+      "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+      "payload" JSON DEFAULT '{}',
+      "settings" JSON
+    )`);
+
+    const defaultVal = { users: "read", posts: ["read", "write"] };
+    await adapter.addColumn("json_data_type", "permissions", "json", {
+      default: JSON.stringify(defaultVal),
+    });
+
+    class JsonDataType extends Base {
+      static {
+        this.tableName = "json_data_type";
+      }
+    }
+    JsonDataType.adapter = adapter;
+    await JsonDataType.loadSchema();
+
+    const defaults = JsonDataType.columnDefaults;
+    expect(defaults["permissions"]).toEqual({ users: "read", posts: ["read", "write"] });
+
+    const record = new JsonDataType();
+    expect((record as any).permissions).toEqual({ users: "read", posts: ["read", "write"] });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -193,6 +193,7 @@ export interface ColumnOptions {
   unique?: boolean;
   primaryKey?: boolean;
   array?: boolean;
+  collation?: string;
 }
 
 export interface AddIndexOptions {
@@ -802,6 +803,10 @@ export class TableDefinition {
       // For types that don't handle PRIMARY KEY internally, append it if requested
       if (col.options.primaryKey && col.type !== "primary_key" && col.type !== "uuid") {
         parts.push("PRIMARY KEY");
+      }
+
+      if (col.options.collation) {
+        parts.push(`COLLATE "${col.options.collation}"`);
       }
 
       if (col.options.array && col.type !== "primary_key") {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -805,8 +805,8 @@ export class TableDefinition {
         parts.push("PRIMARY KEY");
       }
 
-      if (col.options.collation) {
-        parts.push(`COLLATE "${col.options.collation}"`);
+      if (col.options.collation && this._adapterName === "sqlite") {
+        parts.push(`COLLATE ${quoteIdentifier(col.options.collation, this._adapterName)}`);
       }
 
       if (col.options.array && col.type !== "primary_key") {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -740,7 +740,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   ): Promise<void> {
     const sqlType = this.typeToSql(type, options);
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
-    if (options?.collation) sql += ` COLLATE "${options.collation}"`;
+    if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;
     if (options?.null === false) sql += " NOT NULL";
     if (options?.default !== undefined) {
       sql += ` DEFAULT ${this.quoteDefault(options.default)}`;
@@ -1195,17 +1195,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // Mirrors: SQLite3Adapter#table_structure_with_collation
   private _parseCollationsFromTableSql(tableName: string): Map<string, string> {
     const result = new Map<string, string>();
-    const row = this.db
-      .prepare(
-        `SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type='table' AND name=?`,
-      )
-      .get(tableName) as { sql: string } | undefined;
-    if (!row?.sql) return result;
+    const createSql = this._getCreateTableSql(tableName);
+    if (!createSql) return result;
 
-    // Split CREATE TABLE (...) into per-column/constraint strings
     const COLLATE_REGEX = /.*"(\w+)".*\bCOLLATE\s+"(\w+)".*/i;
-    const body = row.sql.replace(/\);*\s*$/, "").replace(/^[^(]*\(/, "");
-    // Split on commas not inside parentheses and not inside quotes
+    const body = createSql.replace(/\);*\s*$/, "").replace(/^[^(]*\(/, "");
     const parts = body.split(/,(?=\s*(?:"|\bCONSTRAINT\b))/i);
     for (const part of parts) {
       const m = COLLATE_REGEX.exec(part);
@@ -1459,7 +1453,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       const col = columns[name];
       let def = `${quoteColumnName(name)} ${col.type ?? "TEXT"}`;
       const collation = col.collation ?? existingCollations.get(name);
-      if (collation) def += ` COLLATE "${collation}"`;
+      if (collation) def += ` COLLATE ${quoteColumnName(String(collation))}`;
       if (!compositePk && col.pk) def += " PRIMARY KEY";
       if (col.notnull) def += " NOT NULL";
       if (col.dflt_value !== null && col.dflt_value !== undefined) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1182,9 +1182,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private _extractValueFromDefault(dfltValue: string | null): unknown {
     if (dfltValue === null) return null;
     if (/^null$/i.test(dfltValue)) return null;
-    const singleQuoted = /^'([\s\S]*)'$/m.exec(dfltValue);
+    const singleQuoted = /^'([\s\S]*)'$/.exec(dfltValue);
     if (singleQuoted) return singleQuoted[1].replace(/''/g, "'");
-    const doubleQuoted = /^"([\s\S]*)"$/m.exec(dfltValue);
+    const doubleQuoted = /^"([\s\S]*)"$/.exec(dfltValue);
     if (doubleQuoted) return doubleQuoted[1].replace(/""/g, '"');
     if (/^-?\d+(\.\d*)?$/.test(dfltValue)) return dfltValue;
     const hexMatch = /^x'(.*)'$/i.exec(dfltValue);
@@ -1452,7 +1452,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const colDefs = colNames.map((name) => {
       const col = columns[name];
       let def = `${quoteColumnName(name)} ${col.type ?? "TEXT"}`;
-      const collation = col.collation ?? existingCollations.get(name);
+      const collation = col.collation === undefined ? existingCollations.get(name) : col.collation;
       if (collation) def += ` COLLATE ${quoteColumnName(String(collation))}`;
       if (!compositePk && col.pk) def += " PRIMARY KEY";
       if (col.notnull) def += " NOT NULL";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -44,6 +44,7 @@ import {
   type AddForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
+import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 
 /**
@@ -414,6 +415,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return this._nativeTypeMap.lookup(normalized);
   }
 
+  lookupCastTypeFromColumn(column: {
+    sqlType?: string | null;
+  }): import("@blazetrails/activemodel").Type {
+    return this.lookupCastType(column.sqlType ?? "");
+  }
+
   get nativeTypeMap(): TypeMap {
     return this._nativeTypeMap;
   }
@@ -733,6 +740,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   ): Promise<void> {
     const sqlType = this.typeToSql(type, options);
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
+    if (options?.collation) sql += ` COLLATE "${options.collation}"`;
     if (options?.null === false) sql += " NOT NULL";
     if (options?.default !== undefined) {
       sql += ` DEFAULT ${this.quoteDefault(options.default)}`;
@@ -803,6 +811,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         if (options?.default !== undefined)
           columns[columnName].dflt_value =
             options.default === null ? null : this.quoteDefault(options.default);
+        if (options?.collation !== undefined) columns[columnName].collation = options.collation;
       }
     });
   }
@@ -1149,6 +1158,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       dflt_value: string | null;
       pk: number;
     }>;
+
+    const collationMap = this._parseCollationsFromTableSql(tableName);
+
     return rows.map((r) => {
       const sqlType = r.type || "";
       const meta = new SqlTypeMetadata({
@@ -1158,10 +1170,48 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         precision: null,
         scale: null,
       });
-      return new Column(r.name, r.dflt_value, meta, r.notnull === 0, {
+      const defaultValue = this._extractValueFromDefault(r.dflt_value);
+      return new Sqlite3Column(r.name, defaultValue, meta, r.notnull === 0, {
         primaryKey: r.pk > 0,
+        collation: collationMap.get(r.name) ?? null,
       });
     });
+  }
+
+  // Mirrors: SQLite3Adapter#extract_value_from_default
+  private _extractValueFromDefault(dfltValue: string | null): unknown {
+    if (dfltValue === null) return null;
+    if (/^null$/i.test(dfltValue)) return null;
+    const singleQuoted = /^'([\s\S]*)'$/m.exec(dfltValue);
+    if (singleQuoted) return singleQuoted[1].replace(/''/g, "'");
+    const doubleQuoted = /^"([\s\S]*)"$/m.exec(dfltValue);
+    if (doubleQuoted) return doubleQuoted[1].replace(/""/g, '"');
+    if (/^-?\d+(\.\d*)?$/.test(dfltValue)) return dfltValue;
+    const hexMatch = /^x'(.*)'$/i.exec(dfltValue);
+    if (hexMatch) return Buffer.from(hexMatch[1], "hex");
+    return null;
+  }
+
+  // Mirrors: SQLite3Adapter#table_structure_with_collation
+  private _parseCollationsFromTableSql(tableName: string): Map<string, string> {
+    const result = new Map<string, string>();
+    const row = this.db
+      .prepare(
+        `SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type='table' AND name=?`,
+      )
+      .get(tableName) as { sql: string } | undefined;
+    if (!row?.sql) return result;
+
+    // Split CREATE TABLE (...) into per-column/constraint strings
+    const COLLATE_REGEX = /.*"(\w+)".*\bCOLLATE\s+"(\w+)".*/i;
+    const body = row.sql.replace(/\);*\s*$/, "").replace(/^[^(]*\(/, "");
+    // Split on commas not inside parentheses and not inside quotes
+    const parts = body.split(/,(?=\s*(?:"|\bCONSTRAINT\b))/i);
+    for (const part of parts) {
+      const m = COLLATE_REGEX.exec(part);
+      if (m) result.set(m[1], m[2]);
+    }
+    return result;
   }
 
   async indexes(tableName: string): Promise<unknown[]> {
@@ -1404,9 +1454,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       .map((c) => c.name);
     const compositePk = pkColumns.length > 1;
 
+    const existingCollations = this._parseCollationsFromTableSql(tableName);
     const colDefs = colNames.map((name) => {
       const col = columns[name];
       let def = `${quoteColumnName(name)} ${col.type ?? "TEXT"}`;
+      const collation = col.collation ?? existingCollations.get(name);
+      if (collation) def += ` COLLATE "${collation}"`;
       if (!compositePk && col.pk) def += " PRIMARY KEY";
       if (col.notnull) def += " NOT NULL";
       if (col.dflt_value !== null && col.dflt_value !== undefined) {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -43,6 +43,7 @@ export interface ColumnInfo {
   limit?: number | null;
   precision?: number | null;
   scale?: number | null;
+  collation?: string | null;
 }
 
 export interface IndexInfo {
@@ -295,6 +296,7 @@ class AdapterSchemaSource implements SchemaSource {
       limit: col.limit ?? undefined,
       precision: col.precision ?? undefined,
       scale: col.scale ?? undefined,
+      collation: col.collation ?? undefined,
     }));
   }
 
@@ -534,6 +536,7 @@ export class SchemaDumper {
         opts.push(`precision: ${col.precision}`);
       if (col.scale !== undefined && col.scale !== null && extraOpts?.scale === undefined)
         opts.push(`scale: ${col.scale}`);
+      if (col.collation != null) opts.push(`collation: ${JSON.stringify(col.collation)}`);
 
       const optionsStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
 


### PR DESCRIPTION
## Summary

- Adds SQLite3 collation support: `columns()` parses `COLLATE` from `CREATE TABLE` SQL (mirrors Rails' `table_structure_with_collation`); `addColumn`/`changeColumn`/`alterTable` preserve the `collation` option; `TableDefinition.toSql()` emits `COLLATE "..."` via a new `collation` field on `ColumnOptions`
- Adds `collation` to `ColumnInfo` and the schema dump loop so `SchemaDumper` emits `collation: "..."` options
- Fixes `columns()` to call `_extractValueFromDefault` (mirrors Rails' `extract_value_from_default`) so string/JSON defaults are unquoted correctly
- Adds `lookupCastTypeFromColumn` to `SQLite3Adapter` so schema reflection uses the right cast type (e.g. `JsonType`) for `columnDefaults`
- Creates `adapters/sqlite3/collation.test.ts` (5 tests) and `adapters/sqlite3/json.test.ts` (1 test: `test_default`)

Brings `test:compare` file coverage from 336/338 → **338/338 (100%)**.

## Test plan

- [ ] `pnpm test` — all SQLite3 tests pass, no regressions
- [ ] `pnpm run test:compare --package activerecord` — 338/338 files ✓