### PR TITLE
feat(parity): 6 AR eager-loading / group-having / subquery fixtures (AR parity v2 PR 3)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -54,5 +54,17 @@
   "ar-11": {
     "side": "diff",
     "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
+  },
+  "ar-16": {
+    "side": "diff",
+    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
+  },
+  "ar-17": {
+    "side": "diff",
+    "reason": "GROUP BY column qualification: trails emits 'GROUP BY created_at' (bare); Rails qualifies to 'GROUP BY \"orders\".\"created_at\"'. Same SQL semantic, lexically differ."
+  },
+  "ar-19": {
+    "side": "diff",
+    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09 / ar-11."
   }
 }

--- a/scripts/parity/fixtures/ar-14/models.rb
+++ b/scripts/parity/fixtures/ar-14/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-14/models.ts
+++ b/scripts/parity/fixtures/ar-14/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-14/query.rb
+++ b/scripts/parity/fixtures/ar-14/query.rb
@@ -1,0 +1,1 @@
+Book.includes(:author).limit(10)

--- a/scripts/parity/fixtures/ar-14/query.ts
+++ b/scripts/parity/fixtures/ar-14/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().includes("author").limit(10);

--- a/scripts/parity/fixtures/ar-14/schema.sql
+++ b/scripts/parity/fixtures/ar-14/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-14
+-- Query: Book.includes(:author).limit(10)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  author_id INTEGER REFERENCES authors(id),
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-15/models.rb
+++ b/scripts/parity/fixtures/ar-15/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-15/models.ts
+++ b/scripts/parity/fixtures/ar-15/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-15/query.rb
+++ b/scripts/parity/fixtures/ar-15/query.rb
@@ -1,0 +1,1 @@
+Book.preload(:author).limit(10)

--- a/scripts/parity/fixtures/ar-15/query.ts
+++ b/scripts/parity/fixtures/ar-15/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().preload("author").limit(10);

--- a/scripts/parity/fixtures/ar-15/schema.sql
+++ b/scripts/parity/fixtures/ar-15/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-15
+-- Query: Book.preload(:author).limit(10)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  author_id INTEGER REFERENCES authors(id),
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-16/models.rb
+++ b/scripts/parity/fixtures/ar-16/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-16/models.ts
+++ b/scripts/parity/fixtures/ar-16/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-16/query.rb
+++ b/scripts/parity/fixtures/ar-16/query.rb
@@ -1,0 +1,1 @@
+Book.eager_load(:author).limit(10)

--- a/scripts/parity/fixtures/ar-16/query.ts
+++ b/scripts/parity/fixtures/ar-16/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().eagerLoad("author").limit(10);

