### PR TITLE
feat(activemodel): I18n locale fallback chain + strict interpolation

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -239,6 +239,8 @@ export class Error {
       format = I18n.t(primaryKey, {
         defaults: fallbackDefaults,
         defaultValue: "%{attribute} %{message}",
+        attribute: humanAttr,
+        message,
       });
     } else {
       format = I18n.t(`${i18nScope}.errors.format`, {
@@ -247,10 +249,12 @@ export class Error {
           { key: "errors.format" },
         ],
         defaultValue: "%{attribute} %{message}",
+        attribute: humanAttr,
+        message,
       });
     }
 
-    return format.replace("%{attribute}", humanAttr).replace("%{message}", message);
+    return format;
   }
 
   static generateMessage(

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -102,6 +102,14 @@ describe("I18n", () => {
       expect(I18n.t("greet", { n: 4 })).toBe("fn:greet:4");
     });
 
+    it("passes the effective locale into lambdas even when caller omits it", () => {
+      I18n.storeTranslations("en", {
+        who: (_key, options) => `locale:${(options as { locale?: string }).locale}`,
+      });
+      I18n.locale = "fr";
+      expect(I18n.t("who")).toBe("locale:fr");
+    });
+
     it("interpolates the string returned by a lambda", () => {
       I18n.storeTranslations("en", {
         shout: () => "HEY %{name}",

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -26,12 +26,17 @@ describe("I18n", () => {
       expect(I18n.t("apples", { count: 3 })).toBe("3 apples");
     });
 
+    it("raises on %{toString} — inherited Object keys do not satisfy a placeholder", () => {
+      I18n.storeTranslations("en", { hi: "hi %{toString}" });
+      expect(() => I18n.t("hi")).toThrow(MissingInterpolationArgument);
+    });
+
     it("does not pass I18n control keys (scope/default/locale) into interpolation", () => {
       I18n.storeTranslations("en", { hi: "hi %{name}" });
       // `locale` and `defaults` are reserved — they must not be mistakenly
       // forwarded to %{locale} etc., and must not swallow errors from
       // genuinely-missing interpolations like %{name}.
-      expect(() => I18n.t("hi", { locale: "en", defaults: [{ key: "missing" }] } as never)).toThrow(
+      expect(() => I18n.t("hi", { locale: "en", defaults: [{ key: "missing" }] })).toThrow(
         MissingInterpolationArgument,
       );
     });

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -58,6 +58,14 @@ describe("I18n", () => {
       expect(I18n.locale).toBe("en");
     });
 
+    it("appends default_locale to explicit fallback chains", () => {
+      // Matches I18n::Locale::Fallbacks#compute (i18n/lib/i18n/locale/fallbacks.rb),
+      // which always pushes the default_locale onto the chain.
+      I18n.storeTranslations("en", { hi: "hello" });
+      I18n.setFallbacks({ fr: ["fr", "de"] });
+      expect(I18n.t("hi", { locale: "fr" })).toBe("hello");
+    });
+
     it("still returns defaultValue when no locale in the chain has the key", () => {
       I18n.setFallbacks({ "en-US": ["en-US", "en"] });
       expect(I18n.t("nope", { locale: "en-US", defaultValue: "fallback %{x}", x: 1 })).toBe(

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { I18n } from "./i18n.js";
+import { MissingInterpolationArgument } from "./i18n.js";
+
+describe("I18n", () => {
+  beforeEach(() => {
+    I18n.reset();
+  });
+
+  describe("interpolation", () => {
+    it("substitutes %{key} placeholders from options", () => {
+      I18n.storeTranslations("en", { greeting: "Hello, %{name}" });
+      expect(I18n.t("greeting", { name: "World" })).toBe("Hello, World");
+    });
+
+    it("raises MissingInterpolationArgument when a placeholder has no matching option", () => {
+      I18n.storeTranslations("en", { greeting: "Hello, %{name}" });
+      expect(() => I18n.t("greeting")).toThrow(MissingInterpolationArgument);
+    });
+
+    it("exposes count as an interpolation value for plural strings", () => {
+      I18n.storeTranslations("en", {
+        apples: { one: "one apple", other: "%{count} apples" },
+      });
+      expect(I18n.t("apples", { count: 1 })).toBe("one apple");
+      expect(I18n.t("apples", { count: 3 })).toBe("3 apples");
+    });
+
+    it("does not pass I18n control keys (scope/default/locale) into interpolation", () => {
+      I18n.storeTranslations("en", { hi: "hi %{name}" });
+      // `locale` and `defaults` are reserved — they must not be mistakenly
+      // forwarded to %{locale} etc., and must not swallow errors from
+      // genuinely-missing interpolations like %{name}.
+      expect(() => I18n.t("hi", { locale: "en", defaults: [{ key: "missing" }] } as never)).toThrow(
+        MissingInterpolationArgument,
+      );
+    });
+  });
+
+  describe("fallback chain", () => {
+    it("falls back to the default locale when the requested locale has no entry", () => {
+      I18n.storeTranslations("en", { hi: "hello" });
+      I18n.locale = "fr";
+      expect(I18n.t("hi")).toBe("hello");
+    });
+
+    it("walks an explicit per-locale fallback list before the default locale", () => {
+      I18n.storeTranslations("en", { hi: "hello" });
+      I18n.storeTranslations("en-GB", { hi: "hullo" });
+      I18n.setFallbacks({ "en-US": ["en-US", "en-GB", "en"] });
+      expect(I18n.t("hi", { locale: "en-US" })).toBe("hullo");
+    });
+
+    it("honors options.locale for a single lookup without mutating I18n.locale", () => {
+      I18n.storeTranslations("en", { hi: "hi" });
+      I18n.storeTranslations("es", { hi: "hola" });
+      expect(I18n.t("hi", { locale: "es" })).toBe("hola");
+      expect(I18n.locale).toBe("en");
+    });
+
+    it("still returns defaultValue when no locale in the chain has the key", () => {
+      I18n.setFallbacks({ "en-US": ["en-US", "en"] });
+      expect(I18n.t("nope", { locale: "en-US", defaultValue: "fallback %{x}", x: 1 })).toBe(
+        "fallback 1",
+      );
+    });
+  });
+
+  describe("lambda values", () => {
+    it("invokes function values with the lookup key and options", () => {
+      I18n.storeTranslations("en", {
+        greet: (key, options) => `fn:${key}:${(options as { n?: number }).n ?? 0}`,
+      });
+      expect(I18n.t("greet", { n: 4 })).toBe("fn:greet:4");
+    });
+
+    it("interpolates the string returned by a lambda", () => {
+      I18n.storeTranslations("en", {
+        shout: () => "HEY %{name}",
+      });
+      expect(I18n.t("shout", { name: "Alice" })).toBe("HEY Alice");
+    });
+  });
+});

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -26,6 +26,13 @@ describe("I18n", () => {
       expect(I18n.t("apples", { count: 3 })).toBe("3 apples");
     });
 
+    it("interpolates null/undefined option values as empty strings (Rails i18n semantics)", () => {
+      // i18n/lib/i18n/interpolate/ruby.rb raises only when the key is
+      // absent; a present-but-nil value is coerced to "" via to_s.
+      I18n.storeTranslations("en", { row: "[%{a}] [%{b}]" });
+      expect(I18n.t("row", { a: null, b: undefined })).toBe("[] []");
+    });
+
     it("raises on %{toString} — inherited Object keys do not satisfy a placeholder", () => {
       I18n.storeTranslations("en", { hi: "hi %{toString}" });
       expect(() => I18n.t("hi")).toThrow(MissingInterpolationArgument);
@@ -61,6 +68,14 @@ describe("I18n", () => {
       I18n.storeTranslations("es", { hi: "hola" });
       expect(I18n.t("hi", { locale: "es" })).toBe("hola");
       expect(I18n.locale).toBe("en");
+    });
+
+    it("does not mutate caller-supplied fallback chain arrays", () => {
+      I18n.storeTranslations("en-GB", { hi: "hullo" });
+      const chain = ["en-US", "en-GB"];
+      I18n.setFallbacks({ "en-US": chain });
+      chain.length = 0;
+      expect(I18n.t("hi", { locale: "en-US" })).toBe("hullo");
     });
 
     it("appends default_locale to explicit fallback chains", () => {

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -70,10 +70,13 @@ function dig(obj: TranslationTree, path: string[]): TranslationValue | undefined
 
 function interpolate(str: string, options: Record<string, unknown>): string {
   return str.replace(/%\{(\w+)\}/g, (_, key) => {
-    if (!Object.prototype.hasOwnProperty.call(options, key) || options[key] === undefined) {
+    // Match Rails i18n (i18n/lib/i18n/interpolate/ruby.rb): raise only when
+    // the key is absent. `nil` values are allowed and interpolate to "".
+    if (!Object.prototype.hasOwnProperty.call(options, key)) {
       throw new MissingInterpolationArgument(key, str);
     }
-    return String(options[key]);
+    const value = options[key];
+    return value == null ? "" : String(value);
   });
 }
 
@@ -88,6 +91,7 @@ class I18nService {
    * I18n::Fallbacks semantics — see i18n/lib/i18n/locale/fallbacks.rb).
    */
   private _fallbacks: Record<string, string[]> = {};
+  private _sharedFallbacks: string[] | undefined;
 
   get locale(): string {
     return this._locale;
@@ -152,10 +156,16 @@ class I18nService {
    * Rails I18n::Fallbacks (i18n/lib/i18n/locale/fallbacks.rb).
    */
   setFallbacks(config: Record<string, string[]> | string[]): void {
+    // Defensive copies: callers can mutate their input arrays without
+    // affecting the configured chains.
     if (Array.isArray(config)) {
-      this._fallbacks = { __shared__: config };
+      this._sharedFallbacks = [...config];
+      this._fallbacks = {};
     } else {
-      this._fallbacks = { ...config };
+      this._sharedFallbacks = undefined;
+      this._fallbacks = Object.fromEntries(
+        Object.entries(config).map(([locale, chain]) => [locale, [...chain]]),
+      );
     }
   }
 
@@ -174,11 +184,12 @@ class I18nService {
     this._locale = "en";
     this._defaultLocale = "en";
     this._fallbacks = {};
+    this._sharedFallbacks = undefined;
     this._storeTranslations("en", defaultEnTranslations);
   }
 
   private _fallbackChain(locale: string): string[] {
-    const explicit = this._fallbacks[locale] ?? this._fallbacks["__shared__"];
+    const explicit = this._fallbacks[locale] ?? this._sharedFallbacks;
     const base = explicit && explicit.length > 0 ? [...explicit] : [];
     if (base[0] !== locale) base.unshift(locale);
     // I18n::Locale::Fallbacks#compute always pushes `defaults` onto every

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -70,7 +70,7 @@ function dig(obj: TranslationTree, path: string[]): TranslationValue | undefined
 
 function interpolate(str: string, options: Record<string, unknown>): string {
   return str.replace(/%\{(\w+)\}/g, (_, key) => {
-    if (!(key in options) || options[key] === undefined) {
+    if (!Object.prototype.hasOwnProperty.call(options, key) || options[key] === undefined) {
       throw new MissingInterpolationArgument(key, str);
     }
     return String(options[key]);
@@ -206,9 +206,6 @@ class I18nService {
     for (const [k, v] of Object.entries(options)) {
       if (!RESERVED_KEYS.has(k)) out[k] = v;
     }
-    // `count` is reserved as a lookup driver but Rails still makes it
-    // available as a `%{count}` interpolation (see I18n::Base#interpolate).
-    if (options.count !== undefined) out.count = options.count;
     return out;
   }
 

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -227,11 +227,17 @@ class I18nService {
   ): string | undefined {
     // Rails allows Procs as translation values; they're invoked with the
     // lookup key + options hash (i18n/lib/i18n/backend/base.rb `resolve`).
+    // Inject the effective locale so lambdas can branch on it even when
+    // the caller relied on the service-wide `I18n.locale`.
     if (typeof value === "function") {
+      const effectiveOptions = {
+        ...(options ?? {}),
+        locale: options?.locale ?? this._locale,
+      };
       return this.resolve(
-        (value as TranslationLambda)(key, (options ?? {}) as Record<string, unknown>),
+        (value as TranslationLambda)(key, effectiveOptions as Record<string, unknown>),
         key,
-        options,
+        effectiveOptions,
       );
     }
     const opts = this._interpolationOptions(options);

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -179,14 +179,14 @@ class I18nService {
 
   private _fallbackChain(locale: string): string[] {
     const explicit = this._fallbacks[locale] ?? this._fallbacks["__shared__"];
-    if (explicit && explicit.length > 0) {
-      return explicit[0] === locale ? explicit : [locale, ...explicit];
-    }
-    // Default chain: requested locale → default locale (Rails ships this
-    // as the `I18n::Backend::Fallbacks` default when no fallbacks are set
-    // and `:default_locale` differs from the active one).
-    if (locale !== this._defaultLocale) return [locale, this._defaultLocale];
-    return [locale];
+    const base = explicit && explicit.length > 0 ? [...explicit] : [];
+    if (base[0] !== locale) base.unshift(locale);
+    // I18n::Locale::Fallbacks#compute always pushes `defaults` onto every
+    // chain (i18n/lib/i18n/locale/fallbacks.rb). Mirror that so a missing
+    // key still falls through to `default_locale` even when an explicit
+    // chain was configured.
+    if (!base.includes(this._defaultLocale)) base.push(this._defaultLocale);
+    return base;
   }
 
   private lookup(key: string, locale: string): TranslationValue | undefined {

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -1,7 +1,12 @@
 import { deepDup, deepMergeInPlace } from "@blazetrails/activesupport";
 import { raiseOnMissingTranslations } from "./translation.js";
 
-type TranslationValue = string | { one?: string; other?: string } | TranslationTree;
+type TranslationLambda = (key: string, options: Record<string, unknown>) => TranslationValue;
+type TranslationValue =
+  | string
+  | { one?: string; other?: string }
+  | TranslationTree
+  | TranslationLambda;
 interface TranslationTree {
   [key: string]: TranslationValue;
 }
@@ -11,13 +16,53 @@ interface TranslateOptions {
   count?: number;
   defaults?: Array<{ key: string } | { message: string }>;
   defaultValue?: string;
+  locale?: string;
   [key: string]: unknown;
 }
+
+/**
+ * Raised when a `%{key}` appears in a translation string but the caller
+ * supplied no matching interpolation option.
+ *
+ * Mirrors: I18n::MissingInterpolationArgument
+ */
+export class MissingInterpolationArgument extends globalThis.Error {
+  readonly key: string;
+  readonly string: string;
+  constructor(key: string, string: string) {
+    super(`missing interpolation argument :${key} in ${JSON.stringify(string)}`);
+    this.name = "MissingInterpolationArgument";
+    this.key = key;
+    this.string = string;
+  }
+}
+
+/**
+ * Keys the I18n gem reserves (not forwarded as `%{}` interpolations).
+ * See i18n/lib/i18n.rb RESERVED_KEYS.
+ */
+const RESERVED_KEYS = new Set([
+  "scope",
+  "default",
+  "defaults",
+  "defaultValue",
+  "separator",
+  "resolve",
+  "object",
+  "fallback",
+  "format",
+  "cascade",
+  "throw",
+  "raise",
+  "deep_interpolation",
+  "locale",
+]);
 
 function dig(obj: TranslationTree, path: string[]): TranslationValue | undefined {
   let current: TranslationValue = obj;
   for (const segment of path) {
     if (current === null || current === undefined || typeof current !== "object") return undefined;
+    if (Array.isArray(current)) return undefined;
     current = (current as TranslationTree)[segment];
   }
   return current;
@@ -25,13 +70,24 @@ function dig(obj: TranslationTree, path: string[]): TranslationValue | undefined
 
 function interpolate(str: string, options: Record<string, unknown>): string {
   return str.replace(/%\{(\w+)\}/g, (_, key) => {
-    return options[key] !== undefined ? String(options[key]) : `%{${key}}`;
+    if (!(key in options) || options[key] === undefined) {
+      throw new MissingInterpolationArgument(key, str);
+    }
+    return String(options[key]);
   });
 }
 
 class I18nService {
   private _locale: string = "en";
+  private _defaultLocale: string = "en";
   private _translations: Translations = {};
+  /**
+   * Per-locale fallback chain. `fallbacks["en-US"] = ["en-US", "en"]`
+   * makes a lookup against "en-US" try "en-US" then "en". The entry
+   * should include the locale itself as the first element (Rails
+   * I18n::Fallbacks semantics — see i18n/lib/i18n/locale/fallbacks.rb).
+   */
+  private _fallbacks: Record<string, string[]> = {};
 
   get locale(): string {
     return this._locale;
@@ -41,29 +97,42 @@ class I18nService {
     this._locale = value;
   }
 
+  get defaultLocale(): string {
+    return this._defaultLocale;
+  }
+
+  set defaultLocale(value: string) {
+    this._defaultLocale = value;
+  }
+
   constructor() {
     this._storeTranslations("en", defaultEnTranslations);
   }
 
   t(key: string, options?: TranslateOptions): string {
-    const result = this.lookup(key);
+    const locale = options?.locale ?? this._locale;
+    const result = this.lookup(key, locale);
     if (result !== undefined) {
-      return this.resolve(result, options);
+      const resolved = this.resolve(result, key, options);
+      if (resolved !== undefined) return resolved;
     }
 
     if (options?.defaults) {
       for (const entry of options.defaults) {
         if ("key" in entry) {
-          const val = this.lookup(entry.key);
-          if (val !== undefined) return this.resolve(val, options);
+          const val = this.lookup(entry.key, locale);
+          if (val !== undefined) {
+            const resolved = this.resolve(val, entry.key, options);
+            if (resolved !== undefined) return resolved;
+          }
         } else if ("message" in entry) {
-          return interpolate(entry.message, options ?? {});
+          return interpolate(entry.message, this._interpolationOptions(options));
         }
       }
     }
 
     if (options?.defaultValue !== undefined) {
-      return interpolate(options.defaultValue, options ?? {});
+      return interpolate(options.defaultValue, this._interpolationOptions(options));
     }
 
     if (raiseOnMissingTranslations()) {
@@ -74,6 +143,20 @@ class I18nService {
 
   storeTranslations(locale: string, data: TranslationTree): void {
     this._storeTranslations(locale, data);
+  }
+
+  /**
+   * Configure the fallback chain. Pass an object mapping locale → chain,
+   * or an array treated as a shared chain for every locale. Each chain
+   * should include the originating locale as its first element, matching
+   * Rails I18n::Fallbacks (i18n/lib/i18n/locale/fallbacks.rb).
+   */
+  setFallbacks(config: Record<string, string[]> | string[]): void {
+    if (Array.isArray(config)) {
+      this._fallbacks = { __shared__: config };
+    } else {
+      this._fallbacks = { ...config };
+    }
   }
 
   private _storeTranslations(locale: string, data: TranslationTree): void {
@@ -89,28 +172,73 @@ class I18nService {
   reset(): void {
     this._translations = {};
     this._locale = "en";
+    this._defaultLocale = "en";
+    this._fallbacks = {};
     this._storeTranslations("en", defaultEnTranslations);
   }
 
-  private lookup(key: string): TranslationValue | undefined {
-    const localeData = this._translations[this._locale];
-    if (!localeData) return undefined;
-    return dig(localeData, key.split("."));
+  private _fallbackChain(locale: string): string[] {
+    const explicit = this._fallbacks[locale] ?? this._fallbacks["__shared__"];
+    if (explicit && explicit.length > 0) {
+      return explicit[0] === locale ? explicit : [locale, ...explicit];
+    }
+    // Default chain: requested locale → default locale (Rails ships this
+    // as the `I18n::Backend::Fallbacks` default when no fallbacks are set
+    // and `:default_locale` differs from the active one).
+    if (locale !== this._defaultLocale) return [locale, this._defaultLocale];
+    return [locale];
   }
 
-  private resolve(value: TranslationValue, options?: TranslateOptions): string {
+  private lookup(key: string, locale: string): TranslationValue | undefined {
+    const path = key.split(".");
+    for (const candidate of this._fallbackChain(locale)) {
+      const localeData = this._translations[candidate];
+      if (!localeData) continue;
+      const hit = dig(localeData, path);
+      if (hit !== undefined) return hit;
+    }
+    return undefined;
+  }
+
+  private _interpolationOptions(options?: TranslateOptions): Record<string, unknown> {
+    if (!options) return {};
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(options)) {
+      if (!RESERVED_KEYS.has(k)) out[k] = v;
+    }
+    // `count` is reserved as a lookup driver but Rails still makes it
+    // available as a `%{count}` interpolation (see I18n::Base#interpolate).
+    if (options.count !== undefined) out.count = options.count;
+    return out;
+  }
+
+  private resolve(
+    value: TranslationValue,
+    key: string,
+    options?: TranslateOptions,
+  ): string | undefined {
+    // Rails allows Procs as translation values; they're invoked with the
+    // lookup key + options hash (i18n/lib/i18n/backend/base.rb `resolve`).
+    if (typeof value === "function") {
+      return this.resolve(
+        (value as TranslationLambda)(key, (options ?? {}) as Record<string, unknown>),
+        key,
+        options,
+      );
+    }
+    const opts = this._interpolationOptions(options);
     if (typeof value === "string") {
-      return interpolate(value, options ?? {});
+      return interpolate(value, opts);
     }
     if (value && typeof value === "object" && options?.count !== undefined) {
       const plural = value as { one?: string; other?: string };
       const form = options.count === 1 ? "one" : "other";
       const str = plural[form] ?? plural["other"];
       if (typeof str === "string") {
-        return interpolate(str, options);
+        return interpolate(str, opts);
       }
     }
-    return "";
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds per-locale fallback chain to the minimal I18n service (`I18n::Locale::Fallbacks`), plus `options.locale` for per-call locale selection without mutating `I18n.locale`.
- Lambda / Proc values are invoked with `(key, options)` and their result is resolved — matches `i18n/lib/i18n/backend/base.rb#resolve`.
- Missing `%{key}` placeholders now raise `MissingInterpolationArgument` (previously left as literal `%{key}` in output). RESERVED_KEYS (scope, default, locale, etc.) are not forwarded as interpolations, matching `i18n/lib/i18n.rb`.
- `error.ts#fullMessage` now passes `attribute` / `message` through the I18n interpolation args instead of post-hoc `String#replace`, so strict-interpolation semantics apply end-to-end.

## Test plan
- [x] 10 new I18n tests (interpolation, fallback chain, lambdas)
- [x] AM 1,479 / AR 9,261 all pass
- [x] typecheck + lint clean