### PR TITLE
feat(activerecord): bigint PR 2 — type system flip

### DIFF
--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -177,12 +177,31 @@ class Article extends Base {
   }
 }
 
+// --- big_integer attribute typing ---
+class BigRecord extends Base {
+  declare score: bigint;
+  declare smallId: bigint;
+
+  static {
+    this.attribute("score", "big_integer");
+    this.attribute("smallId", "big_integer");
+  }
+}
+
 describe("declare patterns — typing runtime-attached members", () => {
   it("attributes: `declare name: string` exposes the typed field", () => {
     const u = new User({ name: "dean", email: "d@example.com", admin: false });
     expectTypeOf(u.name).toBeString();
     expectTypeOf(u.email).toBeString();
     expectTypeOf(u.admin).toBeBoolean();
+  });
+
+  it("big_integer attribute: `declare score: bigint` exposes bigint field", () => {
+    const r = new BigRecord({ score: 2n ** 62n });
+    expectTypeOf(r.score).toEqualTypeOf<bigint>();
+    expectTypeOf(r.smallId).toEqualTypeOf<bigint>();
+    // PrimaryKeyScalar includes bigint
+    expectTypeOf<bigint>().toMatchTypeOf<import("@blazetrails/activerecord").PrimaryKeyScalar>();
   });
 
   it("hasMany accessor: `declare comments: AssociationProxy<Comment>` (chainable + awaitable + array-shaped)", async () => {

--- a/packages/activerecord/src/attribute-methods/query.test.ts
+++ b/packages/activerecord/src/attribute-methods/query.test.ts
@@ -57,6 +57,26 @@ describe("QueryTest", () => {
     expect(p.queryAttribute("views")).toBe(true);
   });
 
+  it("query attribute returns false for zero bigint", () => {
+    class Post extends Base {
+      static {
+        this.attribute("score", "big_integer");
+      }
+    }
+    const p = new Post({ score: 0n });
+    expect(p.queryAttribute("score")).toBe(false);
+  });
+
+  it("query attribute returns true for non-zero bigint", () => {
+    class Post extends Base {
+      static {
+        this.attribute("score", "big_integer");
+      }
+    }
+    const p = new Post({ score: 2n ** 62n });
+    expect(p.queryAttribute("score")).toBe(true);
+  });
+
   it("query attribute respects overridden getter", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -63,6 +63,7 @@ export function _queryAttribute(this: RawReadable, name: string): boolean {
 function castToBoolean(value: unknown): boolean {
   if (value === null || value === undefined) return false;
   if (typeof value === "number") return value !== 0;
+  if (typeof value === "bigint") return value !== 0n;
   const cast = booleanType.cast(value);
   if (cast !== null) return cast;
   return !!value;

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -13,6 +13,7 @@ import {
   setRaiseOnAssignToAttrReadonly,
 } from "./index.js";
 import { SubclassNotFound, NameError } from "./errors.js";
+import { quoteSqlValue } from "./base.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import { registerModel } from "./associations.js";
@@ -2985,6 +2986,27 @@ describe("BasicsTest", () => {
       }
     }
     expect(User.tableName).toBe("app_users");
+  });
+});
+
+// ==========================================================================
+// quoteSqlValue — internal helper used by InsertAll and relation scoping
+// ==========================================================================
+describe("quoteSqlValue", () => {
+  it("emits bare decimal for bigint (not quoted string)", () => {
+    expect(quoteSqlValue(123n)).toBe("123");
+    expect(quoteSqlValue(2n ** 62n)).toBe("4611686018427387904");
+    expect(quoteSqlValue(-1n)).toBe("-1");
+  });
+
+  it("emits bare decimal for number (unchanged)", () => {
+    expect(quoteSqlValue(42)).toBe("42");
+    expect(quoteSqlValue(-7)).toBe("-7");
+  });
+
+  it("emits NULL for null/undefined", () => {
+    expect(quoteSqlValue(null)).toBe("NULL");
+    expect(quoteSqlValue(undefined)).toBe("NULL");
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -136,7 +136,7 @@ import { Associations as _Associations, updateCounterCaches } from "./associatio
 /** @internal */
 export function quoteSqlValue(v: unknown, asArray = false): string {
   if (v === null || v === undefined) return "NULL";
-  if (typeof v === "number") return String(v);
+  if (typeof v === "number" || typeof v === "bigint") return String(v);
   if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
   if (v instanceof Date) return `'${v.toISOString()}'`;
   if (asArray && Array.isArray(v)) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -151,10 +151,11 @@ export function quoteSqlValue(v: unknown, asArray = false): string {
  * A single column of a primary key.
  *
  * - `string` / `number` — the common scalar PK types (auto-increment ids, UUIDs).
+ * - `bigint` — large integer PKs (big_integer columns, e.g. PG int8 / MySQL BIGINT).
  * - `null` / `undefined` — column unset (e.g. a new record, or an unassigned
  *   CPK column).
  */
-export type PrimaryKeyScalar = string | number | null | undefined;
+export type PrimaryKeyScalar = string | number | bigint | null | undefined;
 
 /**
  * Value of a primary key on a persisted (or to-be-persisted) record.

--- a/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/expected.ts
@@ -1,0 +1,9 @@
+export class Counter extends Base {
+  declare hits: bigint;
+  declare user_id: bigint;
+
+  static {
+    this.attribute("hits", "big_integer");
+    this.attribute("user_id", "big_integer");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/input.ts
@@ -1,0 +1,6 @@
+export class Counter extends Base {
+  static {
+    this.attribute("hits", "big_integer");
+    this.attribute("user_id", "big_integer");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/type-registry.ts
+++ b/packages/activerecord/src/type-virtualization/type-registry.ts
@@ -29,7 +29,7 @@ export const ATTRIBUTE_TYPE_MAP: Record<string, string> = {
   cidr: "string",
   citext: "string",
   integer: "number",
-  big_integer: "number",
+  big_integer: "bigint",
   float: "number",
   decimal: "number",
   boolean: "boolean",

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -188,6 +188,20 @@ describe("virtualize — deltas", () => {
     expect(text).toMatch(/declare strict_tags: string\[\];/);
   });
 
+  test("schemaColumnsByTable emits bigint for big_integer schema columns", () => {
+    const src = "export class Post extends Base {}\n";
+    const { text } = virtualize(src, "post.ts", {
+      schemaColumnsByTable: {
+        posts: {
+          score: { type: "big_integer", null: false },
+          score_nullable: { type: "big_integer", null: true },
+        },
+      },
+    });
+    expect(text).toMatch(/declare score: bigint;/);
+    expect(text).toMatch(/declare score_nullable: bigint \| null;/);
+  });
+
   test("schemaColumnsByTable mixing legacy string and rich shape in same table", () => {
     const src = "export class Post extends Base {}\n";
     const { text } = virtualize(src, "post.ts", {

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -86,12 +86,25 @@ class Article extends Base {
   }
 }
 
+class BigRecord extends Base {
+  static {
+    this.attribute("score", "big_integer");
+    this.attribute("smallId", "big_integer");
+  }
+}
+
 describe("virtualized patterns — trails-tsc injects declares + auto-imports", () => {
   it("attributes resolve to their declared type", () => {
     const u = new User({ name: "dean", email: "d@example.com", admin: false });
     expectTypeOf(u.name).toBeString();
     expectTypeOf(u.email).toBeString();
     expectTypeOf(u.admin).toBeBoolean();
+  });
+
+  it("big_integer attribute resolves to bigint", () => {
+    const r = new BigRecord({ score: 2n ** 62n });
+    expectTypeOf(r.score).toEqualTypeOf<bigint>();
+    expectTypeOf(r.smallId).toEqualTypeOf<bigint>();
   });
 
   it("hasMany resolves to AssociationProxy<Target>", async () => {


### PR DESCRIPTION
## Summary

- **`type-registry.ts`**: `big_integer → "bigint"` (was `"number"`). The virtualizer now emits `bigint` for `big_integer` attribute declarations and schema-reflected columns.
- **`PrimaryKeyScalar`**: adds `bigint` to the union — `string | number | bigint | null | undefined`.
- **`quoteSqlValue`**: adds explicit `bigint` branch so bigint values produce bare numeric SQL literals (`123`) instead of quoted strings (`'123'`). Affects `insertAll`/`upsertAll` and relation scoping paths that build `SqlLiteral` nodes from attribute values.
- **`castToBoolean` (query attribute)**: explicit `bigint` branch (`0n → false`, non-zero → true), mirroring the existing `number` branch. Mirrors Rails `query_attribute` which uses `value.zero?` for numeric types.
- **DX type tests** (`declare-patterns`, `virtualized-patterns`): new `BigRecord` class with `big_integer` attributes; assertions that `r.score` resolves to `bigint` at compile time.
- **Virtualizer fixture** (`20-big-integer`): proves end-to-end that `this.attribute("x", "big_integer")` virtualizes to `declare x: bigint`.
- **Virtualizer schema test**: `big_integer` schema columns (nullable and non-nullable) emit `bigint | null` and `bigint` in injected declares.
- **`query.test.ts`**: two new cases covering zero/non-zero bigint query attribute.
- **`base.test.ts`**: unit tests for `quoteSqlValue` bigint behavior.

## No backwards compatibility required

Pre-release project, zero downstream consumers.