### PR TITLE
feat(activerecord): merge-and-resolve-default-url-config + MySQL type map improvements

### DIFF
--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -1,15 +1,156 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/adapter_prevent_writes_test.rb
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { ReadOnlyError } from "./errors.js";
+
+let adapter: SQLite3Adapter;
+
+beforeEach(() => {
+  adapter = new SQLite3Adapter(":memory:");
+  adapter.exec(`CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`);
+});
+
+afterEach(() => {
+  adapter.close();
+});
 
 describe("AdapterPreventWritesTest", () => {
-  it.skip("preventing writes predicate", () => {});
-  it.skip("doesnt error when a select query has encoding errors", () => {});
-  it.skip("doesnt error when a select query has encoding errors", () => {});
-  it.skip("doesnt error when a read query with a cte is called while preventing writes", () => {});
-  it.skip("doesnt error when a select query starting with a slash star comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a slash star comment is called while preventing writes", () => {});
-  it.skip("doesnt error when a select query starting with double dash comments is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a double dash comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a multiline double dash comment is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a slash star comment containing read command is called while preventing writes", () => {});
-  it.skip("errors when an insert query prefixed by a double dash comment containing read command is called while preventing writes", () => {});
+  it("preventing writes predicate", async () => {
+    expect(adapter.preventingWrites).toBe(false);
+
+    await adapter.withPreventedWrites(async () => {
+      expect(adapter.preventingWrites).toBe(true);
+    });
+
+    expect(adapter.preventingWrites).toBe(false);
+  });
+
+  it("errors when an insert query is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an update query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `UPDATE "subscribers" SET "nick" = 'updated' WHERE "nick" = 'test'`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when a delete query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`DELETE FROM "subscribers" WHERE "nick" = 'test'`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("doesnt error when a select query has encoding errors", async () => {
+    await adapter.withPreventedWrites(async () => {
+      // SQLite returns invalid bytes as-is rather than failing
+      await expect(adapter.execute(`SELECT '\xC8'`)).resolves.toBeDefined();
+    });
+  });
+
+  it("doesnt error when a select query is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(`SELECT * FROM "subscribers" WHERE "nick" = 'test'`);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("doesnt error when a read query with a cte is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(`
+        WITH matching AS (SELECT * FROM "subscribers" WHERE "nick" = 'test')
+        SELECT * FROM matching
+      `);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("doesnt error when a select query starting with a slash star comment is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(
+        `/* some comment */ SELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("errors when an insert query prefixed by a slash star comment is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `/* some comment */ INSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("doesnt error when a select query starting with double dash comments is called while preventing writes", async () => {
+    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+
+    await adapter.withPreventedWrites(async () => {
+      const result = await adapter.execute(
+        `-- some comment\n-- comment about INSERT\nSELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  it("errors when an insert query prefixed by a double dash comment is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `-- some comment\nINSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a multiline double dash comment is called while preventing writes", async () => {
+    const manyComments = "-- comment\n".repeat(50);
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(
+          `${manyComments}INSERT INTO "subscribers" ("nick") VALUES ('test')`,
+        ),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a slash star comment containing read command is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`/* SELECT */ INSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("errors when an insert query prefixed by a double dash comment containing read command is called while preventing writes", async () => {
+    await expect(
+      adapter.withPreventedWrites(() =>
+        adapter.executeMutation(`-- SELECT\nINSERT INTO "subscribers" ("nick") VALUES ('test')`),
+      ),
+    ).rejects.toThrow(ReadOnlyError);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -599,6 +599,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     map.registerType(/^int/i, undefined, intType(4));
     map.registerType(/^year/i, undefined, () => new IntegerType());
     map.registerType(/^bit/i, undefined, () => new BinaryType());
+    map.registerType(/^binary/i, undefined, () => new BinaryType());
+    map.registerType(/^varbinary/i, undefined, () => new BinaryType());
     map.registerType(/^enum/i, undefined, () => new StringType());
     map.registerType(/^set/i, undefined, () => new StringType());
     map.registerType(/^char/i, undefined, () => new StringType());
@@ -609,7 +611,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     map.registerType("date", new DateType());
     map.registerType(/^datetime/i, undefined, () => new DateTimeType());
     map.registerType(/^timestamp/i, undefined, () => new DateTimeType());
-    map.registerType(/^time/i, undefined, () => new TimeType());
+    map.registerType(/^time\b/i, undefined, () => new TimeType());
     map.registerType("json", new JsonType());
     // emulate_booleans: tinyint(1) → boolean
     if (options.emulateBooleans) {
@@ -645,8 +647,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   lookupCastTypeFromColumn(column: {
     sqlType?: string | null;
-  }): import("@blazetrails/activemodel").Type {
-    return this.lookupCastType(column.sqlType ?? "");
+  }): import("@blazetrails/activemodel").Type | null {
+    const sqlType = column.sqlType?.trim();
+    if (!sqlType) return null;
+    return this.lookupCastType(sqlType);
   }
 
   static extendedTypeMap(options: {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -31,6 +31,21 @@ import {
   columnNameWithOrderMatcher as mysqlColumnNameWithOrderMatcher,
 } from "./mysql/quoting.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
+import { TypeMap } from "../type/type-map.js";
+import {
+  StringType,
+  IntegerType,
+  FloatType,
+  BooleanType,
+  BinaryType,
+  DecimalType,
+} from "@blazetrails/activemodel";
+import { UnsignedInteger } from "../type/unsigned-integer.js";
+import { Date as DateType } from "../type/date.js";
+import { DateTime as DateTimeType } from "../type/date-time.js";
+import { Time as TimeType } from "../type/time.js";
+import { Text as TextType } from "../type/text.js";
+import { Json as JsonType } from "../type/json.js";
 
 const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
@@ -559,6 +574,79 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (config.sslKey) args.push(`--ssl-key=${config.sslKey}`);
     if (config.database) args.push(config.database as string);
     return args;
+  }
+
+  // Mirrors: AbstractMysqlAdapter::initialize_type_map + extended_type_map
+  static buildTypeMap(options: { emulateBooleans?: boolean } = {}): TypeMap {
+    const map = new TypeMap();
+    const intType = (limit: number) => (sql: string) =>
+      /\bunsigned\b/i.test(sql) ? new UnsignedInteger({ limit }) : new IntegerType({ limit });
+
+    map.registerType(/tinytext/i, undefined, () => new TextType());
+    map.registerType(/tinyblob/i, undefined, () => new BinaryType());
+    map.registerType(/mediumtext/i, undefined, () => new TextType());
+    map.registerType(/mediumblob/i, undefined, () => new BinaryType());
+    map.registerType(/longtext/i, undefined, () => new TextType());
+    map.registerType(/longblob/i, undefined, () => new BinaryType());
+    map.registerType(/text/i, undefined, () => new TextType());
+    map.registerType(/blob/i, undefined, () => new BinaryType());
+    map.registerType(/^float/i, undefined, () => new FloatType());
+    map.registerType(/^double/i, undefined, () => new FloatType());
+    map.registerType(/^bigint/i, undefined, intType(8));
+    map.registerType(/^mediumint/i, undefined, intType(3));
+    map.registerType(/^smallint/i, undefined, intType(2));
+    map.registerType(/^tinyint/i, undefined, intType(1));
+    map.registerType(/^int/i, undefined, intType(4));
+    map.registerType(/^year/i, undefined, () => new IntegerType());
+    map.registerType(/^bit/i, undefined, () => new BinaryType());
+    map.registerType(/^enum/i, undefined, () => new StringType());
+    map.registerType(/^set/i, undefined, () => new StringType());
+    map.registerType(/^char/i, undefined, () => new StringType());
+    map.registerType(/^varchar/i, undefined, () => new StringType());
+    map.registerType(/decimal/i, undefined, () => new DecimalType());
+    map.registerType(/numeric/i, undefined, () => new DecimalType());
+    map.registerType("boolean", new BooleanType());
+    map.registerType("date", new DateType());
+    map.registerType(/^datetime/i, undefined, () => new DateTimeType());
+    map.registerType(/^timestamp/i, undefined, () => new DateTimeType());
+    map.registerType(/^time/i, undefined, () => new TimeType());
+    map.registerType("json", new JsonType());
+    // emulate_booleans: tinyint(1) → boolean
+    if (options.emulateBooleans) {
+      map.registerType(/^tinyint\(1\)/i, undefined, () => new BooleanType());
+    }
+    return map;
+  }
+
+  private _typeMap: TypeMap | null = null;
+  private _emulateBooleans = true;
+
+  get emulateBooleans(): boolean {
+    return this._emulateBooleans;
+  }
+
+  set emulateBooleans(value: boolean) {
+    this._emulateBooleans = value;
+    this._typeMap = null; // invalidate cache
+  }
+
+  get nativeTypeMap(): TypeMap {
+    if (!this._typeMap) {
+      this._typeMap = (this.constructor as typeof AbstractMysqlAdapter).buildTypeMap({
+        emulateBooleans: this._emulateBooleans,
+      });
+    }
+    return this._typeMap;
+  }
+
+  lookupCastType(sqlType: string): import("@blazetrails/activemodel").Type {
+    return this.nativeTypeMap.lookup(sqlType.toLowerCase().trim());
+  }
+
+  lookupCastTypeFromColumn(column: {
+    sqlType?: string | null;
+  }): import("@blazetrails/activemodel").Type {
+    return this.lookupCastType(column.sqlType ?? "");
   }
 
   static extendedTypeMap(options: {

--- a/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
@@ -1,44 +1,387 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DatabaseConfigurations, InvalidConfigurationError } from "../database-configurations.js";
+
+const DEFAULT_ENV = "default_env";
+
+let savedDatabaseUrl: string | undefined;
+let savedRailsEnv: string | undefined;
+let savedRackEnv: string | undefined;
+
+beforeEach(() => {
+  savedDatabaseUrl = process.env["DATABASE_URL"];
+  savedRailsEnv = process.env["RAILS_ENV"];
+  savedRackEnv = process.env["RACK_ENV"];
+  delete process.env["DATABASE_URL"];
+  delete process.env["RAILS_ENV"];
+  delete process.env["RACK_ENV"];
+  DatabaseConfigurations.defaultEnv = DEFAULT_ENV;
+});
+
+afterEach(() => {
+  if (savedDatabaseUrl !== undefined) process.env["DATABASE_URL"] = savedDatabaseUrl;
+  else delete process.env["DATABASE_URL"];
+  if (savedRailsEnv !== undefined) process.env["RAILS_ENV"] = savedRailsEnv;
+  else delete process.env["RAILS_ENV"];
+  if (savedRackEnv !== undefined) process.env["RACK_ENV"] = savedRackEnv;
+  else delete process.env["RACK_ENV"];
+  DatabaseConfigurations.defaultEnv = "development";
+});
+
+function resolveConfig(
+  config: Record<string, unknown>,
+  envName: string = DEFAULT_ENV,
+): Record<string, unknown> | null {
+  const configs = DatabaseConfigurations.fromRaw(config as any);
+  const found = configs.configsFor({ envName, name: "primary" })[0];
+  return found?.configurationHash ?? null;
+}
+
+function resolveDbConfig(spec: string, config: Record<string, unknown>) {
+  const configs = DatabaseConfigurations.fromRaw(config as any);
+  return configs.resolve(spec);
+}
 
 describe("MergeAndResolveDefaultUrlConfigTest", () => {
-  it.skip("invalid string config", () => {});
-  it.skip("invalid symbol config", () => {});
-  it.skip("resolver with database uri and current env symbol key", () => {});
-  it.skip("resolver with database uri and current env symbol key and rails env", () => {});
-  it.skip("resolver with nil database url and current env", () => {});
-  it.skip("resolver with database uri and current env symbol key and rack env", () => {});
-  it.skip("resolver with database uri and known key", () => {});
-  it.skip("resolver with database uri and multiple envs", () => {});
-  it.skip("resolver with database uri and unknown symbol key", () => {});
-  it.skip("resolver with database uri and supplied url", () => {});
-  it.skip("resolver with database uri containing only database name", () => {});
-  it.skip("jdbc url", () => {});
-  it.skip("http url", () => {});
-  it.skip("https url", () => {});
-  it.skip("environment does not exist in config url does exist", () => {});
-  it.skip("url with hyphenated scheme", () => {});
-  it.skip("string connection", () => {});
-  it.skip("url sub key", () => {});
-  it.skip("url removed from hash", () => {});
-  it.skip("url with equals in query value", () => {});
-  it.skip("hash", () => {});
-  it.skip("blank", () => {});
-  it.skip("blank with database url", () => {});
-  it.skip("blank with database url with rails env", () => {});
-  it.skip("blank with database url with rack env", () => {});
-  it.skip("database url with ipv6 host and port", () => {});
-  it.skip("url sub key with database url", () => {});
-  it.skip("no url sub key with database url doesnt trample other envs", () => {});
-  it.skip("merge no conflicts with database url", () => {});
-  it.skip("merge conflicts with database url", () => {});
-  it.skip("merge no conflicts with database url and adapter", () => {});
-  it.skip("merge no conflicts with database url and numeric pool", () => {});
-  it.skip("tiered configs with database url", () => {});
-  it.skip("separate database env vars", () => {});
-  it.skip("does not change other environments", () => {});
-  it.skip("protocol adapter mapping is used", () => {});
-  it.skip("protocol adapter mapping falls through if non found", () => {});
-  it.skip("protocol adapter mapping is used and can be updated", () => {});
-  it.skip("protocol adapter mapping translates underscores to dashes", () => {});
-  it.skip("protocol adapter mapping handles sqlite3 file urls", () => {});
+  it("invalid string config", () => {
+    const config = { foo: "bar" };
+    expect(() => resolveConfig(config as any)).toThrow(InvalidConfigurationError);
+  });
+
+  it.skip("invalid symbol config", () => {
+    // Ruby-specific: symbol values like :bar aren't valid in TS configs
+  });
+
+  it("resolver with database uri and current env symbol key", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { not_production: { adapter: "abstract", database: "not_foo" } };
+    const actual = resolveDbConfig(DEFAULT_ENV, config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+    });
+  });
+
+  it("resolver with database uri and current env symbol key and rails env", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    DatabaseConfigurations.defaultEnv = "foo";
+    const config = { not_production: { adapter: "abstract", database: "not_foo" } };
+    const actual = resolveDbConfig("foo", config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+    });
+  });
+
+  it("resolver with nil database url and current env", () => {
+    DatabaseConfigurations.defaultEnv = "foo";
+    const config = { foo: { adapter: "postgresql", url: undefined } };
+    const actual = resolveDbConfig("foo", config as any);
+    expect(actual.configurationHash).toEqual({ adapter: "postgresql" });
+  });
+
+  it("resolver with database uri and current env symbol key and rack env", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    DatabaseConfigurations.defaultEnv = "foo";
+    const config = { not_production: { adapter: "abstract", database: "not_foo" } };
+    const actual = resolveDbConfig("foo", config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+    });
+  });
+
+  it("resolver with database uri and known key", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { production: { adapter: "abstract", database: "not_foo", host: "localhost" } };
+    const actual = resolveDbConfig("production", config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "abstract",
+      database: "not_foo",
+      host: "localhost",
+    });
+  });
+
+  it("resolver with database uri and multiple envs", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost";
+    DatabaseConfigurations.defaultEnv = "test";
+    const config = {
+      production: { adapter: "postgresql", database: "foo_prod" },
+      test: { adapter: "postgresql", database: "foo_test" },
+    };
+    const actual = resolveDbConfig("test", config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "postgresql",
+      database: "foo_test",
+      host: "localhost",
+    });
+  });
+
+  it("resolver with database uri and unknown symbol key", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { not_production: { adapter: "abstract", database: "not_foo" } };
+    expect(() => resolveDbConfig("production", config as any)).toThrow();
+  });
+
+  it("resolver with database uri and supplied url", () => {
+    process.env["DATABASE_URL"] = "abstract://not-localhost/not_foo";
+    const config = { production: { adapter: "abstract", database: "also_not_foo" } };
+    const actual = resolveDbConfig("postgres://localhost/foo", config as any);
+    expect(actual.configurationHash).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+    });
+  });
+
+  it.skip("resolver with database uri containing only database name", () => {
+    // Rails treats bare "foo" as database name; our URL parser requires a scheme
+  });
+
+  it("jdbc url", () => {
+    const config = { production: { adapter: "abstract", url: "jdbc:postgres://localhost/foo" } };
+    const actual = resolveConfig(config as any, "production");
+    expect(actual).toEqual({ adapter: "abstract", url: "jdbc:postgres://localhost/foo" });
+  });
+
+  it("http url", () => {
+    const config = { production: { adapter: "abstract", url: "http://example.com/path" } };
+    const actual = resolveConfig(config as any, "production");
+    expect(actual).toEqual({ adapter: "abstract", url: "http://example.com/path" });
+  });
+
+  it("https url", () => {
+    const config = { production: { adapter: "abstract", url: "https://example.com" } };
+    const actual = resolveConfig(config as any, "production");
+    expect(actual).toEqual({ adapter: "abstract", url: "https://example.com" });
+  });
+
+  it("environment does not exist in config url does exist", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { not_default_env: { adapter: "abstract", database: "not_foo" } };
+    const actual = resolveConfig(config as any, DEFAULT_ENV);
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it.skip("url with hyphenated scheme", () => {
+    // Requires ConnectionAdapters.register which maps custom schemes; skip for now
+  });
+
+  it("string connection", () => {
+    const config = { default_env: "postgres://localhost/foo" };
+    const actual = resolveConfig(config as any, DEFAULT_ENV);
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("url sub key", () => {
+    const config = { default_env: { url: "postgres://localhost/foo" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("url removed from hash", () => {
+    const config = { default_env: { url: "postgres://localhost/foo" } };
+    const actual = resolveDbConfig(DEFAULT_ENV, config as any);
+    expect(actual.configurationHash).not.toHaveProperty("url");
+  });
+
+  it("url with equals in query value", () => {
+    const config = { default_env: { url: "postgresql://localhost/foo?options=-cmyoption=on" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({
+      options: "-cmyoption=on",
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+    });
+  });
+
+  it("hash", () => {
+    const config = { production: { adapter: "postgresql", database: "foo" } };
+    const actual = resolveConfig(config as any, "production");
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo" });
+  });
+
+  it("blank", () => {
+    const config = {};
+    const actual = resolveConfig(config, DEFAULT_ENV);
+    expect(actual).toBeNull();
+  });
+
+  it("blank with database url", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const actual = resolveConfig({});
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("blank with database url with rails env", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    DatabaseConfigurations.defaultEnv = "not_production";
+    const actual = resolveConfig({}, "not_production");
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("blank with database url with rack env", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    DatabaseConfigurations.defaultEnv = "not_production";
+    const actual = resolveConfig({}, "not_production");
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("database url with ipv6 host and port", () => {
+    process.env["DATABASE_URL"] = "postgres://[::1]:5454/foo";
+    const actual = resolveConfig({});
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "::1", port: 5454 });
+  });
+
+  it("url sub key with database url", () => {
+    process.env["DATABASE_URL"] = "abstract://localhost/NOT_FOO";
+    const config = { default_env: { url: "postgres://localhost/foo" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
+  });
+
+  it("no url sub key with database url doesnt trample other envs", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/baz";
+    const config = {
+      default_env: { adapter: "abstract", database: "foo" },
+      other_env: { url: "postgres://foohost/bardb" },
+    };
+    expect(resolveConfig(config as any, DEFAULT_ENV)).toEqual({
+      database: "baz",
+      adapter: "postgresql",
+      host: "localhost",
+    });
+    expect(resolveConfig(config as any, "other_env")).toEqual({
+      adapter: "postgresql",
+      database: "bardb",
+      host: "foohost",
+    });
+  });
+
+  it("merge no conflicts with database url", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { default_env: { adapter: "abstract", pool: "5" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+      pool: "5",
+    });
+  });
+
+  it("merge conflicts with database url", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { default_env: { adapter: "abstract", database: "NOT-FOO", pool: "5" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+      pool: "5",
+    });
+  });
+
+  it("merge no conflicts with database url and adapter", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { default_env: { adapter: "postgresql", pool: "5" } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({
+      adapter: "postgresql",
+      database: "foo",
+      host: "localhost",
+      pool: "5",
+    });
+  });
+
+  it("merge no conflicts with database url and numeric pool", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = { default_env: { adapter: "abstract", pool: 5 } };
+    const actual = resolveConfig(config as any);
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost", pool: 5 });
+  });
+
+  it("tiered configs with database url", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = {
+      default_env: {
+        primary: { adapter: "abstract", pool: 5 },
+        animals: { adapter: "abstract", pool: 5 },
+      },
+    };
+
+    let configs = DatabaseConfigurations.fromRaw(config as any);
+    let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })[0]!
+      .configurationHash;
+    expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost", pool: 5 });
+
+    configs = DatabaseConfigurations.fromRaw(config as any);
+    actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })[0]!.configurationHash;
+    expect(actual).toEqual({ adapter: "abstract", pool: 5 });
+  });
+
+  it.skip("separate database env vars", () => {
+    // Requires PRIMARY_DATABASE_URL / ANIMALS_DATABASE_URL per-name env var logic
+  });
+
+  it("does not change other environments", () => {
+    process.env["DATABASE_URL"] = "postgres://localhost/foo";
+    const config = {
+      production: { adapter: "abstract", database: "not_foo", host: "localhost" },
+      default_env: {},
+    };
+    const actual1 = resolveDbConfig("production", config as any);
+    expect(actual1.configurationHash).toEqual({
+      adapter: "abstract",
+      database: "not_foo",
+      host: "localhost",
+    });
+
+    const actual2 = resolveDbConfig(DEFAULT_ENV, config as any);
+    expect(actual2.configurationHash).toEqual({
+      host: "localhost",
+      database: "foo",
+      adapter: "postgresql",
+    });
+  });
+
+  it("protocol adapter mapping is used", () => {
+    process.env["DATABASE_URL"] = "mysql://localhost/exampledb";
+    DatabaseConfigurations.defaultEnv = "production";
+    const actual = resolveDbConfig("production", {});
+    expect(actual.configurationHash).toEqual({
+      adapter: "mysql2",
+      database: "exampledb",
+      host: "localhost",
+    });
+  });
+
+  it("protocol adapter mapping falls through if non found", () => {
+    process.env["DATABASE_URL"] = "unknown://localhost/exampledb";
+    DatabaseConfigurations.defaultEnv = "production";
+    const actual = resolveDbConfig("production", {});
+    expect(actual.configurationHash).toEqual({
+      adapter: "unknown",
+      database: "exampledb",
+      host: "localhost",
+    });
+  });
+
+  it.skip("protocol adapter mapping is used and can be updated", () => {
+    // Requires mutable ActiveRecord.protocol_adapters — not yet implemented
+  });
+
+  it.skip("protocol adapter mapping translates underscores to dashes", () => {
+    // Requires mutable ActiveRecord.protocol_adapters — not yet implemented
+  });
+
+  it.skip("protocol adapter mapping handles sqlite3 file urls", () => {
+    // Requires mutable ActiveRecord.protocol_adapters — not yet implemented
+  });
 });

--- a/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
@@ -2,18 +2,24 @@
  * Mirrors Rails activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { DatabaseConfigurations, InvalidConfigurationError } from "../database-configurations.js";
+import {
+  DatabaseConfigurations,
+  InvalidConfigurationError,
+  type RawConfigurations,
+} from "../database-configurations.js";
 
 const DEFAULT_ENV = "default_env";
 
 let savedDatabaseUrl: string | undefined;
 let savedRailsEnv: string | undefined;
 let savedRackEnv: string | undefined;
+let savedDefaultEnv: string;
 
 beforeEach(() => {
   savedDatabaseUrl = process.env["DATABASE_URL"];
   savedRailsEnv = process.env["RAILS_ENV"];
   savedRackEnv = process.env["RACK_ENV"];
+  savedDefaultEnv = DatabaseConfigurations.defaultEnv;
   delete process.env["DATABASE_URL"];
   delete process.env["RAILS_ENV"];
   delete process.env["RACK_ENV"];
@@ -27,27 +33,27 @@ afterEach(() => {
   else delete process.env["RAILS_ENV"];
   if (savedRackEnv !== undefined) process.env["RACK_ENV"] = savedRackEnv;
   else delete process.env["RACK_ENV"];
-  DatabaseConfigurations.defaultEnv = "development";
+  DatabaseConfigurations.defaultEnv = savedDefaultEnv;
 });
 
 function resolveConfig(
-  config: Record<string, unknown>,
+  config: RawConfigurations,
   envName: string = DEFAULT_ENV,
 ): Record<string, unknown> | null {
-  const configs = DatabaseConfigurations.fromRaw(config as any);
+  const configs = DatabaseConfigurations.fromRaw(config);
   const found = configs.configsFor({ envName, name: "primary" })[0];
   return found?.configurationHash ?? null;
 }
 
-function resolveDbConfig(spec: string, config: Record<string, unknown>) {
-  const configs = DatabaseConfigurations.fromRaw(config as any);
+function resolveDbConfig(spec: string, config: RawConfigurations) {
+  const configs = DatabaseConfigurations.fromRaw(config);
   return configs.resolve(spec);
 }
 
 describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("invalid string config", () => {
     const config = { foo: "bar" };
-    expect(() => resolveConfig(config as any)).toThrow(InvalidConfigurationError);
+    expect(() => resolveConfig(config)).toThrow(InvalidConfigurationError);
   });
 
   it.skip("invalid symbol config", () => {
@@ -57,7 +63,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("resolver with database uri and current env symbol key", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { not_production: { adapter: "abstract", database: "not_foo" } };
-    const actual = resolveDbConfig(DEFAULT_ENV, config as any);
+    const actual = resolveDbConfig(DEFAULT_ENV, config);
     expect(actual.configurationHash).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -69,7 +75,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     DatabaseConfigurations.defaultEnv = "foo";
     const config = { not_production: { adapter: "abstract", database: "not_foo" } };
-    const actual = resolveDbConfig("foo", config as any);
+    const actual = resolveDbConfig("foo", config);
     expect(actual.configurationHash).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -80,7 +86,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("resolver with nil database url and current env", () => {
     DatabaseConfigurations.defaultEnv = "foo";
     const config = { foo: { adapter: "postgresql", url: undefined } };
-    const actual = resolveDbConfig("foo", config as any);
+    const actual = resolveDbConfig("foo", config);
     expect(actual.configurationHash).toEqual({ adapter: "postgresql" });
   });
 
@@ -88,7 +94,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     DatabaseConfigurations.defaultEnv = "foo";
     const config = { not_production: { adapter: "abstract", database: "not_foo" } };
-    const actual = resolveDbConfig("foo", config as any);
+    const actual = resolveDbConfig("foo", config);
     expect(actual.configurationHash).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -99,7 +105,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("resolver with database uri and known key", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { production: { adapter: "abstract", database: "not_foo", host: "localhost" } };
-    const actual = resolveDbConfig("production", config as any);
+    const actual = resolveDbConfig("production", config);
     expect(actual.configurationHash).toEqual({
       adapter: "abstract",
       database: "not_foo",
@@ -114,7 +120,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       production: { adapter: "postgresql", database: "foo_prod" },
       test: { adapter: "postgresql", database: "foo_test" },
     };
-    const actual = resolveDbConfig("test", config as any);
+    const actual = resolveDbConfig("test", config);
     expect(actual.configurationHash).toEqual({
       adapter: "postgresql",
       database: "foo_test",
@@ -125,13 +131,13 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("resolver with database uri and unknown symbol key", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { not_production: { adapter: "abstract", database: "not_foo" } };
-    expect(() => resolveDbConfig("production", config as any)).toThrow();
+    expect(() => resolveDbConfig("production", config)).toThrow();
   });
 
   it("resolver with database uri and supplied url", () => {
     process.env["DATABASE_URL"] = "abstract://not-localhost/not_foo";
     const config = { production: { adapter: "abstract", database: "also_not_foo" } };
-    const actual = resolveDbConfig("postgres://localhost/foo", config as any);
+    const actual = resolveDbConfig("postgres://localhost/foo", config);
     expect(actual.configurationHash).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -145,26 +151,26 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
 
   it("jdbc url", () => {
     const config = { production: { adapter: "abstract", url: "jdbc:postgres://localhost/foo" } };
-    const actual = resolveConfig(config as any, "production");
+    const actual = resolveConfig(config, "production");
     expect(actual).toEqual({ adapter: "abstract", url: "jdbc:postgres://localhost/foo" });
   });
 
   it("http url", () => {
     const config = { production: { adapter: "abstract", url: "http://example.com/path" } };
-    const actual = resolveConfig(config as any, "production");
+    const actual = resolveConfig(config, "production");
     expect(actual).toEqual({ adapter: "abstract", url: "http://example.com/path" });
   });
 
   it("https url", () => {
     const config = { production: { adapter: "abstract", url: "https://example.com" } };
-    const actual = resolveConfig(config as any, "production");
+    const actual = resolveConfig(config, "production");
     expect(actual).toEqual({ adapter: "abstract", url: "https://example.com" });
   });
 
   it("environment does not exist in config url does exist", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { not_default_env: { adapter: "abstract", database: "not_foo" } };
-    const actual = resolveConfig(config as any, DEFAULT_ENV);
+    const actual = resolveConfig(config, DEFAULT_ENV);
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
   });
 
@@ -174,25 +180,25 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
 
   it("string connection", () => {
     const config = { default_env: "postgres://localhost/foo" };
-    const actual = resolveConfig(config as any, DEFAULT_ENV);
+    const actual = resolveConfig(config, DEFAULT_ENV);
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
   });
 
   it("url sub key", () => {
     const config = { default_env: { url: "postgres://localhost/foo" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
   });
 
   it("url removed from hash", () => {
     const config = { default_env: { url: "postgres://localhost/foo" } };
-    const actual = resolveDbConfig(DEFAULT_ENV, config as any);
+    const actual = resolveDbConfig(DEFAULT_ENV, config);
     expect(actual.configurationHash).not.toHaveProperty("url");
   });
 
   it("url with equals in query value", () => {
     const config = { default_env: { url: "postgresql://localhost/foo?options=-cmyoption=on" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({
       options: "-cmyoption=on",
       adapter: "postgresql",
@@ -203,7 +209,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
 
   it("hash", () => {
     const config = { production: { adapter: "postgresql", database: "foo" } };
-    const actual = resolveConfig(config as any, "production");
+    const actual = resolveConfig(config, "production");
     expect(actual).toEqual({ adapter: "postgresql", database: "foo" });
   });
 
@@ -242,7 +248,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("url sub key with database url", () => {
     process.env["DATABASE_URL"] = "abstract://localhost/NOT_FOO";
     const config = { default_env: { url: "postgres://localhost/foo" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost" });
   });
 
@@ -252,12 +258,12 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       default_env: { adapter: "abstract", database: "foo" },
       other_env: { url: "postgres://foohost/bardb" },
     };
-    expect(resolveConfig(config as any, DEFAULT_ENV)).toEqual({
+    expect(resolveConfig(config, DEFAULT_ENV)).toEqual({
       database: "baz",
       adapter: "postgresql",
       host: "localhost",
     });
-    expect(resolveConfig(config as any, "other_env")).toEqual({
+    expect(resolveConfig(config, "other_env")).toEqual({
       adapter: "postgresql",
       database: "bardb",
       host: "foohost",
@@ -267,7 +273,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("merge no conflicts with database url", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { default_env: { adapter: "abstract", pool: "5" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -279,7 +285,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("merge conflicts with database url", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { default_env: { adapter: "abstract", database: "NOT-FOO", pool: "5" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -291,7 +297,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("merge no conflicts with database url and adapter", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { default_env: { adapter: "postgresql", pool: "5" } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({
       adapter: "postgresql",
       database: "foo",
@@ -303,7 +309,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("merge no conflicts with database url and numeric pool", () => {
     process.env["DATABASE_URL"] = "postgres://localhost/foo";
     const config = { default_env: { adapter: "abstract", pool: 5 } };
-    const actual = resolveConfig(config as any);
+    const actual = resolveConfig(config);
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost", pool: 5 });
   });
 
@@ -316,12 +322,12 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       },
     };
 
-    let configs = DatabaseConfigurations.fromRaw(config as any);
+    let configs = DatabaseConfigurations.fromRaw(config);
     let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })[0]!
       .configurationHash;
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost", pool: 5 });
 
-    configs = DatabaseConfigurations.fromRaw(config as any);
+    configs = DatabaseConfigurations.fromRaw(config);
     actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })[0]!.configurationHash;
     expect(actual).toEqual({ adapter: "abstract", pool: 5 });
   });
@@ -336,14 +342,14 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       production: { adapter: "abstract", database: "not_foo", host: "localhost" },
       default_env: {},
     };
-    const actual1 = resolveDbConfig("production", config as any);
+    const actual1 = resolveDbConfig("production", config);
     expect(actual1.configurationHash).toEqual({
       adapter: "abstract",
       database: "not_foo",
       host: "localhost",
     });
 
-    const actual2 = resolveDbConfig(DEFAULT_ENV, config as any);
+    const actual2 = resolveDbConfig(DEFAULT_ENV, config);
     expect(actual2.configurationHash).toEqual({
       host: "localhost",
       database: "foo",

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -1,8 +1,72 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
+
+// Minimal subclass — only the type map is needed; no live connection.
+class TestMysqlAdapter extends AbstractMysqlAdapter {
+  constructor() {
+    super();
+  }
+  override isWriteQuery(sql: string): boolean {
+    return /^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|ALTER|DROP|TRUNCATE)/i.test(sql);
+  }
+}
+
+let adapter: TestMysqlAdapter;
+
+beforeEach(() => {
+  adapter = new TestMysqlAdapter();
+  adapter.emulateBooleans = true;
+});
+
+function assertLookupType(expected: string, lookup: string) {
+  const castType = adapter.lookupCastType(lookup);
+  expect(castType.type()).toBe(expected);
+}
 
 describe("MysqlTypeLookupTest", () => {
-  it.skip("boolean types", () => {});
-  it.skip("string types", () => {});
-  it.skip("set type with value matching other type", () => {});
-  it.skip("enum type with value matching other type", () => {});
+  it("boolean types", () => {
+    // emulate_booleans = true: tinyint(1) → boolean
+    assertLookupType("boolean", "tinyint(1)");
+    assertLookupType("boolean", "TINYINT(1)");
+
+    // emulate_booleans = false: tinyint(1) → integer
+    adapter.emulateBooleans = false;
+    assertLookupType("integer", "tinyint(1)");
+    assertLookupType("integer", "TINYINT(1)");
+  });
+
+  it("string types", () => {
+    assertLookupType("string", "enum('one', 'two', 'three')");
+    assertLookupType("string", "ENUM('one', 'two', 'three')");
+    assertLookupType("string", "enum ('one', 'two', 'three')");
+    assertLookupType("string", "ENUM ('one', 'two', 'three')");
+    assertLookupType("string", "set('one', 'two', 'three')");
+    assertLookupType("string", "SET('one', 'two', 'three')");
+    assertLookupType("string", "set ('one', 'two', 'three')");
+    assertLookupType("string", "SET ('one', 'two', 'three')");
+  });
+
+  it("set type with value matching other type", () => {
+    assertLookupType("string", "SET('unicode', '8bit', 'none', 'time')");
+  });
+
+  it("enum type with value matching other type", () => {
+    assertLookupType("string", "ENUM('unicode', '8bit', 'none', 'time')");
+  });
+
+  it("binary types", () => {
+    assertLookupType("binary", "bit");
+    assertLookupType("binary", "BIT");
+  });
+
+  it("integer types", () => {
+    adapter.emulateBooleans = false;
+    assertLookupType("integer", "tinyint(1)");
+    assertLookupType("integer", "TINYINT(1)");
+    assertLookupType("integer", "year");
+    assertLookupType("integer", "YEAR");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -60,6 +60,8 @@ describe("MysqlTypeLookupTest", () => {
   it("binary types", () => {
     assertLookupType("binary", "bit");
     assertLookupType("binary", "BIT");
+    assertLookupType("binary", "binary(100)");
+    assertLookupType("binary", "varbinary(255)");
   });
 
   it("integer types", () => {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -69,7 +69,7 @@ export function connectsTo(
 
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+      const env = DatabaseConfigurations.defaultEnv;
       const found = configs.configsFor({ envName: env, name: dbKey });
       const dbConfig = found[0] ?? new HashConfig(env, dbKey, {});
       const pool = this.connectionHandler.establishConnection(dbConfig, {
@@ -462,11 +462,11 @@ async function establishWithConfig(
     adapterArg = url;
   }
 
-  const dbConfig = new HashConfig(
-    process.env.NODE_ENV || DatabaseConfigurations.defaultEnv,
-    "primary",
-    { adapter: adapterName, url, ...config },
-  );
+  const dbConfig = new HashConfig(DatabaseConfigurations.defaultEnv, "primary", {
+    adapter: adapterName,
+    url,
+    ...config,
+  });
 
   modelClass.connectionHandler.establishConnection(dbConfig, {
     owner: modelClass.connectionClassForSelf(),

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -69,7 +69,7 @@ export function connectsTo(
 
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
-      const env = DatabaseConfigurations.defaultEnv;
+      const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
       const found = configs.configsFor({ envName: env, name: dbKey });
       const dbConfig = found[0] ?? new HashConfig(env, dbKey, {});
       const pool = this.connectionHandler.establishConnection(dbConfig, {
@@ -462,11 +462,15 @@ async function establishWithConfig(
     adapterArg = url;
   }
 
-  const dbConfig = new HashConfig(DatabaseConfigurations.defaultEnv, "primary", {
-    adapter: adapterName,
-    url,
-    ...config,
-  });
+  const dbConfig = new HashConfig(
+    process.env.NODE_ENV || DatabaseConfigurations.defaultEnv,
+    "primary",
+    {
+      adapter: adapterName,
+      url,
+      ...config,
+    },
+  );
 
   modelClass.connectionHandler.establishConnection(dbConfig, {
     owner: modelClass.connectionClassForSelf(),

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -92,10 +92,7 @@ export class DatabaseConfigurations {
       // Uses DatabaseConfigurations.defaultEnv (set by app bootstrap from RAILS_ENV/RACK_ENV),
       // not NODE_ENV — matching Rails' env resolution semantics.
       this._configurations = this._buildConfigs(
-        this._mergeDatabaseUrl(
-          configurations,
-          process.env.NODE_ENV || DatabaseConfigurations._defaultEnv,
-        ),
+        this._mergeDatabaseUrl(configurations, DatabaseConfigurations._defaultEnv),
       );
     }
     // Register this instance as the current one for HashConfig.isPrimary lookup
@@ -112,7 +109,7 @@ export class DatabaseConfigurations {
   static fromRaw(configurations: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
     instance._configurations = instance._buildConfigs(
-      instance._mergeDatabaseUrl(configurations, DatabaseConfigurations._defaultEnv),
+      instance._mergeDatabaseUrl(configurations, DatabaseConfigurations.defaultEnv),
     );
     _currentConfigurations = instance;
     return instance;
@@ -249,9 +246,10 @@ export class DatabaseConfigurations {
    */
   static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
-    instance._configurations = instance._buildConfigs(
-      instance._mergeDatabaseUrl(raw, process.env.NODE_ENV || DatabaseConfigurations._defaultEnv),
-    );
+    // NODE_ENV is the TS equivalent of Rails.env — use it when available so
+    // that DATABASE_URL merges into the active runtime environment.
+    const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+    instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw, env));
     return instance;
   }
 

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -89,8 +89,14 @@ export class DatabaseConfigurations {
     } else {
       // Mirrors Rails: DatabaseConfigurations#initialize calls build_configs which
       // merges DATABASE_URL via environment_url_config + merge_db_environment_variables.
-      const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
-      this._configurations = this._buildConfigs(this._mergeDatabaseUrl(configurations, env));
+      // Uses DatabaseConfigurations.defaultEnv (set by app bootstrap from RAILS_ENV/RACK_ENV),
+      // not NODE_ENV — matching Rails' env resolution semantics.
+      this._configurations = this._buildConfigs(
+        this._mergeDatabaseUrl(
+          configurations,
+          process.env.NODE_ENV || DatabaseConfigurations._defaultEnv,
+        ),
+      );
     }
     // Register this instance as the current one for HashConfig.isPrimary lookup
     _currentConfigurations = this;
@@ -243,8 +249,9 @@ export class DatabaseConfigurations {
    */
   static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
-    const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
-    instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw, env));
+    instance._configurations = instance._buildConfigs(
+      instance._mergeDatabaseUrl(raw, process.env.NODE_ENV || DatabaseConfigurations._defaultEnv),
+    );
     return instance;
   }
 
@@ -290,7 +297,7 @@ export class DatabaseConfigurations {
       // Three-level: merge URL into the "primary" entry only (don't override existing url:)
       const nested = { ...(envConfig as Record<string, DatabaseConfigOptions>) };
       if (nested.primary) {
-        if (!nested.primary.url) nested.primary = { ...nested.primary, url: databaseUrl };
+        if (!("url" in nested.primary)) nested.primary = { ...nested.primary, url: databaseUrl };
       } else {
         nested.primary = { url: databaseUrl };
       }
@@ -298,7 +305,7 @@ export class DatabaseConfigurations {
     } else {
       const existing = envConfig as DatabaseConfigOptions;
       // Don't override an explicit url: key in the config (Rails: env-specific url takes precedence)
-      if (!existing.url) {
+      if (!("url" in existing)) {
         merged[currentEnv] = { ...existing, url: databaseUrl };
       }
     }
@@ -312,8 +319,10 @@ export class DatabaseConfigurations {
       // Mirrors Rails: build_db_config_from_raw_config — string must have a URI scheme
       if (typeof envConfig === "string") {
         if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(envConfig)) {
+          // Redact credentials before including in error message
+          const safe = envConfig.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
           throw new InvalidConfigurationError(
-            `'{ ${envName} => ${envConfig} }' is not a valid configuration. Expected '${envConfig}' to be a URL string or a Hash.`,
+            `'{ ${envName} => ${safe} }' is not a valid configuration. Expected a URL string or a Hash.`,
           );
         }
         configs.push(
@@ -323,7 +332,7 @@ export class DatabaseConfigurations {
       }
       if (typeof envConfig !== "object" || envConfig === null) {
         throw new InvalidConfigurationError(
-          `'{ ${envName} => ${String(envConfig)} }' is not a valid configuration. Expected a URL string or Hash.`,
+          `'{ ${envName} => [${typeof envConfig}] }' is not a valid configuration. Expected a URL string or a Hash.`,
         );
       }
       if (this._isThreeLevelConfig(envConfig)) {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -87,7 +87,9 @@ export class DatabaseConfigurations {
     if (Array.isArray(configurations)) {
       this._configurations = configurations;
     } else {
-      this._configurations = this._buildConfigs(configurations);
+      // Mirrors Rails: DatabaseConfigurations#initialize calls build_configs which
+      // merges DATABASE_URL via environment_url_config + merge_db_environment_variables.
+      this._configurations = this._buildConfigs(this._mergeDatabaseUrl(configurations));
     }
     // Register this instance as the current one for HashConfig.isPrimary lookup
     _currentConfigurations = this;
@@ -98,9 +100,10 @@ export class DatabaseConfigurations {
    * Mirrors Rails' DatabaseConfigurations.new which auto-merges DATABASE_URL.
    * Use this when you want Rails-compatible behavior (constructor + URL merge).
    */
+  // fromRaw: build with explicit defaultEnv (not NODE_ENV) for test isolation.
+  // Used by merge-and-resolve tests that set DatabaseConfigurations.defaultEnv.
   static fromRaw(configurations: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
-    // Use static defaultEnv (not NODE_ENV) — mirrors Rails' DatabaseConfigurations.new
     instance._configurations = instance._buildConfigs(
       instance._mergeDatabaseUrl(configurations, DatabaseConfigurations._defaultEnv),
     );

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -94,6 +94,21 @@ export class DatabaseConfigurations {
   }
 
   /**
+   * Build a DatabaseConfigurations from raw config, merging DATABASE_URL.
+   * Mirrors Rails' DatabaseConfigurations.new which auto-merges DATABASE_URL.
+   * Use this when you want Rails-compatible behavior (constructor + URL merge).
+   */
+  static fromRaw(configurations: RawConfigurations = {}): DatabaseConfigurations {
+    const instance = new DatabaseConfigurations([]);
+    // Use static defaultEnv (not NODE_ENV) — mirrors Rails' DatabaseConfigurations.new
+    instance._configurations = instance._buildConfigs(
+      instance._mergeDatabaseUrl(configurations, DatabaseConfigurations._defaultEnv),
+    );
+    _currentConfigurations = instance;
+    return instance;
+  }
+
+  /**
    * Mirrors: DatabaseConfigurations#empty?
    */
   get empty(): boolean {
@@ -189,6 +204,15 @@ export class DatabaseConfigurations {
     if (config instanceof DatabaseConfig) return config;
     const defaultEnv = DatabaseConfigurations.defaultEnv;
     if (typeof config === "string") {
+      // Mirrors Rails: resolve(symbol) → resolve_symbol_connection → find_db_config
+      // If the string looks like an env name (no URL scheme), find the db config for it.
+      if (!config.includes("://") && !config.startsWith("jdbc:")) {
+        const found = this.findDbConfig(config);
+        if (found) return found;
+        throw new Error(
+          `The \`${config}\` database is not configured for the \`${defaultEnv}\` environment.`,
+        );
+      }
       return new UrlConfig(defaultEnv, "primary", config);
     }
     if (typeof config === "object" && config !== null) {
@@ -220,43 +244,55 @@ export class DatabaseConfigurations {
   /**
    * Merge DATABASE_URL into the raw configurations.
    *
-   * When DATABASE_URL is set:
-   * - If raw configs exist, the URL is merged into each environment's
-   *   primary config (the URL takes precedence).
-   * - If no raw configs exist, a config is synthesized for the current env.
+   * Mirrors Rails: merge_db_environment_variables — only merges into the
+   * current default env's primary config. If no config exists for the
+   * default env, adds one from the URL.
    *
    * Mirrors: ActiveRecord::DatabaseConfigurations#build_url_hash
    */
-  private _mergeDatabaseUrl(raw: RawConfigurations): RawConfigurations {
+  private _mergeDatabaseUrl(raw: RawConfigurations, envOverride?: string): RawConfigurations {
     const databaseUrl = process.env.DATABASE_URL;
     if (!databaseUrl) return raw;
 
     const hasConfigs = Object.keys(raw).length > 0;
 
     if (!hasConfigs) {
-      const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
+      const env = envOverride ?? process.env.NODE_ENV ?? DatabaseConfigurations._defaultEnv;
       return { [env]: { url: databaseUrl } };
     }
 
-    const merged: RawConfigurations = {};
-    for (const [envName, envConfig] of Object.entries(raw)) {
-      if (typeof envConfig !== "object" || envConfig === null) {
-        merged[envName] = envConfig;
-        continue;
-      }
+    const currentEnv = envOverride ?? process.env.NODE_ENV ?? DatabaseConfigurations._defaultEnv;
 
-      if (this._isThreeLevelConfig(envConfig)) {
-        // Three-level: merge URL into the "primary" entry only
-        const nested = { ...envConfig } as Record<string, DatabaseConfigOptions>;
-        if (nested.primary) {
-          nested.primary = { ...nested.primary, url: databaseUrl };
-        } else {
-          // Add a primary entry if one doesn't exist
-          nested.primary = { url: databaseUrl };
-        }
-        merged[envName] = nested;
+    // Check if any config matches the current env
+    const hasDefaultEnvConfig = Object.prototype.hasOwnProperty.call(raw, currentEnv);
+
+    const merged: RawConfigurations = { ...raw };
+
+    if (!hasDefaultEnvConfig) {
+      // Rails: unless db_configs.find(&:for_current_env?) → add URL config for default env
+      merged[currentEnv] = { url: databaseUrl };
+      return merged;
+    }
+
+    const envConfig = raw[currentEnv];
+    if (typeof envConfig !== "object" || envConfig === null) {
+      return merged;
+    }
+
+    if (this._isThreeLevelConfig(envConfig)) {
+      // Three-level: merge URL into the "primary" entry only (don't override existing url:)
+      const nested = { ...(envConfig as Record<string, DatabaseConfigOptions>) };
+      if (nested.primary) {
+        if (!nested.primary.url) nested.primary = { ...nested.primary, url: databaseUrl };
       } else {
-        merged[envName] = { ...envConfig, url: databaseUrl } as DatabaseConfigOptions;
+        nested.primary = { url: databaseUrl };
+      }
+      merged[currentEnv] = nested;
+    } else {
+      const existing = envConfig as DatabaseConfigOptions;
+      // Don't override an explicit url: key in the config (Rails: env-specific url takes precedence)
+      if (!existing.url) {
+        merged[currentEnv] = { ...existing, url: databaseUrl };
       }
     }
     return merged;
@@ -266,6 +302,23 @@ export class DatabaseConfigurations {
     const configs: DatabaseConfig[] = [];
 
     for (const [envName, envConfig] of Object.entries(raw)) {
+      // Mirrors Rails: build_db_config_from_raw_config — string must have a URI scheme
+      if (typeof envConfig === "string") {
+        if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(envConfig)) {
+          throw new InvalidConfigurationError(
+            `'{ ${envName} => ${envConfig} }' is not a valid configuration. Expected '${envConfig}' to be a URL string or a Hash.`,
+          );
+        }
+        configs.push(
+          this._buildConfig(envName, "primary", { url: envConfig } as DatabaseConfigOptions),
+        );
+        continue;
+      }
+      if (typeof envConfig !== "object" || envConfig === null) {
+        throw new InvalidConfigurationError(
+          `'{ ${envName} => ${String(envConfig)} }' is not a valid configuration. Expected a URL string or Hash.`,
+        );
+      }
       if (this._isThreeLevelConfig(envConfig)) {
         for (const [name, dbConfig] of Object.entries(
           envConfig as Record<string, DatabaseConfigOptions>,

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -269,11 +269,11 @@ export class DatabaseConfigurations {
     const hasConfigs = Object.keys(raw).length > 0;
 
     if (!hasConfigs) {
-      const env = envOverride ?? DatabaseConfigurations._defaultEnv;
+      const env = envOverride ?? DatabaseConfigurations.defaultEnv;
       return { [env]: { url: databaseUrl } };
     }
 
-    const currentEnv = envOverride ?? DatabaseConfigurations._defaultEnv;
+    const currentEnv = envOverride ?? DatabaseConfigurations.defaultEnv;
 
     // Check if any config matches the current env
     const hasDefaultEnvConfig = Object.prototype.hasOwnProperty.call(raw, currentEnv);

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -18,9 +18,9 @@ export class InvalidConfigurationError extends Error {
   }
 }
 
-type RawConfigurations = Record<
+export type RawConfigurations = Record<
   string,
-  Record<string, DatabaseConfigOptions> | DatabaseConfigOptions
+  Record<string, DatabaseConfigOptions> | DatabaseConfigOptions | string
 >;
 
 /**
@@ -89,7 +89,8 @@ export class DatabaseConfigurations {
     } else {
       // Mirrors Rails: DatabaseConfigurations#initialize calls build_configs which
       // merges DATABASE_URL via environment_url_config + merge_db_environment_variables.
-      this._configurations = this._buildConfigs(this._mergeDatabaseUrl(configurations));
+      const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
+      this._configurations = this._buildConfigs(this._mergeDatabaseUrl(configurations, env));
     }
     // Register this instance as the current one for HashConfig.isPrimary lookup
     _currentConfigurations = this;
@@ -208,8 +209,10 @@ export class DatabaseConfigurations {
     const defaultEnv = DatabaseConfigurations.defaultEnv;
     if (typeof config === "string") {
       // Mirrors Rails: resolve(symbol) → resolve_symbol_connection → find_db_config
-      // If the string looks like an env name (no URL scheme), find the db config for it.
-      if (!config.includes("://") && !config.startsWith("jdbc:")) {
+      // Strings with a URI scheme (e.g. "postgres://", "sqlite3:") are treated as URLs.
+      // Strings without a scheme are treated as env names (mirrors Ruby symbol lookup).
+      const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config);
+      if (!hasScheme) {
         const found = this.findDbConfig(config);
         if (found) return found;
         throw new Error(
@@ -240,7 +243,8 @@ export class DatabaseConfigurations {
    */
   static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
-    instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw));
+    const env = process.env.NODE_ENV || DatabaseConfigurations._defaultEnv;
+    instance._configurations = instance._buildConfigs(instance._mergeDatabaseUrl(raw, env));
     return instance;
   }
 
@@ -260,11 +264,11 @@ export class DatabaseConfigurations {
     const hasConfigs = Object.keys(raw).length > 0;
 
     if (!hasConfigs) {
-      const env = envOverride ?? process.env.NODE_ENV ?? DatabaseConfigurations._defaultEnv;
+      const env = envOverride ?? DatabaseConfigurations._defaultEnv;
       return { [env]: { url: databaseUrl } };
     }
 
-    const currentEnv = envOverride ?? process.env.NODE_ENV ?? DatabaseConfigurations._defaultEnv;
+    const currentEnv = envOverride ?? DatabaseConfigurations._defaultEnv;
 
     // Check if any config matches the current env
     const hasDefaultEnvConfig = Object.prototype.hasOwnProperty.call(raw, currentEnv);

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -15,7 +15,11 @@ import type { DatabaseConfigOptions } from "./database-config.js";
 // E.g., "postgres" → "postgresql".
 const PROTOCOL_ADAPTERS: Record<string, string> = {
   postgres: "postgresql",
+  postgresql: "postgresql",
+  mysql: "mysql2",
+  mysql2: "mysql2",
   sqlite: "sqlite3",
+  sqlite3: "sqlite3",
 };
 
 export class ConnectionUrlResolver {
@@ -105,8 +109,14 @@ export class ConnectionUrlResolver {
     if (!this._query) return {};
     const result: Record<string, string> = {};
     for (const pair of this._query.split("&")) {
-      const [k, v] = pair.split("=", 2);
-      if (k) result[k] = v ?? "";
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx === -1) {
+        if (pair) result[pair] = "";
+      } else {
+        const k = pair.slice(0, eqIdx);
+        const v = pair.slice(eqIdx + 1);
+        if (k) result[k] = v;
+      }
     }
     return result;
   }
@@ -127,7 +137,8 @@ export class ConnectionUrlResolver {
       password: parsed.password || undefined,
       port: parsed.port ? Number(parsed.port) : undefined,
       database: this._databaseFromPath(parsed.pathname),
-      host: parsed.hostname || undefined,
+      // URL API wraps IPv6 addresses in brackets; strip them to match Rails behavior
+      host: parsed.hostname ? parsed.hostname.replace(/^\[(.+)\]$/, "$1") : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

### `merge-and-resolve-default-url-config.test.ts` (40 tests, 7 skipped)
Implements all Rails-mirroring tests for URL config merging and resolution without a live DB.

- **`DatabaseConfigurations.fromRaw()`**: new factory mirroring Rails' `DatabaseConfigurations.new` — merges `DATABASE_URL` using `defaultEnv` (not `NODE_ENV`) to match Rails' behavior
- **`_mergeDatabaseUrl`**: only merges into `currentEnv` (not all envs); adds config for `defaultEnv` when none exists; preserves explicit `url:` keys (don't override with `DATABASE_URL`)
- **`_buildConfigs`**: validates string configs as URLs (raises `InvalidConfigurationError` for non-URL strings)
- **`resolve`**: env-name strings (no `://` scheme) resolve via `findDbConfig`, matching Rails' `resolve(symbol) → resolve_symbol_connection`

### `ConnectionUrlResolver` fixes
- Adds `mysql→mysql2`, `mysql2→mysql2`, `postgresql→postgresql`, `sqlite3→sqlite3` mappings
- Fixes query string parsing to split on first `=` only (handles `options=-cmyoption=on`)
- Strips IPv6 brackets from hostname (`[::1]` → `::1`)

## Test plan
- [ ] `pnpm test` — all pass, no regressions
- [ ] `pnpm run test:compare --package activerecord` — 33+ new tests in merge-and-resolve file