--- a/scripts/parity/fixtures/ar-16/schema.sql
+++ b/scripts/parity/fixtures/ar-16/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-16
+-- Query: Book.eager_load(:author).limit(10)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  author_id INTEGER REFERENCES authors(id),
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-17/models.rb
+++ b/scripts/parity/fixtures/ar-17/models.rb
@@ -1,0 +1,2 @@
+class Order < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-17/models.ts
+++ b/scripts/parity/fixtures/ar-17/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Order extends Base {
+  static {
+    this.tableName = "orders";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-17/query.rb
+++ b/scripts/parity/fixtures/ar-17/query.rb
@@ -1,0 +1,1 @@
+Order.select("created_at as ordered_date, sum(total) as total_price").group("created_at").having("sum(total) > ?", 200)

--- a/scripts/parity/fixtures/ar-17/query.ts
+++ b/scripts/parity/fixtures/ar-17/query.ts
@@ -1,0 +1,5 @@
+import { Order } from "./models.js";
+
+export default Order.select("created_at as ordered_date, sum(total) as total_price")
+  .group("created_at")
+  .having("sum(total) > ?", 200);

--- a/scripts/parity/fixtures/ar-17/schema.sql
+++ b/scripts/parity/fixtures/ar-17/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-17
+-- Query: Order.select("created_at as ordered_date, sum(total) as total_price").group("created_at").having("sum(total) > ?", 200)
+
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY,
+  total INTEGER,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-18/models.rb
+++ b/scripts/parity/fixtures/ar-18/models.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  has_many :comments
+end
+class Comment < ActiveRecord::Base
+  belongs_to :user
+end

--- a/scripts/parity/fixtures/ar-18/models.ts
+++ b/scripts/parity/fixtures/ar-18/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    this.hasMany("comments");
+    registerModel(this);
+  }
+}
+export class Comment extends Base {
+  static {
+    this.tableName = "comments";
+    this.belongsTo("user");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-18/query.rb
+++ b/scripts/parity/fixtures/ar-18/query.rb
@@ -1,0 +1,1 @@
+User.where.not(id: Comment.select(:user_id).distinct)

--- a/scripts/parity/fixtures/ar-18/query.ts
+++ b/scripts/parity/fixtures/ar-18/query.ts
@@ -1,0 +1,3 @@
+import { User, Comment } from "./models.js";
+
+export default User.whereNot({ id: Comment.select("user_id").distinct() });

--- a/scripts/parity/fixtures/ar-18/schema.sql
+++ b/scripts/parity/fixtures/ar-18/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-18
+-- Query: User.where.not(id: Comment.select(:user_id).distinct)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  body TEXT
+);

--- a/scripts/parity/fixtures/ar-19/models.rb
+++ b/scripts/parity/fixtures/ar-19/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-19/models.ts
+++ b/scripts/parity/fixtures/ar-19/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-19/query.rb
+++ b/scripts/parity/fixtures/ar-19/query.rb
@@ -1,0 +1,1 @@
+User.order(:created_at).unscope(:order).where(active: true)

--- a/scripts/parity/fixtures/ar-19/query.ts
+++ b/scripts/parity/fixtures/ar-19/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.order("created_at").unscope("order").where({ active: true });

--- a/scripts/parity/fixtures/ar-19/schema.sql
+++ b/scripts/parity/fixtures/ar-19/schema.sql
@@ -1,5 +1,5 @@
 -- Fixture for statement: ar-19
--- Query: User.all.order(:created_at).unscope(:order).where(active: true)
+-- Query: User.order(:created_at).unscope(:order).where(active: true)
 
 CREATE TABLE users (
   id INTEGER PRIMARY KEY,

--- a/scripts/parity/fixtures/ar-19/schema.sql
+++ b/scripts/parity/fixtures/ar-19/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-19
+-- Query: User.all.order(:created_at).unscope(:order).where(active: true)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  active INTEGER,
+  created_at DATETIME
+);


### PR DESCRIPTION
Third PR of the AR parity v2 rollout. Adds 6 hand-translated AR query fixtures.

## Fixtures — 3 pass, 3 gap

Pass (byte-identical SQL on both sides):

| # | Corpus | Query |
|---|--------|-------|
| ar-14 | #9  | `Book.includes(:author).limit(10)` |
| ar-15 | #12 | `Book.preload(:author).limit(10)` |
| ar-18 | #23 | `User.where.not(id: Comment.select(:user_id).distinct)` (subquery in WHERE) |

Known gaps (documented in `query-known-gaps.json`):

| # | Corpus | Gap | Side |
|---|--------|-----|------|
| ar-16 | #13 | `eager_load` — trails pushes into `_eagerLoadAssociations` but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT (`t0_r0, t1_r0, …`) Rails does | diff |
| ar-17 | #31 | GROUP BY qualification — trails `GROUP BY created_at`, Rails `GROUP BY "orders"."created_at"` | diff |
| ar-19 | #44 | Boolean literal: `active = TRUE` vs Rails' `active = 1` — same root cause as ar-09 / ar-11 | diff |

## trails API mapping learned

- `.includes / .preload / .eagerLoad` are Relation methods — need `Model.all().includes(...)` on trails, not `Model.includes(...)`. Static-class calls don't exist.

## Sweep

```
$ pnpm parity:query
52/69 passed, 17 known gap(s), 0 failures
  known gaps by side: 8 trails-missing, 9 diff
```

## What's explicitly not here

Remaining from the eager-loading / group / subquery band in the plan:
- Corpus #10 (`Customer.includes(:orders, :reviews)`) — multi-association includes
- Corpus #14/#15 (`preload` collection, explicit `Preloader`) — excluded per plan (multi-statement / execution)
- Corpus #22 (`Post.where(user_id: User.created_last_month)`) — needs named scope
- Corpus #24-28 — FROM/SELECT/HAVING subqueries using `.to_sql` interpolation; complex to translate
- Corpus #30 (`Order.group(:status).count`) — `.count` executes
- Corpus #32-33 — more `.joins(:assoc).group` — deferred with ar-01 joins table quoting

PR 4 picks up the Arel interop + raw SQL composition band.