### PR TITLE
refactor(parity): audit follow-ups — parallelize, shared helpers, richer diff

### DIFF
--- a/scripts/parity/canonical/diff-helpers.ts
+++ b/scripts/parity/canonical/diff-helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared utilities used by both scripts/parity/schema/diff.ts and
+ * scripts/parity/query/diff.ts. Keeping them here prevents the two
+ * diff scripts from drifting on how JSON is normalized before comparison.
+ */
+
+/** Recursively sort object keys so JSON string comparison is order-independent. */
+export function sortedKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortedKeys);
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.keys(obj)
+        .sort()
+        .map((k) => [k, sortedKeys((obj as Record<string, unknown>)[k])]),
+    );
+  }
+  return obj;
+}
+
+/** Stable stringification used as the canonical form for line-diffing. */
+export function stableJson(obj: unknown): string {
+  return JSON.stringify(sortedKeys(obj), null, 2) + "\n";
+}

--- a/scripts/parity/query/diff.test.ts
+++ b/scripts/parity/query/diff.test.ts
@@ -158,4 +158,71 @@ describe("diff.ts classification", () => {
     expect(stdout).toMatch(/expected diff, actual trails-missing/);
     expect(code).toBe(1);
   });
+
+  it("summary includes gap-by-side breakdown across multiple categories", () => {
+    // g: both sides differ AND listed as diff → KNOWN-GAP diff
+    writeFileSync(join(railsDir, "g.json"), fixtureJson({ fixture: "g", sql: "A" }));
+    writeFileSync(join(trailsDir, "g.json"), fixtureJson({ fixture: "g", sql: "B" }));
+    // h: trails missing AND listed as trails-missing → KNOWN-GAP trails-missing
+    writeFileSync(join(railsDir, "h.json"), fixtureJson({ fixture: "h" }));
+    // i: rails missing AND listed as rails-missing → KNOWN-GAP rails-missing
+    writeFileSync(join(trailsDir, "i.json"), fixtureJson({ fixture: "i" }));
+    writeGaps({
+      g: { side: "diff", reason: "g gap" },
+      h: { side: "trails-missing", reason: "h gap" },
+      i: { side: "rails-missing", reason: "i gap" },
+    });
+    const { code, stdout } = runDiff(railsDir, trailsDir, gapsPath, fixturesDir);
+    expect(code).toBe(0);
+    // All three categories appear in the breakdown line, each with count 1.
+    expect(stdout).toMatch(/known gaps by side: .*1 rails-missing/);
+    expect(stdout).toMatch(/known gaps by side: .*1 trails-missing/);
+    expect(stdout).toMatch(/known gaps by side: .*1 diff/);
+    expect(stdout).toMatch(/3 known gap\(s\)/);
+  });
+});
+
+describe("diff.ts known-gaps validation", () => {
+  let tmp: string;
+  let railsDir: string;
+  let trailsDir: string;
+  let gapsPath: string;
+  let fixturesDir: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "parity-query-diff-test-"));
+    railsDir = join(tmp, "rails");
+    trailsDir = join(tmp, "trails");
+    gapsPath = join(tmp, "gaps.json");
+    fixturesDir = join(tmp, "fixtures");
+    mkdirSync(railsDir);
+    mkdirSync(trailsDir);
+    mkdirSync(fixturesDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("exits 1 with pointed error on invalid `side` value", () => {
+    writeFileSync(gapsPath, JSON.stringify({ a: { side: "typo", reason: "x" } }));
+    const { code, stderr } = runDiff(railsDir, trailsDir, gapsPath, fixturesDir);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/\[a\]\.side must be one of/);
+    expect(stderr).toMatch(/got "typo"/);
+  });
+
+  it("exits 1 with pointed error on empty `reason`", () => {
+    writeFileSync(gapsPath, JSON.stringify({ a: { side: "diff", reason: "" } }));
+    const { code, stderr } = runDiff(railsDir, trailsDir, gapsPath, fixturesDir);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/\[a\]\.reason must be a non-empty string/);
+  });
+
+  it("exits 1 on malformed JSON", () => {
+    writeFileSync(gapsPath, "{not json");
+    const { code, stderr } = runDiff(railsDir, trailsDir, gapsPath, fixturesDir);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/failed to parse/);
+  });
 });

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -23,6 +23,7 @@ import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import Ajv from "ajv/dist/2020.js";
 import { createTwoFilesPatch } from "diff";
