### PR TITLE
feat(activerecord): fix columnsForDistinct + extensions schema; unskip 3 pg adapter tests

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -634,7 +634,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("unparsed defaults are at least set when saving", async () => {});
     it.skip("only check for insensitive comparison capability once", async () => {});
     it("extensions omits current schema name", async () => {
-      await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      const wasEnabled = await adapter.extensionEnabled("hstore");
+      if (wasEnabled) await adapter.disableExtension("hstore");
       await adapter.exec(`CREATE SCHEMA IF NOT EXISTS customschema`);
       try {
         await adapter.exec(`CREATE EXTENSION hstore SCHEMA customschema`);
@@ -642,18 +643,18 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(exts).toContain("customschema.hstore");
       } finally {
         await adapter.exec(`DROP SCHEMA IF EXISTS customschema CASCADE`);
-        await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+        if (wasEnabled) await adapter.enableExtension("hstore");
       }
     });
 
     it("extensions includes non current schema name", async () => {
-      await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      const wasEnabled = await adapter.extensionEnabled("hstore");
+      if (!wasEnabled) await adapter.enableExtension("hstore");
       try {
-        await adapter.exec(`CREATE EXTENSION hstore`);
         const exts = await adapter.extensions();
         expect(exts).toContain("hstore");
       } finally {
-        await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+        if (!wasEnabled) await adapter.disableExtension("hstore");
       }
     });
     it.skip("ignores warnings when behaviour ignore", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -649,12 +649,18 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("extensions includes non current schema name", async () => {
       const wasEnabled = await adapter.extensionEnabled("hstore");
-      if (!wasEnabled) await adapter.enableExtension("hstore");
+      const currentSchemaRows = await adapter.execute(
+        `SELECT quote_ident(current_schema()) AS quoted_current_schema`,
+      );
+      const quotedCurrentSchema = currentSchemaRows[0].quoted_current_schema as string;
+      if (wasEnabled) await adapter.disableExtension("hstore");
       try {
+        await adapter.exec(`CREATE EXTENSION hstore SCHEMA ${quotedCurrentSchema}`);
         const exts = await adapter.extensions();
         expect(exts).toContain("hstore");
       } finally {
-        if (!wasEnabled) await adapter.disableExtension("hstore");
+        await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+        if (wasEnabled) await adapter.enableExtension("hstore");
       }
     });
     it.skip("ignores warnings when behaviour ignore", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -4,6 +4,7 @@
 import pg from "pg";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import * as Arel from "@blazetrails/arel";
 import {
   ConnectionNotEstablished,
   InvalidForeignKey,
@@ -142,13 +143,13 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("columns for distinct with order", async () => {
       expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc"])).toBe(
-        "posts.id, posts.created_at",
+        "posts.created_at AS alias_0, posts.id",
       );
     });
 
     it("columns for distinct with order and a column prefix", async () => {
       expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc", "posts.title"])).toBe(
-        "posts.id, posts.created_at, posts.title",
+        "posts.created_at AS alias_0, posts.title AS alias_1, posts.id",
       );
     });
     it("translate exception class", async () => {
@@ -609,13 +610,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("columns for distinct with nulls", async () => {
       expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc NULLS FIRST"])).toBe(
-        "posts.id, posts.created_at",
+        "posts.created_at AS alias_0, posts.id",
       );
     });
 
     it("columns for distinct without order specifiers", async () => {
       expect(adapter.columnsForDistinct("posts.id", ["posts.created_at"])).toBe(
-        "posts.id, posts.created_at",
+        "posts.created_at AS alias_0, posts.id",
       );
     });
     it.skip("raise error when cannot translate exception", async () => {});
@@ -623,8 +624,29 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("reload type map for newly defined types", async () => {});
     it.skip("unparsed defaults are at least set when saving", async () => {});
     it.skip("only check for insensitive comparison capability once", async () => {});
-    it.skip("extensions omits current schema name", async () => {});
-    it.skip("extensions includes non current schema name", async () => {});
+    it("extensions omits current schema name", async () => {
+      await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      await adapter.exec(`CREATE SCHEMA IF NOT EXISTS customschema`);
+      try {
+        await adapter.exec(`CREATE EXTENSION hstore SCHEMA customschema`);
+        const exts = await adapter.extensions();
+        expect(exts).toContain("customschema.hstore");
+      } finally {
+        await adapter.exec(`DROP SCHEMA IF EXISTS customschema CASCADE`);
+        await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      }
+    });
+
+    it("extensions includes non current schema name", async () => {
+      await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      try {
+        await adapter.exec(`CREATE EXTENSION hstore`);
+        const exts = await adapter.extensions();
+        expect(exts).toContain("hstore");
+      } finally {
+        await adapter.exec(`DROP EXTENSION IF EXISTS hstore`);
+      }
+    });
     it.skip("ignores warnings when behaviour ignore", async () => {});
     it.skip("logs warnings when behaviour log", async () => {});
     it.skip("raises warnings when behaviour raise", async () => {});
@@ -700,28 +722,37 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("columns for distinct one order", () => {
       expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc"])).toBe(
-        "posts.id, posts.created_at",
+        "posts.created_at AS alias_0, posts.id",
       );
     });
 
     it("columns for distinct few orders", () => {
       expect(
-        adapter.columnsForDistinct("posts.id", ["posts.created_at desc", "posts.updated_at asc"]),
-      ).toBe("posts.id, posts.created_at, posts.updated_at");
+        adapter.columnsForDistinct("posts.id", ["posts.created_at desc", "posts.position asc"]),
+      ).toBe("posts.created_at AS alias_0, posts.position AS alias_1, posts.id");
     });
 
     it("columns for distinct with case", () => {
-      expect(adapter.columnsForDistinct("posts.id", ["UPPER(posts.name)"])).toBe(
-        "posts.id, UPPER(posts.name)",
+      expect(
+        adapter.columnsForDistinct("posts.id", [
+          "CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END",
+        ]),
+      ).toBe(
+        "CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0, posts.id",
       );
     });
 
     it("columns for distinct blank not nil orders", () => {
-      expect(adapter.columnsForDistinct("posts.id", [""])).toBe("posts.id");
+      expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc", "", "   "])).toBe(
+        "posts.created_at AS alias_0, posts.id",
+      );
     });
 
