### PR TITLE
feat(activerecord): MismatchedForeignKey + MySQL bigint FK type-mismatch tests

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -96,96 +96,93 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skip("exec query nothing raises with no result queries", () => {});
     it.skip("database exists returns false if database does not exist", () => {});
 
-    // FK type-mismatch tests
+    // FK type-mismatch fixture tables — created/dropped around each test so
+    // the FK tests are self-contained. beforeEach/afterEach live directly in
+    // Mysql2AdapterTest so test paths match Rails (no extra describe level).
     // Mirrors Rails: test/cases/adapters/mysql2/mysql2_adapter_test.rb:136–270
     //
-    // Fixture tables:
-    //   old_cars   — integer PK (matches Rails' old_cars fixture)
-    //   cars       — bigint PK  (matches Rails' cars fixture)
-    //   subscribers — varchar PK (matches Rails' subscribers fixture)
-    //   engines    — bigint PK, used as the referencing table for ALTER TABLE tests
-    //
-    // Each test creates/drops its own fixture tables so they run independently.
+    //   old_cars    — integer PK  (Rails' old_cars fixture)
+    //   cars        — bigint PK   (Rails' cars fixture)
+    //   subscribers — varchar PK  (Rails' subscribers fixture)
+    //   engines     — bigint PK, used as the referencing table
+    beforeEach(async () => {
+      await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+      await adapter.executeMutation(
+        "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
+      );
+      await adapter.executeMutation(
+        "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
+      );
+      await adapter.executeMutation(
+        "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY) ENGINE=InnoDB",
+      );
+      await adapter.executeMutation(
+        "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT) ENGINE=InnoDB",
+      );
+    });
 
