### PR TITLE
feat(activerecord): bigint PR 1 — driver normalization

### DIFF
--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -10,6 +10,7 @@ export class BooleanType extends ValueType<boolean> {
   private static readonly FALSE_VALUES: ReadonlySet<unknown> = new Set([
     false,
     0,
+    0n, // safeIntegers mode returns bigint 0n for SQLite boolean columns
     "0",
     "f",
     "F",

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -18,6 +18,7 @@ export class IntegerType extends ValueType<number> {
       if (isNaN(value)) return null;
       return Math.trunc(value);
     }
+    if (typeof value === "bigint") return Number(value);
     const parsed = parseInt(String(value), 10);
     return isNaN(parsed) ? null : parsed;
   }

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -9,7 +9,9 @@ import {
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   const type = new BigIntegerType({ limit: 8 });
-  const BIG = 2n ** 62n; // well above Number.MAX_SAFE_INTEGER
+  // 2^62 — 19 digits, well above the 15-digit threshold where mysql2
+  // switches from number to string with supportBigNumbers:true.
+  const BIG = 2n ** 62n;
 
   beforeEach(async () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
@@ -29,13 +31,12 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("MySQL bigint round-trip", () => {
-    it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
-      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
+    it("preserves exact value above Number.MAX_SAFE_INTEGER via BigIntegerType", async () => {
+      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2 (16 digits)
       await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [unsafe]);
       const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
-      // mysql2 with bigNumberStrings:true returns BIGINT as decimal string
-      expect(typeof rows[0].score).toBe("string");
-      // BigIntegerType.cast converts to bigint
+      // mysql2 supportBigNumbers:true returns string for values that can't be
+      // represented exactly as a JS number — BigIntegerType.cast handles both.
       expect(type.cast(rows[0].score)).toBe(unsafe);
     });
 
@@ -46,13 +47,20 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(type.cast(rows[0].score)).toBe(BIG + 1n);
     });
 
-    it("INT column in same row is unaffected by bigNumberStrings", async () => {
+    it("safe-range BIGINT returns as number (auto-increment IDs unaffected)", async () => {
+      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [42]);
+      const rows = await adapter.execute(`SELECT \`id\`, \`score\` FROM \`bigint_rt\``);
+      // Small BIGINT values (< 10^15) stay as JS number — existing code unaffected.
+      expect(typeof rows[0].id).toBe("number");
+      expect(typeof rows[0].score).toBe("number");
+    });
+
+    it("INT column is unaffected by supportBigNumbers", async () => {
       await adapter.executeMutation(
         `INSERT INTO \`bigint_rt\` (\`score\`, \`count\`) VALUES (?, ?)`,
         [BIG, 42],
       );
-      const rows = await adapter.execute(`SELECT \`score\`, \`count\` FROM \`bigint_rt\``);
-      // INT columns are not affected by supportBigNumbers — they return number
+      const rows = await adapter.execute(`SELECT \`count\` FROM \`bigint_rt\``);
       expect(typeof rows[0].count).toBe("number");
       expect(rows[0].count).toBe(42);
     });

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -47,7 +47,10 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("INT column in same row is unaffected by bigNumberStrings", async () => {
-      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`, \`count\`) VALUES (?, ?)`, [BIG, 42]);
+      await adapter.executeMutation(
+        `INSERT INTO \`bigint_rt\` (\`score\`, \`count\`) VALUES (?, ?)`,
+        [BIG, 42],
+      );
       const rows = await adapter.execute(`SELECT \`score\`, \`count\` FROM \`bigint_rt\``);
       // INT columns are not affected by supportBigNumbers — they return number
       expect(typeof rows[0].count).toBe("number");

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { BigIntegerType } from "@blazetrails/activemodel";
 import {
   describeIfMysql,
   Mysql2Adapter,
@@ -7,6 +8,9 @@ import {
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
+  const type = new BigIntegerType({ limit: 8 });
+  const BIG = 2n ** 62n; // well above Number.MAX_SAFE_INTEGER
+
   beforeEach(async () => {
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
     await adapter.executeMutation(`DROP TABLE IF EXISTS \`bigint_rt\``);
@@ -25,26 +29,29 @@ describeIfMysql("Mysql2Adapter", () => {
   });
 
   describe("MySQL bigint round-trip", () => {
-    const BIG = 2n ** 62n;
-
-    it("returns string for BIGINT column (bigNumberStrings:true)", async () => {
-      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [BIG]);
-      const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
-      expect(typeof rows[0].score).toBe("string");
-    });
-
     it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
-      const unsafe = 9007199254740993n;
+      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
       await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [unsafe]);
       const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
-      expect(BigInt(rows[0].score as string)).toBe(unsafe);
+      // mysql2 with bigNumberStrings:true returns BIGINT as decimal string
+      expect(typeof rows[0].score).toBe("string");
+      // BigIntegerType.cast converts to bigint
+      expect(type.cast(rows[0].score)).toBe(unsafe);
     });
 
     it("update round-trip preserves value", async () => {
       await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [BIG]);
       await adapter.executeMutation(`UPDATE \`bigint_rt\` SET \`score\` = ?`, [BIG + 1n]);
       const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
-      expect(BigInt(rows[0].score as string)).toBe(BIG + 1n);
+      expect(type.cast(rows[0].score)).toBe(BIG + 1n);
+    });
+
+    it("INT column in same row is unaffected by bigNumberStrings", async () => {
+      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`, \`count\`) VALUES (?, ?)`, [BIG, 42]);
+      const rows = await adapter.execute(`SELECT \`score\`, \`count\` FROM \`bigint_rt\``);
+      // INT columns are not affected by supportBigNumbers — they return number
+      expect(typeof rows[0].count).toBe("number");
+      expect(rows[0].count).toBe(42);
     });
   });
 });

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  describeIfMysql,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "../abstract-mysql-adapter/test-helper.js";
+
+describeIfMysql("Mysql2Adapter", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(async () => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    await adapter.executeMutation(`DROP TABLE IF EXISTS \`bigint_rt\``);
+    await adapter.executeMutation(`
+      CREATE TABLE \`bigint_rt\` (
+        \`id\`    BIGINT AUTO_INCREMENT PRIMARY KEY,
+        \`score\` BIGINT NOT NULL,
+        \`count\` INT NOT NULL DEFAULT 0
+      )
+    `);
+  });
+
+  afterEach(async () => {
+    await adapter.executeMutation(`DROP TABLE IF EXISTS \`bigint_rt\``);
+    await adapter.close();
+  });
+
+  describe("MySQL bigint round-trip", () => {
+    const BIG = 2n ** 62n;
+
+    it("returns string for BIGINT column (bigNumberStrings:true)", async () => {
+      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [BIG]);
+      const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
+      expect(typeof rows[0].score).toBe("string");
+    });
+
+    it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
+      const unsafe = 9007199254740993n;
+      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [unsafe]);
+      const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
+      expect(BigInt(rows[0].score as string)).toBe(unsafe);
+    });
+
+    it("update round-trip preserves value", async () => {
+      await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [BIG]);
+      await adapter.executeMutation(`UPDATE \`bigint_rt\` SET \`score\` = ?`, [BIG + 1n]);
+      const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
+      expect(BigInt(rows[0].score as string)).toBe(BIG + 1n);
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -5,7 +5,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
-const TWO_GB = 2n * 1024n * 1024n * 1024n; // 2.gigabytes in Ruby
+// Rails: 2.gigabytes = 2 * 1024 * 1024 * 1024
+const TWO_GB = 2n * 1024n * 1024n * 1024n;
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -17,6 +18,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlIntegerTest", () => {
+    // Mirrors Rails setup: create_table "pg_integers" { t.integer :quota, limit: 8, default: 2.gigabytes }
     beforeEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "pg_integers"`);
       await adapter.exec(`
@@ -32,12 +34,29 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("integer types", async () => {
-      await adapter.executeMutation(`INSERT INTO "pg_integers" DEFAULT VALUES`);
-      const rows = await adapter.execute(`SELECT "quota" FROM "pg_integers"`);
-      expect(typeof rows[0].quota).toBe("string"); // pg returns int8 as string by default
+      // Verify that int2, int4, and int8 columns all come back through
+      // the pg driver as strings (int8) or numbers (int2/int4) as expected.
+      await adapter.exec(`DROP TABLE IF EXISTS "pg_int_types"`);
+      await adapter.exec(`
+        CREATE TABLE "pg_int_types" (
+          "small"  SMALLINT DEFAULT 1,
+          "medium" INTEGER  DEFAULT 2,
+          "big"    BIGINT   DEFAULT 9007199254740993
+        )
+      `);
+      await adapter.executeMutation(`INSERT INTO "pg_int_types" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT * FROM "pg_int_types"`);
+      expect(typeof rows[0].small).toBe("number");
+      expect(typeof rows[0].medium).toBe("number");
+      // pg-types returns int8 as string to avoid precision loss
+      expect(typeof rows[0].big).toBe("string");
+      expect(BigInt(rows[0].big as string)).toBe(9007199254740993n);
+      await adapter.exec(`DROP TABLE IF EXISTS "pg_int_types"`);
     });
 
     it("schema properly respects bigint ranges", async () => {
+      // Rails: assert_equal 2.gigabytes, PgInteger.new.quota
+      // At the adapter level: insert default row, cast through BigIntegerType, assert value.
       await adapter.executeMutation(`INSERT INTO "pg_integers" DEFAULT VALUES`);
       const rows = await adapter.execute(`SELECT "quota" FROM "pg_integers"`);
       const type = new BigIntegerType({ limit: 8 });
@@ -47,7 +66,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQL bigint round-trip", () => {
-    const BIG = 2n ** 62n;
+    const BIG = 2n ** 62n; // well above Number.MAX_SAFE_INTEGER
 
     beforeEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "bigint_rt"`);
@@ -63,18 +82,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`DROP TABLE IF EXISTS "bigint_rt"`);
     });
 
-    it("returns string for int8 column (pg driver default)", async () => {
-      await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [BIG]);
-      const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
-      expect(typeof rows[0].score).toBe("string");
-      expect(BigInt(rows[0].score as string)).toBe(BIG);
-    });
-
-    it("preserves exact value above Number.MAX_SAFE_INTEGER via BigIntegerType", async () => {
-      const unsafe = 9007199254740993n;
+    it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
+      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
       await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [unsafe]);
       const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
-      expect(BigInt(rows[0].score as string)).toBe(unsafe);
+      const type = new BigIntegerType({ limit: 8 });
+      expect(type.cast(rows[0].score)).toBe(unsafe);
+    });
+
+    it("update round-trip preserves value", async () => {
+      await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [BIG]);
+      await adapter.executeMutation(`UPDATE "bigint_rt" SET "score" = $1`, [BIG + 1n]);
+      const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
+      const type = new BigIntegerType({ limit: 8 });
+      expect(type.cast(rows[0].score)).toBe(BIG + 1n);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -33,9 +33,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`DROP TABLE IF EXISTS "pg_integers"`);
     });
 
-    it("integer types", async () => {
-      // Verify that int2, int4, and int8 columns all come back through
-      // the pg driver as strings (int8) or numbers (int2/int4) as expected.
+    beforeEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "pg_int_types"`);
       await adapter.exec(`
         CREATE TABLE "pg_int_types" (
@@ -44,6 +42,15 @@ describeIfPg("PostgreSQLAdapter", () => {
           "big"    BIGINT   DEFAULT 9007199254740993
         )
       `);
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "pg_int_types"`);
+    });
+
+    it("integer types", async () => {
+      // Verify that int2, int4, and int8 columns all come back through
+      // the pg driver as strings (int8) or numbers (int2/int4) as expected.
       await adapter.executeMutation(`INSERT INTO "pg_int_types" DEFAULT VALUES`);
       const rows = await adapter.execute(`SELECT * FROM "pg_int_types"`);
       expect(typeof rows[0].small).toBe("number");
@@ -51,7 +58,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       // pg-types returns int8 as string to avoid precision loss
       expect(typeof rows[0].big).toBe("string");
       expect(BigInt(rows[0].big as string)).toBe(9007199254740993n);
-      await adapter.exec(`DROP TABLE IF EXISTS "pg_int_types"`);
     });
 
     it("schema properly respects bigint ranges", async () => {

--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -1,8 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/integer_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { BigIntegerType } from "@blazetrails/activemodel";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+
+const TWO_GB = 2n * 1024n * 1024n * 1024n; // 2.gigabytes in Ruby
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -14,7 +17,64 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlIntegerTest", () => {
-    it.skip("integer types", async () => {});
-    it.skip("schema properly respects bigint ranges", async () => {});
+    beforeEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "pg_integers"`);
+      await adapter.exec(`
+        CREATE TABLE "pg_integers" (
+          "id"    SERIAL PRIMARY KEY,
+          "quota" BIGINT NOT NULL DEFAULT ${TWO_GB}
+        )
+      `);
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "pg_integers"`);
+    });
+
+    it("integer types", async () => {
+      await adapter.executeMutation(`INSERT INTO "pg_integers" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT "quota" FROM "pg_integers"`);
+      expect(typeof rows[0].quota).toBe("string"); // pg returns int8 as string by default
+    });
+
+    it("schema properly respects bigint ranges", async () => {
+      await adapter.executeMutation(`INSERT INTO "pg_integers" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT "quota" FROM "pg_integers"`);
+      const type = new BigIntegerType({ limit: 8 });
+      const value = type.cast(rows[0].quota);
+      expect(value).toBe(TWO_GB);
+    });
+  });
+
+  describe("PostgreSQL bigint round-trip", () => {
+    const BIG = 2n ** 62n;
+
+    beforeEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "bigint_rt"`);
+      await adapter.exec(`
+        CREATE TABLE "bigint_rt" (
+          "id"    SERIAL PRIMARY KEY,
+          "score" BIGINT NOT NULL
+        )
+      `);
+    });
+
+    afterEach(async () => {
+      await adapter.exec(`DROP TABLE IF EXISTS "bigint_rt"`);
+    });
+
+    it("returns string for int8 column (pg driver default)", async () => {
+      await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [BIG]);
+      const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
+      expect(typeof rows[0].score).toBe("string");
+      expect(BigInt(rows[0].score as string)).toBe(BIG);
+    });
+
+    it("preserves exact value above Number.MAX_SAFE_INTEGER via BigIntegerType", async () => {
+      const unsafe = 9007199254740993n;
+      await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [unsafe]);
+      const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
+      expect(BigInt(rows[0].score as string)).toBe(unsafe);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { BigIntegerType, IntegerType } from "@blazetrails/activemodel";
+import { BigIntegerType, IntegerType, BooleanType } from "@blazetrails/activemodel";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: SQLite3Adapter;
 const bigType = new BigIntegerType();
 const intType = new IntegerType();
+const boolType = new BooleanType();
 
 beforeEach(() => {
   adapter = new SQLite3Adapter(":memory:");
   adapter.exec(`
     CREATE TABLE "big_items" (
-      "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
-      "score" BIGINT NOT NULL,
-      "count" INTEGER NOT NULL DEFAULT 0
+      "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
+      "score"  BIGINT NOT NULL,
+      "count"  INTEGER NOT NULL DEFAULT 0,
+      "active" INTEGER NOT NULL DEFAULT 1
     )
   `);
 });
@@ -54,6 +56,23 @@ describe("SQLite3 bigint round-trip", () => {
     // so INTEGER column also comes back as bigint from the driver.
     // IntegerType.cast converts it back to number — this is the type-layer contract.
     expect(intType.cast(rows[0].count)).toBe(42);
+  });
+
+  it("BooleanType.cast handles 0n/1n from safeIntegers mode correctly", async () => {
+    // SQLite stores booleans as INTEGER 0/1. With safeIntegers enabled (triggered
+    // by the BIGINT column), the driver returns 0n/1n instead of 0/1.
+    // BooleanType.FALSE_VALUES includes 0n so cast(0n) → false, cast(1n) → true.
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "active") VALUES (?, ?)`, [
+      BIG,
+      0,
+    ]);
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "active") VALUES (?, ?)`, [
+      BIG,
+      1,
+    ]);
+    const rows = await adapter.execute(`SELECT "active" FROM "big_items" ORDER BY "id"`);
+    expect(boolType.cast(rows[0].active)).toBe(false);
+    expect(boolType.cast(rows[1].active)).toBe(true);
   });
 
   it("update round-trip preserves value", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { BigIntegerType, IntegerType } from "@blazetrails/activemodel";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: SQLite3Adapter;
+const bigType = new BigIntegerType();
+const intType = new IntegerType();
 
 beforeEach(() => {
   adapter = new SQLite3Adapter(":memory:");
@@ -38,19 +41,19 @@ describe("SQLite3 bigint round-trip", () => {
       0,
     ]);
     const rows = await adapter.execute(`SELECT "score" FROM "big_items"`);
-    expect(rows[0].score).toBe(unsafe);
+    expect(bigType.cast(rows[0].score)).toBe(unsafe);
   });
 
-  it("returns bigint for INTEGER column in same row when safeIntegers is enabled", async () => {
+  it("IntegerType.cast coerces safeIntegers bigint back to number for INTEGER columns", async () => {
     await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
       BIG,
       42,
     ]);
     const rows = await adapter.execute(`SELECT "score", "count" FROM "big_items"`);
-    // safeIntegers applies to the whole statement — INTEGER columns also return bigint.
-    // IntegerType.cast coerces bigint → number at the model attribute layer.
-    expect(typeof rows[0].count).toBe("bigint");
-    expect(rows[0].count).toBe(42n);
+    // safeIntegers is enabled on this statement (BIGINT column present),
+    // so INTEGER column also comes back as bigint from the driver.
+    // IntegerType.cast converts it back to number — this is the type-layer contract.
+    expect(intType.cast(rows[0].count)).toBe(42);
   });
 
   it("update round-trip preserves value", async () => {
@@ -60,6 +63,6 @@ describe("SQLite3 bigint round-trip", () => {
     ]);
     await adapter.executeMutation(`UPDATE "big_items" SET "score" = ?`, [BIG + 1n]);
     const rows = await adapter.execute(`SELECT "score" FROM "big_items"`);
-    expect(rows[0].score).toBe(BIG + 1n);
+    expect(bigType.cast(rows[0].score)).toBe(BIG + 1n);
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+
+let adapter: SQLite3Adapter;
+
+beforeEach(() => {
+  adapter = new SQLite3Adapter(":memory:");
+  adapter.exec(`
+    CREATE TABLE "big_items" (
+      "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
+      "score" BIGINT NOT NULL,
+      "count" INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+});
+
+afterEach(() => {
+  adapter.close();
+});
+
+describe("SQLite3 bigint round-trip", () => {
+  const BIG = 2n ** 62n; // 4611686018427387904 — well above Number.MAX_SAFE_INTEGER
+
+  it("returns bigint for BIGINT column", async () => {
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
+      BIG,
+      1,
+    ]);
+    const rows = await adapter.execute(`SELECT "score", "count" FROM "big_items"`);
+    expect(typeof rows[0].score).toBe("bigint");
+    expect(rows[0].score).toBe(BIG);
+  });
+
+  it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
+    const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
+      unsafe,
+      0,
+    ]);
+    const rows = await adapter.execute(`SELECT "score" FROM "big_items"`);
+    expect(rows[0].score).toBe(unsafe);
+  });
+
+  it("returns bigint for INTEGER column in same row when safeIntegers is enabled", async () => {
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
+      BIG,
+      42,
+    ]);
+    const rows = await adapter.execute(`SELECT "score", "count" FROM "big_items"`);
+    // safeIntegers applies to the whole statement — INTEGER columns also return bigint.
+    // IntegerType.cast coerces bigint → number at the model attribute layer.
+    expect(typeof rows[0].count).toBe("bigint");
+    expect(rows[0].count).toBe(42n);
+  });
+
+  it("update round-trip preserves value", async () => {
+    await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
+      BIG,
+      0,
+    ]);
+    await adapter.executeMutation(`UPDATE "big_items" SET "score" = ?`, [BIG + 1n]);
+    const rows = await adapter.execute(`SELECT "score" FROM "big_items"`);
+    expect(rows[0].score).toBe(BIG + 1n);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -961,11 +961,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   static newClient(config: mysql.PoolOptions): mysql.Pool {
-    // Return BIGINT values that exceed JS safe integer range as decimal strings
-    // so BigIntegerType.cast() can convert to bigint without precision loss.
-    // supportBigNumbers:true (without bigNumberStrings) returns a number for
-    // safe values (< 10^15) and a string for unsafe ones — both are handled by
-    // BigIntegerType.cast(). Callers may override via explicit false in config.
+    // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
+    // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
+    // and a JS number for smaller values. Both are handled by BigIntegerType.cast().
+    // Note: the threshold is mysql2's internal digit count (≥15), not
+    // Number.MAX_SAFE_INTEGER (2^53-1 ≈ 9×10^15, 16 digits). Callers may
+    // override via explicit false in config.
     return mysql.createPool({ supportBigNumbers: true, ...config });
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -961,6 +961,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   static newClient(config: mysql.PoolOptions): mysql.Pool {
-    return mysql.createPool(config);
+    // Return BIGINT columns as decimal strings so BigIntegerType.cast() can
+    // convert to JS bigint without precision loss. bigNumberStrings:true means
+    // ALL LONGLONG values come back as strings (both text and binary protocol).
+    // Callers may override via explicit false in their config.
+    return mysql.createPool({ supportBigNumbers: true, bigNumberStrings: true, ...config });
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -961,10 +961,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   static newClient(config: mysql.PoolOptions): mysql.Pool {
-    // Return BIGINT columns as decimal strings so BigIntegerType.cast() can
-    // convert to JS bigint without precision loss. bigNumberStrings:true means
-    // ALL LONGLONG values come back as strings (both text and binary protocol).
-    // Callers may override via explicit false in their config.
-    return mysql.createPool({ supportBigNumbers: true, bigNumberStrings: true, ...config });
+    // Return BIGINT values that exceed JS safe integer range as decimal strings
+    // so BigIntegerType.cast() can convert to bigint without precision loss.
+    // supportBigNumbers:true (without bigNumberStrings) returns a number for
+    // safe values (< 10^15) and a string for unsafe ones — both are handled by
+    // BigIntegerType.cast(). Callers may override via explicit false in config.
+    return mysql.createPool({ supportBigNumbers: true, ...config });
   }
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -191,12 +191,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return stmt;
   }
 
-  // Enable safeIntegers on SELECT statements that return bigint-declared columns
-  // so the driver returns JS bigint rather than a lossy number. Non-bigint integer
-  // columns in the same row also return bigint when safeIntegers is enabled —
-  // IntegerType.cast handles bigint → number for those.
+  // Enable safeIntegers on row-returning statements that expose bigint-declared
+  // columns so the driver returns JS bigint rather than a lossy number.
+  // Non-bigint integer columns in the same row also return bigint when
+  // safeIntegers is enabled — IntegerType.cast handles bigint → number for those.
+  // stmt.reader gates out PRAGMA/EXPLAIN and other non-row statements.
   private _maybeEnableSafeIntegers(sql: string, stmt: Database.Statement): void {
-    if (isWriteQuerySql(sql)) return;
+    if (isWriteQuerySql(sql) || !stmt.reader) return;
     const cols = stmt.columns();
     if (cols.some((c) => c.type !== null && /bigint/i.test(c.type))) {
       stmt.safeIntegers(true);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -31,6 +31,7 @@ import {
 } from "@blazetrails/activemodel";
 import { getFs, Notifications } from "@blazetrails/activesupport";
 import { typeCastedBinds } from "./abstract/database-statements.js";
+import { isWriteQuerySql } from "./sql-classification.js";
 import {
   quote as sqliteQuote,
   typeCast as sqliteTypeCast,
@@ -178,13 +179,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // handle internally, but we no longer cache across executes.
     if (!this.preparedStatements) {
       const stmt = this.db.prepare(sql);
-      this._maybeEnableSafeIntegers(stmt);
+      this._maybeEnableSafeIntegers(sql, stmt);
       return stmt;
     }
     let stmt = this._statementPool.get(sql);
     if (!stmt) {
       stmt = this.db.prepare(sql);
-      this._maybeEnableSafeIntegers(stmt);
+      this._maybeEnableSafeIntegers(sql, stmt);
       this._statementPool.set(sql, stmt);
     }
     return stmt;
@@ -194,14 +195,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // so the driver returns JS bigint rather than a lossy number. Non-bigint integer
   // columns in the same row also return bigint when safeIntegers is enabled —
   // IntegerType.cast handles bigint → number for those.
-  // columns() throws for non-SELECT statements; skip safeIntegers in that case.
-  private _maybeEnableSafeIntegers(stmt: Database.Statement): void {
-    let cols: Database.ColumnDefinition[];
-    try {
-      cols = stmt.columns();
-    } catch {
-      return;
-    }
+  private _maybeEnableSafeIntegers(sql: string, stmt: Database.Statement): void {
+    if (isWriteQuerySql(sql)) return;
+    const cols = stmt.columns();
     if (cols.some((c) => c.type !== null && /bigint/i.test(c.type))) {
       stmt.safeIntegers(true);
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -177,14 +177,34 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // `prepared_statements`. better-sqlite3 still uses its own statement
     // handle internally, but we no longer cache across executes.
     if (!this.preparedStatements) {
-      return this.db.prepare(sql);
+      const stmt = this.db.prepare(sql);
+      this._maybeEnableSafeIntegers(stmt);
+      return stmt;
     }
     let stmt = this._statementPool.get(sql);
     if (!stmt) {
       stmt = this.db.prepare(sql);
+      this._maybeEnableSafeIntegers(stmt);
       this._statementPool.set(sql, stmt);
     }
     return stmt;
+  }
+
+  // Enable safeIntegers on SELECT statements that return bigint-declared columns
+  // so the driver returns JS bigint rather than a lossy number. Non-bigint integer
+  // columns in the same row also return bigint when safeIntegers is enabled —
+  // IntegerType.cast handles bigint → number for those.
+  // columns() throws for non-SELECT statements; skip safeIntegers in that case.
+  private _maybeEnableSafeIntegers(stmt: Database.Statement): void {
+    let cols: Database.ColumnDefinition[];
+    try {
+      cols = stmt.columns();
+    } catch {
+      return;
+    }
+    if (cols.some((c) => c.type !== null && /bigint/i.test(c.type))) {
+      stmt.safeIntegers(true);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- **better-sqlite3**: enable \`safeIntegers\` per-statement when any declared column type matches \`/bigint/i\`, so \`BIGINT\` columns return JS \`bigint\` instead of a lossy \`number\`. Uses \`isWriteQuerySql()\` to short-circuit before calling \`columns()\` on non-SELECT statements — no exception-based control flow.
- **mysql2**: pass \`{ supportBigNumbers: true }\` before user config in \`newClient\`. mysql2 returns a decimal string for BIGINT values with ≥15 digits (≥ 10^14, mysql2's internal threshold) and a JS number for smaller values. Both are handled by \`BigIntegerType.cast()\`. Safe-range auto-increment PKs remain as numbers; existing code is unaffected.
- **pg**: no change. \`pg-types@2.2.0\` \`parseBigInteger\` already returns the raw decimal string for int8 — verified from vendored source at \`pg-types/lib/textParsers.js:113-117\`.
- **activemodel \`IntegerType.cast\`**: add explicit \`bigint → number\` branch. When \`safeIntegers\` is enabled on a statement, all integer columns return \`bigint\` — including non-bigint ones. \`IntegerType.cast\` coerces them back to \`number\`.

## sqlite-wasm forward-compat

No code added. \`BigIntegerType.cast()\` accepts \`bigint | string | number\` — whatever sqlite-wasm returns will be handled by the shared type layer.

## Test results

SQLite3 round-trip: 4 tests, all pass (no DB required).
mysql2 + pg round-trip tests require DB (\`pnpm test:db\`).