-    it.skip("columns for distinct with arel order", () => {
-      /* needs Arel order node support */
+    it("columns for distinct with arel order", () => {
+      const order = new Arel.Nodes.Descending(Arel.sql("posts.created_at"));
+      expect(adapter.columnsForDistinct("posts.id", [order])).toBe(
+        "posts.created_at AS alias_0, posts.id",
+      );
     });
 
     it("bad connection", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -609,14 +609,23 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(indexes.find((i) => i.name === "idx_nulls_nd")).toBeDefined();
     });
     it("columns for distinct with nulls", async () => {
-      expect(adapter.columnsForDistinct("posts.id", ["posts.created_at desc NULLS FIRST"])).toBe(
-        "posts.created_at AS alias_0, posts.id",
+      expect(adapter.columnsForDistinct("posts.title", ["posts.updater_id desc nulls first"])).toBe(
+        "posts.updater_id AS alias_0, posts.title",
+      );
+      expect(adapter.columnsForDistinct("posts.title", ["posts.updater_id desc nulls last"])).toBe(
+        "posts.updater_id AS alias_0, posts.title",
       );
     });
 
     it("columns for distinct without order specifiers", async () => {
-      expect(adapter.columnsForDistinct("posts.id", ["posts.created_at"])).toBe(
-        "posts.created_at AS alias_0, posts.id",
+      expect(adapter.columnsForDistinct("posts.title", ["posts.updater_id"])).toBe(
+        "posts.updater_id AS alias_0, posts.title",
+      );
+      expect(adapter.columnsForDistinct("posts.title", ["posts.updater_id nulls last"])).toBe(
+        "posts.updater_id AS alias_0, posts.title",
+      );
+      expect(adapter.columnsForDistinct("posts.title", ["posts.updater_id nulls first"])).toBe(
+        "posts.updater_id AS alias_0, posts.title",
       );
     });
     it.skip("raise error when cannot translate exception", async () => {});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1853,20 +1853,35 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return pgTypeCast(value);
   }
 
-  columnsForDistinct(columns: string, orders: string[]): string {
-    if (!orders || orders.length === 0) return columns;
-    const orderColumns = orders
-      .map((o) => o.replace(/\s+(ASC|DESC)\s*(NULLS\s+(FIRST|LAST))?\s*/gi, "").trim())
-      .filter((c) => c.length > 0);
+  columnsForDistinct(columns: string, orders: (string | Nodes.Node)[]): string {
+    const visitor = this.arelVisitor;
+    const orderColumns = (orders ?? [])
+      .map((o) => (typeof o === "string" ? o : visitor.compile(o as Nodes.Node)))
+      .filter((o) => o.trim().length > 0)
+      .map((o, i) => {
+        const col = o
+          .replace(/\s+(?:ASC|DESC)\b/gi, "")
+          .replace(/\s+NULLS\s+(?:FIRST|LAST)\b/gi, "")
+          .trim();
+        return col.length > 0 ? `${col} AS alias_${i}` : null;
+      })
+      .filter((c): c is string => c !== null);
     if (orderColumns.length === 0) return columns;
-    return `${columns}, ${orderColumns.join(", ")}`;
+    return [...orderColumns, columns].join(", ");
   }
 
   async extensions(): Promise<string[]> {
-    const rows = await this.schemaQuery(
-      `SELECT extname FROM pg_extension WHERE extname != 'plpgsql'`,
-    );
-    return rows.map((r) => r.extname as string);
+    const rows = await this.schemaQuery(`
+      SELECT pg_extension.extname, n.nspname AS schema
+      FROM pg_extension
+      JOIN pg_namespace n ON pg_extension.extnamespace = n.oid
+      WHERE pg_extension.extname != 'plpgsql'
+    `);
+    const current = await this.currentSchema();
+    return rows.map((r) => {
+      const schema = r.schema === current ? null : (r.schema as string);
+      return [schema, r.extname as string].filter(Boolean).join(".");
+    });
   }
 
   async extensionEnabled(name: string): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1853,7 +1853,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return pgTypeCast(value);
   }
 
-  columnsForDistinct(columns: string, orders: (string | Nodes.Node)[]): string {
+  columnsForDistinct(columns: string | string[], orders: (string | Nodes.Node)[]): string {
+    const base = Array.isArray(columns) ? columns.join(", ") : columns;
     const visitor = this.arelVisitor;
     // Mirrors Rails two-pass compact_blank: filter blanks before AND after stripping
     // so an order that becomes empty after stripping (e.g. bare "DESC") doesn't
@@ -1869,11 +1870,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       )
       .filter((col) => col.length > 0)
       .map((col, i) => `${col} AS alias_${i}`);
-    if (orderColumns.length === 0) return columns;
-    return [...orderColumns, columns].join(", ");
+    if (orderColumns.length === 0) return base;
+    return [...orderColumns, base].join(", ");
   }
 
   async extensions(): Promise<string[]> {
+    // Rails does not filter plpgsql or any built-in extension — the full list
+    // (including pg_catalog.plpgsql) is returned, matching PostgreSQLAdapter#extensions.
     const rows = await this.schemaQuery(`
       SELECT pg_extension.extname, n.nspname AS schema,
              current_schema() AS current_schema

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1855,31 +1855,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   columnsForDistinct(columns: string, orders: (string | Nodes.Node)[]): string {
     const visitor = this.arelVisitor;
+    // Mirrors Rails two-pass compact_blank: filter blanks before AND after stripping
+    // so an order that becomes empty after stripping (e.g. bare "DESC") doesn't
+    // consume an alias index slot and shift subsequent aliases.
     const orderColumns = (orders ?? [])
       .map((o) => (typeof o === "string" ? o : visitor.compile(o as Nodes.Node)))
       .filter((o) => o.trim().length > 0)
-      .map((o, i) => {
-        const col = o
+      .map((o) =>
+        o
           .replace(/\s+(?:ASC|DESC)\b/gi, "")
           .replace(/\s+NULLS\s+(?:FIRST|LAST)\b/gi, "")
-          .trim();
-        return col.length > 0 ? `${col} AS alias_${i}` : null;
-      })
-      .filter((c): c is string => c !== null);
+          .trim(),
+      )
+      .filter((col) => col.length > 0)
+      .map((col, i) => `${col} AS alias_${i}`);
     if (orderColumns.length === 0) return columns;
     return [...orderColumns, columns].join(", ");
   }
 
   async extensions(): Promise<string[]> {
     const rows = await this.schemaQuery(`
-      SELECT pg_extension.extname, n.nspname AS schema
+      SELECT pg_extension.extname, n.nspname AS schema,
+             current_schema() AS current_schema
       FROM pg_extension
       JOIN pg_namespace n ON pg_extension.extnamespace = n.oid
-      WHERE pg_extension.extname != 'plpgsql'
     `);
-    const current = await this.currentSchema();
     return rows.map((r) => {
-      const schema = r.schema === current ? null : (r.schema as string);
+      const schema = r.schema === r.current_schema ? null : (r.schema as string);
       return [schema, r.extname as string].filter(Boolean).join(".");
     });
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1853,7 +1853,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return pgTypeCast(value);
   }
 
-  columnsForDistinct(columns: string | string[], orders: (string | Nodes.Node)[]): string {
+  columnsForDistinct(columns: string | string[], orders?: (string | Nodes.Node)[]): string {
     const base = Array.isArray(columns) ? columns.join(", ") : columns;
     const visitor = this.arelVisitor;
     // Mirrors Rails two-pass compact_blank: filter blanks before AND after stripping

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -235,7 +235,10 @@ export interface SchemaStatements {
       enumType?: string;
     },
   ): string;
-  columnsForDistinct(columns: string, orders: string[]): string;
+  columnsForDistinct(
+    columns: string | string[],
+    orders: (string | import("@blazetrails/arel").Nodes.Node)[],
+  ): string;
   updateTableDefinition(tableName: string, base: unknown): unknown;
   createSchemaDumper(options: unknown): unknown;
   foreignKeyColumnFor(tableName: string, columnName?: string): string;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -237,7 +237,7 @@ export interface SchemaStatements {
   ): string;
   columnsForDistinct(
     columns: string | string[],
-    orders: (string | import("@blazetrails/arel").Nodes.Node)[],
+    orders?: (string | import("@blazetrails/arel").Nodes.Node)[],
   ): string;
   updateTableDefinition(tableName: string, base: unknown): unknown;
   createSchemaDumper(options: unknown): unknown;


### PR DESCRIPTION
## Summary

- **`columnsForDistinct`**: Rails produces `"order_col AS alias_N, ..., base_cols"` — order columns come first with `AS alias_N` suffix. Our implementation had the order wrong (base columns first, no alias) and only accepted `string[]`. Now accepts `(string | Arel.Nodes.Node)[]`, compiling Arel nodes via the visitor. Fixed all existing test expectations that had the wrong output.
- **`extensions()`**: Fixed to JOIN `pg_namespace` and include the schema prefix for extensions not in the current schema (e.g. `"customschema.hstore"` vs `"hstore"`), matching Rails' `PostgreSQLAdapter#extensions`.

## Tests unskipped (3)

- `columns for distinct with arel order` — uses `new Nodes.Descending(sql("posts.created_at"))`
- `extensions omits current schema name` — creates hstore in a custom schema, verifies `"customschema.hstore"` in extensions list
- `extensions includes non current schema name` — creates hstore in default schema, verifies `"hstore"` (no prefix) in list

## Test plan

- [x] 117 pass, 33 skipped (up from 114/36)
- [x] `pnpm build` + `pnpm typecheck` — clean