-    describe("FK type mismatch errors", () => {
-      beforeEach(async () => {
-        await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
-        await adapter.executeMutation(
-          "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
-        );
-        await adapter.executeMutation(
-          "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
-        );
-        await adapter.executeMutation(
-          "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY) ENGINE=InnoDB",
-        );
-        await adapter.executeMutation(
-          "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT) ENGINE=InnoDB",
-        );
-      });
+    afterEach(async () => {
+      await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `foos`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+      await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+    });
 
-      afterEach(async () => {
-        await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `foos`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
-        await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
-      });
+    it("errors for bigint fks on integer pk table in alter table", async () => {
+      // engines.old_car_id is BIGINT but old_cars.id is INT — type mismatch
+      const error = await adapter
+        .executeMutation(
+          "ALTER TABLE `engines` ADD CONSTRAINT `fk_test` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-      it("errors for bigint fks on integer pk table in alter table", async () => {
-        // engines.old_car_id is BIGINT but old_cars.id is INT — type mismatch
-        const error = await adapter
-          .executeMutation(
-            "ALTER TABLE `engines` ADD CONSTRAINT `fk_test` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
-          )
-          .then(() => null)
-          .catch((e) => e);
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+      );
+      expect(error.message).toMatch(/which has type `int/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+    });
 
-        expect(error).toBeInstanceOf(MismatchedForeignKey);
-        expect(error.message).toMatch(
-          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
-        );
-        expect(error.message).toMatch(/which has type `int/i);
-        expect(error.message).toMatch(
-          /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
-        );
-        expect(error.cause).toBeInstanceOf(Error);
-      });
+    it("errors for multiple fks on mismatched types for pk table in alter table", async () => {
+      // MariaDB does not include mismatched FK details in error message
+      const isMariaDb = adapter.isMariadb();
+      if (isMariaDb) return;
 
-      it("errors for multiple fks on mismatched types for pk table in alter table", async () => {
-        // MariaDB does not include mismatched FK details in error message
-        const isMariaDb = adapter.isMariadb();
-        if (isMariaDb) return;
+      // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
+      await adapter.executeMutation(
+        "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
+      );
 
-        // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
-        await adapter.executeMutation(
-          "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
-        );
+      // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
+      const error = await adapter
+        .executeMutation(
+          "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-        // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
-        const error = await adapter
-          .executeMutation(
-            "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
-          )
-          .then(() => null)
-          .catch((e) => e);
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+      );
+      expect(error.message).toMatch(/which has type `int/i);
+      expect(error.cause).toBeInstanceOf(Error);
+    });
 
-        expect(error).toBeInstanceOf(MismatchedForeignKey);
-        expect(error.message).toMatch(
-          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
-        );
-        expect(error.message).toMatch(/which has type `int/i);
-        expect(error.cause).toBeInstanceOf(Error);
-      });
-
-      it("errors for bigint fks on integer pk table in create table", async () => {
-        // foos.old_car_id is BIGINT but old_cars.id is INT
-        const error = await adapter
-          .executeMutation(
-            `
+    it("errors for bigint fks on integer pk table in create table", async () => {
+      // foos.old_car_id is BIGINT but old_cars.id is INT
+      const error = await adapter
+        .executeMutation(
+          `
             CREATE TABLE \`foos\` (
               \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
               \`old_car_id\` BIGINT,
@@ -193,26 +190,26 @@ describeIfMysql("Mysql2Adapter", () => {
               CONSTRAINT \`fk_foos_old_car\` FOREIGN KEY (\`old_car_id\`) REFERENCES \`old_cars\` (\`id\`)
             ) ENGINE=InnoDB
           `,
-          )
-          .then(() => null)
-          .catch((e) => e);
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-        expect(error).toBeInstanceOf(MismatchedForeignKey);
-        expect(error.message).toMatch(
-          /Column `old_car_id` on table `foos` does not match column `id` on `old_cars`/,
-        );
-        expect(error.message).toMatch(/which has type `int/i);
-        expect(error.message).toMatch(
-          /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
-        );
-        expect(error.cause).toBeInstanceOf(Error);
-      });
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `old_car_id` on table `foos` does not match column `id` on `old_cars`/,
+      );
+      expect(error.message).toMatch(/which has type `int/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+    });
 
-      it("errors for integer fks on bigint pk table in create table", async () => {
-        // foos.car_id is INT but cars.id is BIGINT
-        const error = await adapter
-          .executeMutation(
-            `
+    it("errors for integer fks on bigint pk table in create table", async () => {
+      // foos.car_id is INT but cars.id is BIGINT
+      const error = await adapter
+        .executeMutation(
+          `
             CREATE TABLE \`foos\` (
               \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
               \`car_id\` INT,
@@ -220,26 +217,26 @@ describeIfMysql("Mysql2Adapter", () => {
               CONSTRAINT \`fk_foos_car\` FOREIGN KEY (\`car_id\`) REFERENCES \`cars\` (\`id\`)
             ) ENGINE=InnoDB
           `,
-          )
-          .then(() => null)
-          .catch((e) => e);
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-        expect(error).toBeInstanceOf(MismatchedForeignKey);
-        expect(error.message).toMatch(
-          /Column `car_id` on table `foos` does not match column `id` on `cars`/,
-        );
-        expect(error.message).toMatch(/which has type `bigint/i);
-        expect(error.message).toMatch(
-          /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
-        );
-        expect(error.cause).toBeInstanceOf(Error);
-      });
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `car_id` on table `foos` does not match column `id` on `cars`/,
+      );
+      expect(error.message).toMatch(/which has type `bigint/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+    });
 
-      it("errors for bigint fks on string pk table in create table", async () => {
-        // foos.subscriber_id is BIGINT but subscribers.nick is VARCHAR
-        const error = await adapter
-          .executeMutation(
-            `
+    it("errors for bigint fks on string pk table in create table", async () => {
+      // foos.subscriber_id is BIGINT but subscribers.nick is VARCHAR
+      const error = await adapter
+        .executeMutation(
+          `
             CREATE TABLE \`foos\` (
               \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
               \`subscriber_id\` BIGINT,
@@ -247,20 +244,19 @@ describeIfMysql("Mysql2Adapter", () => {
               CONSTRAINT \`fk_foos_subscriber\` FOREIGN KEY (\`subscriber_id\`) REFERENCES \`subscribers\` (\`nick\`)
             ) ENGINE=InnoDB
           `,
-          )
-          .then(() => null)
-          .catch((e) => e);
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-        expect(error).toBeInstanceOf(MismatchedForeignKey);
-        expect(error.message).toMatch(
-          /Column `subscriber_id` on table `foos` does not match column `nick` on `subscribers`/,
-        );
-        expect(error.message).toMatch(/which has type `varchar/i);
-        expect(error.message).toMatch(
-          /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
-        );
-        expect(error.cause).toBeInstanceOf(Error);
-      });
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `subscriber_id` on table `foos` does not match column `nick` on `subscribers`/,
+      );
+      expect(error.message).toMatch(/which has type `varchar/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
     });
 
     it.skip("read timeout exception", () => {});

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -114,16 +114,16 @@ describeIfMysql("Mysql2Adapter", () => {
         await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
         await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
         await adapter.executeMutation(
-          "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+          "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
         );
         await adapter.executeMutation(
-          "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+          "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
         );
         await adapter.executeMutation(
-          "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY)",
+          "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY) ENGINE=InnoDB",
         );
         await adapter.executeMutation(
-          "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT)",
+          "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT) ENGINE=InnoDB",
         );
       });
 
@@ -191,7 +191,7 @@ describeIfMysql("Mysql2Adapter", () => {
               \`old_car_id\` BIGINT,
               INDEX \`idx_old_car_id\` (\`old_car_id\`),
               CONSTRAINT \`fk_foos_old_car\` FOREIGN KEY (\`old_car_id\`) REFERENCES \`old_cars\` (\`id\`)
-            )
+            ) ENGINE=InnoDB
           `,
           )
           .then(() => null)
@@ -218,7 +218,7 @@ describeIfMysql("Mysql2Adapter", () => {
               \`car_id\` INT,
               INDEX \`idx_car_id\` (\`car_id\`),
               CONSTRAINT \`fk_foos_car\` FOREIGN KEY (\`car_id\`) REFERENCES \`cars\` (\`id\`)
-            )
+            ) ENGINE=InnoDB
           `,
           )
           .then(() => null)
@@ -245,7 +245,7 @@ describeIfMysql("Mysql2Adapter", () => {
               \`subscriber_id\` BIGINT,
               INDEX \`idx_subscriber_id\` (\`subscriber_id\`),
               CONSTRAINT \`fk_foos_subscriber\` FOREIGN KEY (\`subscriber_id\`) REFERENCES \`subscribers\` (\`nick\`)
-            )
+            ) ENGINE=InnoDB
           `,
           )
           .then(() => null)

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../abstract-mysql-adapter/test-helper.js";
 import {
   InvalidForeignKey,
+  MismatchedForeignKey,
   NotNullViolation,
   RecordNotUnique,
   ValueTooLong,
@@ -94,11 +95,174 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skip("exec query with prepared statements", () => {});
     it.skip("exec query nothing raises with no result queries", () => {});
     it.skip("database exists returns false if database does not exist", () => {});
-    it.skip("errors for bigint fks on integer pk table in alter table", () => {});
-    it.skip("errors for multiple fks on mismatched types for pk table in alter table", () => {});
-    it.skip("errors for bigint fks on integer pk table in create table", () => {});
-    it.skip("errors for integer fks on bigint pk table in create table", () => {});
-    it.skip("errors for bigint fks on string pk table in create table", () => {});
+
+    // FK type-mismatch tests
+    // Mirrors Rails: test/cases/adapters/mysql2/mysql2_adapter_test.rb:136–270
+    //
+    // Fixture tables:
+    //   old_cars   — integer PK (matches Rails' old_cars fixture)
+    //   cars       — bigint PK  (matches Rails' cars fixture)
+    //   subscribers — varchar PK (matches Rails' subscribers fixture)
+    //   engines    — bigint PK, used as the referencing table for ALTER TABLE tests
+    //
+    // Each test creates/drops its own fixture tables so they run independently.
+
+    describe("FK type mismatch errors", () => {
+      beforeEach(async () => {
+        await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+        await adapter.executeMutation(
+          "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+        );
+        await adapter.executeMutation(
+          "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+        );
+        await adapter.executeMutation(
+          "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY)",
+        );
+        await adapter.executeMutation(
+          "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT)",
+        );
+      });
+
+      afterEach(async () => {
+        await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `foos`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
+        await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+      });
+
+      it("errors for bigint fks on integer pk table in alter table", async () => {
+        // engines.old_car_id is BIGINT but old_cars.id is INT — type mismatch
+        const error = await adapter
+          .executeMutation(
+            "ALTER TABLE `engines` ADD CONSTRAINT `fk_test` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
+          )
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+        );
+        expect(error.message).toMatch(/which has type `int/i);
+        expect(error.message).toMatch(
+          /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
+        );
+        expect(error.cause).not.toBeNull();
+      });
+
+      it("errors for multiple fks on mismatched types for pk table in alter table", async () => {
+        // MariaDB does not include mismatched FK details in error message
+        const isMariaDb = ((adapter as any)._mariadb as boolean | undefined) ?? false;
+        if (isMariaDb) return;
+
+        // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
+        await adapter.executeMutation(
+          "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
+        );
+
+        // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
+        const error = await adapter
+          .executeMutation(
+            "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
+          )
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+        );
+        expect(error.message).toMatch(/which has type `int/i);
+        expect(error.cause).not.toBeNull();
+      });
+
+      it("errors for bigint fks on integer pk table in create table", async () => {
+        // foos.old_car_id is BIGINT but old_cars.id is INT
+        const error = await adapter
+          .executeMutation(
+            `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`old_car_id\` BIGINT,
+              INDEX \`idx_old_car_id\` (\`old_car_id\`),
+              CONSTRAINT \`fk_foos_old_car\` FOREIGN KEY (\`old_car_id\`) REFERENCES \`old_cars\` (\`id\`)
+            )
+          `,
+          )
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `old_car_id` on table `foos` does not match column `id` on `old_cars`/,
+        );
+        expect(error.message).toMatch(/which has type `int/i);
+        expect(error.message).toMatch(
+          /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
+        );
+        expect(error.cause).not.toBeNull();
+      });
+
+      it("errors for integer fks on bigint pk table in create table", async () => {
+        // foos.car_id is INT but cars.id is BIGINT
+        const error = await adapter
+          .executeMutation(
+            `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`car_id\` INT,
+              INDEX \`idx_car_id\` (\`car_id\`),
+              CONSTRAINT \`fk_foos_car\` FOREIGN KEY (\`car_id\`) REFERENCES \`cars\` (\`id\`)
+            )
+          `,
+          )
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `car_id` on table `foos` does not match column `id` on `cars`/,
+        );
+        expect(error.message).toMatch(/which has type `bigint/i);
+        expect(error.message).toMatch(
+          /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
+        );
+        expect(error.cause).not.toBeNull();
+      });
+
+      it("errors for bigint fks on string pk table in create table", async () => {
+        // foos.subscriber_id is BIGINT but subscribers.nick is VARCHAR
+        const error = await adapter
+          .executeMutation(
+            `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`subscriber_id\` BIGINT,
+              INDEX \`idx_subscriber_id\` (\`subscriber_id\`),
+              CONSTRAINT \`fk_foos_subscriber\` FOREIGN KEY (\`subscriber_id\`) REFERENCES \`subscribers\` (\`nick\`)
+            )
+          `,
+          )
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `subscriber_id` on table `foos` does not match column `nick` on `subscribers`/,
+        );
+        expect(error.message).toMatch(/which has type `varchar/i);
+        expect(error.message).toMatch(
+          /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
+        );
+        expect(error.cause).not.toBeNull();
+      });
+    });
+
     it.skip("read timeout exception", () => {});
     it.skip("statement timeout error codes", () => {});
     it.skip("database timezone changes synced to connection", () => {});

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -152,12 +152,12 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(error.message).toMatch(
           /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
         );
-        expect(error.cause).not.toBeNull();
+        expect(error.cause).toBeInstanceOf(Error);
       });
 
       it("errors for multiple fks on mismatched types for pk table in alter table", async () => {
         // MariaDB does not include mismatched FK details in error message
-        const isMariaDb = ((adapter as any)._mariadb as boolean | undefined) ?? false;
+        const isMariaDb = adapter.isMariadb();
         if (isMariaDb) return;
 
         // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
@@ -178,7 +178,7 @@ describeIfMysql("Mysql2Adapter", () => {
           /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
         );
         expect(error.message).toMatch(/which has type `int/i);
-        expect(error.cause).not.toBeNull();
+        expect(error.cause).toBeInstanceOf(Error);
       });
 
       it("errors for bigint fks on integer pk table in create table", async () => {
@@ -205,7 +205,7 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(error.message).toMatch(
           /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
         );
-        expect(error.cause).not.toBeNull();
+        expect(error.cause).toBeInstanceOf(Error);
       });
 
       it("errors for integer fks on bigint pk table in create table", async () => {
@@ -232,7 +232,7 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(error.message).toMatch(
           /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
         );
-        expect(error.cause).not.toBeNull();
+        expect(error.cause).toBeInstanceOf(Error);
       });
 
       it("errors for bigint fks on string pk table in create table", async () => {
@@ -259,7 +259,7 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(error.message).toMatch(
           /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
         );
-        expect(error.cause).not.toBeNull();
+        expect(error.cause).toBeInstanceOf(Error);
       });
     });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -85,11 +85,17 @@ const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
 const ER_TABLE_EXISTS = 1050;
 
-export abstract class AbstractMysqlAdapter extends AbstractAdapter {
+export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
 
-  /** Implemented by concrete adapters (Mysql2Adapter, TrilogyAdapter). */
-  abstract columns(tableName: string): Promise<Column[]>;
+  /**
+   * Return Column objects for a table. Concrete adapters (Mysql2Adapter,
+   * TrilogyAdapter) override this. The default throws so that unimplemented
+   * adapters fail loudly if FK enrichment is ever triggered.
+   */
+  async columns(_tableName: string): Promise<Column[]> {
+    throw new Error(`${this.constructor.name} must implement columns()`);
+  }
 
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -11,7 +11,7 @@
 import { inspectExplainOption } from "../adapter.js";
 import type { ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
-import { Column } from "./column.js";
+import type { Column } from "./column.js";
 import {
   InvalidForeignKey,
   MismatchedForeignKey,
@@ -85,8 +85,11 @@ const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
 const ER_TABLE_EXISTS = 1050;
 
-export class AbstractMysqlAdapter extends AbstractAdapter {
+export abstract class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly Version = Version;
+
+  /** Implemented by concrete adapters (Mysql2Adapter, TrilogyAdapter). */
+  abstract columns(tableName: string): Promise<Column[]>;
 
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
@@ -753,11 +756,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Map MySQL/MariaDB driver errors to ActiveRecord exception classes by
-   * errno. Matches Rails'
-   * `ConnectionAdapters::AbstractMysqlAdapter#translate_exception`.
-   */
-  /**
    * Build a MismatchedForeignKey from a MySQL FK constraint error.
    * Parses the FK SQL to identify the mismatched columns, then looks up
    * the referenced column's type to produce a helpful suggestion.
@@ -826,8 +824,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (!targetTable || !primaryKey || err.fkDetails.primaryKeySqlType) return err;
 
     try {
-      const adapter = this as unknown as { columns(t: string): Promise<Column[]> };
-      const cols = await adapter.columns(targetTable);
+      const cols = await this.columns(targetTable);
       const col = cols.find((c) => c.name === primaryKey);
       if (!col) return err;
 
@@ -857,6 +854,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
   }
 
+  /**
+   * Map MySQL/MariaDB driver errors to ActiveRecord exception classes by
+   * errno. Matches Rails'
+   * `ConnectionAdapters::AbstractMysqlAdapter#translate_exception`.
+   */
   protected _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const errno = (e as { errno?: number }).errno;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -19,6 +19,7 @@ import {
   RecordNotUnique,
   StatementInvalid,
   ValueTooLong,
+  sqlTypeToMigrationKeyword,
 } from "../errors.js";
 import { sql as arelSql, type Nodes } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
@@ -835,13 +836,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (!col) return err;
 
       const sqlType = col.sqlTypeMetadata?.sqlType ?? col.sqlTypeMetadata?.type ?? "";
-      const primaryKeyType = /bigint/i.test(sqlType)
-        ? "bigint"
-        : /int/i.test(sqlType)
-          ? "integer"
-          : /varchar|char|text/i.test(sqlType)
-            ? "string"
-            : sqlType.split("(")[0].toLowerCase();
+      const primaryKeyType = sqlTypeToMigrationKeyword(sqlType);
 
       return new MismatchedForeignKey({
         message: err.cause instanceof Error ? err.cause.message : undefined,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -11,8 +11,10 @@
 import { inspectExplainOption } from "../adapter.js";
 import type { ExplainOption } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
+import { Column } from "./column.js";
 import {
   InvalidForeignKey,
+  MismatchedForeignKey,
   NotNullViolation,
   RecordNotUnique,
   StatementInvalid,
@@ -66,6 +68,9 @@ const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = 
 };
 
 const ER_DUP_ENTRY = 1062;
+const ER_CANNOT_ADD_FOREIGN = 1215;
+const ER_CANNOT_CREATE_TABLE = 1005;
+const ER_FK_INCOMPATIBLE_COLUMNS = 3780;
 const ER_NOT_NULL_VIOLATION = 1048;
 const ER_DO_NOT_HAVE_DEFAULT = 1364;
 const ER_NO_REFERENCED_ROW = 1216;
@@ -752,6 +757,106 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * errno. Matches Rails'
    * `ConnectionAdapters::AbstractMysqlAdapter#translate_exception`.
    */
+  /**
+   * Build a MismatchedForeignKey from a MySQL FK constraint error.
+   * Parses the FK SQL to identify the mismatched columns, then looks up
+   * the referenced column's type to produce a helpful suggestion.
+   *
+   * Mirrors: AbstractMysqlAdapter#mismatched_foreign_key (abstract_mysql_adapter.rb:1001)
+   */
+  protected _mismatchedForeignKey(
+    message: string,
+    sql: string,
+    binds: unknown[],
+    cause: unknown,
+  ): MismatchedForeignKey {
+    const details = this._mismatchedForeignKeyDetails(message, sql);
+    return new MismatchedForeignKey({ message, sql, binds, cause, ...details });
+  }
+
+  /**
+   * Parse a CREATE TABLE / ALTER TABLE SQL statement to extract the FK
+   * details needed for a helpful MismatchedForeignKey error message.
+   *
+   * Mirrors: AbstractMysqlAdapter#mismatched_foreign_key_details (abstract_mysql_adapter.rb:978)
+   */
+  private _mismatchedForeignKeyDetails(
+    message: string,
+    sql: string,
+  ): Partial<ConstructorParameters<typeof MismatchedForeignKey>[0]> {
+    // Extract the referencing column name from MySQL's error message when
+    // available (MySQL 8+ includes it: "Referencing column 'x' and referenced")
+    const fkFromMsg = /Referencing column '(\w+)' and referenced/i.exec(message)?.[1];
+    const fkPat = fkFromMsg ?? "\\w+";
+
+    const match = new RegExp(
+      String.raw`(?:CREATE|ALTER)\s+TABLE\s*(?:\`?\w+\`?\.)?` +
+        String.raw`\`?(?<table>\w+)\`?.+?` +
+        String.raw`FOREIGN\s+KEY\s*\(\`?(?<foreign_key>${fkPat})\`?\)\s*` +
+        String.raw`REFERENCES\s*\`?(?<target_table>\w+)\`?\s*\(\`?(?<primary_key>\w+)\`?\)`,
+      "ims",
+    ).exec(sql);
+
+    if (!match?.groups) return {};
+
+    const {
+      table,
+      foreign_key: foreignKey,
+      target_table: targetTable,
+      primary_key: primaryKey,
+    } = match.groups;
+
+    // Return the parsed names; _enrichMismatchedForeignKey does the async
+    // column type lookup so the full human-readable message can be built.
+    return { table, foreignKey, targetTable, primaryKey };
+  }
+
+  /**
+   * Async enrichment for MismatchedForeignKey errors — looks up the
+   * referenced column's SQL type and rebuilds the error with a full
+   * human-readable message including the column type suggestion.
+   *
+   * Called after `_translateException` when a MismatchedForeignKey without
+   * type info is returned. Returns the original error if enrichment fails.
+   */
+  protected async _enrichMismatchedForeignKey(
+    err: MismatchedForeignKey,
+  ): Promise<MismatchedForeignKey> {
+    const { table, foreignKey, targetTable, primaryKey } = err.fkDetails;
+    if (!targetTable || !primaryKey || err.fkDetails.primaryKeySqlType) return err;
+
+    try {
+      const adapter = this as unknown as { columns(t: string): Promise<Column[]> };
+      const cols = await adapter.columns(targetTable);
+      const col = cols.find((c) => c.name === primaryKey);
+      if (!col) return err;
+
+      const sqlType = col.sqlTypeMetadata?.sqlType ?? col.sqlTypeMetadata?.type ?? "";
+      const primaryKeyType = /bigint/i.test(sqlType)
+        ? "bigint"
+        : /int/i.test(sqlType)
+          ? "integer"
+          : /varchar|char|text/i.test(sqlType)
+            ? "string"
+            : sqlType.split("(")[0].toLowerCase();
+
+      return new MismatchedForeignKey({
+        message: err.cause instanceof Error ? err.cause.message : undefined,
+        sql: err.sql ?? undefined,
+        binds: err.binds ?? undefined,
+        cause: err.cause,
+        table,
+        foreignKey,
+        targetTable,
+        primaryKey,
+        primaryKeySqlType: sqlType,
+        primaryKeyType,
+      });
+    } catch {
+      return err;
+    }
+  }
+
   protected _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const errno = (e as { errno?: number }).errno;
@@ -765,6 +870,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       case ER_ROW_IS_REFERENCED_2:
       case ER_NO_REFERENCED_ROW_2:
         return new InvalidForeignKey(msg, { sql, binds, cause });
+      case ER_CANNOT_ADD_FOREIGN:
+      case ER_FK_INCOMPATIBLE_COLUMNS:
+        return this._mismatchedForeignKey(msg, sql, binds, cause);
+      case ER_CANNOT_CREATE_TABLE:
+        if (msg.includes("errno: 150") || msg.includes("errno 150")) {
+          return this._mismatchedForeignKey(msg, sql, binds, cause);
+        }
+        return new StatementInvalid(msg, { sql, binds, cause });
       case ER_NOT_NULL_VIOLATION:
       case ER_DO_NOT_HAVE_DEFAULT:
         return new NotNullViolation(msg, { sql, binds, cause });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -795,7 +795,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const fkPat = fkFromMsg ?? "\\w+";
 
     const match = new RegExp(
-      String.raw`(?:CREATE|ALTER)\s+TABLE\s*(?:\`?\w+\`?\.)?` +
+      String.raw`(?:CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?|ALTER\s+TABLE\s+)(?:\`?\w+\`?\.)?` +
         String.raw`\`?(?<table>\w+)\`?.+?` +
         String.raw`FOREIGN\s+KEY\s*\(\`?(?<foreign_key>${fkPat})\`?\)\s*` +
         String.raw`REFERENCES\s*\`?(?<target_table>\w+)\`?\s*\(\`?(?<primary_key>\w+)\`?\)`,

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -12,6 +12,9 @@ class TestMysqlAdapter extends AbstractMysqlAdapter {
   override isWriteQuery(sql: string): boolean {
     return /^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|ALTER|DROP|TRUNCATE)/i.test(sql);
   }
+  async columns(_tableName: string) {
+    return [];
+  }
 }
 
 let adapter: TestMysqlAdapter;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -288,6 +288,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // typed exception classes via _translateException.
         let translated = this._translateException(e, driverSql, driverBinds);
         if (translated instanceof MismatchedForeignKey) {
+          // Release the connection before enrichment — _enrichMismatchedForeignKey
+          // calls columns() which needs its own pool connection. Holding the
+          // current connection while waiting for another would deadlock on
+          // small pools (e.g. connectionLimit: 1).
+          if (conn) {
+            this.releaseConn(conn);
+            conn = undefined;
+          }
           translated = await this._enrichMismatchedForeignKey(translated);
         }
         payload.exception = translated;
@@ -345,6 +353,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // exception classes via _translateException.
         let translated = this._translateException(e, driverSql, driverBinds);
         if (translated instanceof MismatchedForeignKey) {
+          if (conn) {
+            this.releaseConn(conn);
+            conn = undefined;
+          }
           translated = await this._enrichMismatchedForeignKey(translated);
         }
         payload.exception = translated;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -6,6 +6,7 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
+import { MismatchedForeignKey } from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
@@ -285,7 +286,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // acquisition failures as `payload.exception` too. Query-level
         // driver errors (ER_DUP_ENTRY etc.) are translated to Rails'
         // typed exception classes via _translateException.
-        const translated = this._translateException(e, driverSql, driverBinds);
+        let translated = this._translateException(e, driverSql, driverBinds);
+        if (translated instanceof MismatchedForeignKey) {
+          translated = await this._enrichMismatchedForeignKey(translated);
+        }
         payload.exception = translated;
         payload.exception_object = translated;
         throw translated;
@@ -339,7 +343,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // closed) so subscribers still see `payload.exception`. Driver
         // errors (ER_DUP_ENTRY etc.) are translated to Rails' typed
         // exception classes via _translateException.
-        const translated = this._translateException(e, driverSql, driverBinds);
+        let translated = this._translateException(e, driverSql, driverBinds);
+        if (translated instanceof MismatchedForeignKey) {
+          translated = await this._enrichMismatchedForeignKey(translated);
+        }
         payload.exception = translated;
         payload.exception_object = translated;
         throw translated;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -233,6 +233,36 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * Translate a driver exception and, if it's a MismatchedForeignKey,
+   * enrich it with the referenced column's type via an async columns() call.
+   *
+   * Returns the translated (and possibly enriched) error plus a flag
+   * indicating whether the caller's `conn` was released during enrichment
+   * (to prevent double-release in `finally`).
+   */
+  private async _translateAndEnrich(
+    e: unknown,
+    sql: string,
+    binds: unknown[],
+    conn: mysql.PoolConnection | undefined,
+  ): Promise<{ error: Error; connReleased: boolean }> {
+    let translated = this._translateException(e, sql, binds);
+    let connReleased = false;
+    if (translated instanceof MismatchedForeignKey) {
+      // Release connection before enrichment — _enrichMismatchedForeignKey
+      // calls columns() which needs its own pool connection. Holding the
+      // current connection while waiting for another would deadlock on
+      // small pools (e.g. connectionLimit: 1).
+      if (conn) {
+        this.releaseConn(conn);
+        connReleased = true;
+      }
+      translated = await this._enrichMismatchedForeignKey(translated);
+    }
+    return { error: translated, connReleased };
+  }
+
+  /**
    * Convert boolean values in binds to integers for MySQL compatibility.
    */
   private mysqlBinds(binds: unknown[]): unknown[] {
@@ -285,19 +315,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // refused / closed pool); catching here lets subscribers see
         // acquisition failures as `payload.exception` too. Query-level
         // driver errors (ER_DUP_ENTRY etc.) are translated to Rails'
-        // typed exception classes via _translateException.
-        let translated = this._translateException(e, driverSql, driverBinds);
-        if (translated instanceof MismatchedForeignKey) {
-          // Release the connection before enrichment — _enrichMismatchedForeignKey
-          // calls columns() which needs its own pool connection. Holding the
-          // current connection while waiting for another would deadlock on
-          // small pools (e.g. connectionLimit: 1).
-          if (conn) {
-            this.releaseConn(conn);
-            conn = undefined;
-          }
-          translated = await this._enrichMismatchedForeignKey(translated);
-        }
+        // typed exception classes via _translateAndEnrich.
+        const { error: translated, connReleased } = await this._translateAndEnrich(
+          e,
+          driverSql,
+          driverBinds,
+          conn,
+        );
+        if (connReleased) conn = undefined;
         payload.exception = translated;
         payload.exception_object = translated;
         throw translated;
@@ -350,15 +375,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // Guard acquisition failures (pool exhausted / refused /
         // closed) so subscribers still see `payload.exception`. Driver
         // errors (ER_DUP_ENTRY etc.) are translated to Rails' typed
-        // exception classes via _translateException.
-        let translated = this._translateException(e, driverSql, driverBinds);
-        if (translated instanceof MismatchedForeignKey) {
-          if (conn) {
-            this.releaseConn(conn);
-            conn = undefined;
-          }
-          translated = await this._enrichMismatchedForeignKey(translated);
-        }
+        // exception classes via _translateAndEnrich.
+        const { error: translated, connReleased } = await this._translateAndEnrich(
+          e,
+          driverSql,
+          driverBinds,
+          conn,
+        );
+        if (connReleased) conn = undefined;
         payload.exception = translated;
         payload.exception_object = translated;
         throw translated;

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -24,6 +24,11 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
     return "Trilogy";
   }
 
+  async columns(_tableName: string) {
+    // Trilogy driver not yet implemented — stub satisfies abstract contract.
+    return [];
+  }
+
   constructor(config: Record<string, unknown> = {}) {
     super();
     // Fail fast — no Trilogy JS driver available.

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -24,11 +24,6 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
     return "Trilogy";
   }
 
-  async columns(_tableName: string) {
-    // Trilogy driver not yet implemented — stub satisfies abstract contract.
-    return [];
-  }
-
   constructor(config: Record<string, unknown> = {}) {
     super();
     // Fail fast — no Trilogy JS driver available.

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -239,17 +239,30 @@ export class InvalidForeignKey extends WrappedDatabaseException {
 
 /**
  * Normalize a MySQL SQL column type to its Rails migration type keyword.
- * E.g. `int(11)` → `integer`, `bigint(20)` → `bigint`, `varchar(255)` → `string`.
+ * E.g. `int(11)` → `integer`, `bigint(20)` → `bigint`, `varchar(255)` → `string`,
+ * `text` → `text`, `tinyint(1)` → `boolean`.
  *
  * Used by both MismatchedForeignKey (error construction) and
  * _enrichMismatchedForeignKey (adapter enrichment) to keep suggestion
  * messages consistent.
  */
 export function sqlTypeToMigrationKeyword(sqlType: string): string {
-  if (/bigint/i.test(sqlType)) return "bigint";
-  if (/int/i.test(sqlType)) return "integer";
-  if (/varchar|char|text/i.test(sqlType)) return "string";
-  return sqlType.split("(")[0].toLowerCase();
+  const normalized = sqlType.trim().toLowerCase();
+
+  if (/^tinyint\s*\(\s*1\s*\)$/.test(normalized)) return "boolean";
+
+  // Strip size/precision (e.g. `int(11)`, `varchar(255)`) and modifiers
+  // (e.g. `int unsigned`) to get the bare base type.
+  const base = normalized.split("(")[0].trim().split(/\s+/)[0];
+
+  if (base === "bigint") return "bigint";
+  if (base.endsWith("int")) return "integer"; // int, tinyint, smallint, mediumint
+  if (base === "varchar" || base === "char") return "string";
+  if (base === "text" || base === "tinytext" || base === "mediumtext" || base === "longtext") {
+    return "text";
+  }
+
+  return base;
 }
 
 export interface MismatchedForeignKeyOptions {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -283,7 +283,17 @@ export class MismatchedForeignKey extends StatementInvalid {
 
     let msg: string;
     if (table && foreignKey && targetTable && primaryKey && primaryKeySqlType) {
-      const type = primaryKeyType ?? primaryKeySqlType.split("(")[0].toLowerCase();
+      // Normalize the SQL type to a Rails migration type keyword, matching
+      // the same logic in _enrichMismatchedForeignKey (abstract_mysql_adapter.rb).
+      const type =
+        primaryKeyType ??
+        (/bigint/i.test(primaryKeySqlType)
+          ? "bigint"
+          : /int/i.test(primaryKeySqlType)
+            ? "integer"
+            : /varchar|char|text/i.test(primaryKeySqlType)
+              ? "string"
+              : primaryKeySqlType.split("(")[0].toLowerCase());
       msg = [
         `Column \`${foreignKey}\` on table \`${table}\` does not match column \`${primaryKey}\` on \`${targetTable}\`,`,
         `which has type \`${primaryKeySqlType}\`.`,
@@ -295,7 +305,6 @@ export class MismatchedForeignKey extends StatementInvalid {
         "There is a mismatch between the foreign key and primary key column types. " +
         "Verify that the foreign key column type and the primary key of the associated table match types.";
     }
-    if (originalMessage) msg += `\nOriginal message: ${originalMessage}`;
 
     super(msg, rest);
     this.name = "MismatchedForeignKey";

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -256,6 +256,9 @@ export interface MismatchedForeignKeyOptions {
  *
  * Mirrors: ActiveRecord::MismatchedForeignKey (errors.rb:238)
  *
+ * Intentionally extends StatementInvalid (not InvalidForeignKey) — matches
+ * Rails where MismatchedForeignKey < StatementInvalid, not < InvalidForeignKey.
+ *
  * Provides a human-readable message describing the mismatch and suggesting
  * the correct column type to use.
  */

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -237,6 +237,21 @@ export class InvalidForeignKey extends WrappedDatabaseException {
   }
 }
 
+/**
+ * Normalize a MySQL SQL column type to its Rails migration type keyword.
+ * E.g. `int(11)` → `integer`, `bigint(20)` → `bigint`, `varchar(255)` → `string`.
+ *
+ * Used by both MismatchedForeignKey (error construction) and
+ * _enrichMismatchedForeignKey (adapter enrichment) to keep suggestion
+ * messages consistent.
+ */
+export function sqlTypeToMigrationKeyword(sqlType: string): string {
+  if (/bigint/i.test(sqlType)) return "bigint";
+  if (/int/i.test(sqlType)) return "integer";
+  if (/varchar|char|text/i.test(sqlType)) return "string";
+  return sqlType.split("(")[0].toLowerCase();
+}
+
 export interface MismatchedForeignKeyOptions {
   message?: string;
   sql?: string;
@@ -283,17 +298,7 @@ export class MismatchedForeignKey extends StatementInvalid {
 
     let msg: string;
     if (table && foreignKey && targetTable && primaryKey && primaryKeySqlType) {
-      // Normalize the SQL type to a Rails migration type keyword, matching
-      // the same logic in _enrichMismatchedForeignKey (abstract_mysql_adapter.rb).
-      const type =
-        primaryKeyType ??
-        (/bigint/i.test(primaryKeySqlType)
-          ? "bigint"
-          : /int/i.test(primaryKeySqlType)
-            ? "integer"
-            : /varchar|char|text/i.test(primaryKeySqlType)
-              ? "string"
-              : primaryKeySqlType.split("(")[0].toLowerCase());
+      const type = primaryKeyType ?? sqlTypeToMigrationKeyword(primaryKeySqlType);
       msg = [
         `Column \`${foreignKey}\` on table \`${table}\` does not match column \`${primaryKey}\` on \`${targetTable}\`,`,
         `which has type \`${primaryKeySqlType}\`.`,

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -301,9 +301,10 @@ export class MismatchedForeignKey extends StatementInvalid {
         `(For example \`t.${type} :${foreignKey}\`).`,
       ].join(" ");
     } else {
-      msg =
+      const fallback =
         "There is a mismatch between the foreign key and primary key column types. " +
         "Verify that the foreign key column type and the primary key of the associated table match types.";
+      msg = originalMessage ? `${fallback} ${originalMessage}` : fallback;
     }
 
     super(msg, rest);

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -237,6 +237,76 @@ export class InvalidForeignKey extends WrappedDatabaseException {
   }
 }
 
+export interface MismatchedForeignKeyOptions {
+  message?: string;
+  sql?: string;
+  binds?: unknown[];
+  connectionPool?: unknown;
+  cause?: unknown;
+  table?: string;
+  foreignKey?: string;
+  targetTable?: string;
+  primaryKey?: string;
+  primaryKeySqlType?: string;
+  primaryKeyType?: string;
+}
+
+/**
+ * Raised when a FK column type doesn't match the referenced PK column type.
+ *
+ * Mirrors: ActiveRecord::MismatchedForeignKey (errors.rb:238)
+ *
+ * Provides a human-readable message describing the mismatch and suggesting
+ * the correct column type to use.
+ */
+export class MismatchedForeignKey extends StatementInvalid {
+  /** Parsed FK details for async enrichment after construction. */
+  readonly fkDetails: Omit<
+    MismatchedForeignKeyOptions,
+    "message" | "sql" | "binds" | "connectionPool" | "cause"
+  >;
+
+  constructor(options: MismatchedForeignKeyOptions = {}) {
+    const {
+      message: originalMessage,
+      table,
+      foreignKey,
+      targetTable,
+      primaryKey,
+      primaryKeySqlType,
+      primaryKeyType,
+      ...rest
+    } = options;
+
+    let msg: string;
+    if (table && foreignKey && targetTable && primaryKey && primaryKeySqlType) {
+      const type = primaryKeyType ?? primaryKeySqlType.split("(")[0].toLowerCase();
+      msg = [
+        `Column \`${foreignKey}\` on table \`${table}\` does not match column \`${primaryKey}\` on \`${targetTable}\`,`,
+        `which has type \`${primaryKeySqlType}\`.`,
+        `To resolve this issue, change the type of the \`${foreignKey}\` column on \`${table}\` to be :${type}.`,
+        `(For example \`t.${type} :${foreignKey}\`).`,
+      ].join(" ");
+    } else {
+      msg =
+        "There is a mismatch between the foreign key and primary key column types. " +
+        "Verify that the foreign key column type and the primary key of the associated table match types.";
+    }
+    if (originalMessage) msg += `\nOriginal message: ${originalMessage}`;
+
+    super(msg, rest);
+    this.name = "MismatchedForeignKey";
+    this.fkDetails = {
+      table,
+      foreignKey,
+      targetTable,
+      primaryKey,
+      primaryKeySqlType,
+      primaryKeyType,
+    };
+  }
+}
+
 export class NotNullViolation extends StatementInvalid {
   constructor(
     message?: string,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -187,6 +187,7 @@ export {
   WrappedDatabaseException,
   RecordNotUnique,
   InvalidForeignKey,
+  MismatchedForeignKey,
   NotNullViolation,
   StaleObjectError,
   ConfigurationError,


### PR DESCRIPTION
Implements the 5 previously-skipped MySQL FK bigint type-mismatch tests from `mysql2_adapter_test.rb:136–270`.

## Summary

- **`MismatchedForeignKey`** error class (mirrors `ActiveRecord::MismatchedForeignKey`, `errors.rb:238`): generates human-readable message like `Column `old_car_id` on table `engines` does not match column `id` on `old_cars`, which has type `int(11)`. To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer.`
- **Error code handling** in `_translateException`: adds 1215 (`ER_CANNOT_ADD_FOREIGN`), 3780 (`ER_FK_INCOMPATIBLE_COLUMNS`), and 1005 with `errno: 150` (`ER_CANNOT_CREATE_TABLE` + FK constraint violation)
- **Async type enrichment**: `_enrichMismatchedForeignKey` looks up the referenced column's SQL type via `adapter.columns()` and rebuilds the error with the full suggestion message
- **5 FK mismatch tests** implemented with self-contained fixture setup/teardown — no global fixtures needed

## No backwards compatibility required

Pre-release project, zero downstream consumers.