### PR TITLE
feat(encryption): encrypt/decrypt/encryptedAttribute/ciphertextFor instance methods + API tests

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -138,6 +138,10 @@ export function dangerousAttributeMethods(): Set<string> {
     "readAttribute",
     "writeAttribute",
     "assignAttributes",
+    "encrypt",
+    "decrypt",
+    "encryptedAttribute",
+    "ciphertextFor",
   ]);
   return _dangerousMethodsCache;
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -46,6 +46,10 @@ import * as _Validations from "./validations.js";
 import {
   encrypts as _encrypts,
   applyPendingEncryptions,
+  encryptedAttributeQ as _encryptedAttributeQ,
+  ciphertextFor as _ciphertextFor,
+  encryptRecord as _encryptRecord,
+  decryptRecord as _decryptRecord,
   type EncryptsOptions,
 } from "./encryption.js";
 import * as CounterCache from "./counter-cache.js";
@@ -1001,6 +1005,38 @@ export class Base extends Model {
     // is trying to eliminate.
     const target = isStiSubclass(this) ? (getStiBase(this) as typeof Base) : this;
     _encrypts(target, ...args);
+  }
+
+  /**
+   * Returns true if the attribute is currently stored as encrypted ciphertext.
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute?
+   */
+  encryptedAttribute(attributeName: string): boolean {
+    return _encryptedAttributeQ(this, attributeName);
+  }
+
+  /**
+   * Returns the raw ciphertext stored for the attribute.
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord#ciphertext_for
+   */
+  ciphertextFor(attributeName: string): unknown {
+    return _ciphertextFor(this, attributeName);
+  }
+
+  /**
+   * Encrypts all encryptable attributes and persists via update_columns.
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypt
+   */
+  async encrypt(): Promise<void> {
+    return _encryptRecord(this);
+  }
+
+  /**
+   * Decrypts all encryptable attributes and persists via update_columns.
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord#decrypt
+   */
+  async decrypt(): Promise<void> {
+    return _decryptRecord(this);
   }
 
   static async suppress<R>(fn: () => R | Promise<R>): Promise<R> {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -322,6 +322,11 @@ export async function encryptRecord(record: any): Promise<void> {
   for (const [attr, plaintext] of Object.entries(plaintextValues)) {
     record._attributes.writeCastValue(attr, plaintext);
   }
+  // Re-snapshot the dirty tracker so it sees the restored plaintext as the
+  // clean state — updateColumns already called changesApplied() with the
+  // ciphertext values, which would make subsequent attribute writes appear
+  // to change "from" the ciphertext rather than the plaintext.
+  record.changesApplied();
 }
 
 /**

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -25,6 +25,7 @@ import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
 import { globalPreviousSchemesFor } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
+import { withoutEncryption } from "./encryption/context.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -265,10 +266,12 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
  */
 export function encryptedAttributeQ(record: any, attributeName: string): boolean {
   const klass = record.constructor as any;
-  if (!klass._encryptedAttributes?.has(attributeName)) return false;
-  const type = klass._attributeDefinitions?.get(attributeName)?.type;
+  // Resolve attribute aliases (mirrors Rails' attribute_aliases lookup).
+  const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
+  if (!klass._encryptedAttributes?.has(resolved)) return false;
+  const type = klass._attributeDefinitions?.get(resolved)?.type;
   if (!(type instanceof EncryptedAttributeType)) return false;
-  const rawValue = record.readAttributeBeforeTypeCast(attributeName);
+  const rawValue = record.readAttributeBeforeTypeCast(resolved);
   return type.isEncrypted(rawValue);
 }
 
@@ -280,10 +283,12 @@ export function encryptedAttributeQ(record: any, attributeName: string): boolean
  * Mirrors: ActiveRecord::Encryption::EncryptableRecord#ciphertext_for
  */
 export function ciphertextFor(record: any, attributeName: string): unknown {
+  const klass = record.constructor as any;
+  const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
   if (encryptedAttributeQ(record, attributeName)) {
-    return record.readAttributeBeforeTypeCast(attributeName);
+    return record.readAttributeBeforeTypeCast(resolved);
   }
-  return record._attributes.valuesForDatabase()[attributeName];
+  return record._attributes.valuesForDatabase()[resolved];
 }
 
 /**
@@ -294,11 +299,27 @@ export async function encryptRecord(record: any): Promise<void> {
   const klass = record.constructor as any;
   const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
   if (encryptedAttrs.size === 0) return;
+
+  // Save plaintext values before calling updateColumns, which would overwrite
+  // in-memory attributes with the ciphertext (since updateColumns uses cast()).
+  const plaintextValues: Record<string, unknown> = {};
   const assignments: Record<string, unknown> = {};
   for (const attr of encryptedAttrs) {
-    assignments[attr] = record[attr];
+    const plaintext = record[attr];
+    plaintextValues[attr] = plaintext;
+    // Explicitly serialize via the type so updateColumns writes ciphertext —
+    // updateColumns uses cast() not serialize(), so we pre-serialize here.
+    const type = klass._attributeDefinitions?.get(attr)?.type;
+    assignments[attr] =
+      type instanceof EncryptedAttributeType ? type.serialize(plaintext) : plaintext;
   }
+
   await record.updateColumns(assignments);
+
+  // Restore plaintext in-memory so record.attr still reads as plaintext.
+  for (const [attr, plaintext] of Object.entries(plaintextValues)) {
+    record._attributes.set(attr, plaintext);
+  }
 }
 
 /**
@@ -311,7 +332,6 @@ export async function decryptRecord(record: any): Promise<void> {
   const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
   if (encryptedAttrs.size === 0) return;
 
-  const { withoutEncryption } = await import("./encryption/context.js");
   const assignments: Record<string, unknown> = {};
   for (const attr of encryptedAttrs) {
     const type = klass._attributeDefinitions?.get(attr)?.type;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -257,6 +257,74 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
   return false;
 }
 
+// ─── Instance-level encryption API ──────────────────────────────────────────
+
+/**
+ * Returns true if the attribute's current stored value is encrypted ciphertext.
+ * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute?
+ */
+export function encryptedAttributeQ(record: any, attributeName: string): boolean {
+  const klass = record.constructor as any;
+  if (!klass._encryptedAttributes?.has(attributeName)) return false;
+  const type = klass._attributeDefinitions?.get(attributeName)?.type;
+  if (!(type instanceof EncryptedAttributeType)) return false;
+  const rawValue = record.readAttributeBeforeTypeCast(attributeName);
+  return type.isEncrypted(rawValue);
+}
+
+/**
+ * Returns the ciphertext for the given attribute.
+ * For encrypted attributes: returns the raw (before-type-cast) stored value.
+ * For unencrypted attributes: returns the serialized DB value.
+ *
+ * Mirrors: ActiveRecord::Encryption::EncryptableRecord#ciphertext_for
+ */
+export function ciphertextFor(record: any, attributeName: string): unknown {
+  if (encryptedAttributeQ(record, attributeName)) {
+    return record.readAttributeBeforeTypeCast(attributeName);
+  }
+  return record._attributes.valuesForDatabase()[attributeName];
+}
+
+/**
+ * Encrypts all encryptable attributes and persists them via update_columns.
+ * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypt
+ */
+export async function encryptRecord(record: any): Promise<void> {
+  const klass = record.constructor as any;
+  const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+  if (encryptedAttrs.size === 0) return;
+  const assignments: Record<string, unknown> = {};
+  for (const attr of encryptedAttrs) {
+    assignments[attr] = record[attr];
+  }
+  await record.updateColumns(assignments);
+}
+
+/**
+ * Decrypts all encryptable attributes and persists them via update_columns
+ * (with encryption disabled, matching Rails' without_encryption block).
+ * Mirrors: ActiveRecord::Encryption::EncryptableRecord#decrypt
+ */
+export async function decryptRecord(record: any): Promise<void> {
+  const klass = record.constructor as any;
+  const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+  if (encryptedAttrs.size === 0) return;
+
+  const { withoutEncryption } = await import("./encryption/context.js");
+  const assignments: Record<string, unknown> = {};
+  for (const attr of encryptedAttrs) {
+    const type = klass._attributeDefinitions?.get(attr)?.type;
+    const raw = record.readAttributeBeforeTypeCast(attr);
+    if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
+      assignments[attr] = type.deserialize(raw);
+    } else {
+      assignments[attr] = record[attr];
+    }
+  }
+  await withoutEncryption(() => record.updateColumns(assignments));
+}
+
 /** Mirrors: ActiveRecord::Encryption.key_length */
 export function keyLength(): number {
   return Cipher.keyLength;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -316,9 +316,11 @@ export async function encryptRecord(record: any): Promise<void> {
 
   await record.updateColumns(assignments);
 
-  // Restore plaintext in-memory so record.attr still reads as plaintext.
+  // Restore plaintext as the in-memory cast value so record.attr still reads
+  // as plaintext, while preserving the ciphertext as valueBeforeTypeCast
+  // (used by encryptedAttribute? / ciphertextFor on this instance).
   for (const [attr, plaintext] of Object.entries(plaintextValues)) {
-    record._attributes.set(attr, plaintext);
+    record._attributes.writeCastValue(attr, plaintext);
   }
 }
 

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -305,7 +305,7 @@ export async function encryptRecord(record: any): Promise<void> {
   const plaintextValues: Record<string, unknown> = {};
   const assignments: Record<string, unknown> = {};
   for (const attr of encryptedAttrs) {
-    const plaintext = record[attr];
+    const plaintext = record.readAttribute(attr);
     plaintextValues[attr] = plaintext;
     // Explicitly serialize via the type so updateColumns writes ciphertext —
     // updateColumns uses cast() not serialize(), so we pre-serialize here.
@@ -346,7 +346,7 @@ export async function decryptRecord(record: any): Promise<void> {
     if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
       assignments[attr] = type.deserialize(raw);
     } else {
-      assignments[attr] = record[attr];
+      assignments[attr] = record.readAttribute(attr);
     }
   }
   await withoutEncryption(() => record.updateColumns(assignments));

--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -6,11 +6,13 @@ import {
   restoreEncryptionConfig,
   makeEncryptedPost,
   makeEncryptedBook,
-  makeEncryptedAuthor,
+  makeFreshModel,
+  makeKeyProvider,
   assertEncryptedAttribute,
   withoutEncryption,
   Base,
 } from "./test-helpers.js";
+import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
@@ -173,22 +175,34 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
   });
 
   it("encrypt attributes encrypted with a previous encryption scheme", async () => {
-    const Author = makeEncryptedAuthor(freshAdapter());
+    // Build a previous scheme with a different key provider so oldCiphertext
+    // is real ciphertext produced by a different key — mirrors the Rails test
+    // which uses EncryptedAuthor with a previous scheme configured.
+    const prevKeyProvider = makeKeyProvider("prev-key-for-encryption-test-32b!!");
+    const prevScheme = new Scheme({ keyProvider: prevKeyProvider });
+
+    const Author = makeFreshModel(freshAdapter(), { id: "integer", name: "string" });
+    Author.encrypts("name", { previousSchemes: [prevScheme] });
+
     const author = await Author.create({ name: "david" });
 
-    // Store a value encrypted with a previous type scheme
+    // Encrypt "dhh" using the previous scheme to simulate an old row.
     const type = (Author as any)._attributeDefinitions?.get("name")?.type;
+    expect(type.previousTypes.length).toBeGreaterThan(0);
     const prevType = type.previousTypes[0];
-    const oldCiphertext = prevType ? prevType.serialize("dhh") : null;
+    const oldCiphertext = prevType.serialize("dhh") as string;
+    expect(typeof oldCiphertext).toBe("string");
 
-    if (oldCiphertext) {
-      await withoutEncryption(() => author.updateColumns({ name: oldCiphertext }));
-      await author.encrypt();
-      const reloaded = await Author.find(author.id);
-      expect(reloaded.name).toBe("dhh");
-      // Verify the DB row was re-encrypted with the current scheme.
-      expect(reloaded.readAttributeBeforeTypeCast("name")).not.toBe(oldCiphertext);
-    }
+    await withoutEncryption(() => author.updateColumns({ name: oldCiphertext }));
+    // Reload so the in-memory attribute reflects the DB state (old ciphertext)
+    // rather than the raw ciphertext string set by updateColumns.
+    const authorWithOldCiphertext = await Author.find(author.id);
+    await authorWithOldCiphertext.encrypt();
+
+    const reloaded = await Author.find(authorWithOldCiphertext.id);
+    expect(reloaded.name).toBe("dhh");
+    // Verify the DB row was re-encrypted with the current scheme (different ciphertext).
+    expect(reloaded.readAttributeBeforeTypeCast("name")).not.toBe(oldCiphertext);
   });
 
   it.skip("encrypt won't change the encoding of strings even when compression is used", () => {});

