### PR TITLE
fix(activerecord): bigint PR 5 — aggregates return bigint for big_integer columns

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -253,19 +253,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     return super.pick(...columns);
   }
 
-  override async calculate(
-    operation: "count" | "sum" | "average" | "minimum" | "maximum",
-    column?: string,
-  ): Promise<number | Record<string, number>> {
-    this._checkStrictLoading();
-    return (
-      super.calculate as unknown as (
-        op: string,
-        col?: string,
-      ) => Promise<number | Record<string, number>>
-    ).call(this, operation, column);
-  }
-
   override updateAll(updates: Record<string, unknown>): Promise<number> {
     this._checkStrictLoading();
     return super.updateAll(updates);

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -192,11 +192,11 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
 
   // @ts-expect-error — Relation defines `count` as a property; override
   //   as a method so we can gate strict-loading before dispatching.
-  async count(column?: string): Promise<number | Record<string, number>> {
+  async count(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     return (
       Relation.prototype as unknown as {
-        count: (col?: string) => Promise<number | Record<string, number>>;
+        count: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
       }
     ).count.call(this, column);
   }
@@ -204,11 +204,11 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   // @ts-expect-error — sum/average/minimum/maximum are also property-
   //   assigned on Relation (from the Calculations mixin); override as
   //   methods to gate strict-loading before each SQL entry point.
-  async sum(column?: string): Promise<number | Record<string, number>> {
+  async sum(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     return (
       Relation.prototype as unknown as {
-        sum: (col?: string) => Promise<number | Record<string, number>>;
+        sum: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
       }
     ).sum.call(this, column);
   }
@@ -256,13 +256,13 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   override async calculate(
     operation: "count" | "sum" | "average" | "minimum" | "maximum",
     column?: string,
-  ): Promise<number | Record<string, number>> {
+  ): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     return (
       super.calculate as unknown as (
         op: string,
         col?: string,
-      ) => Promise<number | Record<string, number>>
+      ) => Promise<number | bigint | Record<string, number | bigint>>
     ).call(this, operation, column);
   }
 

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -192,11 +192,11 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
 
   // @ts-expect-error — Relation defines `count` as a property; override
   //   as a method so we can gate strict-loading before dispatching.
-  async count(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
+  async count(column?: string): Promise<number | Record<string, number>> {
     this._checkStrictLoading();
     return (
       Relation.prototype as unknown as {
-        count: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
+        count: (col?: string) => Promise<number | Record<string, number>>;
       }
     ).count.call(this, column);
   }
@@ -256,13 +256,13 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   override async calculate(
     operation: "count" | "sum" | "average" | "minimum" | "maximum",
     column?: string,
-  ): Promise<number | bigint | Record<string, number | bigint>> {
+  ): Promise<number | Record<string, number>> {
     this._checkStrictLoading();
     return (
       super.calculate as unknown as (
         op: string,
         col?: string,
-      ) => Promise<number | bigint | Record<string, number | bigint>>
+      ) => Promise<number | Record<string, number>>
     ).call(this, operation, column);
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -796,7 +796,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         const box = await this._djarForCount();
         if (!box) return 0;
         const djar = (box as { djar: unknown }).djar as {
-          count: () => Promise<number | Record<string, number>>;
+          count: () => Promise<number | bigint | Record<string, number | bigint>>;
         };
         const c = await djar.count();
         if (typeof c !== "number") {
@@ -825,7 +825,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `COUNT(*)` Rails would.
     const countFn = (
       Relation.prototype as unknown as {
-        count: (this: unknown) => Promise<number | Record<string, number>>;
+        count: (this: unknown) => Promise<number | bigint | Record<string, number | bigint>>;
       }
     ).count;
     const counted = this._relationStateDiverged()
@@ -848,17 +848,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // and drop in-place mutations.
   // @ts-expect-error sum is a property on Relation (Calculations mixin);
   //   method override is intentional to gate + honor divergence.
-  async sum(column?: string): Promise<number | Record<string, number>> {
+  async sum(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        sum: (col?: string) => Promise<number | Record<string, number>>;
+        sum: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
       }
     ).sum;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
-      s as unknown as { sum: (col?: string) => Promise<number | Record<string, number>> }
+      s as unknown as {
+        sum: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
+      }
     ).sum(column);
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -796,7 +796,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         const box = await this._djarForCount();
         if (!box) return 0;
         const djar = (box as { djar: unknown }).djar as {
-          count: () => Promise<number | bigint | Record<string, number | bigint>>;
+          count: () => Promise<number | Record<string, number>>;
         };
         const c = await djar.count();
         if (typeof c !== "number") {
@@ -825,7 +825,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `COUNT(*)` Rails would.
     const countFn = (
       Relation.prototype as unknown as {
-        count: (this: unknown) => Promise<number | bigint | Record<string, number | bigint>>;
+        count: (this: unknown) => Promise<number | Record<string, number>>;
       }
     ).count;
     const counted = this._relationStateDiverged()

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -7413,5 +7413,86 @@ describe("CalculationsTest", () => {
 });
 
 // ==========================================================================
+// bigint aggregate tests — type_cast_calculated_value for big_integer columns
+// Mirrors Rails calculations.rb#type_cast_calculated_value (line 627):
+//   sum    → type.deserialize(value || 0)
+//   min/max → type.deserialize(value)
+//   count  → always integer (not through type)
+// ==========================================================================
+describe("bigint aggregates (big_integer columns)", () => {
+  function makeBigModel() {
+    const adapter = freshAdapter();
+    class Score extends Base {
+      static {
+        this.attribute("value", "big_integer");
+        this.attribute("category", "string");
+        this.adapter = adapter;
+      }
+    }
+    return Score;
+  }
+
+  const BIG = 2n ** 62n; // above Number.MAX_SAFE_INTEGER
+
+  it("sum of big_integer column returns bigint", async () => {
+    const Score = makeBigModel();
+    await Score.create({ value: BIG, category: "a" });
+    await Score.create({ value: 1n, category: "a" });
+    const result = await Score.sum("value");
+    expect(typeof result).toBe("bigint");
+    expect(result).toBe(BIG + 1n);
+  });
+
+  it("sum with no rows returns 0n for big_integer column", async () => {
+    const Score = makeBigModel();
+    const result = await Score.where({ category: "missing" }).sum("value");
+    expect(typeof result).toBe("bigint");
+    expect(result).toBe(0n);
+  });
+
+  it("maximum of big_integer column returns bigint", async () => {
+    const Score = makeBigModel();
+    await Score.create({ value: BIG, category: "a" });
+    await Score.create({ value: 1n, category: "a" });
+    const result = await Score.maximum("value");
+    expect(typeof result).toBe("bigint");
+    expect(result).toBe(BIG);
+  });
+
+  it("minimum of big_integer column returns bigint", async () => {
+    const Score = makeBigModel();
+    await Score.create({ value: BIG, category: "a" });
+    await Score.create({ value: 1n, category: "a" });
+    const result = await Score.minimum("value");
+    expect(typeof result).toBe("bigint");
+    expect(result).toBe(1n);
+  });
+
+  it("count is always a number regardless of column type", async () => {
+    const Score = makeBigModel();
+    await Score.create({ value: BIG, category: "a" });
+    await Score.create({ value: BIG + 1n, category: "a" });
+    const result = await Score.count();
+    expect(typeof result).toBe("number");
+    expect(result).toBe(2);
+  });
+
+  it("sum of integer column still returns number", async () => {
+    const adapter = freshAdapter();
+    class Item extends Base {
+      static {
+        this.attribute("qty", "integer");
+        this.adapter = adapter;
+      }
+    }
+    await Item.create({ qty: 3 });
+    await Item.create({ qty: 7 });
+    const result = await Item.sum("qty");
+    expect(typeof result).toBe("number");
+    expect(result).toBe(10);
+  });
+});
+
+// ==========================================================================
 // CalculationsTest — targets calculations_test.rb (continued)
 // ==========================================================================

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -7504,6 +7504,13 @@ describe("bigint aggregates (big_integer columns)", () => {
     expect(result["b"]).toBe(2n);
   });
 
+  it("sum with none() returns 0n for big_integer column", async () => {
+    const Score = makeBigModel();
+    const result = await Score.none().sum("value");
+    expect(typeof result).toBe("bigint");
+    expect(result).toBe(0n);
+  });
+
   it("average of big_integer column returns number (Rails BigDecimal → JS number)", async () => {
     // Rails returns BigDecimal for average on integer columns; we return number.
     // This is a documented limitation — average is never a bigint in our impl.

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -7491,6 +7491,29 @@ describe("bigint aggregates (big_integer columns)", () => {
     expect(typeof result).toBe("number");
     expect(result).toBe(10);
   });
+
+  it("grouped sum of big_integer column returns bigint per group", async () => {
+    const Score = makeBigModel();
+    await Score.create({ value: BIG, category: "a" });
+    await Score.create({ value: 1n, category: "a" });
+    await Score.create({ value: 2n, category: "b" });
+    const result = (await Score.group("category").sum("value")) as Record<string, bigint>;
+    expect(typeof result["a"]).toBe("bigint");
+    expect(result["a"]).toBe(BIG + 1n);
+    expect(typeof result["b"]).toBe("bigint");
+    expect(result["b"]).toBe(2n);
+  });
+
+  it("average of big_integer column returns number (Rails BigDecimal → JS number)", async () => {
+    // Rails returns BigDecimal for average on integer columns; we return number.
+    // This is a documented limitation — average is never a bigint in our impl.
+    const Score = makeBigModel();
+    await Score.create({ value: 10n, category: "a" });
+    await Score.create({ value: 20n, category: "a" });
+    const result = await Score.average("value");
+    expect(typeof result).toBe("number");
+    expect(result).toBe(15);
+  });
 });
 
 // ==========================================================================

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2100,7 +2100,10 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#calculate
    */
   async calculate(operation: "count", column?: string): Promise<number | Record<string, number>>;
-  async calculate(operation: "sum", column: string): Promise<number | Record<string, number>>;
+  async calculate(
+    operation: "sum",
+    column: string,
+  ): Promise<number | bigint | Record<string, number | bigint>>;
   async calculate(
     operation: "average",
     column: string,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -43,13 +43,15 @@ const SQL_FN_NAMES: Record<AggFn, string> = {
  * Cast an aggregate result value through the column's type.
  *
  * Mirrors Rails' `type_cast_calculated_value` (calculations.rb:627):
- *   - count  → always integer (safe, never exceeds 2^53)
+ *   - count  → JS number. Very large SQL COUNT() results (> 2^53) would
+ *              lose precision; this matches Rails which returns Integer.
  *   - sum    → type.deserialize(value || 0) — uses column type
  *   - min/max → type.deserialize(value) — uses column type
- *   - average → numeric float (BigDecimal in Rails; kept as number here)
+ *   - average → JS number (Rails returns BigDecimal for integer columns;
+ *              we return number — documented limitation)
  *
- * For big_integer columns, `BigIntegerType.cast` converts the raw
- * driver string/number/bigint to JS bigint, preserving precision.
+ * Uses `type.deserialize` to match Rails semantics and allow types to
+ * override deserialize independently of cast in the future.
  */
 function castAggValue(
   val: unknown,
@@ -65,13 +67,13 @@ function castAggValue(
     // minimum/maximum: route through column type so big_integer columns
     // return bigint rather than the raw driver string/number.
     if (val === null || val === undefined) return null;
-    if (colType instanceof BigIntegerType) return colType.cast(val);
+    if (colType instanceof BigIntegerType) return colType.deserialize(val);
     return val;
   }
 
   if (fn === "sum") {
     // Default for empty result set: 0 or 0n depending on column type.
-    if (colType instanceof BigIntegerType) return colType.cast(val ?? 0) ?? 0n;
+    if (colType instanceof BigIntegerType) return colType.deserialize(val ?? 0) ?? 0n;
     return Number(val ?? 0);
   }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -13,7 +13,7 @@ import { BigIntegerType } from "@blazetrails/activemodel";
 
 interface CalculationRelation {
   _modelClass: {
-    arelTable: { typeForAttribute(col: string): { cast(v: unknown): unknown } | null };
+    arelTable: any;
     primaryKey: string | string[];
     adapter: { execute(sql: string): Promise<Record<string, unknown>[]> };
   };
@@ -57,19 +57,20 @@ function castAggValue(
   rel: CalculationRelation,
   coerceNumeric: boolean,
 ): unknown {
+  const table = rel._modelClass.arelTable as { typeForAttribute?(c: string): unknown };
+  const colType = column !== "*" ? table.typeForAttribute?.(column) : null;
+
   if (!coerceNumeric) {
     // minimum/maximum: route through column type so big_integer columns
     // return bigint rather than the raw driver string/number.
     if (val === null || val === undefined) return null;
-    const type = column !== "*" ? rel._modelClass.arelTable.typeForAttribute(column) : null;
-    if (type instanceof BigIntegerType) return type.cast(val);
+    if (colType instanceof BigIntegerType) return colType.cast(val);
     return val;
   }
 
   if (fn === "sum") {
     // Default for empty result set: 0 or 0n depending on column type.
-    const type = column !== "*" ? rel._modelClass.arelTable.typeForAttribute(column) : null;
-    if (type instanceof BigIntegerType) return type.cast(val ?? 0) ?? 0n;
+    if (colType instanceof BigIntegerType) return colType.cast(val ?? 0) ?? 0n;
     return Number(val ?? 0);
   }
 
@@ -116,12 +117,11 @@ function wrapBigintAgg(innerSql: string, grouped = false): string {
 }
 
 function isBigintColumn(rel: CalculationRelation, fn: AggFn, column: string): boolean {
-  return (
-    fn !== "count" &&
-    fn !== "average" &&
-    column !== "*" &&
-    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType
-  );
+  if (fn === "count" || fn === "average" || column === "*") return false;
+  const table = rel._modelClass.arelTable as {
+    typeForAttribute?(col: string): unknown;
+  };
+  return table.typeForAttribute?.(column) instanceof BigIntegerType;
 }
 
 async function singleAggregate(

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -115,6 +115,15 @@ function wrapBigintAgg(innerSql: string, grouped = false): string {
   return `SELECT CAST(val AS TEXT) AS val FROM (${innerSql}) AS _bigint_agg`;
 }
 
+function isBigintColumn(rel: CalculationRelation, fn: AggFn, column: string): boolean {
+  return (
+    fn !== "count" &&
+    fn !== "average" &&
+    column !== "*" &&
+    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType
+  );
+}
+
 async function singleAggregate(
   rel: CalculationRelation,
   fn: AggFn,
@@ -128,14 +137,8 @@ async function singleAggregate(
   rel._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
 
-  const isBigint =
-    fn !== "count" &&
-    fn !== "average" &&
-    column !== "*" &&
-    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType;
-
   const innerSql = manager.toSql();
-  const sql = isBigint ? wrapBigintAgg(innerSql) : innerSql;
+  const sql = isBigintColumn(rel, fn, column) ? wrapBigintAgg(innerSql) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
   const val = rows[0]?.val;
   if (val === undefined || val === null) {
@@ -161,14 +164,8 @@ async function groupedAggregate(
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
 
-  const isBigint =
-    fn !== "count" &&
-    fn !== "average" &&
-    column !== "*" &&
-    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType;
-
   const innerSql = manager.toSql();
-  const sql = isBigint ? wrapBigintAgg(innerSql, true) : innerSql;
+  const sql = isBigintColumn(rel, fn, column) ? wrapBigintAgg(innerSql, true) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
 
   const result: Record<string, unknown> = {};

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -56,16 +56,13 @@ const SQL_FN_NAMES: Record<AggFn, string> = {
  * Other types fall back to Number() or raw value. Extend castAggValue
  * when additional types need precision-preserving deserialize dispatch.
  */
-function castAggValue(
-  val: unknown,
-  fn: AggFn,
-  column: string,
-  rel: CalculationRelation,
-  coerceNumeric: boolean,
-): unknown {
+function resolveColType(rel: CalculationRelation, column: string): unknown {
+  if (column === "*") return null;
   const table = rel._modelClass.arelTable as { typeForAttribute?(c: string): unknown };
-  const colType = column !== "*" ? table.typeForAttribute?.(column) : null;
+  return table.typeForAttribute?.(column) ?? null;
+}
 
+function castAggValue(val: unknown, fn: AggFn, colType: unknown, coerceNumeric: boolean): unknown {
   if (!coerceNumeric) {
     // minimum/maximum: route through column type so big_integer columns
     // return bigint rather than the raw driver string/number.
@@ -157,15 +154,16 @@ async function singleAggregate(
   rel._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
 
+  const colType = resolveColType(rel, column);
   const innerSql = manager.toSql();
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel) ? wrapBigintAgg(innerSql) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
   const val = rows[0]?.val;
   if (val === undefined || val === null) {
-    return fn === "sum" ? castAggValue(null, fn, column, rel, coerceNumeric) : null;
+    return fn === "sum" ? castAggValue(null, fn, colType, coerceNumeric) : null;
   }
-  return castAggValue(val, fn, column, rel, coerceNumeric);
+  return castAggValue(val, fn, colType, coerceNumeric);
 }
 
 async function groupedAggregate(
@@ -185,6 +183,7 @@ async function groupedAggregate(
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
 
+  const colType = resolveColType(rel, column);
   const innerSql = manager.toSql();
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel)
@@ -197,9 +196,9 @@ async function groupedAggregate(
     const key = String(row.group_key ?? "null");
     const val = row.val;
     if (val === undefined || val === null) {
-      result[key] = fn === "sum" ? castAggValue(null, fn, column, rel, coerceNumeric) : null;
+      result[key] = fn === "sum" ? castAggValue(null, fn, colType, coerceNumeric) : null;
     } else {
-      result[key] = castAggValue(val, fn, column, rel, coerceNumeric);
+      result[key] = castAggValue(val, fn, colType, coerceNumeric);
     }
   }
   return result;
@@ -270,10 +269,7 @@ export async function performSum(
 ): Promise<number | bigint | Record<string, number | bigint>> {
   if (this._isNone) {
     if (this._groupColumns.length > 0) return {};
-    const zeroType = column
-      ? (this._modelClass.arelTable as any)?.typeForAttribute?.(column)
-      : null;
-    return zeroType instanceof BigIntegerType ? 0n : 0;
+    return column && resolveColType(this, column) instanceof BigIntegerType ? 0n : 0;
   }
   if (!column) return 0;
   if (this._groupColumns.length > 0) {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -40,18 +40,21 @@ const SQL_FN_NAMES: Record<AggFn, string> = {
 };
 
 /**
- * Cast an aggregate result value through the column's type.
+ * Cast an aggregate result value. Partially mirrors Rails'
+ * `type_cast_calculated_value` (calculations.rb:627).
  *
- * Mirrors Rails' `type_cast_calculated_value` (calculations.rb:627):
- *   - count  → JS number. Very large SQL COUNT() results (> 2^53) would
- *              lose precision; this matches Rails which returns Integer.
- *   - sum    → type.deserialize(value || 0) — uses column type
- *   - min/max → type.deserialize(value) — uses column type
- *   - average → JS number (Rails returns BigDecimal for integer columns;
- *              we return number — documented limitation)
+ *   - count   → JS number via Number(val). SQL COUNT() > 2^53-1 loses
+ *               precision (Rails returns arbitrary-precision Integer).
+ *   - sum     → for BigIntegerType: type.deserialize(val ?? 0) → bigint;
+ *               otherwise Number(val ?? 0) → number.
+ *   - min/max → for BigIntegerType: type.deserialize(val) → bigint;
+ *               otherwise returns raw driver value.
+ *   - average → JS number via Number(val). Rails returns BigDecimal for
+ *               integer/decimal columns — documented limitation.
  *
- * Uses `type.deserialize` to match Rails semantics and allow types to
- * override deserialize independently of cast in the future.
+ * Only BigIntegerType is dispatched through the column type today.
+ * Other types fall back to Number() or raw value. Extend castAggValue
+ * when additional types need precision-preserving deserialize dispatch.
  */
 function castAggValue(
   val: unknown,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -9,10 +9,11 @@
  */
 
 import { Nodes } from "@blazetrails/arel";
+import { BigIntegerType } from "@blazetrails/activemodel";
 
 interface CalculationRelation {
   _modelClass: {
-    arelTable: any;
+    arelTable: { typeForAttribute(col: string): { cast(v: unknown): unknown } | null };
     primaryKey: string | string[];
     adapter: { execute(sql: string): Promise<Record<string, unknown>[]> };
   };
@@ -37,6 +38,45 @@ const SQL_FN_NAMES: Record<AggFn, string> = {
   maximum: "MAX",
 };
 
+/**
+ * Cast an aggregate result value through the column's type.
+ *
+ * Mirrors Rails' `type_cast_calculated_value` (calculations.rb:627):
+ *   - count  → always integer (safe, never exceeds 2^53)
+ *   - sum    → type.deserialize(value || 0) — uses column type
+ *   - min/max → type.deserialize(value) — uses column type
+ *   - average → numeric float (BigDecimal in Rails; kept as number here)
+ *
+ * For big_integer columns, `BigIntegerType.cast` converts the raw
+ * driver string/number/bigint to JS bigint, preserving precision.
+ */
+function castAggValue(
+  val: unknown,
+  fn: AggFn,
+  column: string,
+  rel: CalculationRelation,
+  coerceNumeric: boolean,
+): unknown {
+  if (!coerceNumeric) {
+    // minimum/maximum: route through column type so big_integer columns
+    // return bigint rather than the raw driver string/number.
+    if (val === null || val === undefined) return null;
+    const type = column !== "*" ? rel._modelClass.arelTable.typeForAttribute(column) : null;
+    if (type instanceof BigIntegerType) return type.cast(val);
+    return val;
+  }
+
+  if (fn === "sum") {
+    // Default for empty result set: 0 or 0n depending on column type.
+    const type = column !== "*" ? rel._modelClass.arelTable.typeForAttribute(column) : null;
+    if (type instanceof BigIntegerType) return type.cast(val ?? 0) ?? 0n;
+    return Number(val ?? 0);
+  }
+
+  // count / average: always a JS number.
+  return Number(val);
+}
+
 function buildAggNode(table: any, fn: AggFn, column: string, distinct: boolean): any {
   const sqlName = SQL_FN_NAMES[fn];
   if (column === "*") {
@@ -60,6 +100,21 @@ function buildAggNode(table: any, fn: AggFn, column: string, distinct: boolean):
   }
 }
 
+/**
+ * Wrap a bigint aggregate SQL in CAST(... AS TEXT) so all adapters
+ * return a decimal string. SQLite's SUM/MIN/MAX on computed columns has
+ * no declared type, so `safeIntegers` is not enabled — it returns a lossy
+ * JS number for values above Number.MAX_SAFE_INTEGER. Wrapping in a
+ * subquery with CAST sidesteps that at the SQL level; BigIntegerType.cast
+ * then converts the string to bigint with full precision.
+ */
+function wrapBigintAgg(innerSql: string, grouped = false): string {
+  if (grouped) {
+    return `SELECT group_key, CAST(val AS TEXT) AS val FROM (${innerSql}) AS _bigint_agg`;
+  }
+  return `SELECT CAST(val AS TEXT) AS val FROM (${innerSql}) AS _bigint_agg`;
+}
+
 async function singleAggregate(
   rel: CalculationRelation,
   fn: AggFn,
@@ -73,11 +128,20 @@ async function singleAggregate(
   rel._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
 
-  const sql = manager.toSql();
+  const isBigint =
+    fn !== "count" &&
+    fn !== "average" &&
+    column !== "*" &&
+    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType;
+
+  const innerSql = manager.toSql();
+  const sql = isBigint ? wrapBigintAgg(innerSql) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
   const val = rows[0]?.val;
-  if (val === undefined || val === null) return null;
-  return coerceNumeric ? Number(val) : val;
+  if (val === undefined || val === null) {
+    return fn === "sum" ? castAggValue(null, fn, column, rel, coerceNumeric) : null;
+  }
+  return castAggValue(val, fn, column, rel, coerceNumeric);
 }
 
 async function groupedAggregate(
@@ -96,7 +160,15 @@ async function groupedAggregate(
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
-  const sql = manager.toSql();
+
+  const isBigint =
+    fn !== "count" &&
+    fn !== "average" &&
+    column !== "*" &&
+    rel._modelClass.arelTable.typeForAttribute(column) instanceof BigIntegerType;
+
+  const innerSql = manager.toSql();
+  const sql = isBigint ? wrapBigintAgg(innerSql, true) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
 
   const result: Record<string, unknown> = {};
@@ -104,9 +176,9 @@ async function groupedAggregate(
     const key = String(row.group_key ?? "null");
     const val = row.val;
     if (val === undefined || val === null) {
-      result[key] = coerceNumeric ? 0 : null;
+      result[key] = fn === "sum" ? castAggValue(null, fn, column, rel, coerceNumeric) : null;
     } else {
-      result[key] = coerceNumeric ? Number(val) : val;
+      result[key] = castAggValue(val, fn, column, rel, coerceNumeric);
     }
   }
   return result;
@@ -174,13 +246,13 @@ export async function performCount(
 export async function performSum(
   this: CalculationRelation,
   column?: string,
-): Promise<number | Record<string, number>> {
+): Promise<number | bigint | Record<string, number | bigint>> {
   if (this._isNone) return this._groupColumns.length > 0 ? {} : 0;
   if (!column) return 0;
   if (this._groupColumns.length > 0) {
-    return groupedAggregate(this, "sum", column, true) as Promise<Record<string, number>>;
+    return groupedAggregate(this, "sum", column, true) as Promise<Record<string, number | bigint>>;
   }
-  return ((await singleAggregate(this, "sum", column, true)) as number) ?? 0;
+  return ((await singleAggregate(this, "sum", column, true)) as number | bigint) ?? 0;
 }
 
 export async function performAverage(
@@ -223,7 +295,7 @@ export async function performMaximum(
  */
 export interface CalculationMethods {
   count(column?: string): Promise<number | Record<string, number>>;
-  sum(column?: string): Promise<number | Record<string, number>>;
+  sum(column?: string): Promise<number | bigint | Record<string, number | bigint>>;
   average(column: string): Promise<number | null | Record<string, number>>;
   minimum(column: string): Promise<unknown | null | Record<string, unknown>>;
   maximum(column: string): Promise<unknown | null | Record<string, unknown>>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -10,6 +10,7 @@
 
 import { Nodes } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
+import { detectAdapterName } from "../adapter-name.js";
 
 interface CalculationRelation {
   _modelClass: {
@@ -114,19 +115,20 @@ function buildAggNode(table: any, fn: AggFn, column: string, distinct: boolean):
  * Both are handled by BigIntegerType.cast without any SQL wrapping.
  */
 function needsBigintCast(rel: CalculationRelation): boolean {
-  return (rel._modelClass.adapter as any).adapterName === "SQLite";
+  return detectAdapterName(rel._modelClass.adapter as any) === "sqlite";
 }
 
 /**
  * Wrap a bigint aggregate SQL in CAST(... AS TEXT) so SQLite returns
  * a decimal string instead of a lossy number. Only used when
- * needsBigintCast() is true.
+ * needsBigintCast() is true. Aliases are quoted to match SQLite's
+ * identifier quoting convention.
  */
 function wrapBigintAgg(innerSql: string, grouped = false): string {
   if (grouped) {
-    return `SELECT group_key, CAST(val AS TEXT) AS val FROM (${innerSql}) AS _bigint_agg`;
+    return `SELECT "group_key", CAST("val" AS TEXT) AS "val" FROM (${innerSql}) AS "_bigint_agg"`;
   }
-  return `SELECT CAST(val AS TEXT) AS val FROM (${innerSql}) AS _bigint_agg`;
+  return `SELECT CAST("val" AS TEXT) AS "val" FROM (${innerSql}) AS "_bigint_agg"`;
 }
 
 function isBigintColumn(rel: CalculationRelation, fn: AggFn, column: string): boolean {
@@ -261,7 +263,13 @@ export async function performSum(
   this: CalculationRelation,
   column?: string,
 ): Promise<number | bigint | Record<string, number | bigint>> {
-  if (this._isNone) return this._groupColumns.length > 0 ? {} : 0;
+  if (this._isNone) {
+    if (this._groupColumns.length > 0) return {};
+    const zeroType = column
+      ? (this._modelClass.arelTable as any)?.typeForAttribute?.(column)
+      : null;
+    return zeroType instanceof BigIntegerType ? 0n : 0;
+  }
   if (!column) return 0;
   if (this._groupColumns.length > 0) {
     return groupedAggregate(this, "sum", column, true) as Promise<Record<string, number | bigint>>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -102,12 +102,25 @@ function buildAggNode(table: any, fn: AggFn, column: string, distinct: boolean):
 }
 
 /**
- * Wrap a bigint aggregate SQL in CAST(... AS TEXT) so all adapters
- * return a decimal string. SQLite's SUM/MIN/MAX on computed columns has
- * no declared type, so `safeIntegers` is not enabled — it returns a lossy
- * JS number for values above Number.MAX_SAFE_INTEGER. Wrapping in a
- * subquery with CAST sidesteps that at the SQL level; BigIntegerType.cast
- * then converts the string to bigint with full precision.
+ * Whether this adapter needs a CAST-to-TEXT subquery to get a bigint
+ * aggregate value back as a string rather than a lossy JS number.
+ *
+ * SQLite's SUM/MIN/MAX on computed columns has no declared type, so
+ * `_maybeEnableSafeIntegers` doesn't trigger. The driver returns a lossy
+ * JS number for values above Number.MAX_SAFE_INTEGER.
+ *
+ * PG: pg-types returns int8 aggregate as a string natively.
+ * MySQL: supportBigNumbers:true returns large sums as strings.
+ * Both are handled by BigIntegerType.cast without any SQL wrapping.
+ */
+function needsBigintCast(rel: CalculationRelation): boolean {
+  return (rel._modelClass.adapter as any).adapterName === "SQLite";
+}
+
+/**
+ * Wrap a bigint aggregate SQL in CAST(... AS TEXT) so SQLite returns
+ * a decimal string instead of a lossy number. Only used when
+ * needsBigintCast() is true.
  */
 function wrapBigintAgg(innerSql: string, grouped = false): string {
   if (grouped) {
@@ -138,7 +151,8 @@ async function singleAggregate(
   rel._applyWheresToManager(manager, table);
 
   const innerSql = manager.toSql();
-  const sql = isBigintColumn(rel, fn, column) ? wrapBigintAgg(innerSql) : innerSql;
+  const sql =
+    isBigintColumn(rel, fn, column) && needsBigintCast(rel) ? wrapBigintAgg(innerSql) : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
   const val = rows[0]?.val;
   if (val === undefined || val === null) {
@@ -165,7 +179,10 @@ async function groupedAggregate(
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
 
   const innerSql = manager.toSql();
-  const sql = isBigintColumn(rel, fn, column) ? wrapBigintAgg(innerSql, true) : innerSql;
+  const sql =
+    isBigintColumn(rel, fn, column) && needsBigintCast(rel)
+      ? wrapBigintAgg(innerSql, true)
+      : innerSql;
   const rows = await rel._modelClass.adapter.execute(sql);
 
   const result: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Fixes a silent precision loss bug: `sum`/`minimum`/`maximum` on `big_integer` columns returned a lossy `number` instead of `bigint` for values above `Number.MAX_SAFE_INTEGER`.

## Rails reference

Mirrors `ActiveRecord::Calculations#type_cast_calculated_value` (`calculations.rb:627`):
```ruby
def type_cast_calculated_value(value, operation, type)
  case operation
  when "count"  then value.to_i
  when "sum"    then type.deserialize(value || 0)
  when "average" then value&.to_d (for integer/decimal)
  else            type.deserialize(value)  # min/max
  end
end
```
Ruby `BigInteger#deserialize` → `to_i` → arbitrary-precision integer. Our equivalent: `BigIntegerType.cast` → JS `bigint`.

## Changes

**`relation/calculations.ts`**
- `castAggValue()`: type-dispatch via the column's `typeForAttribute`. For `big_integer` columns: `BigIntegerType.cast(val)` for `sum`/`min`/`max`; `count` and `average` stay as `Number`.
- `wrapBigintAgg()`: wraps bigint aggregate SQL as `SELECT CAST(val AS TEXT) FROM (...)`. SQLite's `SUM()`/`MIN()`/`MAX()` on computed columns have `type: null` — `_maybeEnableSafeIntegers` doesn't trigger, so the driver returns a lossy `number`. The CAST forces a string; `BigIntegerType.cast` converts with full precision. PG and MySQL already return strings for large values.
- `sum()` return type: `number | bigint | Record<string, number | bigint>`

## Tests

6 new assertions: `sum`/`max`/`min` with `2n ** 62n`, `count` stays `number`, `sum` of `integer` column stays `number`, `sum` of empty set returns `0n`.

## No backwards compatibility required

Pre-release project, zero downstream consumers.