### PR TITLE
feat(encryption): DB-backed EncryptableRecordTest — 24 tests + key provider wiring

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -146,11 +146,12 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
   // encryptor only when no keys are configured at all.
   // Switch to the real Scheme whenever any encryption key material is configured.
-  // If config is incomplete (e.g. primaryKey set but keyDerivationSalt missing),
-  // Config.get() will raise ConfigError at serialize/deserialize time — which
-  // is more informative than silently falling back to the AR_ENC:base64 shim
-  // and storing only base64-encoded data.
-  const hasConfiguredKeys = Configurable.config.primaryKey !== undefined;
+  // If config is incomplete, Config.get() raises ConfigError at serialize/
+  // deserialize time — more informative than silently using the AR_ENC:base64
+  // shim and storing unencrypted data.
+  const { primaryKey, deterministicKey, keyDerivationSalt } = Configurable.config;
+  const hasConfiguredKeys =
+    primaryKey !== undefined || deterministicKey !== undefined || keyDerivationSalt !== undefined;
 
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -141,10 +141,6 @@ function buildScheme(options: EncryptsOptions): Scheme {
     schemeOptions.compressor !== undefined ||
     schemeOptions.supportUnencryptedData !== undefined;
 
-  // When real encryption keys are configured, use the standard scheme so
-  // encrypts() with no options picks up the global key provider from config
-  // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
-  // encryptor only when no keys are configured at all.
   // Switch to the real Scheme whenever any encryption key material is configured.
   // If config is incomplete, Config.get() raises ConfigError at serialize/
   // deserialize time — more informative than silently using the AR_ENC:base64

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -24,6 +24,7 @@ import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
 import { globalPreviousSchemesFor } from "./encryption/encryptable-record.js";
+import { Configurable } from "./encryption/configurable.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -140,9 +141,17 @@ function buildScheme(options: EncryptsOptions): Scheme {
     schemeOptions.compressor !== undefined ||
     schemeOptions.supportUnencryptedData !== undefined;
 
+  // When real encryption keys are configured, use the standard scheme so
+  // encrypts() with no options picks up the global key provider from config
+  // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
+  // encryptor only when no keys are configured at all.
+  const hasConfiguredKeys =
+    Configurable.config.primaryKey !== undefined ||
+    Configurable.config.keyDerivationSalt !== undefined;
+
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
-    : hasSchemeOptions
+    : hasSchemeOptions || hasConfiguredKeys
       ? schemeOptions
       : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
 

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -145,11 +145,12 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // encrypts() with no options picks up the global key provider from config
   // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
   // encryptor only when no keys are configured at all.
-  // Only switch to the real Scheme when primaryKey is set — that's what
-  // _defaultKeyProvider needs to build a usable key. Salt or deterministicKey
-  // alone can't derive a key for non-deterministic attributes, so we keep the
-  // AR_ENC shim in that case rather than failing at serialize time.
-  const hasConfiguredKeys = Configurable.config.primaryKey !== undefined;
+  // Only switch to the real Scheme when both primaryKey and keyDerivationSalt
+  // are set — DerivedSecretKeyProvider.deriveKeyFrom throws if the salt is
+  // missing, so a primaryKey alone would fail at serialize time.
+  const hasConfiguredKeys =
+    Configurable.config.primaryKey !== undefined &&
+    Configurable.config.keyDerivationSalt !== undefined;
 
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -147,7 +147,8 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // encryptor only when no keys are configured at all.
   const hasConfiguredKeys =
     Configurable.config.primaryKey !== undefined ||
-    Configurable.config.keyDerivationSalt !== undefined;
+    Configurable.config.keyDerivationSalt !== undefined ||
+    Configurable.config.deterministicKey !== undefined;
 
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -142,9 +142,10 @@ function buildScheme(options: EncryptsOptions): Scheme {
     schemeOptions.supportUnencryptedData !== undefined;
 
   // Switch to the real Scheme whenever any encryption key material is configured.
-  // If config is incomplete, Config.get() raises ConfigError at serialize/
-  // deserialize time — more informative than silently using the AR_ENC:base64
-  // shim and storing unencrypted data.
+  // If config is incomplete (e.g. only keyDerivationSalt set, no primaryKey),
+  // Scheme._defaultKeyProvider() returns undefined and Encryptor raises
+  // "No encryption key provided" at serialize/deserialize time — still more
+  // informative than silently storing AR_ENC:base64 data.
   const { primaryKey, deterministicKey, keyDerivationSalt } = Configurable.config;
   const hasConfiguredKeys =
     primaryKey !== undefined || deterministicKey !== undefined || keyDerivationSalt !== undefined;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -145,10 +145,11 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // encrypts() with no options picks up the global key provider from config
   // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
   // encryptor only when no keys are configured at all.
-  const hasConfiguredKeys =
-    Configurable.config.primaryKey !== undefined ||
-    Configurable.config.keyDerivationSalt !== undefined ||
-    Configurable.config.deterministicKey !== undefined;
+  // Only switch to the real Scheme when primaryKey is set — that's what
+  // _defaultKeyProvider needs to build a usable key. Salt or deterministicKey
+  // alone can't derive a key for non-deterministic attributes, so we keep the
+  // AR_ENC shim in that case rather than failing at serialize time.
+  const hasConfiguredKeys = Configurable.config.primaryKey !== undefined;
 
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -145,12 +145,12 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // encrypts() with no options picks up the global key provider from config
   // (mirrors Rails' default behavior). Fall back to the dev-only AR_ENC:base64
   // encryptor only when no keys are configured at all.
-  // Only switch to the real Scheme when both primaryKey and keyDerivationSalt
-  // are set — DerivedSecretKeyProvider.deriveKeyFrom throws if the salt is
-  // missing, so a primaryKey alone would fail at serialize time.
-  const hasConfiguredKeys =
-    Configurable.config.primaryKey !== undefined &&
-    Configurable.config.keyDerivationSalt !== undefined;
+  // Switch to the real Scheme whenever any encryption key material is configured.
+  // If config is incomplete (e.g. primaryKey set but keyDerivationSalt missing),
+  // Config.get() will raise ConfigError at serialize/deserialize time — which
+  // is more informative than silently falling back to the AR_ENC:base64 shim
+  // and storing only base64-encoded data.
+  const hasConfiguredKeys = Configurable.config.primaryKey !== undefined;
 
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -3,6 +3,7 @@ import { Contexts } from "./contexts.js";
 
 let _sharedConfig: Config | null = null;
 const _listeners: Array<(klass: any, name: string) => void> = [];
+const _configureHooks: Array<() => void> = [];
 
 /**
  * Configuration API for ActiveRecord::Encryption. Manages the shared
@@ -49,6 +50,11 @@ export class Configurable {
     // Mirror Rails: reset_default_context after setting config so context
     // properties derived from config (e.g. key_provider) are re-evaluated.
     Contexts.resetDefaultContext();
+    for (const hook of _configureHooks) hook();
+  }
+
+  static onConfigure(hook: () => void): void {
+    _configureHooks.push(hook);
   }
 
   static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): () => void {

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -53,8 +53,12 @@ export class Configurable {
     for (const hook of _configureHooks) hook();
   }
 
-  static onConfigure(hook: () => void): void {
+  static onConfigure(hook: () => void): () => void {
     _configureHooks.push(hook);
+    return () => {
+      const idx = _configureHooks.indexOf(hook);
+      if (idx !== -1) _configureHooks.splice(idx, 1);
+    };
   }
 
   static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): () => void {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -9,6 +9,7 @@ import {
   makeEncryptedBookWithDowncaseName,
   makeEncryptedBookIgnoreCase,
   makeEncryptedAuthor,
+  makeFreshModel,
   makeKeyProvider,
   assertEncryptedAttribute,
   ciphertextFor,
@@ -111,31 +112,32 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("can configure a custom key provider on a per-record-class basis through the :key_provider option", async () => {
-    const adapter = freshAdapter();
     const keyProvider = makeKeyProvider("custom-post-body-key-provider-32b!!");
-    const BasePost = makeEncryptedPost(adapter);
-    class PostWithCustomKeyProvider extends (BasePost as any) {
-      static {
-        this.encrypts("body", { keyProvider });
-      }
-    }
-    const post = await PostWithCustomKeyProvider.create({
-      title: "The Starfleet is here!",
-      body: "take cover!",
-    });
+    // Use makeFreshModel to avoid the idempotency guard that skips re-encrypting
+    // an attribute already wrapped with EncryptedAttributeType.
+    const Post = makeFreshModel(freshAdapter(), { id: "integer", title: "string", body: "string" });
+    Post.encrypts("title");
+    Post.encrypts("body", { keyProvider });
+
+    const post = await Post.create({ title: "The Starfleet is here!", body: "take cover!" });
     assertEncryptedAttribute(post, "body", "take cover!");
+
+    // Verify round-trip: reload and decrypt using the scheme's own key provider.
+    const reloaded = await Post.find(post.id);
+    expect(reloaded.body).toBe("take cover!");
   });
 
   it("can configure a custom key on a per-record-class basis through the :key option", async () => {
-    const adapter = freshAdapter();
-    const BaseAuthor = makeEncryptedAuthor(adapter);
-    class AuthorWithKey extends (BaseAuthor as any) {
-      static {
-        this.encrypts("name", { key: "a-custom-key-for-author-32bytes!!" });
-      }
-    }
-    const author = await AuthorWithKey.create({ name: "Stephen King" });
+    const customKey = "a-custom-key-for-author-32bytes!!";
+    const Author = makeFreshModel(freshAdapter(), { id: "integer", name: "string" });
+    Author.encrypts("name", { key: customKey });
+
+    const author = await Author.create({ name: "Stephen King" });
     assertEncryptedAttribute(author, "name", "Stephen King");
+
+    // Verify round-trip: reload and decrypt using the scheme's own key.
+    const reloaded = await Author.find(author.id);
+    expect(reloaded.name).toBe("Stephen King");
   });
 
   it("encrypts multiple attributes with different options at the same time", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -223,10 +223,12 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Author = makeEncryptedAuthor(freshAdapter());
     const author = await withoutEncryption(() => Author.create({ name: "Stephen King" }));
 
-    await expect(async () => {
-      const reloaded = await Author.find(author.id);
-      return reloaded.name;
-    }).rejects.toThrow(DecryptionError);
+    await expect(
+      (async () => {
+        const reloaded = await Author.find(author.id);
+        return reloaded.name;
+      })(),
+    ).rejects.toThrow(DecryptionError);
   });
 
   it("by default, it's case sensitive", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -103,7 +103,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it("ignores empty values", async () => {
     const Book = makeEncryptedBook(freshAdapter());
     const book = await Book.create({ name: "" });
+    // Rails serializes empty strings the same as any other value (encrypts them).
+    // "ignores" means the value round-trips correctly, not that encryption is skipped.
     expect(book.name).toBe("");
+    const reloaded = await Book.find(book.id);
+    expect(reloaded.name).toBe("");
   });
 
   it("can configure a custom key provider on a per-record-class basis through the :key_provider option", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -312,4 +312,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it.skip("binary data can be encrypted uncompressed", () => {});
   it.skip("serialized binary data can be encrypted", () => {});
   it.skip("deterministic ciphertexts remain constant", () => {});
+  it.skip("can compress data with custom compressor", () => {});
+  it.skip("type method returns cast type", () => {});
+  it.skip("encrypts normalized data", () => {});
+  it.skip("encrypts attribute data", () => {});
 });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -1,41 +1,296 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+  makeEncryptedPost,
+  makeEncryptedBook,
+  makeEncryptedBookWithDowncaseName,
+  makeEncryptedBookIgnoreCase,
+  makeEncryptedAuthor,
+  makeKeyProvider,
+  assertEncryptedAttribute,
+  ciphertextFor,
+  withEncryptionContext,
+  withoutEncryption,
+  DecryptionError,
+} from "./test-helpers.js";
+import { Configurable } from "./configurable.js";
+import { EncryptableRecord } from "./encryptable-record.js";
+import { isEncryptedAttribute } from "../encryption.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
-  it.skip("encrypts the attribute seamlessly when creating and updating records", () => {});
-  it.skip("attribute is not accessible with the wrong key", () => {});
-  it.skip("swapping key_providers via with_encryption_context", () => {});
-  it.skip("ignores nil values", () => {});
-  it.skip("ignores empty values", () => {});
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    configSnapshot = snapshotEncryptionConfig();
+    Configurable.config.previousSchemes = [];
+    configureEncryption();
+  });
+
+  afterEach(() => {
+    restoreEncryptionConfig(configSnapshot);
+  });
+
+  it("encrypts the attribute seamlessly when creating and updating records", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const post = await Post.create({ title: "The Starfleet is here!", body: "take cover!" });
+    assertEncryptedAttribute(post, "title", "The Starfleet is here!");
+
+    await post.update({ title: "The Klingons are coming!" });
+    assertEncryptedAttribute(post, "title", "The Klingons are coming!");
+
+    post.title = "You sure?";
+    await post.save();
+    assertEncryptedAttribute(post, "title", "You sure?");
+  });
+
+  it("attribute is not accessible with the wrong key", async () => {
+    Configurable.config.supportUnencryptedData = false;
+    const Post = makeEncryptedPost(freshAdapter());
+    const post = await Post.create({ title: "The Starfleet is here!", body: "take cover!" });
+
+    await expect(
+      withEncryptionContext(
+        { keyProvider: makeKeyProvider("a-different-key-for-testing-purposes!!") },
+        async () => {
+          const reloaded = await Post.find(post.id);
+          return reloaded.title;
+        },
+      ),
+    ).rejects.toThrow(DecryptionError);
+  });
+
+  it("swapping key_providers via with_encryption_context", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const keyProvider1 = makeKeyProvider("key-provider-one-for-testing-32b!!");
+    const keyProvider2 = makeKeyProvider("key-provider-two-for-testing-32b!!");
+
+    const post1 = await withEncryptionContext({ keyProvider: keyProvider1 }, () =>
+      Post.create({ title: "post1!", body: "first post!" }),
+    );
+    const post2 = await withEncryptionContext({ keyProvider: keyProvider2 }, () =>
+      Post.create({ title: "post2!", body: "second post!" }),
+    );
+
+    await expect(
+      withEncryptionContext({ keyProvider: keyProvider2 }, async () => {
+        const r = await Post.find(post1.id);
+        return r.title;
+      }),
+    ).rejects.toThrow(DecryptionError);
+
+    const title1 = await withEncryptionContext({ keyProvider: keyProvider1 }, async () => {
+      const r = await Post.find(post1.id);
+      return r.title;
+    });
+    expect(title1).toBe("post1!");
+
+    const title2 = await withEncryptionContext({ keyProvider: keyProvider2 }, async () => {
+      const r = await Post.find(post2.id);
+      return r.title;
+    });
+    expect(title2).toBe("post2!");
+  });
+
+  it("ignores nil values", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: null });
+    expect(book.name).toBeNull();
+  });
+
+  it("ignores empty values", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "" });
+    expect(book.name).toBe("");
+  });
+
+  it("can configure a custom key provider on a per-record-class basis through the :key_provider option", async () => {
+    const adapter = freshAdapter();
+    const keyProvider = makeKeyProvider("custom-post-body-key-provider-32b!!");
+    const BasePost = makeEncryptedPost(adapter);
+    class PostWithCustomKeyProvider extends (BasePost as any) {
+      static {
+        this.encrypts("body", { keyProvider });
+      }
+    }
+    const post = await PostWithCustomKeyProvider.create({
+      title: "The Starfleet is here!",
+      body: "take cover!",
+    });
+    assertEncryptedAttribute(post, "body", "take cover!");
+  });
+
+  it("can configure a custom key on a per-record-class basis through the :key option", async () => {
+    const adapter = freshAdapter();
+    const BaseAuthor = makeEncryptedAuthor(adapter);
+    class AuthorWithKey extends (BaseAuthor as any) {
+      static {
+        this.encrypts("name", { key: "a-custom-key-for-author-32bytes!!" });
+      }
+    }
+    const author = await AuthorWithKey.create({ name: "Stephen King" });
+    assertEncryptedAttribute(author, "name", "Stephen King");
+  });
+
+  it("encrypts multiple attributes with different options at the same time", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const title = "The Starfleet is here!";
+    const body = "<p>the Starfleet is here, we are safe now!</p>";
+    const post = await Post.create({ title, body });
+    assertEncryptedAttribute(post, "title", title);
+    assertEncryptedAttribute(post, "body", body);
+  });
+
+  it("encrypted_attributes returns the list of encrypted attributes in a model (each record class holds their own list)", () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const Author = makeEncryptedAuthor(freshAdapter());
+    new Post();
+    new Author();
+    expect(EncryptableRecord.encryptedAttributes(Post)).toEqual(new Set(["title", "body"]));
+    expect(EncryptableRecord.encryptedAttributes(Author)).toEqual(new Set(["name"]));
+    expect(EncryptableRecord.encryptedAttributes(Post)).not.toEqual(
+      EncryptableRecord.encryptedAttributes(Author),
+    );
+  });
+
+  it("deterministic_encrypted_attributes returns the list of deterministic encrypted attributes in a model (each record class holds their own list)", () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const Post = makeEncryptedPost(freshAdapter());
+    new Book();
+    new Post();
+    expect(EncryptableRecord.deterministicEncryptedAttributes(Book)).toEqual(new Set(["name"]));
+    expect(EncryptableRecord.deterministicEncryptedAttributes(Post).size).toBe(0);
+  });
+
+  it("by default, encryption is not deterministic", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const post1 = await Post.create({ title: "the same title", body: "some body" });
+    const post2 = await Post.create({ title: "the same title", body: "some body" });
+    expect(ciphertextFor(post1, "title")).not.toBe(ciphertextFor(post2, "title"));
+  });
+
+  it("deterministic attributes can be searched with Active Record queries", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    await Book.create({ name: "Dune" });
+    expect(await Book.findBy({ name: "Dune" })).not.toBeNull();
+    expect(await Book.findBy({ name: "not Dune" })).toBeNull();
+    expect(await Book.where({ name: "Dune" }).count()).toBe(1);
+  });
+
+  it("deterministic attributes can be created by passing deterministic: true", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book1 = await Book.create({ name: "Dune" });
+    const book2 = await Book.create({ name: "Dune" });
+    expect(ciphertextFor(book1, "name")).toBe(ciphertextFor(book2, "name"));
+  });
+
+  it("can work with pre-encryption nil values", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await withoutEncryption(() => Book.create({ name: null }));
+    expect(book.name).toBeNull();
+  });
+
+  it("can work with pre-encryption empty values", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await withoutEncryption(() => Book.create({ name: "" }));
+    expect(book.name).toBe("");
+  });
+
+  it("reading a not encrypted value won't raise a Decryption error when :support_unencrypted_data is true", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const Author = makeEncryptedAuthor(freshAdapter());
+    const author = await withoutEncryption(() => Author.create({ name: "Stephen King" }));
+    const reloaded = await Author.find(author.id);
+    expect(reloaded.name).toBe("Stephen King");
+  });
+
+  it("reading a not encrypted value will raise a Decryption error when :support_unencrypted_data is false", async () => {
+    Configurable.config.supportUnencryptedData = false;
+    const Author = makeEncryptedAuthor(freshAdapter());
+    const author = await withoutEncryption(() => Author.create({ name: "Stephen King" }));
+
+    await expect(async () => {
+      const reloaded = await Author.find(author.id);
+      return reloaded.name;
+    }).rejects.toThrow(DecryptionError);
+  });
+
+  it("by default, it's case sensitive", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    await Book.create({ name: "Dune" });
+    expect(await Book.findBy({ name: "Dune" })).not.toBeNull();
+    expect(await Book.findBy({ name: "dune" })).toBeNull();
+  });
+
+  it("when using downcase: true it ignores case since everything will be downcase", async () => {
+    const Book = makeEncryptedBookWithDowncaseName(freshAdapter());
+    await Book.create({ name: "Dune" });
+    expect(await Book.findBy({ name: "Dune" })).not.toBeNull();
+    expect(await Book.findBy({ name: "dune" })).not.toBeNull();
+    expect(await Book.findBy({ name: "DUNE" })).not.toBeNull();
+  });
+
+  it("when downcase: true it creates content downcased", async () => {
+    const Book = makeEncryptedBookWithDowncaseName(freshAdapter());
+    await Book.create({ name: "Dune" });
+    const found = await Book.findBy({ name: "dune" });
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("dune");
+  });
+
+  it.skip("when ignore_case: true, it ignores case in queries but keep it when reading the attribute", () => {
+    // requires dual-column storage (name + original_name) not yet implemented
+  });
+
+  it("when ignore_case: true, it lets you update attributes normally", async () => {
+    const Book = makeEncryptedBookIgnoreCase(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    await book.update({ name: "Dune II" });
+    expect(book.name).toBe("Dune II");
+  });
+
+  it("won't change the encoding of strings", async () => {
+    const Author = makeEncryptedAuthor(freshAdapter());
+    const author = await Author.create({ name: "Jorge" });
+    const reloaded = await Author.find(author.id);
+    expect(typeof reloaded.name).toBe("string");
+    expect(reloaded.name).toBe("Jorge");
+  });
+
+  it("track previous changes properly for encrypted attributes", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    await book.update({ name: "A new title!" });
+    // After updating the encrypted attribute, it appears in previousChanges.
+    expect("name" in book.previousChanges).toBe(true);
+  });
+
+  it.skip("encryption schemes are resolved when used, not when declared", () => {
+    // Global previous schemes (config.previous) are baked into the scheme at
+    // encrypts() time. Supporting lazy re-evaluation after configure() requires
+    // making globalPreviousSchemesFor run at serialize/deserialize time, not at
+    // class definition time — a larger refactor.
+  });
+
+  it("isEncryptedAttribute identifies encrypted vs plain attributes", () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    new Post();
+    expect(isEncryptedAttribute(Post, "title")).toBe(true);
+    expect(isEncryptedAttribute(Post, "body")).toBe(true);
+    expect(isEncryptedAttribute(Post, "id")).toBe(false);
+  });
+
   it.skip("encrypts serialized attributes", () => {});
   it.skip("encrypts serialized attributes where encrypts is declared first", () => {});
   it.skip("encrypts store attributes with accessors", () => {});
-  it.skip("can configure a custom key provider on a per-record-class basis through the :key_provider option", () => {});
-  it.skip("can configure a custom key on a per-record-class basis through the :key option", () => {});
-  it.skip("encrypts multiple attributes with different options at the same time", () => {});
-  it.skip("encrypted_attributes returns the list of encrypted attributes in a model (each record class holds their own list)", () => {});
-  it.skip("deterministic_encrypted_attributes returns the list of deterministic encrypted attributes in a model (each record class holds their own list)", () => {});
-  it.skip("by default, encryption is not deterministic", () => {});
-  it.skip("deterministic attributes can be searched with Active Record queries", () => {});
-  it.skip("deterministic attributes can be created by passing deterministic: true", () => {});
-  it.skip("deterministic ciphertexts remain constant", () => {});
   it.skip("encryption errors when saving records will raise the error and don't save anything", () => {});
-  it.skip("can work with pre-encryption nil values", () => {});
-  it.skip("can work with pre-encryption empty values", () => {});
   it.skip("can't modify encrypted attributes when frozen_encryption is true", () => {});
   it.skip("can only save unencrypted attributes when frozen encryption is true", () => {});
-  it.skip("won't change the encoding of strings", () => {});
-  it.skip("by default, it's case sensitive", () => {});
-  it.skip("when using downcase: true it ignores case since everything will be downcase", () => {});
-  it.skip("when downcase: true it creates content downcased", () => {});
-  it.skip("when ignore_case: true, it ignores case in queries but keep it when reading the attribute", () => {});
-  it.skip("when ignore_case: true, it keeps both the attribute and the _original counterpart encrypted", () => {});
-  it.skip("when ignore_case: true, it lets you update attributes normally", () => {});
-  it.skip("when ignore_case: true, it returns the actual value when not encrypted", () => {});
-  it.skip("when ignore_case: true, users can override accessors and call super", () => {});
-  it.skip("reading a not encrypted value will raise a Decryption error when :support_unencrypted_data is false", () => {});
-  it.skip("reading a not encrypted value won't raise a Decryption error when :support_unencrypted_data is true", () => {});
   it.skip("validate column sizes", () => {});
-  it.skip("track previous changes properly for encrypted attributes", () => {});
   it.skip("forces UTF-8 encoding for deterministic attributes by default", () => {});
   it.skip("forces encoding for deterministic attributes based on the configured option", () => {});
   it.skip("forced encoding for deterministic attributes will replace invalid characters", () => {});
@@ -44,12 +299,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it.skip("loading records with encrypted attributes defined on columns with default values", () => {});
   it.skip("can dump and load records that use encryption", () => {});
   it.skip("supports decrypting data encrypted non deterministically with SHA1 when digest class is SHA256", () => {});
-  it.skip("encryption schemes are resolved when used, not when declared", () => {});
+  it.skip("when ignore_case: true, it keeps both the attribute and the _original counterpart encrypted", () => {});
+  it.skip("when ignore_case: true, it returns the actual value when not encrypted", () => {});
+  it.skip("when ignore_case: true, users can override accessors and call super", () => {});
   it.skip("binary data can be encrypted", () => {});
   it.skip("binary data can be encrypted uncompressed", () => {});
   it.skip("serialized binary data can be encrypted", () => {});
-  it.skip("can compress data with custom compressor", () => {});
-  it.skip("type method returns cast type", () => {});
-  it.skip("encrypts normalized data", () => {});
-  it.skip("encrypts attribute data", () => {});
+  it.skip("deterministic ciphertexts remain constant", () => {});
 });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -107,6 +107,10 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // Rails serializes empty strings the same as any other value (encrypts them).
     // "ignores" means the value round-trips correctly, not that encryption is skipped.
     expect(book.name).toBe("");
+    // Verify the DB-bound value is ciphertext, not the empty string itself.
+    const dbValues = book._attributes.valuesForDatabase();
+    expect(dbValues.name).not.toBe("");
+    expect(dbValues.name).not.toBeNull();
     const reloaded = await Book.find(book.id);
     expect(reloaded.name).toBe("");
   });

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -25,10 +25,9 @@ function stableKeySignature(
   keyDerivationSalt: string | undefined,
   hashDigestClass: string,
 ): string {
-  // Stable serialisation so equivalent string[] values always hit the same cache
-  // entry regardless of array instance identity.
-  const pk = Array.isArray(primaryKey) ? primaryKey.slice().sort().join(",") : primaryKey;
-  return `${pk}|${keyDerivationSalt ?? ""}|${hashDigestClass}`;
+  // JSON.stringify preserves array order (key rotation order is semantically
+  // meaningful) and is unambiguous — no comma-collision risk from key strings.
+  return JSON.stringify([primaryKey, keyDerivationSalt ?? "", hashDigestClass]);
 }
 
 function getOrCreateDefaultKeyProvider(

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -133,7 +133,7 @@ export class Scheme {
   // Returns the context's keyProvider if set, otherwise derives one from config.primaryKey.
   // Memoized on the primaryKey value to avoid repeated PBKDF2 calls.
   private _defaultKeyProvider(): unknown {
-    const ctxKp = (Configurable as any).keyProvider;
+    const ctxKp = Configurable.keyProvider;
     if (ctxKp != null) return ctxKp;
     const { primaryKey, keyDerivationSalt } = Configurable.config;
     if (primaryKey != null) {

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -137,8 +137,14 @@ export class Scheme {
     if (ctxKp != null) return ctxKp;
     const { primaryKey, keyDerivationSalt } = Configurable.config;
     if (primaryKey != null) {
-      // Keyed on both primaryKey and keyDerivationSalt since both affect the derived key.
-      const cacheKey = JSON.stringify(primaryKey) + "|" + (keyDerivationSalt ?? "");
+      // Keyed on all derivation inputs: primaryKey, keyDerivationSalt, and
+      // hashDigestClass (KeyGenerator reads this at construction time).
+      const cacheKey =
+        JSON.stringify(primaryKey) +
+        "|" +
+        (keyDerivationSalt ?? "") +
+        "|" +
+        Configurable.config.hashDigestClass;
       if (!this._cachedDefaultKeyProvider || this._cachedDefaultKeyProviderKey !== cacheKey) {
         this._cachedDefaultKeyProvider = new DerivedSecretKeyProvider(primaryKey);
         this._cachedDefaultKeyProviderKey = cacheKey;

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -29,7 +29,10 @@ function stableKeySignature(
   // meaningful) and is unambiguous — no comma-collision risk from key strings.
   // Use null for undefined so missing salt is distinct from empty-string salt,
   // ensuring cache invalidation when keyDerivationSalt is cleared.
-  return JSON.stringify([primaryKey, keyDerivationSalt ?? null, hashDigestClass]);
+  // Normalize digest the same way KeyGenerator does (lowercase, no hyphens)
+  // so "SHA-256" and "sha256" resolve to the same cache entry.
+  const digest = hashDigestClass.toLowerCase().replace(/-/g, "");
+  return JSON.stringify([primaryKey, keyDerivationSalt ?? null, digest]);
 }
 
 function getOrCreateDefaultKeyProvider(

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -74,7 +74,7 @@ export class Scheme {
       this._keyProviderParam ??
       this._keyProviderFromKey() ??
       this._deterministicKeyProvider() ??
-      undefined
+      this._defaultKeyProvider()
     );
   }
 
@@ -123,6 +123,18 @@ export class Scheme {
     if (this.key != null) {
       this._cachedKeyProviderFromKey ??= new DerivedSecretKeyProvider(this.key);
       return this._cachedKeyProviderFromKey;
+    }
+    return undefined;
+  }
+
+  // Mirrors Rails' Scheme#default_key_provider → ActiveRecord::Encryption.key_provider.
+  // Returns the context's keyProvider if set, otherwise derives one from config.primaryKey.
+  private _defaultKeyProvider(): unknown {
+    const ctxKp = (Configurable as any).keyProvider;
+    if (ctxKp != null) return ctxKp;
+    const primaryKey = Configurable.config.primaryKey;
+    if (primaryKey != null) {
+      return new DerivedSecretKeyProvider(primaryKey);
     }
     return undefined;
   }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -13,6 +13,27 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 import { Key } from "./key.js";
 
+// Module-level cache for the default key provider, shared across all Scheme
+// instances. PBKDF2 is expensive (65536 iterations); by caching globally keyed
+// on the config tuple, derivation happens once per config rather than once per
+// Scheme instance (i.e. once per encrypted attribute declaration).
+const _defaultKeyProviderCache = new Map<string, DerivedSecretKeyProvider>();
+
+function getOrCreateDefaultKeyProvider(
+  primaryKey: string | string[],
+  keyDerivationSalt: string | undefined,
+  hashDigestClass: string,
+): DerivedSecretKeyProvider {
+  const cacheKey =
+    JSON.stringify(primaryKey) + "|" + (keyDerivationSalt ?? "") + "|" + hashDigestClass;
+  let provider = _defaultKeyProviderCache.get(cacheKey);
+  if (!provider) {
+    provider = new DerivedSecretKeyProvider(primaryKey);
+    _defaultKeyProviderCache.set(cacheKey, provider);
+  }
+  return provider;
+}
+
 export interface SchemeOptions {
   keyProvider?: unknown;
   key?: string;
@@ -30,8 +51,6 @@ export class Scheme {
   private _keyProviderParam?: unknown;
   private _cachedKeyProviderFromKey?: DerivedSecretKeyProvider;
   private _cachedDeterministicKeyProvider?: DeterministicKeyProvider;
-  private _cachedDefaultKeyProvider?: DerivedSecretKeyProvider;
-  private _cachedDefaultKeyProviderKey?: string;
   key?: string;
   deterministic: boolean;
   downcase: boolean;
@@ -135,21 +154,9 @@ export class Scheme {
   private _defaultKeyProvider(): unknown {
     const ctxKp = Configurable.keyProvider;
     if (ctxKp != null) return ctxKp;
-    const { primaryKey, keyDerivationSalt } = Configurable.config;
+    const { primaryKey, keyDerivationSalt, hashDigestClass } = Configurable.config;
     if (primaryKey != null) {
-      // Keyed on all derivation inputs: primaryKey, keyDerivationSalt, and
-      // hashDigestClass (KeyGenerator reads this at construction time).
-      const cacheKey =
-        JSON.stringify(primaryKey) +
-        "|" +
-        (keyDerivationSalt ?? "") +
-        "|" +
-        Configurable.config.hashDigestClass;
-      if (!this._cachedDefaultKeyProvider || this._cachedDefaultKeyProviderKey !== cacheKey) {
-        this._cachedDefaultKeyProvider = new DerivedSecretKeyProvider(primaryKey);
-        this._cachedDefaultKeyProviderKey = cacheKey;
-      }
-      return this._cachedDefaultKeyProvider;
+      return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);
     }
     return undefined;
   }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -13,25 +13,40 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 import { Key } from "./key.js";
 
-// Module-level cache for the default key provider, shared across all Scheme
-// instances. PBKDF2 is expensive (65536 iterations); by caching globally keyed
-// on the config tuple, derivation happens once per config rather than once per
-// Scheme instance (i.e. once per encrypted attribute declaration).
-const _defaultKeyProviderCache = new Map<string, DerivedSecretKeyProvider>();
+// Module-level single-entry cache for the default key provider. Avoids storing
+// plaintext key material as Map keys while still sharing one derived key provider
+// across all Scheme instances for the same config. A generation counter tracks
+// config changes — any change to primaryKey, salt, or digestClass creates a
+// new entry without retaining the old key material.
+let _defaultKeyProviderEntry: { gen: number; provider: DerivedSecretKeyProvider } | undefined;
+let _defaultKeyProviderGen = 0;
+let _defaultKeyProviderLastPk: string | string[] | undefined;
+let _defaultKeyProviderLastSalt: string | undefined;
+let _defaultKeyProviderLastDigest: string | undefined;
 
 function getOrCreateDefaultKeyProvider(
   primaryKey: string | string[],
   keyDerivationSalt: string | undefined,
   hashDigestClass: string,
 ): DerivedSecretKeyProvider {
-  const cacheKey =
-    JSON.stringify(primaryKey) + "|" + (keyDerivationSalt ?? "") + "|" + hashDigestClass;
-  let provider = _defaultKeyProviderCache.get(cacheKey);
-  if (!provider) {
-    provider = new DerivedSecretKeyProvider(primaryKey);
-    _defaultKeyProviderCache.set(cacheKey, provider);
+  // Bump generation if any input changed, so stale entries are not reused.
+  if (
+    primaryKey !== _defaultKeyProviderLastPk ||
+    keyDerivationSalt !== _defaultKeyProviderLastSalt ||
+    hashDigestClass !== _defaultKeyProviderLastDigest
+  ) {
+    _defaultKeyProviderGen++;
+    _defaultKeyProviderLastPk = primaryKey;
+    _defaultKeyProviderLastSalt = keyDerivationSalt;
+    _defaultKeyProviderLastDigest = hashDigestClass;
   }
-  return provider;
+  if (!_defaultKeyProviderEntry || _defaultKeyProviderEntry.gen !== _defaultKeyProviderGen) {
+    _defaultKeyProviderEntry = {
+      gen: _defaultKeyProviderGen,
+      provider: new DerivedSecretKeyProvider(primaryKey),
+    };
+  }
+  return _defaultKeyProviderEntry.provider;
 }
 
 export interface SchemeOptions {
@@ -154,11 +169,13 @@ export class Scheme {
   private _defaultKeyProvider(): unknown {
     const ctxKp = Configurable.keyProvider;
     if (ctxKp != null) return ctxKp;
-    const { primaryKey, keyDerivationSalt, hashDigestClass } = Configurable.config;
-    if (primaryKey != null) {
-      return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);
-    }
-    return undefined;
+    if (Configurable.config.primaryKey == null) return undefined;
+    // Use Config.get() so accessing primaryKey raises ConfigError with the
+    // specific message "Missing encryption key: primaryKey" when unset,
+    // aligning with Config's required-key semantics and Rails' behavior.
+    const primaryKey = Configurable.config.get("primaryKey") as string | string[];
+    const { keyDerivationSalt, hashDigestClass } = Configurable.config;
+    return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);
   }
 
   private _deterministicKeyProvider(): DeterministicKeyProvider | undefined {

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -30,6 +30,8 @@ export class Scheme {
   private _keyProviderParam?: unknown;
   private _cachedKeyProviderFromKey?: DerivedSecretKeyProvider;
   private _cachedDeterministicKeyProvider?: DeterministicKeyProvider;
+  private _cachedDefaultKeyProvider?: DerivedSecretKeyProvider;
+  private _cachedDefaultKeyProviderKey?: string | string[];
   key?: string;
   deterministic: boolean;
   downcase: boolean;
@@ -129,12 +131,17 @@ export class Scheme {
 
   // Mirrors Rails' Scheme#default_key_provider → ActiveRecord::Encryption.key_provider.
   // Returns the context's keyProvider if set, otherwise derives one from config.primaryKey.
+  // Memoized on the primaryKey value to avoid repeated PBKDF2 calls.
   private _defaultKeyProvider(): unknown {
     const ctxKp = (Configurable as any).keyProvider;
     if (ctxKp != null) return ctxKp;
     const primaryKey = Configurable.config.primaryKey;
     if (primaryKey != null) {
-      return new DerivedSecretKeyProvider(primaryKey);
+      if (!this._cachedDefaultKeyProvider || this._cachedDefaultKeyProviderKey !== primaryKey) {
+        this._cachedDefaultKeyProvider = new DerivedSecretKeyProvider(primaryKey);
+        this._cachedDefaultKeyProviderKey = primaryKey;
+      }
+      return this._cachedDefaultKeyProvider;
     }
     return undefined;
   }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -27,7 +27,9 @@ function stableKeySignature(
 ): string {
   // JSON.stringify preserves array order (key rotation order is semantically
   // meaningful) and is unambiguous — no comma-collision risk from key strings.
-  return JSON.stringify([primaryKey, keyDerivationSalt ?? "", hashDigestClass]);
+  // Use null for undefined so missing salt is distinct from empty-string salt,
+  // ensuring cache invalidation when keyDerivationSalt is cleared.
+  return JSON.stringify([primaryKey, keyDerivationSalt ?? null, hashDigestClass]);
 }
 
 function getOrCreateDefaultKeyProvider(

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -13,40 +13,40 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 import { Key } from "./key.js";
 
-// Module-level single-entry cache for the default key provider. Avoids storing
-// plaintext key material as Map keys while still sharing one derived key provider
-// across all Scheme instances for the same config. A generation counter tracks
-// config changes — any change to primaryKey, salt, or digestClass creates a
-// new entry without retaining the old key material.
-let _defaultKeyProviderEntry: { gen: number; provider: DerivedSecretKeyProvider } | undefined;
-let _defaultKeyProviderGen = 0;
-let _defaultKeyProviderLastPk: string | string[] | undefined;
-let _defaultKeyProviderLastSalt: string | undefined;
-let _defaultKeyProviderLastDigest: string | undefined;
+// Module-level single-entry cache for the default key provider. Shared across
+// all Scheme instances so PBKDF2 runs once per (primaryKey, salt, digest) tuple.
+// Uses stable string serialisation for primaryKey so array instances compare by
+// value rather than reference, avoiding spurious re-derivations.
+let _defaultKeyProviderEntry: DerivedSecretKeyProvider | undefined;
+let _defaultKeyProviderSig: string | undefined;
+
+function stableKeySignature(
+  primaryKey: string | string[],
+  keyDerivationSalt: string | undefined,
+  hashDigestClass: string,
+): string {
+  // Stable serialisation so equivalent string[] values always hit the same cache
+  // entry regardless of array instance identity.
+  const pk = Array.isArray(primaryKey) ? primaryKey.slice().sort().join(",") : primaryKey;
+  return `${pk}|${keyDerivationSalt ?? ""}|${hashDigestClass}`;
+}
 
 function getOrCreateDefaultKeyProvider(
   primaryKey: string | string[],
   keyDerivationSalt: string | undefined,
   hashDigestClass: string,
 ): DerivedSecretKeyProvider {
-  // Bump generation if any input changed, so stale entries are not reused.
-  if (
-    primaryKey !== _defaultKeyProviderLastPk ||
-    keyDerivationSalt !== _defaultKeyProviderLastSalt ||
-    hashDigestClass !== _defaultKeyProviderLastDigest
-  ) {
-    _defaultKeyProviderGen++;
-    _defaultKeyProviderLastPk = primaryKey;
-    _defaultKeyProviderLastSalt = keyDerivationSalt;
-    _defaultKeyProviderLastDigest = hashDigestClass;
+  const sig = stableKeySignature(primaryKey, keyDerivationSalt, hashDigestClass);
+  if (!_defaultKeyProviderEntry || _defaultKeyProviderSig !== sig) {
+    _defaultKeyProviderEntry = new DerivedSecretKeyProvider(primaryKey);
+    _defaultKeyProviderSig = sig;
   }
-  if (!_defaultKeyProviderEntry || _defaultKeyProviderEntry.gen !== _defaultKeyProviderGen) {
-    _defaultKeyProviderEntry = {
-      gen: _defaultKeyProviderGen,
-      provider: new DerivedSecretKeyProvider(primaryKey),
-    };
-  }
-  return _defaultKeyProviderEntry.provider;
+  return _defaultKeyProviderEntry;
+}
+
+function clearDefaultKeyProviderCache(): void {
+  _defaultKeyProviderEntry = undefined;
+  _defaultKeyProviderSig = undefined;
 }
 
 export interface SchemeOptions {
@@ -169,11 +169,13 @@ export class Scheme {
   private _defaultKeyProvider(): unknown {
     const ctxKp = Configurable.keyProvider;
     if (ctxKp != null) return ctxKp;
-    if (Configurable.config.primaryKey == null) return undefined;
-    // Use Config.get() so accessing primaryKey raises ConfigError with the
-    // specific message "Missing encryption key: primaryKey" when unset,
-    // aligning with Config's required-key semantics and Rails' behavior.
-    const primaryKey = Configurable.config.get("primaryKey") as string | string[];
+    if (Configurable.config.primaryKey == null) {
+      // No primary key configured — clear any stale cached provider so old
+      // key material can be GC'd (e.g. after config reset in tests).
+      clearDefaultKeyProviderCache();
+      return undefined;
+    }
+    const primaryKey = Configurable.config.primaryKey;
     const { keyDerivationSalt, hashDigestClass } = Configurable.config;
     return getOrCreateDefaultKeyProvider(primaryKey, keyDerivationSalt, hashDigestClass);
   }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -31,7 +31,7 @@ export class Scheme {
   private _cachedKeyProviderFromKey?: DerivedSecretKeyProvider;
   private _cachedDeterministicKeyProvider?: DeterministicKeyProvider;
   private _cachedDefaultKeyProvider?: DerivedSecretKeyProvider;
-  private _cachedDefaultKeyProviderKey?: string | string[];
+  private _cachedDefaultKeyProviderKey?: string;
   key?: string;
   deterministic: boolean;
   downcase: boolean;
@@ -135,11 +135,13 @@ export class Scheme {
   private _defaultKeyProvider(): unknown {
     const ctxKp = (Configurable as any).keyProvider;
     if (ctxKp != null) return ctxKp;
-    const primaryKey = Configurable.config.primaryKey;
+    const { primaryKey, keyDerivationSalt } = Configurable.config;
     if (primaryKey != null) {
-      if (!this._cachedDefaultKeyProvider || this._cachedDefaultKeyProviderKey !== primaryKey) {
+      // Keyed on both primaryKey and keyDerivationSalt since both affect the derived key.
+      const cacheKey = JSON.stringify(primaryKey) + "|" + (keyDerivationSalt ?? "");
+      if (!this._cachedDefaultKeyProvider || this._cachedDefaultKeyProviderKey !== cacheKey) {
         this._cachedDefaultKeyProvider = new DerivedSecretKeyProvider(primaryKey);
-        this._cachedDefaultKeyProviderKey = primaryKey;
+        this._cachedDefaultKeyProviderKey = cacheKey;
       }
       return this._cachedDefaultKeyProvider;
     }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -45,10 +45,14 @@ function getOrCreateDefaultKeyProvider(
   return _defaultKeyProviderEntry;
 }
 
-function clearDefaultKeyProviderCache(): void {
+export function clearDefaultKeyProviderCache(): void {
   _defaultKeyProviderEntry = undefined;
   _defaultKeyProviderSig = undefined;
 }
+
+// Register eager cache invalidation so key material is released whenever
+// Configurable.configure() is called (key rotation, test teardown, etc.).
+Configurable.onConfigure(clearDefaultKeyProviderCache);
 
 export interface SchemeOptions {
   keyProvider?: unknown;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -222,7 +222,7 @@ export function assertEncryptedAttribute(
  */
 export function ciphertextFor(model: any, attrName: string): unknown {
   const klass = model.constructor as any;
-  const type = klass._attributeDefinitions?.get?.(attrName)?.type;
+  const type = klass._attributeDefinitions?.get(attrName)?.type;
   if (type && typeof type.serialize === "function" && typeof type.isEncrypted === "function") {
     const value = model[attrName];
     return type.serialize(value);

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -196,7 +196,9 @@ export function assertEncryptedAttribute(
   }
 
   // Verify the DB-bound value differs from the plaintext — confirms real encryption.
-  if (expectedValue !== null && expectedValue !== undefined && expectedValue !== "") {
+  // Empty strings are also encrypted by EncryptedAttributeType.serialize(), so
+  // include them in this check (only skip null/undefined).
+  if (expectedValue !== null && expectedValue !== undefined) {
     const dbValues = model._attributes.valuesForDatabase();
     const dbValue = dbValues[attrName];
     if (dbValue === expectedValue) {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -91,7 +91,8 @@ export function freshAdapter(): DatabaseAdapter {
 let _freshModelCounter = 0;
 
 export function makeFreshModel(adapter: DatabaseAdapter, attributes: Record<string, string>): any {
-  // Use a unique counter so each call gets a distinct class name and table name.
+  // Each call gets a unique table name via the counter. The class itself is
+  // anonymous (no unique class name), which is fine for test isolation.
   const tableName = `fresh_model_${++_freshModelCounter}`;
   const klass = class extends Base {
     static {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -83,7 +83,8 @@ export function freshAdapter(): DatabaseAdapter {
 // ─── Model factories ──────────────────────────────────────────────────────────
 
 /**
- * Creates a fresh model with only string attributes — no pre-applied encryption.
+ * Creates a fresh model with the given attributes — no pre-applied encryption.
+ * Attribute types are passed as strings (e.g. "integer", "string").
  * Use this when you need to apply a specific encryption scheme to an attribute
  * without the idempotency guard blocking a second encrypts() call.
  */

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -173,12 +173,12 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
 
 /**
  * Mirrors Rails' assert_encrypted_attribute.
- * Checks that the serialized (DB) form is ciphertext (≠ plaintext) and
+ * Checks that the actual DB-bound value is ciphertext (≠ plaintext) and
  * that reading the attribute returns the expected plaintext.
  *
- * Uses the attribute type's serialize() to get the ciphertext form rather
- * than readAttributeBeforeTypeCast, which returns the in-memory before-cast
- * value (not the DB ciphertext for in-memory created records).
+ * Uses _attributes.valuesForDatabase() to get the exact value that would
+ * be written to the DB, matching what Rails' assert_encrypted_attribute
+ * checks via read_attribute_before_type_cast on a persisted record.
  */
 export function assertEncryptedAttribute(
   model: any,
@@ -194,19 +194,15 @@ export function assertEncryptedAttribute(
     );
   }
 
-  // Verify the serialized form (what goes to DB) differs from the plaintext.
+  // Verify the DB-bound value differs from the plaintext — confirms real encryption.
   if (expectedValue !== null && expectedValue !== undefined && expectedValue !== "") {
-    const klass = model.constructor as any;
-    const typeDef = klass._attributeDefinitions?.get?.(attrName);
-    const type = typeDef?.type;
-    if (type && typeof type.serialize === "function") {
-      const serialized = type.serialize(expectedValue);
-      if (serialized === expectedValue) {
-        throw new Error(
-          `assertEncryptedAttribute: expected ${attrName} to be encrypted ` +
-            `(serialized ≠ plaintext), but serialize returned the plaintext unchanged.`,
-        );
-      }
+    const dbValues = model._attributes.valuesForDatabase();
+    const dbValue = dbValues[attrName];
+    if (dbValue === expectedValue) {
+      throw new Error(
+        `assertEncryptedAttribute: expected ${attrName} to be encrypted ` +
+          `(DB value ≠ plaintext), but valuesForDatabase() returned the plaintext unchanged.`,
+      );
     }
   }
 }

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -193,6 +193,18 @@ export function assertEncryptedAttribute(
  * Returns the serialized (encrypted) form of an attribute's current value.
  * Mirrors Rails' model.ciphertext_for(:attr) — the value as stored in the DB.
  */
+/**
+ * Returns a freshly-serialized (encrypted) form of the attribute's current value.
+ *
+ * For deterministic encryption, serialize() is idempotent so this equals the
+ * stored DB ciphertext. For non-deterministic encryption, a fresh IV is used
+ * each call — use this only for comparing two freshly-serialized values (e.g.,
+ * to assert two records produce different ciphertexts), not for reading back
+ * what's actually stored in the DB.
+ *
+ * Mirrors Rails' model.ciphertext_for(:attr) in spirit — use with the same
+ * caveat that Rails' version reads from the DB whereas this re-serializes.
+ */
 export function ciphertextFor(model: any, attrName: string): unknown {
   const klass = model.constructor as any;
   const type = klass._attributeDefinitions?.get?.(attrName)?.type;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -83,6 +83,28 @@ export function freshAdapter(): DatabaseAdapter {
 // ─── Model factories ──────────────────────────────────────────────────────────
 
 /**
+ * Creates a fresh model with only string attributes — no pre-applied encryption.
+ * Use this when you need to apply a specific encryption scheme to an attribute
+ * without the idempotency guard blocking a second encrypts() call.
+ */
+let _freshModelCounter = 0;
+
+export function makeFreshModel(adapter: DatabaseAdapter, attributes: Record<string, string>): any {
+  // Use a unique counter so each call gets a distinct class name and table name.
+  const tableName = `fresh_model_${++_freshModelCounter}`;
+  const klass = class extends Base {
+    static {
+      this._tableName = tableName;
+      for (const [name, type] of Object.entries(attributes)) {
+        this.attribute(name, type);
+      }
+      this.adapter = adapter;
+    }
+  } as any;
+  return klass;
+}
+
+/**
  * EncryptedPost: title and body are both encrypted (non-deterministic).
  * Mirrors Rails' post_encrypted.rb / EncryptedPost.
  */
@@ -190,20 +212,17 @@ export function assertEncryptedAttribute(
 }
 
 /**
- * Returns the serialized (encrypted) form of an attribute's current value.
- * Mirrors Rails' model.ciphertext_for(:attr) — the value as stored in the DB.
- */
-/**
  * Returns a freshly-serialized (encrypted) form of the attribute's current value.
  *
  * For deterministic encryption, serialize() is idempotent so this equals the
- * stored DB ciphertext. For non-deterministic encryption, a fresh IV is used
- * each call — use this only for comparing two freshly-serialized values (e.g.,
- * to assert two records produce different ciphertexts), not for reading back
- * what's actually stored in the DB.
+ * stored DB ciphertext — suitable for equality comparisons across records.
+ * For non-deterministic encryption, a fresh IV is used each call, so the result
+ * differs from what is stored in the DB. Use this only for comparing two
+ * freshly-serialized values (e.g., asserting two records produce different
+ * ciphertexts), not for reading back the actual persisted ciphertext.
  *
- * Mirrors Rails' model.ciphertext_for(:attr) in spirit — use with the same
- * caveat that Rails' version reads from the DB whereas this re-serializes.
+ * Mirrors Rails' model.ciphertext_for(:attr) in spirit, with the caveat that
+ * Rails reads the stored value whereas this re-serializes the current attribute.
  */
 export function ciphertextFor(model: any, attrName: string): unknown {
   const klass = model.constructor as any;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -1,0 +1,211 @@
+/**
+ * Shared helpers for DB-backed encryption tests.
+ *
+ * Mirrors: ActiveRecord::EncryptionTestCase (setup/teardown) and
+ *          ActiveRecord::Encryption::EncryptionHelpers (assertions).
+ */
+
+import { createTestAdapter } from "../test-adapter.js";
+import { Base } from "../index.js";
+import type { DatabaseAdapter } from "../adapter.js";
+import { Configurable } from "./configurable.js";
+import { Contexts } from "./contexts.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { withEncryptionContext, withoutEncryption } from "./context.js";
+import { DecryptionError } from "./errors.js";
+
+export { withEncryptionContext, withoutEncryption, DecryptionError };
+
+// ─── Test key material ────────────────────────────────────────────────────────
+
+// Primary key is used as a PBKDF2 password — any string works.
+export const TEST_PRIMARY_KEY = "test-primary-key-for-encryption-suite";
+// Deterministic key is used as raw AES key material (base64-encoded 32 bytes).
+// "test-deterministic-key-32bytes!!" = exactly 32 bytes, base64-encoded.
+export const TEST_DETERMINISTIC_KEY = "dGVzdC1kZXRlcm1pbmlzdGljLWtleS0zMmJ5dGVzISE=";
+export const TEST_KEY_DERIVATION_SALT = "test-key-derivation-salt-for-encryption";
+
+// ─── Config snapshot/restore ─────────────────────────────────────────────────
+
+interface ConfigSnapshot {
+  primaryKey: string | string[] | undefined;
+  deterministicKey: string | undefined;
+  keyDerivationSalt: string | undefined;
+  supportUnencryptedData: boolean;
+  previousSchemes: typeof Configurable.config.previousSchemes;
+}
+
+export function snapshotEncryptionConfig(): ConfigSnapshot {
+  const c = Configurable.config;
+  return {
+    primaryKey: c.primaryKey,
+    deterministicKey: c.deterministicKey,
+    keyDerivationSalt: c.keyDerivationSalt,
+    supportUnencryptedData: c.supportUnencryptedData,
+    previousSchemes: [...c.previousSchemes],
+  };
+}
+
+export function restoreEncryptionConfig(snapshot: ConfigSnapshot): void {
+  const c = Configurable.config;
+  c.primaryKey = snapshot.primaryKey;
+  c.deterministicKey = snapshot.deterministicKey;
+  c.keyDerivationSalt = snapshot.keyDerivationSalt;
+  c.supportUnencryptedData = snapshot.supportUnencryptedData;
+  c.previousSchemes = snapshot.previousSchemes;
+  Contexts.resetDefaultContext();
+}
+
+export function configureEncryption(
+  overrides: Partial<{
+    primaryKey: string;
+    deterministicKey: string;
+    keyDerivationSalt: string;
+    supportUnencryptedData: boolean;
+  }> = {},
+): void {
+  Configurable.configure({
+    primaryKey: overrides.primaryKey ?? TEST_PRIMARY_KEY,
+    deterministicKey: overrides.deterministicKey ?? TEST_DETERMINISTIC_KEY,
+    keyDerivationSalt: overrides.keyDerivationSalt ?? TEST_KEY_DERIVATION_SALT,
+  });
+  if (overrides.supportUnencryptedData !== undefined) {
+    Configurable.config.supportUnencryptedData = overrides.supportUnencryptedData;
+  }
+}
+
+// ─── Test adapter factory ─────────────────────────────────────────────────────
+
+export function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
+
+// ─── Model factories ──────────────────────────────────────────────────────────
+
+/**
+ * EncryptedPost: title and body are both encrypted (non-deterministic).
+ * Mirrors Rails' post_encrypted.rb / EncryptedPost.
+ */
+export function makeEncryptedPost(adapter: DatabaseAdapter) {
+  return class EncryptedPost extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("title", "string");
+      this.attribute("body", "string");
+      this.adapter = adapter;
+      this.encrypts("title");
+      this.encrypts("body");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBook: name is encrypted deterministically.
+ * Mirrors Rails' book_encrypted.rb / EncryptedBook.
+ */
+export function makeEncryptedBook(adapter: DatabaseAdapter) {
+  return class EncryptedBook extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name", { deterministic: true });
+    }
+  } as any;
+}
+
+export function makeEncryptedBookWithDowncaseName(adapter: DatabaseAdapter) {
+  return class EncryptedBookWithDowncaseName extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name", { deterministic: true, downcase: true });
+    }
+  } as any;
+}
+
+export function makeEncryptedBookIgnoreCase(adapter: DatabaseAdapter) {
+  return class EncryptedBookIgnoreCase extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name", { deterministic: true, ignoreCase: true });
+    }
+  } as any;
+}
+
+export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
+  return class EncryptedAuthor extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name");
+    }
+  } as any;
+}
+
+// ─── Assertion helpers ────────────────────────────────────────────────────────
+
+/**
+ * Mirrors Rails' assert_encrypted_attribute.
+ * Checks that the serialized (DB) form is ciphertext (≠ plaintext) and
+ * that reading the attribute returns the expected plaintext.
+ *
+ * Uses the attribute type's serialize() to get the ciphertext form rather
+ * than readAttributeBeforeTypeCast, which returns the in-memory before-cast
+ * value (not the DB ciphertext for in-memory created records).
+ */
+export function assertEncryptedAttribute(
+  model: any,
+  attrName: string,
+  expectedValue: unknown,
+): void {
+  // Verify the attribute reads back as the expected plaintext.
+  const readValue = model[attrName];
+  if (readValue !== expectedValue) {
+    throw new Error(
+      `assertEncryptedAttribute: expected ${attrName} to equal ` +
+        `${JSON.stringify(expectedValue)}, got ${JSON.stringify(readValue)}`,
+    );
+  }
+
+  // Verify the serialized form (what goes to DB) differs from the plaintext.
+  if (expectedValue !== null && expectedValue !== undefined && expectedValue !== "") {
+    const klass = model.constructor as any;
+    const typeDef = klass._attributeDefinitions?.get?.(attrName);
+    const type = typeDef?.type;
+    if (type && typeof type.serialize === "function") {
+      const serialized = type.serialize(expectedValue);
+      if (serialized === expectedValue) {
+        throw new Error(
+          `assertEncryptedAttribute: expected ${attrName} to be encrypted ` +
+            `(serialized ≠ plaintext), but serialize returned the plaintext unchanged.`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Returns the serialized (encrypted) form of an attribute's current value.
+ * Mirrors Rails' model.ciphertext_for(:attr) — the value as stored in the DB.
+ */
+export function ciphertextFor(model: any, attrName: string): unknown {
+  const klass = model.constructor as any;
+  const type = klass._attributeDefinitions?.get?.(attrName)?.type;
+  if (type && typeof type.serialize === "function" && typeof type.isEncrypted === "function") {
+    const value = model[attrName];
+    return type.serialize(value);
+  }
+  return model.readAttributeBeforeTypeCast(attrName);
+}
+
+/**
+ * Creates a DerivedSecretKeyProvider from a password using the current config.
+ */
+export function makeKeyProvider(password: string) {
+  return new DerivedSecretKeyProvider(password);
+}

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -11,6 +11,7 @@ import type { DatabaseAdapter } from "../adapter.js";
 import { Configurable } from "./configurable.js";
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError } from "./errors.js";
 
@@ -54,6 +55,10 @@ export function restoreEncryptionConfig(snapshot: ConfigSnapshot): void {
   c.supportUnencryptedData = snapshot.supportUnencryptedData;
   c.previousSchemes = snapshot.previousSchemes;
   Contexts.resetDefaultContext();
+  // Eagerly clear so the previous test's key material doesn't linger in
+  // memory after config reset — the lazy clear on next keyProvider access
+  // isn't sufficient when no subsequent access occurs.
+  clearDefaultKeyProviderCache();
 }
 
 export function configureEncryption(


### PR DESCRIPTION
## Summary

First batch of DB-backed encryption tests, using the in-memory SQLite test adapter (no fixtures needed — schema is auto-derived from model `attribute()` declarations).

**New: `test-helpers.ts`** — shared setup/teardown helpers mirroring `ActiveRecord::EncryptionTestCase`:
- `configureEncryption()` / `snapshotEncryptionConfig()` / `restoreEncryptionConfig()`
- Model factories: `makeEncryptedPost`, `makeEncryptedBook`, `makeEncryptedAuthor`, downcase/ignoreCase variants
- `assertEncryptedAttribute()`, `ciphertextFor()`, `makeKeyProvider()`

**24 tests implemented** in `EncryptableRecordTest`:
- Transparent encrypt/decrypt on create + update
- Wrong-key access raises `DecryptionError`
- Swapping key providers via `withEncryptionContext`
- Nil/empty value handling
- Custom `keyProvider:` and `key:` options per attribute
- Multiple encrypted attributes simultaneously
- Deterministic vs non-deterministic (different ciphertexts per record)
- DB queries on deterministic attributes (`findBy`, `where`, `count`)
- `supportUnencryptedData` on/off
- Case sensitivity and `downcase: true`
- Previous changes tracking

**Two infrastructure fixes** needed to make real encryption work with configured keys:
1. `Scheme._defaultKeyProvider()`: falls back to `DerivedSecretKeyProvider(config.primaryKey)` — mirrors Rails' `Scheme#default_key_provider`
2. `encryption.ts buildScheme()`: uses real scheme (not `defaultEncryptor` shim) when keys are configured in config

## Test plan
- [ ] 24 new EncryptableRecordTest tests pass
- [ ] Full suite: 208 pass, 69 skipped (was 184/96)
- [ ] No regressions in existing encryption tests