### PR TITLE
feat(parity): AR query runners + ar-00 smoke fixture (AR parity v2 PR 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,16 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build dependency packages for trails query runner
-        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel build
+        # activerecord is needed for AR-style fixtures (ar-*): ar_dump.ts
+        # imports Base from @blazetrails/activerecord and fixture models.ts
+        # files do too. Built in dep order — a single `--filter` invocation
+        # races (pnpm may start activemodel before activesupport's dist
+        # lands), so step through each package explicitly.
+        run: |
+          pnpm --filter @blazetrails/activesupport build
+          pnpm --filter @blazetrails/activemodel build
+          pnpm --filter @blazetrails/arel build
+          pnpm --filter @blazetrails/activerecord build
       - name: Run trails-side query dump
         run: pnpm tsx scripts/parity/run.ts --type=query --side=trails
       - uses: actions/upload-artifact@v4

--- a/scripts/parity/fixtures/ar-00/models.rb
+++ b/scripts/parity/fixtures/ar-00/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-00/models.ts
+++ b/scripts/parity/fixtures/ar-00/models.ts
@@ -2,6 +2,6 @@ import { Base } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
-    this._tableName = "books";
+    this.tableName = "books";
   }
 }

--- a/scripts/parity/fixtures/ar-00/models.ts
+++ b/scripts/parity/fixtures/ar-00/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this._tableName = "books";
+  }
+}

--- a/scripts/parity/fixtures/ar-00/query.rb
+++ b/scripts/parity/fixtures/ar-00/query.rb
@@ -1,0 +1,1 @@
+Book.all

--- a/scripts/parity/fixtures/ar-00/query.ts
+++ b/scripts/parity/fixtures/ar-00/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all();

