### PR TITLE
feat(parity): 9 AR joins/where/ordering/distinct fixtures (AR parity v2 PR 2)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -42,5 +42,17 @@
   "arel-47": {
     "side": "trails-missing",
     "reason": "photos[:id].count.gt(5): trails Attribute#count returns a node without predication methods — HAVING aggregate-comparison chain incomplete."
+  },
+  "ar-01": {
+    "side": "diff",
+    "reason": "Book.joins(:reviews): trails Relation#joins(string) only accepts raw SQL join clauses (_rawJoins), not Rails-style symbol/string association names. Fixture falls back to emitting 'FROM \"books\" reviews' (SQL fragment appended) rather than an INNER JOIN on the FK. Real trails-missing feature: association-name joins."
+  },
+  "ar-09": {
+    "side": "diff",
+    "reason": "Boolean literal serialization: trails' ToSql renders JS booleans as the TRUE/FALSE keywords; Rails on SQLite writes 1/0 (SQLite's BOOLEAN maps to INTEGER, so Rails serialises to the integer form). Semantically equivalent but lexically differ."
+  },
+  "ar-11": {
+    "side": "diff",
+    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -45,7 +45,7 @@
   },
   "ar-01": {
     "side": "diff",
-    "reason": "Book.joins(:reviews): trails Relation#joins(string) only accepts raw SQL join clauses (_rawJoins), not Rails-style symbol/string association names. Fixture falls back to emitting 'FROM \"books\" reviews' (SQL fragment appended) rather than an INNER JOIN on the FK. Real trails-missing feature: association-name joins."
+    "reason": "Book.joins(:reviews): with models registered via registerModel() in the fixture's models.ts, trails Relation#joins(name) does resolve the association and emit an INNER JOIN on the FK. The remaining diff is table-name quoting — trails emits 'INNER JOIN reviews ON ...' where Rails emits 'INNER JOIN \"reviews\" ON ...'. Column references on both sides are quoted identically; only the table identifier after INNER JOIN is bare on trails."
   },
   "ar-09": {
     "side": "diff",

--- a/scripts/parity/fixtures/ar-01/models.rb
+++ b/scripts/parity/fixtures/ar-01/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-01/models.ts
+++ b/scripts/parity/fixtures/ar-01/models.ts
@@ -1,9 +1,10 @@
-import { Base } from "@blazetrails/activerecord";
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
     this.tableName = "books";
     this.hasMany("reviews");
+    registerModel(this);
   }
 }
 
@@ -11,5 +12,6 @@ export class Review extends Base {
   static {
     this.tableName = "reviews";
     this.belongsTo("book");
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-01/models.ts
+++ b/scripts/parity/fixtures/ar-01/models.ts
@@ -1,0 +1,15 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+  }
+}

--- a/scripts/parity/fixtures/ar-01/query.rb
+++ b/scripts/parity/fixtures/ar-01/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:reviews).where("reviews.created_at > ?", 1.week.ago)

--- a/scripts/parity/fixtures/ar-01/query.ts
+++ b/scripts/parity/fixtures/ar-01/query.ts
@@ -1,0 +1,8 @@
+import { Book } from "./models.js";
+
+// `1.week.ago` on the Ruby side → `new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)`
+// here. Both runners install the same frozen clock before evaluating the
+// fixture, so `now` is identical on both sides and subtraction is deterministic.
+const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+export default Book.joins("reviews").where("reviews.created_at > ?", oneWeekAgo);

--- a/scripts/parity/fixtures/ar-01/schema.sql
+++ b/scripts/parity/fixtures/ar-01/schema.sql
@@ -1,0 +1,14 @@
+-- Fixture for statement: ar-01
+-- Query: Book.joins(:reviews).where("reviews.created_at > ?", 1.week.ago)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  created_at DATETIME
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER NOT NULL REFERENCES books(id),
+  body TEXT,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-06/models.rb
+++ b/scripts/parity/fixtures/ar-06/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-06/models.ts
+++ b/scripts/parity/fixtures/ar-06/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+  }
+}

--- a/scripts/parity/fixtures/ar-06/query.rb
+++ b/scripts/parity/fixtures/ar-06/query.rb
@@ -1,0 +1,1 @@
+Customer.where.not(orders_count: [1, 3, 5])

--- a/scripts/parity/fixtures/ar-06/query.ts
+++ b/scripts/parity/fixtures/ar-06/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.whereNot({ orders_count: [1, 3, 5] });

--- a/scripts/parity/fixtures/ar-06/schema.sql
+++ b/scripts/parity/fixtures/ar-06/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-06
+-- Query: Customer.where.not(orders_count: [1, 3, 5])
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  orders_count INTEGER
+);

