### PR TITLE
docs(activerecord): bigint audit — document count/average precision limits and ids() runtime types

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1558,6 +1558,24 @@ describe("BasicsTest", () => {
     expect(ids).toContain(u1.id);
     expect(ids).toContain(u2.id);
   });
+
+  it("ids returns tuples for composite primary keys", async () => {
+    class Order extends Base {
+      static {
+        this.primaryKey = ["shop_id", "id"];
+        this.attribute("shop_id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const o1 = await Order.create({ shop_id: 1, name: "first" });
+    const o2 = await Order.create({ shop_id: 2, name: "second" });
+    const ids = await Order.ids();
+    expect(ids).toHaveLength(2);
+    // Each element is a tuple [shop_id, id]
+    expect(ids).toContainEqual([o1.readAttribute("shop_id"), o1.readAttribute("id")]);
+    expect(ids).toContainEqual([o2.readAttribute("shop_id"), o2.readAttribute("id")]);
+  });
   it("minimum returns min value", async () => {
     class User extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2182,12 +2182,15 @@ export class Relation<T extends Base> {
    * Pluck the primary key values.
    *
    * Mirrors: ActiveRecord::Relation#ids
+   *
+   * Single-column PKs: returns flat array (string | number | bigint).
+   * big_integer PKs return JS bigint after driver normalization.
+   * Composite PKs: returns an array of tuples (unknown[][]).
    */
   async ids(): Promise<unknown[]> {
-    // Runtime values are string | number | bigint for single-column PKs,
-    // or unknown[] (tuple) for composite PKs. bigint PKs (big_integer
-    // columns) return JS bigint after driver normalization (PR #783).
-    return this.pluck(this._modelClass.primaryKey as string);
+    const pk = this._modelClass.primaryKey;
+    const cols = Array.isArray(pk) ? pk : [pk];
+    return this.pluck(...(cols as [string, ...string[]]));
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2183,8 +2183,10 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#ids
    *
-   * Single-column PKs: returns flat array (string | number | bigint).
-   * big_integer PKs return JS bigint after driver normalization.
+   * Single-column PKs: returns a flat array of scalar values. The JS
+   * type depends on the adapter — SQLite returns JS bigint for big_integer
+   * PKs (safeIntegers); PG returns decimal string for int8; MySQL returns
+   * string for large BIGINT values and number for small ones.
    * Composite PKs: returns an array of tuples (unknown[][]).
    */
   async ids(): Promise<unknown[]> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2184,6 +2184,9 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#ids
    */
   async ids(): Promise<unknown[]> {
+    // Runtime values are string | number | bigint for single-column PKs,
+    // or unknown[] (tuple) for composite PKs. bigint PKs (big_integer
+    // columns) return JS bigint after driver normalization (PR #783).
     return this.pluck(this._modelClass.primaryKey as string);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2183,11 +2183,12 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#ids
    *
-   * Single-column PKs: returns a flat array of scalar values. The JS
-   * type depends on the adapter — SQLite returns JS bigint for big_integer
-   * PKs (safeIntegers); PG returns decimal string for int8; MySQL returns
-   * string for large BIGINT values and number for small ones.
-   * Composite PKs: returns an array of tuples (unknown[][]).
+   * Return type is `unknown[]` in both cases:
+   * - Single-column PKs: each element is a scalar (string | number | bigint).
+   *   The concrete JS type depends on the adapter — SQLite returns bigint for
+   *   big_integer PKs (safeIntegers); PG returns decimal string for int8;
+   *   MySQL returns string for large BIGINT values and number for small ones.
+   * - Composite PKs: each element is itself an array (tuple of scalars).
    */
   async ids(): Promise<unknown[]> {
     const pk = this._modelClass.primaryKey;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -204,6 +204,11 @@ async function groupedAggregate(
   return result;
 }
 
+/**
+ * SQL COUNT() results are returned as JS number. Tables with more than
+ * 2^53-1 rows would lose precision; this matches Rails which returns
+ * arbitrary-precision Integer but the practical risk is negligible.
+ */
 export async function performCount(
   this: CalculationRelation,
   column?: string,
@@ -278,6 +283,11 @@ export async function performSum(
   return ((await singleAggregate(this, "sum", column, true)) as number | bigint) ?? 0;
 }
 
+/**
+ * Rails returns BigDecimal for average on integer/decimal columns.
+ * We return number here — precision is lost for values whose average
+ * exceeds Number.MAX_SAFE_INTEGER (2^53-1).
+ */
 export async function performAverage(
   this: CalculationRelation,
   column: string,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -205,9 +205,10 @@ async function groupedAggregate(
 }
 
 /**
- * SQL COUNT() results are returned as JS number. Tables with more than
- * 2^53-1 rows would lose precision; this matches Rails which returns
- * arbitrary-precision Integer but the practical risk is negligible.
+ * SQL COUNT() results are returned as JS number. This diverges from
+ * Rails, which returns arbitrary-precision Integer. Tables with more
+ * than 2^53-1 rows would silently lose precision; the practical risk
+ * is negligible but the divergence is documented.
  */
 export async function performCount(
   this: CalculationRelation,


### PR DESCRIPTION
Post-audit cleanup from the bigint implementation (PRs #783–#798).

- **`performCount`**: JSDoc noting SQL COUNT() > 2^53-1 rows would diverge from Rails (which returns arbitrary-precision Integer); JS number used here.
- **`performAverage`**: JSDoc noting `average` returns `number`, not `bigint`, unlike Rails' BigDecimal.
- **`ids()`**: Two changes:
  1. **Bug fix**: composite PKs were passed as `pluck('id,shop_id')` (a single mangled column name) instead of `pluck('id', 'shop_id')`. Now spreads the PK array correctly so composite PKs return actual tuples.
  2. **Comment**: documents adapter-specific runtime shapes — SQLite returns bigint for big_integer PKs via safeIntegers; PG returns decimal string for int8; MySQL returns string/number depending on value size.