### PR TITLE
fix(repo): committed bin wrappers so pnpm install is warning-free in fresh worktrees

### DIFF
--- a/packages/activerecord/bin/trails-schema-dump.js
+++ b/packages/activerecord/bin/trails-schema-dump.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/bin/trails-schema-dump.js";

--- a/packages/activerecord/bin/trails-tsc.js
+++ b/packages/activerecord/bin/trails-tsc.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/tsc-wrapper/cli.js";

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -40,8 +40,8 @@
     }
   },
   "bin": {
-    "trails-tsc": "./dist/tsc-wrapper/cli.js",
-    "trails-schema-dump": "./dist/bin/trails-schema-dump.js"
+    "trails-tsc": "./bin/trails-tsc.js",
+    "trails-schema-dump": "./bin/trails-schema-dump.js"
   },
   "scripts": {
     "build": "tsc"
@@ -55,7 +55,8 @@
     "typescript": ">=5.0.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "license": "MIT"
 }

--- a/packages/trailties/bin/trails.js
+++ b/packages/trailties/bin/trails.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/bin.js";

--- a/packages/trailties/package.json
+++ b/packages/trailties/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "trails": "./dist/bin.js"
+    "trails": "./bin/trails.js"
   },
   "exports": {
     ".": "./dist/cli.js",
@@ -14,7 +14,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "dependencies": {
     "@blazetrails/activerecord": "workspace:*",


### PR DESCRIPTION
## Summary

- `packages/activerecord` and `packages/trailties` had `package.json#bin` pointing at `./dist/*.js`. In a fresh worktree `dist/` does not yet exist (gitignored), so `pnpm install` emitted `WARN Failed to create bin …` and skipped the symlinks. Any later `pnpm exec trails-tsc` / `trails-schema-dump` / `trails` then failed until the worktree had been built.
- Added committed `.mjs` shim files under `packages/*/bin/` that dynamic-import the real `dist/` entrypoint. The shim paths always exist, so pnpm's install-time symlink always succeeds. Runtime behaviour is unchanged — the shim just forwards to the built module.
- Added `bin` to the `files` array of each package so the wrappers are included when published.

## Test plan

- [x] Fresh `git worktree add` + `pnpm install` — no `Failed to create bin` warnings; `.bin/trails-tsc` etc. present in downstream packages' `node_modules/.bin/`.
- [ ] CI green.