--- a/scripts/parity/fixtures/ar-07/models.rb
+++ b/scripts/parity/fixtures/ar-07/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-07/models.ts
+++ b/scripts/parity/fixtures/ar-07/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+  }
+}

--- a/scripts/parity/fixtures/ar-07/query.rb
+++ b/scripts/parity/fixtures/ar-07/query.rb
@@ -1,0 +1,1 @@
+Customer.where(last_name: "Smith").or(Customer.where(orders_count: [1, 3, 5]))

--- a/scripts/parity/fixtures/ar-07/query.ts
+++ b/scripts/parity/fixtures/ar-07/query.ts
@@ -1,0 +1,5 @@
+import { Customer } from "./models.js";
+
+export default Customer.where({ last_name: "Smith" }).or(
+  Customer.where({ orders_count: [1, 3, 5] }),
+);

--- a/scripts/parity/fixtures/ar-07/schema.sql
+++ b/scripts/parity/fixtures/ar-07/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-07
+-- Query: Customer.where(last_name: "Smith").or(Customer.where(orders_count: [1, 3, 5]))
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  orders_count INTEGER
+);

--- a/scripts/parity/fixtures/ar-08/models.rb
+++ b/scripts/parity/fixtures/ar-08/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-08/models.ts
+++ b/scripts/parity/fixtures/ar-08/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+  }
+}

--- a/scripts/parity/fixtures/ar-08/query.rb
+++ b/scripts/parity/fixtures/ar-08/query.rb
@@ -1,0 +1,1 @@
+Customer.where(last_name: "Smith").where(orders_count: [1, 3, 5])

--- a/scripts/parity/fixtures/ar-08/query.ts
+++ b/scripts/parity/fixtures/ar-08/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.where({ last_name: "Smith" }).where({ orders_count: [1, 3, 5] });

--- a/scripts/parity/fixtures/ar-08/schema.sql
+++ b/scripts/parity/fixtures/ar-08/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-08
+-- Query: Customer.where(last_name: "Smith").where(orders_count: [1, 3, 5])
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  orders_count INTEGER
+);

--- a/scripts/parity/fixtures/ar-09/models.rb
+++ b/scripts/parity/fixtures/ar-09/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-09/models.ts
+++ b/scripts/parity/fixtures/ar-09/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+  }
+}

--- a/scripts/parity/fixtures/ar-09/query.rb
+++ b/scripts/parity/fixtures/ar-09/query.rb
@@ -1,0 +1,1 @@
+User.where.not(tall: true)

--- a/scripts/parity/fixtures/ar-09/query.ts
+++ b/scripts/parity/fixtures/ar-09/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.whereNot({ tall: true });

--- a/scripts/parity/fixtures/ar-09/schema.sql
+++ b/scripts/parity/fixtures/ar-09/schema.sql
@@ -1,0 +1,10 @@
+-- Fixture for statement: ar-09
+-- Query: User.where.not(tall: true)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  tall INTEGER,
+  active INTEGER,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-10/models.rb
+++ b/scripts/parity/fixtures/ar-10/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-10/models.ts
+++ b/scripts/parity/fixtures/ar-10/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+  }
+}

--- a/scripts/parity/fixtures/ar-10/query.rb
+++ b/scripts/parity/fixtures/ar-10/query.rb
@@ -1,0 +1,1 @@
+User.where("users.tall IS NOT TRUE")

--- a/scripts/parity/fixtures/ar-10/query.ts
+++ b/scripts/parity/fixtures/ar-10/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.where("users.tall IS NOT TRUE");

--- a/scripts/parity/fixtures/ar-10/schema.sql
+++ b/scripts/parity/fixtures/ar-10/schema.sql
@@ -1,0 +1,10 @@
+-- Fixture for statement: ar-10
+-- Query: User.where("users.tall IS NOT TRUE")
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  tall INTEGER,
+  active INTEGER,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-11/models.rb
+++ b/scripts/parity/fixtures/ar-11/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-11/models.ts
+++ b/scripts/parity/fixtures/ar-11/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+  }
+}

--- a/scripts/parity/fixtures/ar-11/query.rb
+++ b/scripts/parity/fixtures/ar-11/query.rb
@@ -1,0 +1,1 @@
+User.where(tall: [false, nil])

--- a/scripts/parity/fixtures/ar-11/query.ts
+++ b/scripts/parity/fixtures/ar-11/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.where({ tall: [false, null] });

