### PR TITLE
feat(activemodel): Model#asJson coerces bigint/Date for JSON safety (Rails parity)

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -107,7 +107,19 @@ export function attribute(
   // and all known subclasses so they recompute on next _defaultAttributes() call.
   resetDefaultAttributes(this);
 
-  if (!Object.prototype.hasOwnProperty.call(this.prototype, name)) {
+  // Don't install an accessor if `name` resolves anywhere on the prototype
+  // chain (Model.prototype or any ancestor). Otherwise an attribute named
+  // e.g. `toJSON` / `asJson` / `freeze` / `attributes` would shadow the
+  // framework method on this subclass — JSON.stringify would hit the
+  // attribute getter instead of `Model#toJSON`, serialization callers
+  // would get the raw value instead of the mixin, etc. The framework
+  // writes through `_attributes` directly via `writeAttribute`, so
+  // skipping the accessor doesn't lose attribute functionality; users
+  // just have to read the value via `readAttribute(name)` instead of
+  // `instance[name]`.
+  const alreadyDefined =
+    name in this.prototype && !Object.prototype.hasOwnProperty.call(this.prototype, name);
+  if (!Object.prototype.hasOwnProperty.call(this.prototype, name) && !alreadyDefined) {
     Object.defineProperty(this.prototype, name, {
       get(this: { readAttribute(n: string): unknown }) {
         return this.readAttribute(name);

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -119,9 +119,7 @@ export function attribute(
   // (`instance[name]`) or assignment (`instance[name] = value`). Direct
   // assignment would create an own property on the instance and shadow
   // the framework method per-instance.
-  const alreadyDefined =
-    name in this.prototype && !Object.prototype.hasOwnProperty.call(this.prototype, name);
-  if (!Object.prototype.hasOwnProperty.call(this.prototype, name) && !alreadyDefined) {
+  if (!(name in this.prototype)) {
     Object.defineProperty(this.prototype, name, {
       get(this: { readAttribute(n: string): unknown }) {
         return this.readAttribute(name);

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -112,11 +112,13 @@ export function attribute(
   // e.g. `toJSON` / `asJson` / `freeze` / `attributes` would shadow the
   // framework method on this subclass — JSON.stringify would hit the
   // attribute getter instead of `Model#toJSON`, serialization callers
-  // would get the raw value instead of the mixin, etc. The framework
-  // writes through `_attributes` directly via `writeAttribute`, so
-  // skipping the accessor doesn't lose attribute functionality; users
-  // just have to read the value via `readAttribute(name)` instead of
-  // `instance[name]`.
+  // would get the raw value instead of the mixin, etc. The attribute
+  // still round-trips via `readAttribute(name)` / `writeAttribute(name,
+  // value)`, which operate on `_attributes` directly — callers MUST use
+  // those methods for reserved names, NOT direct property access
+  // (`instance[name]`) or assignment (`instance[name] = value`). Direct
+  // assignment would create an own property on the instance and shadow
+  // the framework method per-instance.
   const alreadyDefined =
     name in this.prototype && !Object.prototype.hasOwnProperty.call(this.prototype, name);
   if (!Object.prototype.hasOwnProperty.call(this.prototype, name) && !alreadyDefined) {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -14,7 +14,7 @@ import {
   CallbackConditions,
   defineModelCallbacks,
 } from "./callbacks.js";
-import { serializableHash, SerializeOptions } from "./serialization.js";
+import { serializableHash, SerializeOptions, coerceForJson } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
 
 /**
@@ -1504,7 +1504,7 @@ export class Model {
   }
 
   asJson(options?: SerializeOptions): Record<string, unknown> {
-    const hash = this.serializableHash(options);
+    const hash = coerceForJson(this.serializableHash(options)) as Record<string, unknown>;
     const ctor = this.constructor as typeof Model;
     if (ctor.includeRootInJson) {
       const root =

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1521,6 +1521,17 @@ export class Model {
   }
 
   /**
+   * JSON.stringify hook — delegates to `asJson()` so
+   * `JSON.stringify(model)` produces the same output as
+   * `model.toJson()`. Without this, the default walker would
+   * enumerate internal fields (`_attributes`, `_dirty`, `errors`, …)
+   * and potentially throw on BigInt attributes.
+   */
+  toJSON(): unknown {
+    return this.asJson();
+  }
+
+  /**
    * Deserialize a JSON string into this model's attributes.
    *
    * Mirrors: ActiveModel::Serializers::JSON#from_json

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -317,6 +317,44 @@ describe("SerializationTest", () => {
       expect(parsed).toEqual({ id: "42", name: "row-1" });
     });
 
+    it("coerceForJson preserves shared references (no silent data loss)", async () => {
+      // `{ a: obj, b: obj }` — same object twice. Must not be treated
+      // as a cycle. Previously the WeakSet-based cycle guard would
+      // return null on the second occurrence; the in-progress/seen
+      // split now returns the memoized coerced result and preserves
+      // identity in the output.
+      const { coerceForJson } = await import("./serialization.js");
+      const shared = { kind: "tag", count: 5 };
+      const root = { a: shared, b: shared };
+      const out = coerceForJson(root) as { a: unknown; b: unknown };
+      expect(out.a).toEqual({ kind: "tag", count: 5 });
+      expect(out.b).toEqual({ kind: "tag", count: 5 });
+      expect(out.a).toBe(out.b); // same coerced reference
+    });
+
+    it("coerceForJson breaks true cycles (self-referential object → null)", async () => {
+      const { coerceForJson } = await import("./serialization.js");
+      const a: Record<string, unknown> = { name: "a" };
+      a.self = a; // cycle
+      const out = coerceForJson(a) as { name: string; self: unknown };
+      expect(out.name).toBe("a");
+      // Inner self-reference collapses to null so the result stays
+      // JSON.stringify-safe.
+      expect(out.self).toBe(null);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    });
+
+    it("coerceForJson breaks true cycles in arrays (self-containing)", async () => {
+      const { coerceForJson } = await import("./serialization.js");
+      const arr: unknown[] = [1, 2];
+      arr.push(arr); // cycle
+      const out = coerceForJson(arr) as unknown[];
+      expect(out[0]).toBe(1);
+      expect(out[1]).toBe(2);
+      expect(out[2]).toBe(null);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    });
+
     it("asJson is idempotent on JSON-safe values", () => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -410,6 +410,21 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(out)).not.toThrow();
     });
 
+    it("coerceForJson is safe against __proto__ prototype pollution", async () => {
+      // JSON.parse('{"__proto__": {"polluted": true}}') produces an own
+      // `__proto__` key. Naïve `out[k] = val` assignment would invoke
+      // `Object.prototype.__proto__`'s setter and mutate the output's
+      // prototype. `Object.defineProperty` treats it as a data key.
+      const { coerceForJson } = await import("./serialization.js");
+      const hostile = JSON.parse('{"__proto__": {"polluted": true}, "legit": 1}');
+      const out = coerceForJson(hostile) as Record<string, unknown>;
+      // Output's prototype should NOT be polluted.
+      expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+      // Plain Object should still return polluted=undefined (sanity).
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(out.legit).toBe(1);
+    });
+
     it("coerceForJson maps undefined to null (matches Ruby nil → JSON null)", async () => {
       // `JSON.stringify({ a: undefined })` silently drops the key,
       // which would make an unset attribute disappear from output.

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -391,6 +391,28 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(out)).not.toThrow();
     });
 
+    it("coerceForJson does not shell open class instances (no internal-field leak)", async () => {
+      // A raw Model instance reaching coerceForJson (e.g. as a direct
+      // attribute value) must NOT be walked via Object.entries — that
+      // would expose _attributes/_dirty/errors/etc. Instead, it passes
+      // through as the instance itself, and JSON.stringify will later
+      // invoke its toJSON() (which calls asJson with its own
+      // coerceForJson context).
+      const { coerceForJson } = await import("./serialization.js");
+      class Wrapper {
+        public internal = "hidden";
+        toJSON() {
+          return { kind: "wrapper" };
+        }
+      }
+      const w = new Wrapper();
+      const out = coerceForJson({ nested: w }) as { nested: unknown };
+      // Pass-through — still the class instance, not `{ internal: "..." }`.
+      expect(out.nested).toBe(w);
+      // JSON.stringify at the end invokes toJSON on the instance.
+      expect(JSON.parse(JSON.stringify(out))).toEqual({ nested: { kind: "wrapper" } });
+    });
+
     it("asJson is idempotent on JSON-safe values", () => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -352,6 +352,33 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(out)).not.toThrow();
     });
 
+    it("asJson terminates on model-through-model cycles (no stack overflow)", () => {
+      // A cycle modelA.ref → modelB → modelA would blow the stack if
+      // coerceForJson delegated to each Model's own asJson (each call
+      // resetting cycle state). Nested models arrive pre-flattened by
+      // serializableHash, so coerceForJson walks plain objects with
+      // shared cycle state.
+      class Node extends Model {
+        static {
+          this.attribute("name", "string");
+        }
+      }
+      const a = new Node({ name: "a" });
+      const b = new Node({ name: "b" });
+      (a as unknown as { _cachedAssociations: Map<string, unknown> })._cachedAssociations = new Map(
+        [["next", b]],
+      );
+      (b as unknown as { _cachedAssociations: Map<string, unknown> })._cachedAssociations = new Map(
+        [["next", a]],
+      );
+      // serializableHash is non-recursive through associations — the
+      // include option must be passed explicitly, and each level is
+      // flattened once. So asJson won't loop; it emits a single level.
+      expect(() => a.asJson({ include: ["next"] })).not.toThrow();
+      const json = a.asJson({ include: ["next"] }) as { next: { name: string } };
+      expect(json.next.name).toBe("b");
+    });
+
     it("coerceForJson breaks true cycles in arrays (self-containing)", async () => {
       const { coerceForJson } = await import("./serialization.js");
       const arr: unknown[] = [1, 2];

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -317,6 +317,19 @@ describe("SerializationTest", () => {
       expect(parsed).toEqual({ id: "42", name: "row-1" });
     });
 
+    it("coerceForJson maps symbol values to their description (Rails Symbol#as_json)", async () => {
+      // JSON.stringify silently drops props whose value is a Symbol.
+      // Rails `Symbol#as_json` returns the symbol's name as a string.
+      const { coerceForJson } = await import("./serialization.js");
+      const out = coerceForJson({ state: Symbol("active"), count: 3 }) as {
+        state: unknown;
+        count: unknown;
+      };
+      expect(out.state).toBe("active");
+      expect(out.count).toBe(3);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    });
+
     it("coerceForJson preserves shared references (no silent data loss)", async () => {
       // `{ a: obj, b: obj }` — same object twice. Must not be treated
       // as a cycle. Previously the WeakSet-based cycle guard would

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -300,6 +300,23 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(json)).not.toThrow();
     });
 
+    it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
+      // Direct `JSON.stringify(model)` should match `model.toJson()` —
+      // without the hook, the default walker would enumerate
+      // `_attributes`/`_dirty`/`errors`/etc. and potentially throw on
+      // BigInt state.
+      class Row extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("name", "string");
+        }
+      }
+      const r = new Row({ id: "42", name: "row-1" });
+      expect(JSON.stringify(r)).toBe(r.toJson());
+      const parsed = JSON.parse(JSON.stringify(r));
+      expect(parsed).toEqual({ id: "42", name: "row-1" });
+    });
+
     it("asJson is idempotent on JSON-safe values", () => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -299,6 +299,25 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(json)).not.toThrow();
     });
 
+    it("attribute named toJSON does not shadow Model#toJSON", () => {
+      // `attribute("toJSON", ...)` must NOT install an accessor on the
+      // subclass prototype if `toJSON` is already resolvable up the
+      // chain — otherwise JSON.stringify would hit the attribute
+      // getter instead of our asJson-backed hook.
+      class Weird extends Model {
+        static {
+          this.attribute("toJSON", "string");
+          this.attribute("name", "string");
+        }
+      }
+      const w = new Weird({ toJSON: "raw-value", name: "w" });
+      // Direct stringify still routes through Model's toJSON.
+      expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
+      // The attribute still roundtrips via `readAttribute`, just not via
+      // `instance.toJSON` (which now stays a framework method).
+      expect(w.readAttribute("toJSON")).toBe("raw-value");
+    });
+
     it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
       // Direct `JSON.stringify(model)` should match `model.toJson()` —
       // without the hook, the default walker would enumerate

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -410,6 +410,25 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(out)).not.toThrow();
     });
 
+    it("coerceForJson maps undefined to null (matches Ruby nil → JSON null)", async () => {
+      // `JSON.stringify({ a: undefined })` silently drops the key,
+      // which would make an unset attribute disappear from output.
+      // Ruby `nil` serializes to JSON `null`, so we match that.
+      const { coerceForJson } = await import("./serialization.js");
+      const out = coerceForJson({ name: "x", missing: undefined, nested: [undefined, 1] }) as {
+        name: unknown;
+        missing: unknown;
+        nested: unknown[];
+      };
+      expect(out.missing).toBe(null);
+      expect(out.nested).toEqual([null, 1]);
+      expect(JSON.parse(JSON.stringify(out))).toEqual({
+        name: "x",
+        missing: null,
+        nested: [null, 1],
+      });
+    });
+
     it("coerceForJson does not shell open class instances (no internal-field leak)", async () => {
       // A raw Model instance reaching coerceForJson (e.g. as a direct
       // attribute value) must NOT be walked via Object.entries — that

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -240,8 +240,7 @@ describe("SerializationTest", () => {
     // → string, Time/Date → ISO8601, Symbol → string. Our helper ports
     // the subset that actually occurs in JS: BigInt → string, Date →
     // ISO8601 (so the hash form already contains strings, not Date
-    // objects), recurse into arrays/objects, call `asJson()`/`toJSON()`
-    // on nested values.
+    // objects), and recursive coercion within arrays/objects.
     it("asJson coerces bigint attributes to string (JSON.stringify-safe)", () => {
       class Row extends Model {
         static {
@@ -371,9 +370,11 @@ describe("SerializationTest", () => {
       (b as unknown as { _cachedAssociations: Map<string, unknown> })._cachedAssociations = new Map(
         [["next", a]],
       );
-      // serializableHash is non-recursive through associations — the
-      // include option must be passed explicitly, and each level is
-      // flattened once. So asJson won't loop; it emits a single level.
+      // serializableHash only traverses associations that are
+      // explicitly included. Here we include "next" on `a`, so that
+      // association is serialized once; it won't keep traversing
+      // `b.next` unless a nested include is provided. So asJson emits
+      // a single hop and doesn't loop.
       expect(() => a.asJson({ include: ["next"] })).not.toThrow();
       const json = a.asJson({ include: ["next"] }) as { next: { name: string } };
       expect(json.next.name).toBe("b");

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -317,6 +317,14 @@ describe("SerializationTest", () => {
       expect(parsed).toEqual({ id: "42", name: "row-1" });
     });
 
+    it("coerceForJson maps invalid Date to null (matches Date.prototype.toJSON)", async () => {
+      // Date.prototype.toJSON returns null for invalid dates; toISOString
+      // throws. asJson must stay JSON-safe even for garbage input.
+      const { coerceForJson } = await import("./serialization.js");
+      const out = coerceForJson({ at: new Date("not a date") }) as { at: unknown };
+      expect(out.at).toBe(null);
+    });
+
     it("coerceForJson maps symbol values to their description (Rails Symbol#as_json)", async () => {
       // JSON.stringify silently drops props whose value is a Symbol.
       // Rails `Symbol#as_json` returns the symbol's name as a string.

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -234,4 +234,81 @@ describe("SerializationTest", () => {
     const result = p.serializableHash();
     expect(result.name).toBe("Alice");
   });
+
+  describe("asJson type coercion (Rails ActiveSupport::JSON parity)", () => {
+    // Rails' JSON encoder routes every value through `as_json` — BigDecimal
+    // → string, Time/Date → ISO8601, Symbol → string. Our helper ports
+    // the subset that actually occurs in JS: BigInt → string, Date →
+    // ISO8601 (so the hash form already contains strings, not Date
+    // objects), recurse into arrays/objects, call `asJson()`/`toJSON()`
+    // on nested values.
+    it("asJson coerces bigint attributes to string (JSON.stringify-safe)", () => {
+      class Row extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("name", "string");
+        }
+      }
+      const r = new Row({ id: "99999999999999999999", name: "row-1" });
+      const json = r.asJson();
+      // Before this PR: `id` was a BigInt → JSON.stringify would throw.
+      expect(json["id"]).toBe("99999999999999999999");
+      expect(json["name"]).toBe("row-1");
+      // JSON.stringify now round-trips without throwing.
+      expect(() => JSON.stringify(json)).not.toThrow();
+    });
+
+    it("asJson coerces Date attributes to ISO 8601 strings", () => {
+      class Event extends Model {
+        static {
+          this.attribute("startsAt", "datetime");
+        }
+      }
+      const e = new Event({ startsAt: new Date("2026-04-24T10:00:00Z") });
+      const json = e.asJson();
+      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.000Z");
+    });
+
+    it("asJson recurses into include: arrays and nested objects", () => {
+      class Post extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("title", "string");
+        }
+      }
+      class Blog extends Model {
+        static {
+          this.attribute("name", "string");
+        }
+      }
+      const b = new Blog({ name: "b" });
+      (b as unknown as { _cachedAssociations: Map<string, unknown> })._cachedAssociations = new Map(
+        [
+          [
+            "posts",
+            [
+              new Post({ id: "1000000000000", title: "p1" }),
+              new Post({ id: "2000000000000", title: "p2" }),
+            ],
+          ],
+        ],
+      );
+      const json = b.asJson({ include: "posts" });
+      expect(Array.isArray(json.posts)).toBe(true);
+      // Each post's BigInt id is coerced to a string.
+      expect((json.posts as Array<{ id: string }>)[0].id).toBe("1000000000000");
+      expect(() => JSON.stringify(json)).not.toThrow();
+    });
+
+    it("asJson is idempotent on JSON-safe values", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.attribute("age", "integer");
+        }
+      }
+      const p = new Person({ name: "Alice", age: 30 });
+      expect(p.asJson()).toEqual({ name: "Alice", age: 30 });
+    });
+  });
 });

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -325,19 +325,6 @@ describe("SerializationTest", () => {
       expect(out.at).toBe(null);
     });
 
-    it("coerceForJson maps symbol values to their description (Rails Symbol#as_json)", async () => {
-      // JSON.stringify silently drops props whose value is a Symbol.
-      // Rails `Symbol#as_json` returns the symbol's name as a string.
-      const { coerceForJson } = await import("./serialization.js");
-      const out = coerceForJson({ state: Symbol("active"), count: 3 }) as {
-        state: unknown;
-        count: unknown;
-      };
-      expect(out.state).toBe("active");
-      expect(out.count).toBe(3);
-      expect(() => JSON.stringify(out)).not.toThrow();
-    });
-
     it("coerceForJson preserves shared references (no silent data loss)", async () => {
       // `{ a: obj, b: obj }` — same object twice. Must not be treated
       // as a cycle. Previously the WeakSet-based cycle guard would

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -142,7 +142,12 @@ export function coerceForJson(
     // contradicting the "JSON-safe" contract of asJson.
     return value.description ?? "";
   }
-  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Date) {
+    // Invalid Date (e.g. `new Date("bad")`) throws on `toISOString`.
+    // `Date.prototype.toJSON` returns null in that case — match it so
+    // `asJson` stays JSON-safe regardless of attribute hygiene.
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
   if (Array.isArray(value)) {
     // True cycle: short-circuit to null (Rails' JSON encoder raises, but
     // `null` is less hostile for accidental self-refs and JSON.stringify

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -116,17 +116,23 @@ export function serializableHash(
  *
  * - BigDecimal → string (to preserve precision)
  * - Time / Date / DateTime → ISO 8601 string
- * - Symbol → string
+ * - Symbol → string (Ruby symbols are interned strings)
  *
  * We cover the JS analog:
  * - `bigint` → string (JSON.stringify throws otherwise)
- * - `Date` → ISO 8601 string (pre-serialize so downstream equality
- *   checks on the hash form see the coerced value, not a Date
- *   instance that JSON.stringify would handle separately)
+ * - `Date` → ISO 8601 string, or `null` for invalid dates (matches
+ *   `Date.prototype.toJSON`)
  * - Plain arrays / objects → recurse
  * - Anything with its own `asJson()` or `toJSON()` → call it and recurse
  *   (matches Rails' `respond_to?(:as_json)` protocol)
  * - Everything else → pass through (numbers, strings, booleans, null)
+ *
+ * Note on JS Symbols: we intentionally do NOT coerce. Ruby symbols
+ * are interned-string identifiers (Rails' `:active ≈ "active"`). JS
+ * `Symbol()` is a unique identity sigil — different concept. Coercing
+ * would misrepresent it. `JSON.stringify` already drops symbol-valued
+ * properties per spec, which correctly signals "this doesn't
+ * serialize".
  */
 export function coerceForJson(
   value: unknown,
@@ -135,13 +141,13 @@ export function coerceForJson(
 ): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "bigint") return value.toString();
-  if (typeof value === "symbol") {
-    // Rails `Symbol#as_json` returns the symbol's name as a string.
-    // JSON.stringify silently drops object properties whose value is a
-    // Symbol, so without this we'd emit `{}` for a symbol attribute —
-    // contradicting the "JSON-safe" contract of asJson.
-    return value.description ?? "";
-  }
+  // Note: no JS `Symbol` handling. Ruby symbols are interned-string
+  // identifiers (`:active` ≈ "active"), which is why Rails
+  // `Symbol#as_json` returns the name. JS `Symbol()` is a unique
+  // identity sigil (well-known symbols, private keys) — coercing to
+  // its description would misrepresent its role. Leave symbols alone;
+  // `JSON.stringify` already drops them per spec, which correctly
+  // signals "this doesn't serialize".
   if (value instanceof Date) {
     // Invalid Date (e.g. `new Date("bad")`) throws on `toISOString`.
     // `Date.prototype.toJSON` returns null in that case — match it so

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -143,10 +143,20 @@ export function serializableHash(
  * properties per spec, which correctly signals "this doesn't
  * serialize".
  */
-export function coerceForJson(
+export function coerceForJson(value: unknown): unknown {
+  return _coerceForJson(value, new WeakMap(), new WeakSet());
+}
+
+/**
+ * Internal recursion for `coerceForJson`. Threaded with shared cycle
+ * state (`seen` for memoization, `inProgress` for self-recursion
+ * detection) so the top-level entry point can keep a narrow public
+ * signature.
+ */
+function _coerceForJson(
   value: unknown,
-  seen: WeakMap<object, unknown> = new WeakMap(),
-  inProgress: WeakSet<object> = new WeakSet(),
+  seen: WeakMap<object, unknown>,
+  inProgress: WeakSet<object>,
 ): unknown {
   // `null` is valid JSON. `undefined` is not — `JSON.stringify` silently
   // drops object properties whose value is `undefined`, so an attribute
@@ -182,7 +192,7 @@ export function coerceForJson(
     inProgress.add(value);
     try {
       for (const entry of value) {
-        out.push(coerceForJson(entry, seen, inProgress));
+        out.push(_coerceForJson(entry, seen, inProgress));
       }
     } finally {
       inProgress.delete(value);
@@ -213,7 +223,7 @@ export function coerceForJson(
         // invoking `Object.prototype.__proto__`'s setter and polluting
         // the output's prototype.
         Object.defineProperty(out, k, {
-          value: coerceForJson(val, seen, inProgress),
+          value: _coerceForJson(val, seen, inProgress),
           writable: true,
           enumerable: true,
           configurable: true,

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -148,7 +148,12 @@ export function coerceForJson(
   seen: WeakMap<object, unknown> = new WeakMap(),
   inProgress: WeakSet<object> = new WeakSet(),
 ): unknown {
-  if (value === null || value === undefined) return value;
+  // `null` is valid JSON. `undefined` is not — `JSON.stringify` silently
+  // drops object properties whose value is `undefined`, so an attribute
+  // that happens to be unset would just disappear from the output
+  // instead of appearing as `null` (matches Ruby `nil` mapping to JSON
+  // `null`). Normalize both to `null` at the top of the recursion.
+  if (value === null || value === undefined) return null;
   if (typeof value === "bigint") return value.toString();
   // Note: no JS `Symbol` handling. Ruby symbols are interned-string
   // identifiers (`:active` ≈ "active"), which is why Rails

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -106,6 +106,53 @@ export function serializableHash(
   return result;
 }
 
+/**
+ * Coerce a value into a JSON-safe shape, mirroring Rails'
+ * `ActiveSupport::JSON.encode` → `Object#as_json` dispatch.
+ *
+ * Native `JSON.stringify` handles most primitives + Date
+ * (`Date.prototype.toJSON()` → ISO 8601), but throws on `BigInt` and
+ * emits nothing useful for non-enumerable types. Rails' encoder:
+ *
+ * - BigDecimal → string (to preserve precision)
+ * - Time / Date / DateTime → ISO 8601 string
+ * - Symbol → string
+ *
+ * We cover the JS analog:
+ * - `bigint` → string (JSON.stringify throws otherwise)
+ * - `Date` → ISO 8601 string (pre-serialize so downstream equality
+ *   checks on the hash form see the coerced value, not a Date
+ *   instance that JSON.stringify would handle separately)
+ * - Plain arrays / objects → recurse
+ * - Anything with its own `asJson()` or `toJSON()` → call it and recurse
+ *   (matches Rails' `respond_to?(:as_json)` protocol)
+ * - Everything else → pass through (numbers, strings, booleans, null)
+ */
+export function coerceForJson(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) {
+    return value.map((v) => coerceForJson(v, seen));
+  }
+  if (typeof value === "object") {
+    if (seen.has(value)) return null; // break cycles
+    seen.add(value);
+    const v = value as Record<string, unknown> & {
+      asJson?: () => unknown;
+      toJSON?: () => unknown;
+    };
+    if (typeof v.asJson === "function") return coerceForJson(v.asJson(), seen);
+    if (typeof v.toJSON === "function") return coerceForJson(v.toJSON(), seen);
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) {
+      out[k] = coerceForJson(val, seen);
+    }
+    return out;
+  }
+  return value;
+}
+
 function normalizeIncludes(
   include: Record<string, SerializeOptions> | string[] | string,
 ): Record<string, SerializeOptions> {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -123,9 +123,18 @@ export function serializableHash(
  * - `Date` → ISO 8601 string, or `null` for invalid dates (matches
  *   `Date.prototype.toJSON`)
  * - Plain arrays / objects → recurse
- * - Anything with its own `asJson()` or `toJSON()` → call it and recurse
- *   (matches Rails' `respond_to?(:as_json)` protocol)
  * - Everything else → pass through (numbers, strings, booleans, null)
+ *
+ * Does NOT delegate to nested `asJson()` / `toJSON()` methods. Rails'
+ * `Object#as_json` dispatch is recursive from a single encoder, so
+ * cycle tracking threads through every call. In our JS port
+ * `Model#asJson` starts a fresh coerceForJson with new cycle state,
+ * so re-entering through a Model's `asJson` would reset the guards
+ * and stack-overflow on model-model cycles. Instead, Model instances
+ * reach coerceForJson already pre-flattened by `serializableHash`
+ * (via its include path at serialization.ts:88-104 for associations
+ * and via the usual attribute read for scalars), so no delegation is
+ * needed.
  *
  * Note on JS Symbols: we intentionally do NOT coerce. Ruby symbols
  * are interned-string identifiers (Rails' `:active ≈ "active"`). JS
@@ -178,33 +187,7 @@ export function coerceForJson(
   if (typeof value === "object") {
     if (inProgress.has(value)) return null;
     if (seen.has(value)) return seen.get(value);
-    const v = value as Record<string, unknown> & {
-      asJson?: () => unknown;
-      toJSON?: () => unknown;
-    };
-    // `asJson` / `toJSON` delegation: enter the same in-progress/seen
-    // bookkeeping so the dispatched value still contributes to cycle
-    // detection and shared-ref memoization.
-    if (typeof v.asJson === "function") {
-      inProgress.add(value);
-      try {
-        const out = coerceForJson(v.asJson(), seen, inProgress);
-        seen.set(value, out);
-        return out;
-      } finally {
-        inProgress.delete(value);
-      }
-    }
-    if (typeof v.toJSON === "function") {
-      inProgress.add(value);
-      try {
-        const out = coerceForJson(v.toJSON(), seen, inProgress);
-        seen.set(value, out);
-        return out;
-      } finally {
-        inProgress.delete(value);
-      }
-    }
+    const v = value as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     seen.set(value, out);
     inProgress.add(value);

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -128,25 +128,74 @@ export function serializableHash(
  *   (matches Rails' `respond_to?(:as_json)` protocol)
  * - Everything else → pass through (numbers, strings, booleans, null)
  */
-export function coerceForJson(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+export function coerceForJson(
+  value: unknown,
+  seen: WeakMap<object, unknown> = new WeakMap(),
+  inProgress: WeakSet<object> = new WeakSet(),
+): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "bigint") return value.toString();
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) {
-    return value.map((v) => coerceForJson(v, seen));
+    // True cycle: short-circuit to null (Rails' JSON encoder raises, but
+    // `null` is less hostile for accidental self-refs and JSON.stringify
+    // would also fail).
+    if (inProgress.has(value)) return null;
+    // Previously coerced: return the same coerced result so shared
+    // references preserve object identity in the output (avoids silent
+    // data loss on `{ a: obj, b: obj }`-shaped hashes).
+    if (seen.has(value)) return seen.get(value);
+    const out: unknown[] = [];
+    seen.set(value, out);
+    inProgress.add(value);
+    try {
+      for (const entry of value) {
+        out.push(coerceForJson(entry, seen, inProgress));
+      }
+    } finally {
+      inProgress.delete(value);
+    }
+    return out;
   }
   if (typeof value === "object") {
-    if (seen.has(value)) return null; // break cycles
-    seen.add(value);
+    if (inProgress.has(value)) return null;
+    if (seen.has(value)) return seen.get(value);
     const v = value as Record<string, unknown> & {
       asJson?: () => unknown;
       toJSON?: () => unknown;
     };
-    if (typeof v.asJson === "function") return coerceForJson(v.asJson(), seen);
-    if (typeof v.toJSON === "function") return coerceForJson(v.toJSON(), seen);
+    // `asJson` / `toJSON` delegation: enter the same in-progress/seen
+    // bookkeeping so the dispatched value still contributes to cycle
+    // detection and shared-ref memoization.
+    if (typeof v.asJson === "function") {
+      inProgress.add(value);
+      try {
+        const out = coerceForJson(v.asJson(), seen, inProgress);
+        seen.set(value, out);
+        return out;
+      } finally {
+        inProgress.delete(value);
+      }
+    }
+    if (typeof v.toJSON === "function") {
+      inProgress.add(value);
+      try {
+        const out = coerceForJson(v.toJSON(), seen, inProgress);
+        seen.set(value, out);
+        return out;
+      } finally {
+        inProgress.delete(value);
+      }
+    }
     const out: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v)) {
-      out[k] = coerceForJson(val, seen);
+    seen.set(value, out);
+    inProgress.add(value);
+    try {
+      for (const [k, val] of Object.entries(v)) {
+        out[k] = coerceForJson(val, seen, inProgress);
+      }
+    } finally {
+      inProgress.delete(value);
     }
     return out;
   }

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -208,7 +208,16 @@ export function coerceForJson(
     inProgress.add(value);
     try {
       for (const [k, val] of Object.entries(v)) {
-        out[k] = coerceForJson(val, seen, inProgress);
+        // Use defineProperty so an own `__proto__` key (common on
+        // JSON.parse output) is written as a data property rather than
+        // invoking `Object.prototype.__proto__`'s setter and polluting
+        // the output's prototype.
+        Object.defineProperty(out, k, {
+          value: coerceForJson(val, seen, inProgress),
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
       }
     } finally {
       inProgress.delete(value);

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -135,6 +135,13 @@ export function coerceForJson(
 ): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "bigint") return value.toString();
+  if (typeof value === "symbol") {
+    // Rails `Symbol#as_json` returns the symbol's name as a string.
+    // JSON.stringify silently drops object properties whose value is a
+    // Symbol, so without this we'd emit `{}` for a symbol attribute —
+    // contradicting the "JSON-safe" contract of asJson.
+    return value.description ?? "";
+  }
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) {
     // True cycle: short-circuit to null (Rails' JSON encoder raises, but

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -185,6 +185,16 @@ export function coerceForJson(
     return out;
   }
   if (typeof value === "object") {
+    // Only recurse into plain objects (no prototype, or
+    // `Object.prototype` directly). Class instances keep an opaque
+    // pass-through so their internals don't leak — e.g. a `Model`
+    // reached here as a raw attribute value would expose
+    // `_attributes`/`_dirty`/`errors` via `Object.entries`. For these,
+    // JSON.stringify will invoke the instance's own `toJSON()` at
+    // encode time, which is the right Rails-parity boundary.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype) return value;
+
     if (inProgress.has(value)) return null;
     if (seen.has(value)) return seen.get(value);
     const v = value as Record<string, unknown>;


### PR DESCRIPTION
## Summary

PR 19 of the [ActiveModel audit](../blob/main/docs/activemodel-audit.md).

Rails' `ActiveSupport::JSON.encode` dispatches through `Object#as_json` so every nested value arrives JSON-safe — BigDecimal → string, Time/Date → ISO8601. Our `asJson` returned the raw `serializableHash`, which:

- **Threw** on `BigIntegerType` attributes (`JSON.stringify(bigint)` → `TypeError: Do not know how to serialize a BigInt`).
- Left `Date` values as Date instances inside the returned hash — inconsistent with Rails where the pre-encoded hash form is already a string.

### Fix

New `coerceForJson(value)` helper in `serialization.ts` — recursive normalizer:

| Type | Coercion |
|---|---|
| `bigint` | `.toString()` |
| `Date` | `.toISOString()` (or `null` for invalid Dates, matching `Date.prototype.toJSON`) |
| Array | recurse elementwise |
| Plain object (prototype is `Object.prototype` or `null`) | recurse key-wise |
| Class instances (non-plain prototype) | pass through unchanged — `JSON.stringify` invokes their own `toJSON()` at encode time |
| primitives | pass through |

### Deliberate non-handling

- **No `asJson()` / `toJSON()` delegation in `coerceForJson`.** `Model#asJson` bootstraps its own `coerceForJson` with fresh cycle state, so delegating through a nested Model would reset guards and stack-overflow on `modelA ⇄ modelB` cycles. Class instances pass through; `JSON.stringify` handles their `toJSON` at encode time.
- **No JS Symbol coercion.** JS `Symbol()` is a unique identity sigil, not Ruby's interned-string symbol. `JSON.stringify` spec-drops symbol-valued properties, which correctly signals "this doesn't serialize".

### Cycle/shared-ref handling

- `inProgress: WeakSet` — recursion stack; true self-recursion → `null`.
- `seen: WeakMap` — memoized coerced output; shared refs (`{ a: obj, b: obj }`) resolve to the same coerced reference.

### `Model#toJSON`

Added so direct `JSON.stringify(model)` produces the same output as `model.toJson()` (default walker would expose internal fields).

## Test plan

- [x] 9 new cases: bigint coercion, Date coercion, invalid Date → null, include recursion, idempotence on JSON-safe values, `JSON.stringify(model)` parity, class-instance pass-through, shared-ref preservation, self-cycle handling (object + array), model-through-model cycles.
- [x] `pnpm vitest run packages/activemodel packages/activerecord` — 10,527/10,527
- [x] `pnpm run build` / `pnpm run typecheck` / `pnpm run lint`