### PR TITLE
docs/test(activerecord): bigint PR 3 — JSON serialization

### DIFF
--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -347,7 +347,9 @@ describe("SerializationTest", () => {
       const r = new Row({ id: big, name: "row-2" });
       expect(() => JSON.stringify(r)).not.toThrow();
       const parsed = JSON.parse(JSON.stringify(r));
-      // bigint is coerced to decimal string; consumers must parse with BigInt().
+      // bigint is coerced to decimal string (not number — JS number loses
+      // precision above 2^53-1). Consumers must parse with BigInt(str).
+      expect(typeof parsed.id).toBe("string");
       expect(parsed.id).toBe("4611686018427387904");
       expect(parsed.name).toBe("row-2");
     });

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -250,7 +250,7 @@ describe("SerializationTest", () => {
       }
       const r = new Row({ id: "99999999999999999999", name: "row-1" });
       const json = r.asJson();
-      // Before this PR: `id` was a BigInt → JSON.stringify would throw.
+      // bigint attributes are coerced to decimal strings by coerceForJson.
       expect(json["id"]).toBe("99999999999999999999");
       expect(json["name"]).toBe("row-1");
       // JSON.stringify now round-trips without throwing.
@@ -333,6 +333,23 @@ describe("SerializationTest", () => {
       expect(JSON.stringify(r)).toBe(r.toJson());
       const parsed = JSON.parse(JSON.stringify(r));
       expect(parsed).toEqual({ id: "42", name: "row-1" });
+    });
+
+    it("JSON.stringify(model) with large bigint id above Number.MAX_SAFE_INTEGER", () => {
+      class Row extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("name", "string");
+        }
+      }
+      // 2^62 — cannot be represented as a JS number without precision loss.
+      const big = 2n ** 62n;
+      const r = new Row({ id: big, name: "row-2" });
+      expect(() => JSON.stringify(r)).not.toThrow();
+      const parsed = JSON.parse(JSON.stringify(r));
+      // bigint is coerced to decimal string; consumers must parse with BigInt().
+      expect(parsed.id).toBe("4611686018427387904");
+      expect(parsed.name).toBe("row-2");
     });
 
     it("coerceForJson maps invalid Date to null (matches Date.prototype.toJSON)", async () => {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -119,7 +119,12 @@ export function serializableHash(
  * - Symbol → string (Ruby symbols are interned strings)
  *
  * We cover the JS analog:
- * - `bigint` → string (JSON.stringify throws otherwise)
+ * - `bigint` → decimal string. Rails serializes large integers as JSON
+ *   numbers because Ruby's Integer is arbitrary-precision and the JSON
+ *   encoder handles them natively. JS `JSON.stringify` throws on bigint,
+ *   and JS numbers lose precision above 2^53-1, so we emit a decimal
+ *   string instead. Consumers that need the numeric value must parse
+ *   with `BigInt(str)`.
  * - `Date` → ISO 8601 string, or `null` for invalid dates (matches
  *   `Date.prototype.toJSON`)
  * - Plain arrays / objects → recurse

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -54,15 +54,14 @@ export type DjarIds = unknown[] | unknown[][];
  * as-is (Map identity already works); tuples are serialized so
  * `[1, 100]` from two independent reads collides in the bucket.
  *
- * JSON covers the primitive shapes pluck returns (number/string/
- * null/bool), but `bigint` throws in `JSON.stringify` — the `big_integer`
- * cast type produces bigints, and composite PKs on large tables are
- * the exact case that hits them. Normalize bigints via a replacer
- * that emits `"\u0000B<decimal>"` (a NUL-prefixed string), so a
- * `123n` component serializes distinctly from the plain string
- * `"123"`. The outer tuple key also carries a leading `\u0000T`
- * marker so tuple keys are non-collidable with any plausible scalar
- * passed through this helper.
+ * `big_integer` columns (PG int8 / MySQL BIGINT) produce JS `bigint`
+ * values after driver normalization — composite PKs on large tables are
+ * the primary case. `bigint` cannot appear in `JSON.stringify` without a
+ * replacer, so we normalize via one that emits `"\u0000B<decimal>"`
+ * (a NUL-prefixed tag), keeping `123n` distinct from the plain string
+ * `"123"` in the same tuple position. The outer tuple key carries a
+ * leading `"\u0000T"` marker so tuple keys are non-collidable with any
+ * plausible scalar passed through this helper.
  */
 function serializeKey(v: unknown, composite: boolean): unknown {
   if (!composite) return v;


### PR DESCRIPTION
JSON serialization of bigint fields was already implemented. This PR cleans up stale comments and adds large-value test coverage.

- disable-joins-association-relation.ts: update serializeKey comment to reflect bigint PKs are first-class after PR 1 driver normalization
- serialization.test.ts: remove stale 'Before this PR' comment; add test for JSON.stringify with 2^62 bigint confirming decimal string output