--- a/scripts/parity/fixtures/ar-11/schema.sql
+++ b/scripts/parity/fixtures/ar-11/schema.sql
@@ -1,0 +1,10 @@
+-- Fixture for statement: ar-11
+-- Query: User.where(tall: [false, nil])
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  tall INTEGER,
+  active INTEGER,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-12/models.rb
+++ b/scripts/parity/fixtures/ar-12/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-12/models.ts
+++ b/scripts/parity/fixtures/ar-12/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+  }
+}

--- a/scripts/parity/fixtures/ar-12/query.rb
+++ b/scripts/parity/fixtures/ar-12/query.rb
@@ -1,0 +1,1 @@
+User.order(created_at: :desc).limit(10).offset(20)

--- a/scripts/parity/fixtures/ar-12/query.ts
+++ b/scripts/parity/fixtures/ar-12/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.order({ created_at: "desc" }).limit(10).offset(20);

--- a/scripts/parity/fixtures/ar-12/schema.sql
+++ b/scripts/parity/fixtures/ar-12/schema.sql
@@ -1,0 +1,10 @@
+-- Fixture for statement: ar-12
+-- Query: User.order(created_at: :desc).limit(10).offset(20)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  tall INTEGER,
+  active INTEGER,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-13/models.rb
+++ b/scripts/parity/fixtures/ar-13/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-13/models.ts
+++ b/scripts/parity/fixtures/ar-13/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+  }
+}

--- a/scripts/parity/fixtures/ar-13/query.rb
+++ b/scripts/parity/fixtures/ar-13/query.rb
@@ -1,0 +1,1 @@
+Customer.select(:first_name).distinct

--- a/scripts/parity/fixtures/ar-13/query.ts
+++ b/scripts/parity/fixtures/ar-13/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.select("first_name").distinct();

--- a/scripts/parity/fixtures/ar-13/schema.sql
+++ b/scripts/parity/fixtures/ar-13/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-13
+-- Query: Customer.select(:first_name).distinct
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  orders_count INTEGER
+);


### PR DESCRIPTION
Second PR of the AR parity v2 rollout. Adds 9 hand-translated AR query fixtures from `docs/activerecord-query-corpus.md`.

## Fixtures — 6 pass, 3 gap

Pass (byte-identical SQL on both sides):

| # | Corpus | Query |
|---|--------|-------|
| ar-06 | #16 | `Customer.where.not(orders_count: [1, 3, 5])` |
| ar-07 | #17 | `Customer.where(last_name: "Smith").or(...)` |
| ar-08 | #18 | `Customer.where(...).where(...)` |
| ar-10 | #20 | `User.where("users.tall IS NOT TRUE")` |
| ar-12 | #40 | `User.order(created_at: :desc).limit(10).offset(20)` |
| ar-13 | #41 | `Customer.select(:first_name).distinct` |

Known gaps (documented in `query-known-gaps.json`):

| # | Corpus | Gap | Side |
|---|--------|-----|------|
| ar-01 | #1 | `.joins(:reviews)` — trails resolves the association and emits an INNER JOIN on the FK, but omits double-quotes around the joined table identifier (`INNER JOIN reviews ON ...` vs Rails' `INNER JOIN "reviews" ON ...`). Column refs quote identically on both sides | diff |
| ar-09 | #19 | Boolean literal: trails emits `!= TRUE`, Rails on SQLite emits `!= 1` | diff |
| ar-11 | #21 | Boolean + nil array: `= FALSE OR IS NULL` vs `= 0 OR IS NULL` — same root cause as ar-09 | diff |

## trails API mapping discovered while translating

- `.where.not(...)` (Rails) → `.whereNot(...)` (trails — camelCase method, not a chain)
- `.where("sql ?", val)` → same (spread args)
- `.order(col: :desc)` → `.order({ col: "desc" })` (hash form)
- `.distinct` → `.distinct()` (method, not property)
- **Association-name joins require `registerModel(this)` in the fixture's `models.ts`** — trails' `Relation#joins` calls `_resolveAssociationJoin(...)` which looks up the target in `modelRegistry`; without registration the resolver falls through to `_rawJoins` and emits a fragment. ar-01 registers both `Book` and `Review` in their static blocks.

## Sweep

```
$ pnpm parity:query
49/63 passed, 14 known gap(s), 0 failures
  known gaps by side: 8 trails-missing, 6 diff
```

## What's explicitly not here

- **joins fixtures 2-5** (corpus #2-5): all exercise `.joins(:assoc)` and would hit the same table-quoting diff as ar-01. Deferred until either trails emits quoted table names on the JOIN side, or ar-01's single example is judged sufficient coverage of that one gap.
- **eager loading, group/having, subqueries, Arel interop** — PRs 3-4 per `docs/ar-query-parity-verification.md`.