### PR TITLE
feat(activerecord): trails-models-dump CLI (PR 3 of 4)

### DIFF
--- a/packages/activerecord/bin/trails-models-dump.js
+++ b/packages/activerecord/bin/trails-models-dump.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/bin/trails-models-dump.js";

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -41,7 +41,8 @@
   },
   "bin": {
     "trails-tsc": "./bin/trails-tsc.js",
-    "trails-schema-dump": "./bin/trails-schema-dump.js"
+    "trails-schema-dump": "./bin/trails-schema-dump.js",
+    "trails-models-dump": "./bin/trails-models-dump.js"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/activerecord/src/bin/trails-models-dump.test.ts
+++ b/packages/activerecord/src/bin/trails-models-dump.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,6 +48,35 @@ function applySchema(dbPath: string, sql: string): void {
     db.close();
   }
 }
+
+// The CLI imports from @blazetrails/activesupport (via getFsAsync) and
+// transitively from @blazetrails/arel / activemodel. pnpm workspace
+// resolution points those imports at each package's dist/index.js. The
+// unit-test CI job doesn't build workspace packages first, so when any
+// expected dist/ is missing we build the three the CLI depends on in
+// dependency order (activesupport → activemodel → arel). Building them
+// in a single `--filter a --filter b --filter c` call races — pnpm may
+// start activemodel/arel before activesupport's dist lands, causing
+// "Cannot find module @blazetrails/activesupport". Serial invocation
+// is predictable and still fast when already built (tsc incremental).
+beforeAll(() => {
+  const packagesRoot = resolve(REPO_ROOT, "packages");
+  const depsInOrder = ["activesupport", "activemodel", "arel"];
+  const anyMissing = depsInOrder.some(
+    (p) => !existsSync(join(packagesRoot, p, "dist", "index.js")),
+  );
+  if (!anyMissing) return;
+  for (const pkg of depsInOrder) {
+    const res = spawnSync("pnpm", ["--filter", `@blazetrails/${pkg}`, "build"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: "inherit",
+    });
+    if (res.status !== 0) {
+      throw new Error(`failed to build @blazetrails/${pkg} for the test fixture`);
+    }
+  }
+}, 180_000);
 
 describe("trails-models-dump CLI", () => {
   let tmp: string;

--- a/packages/activerecord/src/bin/trails-models-dump.test.ts
+++ b/packages/activerecord/src/bin/trails-models-dump.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+// Integration tests for trails-models-dump. Each case spins up an in-memory
+// SQLite DB (persisted to a tmp file so the adapter can reconnect to it),
+// applies a small schema, invokes the bin via tsx, and asserts the
+// generated module shape or exit behaviour.
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "../../../..");
+const BIN_PATH = join(SCRIPT_DIR, "trails-models-dump.ts");
+const TSX_BIN = resolve(
+  REPO_ROOT,
+  "node_modules/.bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runDump(args: string[], env: NodeJS.ProcessEnv = {}): RunResult {
+  const res = spawnSync(TSX_BIN, [BIN_PATH, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    cwd: REPO_ROOT,
+  });
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+function applySchema(dbPath: string, sql: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.pragma("foreign_keys = ON");
+    db.exec(sql);
+  } finally {
+    db.close();
+  }
+}
+
+describe("trails-models-dump CLI", () => {
+  let tmp: string;
+  let dbPath: string;
+  let outPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "tmd-"));
+    dbPath = join(tmp, "test.db");
+    outPath = join(tmp, "models.ts");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("prints usage and exits 0 on --help", () => {
+    const { code, stdout } = runDump(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/Usage: trails-models-dump/);
+  });
+
+  it("exits 1 with pointed error when no database URL is provided", () => {
+    // Strip DATABASE_URL so the env-fallback doesn't kick in.
+    const { code, stderr } = runDump([], { DATABASE_URL: "" });
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/no database URL/);
+  });
+
+  it("exits 1 when --only and --ignore are both passed", () => {
+    const { code, stderr } = runDump(["--only", "a", "--ignore", "b"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/--only and --ignore are mutually exclusive/);
+  });
+
+  it("exits 1 on unknown argument", () => {
+    const { code, stderr } = runDump(["--nope"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/unknown argument: --nope/);
+  });
+
+  it("generates a valid model module from a three-table SQLite DB", () => {
+    applySchema(
+      dbPath,
+      `
+      CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT);
+      CREATE TABLE books (
+        id INTEGER PRIMARY KEY,
+        author_id INTEGER NOT NULL REFERENCES authors(id),
+        title TEXT
+      );
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY,
+        book_id INTEGER NOT NULL REFERENCES books(id),
+        body TEXT
+      );
+      `,
+    );
+
+    const { code, stdout, stderr } = runDump([
+      "--database-url",
+      `sqlite3://${dbPath}`,
+      "--out",
+      outPath,
+    ]);
+    expect(code, `stderr: ${stderr}\nstdout: ${stdout}`).toBe(0);
+    expect(stdout).toMatch(new RegExp(`wrote .*${outPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+
+    const generated = readFileSync(outPath, "utf8");
+    expect(generated).toMatch(/import \{ Base \} from "@blazetrails\/activerecord";/);
+    expect(generated).toMatch(/export class Author extends Base \{/);
+    expect(generated).toMatch(/export class Book extends Base \{/);
+    expect(generated).toMatch(/export class Review extends Base \{/);
+    expect(generated).toMatch(/this\.belongsTo\("author"\)/);
+    expect(generated).toMatch(/this\.hasMany\("books"\)/);
+    expect(generated).toMatch(/this\.belongsTo\("book"\)/);
+    expect(generated).toMatch(/this\.hasMany\("reviews"\)/);
+  });
+
+  it("ignores built-in bookkeeping tables by default", () => {
+    applySchema(
+      dbPath,
+      `
+      CREATE TABLE schema_migrations (version TEXT PRIMARY KEY);
+      CREATE TABLE ar_internal_metadata (key TEXT PRIMARY KEY, value TEXT);
+      CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+      `,
+    );
+
+    const { code, stdout } = runDump(["--database-url", `sqlite3://${dbPath}`]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/export class User extends Base/);
+    expect(stdout).not.toMatch(/class SchemaMigration/);
+    expect(stdout).not.toMatch(/class ArInternalMetadatum/);
+  });
+
+  it("exits 1 when --only matches no tables", () => {
+    applySchema(dbPath, `CREATE TABLE users (id INTEGER PRIMARY KEY);`);
+    const { code, stderr } = runDump([
+      "--database-url",
+      `sqlite3://${dbPath}`,
+      "--only",
+      "does_not_exist",
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/no tables to generate/);
+  });
+
+  it("writes to stdout when --out is absent", () => {
+    applySchema(dbPath, `CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT);`);
+    const { code, stdout } = runDump(["--database-url", `sqlite3://${dbPath}`]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/export class Widget extends Base/);
+  });
+
+  it("creates --out parent directories that don't exist", () => {
+    applySchema(dbPath, `CREATE TABLE widgets (id INTEGER PRIMARY KEY);`);
+    const nested = join(tmp, "deep", "nested", "models.ts");
+    const { code, stderr } = runDump(["--database-url", `sqlite3://${dbPath}`, "--out", nested]);
+    expect(code, `stderr: ${stderr}`).toBe(0);
+    // File exists now.
+    expect(readFileSync(nested, "utf8")).toMatch(/export class Widget/);
+  });
+
+  it("respects --strip-prefix", () => {
+    applySchema(
+      dbPath,
+      `
+      CREATE TABLE blog_posts (id INTEGER PRIMARY KEY, title TEXT);
+      `,
+    );
+    const { code, stdout } = runDump([
+      "--database-url",
+      `sqlite3://${dbPath}`,
+      "--strip-prefix",
+      "blog_",
+      "--no-header",
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/export class Post extends Base/);
+    expect(stdout).toMatch(/this\._tableName = "blog_posts"/);
+  });
+
+  it("suppresses the GENERATED header with --no-header", () => {
+    applySchema(dbPath, `CREATE TABLE items (id INTEGER PRIMARY KEY);`);
+    const { code, stdout } = runDump(["--database-url", `sqlite3://${dbPath}`, "--no-header"]);
+    expect(code).toBe(0);
+    expect(stdout).not.toMatch(/GENERATED by trails-models-dump/);
+  });
+
+  it("falls back to env DATABASE_URL when --database-url is absent", () => {
+    applySchema(dbPath, `CREATE TABLE items (id INTEGER PRIMARY KEY);`);
+    const { code, stdout } = runDump(["--no-header"], {
+      DATABASE_URL: `sqlite3://${dbPath}`,
+    });
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/export class Item extends Base/);
+  });
+
+  it("uses DATABASE_URL as sourceHint in the header", () => {
+    applySchema(dbPath, `CREATE TABLE items (id INTEGER PRIMARY KEY);`);
+    const { code, stdout } = runDump(["--database-url", `sqlite3://${dbPath}`]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(
+      new RegExp(`from sqlite3://${dbPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+    );
+  });
+});

--- a/packages/activerecord/src/bin/trails-models-dump.ts
+++ b/packages/activerecord/src/bin/trails-models-dump.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+/**
+ * Dump the live database schema as a TypeScript module declaring one
+ * `@blazetrails/activerecord` model class per table, with belongsTo /
+ * hasMany associations inferred from foreign keys.
+ *
+ * Usage:
+ *   trails-models-dump [--database-url <url>] [--out <path>]
+ *                      [--ignore t1,t2] [--only t1,t2]
+ *                      [--strip-prefix <str>] [--strip-suffix <str>]
+ *                      [--no-header] [--format]
+ *
+ * The database URL is taken from, in order:
+ *   1. --database-url <url>
+ *   2. $DATABASE_URL
+ *
+ * Output:
+ *   --out <path>   writes a .ts module to the given file
+ *   (absent)       prints the .ts module to stdout
+ *
+ * The generated module is pure trails ActiveRecord — `class X extends Base`
+ * with static-block declarations. Users own the file afterward; there is
+ * no round-trip merge. Re-running regenerates.
+ */
+
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+
+import { Base } from "../base.js";
+import {
+  introspectTables,
+  introspectColumns,
+  introspectPrimaryKey,
+  introspectForeignKeys,
+} from "../schema-introspection.js";
+import { generateModels, type IntrospectedTable } from "../model-codegen.js";
+
+interface Args {
+  databaseUrl?: string;
+  outPath?: string;
+  ignore: readonly string[];
+  only: readonly string[];
+  stripPrefix?: string;
+  stripSuffix?: string;
+  noHeader: boolean;
+  format: boolean;
+}
+
+function usage(stream: NodeJS.WriteStream): void {
+  stream.write(
+    "Usage: trails-models-dump [--database-url <url>] [--out <path>]\n" +
+      "                         [--ignore t1,t2] [--only t1,t2]\n" +
+      "                         [--strip-prefix <str>] [--strip-suffix <str>]\n" +
+      "                         [--no-header] [--format]\n",
+  );
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const out: {
+    databaseUrl?: string;
+    outPath?: string;
+    ignore: string[];
+    only: string[];
+    stripPrefix?: string;
+    stripSuffix?: string;
+    noHeader: boolean;
+    format: boolean;
+  } = { ignore: [], only: [], noHeader: false, format: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    const readValue = (flag: string): string => {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        process.stderr.write(`trails-models-dump: ${flag} expects a value.\n`);
+        process.exit(1);
+      }
+      i++;
+      return next;
+    };
+    if (a === "--database-url") out.databaseUrl = readValue("--database-url");
+    else if (a.startsWith("--database-url=")) out.databaseUrl = a.slice("--database-url=".length);
+    else if (a === "--out") out.outPath = readValue("--out");
+    else if (a.startsWith("--out=")) out.outPath = a.slice("--out=".length);
+    else if (a === "--ignore") {
+      out.ignore.push(...readValue("--ignore").split(",").filter(Boolean));
+    } else if (a.startsWith("--ignore=")) {
+      out.ignore.push(...a.slice("--ignore=".length).split(",").filter(Boolean));
+    } else if (a === "--only") {
+      out.only.push(...readValue("--only").split(",").filter(Boolean));
+    } else if (a.startsWith("--only=")) {
+      out.only.push(...a.slice("--only=".length).split(",").filter(Boolean));
+    } else if (a === "--strip-prefix") out.stripPrefix = readValue("--strip-prefix");
+    else if (a.startsWith("--strip-prefix=")) out.stripPrefix = a.slice("--strip-prefix=".length);
+    else if (a === "--strip-suffix") out.stripSuffix = readValue("--strip-suffix");
+    else if (a.startsWith("--strip-suffix=")) out.stripSuffix = a.slice("--strip-suffix=".length);
+    else if (a === "--no-header") out.noHeader = true;
+    else if (a === "--format") out.format = true;
+    else if (a === "-h" || a === "--help") {
+      usage(process.stdout);
+      process.exit(0);
+    } else {
+      process.stderr.write(`trails-models-dump: unknown argument: ${a}\n`);
+      process.exit(1);
+    }
+  }
+  if (out.ignore.length > 0 && out.only.length > 0) {
+    process.stderr.write("trails-models-dump: --only and --ignore are mutually exclusive\n");
+    process.exit(1);
+  }
+  return out;
+}
+
+// Built-ins match trails-schema-dump — metadata tables Rails maintains
+// that users shouldn't be modelling.
+const BUILTIN_IGNORE = new Set(["schema_migrations", "ar_internal_metadata"]);
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const url = args.databaseUrl ?? process.env.DATABASE_URL;
+  if (!url) {
+    process.stderr.write(
+      "trails-models-dump: no database URL — pass --database-url or set DATABASE_URL.\n",
+    );
+    process.exit(1);
+  }
+
+  await Base.establishConnection(url);
+  const adapter = Base.adapter;
+
+  const allTables = await introspectTables(adapter);
+  const ignoreSet = new Set([...BUILTIN_IGNORE, ...args.ignore]);
+  const onlySet = args.only.length > 0 ? new Set(args.only) : null;
+  const keep = (name: string): boolean => {
+    if (onlySet) return onlySet.has(name);
+    return !ignoreSet.has(name);
+  };
+  const tableNames = allTables.filter(keep);
+
+  if (tableNames.length === 0) {
+    process.stderr.write("trails-models-dump: no tables to generate (check --only/--ignore)\n");
+    process.exit(1);
+  }
+
+  // Assemble IntrospectedTable[] — run the four introspection helpers per
+  // table in parallel. generateModels requires primaryKey / foreignKeys /
+  // columns; we pass columns through for polymorphic + STI detection.
+  const introspected: IntrospectedTable[] = await Promise.all(
+    tableNames.map(async (name): Promise<IntrospectedTable> => {
+      const [pk, cols, fks] = await Promise.all([
+        introspectPrimaryKey(adapter, name),
+        introspectColumns(adapter, name),
+        introspectForeignKeys(adapter, name),
+      ]);
+      // introspectPrimaryKey normalises no-PK to []; treat [] as null for
+      // generateModels's view-skip logic so the header tally picks it up.
+      const primaryKey = pk.length === 0 ? null : pk.length === 1 ? pk[0]! : pk;
+      return {
+        name,
+        primaryKey,
+        foreignKeys: fks,
+        columns: cols.map((c) => ({
+          name: c.name,
+          type: c.sqlType ?? c.type ?? "",
+        })),
+      };
+    }),
+  );
+
+  let output = generateModels(introspected, {
+    sourceHint: url,
+    stripPrefix: args.stripPrefix,
+    stripSuffix: args.stripSuffix,
+    noHeader: args.noHeader,
+  });
+
+  if (args.format) {
+    output = await maybePrettierFormat(output);
+  }
+
+  if (args.outPath) {
+    // getFsAsync / getPathAsync auto-register a Node adapter via dynamic
+    // import(), which works both in ESM (tsx) and CJS (built bin). The sync
+    // getFs()/getPath() variants auto-register via require(), which returns
+    // undefined under ESM — so the async pair is the portable choice here.
+    const path = await getPathAsync();
+    const fs = await getFsAsync();
+    const resolved = path.resolve(args.outPath);
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.writeFileSync(resolved, output);
+    process.stdout.write(`trails-models-dump: wrote ${resolved}\n`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+async function maybePrettierFormat(code: string): Promise<string> {
+  try {
+    // Dynamic import so prettier stays an opt-in runtime dep — users who
+    // don't pass --format never need it installed.
+    const prettier = (await import("prettier")) as {
+      format(src: string, opts: { parser: string }): Promise<string>;
+    };
+    return await prettier.format(code, { parser: "typescript" });
+  } catch {
+    process.stderr.write(
+      "trails-models-dump: warning: --format requested but prettier is not installed; writing unformatted output\n",
+    );
+    return code;
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`trails-models-dump: ${msg}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Stacked on #786 (model-codegen). Wires PR 1's introspection + PR 2's codegen into a user-facing bin.

## Usage

```
trails-models-dump [--database-url <url>] [--out <path>]
                   [--ignore t1,t2] [--only t1,t2]
                   [--strip-prefix <str>] [--strip-suffix <str>]
                   [--no-header] [--format]
```

Layout, flag parsing, exit codes, and error format mirror `bin/trails-schema-dump.ts` exactly.

## Implementation notes

- **`getFsAsync`/`getPathAsync`**: the sync variants auto-register via `require()`, which returns undefined under ESM (tsx). The async pair uses dynamic `import()` and works in both ESM source and the CJS-compiled bin.
- **Parallel introspection**: four helpers run via `Promise.all` per table, so large schemas don't serialise PRAGMA queries.
- **Primary-key normalisation**: `introspectPrimaryKey` returns `[]` for no-PK tables; the CLI converts `[]` to `null` before handing to `generateModels`, which uses `null` as the view-skip signal.
- **Prettier opt-in**: `--format` dynamically imports prettier; if absent, writes unformatted output with a stderr warning. No hard dependency.

## Tests (13 integration cases)

`--help`, missing URL, `--only + --ignore` conflict, unknown arg, end-to-end 3-table SQLite, built-in ignores, `--only` misses, stdout fallback, mkdir -p for `--out` parent, `--strip-prefix`, `--no-header`, env `DATABASE_URL` fallback, sourceHint in header.

All 13 pass.

## package.json

```
"bin": {
  ...,
  "trails-schema-dump": "./dist/bin/trails-schema-dump.js",
  "trails-models-dump": "./dist/bin/trails-models-dump.js"
}
```