### PR TITLE
feat(activemodel): DateType ISO fast-path + DecimalType#applyScale

### DIFF
--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -8,16 +8,10 @@ import { Types } from "../index.js";
  */
 class TestableDateType extends Types.DateType {
   publicFastStringToDate(value: string) {
-    return (this as unknown as { fastStringToDate(v: string): Date | null }).fastStringToDate(
-      value,
-    );
+    return this.fastStringToDate(value);
   }
   publicNewDate(year: number, month: number, day: number) {
-    return (this as unknown as { newDate(y: number, m: number, d: number): Date | null }).newDate(
-      year,
-      month,
-      day,
-    );
+    return this.newDate(year, month, day);
   }
 }
 

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect } from "vitest";
 import { Types } from "../index.js";
 
+/**
+ * Test-only subclass that promotes Rails' private helpers to callable
+ * methods so behavior can be asserted directly (e.g. new_date returns
+ * nil for year 0 in a way `cast` can't reliably surface).
+ */
+class TestableDateType extends Types.DateType {
+  publicFastStringToDate(value: string) {
+    return (this as unknown as { fastStringToDate(v: string): Date | null }).fastStringToDate(
+      value,
+    );
+  }
+  publicNewDate(year: number, month: number, day: number) {
+    return (this as unknown as { newDate(y: number, m: number, d: number): Date | null }).newDate(
+      year,
+      month,
+      day,
+    );
+  }
+}
+
 describe("DateTest", () => {
   it("type cast date", () => {
     const type = new Types.DateType();
@@ -18,27 +38,27 @@ describe("DateTest", () => {
   it("fast_string_to_date matches ISO YYYY-MM-DD only", () => {
     // Rails type/date.rb — ISO_DATE regex, fast path; everything else
     // falls through to fallback_string_to_date.
-    const type = new Types.DateType();
-    expect(type.fastStringToDate("2024-06-01")).not.toBeNull();
-    expect(type.fastStringToDate("2024/06/01")).toBeNull();
-    expect(type.fastStringToDate("2024-06-01T00:00:00")).toBeNull();
+    const type = new TestableDateType();
+    expect(type.publicFastStringToDate("2024-06-01")).not.toBeNull();
+    expect(type.publicFastStringToDate("2024/06/01")).toBeNull();
+    expect(type.publicFastStringToDate("2024-06-01T00:00:00")).toBeNull();
   });
 
   it("new_date preserves literal years 1–99 (not the JS Date.UTC 1900+ hack)", () => {
-    const type = new Types.DateType();
-    expect(type.newDate(1, 1, 1)!.getUTCFullYear()).toBe(1);
+    const type = new TestableDateType();
+    expect(type.publicNewDate(1, 1, 1)!.getUTCFullYear()).toBe(1);
     expect(type.cast("0001-01-01")!.getUTCFullYear()).toBe(1);
-    expect(type.newDate(99, 12, 31)!.getUTCFullYear()).toBe(99);
+    expect(type.publicNewDate(99, 12, 31)!.getUTCFullYear()).toBe(99);
   });
 
   it("new_date rejects year 0 and day/month overflow", () => {
     // Mirrors Rails new_date, which returns nil when year is 0 or when
     // Date.new raises ArgumentError.
-    const type = new Types.DateType();
-    expect(type.newDate(0, 1, 1)).toBeNull();
-    expect(type.newDate(2024, 13, 1)).toBeNull();
-    expect(type.newDate(2024, 2, 31)).toBeNull();
-    const d = type.newDate(2024, 6, 15);
+    const type = new TestableDateType();
+    expect(type.publicNewDate(0, 1, 1)).toBeNull();
+    expect(type.publicNewDate(2024, 13, 1)).toBeNull();
+    expect(type.publicNewDate(2024, 2, 31)).toBeNull();
+    const d = type.publicNewDate(2024, 6, 15);
     expect(d!.getUTCFullYear()).toBe(2024);
     expect(d!.getUTCMonth()).toBe(5);
     expect(d!.getUTCDate()).toBe(15);

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -38,9 +38,11 @@ describe("DateTest", () => {
   });
 
   it("cast falls through to fallback parser for non-ISO strings", () => {
+    // Use an ISO-datetime form — deterministic across JS runtimes but
+    // does not match the ISO_DATE fast path (which is YYYY-MM-DD only).
     const type = new Types.DateType();
-    const d = type.cast("June 1, 2024");
+    const d = type.cast("2024-06-01T00:00:00Z");
     expect(d).toBeInstanceOf(Date);
-    expect(d!.getFullYear()).toBe(2024);
+    expect(d!.getUTCFullYear()).toBe(2024);
   });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -14,4 +14,33 @@ describe("DateTest", () => {
     const result = type.cast("2024-01-15");
     expect(result!.getUTCFullYear()).toBe(2024);
   });
+
+  it("fast_string_to_date matches ISO YYYY-MM-DD only", () => {
+    // Rails type/date.rb — ISO_DATE regex, fast path; everything else
+    // falls through to fallback_string_to_date.
+    const type = new Types.DateType();
+    expect(type.fastStringToDate("2024-06-01")).not.toBeNull();
+    expect(type.fastStringToDate("2024/06/01")).toBeNull();
+    expect(type.fastStringToDate("2024-06-01T00:00:00")).toBeNull();
+  });
+
+  it("new_date rejects year 0 and day/month overflow", () => {
+    // Mirrors Rails new_date, which returns nil when year is 0 or when
+    // Date.new raises ArgumentError.
+    const type = new Types.DateType();
+    expect(type.newDate(0, 1, 1)).toBeNull();
+    expect(type.newDate(2024, 13, 1)).toBeNull();
+    expect(type.newDate(2024, 2, 31)).toBeNull();
+    const d = type.newDate(2024, 6, 15);
+    expect(d!.getUTCFullYear()).toBe(2024);
+    expect(d!.getUTCMonth()).toBe(5);
+    expect(d!.getUTCDate()).toBe(15);
+  });
+
+  it("cast falls through to fallback parser for non-ISO strings", () => {
+    const type = new Types.DateType();
+    const d = type.cast("June 1, 2024");
+    expect(d).toBeInstanceOf(Date);
+    expect(d!.getFullYear()).toBe(2024);
+  });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -24,6 +24,13 @@ describe("DateTest", () => {
     expect(type.fastStringToDate("2024-06-01T00:00:00")).toBeNull();
   });
 
+  it("new_date preserves literal years 1–99 (not the JS Date.UTC 1900+ hack)", () => {
+    const type = new Types.DateType();
+    expect(type.newDate(1, 1, 1)!.getUTCFullYear()).toBe(1);
+    expect(type.cast("0001-01-01")!.getUTCFullYear()).toBe(1);
+    expect(type.newDate(99, 12, 31)!.getUTCFullYear()).toBe(99);
+  });
+
   it("new_date rejects year 0 and day/month overflow", () => {
     // Mirrors Rails new_date, which returns nil when year is 0 or when
     // Date.new raises ArgumentError.

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,13 +1,57 @@
 import { ValueType } from "./value.js";
 
+/** `YYYY-MM-DD` — Rails `ISO_DATE` (type/date.rb). */
+const ISO_DATE = /^(\d{4})-(\d\d)-(\d\d)$/;
+
 export class DateType extends ValueType<Date> {
   readonly name: string = "date";
 
   cast(value: unknown): Date | null {
     if (value === null || value === undefined) return null;
     if (value instanceof Date) return value;
+    if (typeof value === "string") {
+      if (value === "") return null;
+      return this.fastStringToDate(value) ?? this.fallbackStringToDate(value);
+    }
     const d = new Date(String(value));
     return isNaN(d.getTime()) ? null : d;
+  }
+
+  /**
+   * Skip `Date.parse` for the ISO-8601 date fast case, matching Rails'
+   * `type/date.rb#fast_string_to_date`.
+   */
+  fastStringToDate(value: string): Date | null {
+    const m = ISO_DATE.exec(value);
+    if (!m) return null;
+    return this.newDate(Number(m[1]), Number(m[2]), Number(m[3]));
+  }
+
+  /**
+   * Parse dates that don't match the ISO fast path; mirrors
+   * `type/date.rb#fallback_string_to_date` (which delegates to
+   * `Date._parse`). We fall back to the JS `Date` constructor since
+   * TS doesn't ship a locale-aware date parser.
+   */
+  fallbackStringToDate(value: string): Date | null {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  /**
+   * Mirrors `type/date.rb#new_date`: rejects year 0 / missing year
+   * rather than returning a bogus Date.
+   */
+  newDate(year: number, month: number, day: number): Date | null {
+    if (!year || year === 0) return null;
+    const d = new Date(Date.UTC(year, month - 1, day));
+    if (isNaN(d.getTime())) return null;
+    // Reject overflow — Date(UTC) silently normalizes month=13 into Jan
+    // of the next year; Rails raises and we want `null` instead.
+    if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+      return null;
+    }
+    return d;
   }
 
   serialize(value: unknown): Date | null {

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -21,7 +21,7 @@ export class DateType extends ValueType<Date> {
    * Skip `Date.parse` for the ISO-8601 date fast case, matching Rails'
    * `type/date.rb#fast_string_to_date`.
    */
-  fastStringToDate(value: string): Date | null {
+  protected fastStringToDate(value: string): Date | null {
     const m = ISO_DATE.exec(value);
     if (!m) return null;
     return this.newDate(Number(m[1]), Number(m[2]), Number(m[3]));
@@ -33,7 +33,7 @@ export class DateType extends ValueType<Date> {
    * `Date._parse`). We fall back to the JS `Date` constructor since
    * TS doesn't ship a locale-aware date parser.
    */
-  fallbackStringToDate(value: string): Date | null {
+  protected fallbackStringToDate(value: string): Date | null {
     const d = new Date(value);
     return isNaN(d.getTime()) ? null : d;
   }
@@ -42,7 +42,7 @@ export class DateType extends ValueType<Date> {
    * Mirrors `type/date.rb#new_date`: rejects year 0 / missing year
    * rather than returning a bogus Date.
    */
-  newDate(year: number, month: number, day: number): Date | null {
+  protected newDate(year: number, month: number, day: number): Date | null {
     if (!year || year === 0) return null;
     // `Date.UTC(y, ...)` interprets 0–99 as 1900–1999; use setUTCFullYear
     // so "0001-01-01" round-trips as literal year 1 instead of 1901.

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -44,7 +44,10 @@ export class DateType extends ValueType<Date> {
    */
   newDate(year: number, month: number, day: number): Date | null {
     if (!year || year === 0) return null;
-    const d = new Date(Date.UTC(year, month - 1, day));
+    // `Date.UTC(y, ...)` interprets 0–99 as 1900–1999; use setUTCFullYear
+    // so "0001-01-01" round-trips as literal year 1 instead of 1901.
+    const d = new Date(Date.UTC(2000, month - 1, day));
+    d.setUTCFullYear(year);
     if (isNaN(d.getTime())) return null;
     // Reject overflow — Date(UTC) silently normalizes month=13 into Jan
     // of the next year; Rails raises and we want `null` instead.

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -37,24 +37,24 @@ describe("DecimalTest", () => {
 
   it("apply_scale handles leading-dot and trailing-dot numeric forms", () => {
     const type = new Types.DecimalType({ scale: 2 });
-    // `_castWithoutScale` can emit forms like ".5" or "1." — applyScale
+    // `_castWithoutScale` can emit forms like ".5" or "1." — apply_scale
     // must normalize them, not silently pass through.
-    expect(type.applyScale(".5")).toBe("0.50");
-    expect(type.applyScale("1.")).toBe("1.00");
+    expect(type.cast(".5")).toBe("0.50");
+    expect(type.cast("1.")).toBe("1.00");
   });
 
   it("apply_scale does not OOM on adversarial exponents", () => {
     // `"1e10000000"` would force splitDecimal to allocate a ~10M-digit
     // string if expanded naively. The cap leaves the raw form alone.
     const type = new Types.DecimalType({ scale: 2 });
-    expect(type.applyScale("1e10000000")).toBe("1e10000000");
+    expect(type.cast("1e10000000")).toBe("1e10000000");
   });
 
   it("apply_scale ignores non-integer/negative scale values", () => {
     // Ruby BigDecimal#round(n) requires an Integer; rather than invent
     // new semantics, leave the raw value alone for scale = 2.5 / -1.
-    expect(new Types.DecimalType({ scale: 2.5 }).applyScale("1.234")).toBe("1.234");
-    expect(new Types.DecimalType({ scale: -1 }).applyScale("1.234")).toBe("1.234");
+    expect(new Types.DecimalType({ scale: 2.5 }).cast("1.234")).toBe("1.234");
+    expect(new Types.DecimalType({ scale: -1 }).cast("1.234")).toBe("1.234");
   });
 
   it("apply_scale rounds half away from zero", () => {

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -50,6 +50,13 @@ describe("DecimalTest", () => {
     expect(type.applyScale("1e10000000")).toBe("1e10000000");
   });
 
+  it("apply_scale ignores non-integer/negative scale values", () => {
+    // Ruby BigDecimal#round(n) requires an Integer; rather than invent
+    // new semantics, leave the raw value alone for scale = 2.5 / -1.
+    expect(new Types.DecimalType({ scale: 2.5 }).applyScale("1.234")).toBe("1.234");
+    expect(new Types.DecimalType({ scale: -1 }).applyScale("1.234")).toBe("1.234");
+  });
+
   it("apply_scale rounds half away from zero", () => {
     // Ruby BigDecimal#round default is ROUND_HALF_UP (away from zero).
     const type = new Types.DecimalType({ scale: 2 });

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -27,9 +27,21 @@ describe("DecimalTest", () => {
   });
 
   it("scale is applied before precision to prevent rounding errors", () => {
-    const decimalType = new Types.DecimalType();
-    const result = decimalType.cast("1.23");
-    expect(result).toBe("1.23");
+    // Rails decimal_test.rb: Type::Decimal.new(precision: 5, scale: 3).cast(1.2346)
+    // rounds to BigDecimal("1.235") via apply_scale before storage.
+    const type = new Types.DecimalType({ precision: 5, scale: 3 });
+    expect(type.cast(1.2346)).toBe("1.235");
+    expect(type.cast("1.2346")).toBe("1.235");
+    expect(type.cast("1.23")).toBe("1.230");
+  });
+
+  it("apply_scale rounds half away from zero", () => {
+    // Ruby BigDecimal#round default is ROUND_HALF_UP (away from zero).
+    const type = new Types.DecimalType({ scale: 2 });
+    expect(type.cast("1.005")).toBe("1.01");
+    expect(type.cast("-1.005")).toBe("-1.01");
+    expect(type.cast("9.999")).toBe("10.00");
+    expect(type.cast("-9.999")).toBe("-10.00");
   });
 
   it("type cast decimal", () => {

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -35,6 +35,21 @@ describe("DecimalTest", () => {
     expect(type.cast("1.23")).toBe("1.230");
   });
 
+  it("apply_scale handles leading-dot and trailing-dot numeric forms", () => {
+    const type = new Types.DecimalType({ scale: 2 });
+    // `_castWithoutScale` can emit forms like ".5" or "1." — applyScale
+    // must normalize them, not silently pass through.
+    expect(type.applyScale(".5")).toBe("0.50");
+    expect(type.applyScale("1.")).toBe("1.00");
+  });
+
+  it("apply_scale does not OOM on adversarial exponents", () => {
+    // `"1e10000000"` would force splitDecimal to allocate a ~10M-digit
+    // string if expanded naively. The cap leaves the raw form alone.
+    const type = new Types.DecimalType({ scale: 2 });
+    expect(type.applyScale("1e10000000")).toBe("1e10000000");
+  });
+
   it("apply_scale rounds half away from zero", () => {
     // Ruby BigDecimal#round default is ROUND_HALF_UP (away from zero).
     const type = new Types.DecimalType({ scale: 2 });

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -26,6 +26,11 @@ export class DecimalType extends ValueType<string> {
   applyScale(value: string | null): string | null {
     if (value === null) return null;
     if (this.scale === undefined) return value;
+    // Ruby `BigDecimal#round(n)` only accepts an Integer argument; a
+    // non-integer or negative TS `scale:` option would just misfire our
+    // slice/charCodeAt math, so leave the value untouched rather than
+    // invent new semantics.
+    if (!Number.isInteger(this.scale) || this.scale < 0) return value;
     return roundHalfUpToScale(value, this.scale);
   }
 
@@ -65,11 +70,12 @@ export class DecimalType extends ValueType<string> {
  * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional parts.
  */
 /**
- * Cap exponent magnitude so adversarial input like `"1e10000000"` can't
- * drive `padEnd`/`padStart` into allocating multi-gigabyte strings. At
- * |exp| > this many digits the value has more precision than any
- * realistic `scale:` will keep anyway; returning null makes `applyScale`
- * leave the raw form alone rather than OOM the process.
+ * Normalize a decimal-string representation (including scientific notation
+ * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional
+ * parts. Exponent magnitude is capped at `MAX_EXPONENT_EXPANSION` so
+ * adversarial input like `"1e10000000"` can't drive `padEnd`/`padStart`
+ * into allocating multi-gigabyte strings; over the cap we return null and
+ * callers leave the raw form alone.
  */
 const MAX_EXPONENT_EXPANSION = 4000;
 

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -64,6 +64,15 @@ export class DecimalType extends ValueType<string> {
  * Normalize a decimal-string representation (including scientific notation
  * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional parts.
  */
+/**
+ * Cap exponent magnitude so adversarial input like `"1e10000000"` can't
+ * drive `padEnd`/`padStart` into allocating multi-gigabyte strings. At
+ * |exp| > this many digits the value has more precision than any
+ * realistic `scale:` will keep anyway; returning null makes `applyScale`
+ * leave the raw form alone rather than OOM the process.
+ */
+const MAX_EXPONENT_EXPANSION = 4000;
+
 function splitDecimal(raw: string): { sign: "" | "-"; intPart: string; fracPart: string } | null {
   let s = raw;
   let sign: "" | "-" = "";
@@ -73,12 +82,15 @@ function splitDecimal(raw: string): { sign: "" | "-"; intPart: string; fracPart:
   } else if (s.startsWith("+")) {
     s = s.slice(1);
   }
-  // Expand scientific notation into plain digits.
-  const m = s.match(/^(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
+  // Accept the same numeric forms `_castWithoutScale` emits: `1`, `1.`,
+  // `.5`, `1.5`, `1e3`, `1.e3`. Reject input with no digits at all.
+  const m = s.match(/^(\d*)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/);
   if (!m) return null;
-  let intPart = m[1];
+  if (m[1] === "" && (m[2] ?? "") === "") return null;
+  let intPart = m[1] || "0";
   let fracPart = m[2] ?? "";
   const exp = m[3] ? Number(m[3]) : 0;
+  if (Math.abs(exp) > MAX_EXPONENT_EXPANSION) return null;
   if (exp > 0) {
     if (fracPart.length >= exp) {
       intPart += fracPart.slice(0, exp);

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -23,7 +23,7 @@ export class DecimalType extends ValueType<string> {
    * Mirrors: ActiveModel::Type::Decimal#apply_scale
    * (activemodel/lib/active_model/type/decimal.rb).
    */
-  applyScale(value: string | null): string | null {
+  protected applyScale(value: string | null): string | null {
     if (value === null) return null;
     if (this.scale === undefined) return value;
     // Ruby `BigDecimal#round(n)` only accepts an Integer argument; a
@@ -129,19 +129,26 @@ function roundHalfUpToScale(raw: string, scale: number): string {
     return scale > 0 ? `${sign}${intPart}.${keep}` : `${sign}${intPart}`;
   }
   // Carry: half-away-from-zero bumps magnitude by 1 ulp at position `scale`.
-  const digits = (intPart + keep).split("");
-  for (let i = digits.length - 1; i >= 0; i--) {
-    if (digits[i] === "9") {
-      digits[i] = "0";
-      if (i === 0) digits.unshift("1");
-    } else {
-      digits[i] = String(digits[i].charCodeAt(0) - 48 + 1);
-      break;
-    }
-  }
-  const out = digits.join("");
+  const out = incrementDecimalDigits(intPart + keep);
   const newIntLen = out.length - scale;
   const newInt = out.slice(0, newIntLen);
   const newFrac = out.slice(newIntLen);
   return scale > 0 ? `${sign}${newInt}.${newFrac}` : `${sign}${newInt}`;
+}
+
+/**
+ * Increment a run of ASCII digits by 1 with carry, returning a new
+ * string. Uses no intermediate arrays so a multi-million-digit input
+ * doesn't blow up memory.
+ */
+function incrementDecimalDigits(digits: string): string {
+  let i = digits.length - 1;
+  while (i >= 0 && digits.charCodeAt(i) === 57 /* "9" */) {
+    i -= 1;
+  }
+  if (i < 0) {
+    return `1${"0".repeat(digits.length)}`;
+  }
+  const incremented = String.fromCharCode(digits.charCodeAt(i) + 1);
+  return `${digits.slice(0, i)}${incremented}${"0".repeat(digits.length - i - 1)}`;
 }

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -11,6 +11,25 @@ export class DecimalType extends ValueType<string> {
   // We mirror the same shape, returning the string form rather than a
   // BigDecimal wrapper.
   cast(value: unknown): string | null {
+    const casted = this._castWithoutScale(value);
+    return this.applyScale(casted);
+  }
+
+  /**
+   * Apply Rails' `scale:` option to a decimal string, rounding to the
+   * configured number of fractional digits using Ruby's default
+   * `BigDecimal#round` mode (`ROUND_HALF_UP` — half away from zero).
+   *
+   * Mirrors: ActiveModel::Type::Decimal#apply_scale
+   * (activemodel/lib/active_model/type/decimal.rb).
+   */
+  applyScale(value: string | null): string | null {
+    if (value === null) return null;
+    if (this.scale === undefined) return value;
+    return roundHalfUpToScale(value, this.scale);
+  }
+
+  private _castWithoutScale(value: unknown): string | null {
     if (value === null || value === undefined) return null;
     if (typeof value === "bigint") return value.toString();
     if (typeof value === "number") {
@@ -39,4 +58,75 @@ export class DecimalType extends ValueType<string> {
   typeCastForSchema(value: unknown): string {
     return JSON.stringify(value) ?? String(value);
   }
+}
+
+/**
+ * Normalize a decimal-string representation (including scientific notation
+ * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional parts.
+ */
+function splitDecimal(raw: string): { sign: "" | "-"; intPart: string; fracPart: string } | null {
+  let s = raw;
+  let sign: "" | "-" = "";
+  if (s.startsWith("-")) {
+    sign = "-";
+    s = s.slice(1);
+  } else if (s.startsWith("+")) {
+    s = s.slice(1);
+  }
+  // Expand scientific notation into plain digits.
+  const m = s.match(/^(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
+  if (!m) return null;
+  let intPart = m[1];
+  let fracPart = m[2] ?? "";
+  const exp = m[3] ? Number(m[3]) : 0;
+  if (exp > 0) {
+    if (fracPart.length >= exp) {
+      intPart += fracPart.slice(0, exp);
+      fracPart = fracPart.slice(exp);
+    } else {
+      intPart += fracPart.padEnd(exp, "0");
+      fracPart = "";
+    }
+  } else if (exp < 0) {
+    const shift = -exp;
+    if (intPart.length > shift) {
+      fracPart = intPart.slice(intPart.length - shift) + fracPart;
+      intPart = intPart.slice(0, intPart.length - shift);
+    } else {
+      fracPart = intPart.padStart(shift, "0") + fracPart;
+      intPart = "0";
+    }
+  }
+  return { sign, intPart: intPart.replace(/^0+(?=\d)/, "") || "0", fracPart };
+}
+
+function roundHalfUpToScale(raw: string, scale: number): string {
+  const parts = splitDecimal(raw);
+  if (!parts) return raw;
+  const { sign, intPart, fracPart } = parts;
+  if (fracPart.length <= scale) {
+    const padded = scale > 0 ? `.${fracPart.padEnd(scale, "0")}` : "";
+    return `${sign}${intPart}${padded}`;
+  }
+  const keep = fracPart.slice(0, scale);
+  const roundDigit = fracPart.charCodeAt(scale) - 48; // '0' → 0
+  if (roundDigit < 5) {
+    return scale > 0 ? `${sign}${intPart}.${keep}` : `${sign}${intPart}`;
+  }
+  // Carry: half-away-from-zero bumps magnitude by 1 ulp at position `scale`.
+  const digits = (intPart + keep).split("");
+  for (let i = digits.length - 1; i >= 0; i--) {
+    if (digits[i] === "9") {
+      digits[i] = "0";
+      if (i === 0) digits.unshift("1");
+    } else {
+      digits[i] = String(digits[i].charCodeAt(0) - 48 + 1);
+      break;
+    }
+  }
+  const out = digits.join("");
+  const newIntLen = out.length - scale;
+  const newInt = out.slice(0, newIntLen);
+  const newFrac = out.slice(newIntLen);
+  return scale > 0 ? `${sign}${newInt}.${newFrac}` : `${sign}${newInt}`;
 }

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -65,10 +65,8 @@ export class DecimalType extends ValueType<string> {
   }
 }
 
-/**
- * Normalize a decimal-string representation (including scientific notation
- * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional parts.
- */
+const MAX_EXPONENT_EXPANSION = 4000;
+
 /**
  * Normalize a decimal-string representation (including scientific notation
  * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional
@@ -77,7 +75,6 @@ export class DecimalType extends ValueType<string> {
  * into allocating multi-gigabyte strings; over the cap we return null and
  * callers leave the raw form alone.
  */
-const MAX_EXPONENT_EXPANSION = 4000;
 
 function splitDecimal(raw: string): { sign: "" | "-"; intPart: string; fracPart: string } | null {
   let s = raw;


### PR DESCRIPTION
## Summary
Two self-contained type ports from the ActiveModel audit:

- **PR 22c** — DateType ISO_DATE fast path (`fastStringToDate` + `fallbackStringToDate` + `newDate` with year==0 / overflow rejection), mirroring `activemodel/lib/active_model/type/date.rb:31-35`.
- **PR 22e** — DecimalType `applyScale` using string-based ROUND_HALF_UP arithmetic so `scale:` round-trips (`1.005` → `1.01`) without IEEE-754 drift. Mirrors Ruby `BigDecimal#round` default mode.

**Scope note:** PR 22d (bool-literal `"t"`/`"f"` in immutable-string cast) deferred — it cascades into the acceptance-validator default accept list and needs its own paired PR.

## Test plan
- [x] New tests for decimal scale + date fast-path / new_date / fallback parse
- [x] 1,483 AM / 9,274 AR pass
- [x] typecheck + lint clean