--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -1,23 +1,189 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+  makeEncryptedPost,
+  makeEncryptedBook,
+  makeEncryptedAuthor,
+  assertEncryptedAttribute,
+  withoutEncryption,
+  Base,
+} from "./test-helpers.js";
+import { Configurable } from "./configurable.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
-  it.skip("encrypt encrypts all the encryptable attributes", () => {});
-  it.skip("encrypt won't fail for classes without attributes to encrypt", () => {});
-  it.skip("decrypt decrypts encrypted attributes", () => {});
-  it.skip("decrypt can be invoked multiple times", () => {});
-  it.skip("encrypt can be invoked multiple times", () => {});
-  it.skip("encrypted_attribute? returns false for regular attributes", () => {});
-  it.skip("encrypted_attribute? returns true for encrypted attributes which content is encrypted", () => {});
-  it.skip("encrypted_attribute? returns false for encrypted attributes which content is not encrypted", () => {});
-  it.skip("ciphertext_for returns the ciphertext for a given attribute", () => {});
-  it.skip("ciphertext_for returns the persisted ciphertext for a non-deterministically encrypted attribute", () => {});
-  it.skip("ciphertext_for returns the ciphertext of a new value", () => {});
-  it.skip("ciphertext_for returns the ciphertext of a decrypted value", () => {});
-  it.skip("ciphertext_for returns the ciphertext of a value when the record is new", () => {});
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    configSnapshot = snapshotEncryptionConfig();
+    Configurable.config.previousSchemes = [];
+    configureEncryption();
+    Configurable.config.supportUnencryptedData = true;
+  });
+
+  afterEach(() => {
+    restoreEncryptionConfig(configSnapshot);
+  });
+
+  it("encrypt encrypts all the encryptable attributes", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const title = "The Starfleet is here!";
+    const body = "<p>the Starfleet is here, we are safe now!</p>";
+
+    const post = await withoutEncryption(() => Post.create({ title, body }));
+    await post.encrypt();
+
+    assertEncryptedAttribute(post, "title", title);
+    assertEncryptedAttribute(post, "body", body);
+  });
+
+  it("encrypt won't fail for classes without attributes to encrypt", async () => {
+    const adapter = freshAdapter();
+    const PlainPost = class extends (Base as any) {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    } as any;
+    const post = await PlainPost.create({ title: "hello" });
+    await expect(post.encrypt()).resolves.toBeUndefined();
+  });
+
+  it("decrypt decrypts encrypted attributes", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const title = "the Starfleet is here!";
+    const body = "<p>the Starfleet is here, we are safe now!</p>";
+    const post = await Post.create({ title, body });
+    assertEncryptedAttribute(post, "title", title);
+
+    await post.decrypt();
+
+    const reloaded = await Post.find(post.id);
+    expect(reloaded.readAttributeBeforeTypeCast("title")).toBe(title);
+    expect(reloaded.title).toBe(title);
+  });
+
+  it("decrypt can be invoked multiple times", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const post = await Post.create({
+      title: "the Starfleet is here",
+      body: "<p>the Starfleet is here, we are safe now!</p>",
+    });
+
+    for (let i = 0; i < 3; i++) await post.decrypt();
+
+    const reloaded = await Post.find(post.id);
+    expect(reloaded.readAttributeBeforeTypeCast("title")).toBe("the Starfleet is here");
+  });
+
+  it("encrypt can be invoked multiple times", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const post = await Post.create({
+      title: "the Starfleet is here",
+      body: "<p>the Starfleet is here, we are safe now!</p>",
+    });
+
+    for (let i = 0; i < 3; i++) await post.encrypt();
+
+    const reloaded = await Post.find(post.id);
+    assertEncryptedAttribute(reloaded, "title", "the Starfleet is here");
+  });
+
+  it("encrypted_attribute? returns false for regular attributes", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    expect(book.encryptedAttribute("id")).toBe(false);
+  });
+
+  it("encrypted_attribute? returns true for encrypted attributes which content is encrypted", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    // Reload so readAttributeBeforeTypeCast returns the DB ciphertext, not the in-memory plaintext.
+    const reloaded = await Book.find(book.id);
+    expect(reloaded.encryptedAttribute("name")).toBe(true);
+  });
+
+  it("encrypted_attribute? returns false for encrypted attributes which content is not encrypted", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await withoutEncryption(() => Book.create({ name: "Dune" }));
+    expect(book.encryptedAttribute("name")).toBe(false);
+  });
+
+  it("ciphertext_for returns the ciphertext for a given attribute", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    const ciphertext = book.ciphertextFor("name");
+    expect(typeof ciphertext).toBe("string");
+    expect(ciphertext).not.toBe("Dune");
+    // Verify the ciphertext decrypts to the correct value.
+    const type = (Book as any)._attributeDefinitions?.get("name")?.type;
+    expect(type.deserialize(ciphertext)).toBe("Dune");
+  });
+
+  it("ciphertext_for returns the persisted ciphertext for a non-deterministically encrypted attribute", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    const post = await Post.create({
+      title: "Fear is the mind-killer",
+      body: "Fear is the little-death...",
+    });
+    // Reload so readAttributeBeforeTypeCast returns the persisted DB ciphertext.
+    const reloaded = await Post.find(post.id);
+    const ciphertext = reloaded.ciphertextFor("title");
+    expect(ciphertext).toBe(reloaded.readAttributeBeforeTypeCast("title"));
+    const type = (Post as any)._attributeDefinitions?.get("title")?.type;
+    expect(type.deserialize(ciphertext)).toBe("Fear is the mind-killer");
+  });
+
+  it("ciphertext_for returns the ciphertext of a new value", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    book.name = "Arrakis";
+    const ciphertext = book.ciphertextFor("name");
+    const type = (Book as any)._attributeDefinitions?.get("name")?.type;
+    expect(type.deserialize(ciphertext)).toBe("Arrakis");
+  });
+
+  it("ciphertext_for returns the ciphertext of a decrypted value", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = await Book.create({ name: "Dune" });
+    await book.decrypt();
+    const ciphertext = book.ciphertextFor("name");
+    const type = (Book as any)._attributeDefinitions?.get("name")?.type;
+    expect(type.deserialize(ciphertext)).toBe("Dune");
+  });
+
+  it("ciphertext_for returns the ciphertext of a value when the record is new", () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    const book = new Book() as any;
+    book.name = "Dune";
+    const ciphertext = book.ciphertextFor("name");
+    const type = (Book as any)._attributeDefinitions?.get("name")?.type;
+    expect(type.deserialize(ciphertext)).toBe("Dune");
+  });
+
+  it("encrypt attributes encrypted with a previous encryption scheme", async () => {
+    const Author = makeEncryptedAuthor(freshAdapter());
+    const author = await Author.create({ name: "david" });
+
+    // Store a value encrypted with a previous type scheme
+    const type = (Author as any)._attributeDefinitions?.get("name")?.type;
+    const prevType = type.previousTypes[0];
+    const oldCiphertext = prevType ? prevType.serialize("dhh") : null;
+
+    if (oldCiphertext) {
+      await withoutEncryption(() => author.updateColumns({ name: oldCiphertext }));
+      await author.encrypt();
+      const reloaded = await Author.find(author.id);
+      expect(reloaded.name).toBe("dhh");
+    }
+  });
+
   it.skip("encrypt won't change the encoding of strings even when compression is used", () => {});
   it.skip("encrypt will honor forced encoding for deterministic attributes", () => {});
   it.skip("encrypt won't force encoding for deterministic attributes when option is nil", () => {});
   it.skip("encrypt will preserve case when :ignore_case option is used", () => {});
   it.skip("re-encrypting will preserve case when :ignore_case option is used", () => {});
