### PR TITLE
feat(activerecord): adapter-prevent-writes + MySQL type map + mysql-type-lookup tests

### DIFF
--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -1,15 +1,156 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/adapter_prevent_writes_test.rb
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { ReadOnlyError } from "./errors.js";
+
+let adapter: SQLite3Adapter;
+
+beforeEach(() => {
+  adapter = new SQLite3Adapter(":memory:");
+  adapter.exec(`CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`);
+});
+
+afterEach(() => {
+  adapter.close();
+});
 
 describe("AdapterPreventWritesTest", () => {
-  it.skip("preventing writes predicate", () => {});
-  it.skip("doesnt error when a select query has encoding errors", () => {});
-  it.skip("doesnt error when a select query has encoding errors", () => {});
-  it.skip("doesnt error when a read query with a cte is called while preventing writes", () => {});
-  it.skip("doesnt error when a select query starting with a slash star comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a slash star comment is called while preventing writes", () => {});
-  it.skip("doesnt error when a select query starting with double dash comments is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a double dash comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a multiline double dash comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a slash star comment containing read command is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a double dash comment containing read command is called while preventing writes", () => {});
+  it("preventing writes predicate", async () => {
+    expect(adapter.preventingWrites).toBe(false);
+
+    await adapter.withPreventedWrites(async () => {
+      expect(adapter.preventingWrites).toBe(true);
+    });
+
+    expect(adapter.preventingWrites).toBe(false);
+  });
+
+  it("errors when an insert query is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an update query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `UPDATE "subscribers" SET "nick" = 'updated' WHERE "nick" = 'test'`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when a delete query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`DELETE FROM "subscribers" WHERE "nick" = 'test'`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("doesnt error when a select query has encoding errors", async () => {
+    await adapter.withPreventedWrites(async () => {
+      // SQLite returns invalid bytes as-is rather than failing
+      await expect(adapter.execute(`SELECT '\xC8'`)).resolves.toBeDefined();
+    });
+  });
+
+  it("doesnt error when a select query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(`SELECT * FROM "subscribers" WHERE "nick" = 'test'`);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("doesnt error when a read query with a cte is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(`
+        WITH matching AS (SELECT * FROM "subscribers" WHERE "nick" = 'test')
+        SELECT * FROM matching
+      `);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("doesnt error when a select query starting with a slash star comment is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(
+        `/* some comment */ SELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("errors when an insert query prefixed by a slash star comment is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `/* some comment */ INSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("doesnt error when a select query starting with double dash comments is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(
+        `-- some comment\n-- comment about INSERT\nSELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("errors when an insert query prefixed by a double dash comment is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `-- some comment\nINSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a multiline double dash comment is called while preventing writes", async () => {
+    const manyComments = "-- comment\n".repeat(50);
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `${manyComments}INSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a slash star comment containing read command is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`/* SELECT */ INSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a double dash comment containing read command is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`-- SELECT\nINSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -599,6 +599,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     map.registerType(/^int/i, undefined, intType(4));
     map.registerType(/^year/i, undefined, () => new IntegerType());
     map.registerType(/^bit/i, undefined, () => new BinaryType());
+    map.registerType(/^binary/i, undefined, () => new BinaryType());
+    map.registerType(/^varbinary/i, undefined, () => new BinaryType());
     map.registerType(/^enum/i, undefined, () => new StringType());
     map.registerType(/^set/i, undefined, () => new StringType());
     map.registerType(/^char/i, undefined, () => new StringType());
@@ -609,7 +611,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     map.registerType("date", new DateType());
     map.registerType(/^datetime/i, undefined, () => new DateTimeType());
     map.registerType(/^timestamp/i, undefined, () => new DateTimeType());
-    map.registerType(/^time/i, undefined, () => new TimeType());
+    map.registerType(/^time\b/i, undefined, () => new TimeType());
     map.registerType("json", new JsonType());
     // emulate_booleans: tinyint(1) → boolean
     if (options.emulateBooleans) {
@@ -645,8 +647,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   lookupCastTypeFromColumn(column: {
     sqlType?: string | null;
-  }): import("@blazetrails/activemodel").Type {
-    return this.lookupCastType(column.sqlType ?? "");
+  }): import("@blazetrails/activemodel").Type | null {
+    const sqlType = column.sqlType?.trim();
+    if (!sqlType) return null;
+    return this.lookupCastType(sqlType);
   }
 
   static extendedTypeMap(options: {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -31,6 +31,21 @@ import {
   columnNameWithOrderMatcher as mysqlColumnNameWithOrderMatcher,
 } from "./mysql/quoting.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import { TypeMap } from "../type/type-map.js";
+import {
+  StringType,
+  IntegerType,
+  FloatType,
+  BooleanType,
+  BinaryType,
+  DecimalType,
+} from "@blazetrails/activemodel";
+import { UnsignedInteger } from "../type/unsigned-integer.js";
+import { Date as DateType } from "../type/date.js";
+import { DateTime as DateTimeType } from "../type/date-time.js";
+import { Time as TimeType } from "../type/time.js";
+import { Text as TextType } from "../type/text.js";
+import { Json as JsonType } from "../type/json.js";
 
 const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
@@ -559,6 +574,79 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (config.sslKey) args.push(`--ssl-key=${config.sslKey}`);
     if (config.database) args.push(config.database as string);
     return args;
+  }
+
+  // Mirrors: AbstractMysqlAdapter::initialize_type_map + extended_type_map
+  static buildTypeMap(options: { emulateBooleans?: boolean } = {}): TypeMap {
+    const map = new TypeMap();
+    const intType = (limit: number) => (sql: string) =>
+      /\bunsigned\b/i.test(sql) ? new UnsignedInteger({ limit }) : new IntegerType({ limit });
+
+    map.registerType(/tinytext/i, undefined, () => new TextType());
+    map.registerType(/tinyblob/i, undefined, () => new BinaryType());
+    map.registerType(/mediumtext/i, undefined, () => new TextType());
+    map.registerType(/mediumblob/i, undefined, () => new BinaryType());
+    map.registerType(/longtext/i, undefined, () => new TextType());
+    map.registerType(/longblob/i, undefined, () => new BinaryType());
+    map.registerType(/text/i, undefined, () => new TextType());
+    map.registerType(/blob/i, undefined, () => new BinaryType());
+    map.registerType(/^float/i, undefined, () => new FloatType());
+    map.registerType(/^double/i, undefined, () => new FloatType());
+    map.registerType(/^bigint/i, undefined, intType(8));
+    map.registerType(/^mediumint/i, undefined, intType(3));
+    map.registerType(/^smallint/i, undefined, intType(2));
+    map.registerType(/^tinyint/i, undefined, intType(1));
+    map.registerType(/^int/i, undefined, intType(4));
+    map.registerType(/^year/i, undefined, () => new IntegerType());
+    map.registerType(/^bit/i, undefined, () => new BinaryType());
+    map.registerType(/^enum/i, undefined, () => new StringType());
+    map.registerType(/^set/i, undefined, () => new StringType());
+    map.registerType(/^char/i, undefined, () => new StringType());
+    map.registerType(/^varchar/i, undefined, () => new StringType());
+    map.registerType(/decimal/i, undefined, () => new DecimalType());
+    map.registerType(/numeric/i, undefined, () => new DecimalType());
+    map.registerType("boolean", new BooleanType());
+    map.registerType("date", new DateType());
+    map.registerType(/^datetime/i, undefined, () => new DateTimeType());
+    map.registerType(/^timestamp/i, undefined, () => new DateTimeType());
+    map.registerType(/^time/i, undefined, () => new TimeType());
+    map.registerType("json", new JsonType());
+    // emulate_booleans: tinyint(1) → boolean
+    if (options.emulateBooleans) {
+      map.registerType(/^tinyint\(1\)/i, undefined, () => new BooleanType());
+    }
+    return map;
+  }
+
+  private _typeMap: TypeMap | null = null;
+  private _emulateBooleans = true;
+
+  get emulateBooleans(): boolean {
+    return this._emulateBooleans;
+  }
+
+  set emulateBooleans(value: boolean) {
+    this._emulateBooleans = value;
+    this._typeMap = null; // invalidate cache
+  }
+
+  get nativeTypeMap(): TypeMap {
+    if (!this._typeMap) {
+      this._typeMap = (this.constructor as typeof AbstractMysqlAdapter).buildTypeMap({
+        emulateBooleans: this._emulateBooleans,
+      });
+    }
+    return this._typeMap;
+  }
+
+  lookupCastType(sqlType: string): import("@blazetrails/activemodel").Type {
+    return this.nativeTypeMap.lookup(sqlType.toLowerCase().trim());
+  }
+
+  lookupCastTypeFromColumn(column: {
+    sqlType?: string | null;
+  }): import("@blazetrails/activemodel").Type {
+    return this.lookupCastType(column.sqlType ?? "");
   }
 
   static extendedTypeMap(options: {

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -1,8 +1,72 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
+
+// Minimal subclass — only the type map is needed; no live connection.
+class TestMysqlAdapter extends AbstractMysqlAdapter {
+  constructor() {
+    super();
+  }
+  override isWriteQuery(sql: string): boolean {
+    return /^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|ALTER|DROP|TRUNCATE)/i.test(sql);
+  }
+}
+
+let adapter: TestMysqlAdapter;
+
+beforeEach(() => {
+  adapter = new TestMysqlAdapter();
+  adapter.emulateBooleans = true;
+});
+
+function assertLookupType(expected: string, lookup: string) {
+  const castType = adapter.lookupCastType(lookup);
+  expect(castType.type()).toBe(expected);
+}
 
 describe("MysqlTypeLookupTest", () => {
-  it.skip("boolean types", () => {});
-  it.skip("string types", () => {});
-  it.skip("set type with value matching other type", () => {});
-  it.skip("enum type with value matching other type", () => {});
+  it("boolean types", () => {
+    // emulate_booleans = true: tinyint(1) → boolean
+    assertLookupType("boolean", "tinyint(1)");
+    assertLookupType("boolean", "TINYINT(1)");
+
+    // emulate_booleans = false: tinyint(1) → integer
+    adapter.emulateBooleans = false;
+    assertLookupType("integer", "tinyint(1)");
+    assertLookupType("integer", "TINYINT(1)");
+  });
+
+  it("string types", () => {
+    assertLookupType("string", "enum('one', 'two', 'three')");
+    assertLookupType("string", "ENUM('one', 'two', 'three')");
+    assertLookupType("string", "enum ('one', 'two', 'three')");
+    assertLookupType("string", "ENUM ('one', 'two', 'three')");
+    assertLookupType("string", "set('one', 'two', 'three')");
+    assertLookupType("string", "SET('one', 'two', 'three')");
+    assertLookupType("string", "set ('one', 'two', 'three')");
+    assertLookupType("string", "SET ('one', 'two', 'three')");
+  });
+
+  it("set type with value matching other type", () => {
+    assertLookupType("string", "SET('unicode', '8bit', 'none', 'time')");
+  });
+
+  it("enum type with value matching other type", () => {
+    assertLookupType("string", "ENUM('unicode', '8bit', 'none', 'time')");
+  });
+
+  it("binary types", () => {
+    assertLookupType("binary", "bit");
+    assertLookupType("binary", "BIT");
+  });
+
+  it("integer types", () => {
+    adapter.emulateBooleans = false;
+    assertLookupType("integer", "tinyint(1)");
+    assertLookupType("integer", "TINYINT(1)");
+    assertLookupType("integer", "year");
+    assertLookupType("integer", "YEAR");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -60,6 +60,8 @@ describe("MysqlTypeLookupTest", () => {
   it("binary types", () => {
     assertLookupType("binary", "bit");
     assertLookupType("binary", "BIT");
+    assertLookupType("binary", "binary(100)");
+    assertLookupType("binary", "varbinary(255)");
   });
 
   it("integer types", () => {


### PR DESCRIPTION
## Summary

- **`adapter-prevent-writes.test.ts`** (14 tests): unskips all 11 stubs + adds 4 missing Rails tests (insert/update/delete/select while preventing writes). Tests `withPreventedWrites`, `ReadOnlyError` on mutations, SELECT passthrough, CTE passthrough, comment-prefixed query handling.

- **`AbstractMysqlAdapter.buildTypeMap()`**: Rails-parity type map mirroring `initialize_type_map` — tinyint/int/bigint/mediumint/smallint with unsigned support, text/blob variants, float/double, year→integer, bit→binary, enum/set→string, decimal/numeric, datetime/timestamp/time/date/json. `emulateBooleans` flag makes tinyint(1) → boolean. Adds `nativeTypeMap`, `lookupCastType()`, `lookupCastTypeFromColumn()`.

- **`connection-adapters/mysql-type-lookup.test.ts`** (6 tests): implements all 4 stubs + 2 new Rails tests (binary, integer types) using a minimal `TestMysqlAdapter` — no live DB needed.

## Test plan
- [ ] `pnpm test` — all pass, no regressions
- [ ] `pnpm run test:compare --package activerecord` — improved counts on both files