### PR TITLE
fix(activerecord): pg test quality follow-ups from #792 Copilot reviews

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/bytea_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -28,7 +28,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("write with hex format", async () => {});
     it.skip("write with escape format", async () => {});
     it.skip("write via fixture", async () => {});
-    it.skip("binary columns are limitless the upper limit is one GB", () => {});
+    it("binary columns are limitless the upper limit is one GB", () => {
+      expect(adapter.typeToSql("binary", { limit: 100_000 })).toBe("bytea");
+      expect(() => adapter.typeToSql("binary", { limit: 4_294_967_295 })).toThrow();
+    });
     it.skip("type cast binary converts the encoding", () => {});
     it.skip("type cast binary value", () => {});
     it.skip("type case nil", () => {});

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -10,7 +10,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
   });
   afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS ex CASCADE`);
+    await adapter.exec(`DROP TABLE IF EXISTS dt_ex CASCADE`);
     await adapter.close();
   });
 
@@ -47,16 +47,16 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLInternalDatatypeTest", () => {
     it("name column type", async () => {
-      await adapter.exec(`CREATE TABLE ex (data name)`);
-      const cols = await adapter.columns("ex");
+      await adapter.exec(`CREATE TABLE dt_ex (data name)`);
+      const cols = await adapter.columns("dt_ex");
       const col = cols.find((c) => c.name === "data");
       expect(col).toBeDefined();
       expect(col!.baseType).toBe("string");
     });
 
     it("char column type", async () => {
-      await adapter.exec(`CREATE TABLE ex (data "char")`);
-      const cols = await adapter.columns("ex");
+      await adapter.exec(`CREATE TABLE dt_ex (data "char")`);
+      const cols = await adapter.columns("dt_ex");
       const col = cols.find((c) => c.name === "data");
       expect(col).toBeDefined();
       expect(col!.baseType).toBe("string");

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/datatype_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -10,6 +10,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
   });
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS ex CASCADE`);
     await adapter.close();
   });
 
@@ -23,17 +24,42 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("text column", async () => {});
     it.skip("binary column", async () => {});
     it.skip("oid column", async () => {});
-    it.skip("data type of time types", async () => {});
-    it.skip("data type of oid types", async () => {});
-    it.skip("time values", async () => {});
+    it.skip("data type of time types", async () => {
+      // Requires AR model with interval column; no adapter-level equivalent
+    });
+    it.skip("data type of oid types", async () => {
+      // Requires AR model with oid column; no adapter-level equivalent
+    });
+    it.skip("time values", async () => {
+      // Requires AR model (PostgresqlTime); no adapter-level equivalent
+    });
     it.skip("update large time in seconds", async () => {});
-    it.skip("oid values", async () => {});
+    it.skip("oid values", async () => {
+      // Requires AR model (PostgresqlOid); no adapter-level equivalent
+    });
     it.skip("update oid", async () => {});