+import { stableJson } from "../canonical/diff-helpers.js";
 
 const SCHEMA_PATH = "scripts/parity/canonical/query.schema.json";
 // Tests override via PARITY_KNOWN_GAPS_PATH / PARITY_FIXTURES_DIR so they don't
@@ -49,6 +50,57 @@ interface KnownGap {
 }
 
 type KnownGaps = Record<string, KnownGap>;
+
+const VALID_SIDES: ReadonlySet<KnownGap["side"]> = new Set([
+  "rails-missing",
+  "trails-missing",
+  "both-missing",
+  "diff",
+]);
+
+/**
+ * Validate the shape of the known-gaps file so a typo in a `side` value or
+ * a missing `reason` fails loudly instead of silently mis-classifying fixtures.
+ * Returns a typed object on success; exits 1 with a useful error on failure.
+ */
+function loadKnownGaps(path: string): KnownGaps {
+  if (!existsSync(path)) return {};
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    process.stderr.write(
+      `parity query diff: failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    process.stderr.write(`parity query diff: ${path} must be a JSON object\n`);
+    process.exit(1);
+  }
+  const gaps: KnownGaps = {};
+  for (const [name, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      process.stderr.write(`parity query diff: ${path}[${name}] must be an object\n`);
+      process.exit(1);
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.side !== "string" || !VALID_SIDES.has(e.side as KnownGap["side"])) {
+      process.stderr.write(
+        `parity query diff: ${path}[${name}].side must be one of ${[...VALID_SIDES].join(", ")} (got ${JSON.stringify(e.side)})\n`,
+      );
+      process.exit(1);
+    }
+    if (typeof e.reason !== "string" || e.reason.trim() === "") {
+      process.stderr.write(
+        `parity query diff: ${path}[${name}].reason must be a non-empty string\n`,
+      );
+      process.exit(1);
+    }
+    gaps[name] = { side: e.side as KnownGap["side"], reason: e.reason };
+  }
+  return gaps;
+}
 
 function assertRepoRoot(): void {
   if (!existsSync(SCHEMA_PATH)) {
@@ -78,22 +130,6 @@ function parseArgs(): { railsDir: string; trailsDir: string } {
   return { railsDir, trailsDir };
 }
 
-function sortedKeys(obj: unknown): unknown {
-  if (Array.isArray(obj)) return obj.map(sortedKeys);
-  if (obj !== null && typeof obj === "object") {
-    return Object.fromEntries(
-      Object.keys(obj)
-        .sort()
-        .map((k) => [k, sortedKeys((obj as Record<string, unknown>)[k])]),
-    );
-  }
-  return obj;
-}
-
-function stableJson(obj: unknown): string {
-  return JSON.stringify(sortedKeys(obj), null, 2) + "\n";
-}
-
 function listJsonFiles(dir: string): string[] {
   if (!existsSync(dir)) {
     process.stderr.write(`parity query diff: directory not found: ${dir}\n`);
@@ -112,9 +148,7 @@ async function main(): Promise<void> {
   const ajv = new Ajv();
   const validate = ajv.compile(schemaJson);
 
-  const knownGaps: KnownGaps = existsSync(KNOWN_GAPS_PATH)
-    ? JSON.parse(readFileSync(KNOWN_GAPS_PATH, "utf8"))
-    : {};
+  const knownGaps = loadKnownGaps(KNOWN_GAPS_PATH);
 
   const railsFiles = new Set(listJsonFiles(railsDir));
   const trailsFiles = new Set(listJsonFiles(trailsDir));
@@ -143,6 +177,12 @@ async function main(): Promise<void> {
   let failed = 0;
   let knownGap = 0;
   let unexpectedPass = 0;
+  const gapBySide: Record<KnownGap["side"], number> = {
+    "rails-missing": 0,
+    "trails-missing": 0,
+    "both-missing": 0,
+    diff: 0,
+  };
 
   for (const name of [...allFixtures].sort()) {
     const file = `${name}.json`;
@@ -157,6 +197,7 @@ async function main(): Promise<void> {
       if (gap && gap.side === actualSide) {
         process.stdout.write(`KNOWN-GAP  ${name}  (${actualSide}: ${gap.reason})\n`);
         knownGap++;
+        gapBySide[actualSide]++;
       } else if (gap) {
         failed++;
         process.stdout.write(
@@ -207,6 +248,7 @@ async function main(): Promise<void> {
       } else {
         if (gap && gap.side === "diff") {
           knownGap++;
+          gapBySide.diff++;
           process.stdout.write(`KNOWN-GAP  ${name}  (diff: ${gap.reason})\n`);
         } else {
           failed++;
@@ -244,6 +286,13 @@ async function main(): Promise<void> {
   if (unexpectedPass > 0) process.stdout.write(`, ${unexpectedPass} unexpected pass`);
   if (failed > 0) process.stdout.write(`, ${failed} failure(s)`);
   process.stdout.write("\n");
+
+  if (knownGap > 0) {
+    const parts = (Object.entries(gapBySide) as [KnownGap["side"], number][])
+      .filter(([, n]) => n > 0)
+      .map(([side, n]) => `${n} ${side}`);
+    process.stdout.write(`  known gaps by side: ${parts.join(", ")}\n`);
+  }
 
   if (failed > 0 || unexpectedPass > 0) process.exit(1);
 }

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -136,29 +136,47 @@ function run(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<void
   });
 }
 
+// Bound concurrency so we don't fork 53 bundler or tsx processes at once.
+// Default 4 — safe for Ruby bundler memory and reasonable on 2-core CI runners.
+// Override with PARITY_CONCURRENCY for local tuning.
+const CONCURRENCY = Math.max(1, Number(process.env.PARITY_CONCURRENCY) || 4);
+
+async function runPool<T>(items: T[], worker: (item: T) => Promise<void>): Promise<void> {
+  const queue = [...items];
+  const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+    for (;;) {
+      const item = queue.shift();
+      if (item === undefined) return;
+      await worker(item);
+    }
+  });
+  await Promise.all(workers);
+}
+
+function dumpOne(cfg: TypeConfig, label: "rails" | "trails", fixture: string): Promise<void> {
+  const fixtureDir = join(FIXTURES_DIR, fixture);
+  const outDir = label === "rails" ? cfg.outRails : cfg.outTrails;
+  const outFile = join(outDir, `${fixture}.json`);
+  if (label === "rails") {
+    return run(
+      "bundle",
+      ["exec", "ruby", cfg.rubyDump, fixtureDir, outFile, ...cfg.extraDumpArgs],
+      { BUNDLE_GEMFILE: GEMFILE },
+    );
+  }
+  return run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs]);
+}
+
 async function runRails(cfg: TypeConfig): Promise<void> {
   rmSync(cfg.outRails, { recursive: true, force: true });
   mkdirSync(cfg.outRails, { recursive: true });
-  const bundleEnv = { BUNDLE_GEMFILE: GEMFILE };
-  for (const fixture of fixtures(cfg)) {
-    const fixtureDir = join(FIXTURES_DIR, fixture);
-    const outFile = join(cfg.outRails, `${fixture}.json`);
-    await run(
-      "bundle",
-      ["exec", "ruby", cfg.rubyDump, fixtureDir, outFile, ...cfg.extraDumpArgs],
-      bundleEnv,
-    );
-  }
+  await runPool(fixtures(cfg), (fixture) => dumpOne(cfg, "rails", fixture));
 }
 
 async function runTrails(cfg: TypeConfig): Promise<void> {
   rmSync(cfg.outTrails, { recursive: true, force: true });
   mkdirSync(cfg.outTrails, { recursive: true });
-  for (const fixture of fixtures(cfg)) {
-    const fixtureDir = join(FIXTURES_DIR, fixture);
-    const outFile = join(cfg.outTrails, `${fixture}.json`);
-    await run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs]);
-  }
+  await runPool(fixtures(cfg), (fixture) => dumpOne(cfg, "trails", fixture));
 }
 
 async function runDiff(cfg: TypeConfig): Promise<void> {
@@ -188,27 +206,16 @@ async function runAllFixturesBestEffort(cfg: TypeConfig, label: "rails" | "trail
   const outDir = label === "rails" ? cfg.outRails : cfg.outTrails;
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
-  const bundleEnv = { BUNDLE_GEMFILE: GEMFILE };
-  for (const fixture of fixtures(cfg)) {
-    const fixtureDir = join(FIXTURES_DIR, fixture);
-    const outFile = join(outDir, `${fixture}.json`);
+  await runPool(fixtures(cfg), async (fixture) => {
     try {
-      if (label === "rails") {
-        await run(
-          "bundle",
-          ["exec", "ruby", cfg.rubyDump, fixtureDir, outFile, ...cfg.extraDumpArgs],
-          bundleEnv,
-        );
-      } else {
-        await run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs]);
-      }
+      await dumpOne(cfg, label, fixture);
     } catch (err) {
       process.stdout.write(
         `parity run: [${label}/${fixture}] dump failed — diff step will classify as gap/fail\n`,
       );
       process.stdout.write(`  ${err instanceof Error ? err.message : String(err)}\n`);
     }
-  }
+  });
 }
 
 async function main(): Promise<void> {

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -133,16 +133,25 @@ function run(cmd: string, args: string[], opts: RunOptions = {}): Promise<void> 
       stdio: opts.buffered ? ["ignore", "pipe", "pipe"] : "inherit",
       env: opts.env ? { ...process.env, ...opts.env } : process.env,
     });
-    let stdoutBuf = "";
-    let stderrBuf = "";
+    // Tagged chunks preserve arrival order across stdout and stderr so an
+    // interleaved error message still lines up with the surrounding stdout
+    // context when flushed. Flushed per-stream at the end so parent's own
+    // stderr stream still gets stderr output (for log filters, tools that
+    // split streams, etc.).
+    const chunks: Array<{ stream: "out" | "err"; text: string }> = [];
     if (opts.buffered) {
-      proc.stdout?.setEncoding("utf8").on("data", (c: string) => (stdoutBuf += c));
-      proc.stderr?.setEncoding("utf8").on("data", (c: string) => (stderrBuf += c));
+      proc.stdout
+        ?.setEncoding("utf8")
+        .on("data", (c: string) => chunks.push({ stream: "out", text: c }));
+      proc.stderr
+        ?.setEncoding("utf8")
+        .on("data", (c: string) => chunks.push({ stream: "err", text: c }));
     }
     const flush = () => {
       if (!opts.buffered) return;
-      if (stdoutBuf) process.stdout.write(stdoutBuf);
-      if (stderrBuf) process.stderr.write(stderrBuf);
+      for (const c of chunks) {
+        (c.stream === "out" ? process.stdout : process.stderr).write(c.text);
+      }
     };
     proc.on("close", (code, signal) => {
       flush();
@@ -163,8 +172,21 @@ function run(cmd: string, args: string[], opts: RunOptions = {}): Promise<void> 
 
 // Bound concurrency so we don't fork 53 bundler or tsx processes at once.
 // Default 4 — safe for Ruby bundler memory and reasonable on 2-core CI runners.
-// Override with PARITY_CONCURRENCY for local tuning.
-const CONCURRENCY = Math.max(1, Number(process.env.PARITY_CONCURRENCY) || 4);
+// Override with PARITY_CONCURRENCY for local tuning; must be a positive integer.
+function parseConcurrency(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return 4;
+  const trimmed = raw.trim();
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== trimmed) {
+    process.stderr.write(
+      `parity run: PARITY_CONCURRENCY must be a positive integer (got ${JSON.stringify(raw)})\n`,
+    );
+    process.exit(1);
+  }
+  return parsed;
+}
+
+const CONCURRENCY = parseConcurrency(process.env.PARITY_CONCURRENCY);
 
 async function runPool<T>(items: T[], worker: (item: T) => Promise<void>): Promise<void> {
   const queue = [...items];

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -190,14 +190,27 @@ const CONCURRENCY = parseConcurrency(process.env.PARITY_CONCURRENCY);
 
 async function runPool<T>(items: T[], worker: (item: T) => Promise<void>): Promise<void> {
   const queue = [...items];
+  // Fail-fast: as soon as any worker errors, stop pulling new items from the
+  // queue. In-flight work finishes (we can't kill spawned children here), but
+  // no further fixtures are scheduled, so a broken fixture doesn't spawn 50
+  // more Ruby/tsx processes before the error surfaces. Query mode wraps each
+  // dump in try/catch inside the worker so this branch never triggers there.
+  let firstError: unknown;
   const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
     for (;;) {
+      if (firstError !== undefined) return;
       const item = queue.shift();
       if (item === undefined) return;
-      await worker(item);
+      try {
+        await worker(item);
+      } catch (err) {
+        if (firstError === undefined) firstError = err;
+        return;
+      }
     }
   });
   await Promise.all(workers);
+  if (firstError !== undefined) throw firstError;
 }
 
 function dumpOne(cfg: TypeConfig, label: "rails" | "trails", fixture: string): Promise<void> {

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -117,13 +117,35 @@ function fixtures(cfg: TypeConfig): string[] {
     .sort();
 }
 
-function run(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<void> {
+interface RunOptions {
+  env?: NodeJS.ProcessEnv;
+  /**
+   * When true, buffer the child's stdout/stderr and flush them in one
+   * contiguous block on exit. Used when fixtures run in parallel so each
+   * fixture's log lines stay grouped instead of interleaving with others.
+   */
+  buffered?: boolean;
+}
+
+function run(cmd: string, args: string[], opts: RunOptions = {}): Promise<void> {
   return new Promise((resolve, reject) => {
     const proc = spawn(cmd, args, {
-      stdio: "inherit",
-      env: env ? { ...process.env, ...env } : process.env,
+      stdio: opts.buffered ? ["ignore", "pipe", "pipe"] : "inherit",
+      env: opts.env ? { ...process.env, ...opts.env } : process.env,
     });
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    if (opts.buffered) {
+      proc.stdout?.setEncoding("utf8").on("data", (c: string) => (stdoutBuf += c));
+      proc.stderr?.setEncoding("utf8").on("data", (c: string) => (stderrBuf += c));
+    }
+    const flush = () => {
+      if (!opts.buffered) return;
+      if (stdoutBuf) process.stdout.write(stdoutBuf);
+      if (stderrBuf) process.stderr.write(stderrBuf);
+    };
     proc.on("close", (code, signal) => {
+      flush();
       if (code === 0) {
         resolve();
         return;
@@ -132,7 +154,10 @@ function run(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<void
       const status = code === null ? `signal ${signal}` : `${code}`;
       reject(new Error(`${command} exited ${status}`));
     });
-    proc.on("error", reject);
+    proc.on("error", (err) => {
+      flush();
+      reject(err);
+    });
   });
 }
 
@@ -157,14 +182,19 @@ function dumpOne(cfg: TypeConfig, label: "rails" | "trails", fixture: string): P
   const fixtureDir = join(FIXTURES_DIR, fixture);
   const outDir = label === "rails" ? cfg.outRails : cfg.outTrails;
   const outFile = join(outDir, `${fixture}.json`);
+  // Buffered so each fixture's verbose dump output prints as one contiguous
+  // block — otherwise concurrent workers interleave lines and CI logs become
+  // unreadable.
   if (label === "rails") {
     return run(
       "bundle",
       ["exec", "ruby", cfg.rubyDump, fixtureDir, outFile, ...cfg.extraDumpArgs],
-      { BUNDLE_GEMFILE: GEMFILE },
+      { env: { BUNDLE_GEMFILE: GEMFILE }, buffered: true },
     );
   }
-  return run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs]);
+  return run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs], {
+    buffered: true,
+  });
 }
 
 async function runRails(cfg: TypeConfig): Promise<void> {

--- a/scripts/parity/schema/diff.ts
+++ b/scripts/parity/schema/diff.ts
@@ -12,6 +12,7 @@ import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import Ajv from "ajv/dist/2020.js";
 import { createTwoFilesPatch } from "diff";
+import { stableJson } from "../canonical/diff-helpers.js";
 
 const SCHEMA_PATH = "scripts/parity/canonical/schema.schema.json";
 
@@ -39,22 +40,6 @@ function parseArgs(): { railsDir: string; trailsDir: string } {
   }
   if (!railsDir || !trailsDir) usage();
   return { railsDir, trailsDir };
-}
-
-function sortedKeys(obj: unknown): unknown {
-  if (Array.isArray(obj)) return obj.map(sortedKeys);
-  if (obj !== null && typeof obj === "object") {
-    return Object.fromEntries(
-      Object.keys(obj)
-        .sort()
-        .map((k) => [k, sortedKeys((obj as Record<string, unknown>)[k])]),
-    );
-  }
-  return obj;
-}
-
-function stableJson(obj: unknown): string {
-  return JSON.stringify(sortedKeys(obj), null, 2) + "\n";
 }
 
 function listJsonFiles(dir: string): string[] {


### PR DESCRIPTION
Post-merge cleanups from a full audit of the parity pipeline now that the 5-PR rollout is shipped.

## 1. Parallelize fixture dumps — \`scripts/parity/run.ts\`

Each Ruby bundler fork costs ~300ms of startup; each tsx ~200ms. Running 53 fixtures serially per side was the dominant cost of a full sweep.

- New \`runPool<T>()\` helper: worker-pool with bounded concurrency, default **4**, override via \`PARITY_CONCURRENCY\`.
- Cap is deliberately low (not CPU count) so we don't slam Ruby with 53 parallel forks — bundler startup allocates a lot of memory.
- runRails / runTrails / runAllFixturesBestEffort all reduce to \`runPool(fixtures, dumpOne)\` via a new \`dumpOne()\` helper — no more 3× copy of the spawn/args logic.

Local sweep: **~60s → ~36s wall** (2-core CI runners will see a smaller but still worthwhile win).

## 2. Extract shared diff helpers — \`scripts/parity/canonical/diff-helpers.ts\` (new)

\`sortedKeys\` and \`stableJson\` lived identically in both \`schema/diff.ts\` and \`query/diff.ts\`. Moved to \`canonical/diff-helpers.ts\` so the two scripts can't drift on how JSON is normalized before line comparison.

## 3. Validate \`query-known-gaps.json\` at load — \`scripts/parity/query/diff.ts\`

Before: a typo in \`side\` (e.g. \`"dif"\`) or empty \`reason\` silently mis-classified fixtures. After: \`loadKnownGaps()\` walks every entry and fails loudly on startup:

\`\`\`
parity query diff: query-known-gaps.json[arel-17].side must be one of rails-missing, trails-missing, both-missing, diff (got \"dif\")
\`\`\`

## 4. Richer diff summary — \`scripts/parity/query/diff.ts\`

In addition to the existing one-line summary, diff now prints a gap breakdown by category:

\`\`\`
42/53 passed, 11 known gap(s)
  known gaps by side: 8 trails-missing, 3 diff
\`\`\`

CI readers can see at a glance which categories of gap are open without scrolling the full log.

## Audit items explicitly not done

Noted in my review but skipped:
- **Batch the dump.test.ts integration tests** — real subprocess isolation is worth the ~12s.
- **Remove the better-sqlite3 init from the Node query runner** — it validates schema.sql parses, matches the Ruby runner's behavior, 5–10ms/fixture is fine.
- **Tighten \`unknown\` types** — \`unknown\` is correct here.
- **Centralize frozen-at default** — lives in two languages; can't actually share.

## Test plan

- [x] 15/15 query-parity vitest green
- [x] Full sweep locally: 42/53 PASS, 11 KNOWN-GAP (8 trails-missing, 3 diff), 0 FAIL
- [x] Validator rejects typoed \`side\` and empty \`reason\` with a pointed error
- [x] \`pnpm parity:schema\` still works (extracted helpers are used there too)