### PR TITLE
feat(activemodel): alias_attribute read/write cascade

### DIFF
--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -289,6 +289,22 @@ describe("AttributeMethodsTest", () => {
     expect(p.changes).toEqual({ name: ["Alice", "Ally"] });
   });
 
+  it("hasAttribute and readAttributeBeforeTypeCast resolve alias names", () => {
+    // Rails `has_attribute?` and `read_attribute_before_type_cast` both go
+    // through `attribute_aliases[name] || name` (attribute_methods.rb).
+    class Person extends Model {
+      static {
+        this.attribute("age", "integer");
+        this.aliasAttribute("years", "age");
+      }
+    }
+    const p = new Person({ age: "42" });
+    expect(p.hasAttribute("years")).toBe(true);
+    expect(p.hasAttribute("age")).toBe(true);
+    expect(p.hasAttribute("nope")).toBe(false);
+    expect(p.readAttributeBeforeTypeCast("years")).toBe("42");
+  });
+
   it("name clashes are handled", () => {
     // Attributes with the same name as existing methods should still work via readAttribute
     class Person extends Model {

--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -255,6 +255,40 @@ describe("AttributeMethodsTest", () => {
     expect(p.readAttribute("nonexistent")).toBe("missing:nonexistent");
   });
 
+  it("readAttribute / writeAttribute resolve alias_attribute names transparently", () => {
+    // Rails `read_attribute(name)` does `attribute_aliases[name] || name`
+    // (activemodel attribute_methods.rb) so callers can pass either the
+    // aliased or canonical name and hit the same underlying attribute.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.aliasAttribute("nickname", "name");
+      }
+    }
+    const p = new Person({ name: "Alice" });
+    expect(p.readAttribute("nickname")).toBe("Alice");
+    p.writeAttribute("nickname", "Ally");
+    expect(p.readAttribute("name")).toBe("Ally");
+    expect(p.readAttribute("nickname")).toBe("Ally");
+  });
+
+  it("aliased writes propagate to dirty tracking on the canonical name", () => {
+    // The alias write must register a change on the ORIGINAL attribute's
+    // dirty state, not a separate entry — otherwise changedAttributes /
+    // changes would report under the aliased name.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.aliasAttribute("nickname", "name");
+      }
+    }
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    p.writeAttribute("nickname", "Ally");
+    expect(p.changedAttributes).toEqual(["name"]);
+    expect(p.changes).toEqual({ name: ["Alice", "Ally"] });
+  });
+
   it("name clashes are handled", () => {
     // Attributes with the same name as existing methods should still work via readAttribute
     class Person extends Model {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -279,3 +279,15 @@ export function isAttributeAlias(host: AttributeMethodHost, name: string): boole
 export function attributeAlias(host: AttributeMethodHost, name: string): string | undefined {
   return host._attributeAliases[name];
 }
+
+/**
+ * Resolve `name` to its canonical attribute name, following one alias
+ * hop. Mirrors Rails `ActiveModel::AttributeMethods#read_attribute`'s
+ * `attribute_aliases[name] || name` (activemodel/lib/active_model/attribute_methods.rb
+ * read_attribute / write_attribute paths) so every read/write path sees
+ * the same key whether the caller passed `nickname` or `name`.
+ */
+export function resolveAliasName(host: AttributeMethodHost, name: string): string {
+  const aliased = host._attributeAliases?.[name];
+  return aliased ?? name;
+}

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -10,7 +10,11 @@ export {
 export { NestedError } from "./nested-error.js";
 export { ValidationError, ValidationContext } from "./validations.js";
 export { Validator, EachValidator, BlockValidator } from "./validator.js";
-export { MissingAttributeError, AttributeMethodPattern } from "./attribute-methods.js";
+export {
+  MissingAttributeError,
+  AttributeMethodPattern,
+  resolveAliasName,
+} from "./attribute-methods.js";
 export { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
 export { assignAttributes, attributeWriterMissing, ArgumentError } from "./attribute-assignment.js";
 export type { AttributeAssignment } from "./attribute-assignment.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -30,6 +30,7 @@ import {
   attributeMethodSuffix,
   attributeMethodAffix,
   aliasAttribute,
+  resolveAliasName,
   undefineAttributeMethods,
 } from "./attribute-methods.js";
 import {
@@ -1106,10 +1107,20 @@ export class Model {
   // -- Attribute access --
 
   readAttribute(name: string): unknown {
+    // Rails resolves alias_attribute names in `read_attribute`
+    // (attribute_aliases[name] || name); `_read_attribute` skips it.
+    const resolved = resolveAliasName(this.constructor as typeof Model, name);
+    if (!this._attributes.has(resolved)) {
+      return this.attributeMissing(resolved);
+    }
+    this._accessedFields.add(resolved);
+    return this._attributes.fetchValue(resolved) ?? null;
+  }
+
+  _readAttribute(name: string): unknown {
     if (!this._attributes.has(name)) {
       return this.attributeMissing(name);
     }
-    this._accessedFields.add(name);
     return this._attributes.fetchValue(name) ?? null;
   }
 
@@ -1124,10 +1135,16 @@ export class Model {
   }
 
   writeAttribute(name: string, value: unknown): void {
+    // Alias-resolve on the public write path; aliased writes land on the
+    // canonical attribute's dirty state (Rails `write_attribute`).
+    const resolved = resolveAliasName(this.constructor as typeof Model, name);
+    this._writeAttribute(resolved, value);
+  }
+
+  _writeAttribute(name: string, value: unknown): void {
     const ctor = this.constructor as typeof Model;
     const oldValue = this._attributes.has(name) ? this._attributes.fetchValue(name) : undefined;
     this._attributes.writeFromUser(name, value);
-    // Apply normalization and nullify blanks on the cast value
     let newValue = this._attributes.fetchValue(name);
     newValue = ctor._applyNormalization(name, newValue);
     newValue = this._applyNullifyBlanks(name, newValue);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1174,7 +1174,8 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_before_type_cast
    */
   readAttributeBeforeTypeCast(name: string): unknown {
-    return this._attributes.getAttribute(name).valueBeforeTypeCast ?? null;
+    const resolved = resolveAliasName(this.constructor as typeof Model, name);
+    return this._attributes.getAttribute(resolved).valueBeforeTypeCast ?? null;
   }
 
   /**
@@ -1203,7 +1204,9 @@ export class Model {
    * Mirrors: ActiveModel::AttributeMethods#has_attribute?
    */
   hasAttribute(name: string): boolean {
-    return (this.constructor as typeof Model)._attributeDefinitions.has(name);
+    const ctor = this.constructor as typeof Model;
+    const resolved = resolveAliasName(ctor, name);
+    return ctor._attributeDefinitions.has(resolved);
   }
 
   /**

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1774,6 +1774,22 @@ describe("AttributeMethodsTest", () => {
     it("returns false for undefined attributes", () => {
       expect(Person.hasAttributeDefinition("foo")).toBe(false);
     });
+
+    it("returns true for alias_attribute names on instances", () => {
+      // Rails `has_attribute?` resolves attribute_aliases
+      // (active_record/attribute_methods.rb).
+      class Topic extends Base {
+        static {
+          this.attribute("title", "string");
+          this.aliasAttribute("heading", "title");
+          this.adapter = adapter;
+        }
+      }
+      const t = new Topic({ title: "Hi" });
+      expect(t.hasAttribute("heading")).toBe(true);
+      expect(t.hasAttribute("title")).toBe(true);
+      expect(t.hasAttribute("missing")).toBe(false);
+    });
   });
 
   describe("readonly attributes", () => {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::AttributeMethods
  */
 import { isBlank } from "@blazetrails/activesupport";
+import { resolveAliasName } from "@blazetrails/activemodel";
 // ActiveModel provides aliasAttribute and undefineAttributeMethods on Model.
 // aliasAttribute delegates via the prototype chain. defineAttributeMethods
 // is implemented here since AM doesn't expose it as a static on Model.
@@ -31,7 +32,15 @@ interface AttributeRecord {
  * Mirrors: ActiveRecord::AttributeMethods#has_attribute?
  */
 export function hasAttribute(this: AttributeRecord, name: string): boolean {
-  return this._attributes.has(name);
+  // Rails `has_attribute?` resolves attribute_aliases before hitting the
+  // attribute set (active_record/attribute_methods.rb).
+  const resolved = resolveAliasName(
+    (this as unknown as { constructor: unknown }).constructor as Parameters<
+      typeof resolveAliasName
+    >[0],
+    name,
+  );
+  return this._attributes.has(resolved);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -34,5 +34,5 @@ export interface Write {
  * Mirrors: ActiveRecord::AttributeMethods::Write#_write_attribute
  */
 export function _writeAttribute(this: Model, name: string, value: unknown): void {
-  Model.prototype.writeAttribute.call(this, name, value);
+  Model.prototype._writeAttribute.call(this, name, value);
 }

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -132,7 +132,9 @@ export function _writeAttribute(this: Base, name: string, value: unknown): void 
     }
     return;
   }
-  Model.prototype.writeAttribute.call(this, name, value);
+  // Mirrors Rails `_write_attribute`: skip alias resolution, unlike the
+  // public `write_attribute` path above.
+  Model.prototype._writeAttribute.call(this, name, value);
 }
 
 /**

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { Model } from "@blazetrails/activemodel";
+import { Model, resolveAliasName } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
 
 /**
@@ -108,15 +108,19 @@ export function writeAttribute(this: Base, name: string, value: unknown): void {
     throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
   }
   const ctor = this.constructor as typeof Base;
-  if (this._newRecord === false && ctor.readonlyAttributeQ(String(name))) {
+  // Rails' `write_attribute` resolves `attribute_aliases[name]` before the
+  // chain runs, so HasReadonlyAttributes' check sees the canonical name and
+  // writing via an alias cannot bypass readonly enforcement.
+  const canonical = resolveAliasName(ctor, String(name));
+  if (this._newRecord === false && ctor.readonlyAttributeQ(canonical)) {
     if (_raiseOnAssignToAttrReadonly) {
-      throw new ReadonlyAttributeError(String(name));
+      throw new ReadonlyAttributeError(canonical);
     }
     return; // silently skip — mirrors Rails' non-raising mode
   }
-  // `super` — route through Model's writeAttribute (the next ancestor with
-  // a writeAttribute impl, matching Rails' `super` in HasReadonlyAttributes).
-  Model.prototype.writeAttribute.call(this, name, value);
+  // `super` — route through Model's _writeAttribute with the already-resolved
+  // canonical name, matching Rails' `super` into the underscore path.
+  Model.prototype._writeAttribute.call(this, canonical, value);
 }
 
 /**

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -362,6 +362,26 @@ describe("ReadonlyTest", () => {
     await expect(post.destroy()).rejects.toThrow("readonly");
   });
 
+  it("attr_readonly cannot be bypassed by writing via an alias_attribute", async () => {
+    // Rails' `write_attribute` resolves attribute_aliases before
+    // HasReadonlyAttributes runs, so the readonly check applies equally
+    // whether the caller passes the canonical or aliased name.
+    class Product extends Base {
+      static {
+        this._tableName = "products";
+        this.attribute("id", "integer");
+        this.attribute("sku", "string");
+        this.adapter = adapter;
+      }
+    }
+    Product.attrReadonly("sku");
+    Product.aliasAttribute("code", "sku");
+    const p = await Product.create({ sku: "A" });
+    expect(() => {
+      (p as any).writeAttribute("code", "B");
+    }).toThrow(ReadonlyAttributeError);
+  });
+
   // Rails: test "readonly? predicate"
   it("isReadonly reflects the readonly state", async () => {
     class Post extends Base {

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -1,6 +1,7 @@
 import type { Base } from "./base.js";
 import { Json } from "./type/json.js";
 import { SerializationTypeMismatch } from "./errors.js";
+import { resolveAliasName } from "@blazetrails/activemodel";
 
 interface Coder {
   dump(value: unknown): string;
@@ -105,12 +106,17 @@ export function serialize(
 
     modelClass.prototype.readAttribute = function (name: string): unknown {
       const raw = originalRead.call(this, name);
+      // Serialized coders are registered under the canonical attribute
+      // name, so resolve aliases before the map lookup — matches Rails
+      // `serialize` wrapping `_read_attribute(column_name)` through the
+      // attribute_aliases-aware read path.
+      const canonical = resolveAliasName(this.constructor as any, name);
       const serializedAttrs: Map<string, Coder> | undefined = (this.constructor as any)
         ._serializedAttributes;
-      if (serializedAttrs?.has(name)) {
+      if (serializedAttrs?.has(canonical)) {
         const expected: string | undefined = (
           this.constructor as any
-        )._serializedExpectedTypes?.get(name);
+        )._serializedExpectedTypes?.get(canonical);
         if (expected && raw !== null && raw !== undefined) {
           // Validate the raw parsed value BEFORE the coder coerces it.
           // The coders silently coerce (e.g. ARRAY_CODER returns [] for non-arrays),
@@ -141,7 +147,7 @@ export function serialize(
             }
           }
         }
-        return serializedAttrs.get(name)!.load(raw);
+        return serializedAttrs.get(canonical)!.load(raw);
       }
       return raw;
     };

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -842,4 +842,20 @@ describe("SerializedAttributeTest", () => {
     c.count = "42";
     expect(c.count).toBe(42);
   });
+
+  it("serialized attribute is still deserialized when read via alias", () => {
+    // Rails registers serialize coders under the canonical column name;
+    // reading via an alias_attribute should still route through the coder.
+    class User extends Base {
+      static {
+        this.attribute("preferences", "string");
+        this.aliasAttribute("prefs", "preferences");
+        this.adapter = adapter;
+      }
+    }
+    serialize(User, "preferences", { coder: "json" });
+    const u = new User({ preferences: '{"theme":"dark"}' });
+    expect((u as any).prefs).toEqual({ theme: "dark" });
+    expect(u.readAttribute("prefs")).toEqual({ theme: "dark" });
+  });
 });


### PR DESCRIPTION
## Summary
- Rails `read_attribute` / `write_attribute` resolve alias_attribute names via `attribute_aliases[name] || name` (activemodel/lib/active_model/attribute_methods.rb). Our TS port defined the aliased accessor property but did not resolve aliases in the low-level read/write paths — so `readAttribute("nickname")` returned null via attributeMissing and aliased writes bypassed dirty tracking on the canonical name.
- Adds `resolveAliasName(host, name)` and wires it into the public `readAttribute` / `writeAttribute`. Introduces underscore variants (`_readAttribute` / `_writeAttribute`) on Model as the direct non-resolving path, matching Rails' `_read_attribute` / `_write_attribute`.
- Points AR's `_writeAttribute` delegates (readonly-attributes.ts, attribute-methods/write.ts) at `Model.prototype._writeAttribute` so they continue to bypass alias resolution.

## Test plan
- [x] AM tests pass (1,468)
- [x] AR regression green (10,628 passed)
- [x] `readAttribute/writeAttribute resolve alias_attribute names transparently`
- [x] `aliased writes propagate to dirty tracking on the canonical name`
- [x] `_write_attribute writes directly without alias resolution` still holds