-    it.skip("text columns are limitless the upper limit is one GB", async () => {});
+
+    it("text columns are limitless the upper limit is one GB", async () => {
+      expect(adapter.typeToSql("text", { limit: 100_000 })).toBe("text");
+      expect(() => adapter.typeToSql("text", { limit: 4_294_967_295 })).toThrow();
+    });
   });
 
   describe("PostgreSQLInternalDatatypeTest", () => {
-    it.skip("name column type", async () => {});
-    it.skip("char column type", async () => {});
+    it("name column type", async () => {
+      await adapter.exec(`CREATE TABLE ex (data name)`);
+      const cols = await adapter.columns("ex");
+      const col = cols.find((c) => c.name === "data");
+      expect(col).toBeDefined();
+      expect(col!.baseType).toBe("string");
+    });
+
+    it("char column type", async () => {
+      await adapter.exec(`CREATE TABLE ex (data "char")`);
+      const cols = await adapter.columns("ex");
+      const col = cols.find((c) => c.name === "data");
+      expect(col).toBeDefined();
+      expect(col!.baseType).toBe("string");
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -100,14 +100,5 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       expect(rows).toHaveLength(1);
     });
-
-    it("errors when a data modifying cte is called while preventing writes", async () => {
-      preventWrites(adapter);
-      await expect(
-        adapter.execute(
-          `WITH inserted AS (INSERT INTO ex (data) VALUES ('cte_write') RETURNING id) SELECT * FROM inserted`,
-        ),
-      ).rejects.toBeInstanceOf(ReadOnlyError);
-    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -1,17 +1,28 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { ReadOnlyError } from "../../errors.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`CREATE TEMP TABLE ex (id serial primary key, data character varying(255))`);
   });
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS ex`);
     await adapter.close();
   });
+
+  function preventWrites(a: PostgreSQLAdapter): void {
+    (a as unknown as { _config: Record<string, unknown> })._config.preventWrites = true;
+  }
+
+  function allowWrites(a: PostgreSQLAdapter): void {
+    (a as unknown as { _config: Record<string, unknown> })._config.preventWrites = false;
+  }
 
   describe("PostgreSQLAdapterPreventWritesTest", () => {
     it.skip("prevent writes insert", async () => {});
@@ -22,13 +33,72 @@ describeIfPg("PostgreSQLAdapter", () => {
     it.skip("prevent writes allows select", async () => {});
     it.skip("prevent writes allows explain", async () => {});
     it.skip("prevent writes toggle", async () => {});
-    it.skip("doesnt error when a read query with cursors is called while preventing writes", async () => {});
-    it.skip("errors when an insert query is called while preventing writes", () => {});
-    it.skip("errors when an update query is called while preventing writes", () => {});
-    it.skip("errors when a delete query is called while preventing writes", () => {});
-    it.skip("doesnt error when a select query is called while preventing writes", () => {});
-    it.skip("doesnt error when a show query is called while preventing writes", () => {});
-    it.skip("doesnt error when a set query is called while preventing writes", () => {});
-    it.skip("doesnt error when a read query with leading chars is called while preventing writes", () => {});
+
+    it("doesnt error when a read query with cursors is called while preventing writes", async () => {
+      preventWrites(adapter);
+      await adapter.beginTransaction();
+      try {
+        await adapter.execute("DECLARE cur_ex CURSOR FOR SELECT * FROM ex");
+        await adapter.execute("FETCH cur_ex");
+        await adapter.execute("MOVE cur_ex");
+        await adapter.execute("CLOSE cur_ex");
+      } finally {
+        await adapter.rollback();
+      }
+    });
+
+    it("errors when an insert query is called while preventing writes", async () => {
+      preventWrites(adapter);
+      await expect(
+        adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')"),
+      ).rejects.toBeInstanceOf(ReadOnlyError);
+    });
+
+    it("errors when an update query is called while preventing writes", async () => {
+      allowWrites(adapter);
+      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      preventWrites(adapter);
+      await expect(
+        adapter.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'"),
+      ).rejects.toBeInstanceOf(ReadOnlyError);
+    });
+
+    it("errors when a delete query is called while preventing writes", async () => {
+      allowWrites(adapter);
+      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      preventWrites(adapter);
+      await expect(
+        adapter.execute("DELETE FROM ex WHERE data = '138853948594'"),
+      ).rejects.toBeInstanceOf(ReadOnlyError);
+    });
+
+    it("doesnt error when a select query is called while preventing writes", async () => {
+      allowWrites(adapter);
+      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      preventWrites(adapter);
+      const rows = await adapter.execute("SELECT * FROM ex WHERE data = '138853948594'");
+      expect(rows).toHaveLength(1);
+    });
+
+    it("doesnt error when a show query is called while preventing writes", async () => {
+      preventWrites(adapter);
+      const rows = await adapter.execute("SHOW TIME ZONE");
+      expect(rows).toHaveLength(1);
+    });
+
+    it("doesnt error when a set query is called while preventing writes", async () => {
+      preventWrites(adapter);
+      await expect(adapter.execute("SET standard_conforming_strings = on")).resolves.toBeDefined();
+    });
+
+    it("doesnt error when a read query with leading chars is called while preventing writes", async () => {
+      allowWrites(adapter);
+      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      preventWrites(adapter);
+      const rows = await adapter.execute(
+        "/*action:index*/(\n( SELECT * FROM ex WHERE data = '138853948594' ) )",
+      );
+      expect(rows).toHaveLength(1);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -100,5 +100,14 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       expect(rows).toHaveLength(1);
     });
+
+    it("errors when a data modifying cte is called while preventing writes", async () => {
+      preventWrites(adapter);
+      await expect(
+        adapter.execute(
+          `WITH inserted AS (INSERT INTO ex (data) VALUES ('cte_write') RETURNING id) SELECT * FROM inserted`,
+        ),
+      ).rejects.toBeInstanceOf(ReadOnlyError);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -16,12 +16,16 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.close();
   });
 
+  // isPreventingWrites() checks pool.preventWrites before _config, and pool
+  // is a public property — safer than reaching into protected _config.
   function preventWrites(a: PostgreSQLAdapter): void {
-    (a as unknown as { _config: Record<string, unknown> })._config.preventWrites = true;
+    (a as PostgreSQLAdapter & { pool: { preventWrites?: boolean } }).pool = { preventWrites: true };
   }
 
   function allowWrites(a: PostgreSQLAdapter): void {
-    (a as unknown as { _config: Record<string, unknown> })._config.preventWrites = false;
+    (a as PostgreSQLAdapter & { pool: { preventWrites?: boolean } }).pool = {
+      preventWrites: false,
+    };
   }
 
   describe("PostgreSQLAdapterPreventWritesTest", () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -9,7 +9,8 @@ describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await adapter.exec(`CREATE TEMP TABLE ex (id serial primary key, data character varying(255))`);
+    await adapter.exec(`DROP TABLE IF EXISTS ex`);
+    await adapter.exec(`CREATE TABLE ex (id serial primary key, data character varying(255))`);
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS ex`);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -9,11 +9,11 @@ describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await adapter.exec(`DROP TABLE IF EXISTS ex`);
-    await adapter.exec(`CREATE TABLE ex (id serial primary key, data character varying(255))`);
+    await adapter.exec(`DROP TABLE IF EXISTS pw_ex`);
+    await adapter.exec(`CREATE TABLE pw_ex (id serial primary key, data character varying(255))`);
   });
   afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS ex`);
+    await adapter.exec(`DROP TABLE IF EXISTS pw_ex`);
     await adapter.close();
   });
 
@@ -43,7 +43,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       preventWrites(adapter);
       await adapter.beginTransaction();
       try {
-        await adapter.execute("DECLARE cur_ex CURSOR FOR SELECT * FROM ex");
+        await adapter.execute("DECLARE cur_ex CURSOR FOR SELECT * FROM pw_ex");
         await adapter.execute("FETCH cur_ex");
         await adapter.execute("MOVE cur_ex");
         await adapter.execute("CLOSE cur_ex");
@@ -55,33 +55,33 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("errors when an insert query is called while preventing writes", async () => {
       preventWrites(adapter);
       await expect(
-        adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')"),
+        adapter.execute("INSERT INTO pw_ex (data) VALUES ('138853948594')"),
       ).rejects.toBeInstanceOf(ReadOnlyError);
     });
 
     it("errors when an update query is called while preventing writes", async () => {
       allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      await adapter.execute("INSERT INTO pw_ex (data) VALUES ('138853948594')");
       preventWrites(adapter);
       await expect(
-        adapter.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'"),
+        adapter.execute("UPDATE pw_ex SET data = '9989' WHERE data = '138853948594'"),
       ).rejects.toBeInstanceOf(ReadOnlyError);
     });
 
     it("errors when a delete query is called while preventing writes", async () => {
       allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      await adapter.execute("INSERT INTO pw_ex (data) VALUES ('138853948594')");
       preventWrites(adapter);
       await expect(
-        adapter.execute("DELETE FROM ex WHERE data = '138853948594'"),
+        adapter.execute("DELETE FROM pw_ex WHERE data = '138853948594'"),
       ).rejects.toBeInstanceOf(ReadOnlyError);
     });
 
     it("doesnt error when a select query is called while preventing writes", async () => {
       allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      await adapter.execute("INSERT INTO pw_ex (data) VALUES ('138853948594')");
       preventWrites(adapter);
-      const rows = await adapter.execute("SELECT * FROM ex WHERE data = '138853948594'");
+      const rows = await adapter.execute("SELECT * FROM pw_ex WHERE data = '138853948594'");
       expect(rows).toHaveLength(1);
     });
 
@@ -98,10 +98,10 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("doesnt error when a read query with leading chars is called while preventing writes", async () => {
       allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+      await adapter.execute("INSERT INTO pw_ex (data) VALUES ('138853948594')");
       preventWrites(adapter);
       const rows = await adapter.execute(
-        "/*action:index*/(\n( SELECT * FROM ex WHERE data = '138853948594' ) )",
+        "/*action:index*/(\n( SELECT * FROM pw_ex WHERE data = '138853948594' ) )",
       );
       expect(rows).toHaveLength(1);
     });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -973,7 +973,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   // ── DatabaseStatements ────────────────────────────────────────────
   describe("DatabaseStatements", () => {
     it("isWriteQuery returns false for read-like statements", () => {
-      expect(adapter.isWriteQuery("SELECT 1")).toBe(true);
+      expect(adapter.isWriteQuery("SELECT 1")).toBe(false);
       expect(adapter.isWriteQuery("SET search_path TO public")).toBe(false);
       expect(adapter.isWriteQuery("SHOW server_version")).toBe(false);
     });

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { IntegerOutOf64BitRange } from "../../connection-adapters/postgresql/quoting.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -123,9 +124,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("raise when int is wider than 64bit", async () => {
       const tooBig = BigInt("9223372036854775808"); // MAX_INT64 + 1
-      expect(() => adapter.quote(tooBig)).toThrow();
+      expect(() => adapter.quote(tooBig)).toThrow(IntegerOutOf64BitRange);
       const tooSmall = BigInt("-9223372036854775809"); // MIN_INT64 - 1
-      expect(() => adapter.quote(tooSmall)).toThrow();
+      expect(() => adapter.quote(tooSmall)).toThrow(IntegerOutOf64BitRange);
     });
 
     it("do not raise when int is not wider than 64bit", async () => {

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -60,9 +60,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows).toHaveLength(0);
     });
 
-    it.skip("quote table name with schema", async () => {});
-    it.skip("quote unicode string", async () => {});
-    it.skip("quote binary", async () => {});
+    it("quote table name with schema", async () => {
+      expect(adapter.quoteTableName("foo.bar")).toBe('"foo"."bar"');
+    });
+
+    it.skip("quote unicode string", async () => {
+      // unicode string quoting verified via standard string quoting; no special PG behavior
+    });
+    it.skip("quote binary", async () => {
+      // binary quoting tested via write/read bytea round-trips; requires bytea column setup
+    });
     it("quote date", async () => {
       const rows = await adapter.execute("SELECT DATE '2023-01-15' AS val");
       const val = rows[0].val;
@@ -96,9 +103,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows[0].val).toBe(42);
     });
 
-    it.skip("quote big decimal", async () => {});
-    it.skip("quote rational", async () => {});
-    it.skip("quote bit string", async () => {});
+    it("quote big decimal", async () => {
+      expect(adapter.quote(4.2)).toBe("4.2");
+    });
+
+    it.skip("quote rational", async () => {
+      // Ruby-only: Rational(3,4). No JS equivalent; numeric literals work without a Rational type.
+    });
+    it.skip("quote bit string", async () => {
+      // Requires OID::Bit type serialization; covered by bit_string tests.
+    });
 
     it("quote table name with spaces", async () => {
       await adapter.exec(`CREATE TABLE "table with spaces" ("id" SERIAL PRIMARY KEY)`);
@@ -107,11 +121,20 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(rows).toHaveLength(1);
     });
 
-    it.skip("raise when int is wider than 64bit", async () => {});
-    it("do not raise when int is not wider than 64bit", async () => {
-      const rows = await adapter.execute("SELECT 2147483647::integer AS val");
-      expect(rows[0].val).toBe(2147483647);
+    it("raise when int is wider than 64bit", async () => {
+      const tooBig = BigInt("9223372036854775808"); // MAX_INT64 + 1
+      expect(() => adapter.quote(tooBig)).toThrow();
+      const tooSmall = BigInt("-9223372036854775809"); // MIN_INT64 - 1
+      expect(() => adapter.quote(tooSmall)).toThrow();
     });
-    it.skip("do not raise when raise int wider than 64bit is false", async () => {});
+
+    it("do not raise when int is not wider than 64bit", async () => {
+      expect(adapter.quote(BigInt("9223372036854775807"))).toBe("9223372036854775807");
+      expect(adapter.quote(BigInt("-9223372036854775808"))).toBe("-9223372036854775808");
+    });
+
+    it.skip("do not raise when raise int wider than 64bit is false", async () => {
+      // Requires ActiveRecord.raise_int_wider_than_64bit class-level flag; not yet implemented.
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -140,8 +140,43 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQLTimestampMigrationTest", () => {
-    it.skip("adds column as timestamp", () => {});
-    it.skip("adds column as timestamptz if datetime type changed", () => {});
-    it.skip("adds column as custom type", () => {});
+    it("adds column as timestamp", async () => {
+      await adapter.exec(
+        `CREATE TABLE IF NOT EXISTS postgresql_timestamp_with_zones (id serial primary key)`,
+      );
+      try {
+        await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
+        const rows = await adapter.execute(
+          `SELECT data_type FROM information_schema.columns
+           WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
+        );
+        expect(rows[0]?.data_type).toBe("timestamp without time zone");
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+      }
+    });
+
+    it("adds column as timestamptz if datetime type changed", async () => {
+      await adapter.exec(
+        `CREATE TABLE IF NOT EXISTS postgresql_timestamp_with_zones (id serial primary key)`,
+      );
+      const original = (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType;
+      try {
+        (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType = "timestamptz";
+        await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
+        const rows = await adapter.execute(
+          `SELECT data_type FROM information_schema.columns
+           WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
+        );
+        expect(rows[0]?.data_type).toBe("timestamp with time zone");
+      } finally {
+        (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType = original;
+        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+      }
+    });
+
+    it.skip("adds column as custom type", async () => {
+      // Requires creating a custom enum type and patching NATIVE_DATABASE_TYPES
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -157,21 +157,23 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("adds column as timestamptz if datetime type changed", async () => {
-      await adapter.exec(
+      class TimestamptzAdapter extends PostgreSQLAdapter {
+        static override datetimeType: "timestamp" | "timestamptz" = "timestamptz";
+      }
+      const tzAdapter = new TimestamptzAdapter(PG_TEST_URL);
+      await tzAdapter.exec(
         `CREATE TABLE IF NOT EXISTS postgresql_timestamp_with_zones (id serial primary key)`,
       );
-      const original = (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType;
       try {
-        (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType = "timestamptz";
-        await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
-        const rows = await adapter.execute(
+        await tzAdapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
+        const rows = await tzAdapter.execute(
           `SELECT data_type FROM information_schema.columns
            WHERE table_name = 'postgresql_timestamp_with_zones' AND column_name = 'times'`,
         );
         expect(rows[0]?.data_type).toBe("timestamp with time zone");
       } finally {
-        (PostgreSQLAdapter as unknown as { datetimeType: string }).datetimeType = original;
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        await tzAdapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        await tzAdapter.close();
       }
     });
 

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -141,10 +141,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLTimestampMigrationTest", () => {
     it("adds column as timestamp", async () => {
-      await adapter.exec(
-        `CREATE TABLE IF NOT EXISTS postgresql_timestamp_with_zones (id serial primary key)`,
-      );
+      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
       try {
+        await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
         await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
         const rows = await adapter.execute(
           `SELECT data_type FROM information_schema.columns
@@ -161,10 +160,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         static override datetimeType: "timestamp" | "timestamptz" = "timestamptz";
       }
       const tzAdapter = new TimestamptzAdapter(PG_TEST_URL);
-      await tzAdapter.exec(
-        `CREATE TABLE IF NOT EXISTS postgresql_timestamp_with_zones (id serial primary key)`,
-      );
       try {
+        await tzAdapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        await tzAdapter.exec(
+          `CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`,
+        );
         await tzAdapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
         const rows = await tzAdapter.execute(
           `SELECT data_type FROM information_schema.columns

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -831,6 +831,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     binds: unknown[] = [],
     name: string = "SQL",
   ): Promise<Record<string, unknown>[]> {
+    this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
     const rewritten = this.rewriteBinds(sql, binds);
     // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -869,6 +869,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `rowCount` is returned.
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
+    this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
     const pgSql = this.rewriteBinds(sql, binds);
     // payload.sql records the rewritten SQL — ExplainSubscriber captures

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -9,8 +9,12 @@ import type { ExplainOption } from "../../adapter.js";
 import type { Result } from "../../result.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
-// SQL statements that do not modify data — write_query? returns false for these.
-export const READ_QUERY = /^[\s]*(?:close|declare|fetch|move|set|show)\b/i;
+// Mirrors Rails' build_read_query_regexp which combines the default read list
+// (begin, commit, explain, release, rollback, savepoint, select, with) with
+// the PG-specific additions (close, declare, fetch, move, set, show).
+// Leading whitespace and block/line comments are also allowed before the keyword.
+export const READ_QUERY =
+  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show|with)\b/is;
 
 export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -16,9 +16,10 @@ import type { Result } from "../../result.js";
 // Rails does not perform deep CTE analysis — data-modifying CTEs starting
 // with WITH are treated as read-only, the same as pure-read CTEs. This
 // mirrors DEFAULT_READ_QUERY + PG additions from build_read_query_regexp.
-// Leading whitespace and block/line comments are also allowed before the keyword.
+// Leading whitespace, block/line comments, and opening parentheses are
+// allowed before the keyword in any order.
 export const READ_QUERY =
-  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show|with)\b/is;
+  /^(?:\s|\/\*.*?\*\/|--[^\n]*(?:\n|$)|\()*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show|with)\b/is;
 
 export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -12,12 +12,13 @@ import type { Result } from "../../result.js";
 // Mirrors Rails' build_read_query_regexp which combines the default read list
 // (begin, commit, explain, release, rollback, savepoint, select) with
 // the PG-specific additions (close, declare, fetch, move, set, show).
-// `with` is intentionally excluded: PostgreSQL CTEs can perform writes
-// (e.g. WITH x AS (INSERT ...) SELECT ...) and must not be treated as
-// universally read-only — those queries fall through to isWriteQuerySql.
+// Matches Rails exactly: `with` is included in the read list.
+// Rails does not perform deep CTE analysis — data-modifying CTEs starting
+// with WITH are treated as read-only, the same as pure-read CTEs. This
+// mirrors DEFAULT_READ_QUERY + PG additions from build_read_query_regexp.
 // Leading whitespace and block/line comments are also allowed before the keyword.
 export const READ_QUERY =
-  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show)\b/is;
+  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show|with)\b/is;
 
 export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -10,11 +10,14 @@ import type { Result } from "../../result.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
 // Mirrors Rails' build_read_query_regexp which combines the default read list
-// (begin, commit, explain, release, rollback, savepoint, select, with) with
+// (begin, commit, explain, release, rollback, savepoint, select) with
 // the PG-specific additions (close, declare, fetch, move, set, show).
+// `with` is intentionally excluded: PostgreSQL CTEs can perform writes
+// (e.g. WITH x AS (INSERT ...) SELECT ...) and must not be treated as
+// universally read-only — those queries fall through to isWriteQuerySql.
 // Leading whitespace and block/line comments are also allowed before the keyword.
 export const READ_QUERY =
-  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show|with)\b/is;
+  /^(?:\s|\/\*.*?\*\/|--[^\n]*\n)*(?:\([\s(]*)*(?:begin|close|commit|declare|explain|fetch|move|release|rollback|savepoint|select|set|show)\b/is;
 
 export interface DatabaseStatements {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -194,6 +194,12 @@ export function quote(value: unknown): string {
   if (value instanceof Range) {
     return quoteString(encodeRange(value));
   }
+  // Mirrors: PostgreSQL::Quoting#quote raises IntegerOutOf64BitRange for
+  // integers exceeding the 64-bit signed range (e.g. BigInt values).
+  if (typeof value === "bigint") {
+    checkIntegerRange(value);
+    return String(value);
+  }
   return abstractQuote(value);
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -195,8 +195,10 @@ export function quote(value: unknown): string {
     return quoteString(encodeRange(value));
   }
   // Mirrors: PostgreSQL::Quoting#quote raises IntegerOutOf64BitRange for
-  // integers exceeding the 64-bit signed range (e.g. BigInt values).
-  if (typeof value === "bigint") {
+  // integers exceeding the 64-bit signed range. Covers both bigint and
+  // integer number values — JS integers beyond MAX_SAFE_INTEGER lose
+  // precision silently, so they must be rejected the same way bigints are.
+  if (typeof value === "bigint" || (typeof value === "number" && Number.isInteger(value))) {
     checkIntegerRange(value);
     return String(value);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -125,6 +125,11 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.aliasType("char", "varchar");
   m.aliasType("name", "varchar");
   m.aliasType("bpchar", "varchar");
+  // Register fixed OIDs for internal PG string-like types so columns() can
+  // resolve their semantic type without a pg_type round-trip. OIDs are
+  // stable built-ins that don't vary across PG versions.
+  m.registerType(18, new StringType()); // "char" — single internal byte
+  m.registerType(19, new StringType()); // name   — 63-byte identifier type
   m.registerType("bool", new BooleanType());
   registerClassWithLimit(m, "bit", Bit);
   registerClassWithLimit(m, "varbit", BitVarying);

--- a/packages/activerecord/src/connection-adapters/sql-classification.ts
+++ b/packages/activerecord/src/connection-adapters/sql-classification.ts
@@ -6,9 +6,10 @@
  * duplicating the logic.
  */
 
-// Mirrors Rails PG adapter READ_QUERY which adds :close, :declare, :fetch,
-// :move, :set, :show to the default list. CLOSE/DECLARE/FETCH/MOVE are
-// PostgreSQL cursor operations that read or manage cursors — not data writes.
+// Shared read-only statement allowlist used for cross-adapter SQL
+// classification, including adapter-specific additions such as PostgreSQL
+// cursor operations. CLOSE/DECLARE/FETCH/MOVE read or manage cursors — not
+// data writes.
 const READ_ONLY_STATEMENTS =
   /^(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|DESCRIBE|DESC|USE|KILL|CLOSE|DECLARE|FETCH|MOVE)$/;
 

--- a/packages/activerecord/src/connection-adapters/sql-classification.ts
+++ b/packages/activerecord/src/connection-adapters/sql-classification.ts
@@ -6,8 +6,11 @@
  * duplicating the logic.
  */
 
+// Mirrors Rails PG adapter READ_QUERY which adds :close, :declare, :fetch,
+// :move, :set, :show to the default list. CLOSE/DECLARE/FETCH/MOVE are
+// PostgreSQL cursor operations that read or manage cursors — not data writes.
 const READ_ONLY_STATEMENTS =
-  /^(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|DESCRIBE|DESC|USE|KILL)$/;
+  /^(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|DESCRIBE|DESC|USE|KILL|CLOSE|DECLARE|FETCH|MOVE)$/;
 
 /**
  * Strip SQL block comments and line comments.


### PR DESCRIPTION
## Summary

Follow-up fixes from Copilot review comments on #792, addressing 6 rounds of reviews:

- `READ_QUERY`: restore `with` (Rails parity), fix regex to allow parens/comments/whitespace in any order before keyword, fix misleading comment
- `sql-classification.ts`: update comment to describe shared cross-adapter allowlist, not PG-specific
- `executeMutation`: add `checkIfWriteQuery` to cover mutation path alongside `execute()`
- `quoting.ts`: range-check integer `number` values in `quote()` (not just `bigint`); assert specific `IntegerOutOf64BitRange` type in test
- timestamp migration test: use subclass instead of global static mutation; drop before create for determinism; wrap entire body in try/finally
- prevent-writes test: use `pool.preventWrites` (public) instead of `_config` (protected); switch from TEMP table to regular table; use file-scoped table name `pw_ex`
- `datatype.test.ts`: rename table `ex` → `dt_ex` to avoid parallel-run collision

## Test plan

- [x] All affected tests pass
- [x] `pnpm build` + `pnpm typecheck` — clean