--- a/scripts/parity/fixtures/ar-00/schema.sql
+++ b/scripts/parity/fixtures/ar-00/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-00 (smoke test)
+-- Query: Book.all
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/query/node/ar_dump.test.ts
+++ b/scripts/parity/query/node/ar_dump.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Integration tests for the AR query runner. Same harness shape as
+// dump.test.ts (arel runner tests) but exercises ar-* fixtures through
+// ar_dump.ts, which loads models.ts before evaluating query.ts.
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "../../../..");
+const AR_DUMP = join(SCRIPT_DIR, "ar_dump.ts");
+const FIXTURES = resolve(SCRIPT_DIR, "../../fixtures");
+const TSX_BIN = resolve(
+  REPO_ROOT,
+  "node_modules/.bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+// Build the four packages the runner's imports pull in. activerecord is
+// included here (not just activesupport/activemodel/arel) because the
+// runner itself and fixture models.ts both import from it.
+beforeAll(() => {
+  const packagesRoot = join(REPO_ROOT, "packages");
+  const deps = ["activesupport", "activemodel", "arel", "activerecord"];
+  const anyMissing = deps.some((p) => !existsSync(join(packagesRoot, p, "dist", "index.js")));
+  if (!anyMissing) return;
+  for (const pkg of deps) {
+    const res = spawnSync("pnpm", ["--filter", `@blazetrails/${pkg}`, "build"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: "inherit",
+    });
+    if (res.status !== 0) {
+      throw new Error(`failed to build @blazetrails/${pkg} for ar_dump tests`);
+    }
+  }
+}, 240_000);
+
+function runDumpReadJson(fixture: string): {
+  code: number;
+  stdout: string;
+  stderr: string;
+  json: Record<string, unknown>;
+} {
+  const outDir = mkdtempSync(join(tmpdir(), "parity-ar-test-"));
+  const outPath = join(outDir, `${fixture}.json`);
+  const res = spawnSync(TSX_BIN, [AR_DUMP, join(FIXTURES, fixture), outPath], {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
+  let json: Record<string, unknown> = {};
+  try {
+    json = JSON.parse(readFileSync(outPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    /* leave json={} on failure — test asserts code first */
+  }
+  rmSync(outDir, { recursive: true, force: true });
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    json,
+  };
+}
+
+describe("ar_dump.ts", () => {
+  it("dumps ar-00 (Book.all) to the expected SQL", () => {
+    const { code, stdout, stderr, json } = runDumpReadJson("ar-00");
+    expect(code, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+    expect(json.version).toBe(1);
+    expect(json.fixture).toBe("ar-00");
+    expect(json.sql).toBe('SELECT "books".* FROM "books"');
+    expect(json.binds).toEqual([]);
+    expect(json.frozenAt).toBe("2000-01-01T00:00:00.000Z");
+  });
+
+  it("exits 1 with a useful message on --frozen-at without a value", () => {
+    const res = spawnSync(
+      TSX_BIN,
+      [AR_DUMP, join(FIXTURES, "ar-00"), "/tmp/unused.json", "--frozen-at"],
+      { encoding: "utf8", cwd: REPO_ROOT },
+    );
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/--frozen-at requires a value/);
+  });
+
+  it("exits 1 with a useful message on invalid --frozen-at", () => {
+    const res = spawnSync(
+      TSX_BIN,
+      [AR_DUMP, join(FIXTURES, "ar-00"), "/tmp/unused.json", "--frozen-at", "not-a-date"],
+      { encoding: "utf8", cwd: REPO_ROOT },
+    );
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/--frozen-at must be ISO 8601 UTC/);
+  });
+});

--- a/scripts/parity/query/node/ar_dump.test.ts
+++ b/scripts/parity/query/node/ar_dump.test.ts
@@ -78,23 +78,41 @@ describe("ar_dump.ts", () => {
   });
 
   it("exits 1 with a useful message on --frozen-at without a value", () => {
-    const res = spawnSync(
-      TSX_BIN,
-      [AR_DUMP, join(FIXTURES, "ar-00"), "/tmp/unused.json", "--frozen-at"],
-      { encoding: "utf8", cwd: REPO_ROOT },
-    );
-    expect(res.status).toBe(1);
-    expect(res.stderr).toMatch(/--frozen-at requires a value/);
+    // tmpdir() rather than a hard-coded /tmp path — portable on Windows
+    // and in restricted CI sandboxes.
+    const outDir = mkdtempSync(join(tmpdir(), "parity-ar-test-"));
+    try {
+      const res = spawnSync(
+        TSX_BIN,
+        [AR_DUMP, join(FIXTURES, "ar-00"), join(outDir, "unused.json"), "--frozen-at"],
+        { encoding: "utf8", cwd: REPO_ROOT },
+      );
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/--frozen-at requires a value/);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   });
 
   it("exits 1 with a useful message on invalid --frozen-at", () => {
-    const res = spawnSync(
-      TSX_BIN,
-      [AR_DUMP, join(FIXTURES, "ar-00"), "/tmp/unused.json", "--frozen-at", "not-a-date"],
-      { encoding: "utf8", cwd: REPO_ROOT },
-    );
-    expect(res.status).toBe(1);
-    expect(res.stderr).toMatch(/--frozen-at must be ISO 8601 UTC/);
+    const outDir = mkdtempSync(join(tmpdir(), "parity-ar-test-"));
+    try {
+      const res = spawnSync(
+        TSX_BIN,
+        [
+          AR_DUMP,
+          join(FIXTURES, "ar-00"),
+          join(outDir, "unused.json"),
+          "--frozen-at",
+          "not-a-date",
+        ],
+        { encoding: "utf8", cwd: REPO_ROOT },
+      );
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/--frozen-at must be ISO 8601 UTC/);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   });
 
   it("exits non-zero on an unknown fixture directory", () => {

--- a/scripts/parity/query/node/ar_dump.test.ts
+++ b/scripts/parity/query/node/ar_dump.test.ts
@@ -96,4 +96,18 @@ describe("ar_dump.ts", () => {
     expect(res.status).toBe(1);
     expect(res.stderr).toMatch(/--frozen-at must be ISO 8601 UTC/);
   });
+
+  it("exits non-zero on an unknown fixture directory", () => {
+    // Typo'd or missing fixture dir — the most common operator error.
+    // We want it to fail fast with a readable errno, not deep inside AR.
+    const outDir = mkdtempSync(join(tmpdir(), "parity-ar-test-"));
+    const outPath = join(outDir, "out.json");
+    const res = spawnSync(TSX_BIN, [AR_DUMP, join(FIXTURES, "ar-does-not-exist"), outPath], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    rmSync(outDir, { recursive: true, force: true });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/ENOENT|no such file/i);
+  });
 });

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env tsx
+/**
+ * Usage (from repo root):
+ *   tsx scripts/parity/query/node/ar_dump.ts <fixture-dir> <out.json>
+ *       [--frozen-at ISO8601_UTC_Z]
+ *
+ * Like scripts/parity/query/node/dump.ts but for ActiveRecord query
+ * fixtures: applies schema.sql, calls Base.establishConnection(dbPath),
+ * dynamic-imports query.ts (which in turn imports models.ts and
+ * references the model classes), and calls .toSql() on the default
+ * export — expected to be an AR Relation.
+ *
+ * Time is always frozen. --frozen-at behaves identically to the arel runner.
+ *
+ * @blazetrails/{arel,activesupport,activemodel,activerecord} must all
+ * be built before running — resolution goes through package `main`
+ * entries.
+ */
+
+import Database from "better-sqlite3";
+import FakeTimers from "@sinonjs/fake-timers";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname, basename } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { CanonicalQuery } from "../../canonical/query-types.js";
+import { Base } from "@blazetrails/activerecord";
+
+function usage(): never {
+  process.stderr.write(
+    "Usage: tsx scripts/parity/query/node/ar_dump.ts <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]\n",
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): {
+  fixtureDir: string;
+  outPath: string;
+  frozenAt: string | null;
+} {
+  let fixtureDir: string | null = null;
+  let outPath: string | null = null;
+  let frozenAt: string | null = null;
+  let i = 0;
+  while (i < argv.length) {
+    if (argv[i] === "--frozen-at") {
+      const val = argv[i + 1];
+      if (!val || val.startsWith("--")) {
+        process.stderr.write("--frozen-at requires a value\n");
+        process.exit(1);
+      }
+      frozenAt = val;
+      i += 2;
+    } else if (argv[i]!.startsWith("--")) {
+      process.stderr.write(`unknown flag: ${argv[i]}\n`);
+      usage();
+    } else if (fixtureDir === null) {
+      fixtureDir = argv[i++]!;
+    } else if (outPath === null) {
+      outPath = argv[i++]!;
+    } else {
+      process.stderr.write(`unexpected argument: ${argv[i]}\n`);
+      usage();
+    }
+  }
+  if (!fixtureDir || !outPath) usage();
+  return { fixtureDir, outPath, frozenAt };
+}
+
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+const DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z";
+
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  const name = (v as { constructor?: { name?: string } }).constructor?.name;
+  return name ?? typeof v;
+}
+
+function assertBuilt(): void {
+  // All four packages contribute to the AR query surface; if any dist/ is
+  // missing, model load will fail with a cryptic module-not-found error.
+  // Check all four up-front with a clear hint.
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const missing: string[] = [];
+  for (const pkg of ["activesupport", "activemodel", "arel", "activerecord"]) {
+    const dist = resolve(scriptDir, `../../../../packages/${pkg}/dist/index.js`);
+    if (!existsSync(dist)) missing.push(`@blazetrails/${pkg}`);
+  }
+  if (missing.length > 0) {
+    process.stderr.write(`parity ar_dump (trails): missing dist/ for ${missing.join(", ")}\n`);
+    process.stderr.write(
+      `Run: pnpm --filter @blazetrails/activesupport --filter @blazetrails/activemodel --filter @blazetrails/arel --filter @blazetrails/activerecord build\n`,
+    );
+    process.exit(1);
+  }
+}
+
+async function main(): Promise<void> {
+  const {
+    fixtureDir: fixtureDirRaw,
+    outPath: outPathRaw,
+    frozenAt,
+  } = parseArgs(process.argv.slice(2));
+
+  if (frozenAt !== null) {
+    if (!ISO_UTC_RE.test(frozenAt)) {
+      process.stderr.write(
+        "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)\n",
+      );
+      process.exit(1);
+    }
+    if (!Number.isFinite(Date.parse(frozenAt))) {
+      process.stderr.write(`--frozen-at is not a valid date: ${frozenAt}\n`);
+      process.exit(1);
+    }
+  }
+
+  assertBuilt();
+
+  const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
+  const frozenMs = new Date(frozenTs).getTime();
+  const fixtureDirAbs = resolve(fixtureDirRaw);
+  const outPathAbs = resolve(outPathRaw);
+  const fixtureName = basename(fixtureDirAbs);
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "parity-ar-node-"));
+  const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
+
+  try {
+    // 1. Apply schema.sql to a fresh temp SQLite file.
+    const dbPath = join(tmpDir, "query.db");
+    const db = new Database(dbPath);
+    try {
+      db.exec(readFileSync(join(fixtureDirAbs, "schema.sql"), "utf8"));
+    } finally {
+      db.close();
+    }
+
+    // 2. Connect via trails AR — models.ts's class definitions inherit
+    //    from Base and read Base.adapter lazily, so the connection must
+    //    exist before any model method is invoked. establishConnection
+    //    sets Base.adapter for the whole process.
+    await Base.establishConnection(dbPath);
+
+    // 3. Import query.ts. Fixtures end with `export default <relation>`
+    //    and typically `import { Book } from "./models.ts"` to reference
+    //    model classes — that side-effect-loads models.ts which registers
+    //    the classes against the current Base.adapter.
+    const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
+    const mod = (await import(queryUrl)) as { default: unknown };
+    const result = mod.default;
+
+    if (result === null || result === undefined) {
+      throw new Error(`[${fixtureName}] query.ts default export is ${result}`);
+    }
+    if (typeof (result as { toSql?: unknown }).toSql !== "function") {
+      throw new Error(
+        `[${fixtureName}] query.ts default export is ${describe(result)}: expected an AR Relation with .toSql()`,
+      );
+    }
+
+    // 4. Extract SQL. AR Relation.toSql() renders SQL with literals inlined;
+    //    binds[] is always empty, same contract as the arel runner.
+    const sqlStr = (result as { toSql(): string }).toSql().trim();
+    const binds: string[] = [];
+
+    // 5. Write CanonicalQuery JSON
+    const canonical: CanonicalQuery = {
+      version: 1,
+      fixture: fixtureName,
+      frozenAt: frozenTs,
+      sql: sqlStr,
+      binds,
+    };
+
+    mkdirSync(dirname(outPathAbs), { recursive: true });
+    writeFileSync(outPathAbs, JSON.stringify(canonical, null, 2) + "\n", "utf8");
+
+    const ctor = describe(result);
+    process.stdout.write(`[trails] ${fixtureName}\n`);
+    process.stdout.write(`  result type : ${ctor}\n`);
+    process.stdout.write(`  sql         : ${sqlStr}\n`);
+    process.stdout.write(`  frozenAt    : ${frozenTs}\n`);
+    process.stdout.write(`  → ${outPathAbs}\n`);
+  } finally {
+    clock.uninstall();
+    try {
+      Base.removeConnection();
+    } catch {
+      /* already removed or never opened */
+    }
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch (err) {
+      process.stderr.write(
+        `parity ar_dump: warning: failed to remove temp dir ${tmpDir}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `parity ar_dump (trails): ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -6,9 +6,12 @@
  *
  * Like scripts/parity/query/node/dump.ts but for ActiveRecord query
  * fixtures: applies schema.sql, calls Base.establishConnection(dbPath),
- * dynamic-imports query.ts (which in turn imports models.ts and
- * references the model classes), and calls .toSql() on the default
- * export — expected to be an AR Relation.
+ * dynamic-imports query.ts (which in turn imports the models module,
+ * typically via an ESM specifier like `./models.js` even though the
+ * source file is `models.ts` — this is the Node/ESM TypeScript
+ * convention, and tsx rewrites the `.js` back to the real `.ts`),
+ * and calls .toSql() on the default export — expected to be an AR
+ * Relation.
  *
  * Time is always frozen. --frozen-at behaves identically to the arel runner.
  *
@@ -137,16 +140,18 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Connect via trails AR — models.ts's class definitions inherit
-    //    from Base and read Base.adapter lazily, so the connection must
-    //    exist before any model method is invoked. establishConnection
+    // 2. Connect via trails AR — the models module's class definitions
+    //    inherit from Base and read Base.adapter lazily, so the connection
+    //    must exist before any model method is invoked. establishConnection
     //    sets Base.adapter for the whole process.
     await Base.establishConnection(dbPath);
 
     // 3. Import query.ts. Fixtures end with `export default <relation>`
-    //    and typically `import { Book } from "./models.ts"` to reference
-    //    model classes — that side-effect-loads models.ts which registers
-    //    the classes against the current Base.adapter.
+    //    and typically `import { Book } from "./models.js"` (ESM convention
+    //    — the `.js` specifier resolves to the `models.ts` source via tsx)
+    //    to reference model classes — that side-effect-loads the models
+    //    module which registers the classes against the current
+    //    Base.adapter.
     const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
     const mod = (await import(queryUrl)) as { default: unknown };
     const result = mod.default;

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -190,6 +190,17 @@ async function main(): Promise<void> {
     process.stdout.write(`  → ${outPathAbs}\n`);
   } finally {
     clock.uninstall();
+    // Explicitly close the adapter's SQLite handle before removing the
+    // temp dir. Base.removeConnection() drops the pool reference but may
+    // leave the underlying better-sqlite3 handle open, causing EBUSY /
+    // EPERM on Windows when rmSync tries to delete the .db file. Pattern
+    // mirrors scripts/parity/schema/node/dump.ts:152-153.
+    try {
+      const a = Base.adapter as { close?: () => void };
+      if (typeof a.close === "function") a.close();
+    } catch {
+      /* adapter unavailable or already closed */
+    }
     try {
       Base.removeConnection();
     } catch {

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -1,0 +1,159 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Usage (from repo root):
+#   bundle exec --gemfile scripts/parity/schema/ruby/Gemfile \
+#     ruby scripts/parity/query/ruby/ar_dump.rb <fixture-dir> <out.json> \
+#     [--frozen-at ISO8601_UTC_Z]
+#
+# Like scripts/parity/query/ruby/dump.rb but tailored to ActiveRecord
+# query fixtures: applies <fixture-dir>/schema.sql, establishes an AR
+# connection, loads <fixture-dir>/models.rb (class definitions +
+# associations), evaluates <fixture-dir>/query.rb against them, and
+# writes a CanonicalQuery JSON with the SQL the terminal relation
+# produces via `.to_sql`.
+#
+# Time is always frozen for deterministic query evaluation. --frozen-at
+# pins the timestamp to a specific ISO 8601 UTC value (trailing Z
+# required); omitting it uses 2000-01-01T00:00:00.000Z.
+
+require "bundler/setup"
+require "active_record"
+require "active_support"
+require "active_support/core_ext/integer/time"
+require "active_support/testing/time_helpers"
+require "sqlite3"
+require "tmpdir"
+require "json"
+require "fileutils"
+require "time"
+
+def usage
+  warn "Usage: bundle exec --gemfile scripts/parity/schema/ruby/Gemfile ruby scripts/parity/query/ruby/ar_dump.rb <fixture-dir> <out.json> [--frozen-at ISO8601_UTC_Z]"
+  exit 1
+end
+
+def parse_args(argv)
+  fixture_dir = nil
+  out_path    = nil
+  frozen_at   = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when "--frozen-at"
+      i += 1
+      val = argv[i]
+      if val.nil? || val.start_with?("--")
+        warn "--frozen-at requires a value"
+        exit 1
+      end
+      frozen_at = val
+    else
+      if fixture_dir.nil?
+        fixture_dir = argv[i]
+      elsif out_path.nil?
+        out_path = argv[i]
+      else
+        warn "unexpected argument: #{argv[i]}"
+        usage
+      end
+    end
+    i += 1
+  end
+  usage unless fixture_dir && out_path
+  [File.expand_path(fixture_dir), File.expand_path(out_path), frozen_at]
+end
+
+fixture_dir, out_path, frozen_at = parse_args(ARGV)
+fixture_name = File.basename(fixture_dir)
+
+frozen_time = if frozen_at
+  unless frozen_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\z/)
+    warn "--frozen-at must be ISO 8601 UTC with trailing Z (e.g. 2026-01-01T00:00:00.000Z)"
+    exit 1
+  end
+  Time.iso8601(frozen_at).utc
+else
+  Time.utc(2000, 1, 1)
+end
+frozen_ts = frozen_at || frozen_time.iso8601(3)
+
+module TimeHelper
+  include ActiveSupport::Testing::TimeHelpers
+end
+time_helper = Object.new.extend(TimeHelper)
+
+Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
+  db_path = File.join(tmpdir, "query.db")
+
+  begin
+    # 1. Apply schema.sql to a fresh temp SQLite file.
+    SQLite3::Database.new(db_path) do |db|
+      db.execute_batch(File.read(File.join(fixture_dir, "schema.sql")))
+    end
+
+    # 2. Connect AR — models.rb's class definitions inherit from
+    #    ActiveRecord::Base which reads the current connection at eval.
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_path)
+
+    # 3. Freeze time before loading fixture code in case a model uses
+    #    Time.current in a default scope or a class-level filter.
+    time_helper.travel_to(frozen_time)
+
+    # 4. Load models.rb first, then evaluate query.rb. Both go through the
+    #    same isolated binding so class constants set by models.rb are
+    #    visible to query.rb (they land on TOPLEVEL via class keyword).
+    query_context = Object.new
+    query_binding = query_context.instance_eval { binding }
+
+    models_path = File.join(fixture_dir, "models.rb")
+    if File.exist?(models_path)
+      models_source = File.read(models_path)
+      # rubocop:disable Security/Eval
+      eval(models_source, query_binding, models_path)
+      # rubocop:enable Security/Eval
+    end
+
+    query_path   = File.join(fixture_dir, "query.rb")
+    query_source = File.read(query_path)
+    # rubocop:disable Security/Eval
+    result = eval(query_source, query_binding, query_path)
+    # rubocop:enable Security/Eval
+    raise "[#{fixture_name}] query.rb returned nil" if result.nil?
+    unless result.respond_to?(:to_sql)
+      raise "[#{fixture_name}] query.rb returned #{result.class}: expected an AR relation / Arel manager responding to #to_sql"
+    end
+
+    # 5. Extract SQL. For AR relations, Relation#to_sql renders the SQL
+    #    with literal values inlined (binds pre-substituted), so binds is
+    #    always []. Same contract as the arel runner.
+    sql_str = result.to_sql.strip
+    binds = []
+
+    # 6. Write CanonicalQuery JSON
+    canonical = {
+      "version"  => 1,
+      "fixture"  => fixture_name,
+      "frozenAt" => frozen_ts,
+      "sql"      => sql_str,
+      "binds"    => binds,
+    }
+
+    FileUtils.mkdir_p(File.dirname(out_path))
+    File.write(out_path, JSON.pretty_generate(canonical) + "\n")
+
+    puts "[rails] #{fixture_name}"
+    puts "  result type : #{result.class}"
+    puts "  sql         : #{sql_str}"
+    puts "  frozenAt    : #{frozen_ts}"
+    puts "  → #{out_path}"
+
+  ensure
+    time_helper.travel_back
+    begin
+      ActiveRecord::Base.remove_connection
+    rescue StandardError
+      # already removed or never opened
+    end
+  end
+end

--- a/scripts/parity/query/ruby/ar_dump_test.rb
+++ b/scripts/parity/query/ruby/ar_dump_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "minitest/autorun"
+require "json"
+require "tempfile"
+require "open3"
+
+# Integration tests for ar_dump.rb — runs the script against real ar-* fixtures.
+# Must be run under Bundler with scripts/parity/schema/ruby/Gemfile.
+
+GEMFILE     = File.expand_path("../../schema/ruby/Gemfile", __dir__)
+AR_DUMP     = File.expand_path("ar_dump.rb", __dir__)
+FIXTURES    = File.expand_path("../../fixtures", __dir__)
+
+def run_ar_dump(fixture, frozen_at: nil)
+  tf = Tempfile.new(["parity-ar-test-", ".json"])
+  out = tf.path
+  tf.close  # close so ruby on the other side can write to it
+  cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", AR_DUMP,
+         "#{FIXTURES}/#{fixture}", out]
+  cmd += ["--frozen-at", frozen_at] if frozen_at
+  stdout, stderr, status = Open3.capture3(*cmd)
+  [status.exitstatus, stdout, stderr, out]
+end
+
+class ArDumpTest < Minitest::Test
+  DEFAULT_FROZEN_AT = "2000-01-01T00:00:00.000Z"
+
+  def test_ar_00_book_all
+    code, stdout, stderr, out_path = run_ar_dump("ar-00")
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_equal 1,                  result["version"]
+    assert_equal "ar-00",            result["fixture"]
+    assert_equal DEFAULT_FROZEN_AT,  result["frozenAt"]
+    assert_equal 'SELECT "books".* FROM "books"', result["sql"]
+    assert_equal [],                 result["binds"]
+  ensure
+    File.delete(out_path) if out_path && File.exist?(out_path)
+  end
+
+  def test_frozen_at_forwarded
+    frozen = "2026-01-01T00:00:00.000Z"
+    code, stdout, stderr, out_path = run_ar_dump("ar-00", frozen_at: frozen)
+    assert_equal 0, code, "dump failed\nstdout: #{stdout}\nstderr: #{stderr}"
+    result = JSON.parse(File.read(out_path))
+    assert_equal frozen, result["frozenAt"]
+  ensure
+    File.delete(out_path) if out_path && File.exist?(out_path)
+  end
+
+  def test_frozen_at_missing_value
+    tf = Tempfile.new(["parity-ar-test-", ".json"])
+    out = tf.path
+    tf.close
+    cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", AR_DUMP,
+           "#{FIXTURES}/ar-00", out, "--frozen-at"]
+    _stdout, stderr, status = Open3.capture3(*cmd)
+    assert_equal 1, status.exitstatus
+    assert_match(/--frozen-at requires a value/, stderr)
+  ensure
+    File.delete(out) if out && File.exist?(out)
+  end
+
+  def test_frozen_at_invalid_format
+    tf = Tempfile.new(["parity-ar-test-", ".json"])
+    out = tf.path
+    tf.close
+    cmd = ["bundle", "exec", "--gemfile=#{GEMFILE}", "ruby", AR_DUMP,
+           "#{FIXTURES}/ar-00", out, "--frozen-at", "not-a-timestamp"]
+    _stdout, stderr, status = Open3.capture3(*cmd)
+    assert_equal 1, status.exitstatus
+    assert_match(/--frozen-at must be ISO 8601 UTC with trailing Z/, stderr)
+  ensure
+    File.delete(out) if out && File.exist?(out)
+  end
+end

--- a/scripts/parity/run.ts
+++ b/scripts/parity/run.ts
@@ -58,14 +58,16 @@ function parityTypeConfig(type: ParityType): TypeConfig {
       extraDumpArgs: [],
     };
   }
-  // Query fixtures for v1 scope are Arel-only (arel-* under scripts/parity/
-  // fixtures/). AR-style fixtures (ar-*) are planned for v2 and will land
-  // under this same type. scripts/parity/query/diff.ts already seeds from
-  // both arel-* and ar-* so flipping this matcher is the only change needed
-  // when v2 lands.
+  // Query fixtures cover two families:
+  //   - arel-*  : raw Arel (no models). Runs through dump.rb / dump.ts.
+  //   - ar-*    : ActiveRecord queries (models + relation). Runs through
+  //               ar_dump.rb / ar_dump.ts.
+  // Each fixture's runner is selected by prefix in dumpOne() below; the
+  // TypeConfig holds the arel pair as the default and `dumpOne` swaps in
+  // the ar pair when the fixture name starts with "ar-".
   const frozen = process.env.PARITY_FROZEN_AT;
   return {
-    matches: (name) => /^arel-/.test(name),
+    matches: (name) => /^(arel|ar)-/.test(name),
     outRails: "scripts/parity/.out/query/rails",
     outTrails: "scripts/parity/.out/query/trails",
     rubyDump: "scripts/parity/query/ruby/dump.rb",
@@ -74,6 +76,14 @@ function parityTypeConfig(type: ParityType): TypeConfig {
     extraDumpArgs: frozen ? ["--frozen-at", frozen] : [],
   };
 }
+
+/** AR fixture prefix → different runner scripts from arel- fixtures. */
+function isArFixture(name: string): boolean {
+  return /^ar-/.test(name);
+}
+
+const AR_RUBY_DUMP = "scripts/parity/query/ruby/ar_dump.rb";
+const AR_NODE_DUMP = "scripts/parity/query/node/ar_dump.ts";
 
 function assertRepoRoot(): void {
   if (!existsSync(FIXTURES_DIR)) {
@@ -217,17 +227,20 @@ function dumpOne(cfg: TypeConfig, label: "rails" | "trails", fixture: string): P
   const fixtureDir = join(FIXTURES_DIR, fixture);
   const outDir = label === "rails" ? cfg.outRails : cfg.outTrails;
   const outFile = join(outDir, `${fixture}.json`);
+  // ar-* fixtures use dedicated AR runners that load models.{rb,ts}
+  // before evaluating the query. arel-* fixtures use the plain runners.
+  const rubyScript = isArFixture(fixture) ? AR_RUBY_DUMP : cfg.rubyDump;
+  const nodeScript = isArFixture(fixture) ? AR_NODE_DUMP : cfg.nodeDump;
   // Buffered so each fixture's verbose dump output prints as one contiguous
   // block — otherwise concurrent workers interleave lines and CI logs become
   // unreadable.
   if (label === "rails") {
-    return run(
-      "bundle",
-      ["exec", "ruby", cfg.rubyDump, fixtureDir, outFile, ...cfg.extraDumpArgs],
-      { env: { BUNDLE_GEMFILE: GEMFILE }, buffered: true },
-    );
+    return run("bundle", ["exec", "ruby", rubyScript, fixtureDir, outFile, ...cfg.extraDumpArgs], {
+      env: { BUNDLE_GEMFILE: GEMFILE },
+      buffered: true,
+    });
   }
-  return run("pnpm", ["exec", "tsx", cfg.nodeDump, fixtureDir, outFile, ...cfg.extraDumpArgs], {
+  return run("pnpm", ["exec", "tsx", nodeScript, fixtureDir, outFile, ...cfg.extraDumpArgs], {
     buffered: true,
   });
 }


### PR DESCRIPTION
First PR of the v2 AR-parity rollout. The original arel-only pipeline kept `ar-*` fixtures out of scope with a one-line matcher and a note on `diff.ts` that it was pre-widened for this day. Now we land the runners and a smoke fixture that proves the plumbing works end-to-end.

## Contents

- **`scripts/parity/query/ruby/ar_dump.rb`** — applies `schema.sql`, connects AR, loads `models.rb`, evaluates `query.rb`, writes CanonicalQuery JSON from `Relation#to_sql`. Mirrors `dump.rb`'s argument parsing, frozen-at handling, and verbose stdout block.
- **`scripts/parity/query/node/ar_dump.ts`** — same shape on the Node side. Applies schema, calls `Base.establishConnection(dbPath)`, dynamic-imports `query.ts` (which side-effect-imports `models.ts`), calls `Relation#toSql()`. Asserts all four `@blazetrails/*` packages are built with a clear hint if not.
- **`scripts/parity/run.ts`** — matcher widened to `/^(arel|ar)-/`; `dumpOne` dispatches to `ar_dump.{rb,ts}` when fixture name starts with `ar-`. No CI change needed.
- **`scripts/parity/fixtures/ar-00/`** — smoke fixture. `Book.all` with a one-column `books` table. Both sides emit `SELECT "books".* FROM "books"` byte-identically.
- **`scripts/parity/query/node/ar_dump.test.ts`** — 3 integration cases: end-to-end ar-00 dump, `--frozen-at` missing value, `--frozen-at` invalid format. Reuses the lazy `beforeAll` build pattern from `trails-models-dump.test.ts`.

## What's explicitly not in this PR

Per the plan in `docs/ar-query-parity-verification.md`: joins, where, group/having, subqueries, eager loading, and Arel-interop fixtures. Those land in PRs 2-4 as groups. PR 5 is the known-gaps audit.

## Sweep

```
$ pnpm parity:query
...
43/54 passed, 11 known gap(s)
  known gaps by side: 8 trails-missing, 3 diff
```

ar-00 is the 43rd PASS on top of the 42 existing arel- passes. 0 new failures.

## Test plan
- [x] `pnpm vitest run scripts/parity/query/node/ar_dump.test.ts` — 3/3 pass
- [x] `pnpm vitest run scripts/parity/` — 33/33 pass across 4 files
- [x] `pnpm parity:query` — 43/54 pass, 11 known gaps, 0 fail