### PR TITLE
test(activerecord): bigint PR 4 — unskip tests + model round-trips

### DIFF
--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -12,7 +12,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 
 const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
 
-describe("SQLite3 bigint model round-trip", () => {
+describe("bigint model round-trip (all adapters)", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {
@@ -80,5 +80,17 @@ describe("SQLite3 bigint model round-trip", () => {
     const results = await Metric.where({ score: BIG }).toArray();
     expect(results).toHaveLength(1);
     expect(results[0].label).toBe("target");
+  });
+
+  it("queryAttribute returns false for 0n, true for non-zero bigint", async () => {
+    // Mirrors Rails query_attribute which uses value.zero? for numeric types.
+    // Mirrors activerecord/lib/active_record/attribute_methods/query.rb
+    const Metric = makeModel();
+    const zero = await Metric.create({ score: 0n, label: "zero" });
+    const nonzero = await Metric.create({ score: BIG, label: "nonzero" });
+    const foundZero = await Metric.find(zero.id);
+    const foundNonzero = await Metric.find(nonzero.id);
+    expect(foundZero.queryAttribute("score")).toBe(false);
+    expect(foundNonzero.queryAttribute("score")).toBe(true);
   });
 });

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Model-level bigint round-trip tests (all adapters).
+ *
+ * Tests the full AR stack (create, find, update, dirty tracking,
+ * JSON.stringify, where) with big_integer attributes. Runs on SQLite3
+ * by default (no DB); runs on PG/MySQL when *_TEST_URL env vars are set.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base } from "./index.js";
+import { createTestAdapter } from "./test-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
+
+describe("SQLite3 bigint model round-trip", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  function makeModel() {
+    class Metric extends Base {
+      static {
+        this.attribute("score", "big_integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    return Metric;
+  }
+
+  it("create and find preserves bigint value", async () => {
+    const Metric = makeModel();
+    const m = await Metric.create({ score: BIG, label: "a" });
+    const found = await Metric.find(m.id);
+    expect(found.score).toBe(BIG);
+    expect(typeof found.score).toBe("bigint");
+  });
+
+  it("update preserves bigint value", async () => {
+    const Metric = makeModel();
+    const m = await Metric.create({ score: BIG, label: "a" });
+    await m.update({ score: BIG + 1n });
+    const found = await Metric.find(m.id);
+    expect(found.score).toBe(BIG + 1n);
+  });
+
+  it("dirty tracking: no change when assigning same bigint", async () => {
+    const Metric = makeModel();
+    const m = await Metric.create({ score: BIG, label: "a" });
+    const found = await Metric.find(m.id);
+    found.score = BIG;
+    expect(found.changed).toBe(false);
+  });
+
+  it("dirty tracking: change detected on different bigint", async () => {
+    const Metric = makeModel();
+    const m = await Metric.create({ score: BIG, label: "a" });
+    const found = await Metric.find(m.id);
+    found.score = BIG + 1n;
+    expect(found.changed).toBe(true);
+    expect(found.changes.score).toEqual([BIG, BIG + 1n]);
+  });
+
+  it("JSON.stringify emits decimal string for bigint attribute", async () => {
+    const Metric = makeModel();
+    const m = await Metric.create({ score: BIG, label: "a" });
+    const found = await Metric.find(m.id);
+    expect(() => JSON.stringify(found)).not.toThrow();
+    const parsed = JSON.parse(JSON.stringify(found));
+    expect(typeof parsed.score).toBe("string");
+    expect(parsed.score).toBe(BIG.toString());
+  });
+
+  it("where with bigint value finds the record", async () => {
+    const Metric = makeModel();
+    await Metric.create({ score: BIG, label: "target" });
+    await Metric.create({ score: BIG + 1n, label: "other" });
+    const results = await Metric.where({ score: BIG }).toArray();
+    expect(results).toHaveLength(1);
+    expect(results[0].label).toBe("target");
+  });
+});

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -250,8 +250,15 @@ describe("SchemaDumperTest", () => {
     expect(output).toContain("scale: 2");
   });
 
-  it.skip("schema dump includes bigint default", () => {
-    /* needs bigint column type in TableDefinition */
+  it("schema dump includes bigint default", async () => {
+    // Mirrors Rails: test_schema_dump_includes_bigint_default
+    // (activerecord/test/cases/schema_dumper_test.rb:366)
+    // assert_match %r{t\.bigint\s+"bigint_default",\s+default: 0}, output
+    await ctx.createTable("defaults", {}, (t) => {
+      t.bigint("bigint_default", { default: 0 });
+    });
+    const output = SchemaDumper.dump(ctx);
+    expect(output).toMatch(/t\.bigint\("bigint_default",\s*\{[^}]*default:\s*0[^}]*\}/);
   });
 
   it.skip("schema dump includes limit on array type", () => {


### PR DESCRIPTION
## Summary

- **schema-dumper.test.ts**: implement `schema dump includes bigint default` (previously skipped). Mirrors Rails `test_schema_dump_includes_bigint_default` (`schema_dumper_test.rb:366`): creates a `defaults` table with a `bigint_default` column (`default: 0`), asserts dump output matches `t.bigint("bigint_default", { default: 0 })`. No dumper code change needed — bigint/int8 → `t.bigint()` was already wired at `schema-dumper.ts:85–86`.

- **bigint-roundtrip.test.ts** (new): model-level round-trips through the full AR stack on all adapters (SQLite3 by default; PG/MySQL when `*_TEST_URL` env vars are set):
  - `create` + `find` preserves `bigint` value (`2n ** 62n`, above `Number.MAX_SAFE_INTEGER`)
  - `update` preserves bigint value
  - dirty tracking: no change when same bigint is assigned; change detected on different value
  - `JSON.stringify` emits decimal string, not number
  - `where({ score: bigint })` finds the record

## Previously skipped tests status
- `type-lookup.test.ts` `bigint limit` — was already implemented (not skipped)
- `integer.test.ts` — unskipped in PR 1 (#783)

## No backwards compatibility required

Pre-release project, zero downstream consumers.