-  it.skip("encrypt attributes encrypted with a previous encryption scheme", () => {});
 });

--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -37,6 +37,13 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
 
     assertEncryptedAttribute(post, "title", title);
     assertEncryptedAttribute(post, "body", body);
+
+    // Verify the DB was actually updated with ciphertext.
+    const reloaded = await Post.find(post.id);
+    expect(reloaded.readAttributeBeforeTypeCast("title")).not.toBe(title);
+    expect(reloaded.readAttributeBeforeTypeCast("body")).not.toBe(body);
+    expect(reloaded.title).toBe(title);
+    expect(reloaded.body).toBe(body);
   });
 
   it("encrypt won't fail for classes without attributes to encrypt", async () => {
@@ -90,6 +97,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
 
     const reloaded = await Post.find(post.id);
     assertEncryptedAttribute(reloaded, "title", "the Starfleet is here");
+    expect(reloaded.encryptedAttribute("title")).toBe(true);
   });
 
   it("encrypted_attribute? returns false for regular attributes", async () => {
@@ -178,6 +186,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
       await author.encrypt();
       const reloaded = await Author.find(author.id);
       expect(reloaded.name).toBe("dhh");
+      // Verify the DB row was re-encrypted with the current scheme.
+      expect(reloaded.readAttributeBeforeTypeCast("name")).not.toBe(oldCiphertext);
     }
   });
 

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -8,6 +8,8 @@
 import { createTestAdapter } from "../test-adapter.js";
 import { Base } from "../index.js";
 import type { DatabaseAdapter } from "../adapter.js";
+
+export { Base };
 import { Configurable } from "./configurable.js";
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";


### PR DESCRIPTION
## Summary

Adds Rails-parity instance methods to every model class and implements 14 of 19 `EncryptableRecordApiTest` cases:

**New instance methods on `Base`:**
- `encrypt()` — encrypts all declared encrypted attributes and persists via `updateColumns`
- `decrypt()` — decrypts encrypted attributes and persists with encryption disabled (mirrors Rails' `without_encryption` block)
- `encryptedAttribute(name)` — returns true iff the stored DB value is ciphertext (checks `EncryptedAttributeType#isEncrypted` on the raw before-type-cast value)
- `ciphertextFor(name)` — returns the ciphertext for an attribute; for encrypted attributes returns `readAttributeBeforeTypeCast`, for others returns the serialized DB value

## Rails source
`activerecord/lib/active_record/encryption/encryptable_record.rb` lines 146–196

## Test plan
- [ ] 14 `EncryptableRecordApiTest` tests pass (5 skipped: encoding/ignore_case tests)
- [ ] Full encryption suite: 222 pass, 59 skipped (was 208/73)