### PR TITLE
refactor(activemodel): unify sync/async callback runners

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -548,3 +548,105 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     expect(log).toEqual(["prepended", "registered-first", "block"]);
   });
 });
+
+describe("unified sync/async runner", () => {
+  it("returns a boolean synchronously when all callbacks and block are sync", () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "save", () => {
+      log.push("before");
+    });
+    chain.register("after", "save", () => {
+      log.push("after");
+    });
+    const result = chain.runCallbacks("save", {}, () => log.push("block"));
+    expect(result).toBe(true);
+    expect(log).toEqual(["before", "block", "after"]);
+  });
+
+  it("returns a Promise when a before callback is async", async () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "save", async () => {
+      await Promise.resolve();
+      log.push("before");
+    });
+    chain.register("after", "save", () => {
+      log.push("after");
+    });
+    const result = chain.runCallbacks("save", {}, () => log.push("block"));
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBe(true);
+    expect(log).toEqual(["before", "block", "after"]);
+  });
+
+  it("returns a Promise when the block is async", async () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "save", () => log.push("before"));
+    chain.register("after", "save", () => log.push("after"));
+    const result = chain.runCallbacks("save", {}, async () => {
+      await Promise.resolve();
+      log.push("block");
+    });
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBe(true);
+    expect(log).toEqual(["before", "block", "after"]);
+  });
+
+  it("awaits async callbacks in order", async () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "save", async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      log.push("b1");
+    });
+    chain.register("before", "save", () => {
+      log.push("b2");
+    });
+    chain.register("after", "save", async () => {
+      await Promise.resolve();
+      log.push("a1");
+    });
+    await chain.runCallbacks("save", {}, () => log.push("block"));
+    expect(log).toEqual(["b1", "b2", "block", "a1"]);
+  });
+
+  it("async before halts chain when resolving to false", async () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "save", async () => false);
+    chain.register("after", "save", () => log.push("after"));
+    const ok = await chain.runCallbacks("save", {}, () => log.push("block"));
+    expect(ok).toBe(false);
+    expect(log).toEqual([]);
+  });
+
+  it("strict: 'sync' throws when a before callback returns a Promise", () => {
+    const chain = new CallbackChain();
+    chain.register("before", "validation", async () => {});
+    expect(() => chain.runCallbacks("validation", {}, () => {}, { strict: "sync" })).toThrow(
+      /Async callback registered on sync event 'validation'/,
+    );
+  });
+
+  it("strict: 'sync' throws when an after callback returns a Promise", () => {
+    const chain = new CallbackChain();
+    chain.register("after", "initialize", async () => {});
+    expect(() => chain.runAfter("initialize", {}, { strict: "sync" })).toThrow(
+      /Async callback registered on sync event 'initialize'/,
+    );
+  });
+
+  it("strict: 'sync' allows fully-sync chains", () => {
+    const chain = new CallbackChain();
+    const log: string[] = [];
+    chain.register("before", "validation", () => log.push("before"));
+    chain.register("after", "validation", () => log.push("after"));
+    const result = chain.runCallbacks("validation", {}, () => log.push("block"), {
+      strict: "sync",
+    });
+    expect(result).toBe(true);
+    expect(log).toEqual(["before", "block", "after"]);
+  });
+});

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -638,6 +638,22 @@ describe("unified sync/async runner", () => {
     );
   });
 
+  it("async validator registered via validatesWith is caught at runtime", () => {
+    class AsyncValidator {
+      async validate(_record: unknown): Promise<void> {
+        await Promise.resolve();
+      }
+    }
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validatesWith(AsyncValidator);
+      }
+    }
+    const p = new Person({ name: "test" });
+    expect(() => p.isValid()).toThrow(/Async callback registered on sync event 'validate'/);
+  });
+
   it("strict: 'sync' allows fully-sync chains", () => {
     const chain = new CallbackChain();
     const log: string[] = [];

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -638,6 +638,33 @@ describe("unified sync/async runner", () => {
     );
   });
 
+  it("async validator function registered via Model.validate is caught at runtime", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validate(async (_r: any) => {
+          await Promise.resolve();
+        });
+      }
+    }
+    const p = new Person({ name: "test" });
+    expect(() => p.isValid()).toThrow(/Async callback registered on sync event 'validate'/);
+  });
+
+  it("async validator method registered via Model.validate is caught at runtime", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.validate("checkRemote");
+      }
+      async checkRemote() {
+        await Promise.resolve();
+      }
+    }
+    const p = new Person({ name: "test" });
+    expect(() => p.isValid()).toThrow(/Async callback registered on sync event 'validate'/);
+  });
+
   it("async validator registered via validatesWith is caught at runtime", () => {
     class AsyncValidator {
       async validate(_record: unknown): Promise<void> {

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -598,7 +598,7 @@ describe("unified sync/async runner", () => {
     const chain = new CallbackChain();
     const log: string[] = [];
     chain.register("before", "save", async () => {
-      await new Promise((r) => setTimeout(r, 5));
+      await Promise.resolve();
       log.push("b1");
     });
     chain.register("before", "save", () => {

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -192,7 +192,7 @@ export interface RunCallbacksOptions {
   strict?: "sync";
 }
 
-function isThenable(v: unknown): v is Promise<unknown> {
+function isThenable(v: unknown): v is PromiseLike<unknown> {
   return (
     v !== null &&
     (typeof v === "object" || typeof v === "function") &&
@@ -207,7 +207,7 @@ function isThenable(v: unknown): v is Promise<unknown> {
  */
 function swallowRejection(v: unknown): void {
   if (isThenable(v)) {
-    void Promise.resolve(v as Promise<unknown>).catch(() => {});
+    void Promise.resolve(v).catch(() => {});
   }
 }
 
@@ -494,7 +494,7 @@ export class CallbackChain {
   ): boolean | Promise<boolean> {
     const beforeResult = this.runBefore(event, record, opts);
     if (isThenable(beforeResult)) {
-      return beforeResult.then((ok) =>
+      return Promise.resolve(beforeResult).then((ok) =>
         ok ? this._runAroundBlockAndAfter(event, record, block, opts) : false,
       );
     }
@@ -516,7 +516,7 @@ export class CallbackChain {
     const trackedBlock = (): void | Promise<void> => {
       const r = block();
       if (isThenable(r)) {
-        return r.then(() => {
+        return Promise.resolve(r).then(() => {
           blockExecuted = true;
         });
       }
@@ -576,7 +576,7 @@ export class CallbackChain {
     const finish = (): boolean | Promise<boolean> => {
       if (!blockExecuted) return false;
       const afterResult = this.runAfter(event, record, opts);
-      if (isThenable(afterResult)) return afterResult.then(() => true);
+      if (isThenable(afterResult)) return Promise.resolve(afterResult).then(() => true);
       return true;
     };
 
@@ -587,7 +587,7 @@ export class CallbackChain {
           `Async callback registered on sync event '${event}' — around callback or block returned a Promise`,
         );
       }
-      return chainResult.then(finish);
+      return Promise.resolve(chainResult).then(finish);
     }
     return finish();
   }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -169,11 +169,13 @@ function resolveCallback(
 /**
  * Callback types.
  *
- * CallbackFn allows Promise returns because the same callback chain serves
- * both sync events (validation, initialize) and async events (save, destroy).
- * The sync API (runCallbacks/runBefore/runAfter) ignores Promise returns —
- * only use sync callbacks on sync events. The async API
- * (runCallbacksAsync/runBeforeAsync/runAfterAsync) properly awaits Promises.
+ * CallbackFn allows Promise returns. The unified runner
+ * (runCallbacks/runBefore/runAfter) returns synchronously when every
+ * registered callback and block is synchronous, and returns a Promise
+ * as soon as any callback or block returns a thenable. Pass
+ * `{ strict: "sync" }` on events that must remain synchronous
+ * (validation, initialize, find); the runner throws if any callback
+ * returns a Promise on such events.
  *
  * AroundCallbackFn's proceed() returns void | Promise<void> because the
  * wrapped block may be async (e.g., DB operations in persistence). Around
@@ -184,6 +186,17 @@ export type AroundCallbackFn = (
   record: AnyRecord,
   proceed: () => void | Promise<void>,
 ) => void | Promise<void>;
+
+export interface RunCallbacksOptions {
+  /** If "sync", throw when any callback returns a Promise. */
+  strict?: "sync";
+}
+
+function isThenable(v: unknown): v is Promise<unknown> {
+  return (
+    v !== null && typeof v === "object" && typeof (v as { then?: unknown }).then === "function"
+  );
+}
 
 export type CallbackTiming = "before" | "after" | "around";
 export type CallbackEvent = string;
@@ -216,11 +229,13 @@ interface CallbackEntry {
  *
  * Mirrors: ActiveModel::Callbacks
  *
- * The primary API is synchronous, matching Rails where callbacks are
- * synchronous Ruby methods. runCallbacks/runBefore/runAfter execute
- * callbacks in registration order and do not await returned Promises.
- * For persistence events where callbacks or blocks are asynchronous,
- * use the async variants (runCallbacksAsync/runBeforeAsync/runAfterAsync).
+ * `runCallbacks`, `runBefore`, and `runAfter` return `T | Promise<T>`:
+ * synchronously when every callback and block is synchronous, as a Promise
+ * as soon as any callback or block returns a thenable. Async call sites
+ * (save/destroy/touch/commit) simply `await` the result. Sync call sites
+ * (validation/initialize/find) pass `{ strict: "sync" }` so that a
+ * registered async callback throws loudly instead of being silently
+ * awaited or dropped.
  */
 export class CallbackChain {
   private callbacks: CallbackEntry[] = [];
@@ -343,139 +358,203 @@ export class CallbackChain {
   }
 
   /**
-   * Run callbacks for a given event around a block.
-   * Returns false if a before callback returns false (halting)
-   * or if an around callback does not call proceed().
-   *
-   * Mirrors: ActiveSupport::Callbacks#run_callbacks
-   */
-  runCallbacks(event: CallbackEvent, record: AnyRecord, block: () => void): boolean {
-    if (!this.runBefore(event, record)) return false;
-
-    const arounds = this.callbacks.filter(
-      (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
-    );
-
-    let blockExecuted = false;
-    const trackedBlock = () => {
-      block();
-      blockExecuted = true;
-    };
-
-    let chain: () => void = trackedBlock;
-    for (const cb of [...arounds].reverse()) {
-      const prev = chain;
-      chain = () => (cb.fn as AroundCallbackFn)(record, prev);
-    }
-    chain();
-
-    if (!blockExecuted) return false;
-
-    this.runAfter(event, record);
-
-    return true;
-  }
-
-  /**
-   * Run before callbacks for a given event.
-   * Returns false if any callback returns false (halting the chain).
+   * Run before callbacks. Returns `false` if any callback returns `false`
+   * (halting the chain). Returns a Promise if any callback returns a
+   * thenable; otherwise returns synchronously.
    *
    * Mirrors: ActiveSupport::Callbacks — before filter chain
    */
-  runBefore(event: CallbackEvent, record: AnyRecord): boolean {
+  runBefore(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts: RunCallbacksOptions & { strict: "sync" },
+  ): boolean;
+  runBefore(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean>;
+  runBefore(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean> {
     const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
-    for (const cb of befores) {
+    for (let i = 0; i < befores.length; i++) {
+      const cb = befores[i];
       if (!this._shouldRun(cb, record)) continue;
       const result = (cb.fn as CallbackFn)(record);
+      if (isThenable(result)) {
+        if (opts?.strict === "sync") {
+          throw new Error(
+            `Async callback registered on sync event '${event}' — before callback returned a Promise`,
+          );
+        }
+        const rest = befores.slice(i + 1);
+        return (async () => {
+          const awaited = await result;
+          if (awaited === false) return false;
+          for (const cb2 of rest) {
+            if (!this._shouldRun(cb2, record)) continue;
+            const r = await (cb2.fn as CallbackFn)(record);
+            if (r === false) return false;
+          }
+          return true;
+        })();
+      }
       if (result === false) return false;
     }
     return true;
   }
 
   /**
-   * Run after callbacks for a given event.
+   * Run after callbacks. Returns a Promise if any callback returns a
+   * thenable; otherwise returns synchronously.
    *
    * Mirrors: ActiveSupport::Callbacks — after filter chain
    */
-  runAfter(event: CallbackEvent, record: AnyRecord): void {
+  runAfter(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts: RunCallbacksOptions & { strict: "sync" },
+  ): void;
+  runAfter(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts?: RunCallbacksOptions,
+  ): void | Promise<void>;
+  runAfter(
+    event: CallbackEvent,
+    record: AnyRecord,
+    opts?: RunCallbacksOptions,
+  ): void | Promise<void> {
     const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
-    for (const cb of afters) {
+    for (let i = 0; i < afters.length; i++) {
+      const cb = afters[i];
       if (!this._shouldRun(cb, record)) continue;
-      (cb.fn as CallbackFn)(record);
+      const result = (cb.fn as CallbackFn)(record);
+      if (isThenable(result)) {
+        if (opts?.strict === "sync") {
+          throw new Error(
+            `Async callback registered on sync event '${event}' — after callback returned a Promise`,
+          );
+        }
+        const rest = afters.slice(i + 1);
+        return (async () => {
+          await result;
+          for (const cb2 of rest) {
+            if (!this._shouldRun(cb2, record)) continue;
+            await (cb2.fn as CallbackFn)(record);
+          }
+        })();
+      }
     }
   }
 
-  // -- Async variants for persistence lifecycle (save/create/update/destroy) --
-  // These exist because activerecord's before_destroy/before_save callbacks
-  // can trigger cascading DB operations (dependent: :destroy) which are
-  // inherently async in Node.js. Validation callbacks use the sync API above.
-
-  async runCallbacksAsync(
+  /**
+   * Run callbacks around a block. Returns `false` if a before callback
+   * halts the chain or an around callback does not call `proceed()`.
+   * Returns a Promise as soon as any callback or the block itself returns
+   * a thenable; otherwise returns synchronously.
+   *
+   * Mirrors: ActiveSupport::Callbacks#run_callbacks
+   */
+  runCallbacks(
     event: CallbackEvent,
     record: AnyRecord,
-    block: () => void | Promise<void>,
-  ): Promise<boolean> {
-    if (!(await this.runBeforeAsync(event, record))) return false;
+    block: () => unknown,
+    opts: RunCallbacksOptions & { strict: "sync" },
+  ): boolean;
+  runCallbacks(
+    event: CallbackEvent,
+    record: AnyRecord,
+    block: () => unknown,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean>;
+  runCallbacks(
+    event: CallbackEvent,
+    record: AnyRecord,
+    block: () => unknown,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean> {
+    const beforeResult = this.runBefore(event, record, opts);
+    if (isThenable(beforeResult)) {
+      return beforeResult.then((ok) =>
+        ok ? this._runAroundBlockAndAfter(event, record, block, opts) : false,
+      );
+    }
+    if (!beforeResult) return false;
+    return this._runAroundBlockAndAfter(event, record, block, opts);
+  }
 
+  private _runAroundBlockAndAfter(
+    event: CallbackEvent,
+    record: AnyRecord,
+    block: () => unknown,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean> {
     const arounds = this.callbacks.filter(
       (c) => c.timing === "around" && c.event === event && this._shouldRun(c, record),
     );
 
     let blockExecuted = false;
-    const trackedBlock = async () => {
-      await block();
+    const trackedBlock = (): void | Promise<void> => {
+      const r = block();
+      if (isThenable(r)) {
+        return r.then(() => {
+          blockExecuted = true;
+        });
+      }
       blockExecuted = true;
     };
 
-    // Build the around chain. Each around callback wraps the previous.
-    // The pendingProceed pattern ensures that even if a sync around callback
-    // calls proceed() without awaiting it, the async block's Promise is
-    // still awaited before moving on.
     let chain: () => void | Promise<void> = trackedBlock;
     for (const cb of [...arounds].reverse()) {
       const prev = chain;
-      chain = async () => {
+      chain = () => {
         let pendingProceed: Promise<void> | undefined;
         const wrappedProceed = () => {
           const result = prev();
-          if (result && typeof (result as Promise<void>).then === "function") {
-            pendingProceed = result as Promise<void>;
-          }
+          if (isThenable(result)) pendingProceed = result as Promise<void>;
           return result;
         };
-        try {
-          await (cb.fn as AroundCallbackFn)(record, wrappedProceed);
-          if (pendingProceed) await pendingProceed;
-        } catch (aroundError) {
-          if (pendingProceed) await pendingProceed.catch(() => {});
-          throw aroundError;
+        const cbResult = (cb.fn as AroundCallbackFn)(record, wrappedProceed);
+        if (isThenable(cbResult) || pendingProceed) {
+          if (opts?.strict === "sync") {
+            throw new Error(
+              `Async callback registered on sync event '${event}' — around callback or block returned a Promise`,
+            );
+          }
+          return (async () => {
+            try {
+              await cbResult;
+              if (pendingProceed) await pendingProceed;
+            } catch (aroundError) {
+              if (pendingProceed) await pendingProceed.catch(() => {});
+              throw aroundError;
+            }
+          })();
         }
       };
     }
-    await chain();
 
-    if (!blockExecuted) return false;
+    const chainResult = chain();
 
-    await this.runAfterAsync(event, record);
+    const finish = (): boolean | Promise<boolean> => {
+      if (!blockExecuted) return false;
+      const afterResult = this.runAfter(event, record, opts);
+      if (isThenable(afterResult)) return afterResult.then(() => true);
+      return true;
+    };
 
-    return true;
-  }
-
-  async runBeforeAsync(event: CallbackEvent, record: AnyRecord): Promise<boolean> {
-    const befores = this.callbacks.filter((c) => c.timing === "before" && c.event === event);
-    for (const cb of befores) {
-      if (!this._shouldRun(cb, record)) continue;
-      const result = await (cb.fn as CallbackFn)(record);
-      if (result === false) return false;
+    if (isThenable(chainResult)) {
+      if (opts?.strict === "sync") {
+        throw new Error(
+          `Async callback registered on sync event '${event}' — around callback or block returned a Promise`,
+        );
+      }
+      return chainResult.then(finish);
     }
-    return true;
-  }
-
-  async runAfterAsync(event: CallbackEvent, record: AnyRecord): Promise<void> {
-    const afters = this.callbacks.filter((c) => c.timing === "after" && c.event === event);
-    for (const cb of afters) {
-      if (!this._shouldRun(cb, record)) continue;
-      await (cb.fn as CallbackFn)(record);
-    }
+    return finish();
   }
 }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -533,7 +533,21 @@ export class CallbackChain {
           if (isThenable(result)) pendingProceed = result as Promise<void>;
           return result;
         };
-        const cbResult = (cb.fn as AroundCallbackFn)(record, wrappedProceed);
+        let cbResult: void | Promise<void>;
+        try {
+          cbResult = (cb.fn as AroundCallbackFn)(record, wrappedProceed);
+        } catch (aroundError) {
+          // Sync throw from an around callback after it already kicked off an
+          // async proceed(). Consume the pending rejection so the caller sees
+          // only the thrown error, not a stray unhandled rejection.
+          if (pendingProceed) {
+            return (async () => {
+              await pendingProceed!.catch(() => {});
+              throw aroundError;
+            })();
+          }
+          throw aroundError;
+        }
         if (isThenable(cbResult) || pendingProceed) {
           if (opts?.strict === "sync") {
             swallowRejection(cbResult);

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -194,8 +194,21 @@ export interface RunCallbacksOptions {
 
 function isThenable(v: unknown): v is Promise<unknown> {
   return (
-    v !== null && typeof v === "object" && typeof (v as { then?: unknown }).then === "function"
+    v !== null &&
+    (typeof v === "object" || typeof v === "function") &&
+    typeof (v as { then?: unknown }).then === "function"
   );
+}
+
+/**
+ * Consume a thenable's rejection before throwing in strict-sync mode,
+ * so the error we throw isn't accompanied by an unhandled-rejection
+ * warning (or process termination under `--unhandled-rejections=strict`).
+ */
+function swallowRejection(v: unknown): void {
+  if (isThenable(v)) {
+    void Promise.resolve(v as Promise<unknown>).catch(() => {});
+  }
 }
 
 export type CallbackTiming = "before" | "after" | "around";
@@ -386,6 +399,7 @@ export class CallbackChain {
       const result = (cb.fn as CallbackFn)(record);
       if (isThenable(result)) {
         if (opts?.strict === "sync") {
+          swallowRejection(result);
           throw new Error(
             `Async callback registered on sync event '${event}' — before callback returned a Promise`,
           );
@@ -435,6 +449,7 @@ export class CallbackChain {
       const result = (cb.fn as CallbackFn)(record);
       if (isThenable(result)) {
         if (opts?.strict === "sync") {
+          swallowRejection(result);
           throw new Error(
             `Async callback registered on sync event '${event}' — after callback returned a Promise`,
           );
@@ -521,6 +536,8 @@ export class CallbackChain {
         const cbResult = (cb.fn as AroundCallbackFn)(record, wrappedProceed);
         if (isThenable(cbResult) || pendingProceed) {
           if (opts?.strict === "sync") {
+            swallowRejection(cbResult);
+            swallowRejection(pendingProceed);
             throw new Error(
               `Async callback registered on sync event '${event}' — around callback or block returned a Promise`,
             );
@@ -549,6 +566,7 @@ export class CallbackChain {
 
     if (isThenable(chainResult)) {
       if (opts?.strict === "sync") {
+        swallowRejection(chainResult);
         throw new Error(
           `Async callback registered on sync event '${event}' — around callback or block returned a Promise`,
         );

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -174,7 +174,7 @@ function resolveCallback(
  * registered callback and block is synchronous, and returns a Promise
  * as soon as any callback or block returns a thenable. Pass
  * `{ strict: "sync" }` on events that must remain synchronous
- * (validation, initialize, find); the runner throws if any callback
+ * (validation, validate, initialize, find); the runner throws if any callback
  * returns a Promise on such events.
  *
  * AroundCallbackFn's proceed() returns void | Promise<void> because the
@@ -246,7 +246,7 @@ interface CallbackEntry {
  * synchronously when every callback and block is synchronous, as a Promise
  * as soon as any callback or block returns a thenable. Async call sites
  * (save/destroy/touch/commit) simply `await` the result. Sync call sites
- * (validation/initialize/find) pass `{ strict: "sync" }` so that a
+ * (validation/validate/initialize/find) pass `{ strict: "sync" }` so that a
  * registered async callback throws loudly instead of being silently
  * awaited or dropped.
  */
@@ -530,7 +530,9 @@ export class CallbackChain {
         let pendingProceed: Promise<void> | undefined;
         const wrappedProceed = () => {
           const result = prev();
-          if (isThenable(result)) pendingProceed = result as Promise<void>;
+          // Normalize to a real Promise so .catch() below is always safe;
+          // `isThenable` accepts any A+ thenable, which may lack `.catch`.
+          if (isThenable(result)) pendingProceed = Promise.resolve(result) as Promise<void>;
           return result;
         };
         let cbResult: void | Promise<void>;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -417,7 +417,7 @@ export class Model {
     this._callbackChain.register(
       "before",
       "validate",
-      (record: AnyRecord) => validator.validate(record),
+      (record: AnyRecord) => validator.validate(record) as unknown as void,
       this._buildValidateConditions(options),
     );
   }
@@ -487,7 +487,7 @@ export class Model {
           }
         };
       } else {
-        callbackFn = (record: AnyRecord) => validator.validate(record);
+        callbackFn = (record: AnyRecord) => validator.validate(record) as unknown as void;
       }
 
       this._ensureOwnCallbacks();
@@ -1212,7 +1212,7 @@ export class Model {
     // then fire after_initialize in Rails-compatible order.
     const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
     if (callbackSuppressor._suppressInitializeCallback !== true) {
-      ctor._callbackChain.runAfter("initialize", this);
+      ctor._callbackChain.runAfter("initialize", this, { strict: "sync" });
     }
   }
 
@@ -1373,9 +1373,14 @@ export class Model {
     this._validationContext = normalized;
 
     try {
-      const completed = ctor._callbackChain.runCallbacks("validation", this, () => {
-        this._runValidateCallbacks();
-      });
+      const completed = ctor._callbackChain.runCallbacks(
+        "validation",
+        this,
+        () => {
+          this._runValidateCallbacks();
+        },
+        { strict: "sync" },
+      );
       if (!completed) return false;
       return this.errors.empty;
     } finally {
@@ -1385,7 +1390,7 @@ export class Model {
 
   private _runValidateCallbacks(): void {
     const ctor = this.constructor as typeof Model;
-    ctor._callbackChain.runBefore("validate", this);
+    ctor._callbackChain.runBefore("validate", this, { strict: "sync" });
   }
 
   /**
@@ -1876,7 +1881,7 @@ export class Model {
 
   // -- Callbacks helper for subclasses --
 
-  runCallbacks(event: string, block: () => void): boolean {
+  runCallbacks(event: string, block: () => unknown): boolean | Promise<boolean> {
     return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block);
   }
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -12,6 +12,7 @@ import {
   AroundCallbackFn,
   type CallbackObject,
   CallbackConditions,
+  type RunCallbacksOptions,
   defineModelCallbacks,
 } from "./callbacks.js";
 import { serializableHash, SerializeOptions, coerceForJson } from "./serialization.js";
@@ -1886,8 +1887,12 @@ export class Model {
 
   // -- Callbacks helper for subclasses --
 
-  runCallbacks(event: string, block: () => unknown): boolean | Promise<boolean> {
-    return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block);
+  runCallbacks(
+    event: string,
+    block: () => unknown,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean> {
+    return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block, opts);
   }
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1890,6 +1890,16 @@ export class Model {
   runCallbacks(
     event: string,
     block: () => unknown,
+    opts: RunCallbacksOptions & { strict: "sync" },
+  ): boolean;
+  runCallbacks(
+    event: string,
+    block: () => unknown,
+    opts?: RunCallbacksOptions,
+  ): boolean | Promise<boolean>;
+  runCallbacks(
+    event: string,
+    block: () => unknown,
     opts?: RunCallbacksOptions,
   ): boolean | Promise<boolean> {
     return (this.constructor as typeof Model)._callbackChain.runCallbacks(event, this, block, opts);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -477,14 +477,16 @@ export class Model {
           const origErrors = record.errors;
           const tempErrors = new Errors(record);
           record.errors = tempErrors;
+          let validateResult: unknown;
           try {
-            validator.validate(record);
+            validateResult = validator.validate(record);
           } finally {
             record.errors = origErrors;
           }
           if (tempErrors.any) {
             throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
           }
+          return validateResult as void;
         };
       } else {
         callbackFn = (record: AnyRecord) => validator.validate(record) as unknown as void;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -387,14 +387,17 @@ export class Model {
   }
 
   static validate(
-    methodOrFn: string | ((record: AnyRecord) => void),
+    methodOrFn: string | ((record: AnyRecord) => unknown),
     options: ConditionalOptions = {},
   ): void {
     const fn: CallbackFn = (record: AnyRecord) => {
+      // Return the underlying result so an `async` validator's Promise flows
+      // into the callback runner, where strict-sync mode (on the `validate`
+      // event) will throw instead of dropping it as an unhandled rejection.
       if (typeof methodOrFn === "function") {
-        methodOrFn(record);
+        return methodOrFn(record) as void;
       } else if (typeof record[methodOrFn] === "function") {
-        record[methodOrFn]();
+        return record[methodOrFn]() as void;
       }
     };
     this._ensureOwnCallbacks();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1937,8 +1937,8 @@ export class Base extends Model {
     if (this._strictLoadingByDefault) {
       record._strictLoading = true;
     }
-    this._callbackChain.runAfter("find", record);
-    this._callbackChain.runAfter("initialize", record);
+    this._callbackChain.runAfter("find", record, { strict: "sync" });
+    this._callbackChain.runAfter("initialize", record, { strict: "sync" });
     return record;
   }
 
@@ -2127,7 +2127,7 @@ export class Base extends Model {
   private async _createOrUpdate(): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
     let saved = false;
-    if (!(await ctor._callbackChain.runBeforeAsync("save", this))) return false;
+    if (!(await ctor._callbackChain.runBefore("save", this))) return false;
 
     const belongsToOk = await autosaveBelongsTo(this);
     if (!belongsToOk) {
@@ -2137,7 +2137,7 @@ export class Base extends Model {
 
     const wasNewRecord = this._newRecord;
     if (this._newRecord) {
-      const createResult = await ctor._callbackChain.runCallbacksAsync("create", this, async () => {
+      const createResult = await ctor._callbackChain.runCallbacks("create", this, async () => {
         this._performInsert();
         if (this._pendingOperation) {
           await this._pendingOperation;
@@ -2150,7 +2150,7 @@ export class Base extends Model {
       });
       if (!createResult) saved = false;
     } else {
-      const updateResult = await ctor._callbackChain.runCallbacksAsync("update", this, async () => {
+      const updateResult = await ctor._callbackChain.runCallbacks("update", this, async () => {
         this._performUpdate();
         if (this._pendingOperation) {
           await this._pendingOperation;
@@ -2169,7 +2169,7 @@ export class Base extends Model {
       (this as any)._newRecordBeforeLastCommit = wasNewRecord;
       (this as any)._triggerUpdateCallback = !wasNewRecord;
 
-      await ctor._callbackChain.runAfterAsync("save", this);
+      await ctor._callbackChain.runAfter("save", this);
 
       if (wasNewRecord) {
         await updateCounterCaches(this, "increment");
@@ -2333,7 +2333,7 @@ export class Base extends Model {
     const ctor = this.constructor as typeof Base;
 
     let didDelete = false;
-    const destroyResult = await ctor._callbackChain.runCallbacksAsync("destroy", this, async () => {
+    const destroyResult = await ctor._callbackChain.runCallbacks("destroy", this, async () => {
       const table = ctor.arelTable;
       const pk = this.id;
       if (!(Array.isArray(pk) ? pk.every((v) => v == null) : pk == null)) {

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -1626,7 +1626,7 @@ describe("CallbacksTest", () => {
         this.attribute("name", "string");
         this.adapter = adapter;
         this.beforeSave(async (r: any) => {
-          await new Promise((res) => setTimeout(res, 5));
+          await Promise.resolve();
           order.push(`before:${r.name}`);
         });
         this.afterSave((r: any) => {

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -1617,6 +1617,111 @@ describe("CallbacksTest", () => {
     expect(notifications).toEqual(["order:100"]); // Not called for silent
   });
 
+  it("awaits async before_save before persisting", async () => {
+    const order: string[] = [];
+    class Widget extends Base {
+      static {
+        this._tableName = "widgets";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        this.beforeSave(async (r: any) => {
+          await new Promise((res) => setTimeout(res, 5));
+          order.push(`before:${r.name}`);
+        });
+        this.afterSave((r: any) => {
+          order.push(`after:${r.name}`);
+        });
+      }
+    }
+    const w = await Widget.create({ name: "gear" });
+    expect(w.isPersisted()).toBe(true);
+    expect(order).toEqual(["before:gear", "after:gear"]);
+  });
+
+  it("awaits async after_save after persisting", async () => {
+    const seen: number[] = [];
+    class Gadget extends Base {
+      static {
+        this._tableName = "gadgets";
+        this.attribute("id", "integer");
+        this.attribute("value", "integer");
+        this.adapter = adapter;
+        this.afterSave(async (r: any) => {
+          await Promise.resolve();
+          seen.push(r.id);
+        });
+      }
+    }
+    const g = await Gadget.create({ value: 1 });
+    expect(seen).toEqual([g.id]);
+  });
+
+  it("async before_save returning false halts save", async () => {
+    class Locked extends Base {
+      static {
+        this._tableName = "lockeds";
+        this.attribute("id", "integer");
+        this.attribute("allowed", "boolean");
+        this.adapter = adapter;
+        this.beforeSave(async (r: any) => {
+          await Promise.resolve();
+          return r.allowed === true;
+        });
+      }
+    }
+    const ok = new Locked();
+    ok.allowed = true;
+    expect(await ok.save()).toBe(true);
+
+    const blocked = new Locked();
+    blocked.allowed = false;
+    expect(await blocked.save()).toBe(false);
+    expect(blocked.isPersisted()).toBe(false);
+  });
+
+  it("async around_create wraps the insert block and awaits both sides", async () => {
+    const order: string[] = [];
+    class Envelope extends Base {
+      static {
+        this._tableName = "envelopes";
+        this.attribute("id", "integer");
+        this.attribute("label", "string");
+        this.adapter = adapter;
+        this.aroundCreate(async (_r: any, proceed: () => void | Promise<void>) => {
+          order.push("around:before");
+          await proceed();
+          await Promise.resolve();
+          order.push("around:after");
+        });
+        this.afterSave(() => {
+          order.push("after");
+        });
+      }
+    }
+    await Envelope.create({ label: "x" });
+    expect(order).toEqual(["around:before", "around:after", "after"]);
+  });
+
+  it("async before_destroy halts destroy", async () => {
+    class Protected extends Base {
+      static {
+        this._tableName = "protecteds";
+        this.attribute("id", "integer");
+        this.attribute("sealed", "boolean");
+        this.adapter = adapter;
+        this.beforeDestroy(async (r: any) => {
+          await Promise.resolve();
+          return r.sealed !== true;
+        });
+      }
+    }
+    const r = await Protected.create({ sealed: true });
+    const result = await r.destroy();
+    expect(result).toBe(false);
+    expect(await Protected.count()).toBe(1);
+  });
+
   // Rails: test "halt callback chain with false"
   it("before save throwing abort", async () => {
     class Immutable extends Base {

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -198,8 +198,8 @@ function directInstantiate(klass: typeof Base, row: Record<string, unknown>): Ba
     (record as any)._strictLoading = true;
   }
   // Rails' init_with_attributes fires after_find then after_initialize
-  (klass as any)._callbackChain?.runAfter?.("find", record);
-  (klass as any)._callbackChain?.runAfter?.("initialize", record);
+  (klass as any)._callbackChain?.runAfter?.("find", record, { strict: "sync" });
+  (klass as any)._callbackChain?.runAfter?.("initialize", record, { strict: "sync" });
   return record;
 }
 

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -35,7 +35,7 @@ export async function touch(this: Base, ...names: string[]): Promise<boolean> {
 
   await this.updateColumns(attrs);
 
-  await ctor._callbackChain.runAfterAsync("touch", this);
+  await ctor._callbackChain.runAfter("touch", this);
   return true;
 }
 

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -170,7 +170,7 @@ async function touchDeferredAttributes(record: Base): Promise<void> {
   // Run after_touch callbacks — mirrors touch() going through Timestamp#touch
   // which fires the after_touch chain.
   const ctor = record.constructor as typeof Base;
-  await (ctor as any)._callbackChain?.runAfterAsync?.("touch", record);
+  await (ctor as any)._callbackChain?.runAfter?.("touch", record);
 }
 
 export const InstanceMethods = {


### PR DESCRIPTION
## Summary

- Collapses `runCallbacks`/`runBefore`/`runAfter` and their `*Async` twins into a single API that returns `T | Promise<T>`: synchronously when every callback and block is sync, as a Promise as soon as any callback or block returns a thenable. Async call sites (`save`/`create`/`update`/`destroy`/`touch`) simply `await` the unified runner.
- Adds a `{ strict: "sync" }` option for events that must stay synchronous (`validation`, `validate`, `initialize`, `find`). The runner throws with a clear message if any registered callback returns a Promise, replacing the previous silent fire-and-forget behavior that could let an `async` validator or initializer slip through unnoticed.
- Typed overloads narrow the return to `boolean`/`void` when `strict: "sync"` is passed, so sync callers no longer need to cast.
- Migrates all callers across `activerecord` (`base.ts`, `timestamp.ts`, `touch-later.ts`) and the validation/initialize/find paths in `activemodel`/`activerecord` to the unified API.
- Adds tests covering: fully-sync chains stay sync, async-in-before/block/after promote to async, strict mode throws, and halt semantics work across both paths.

## Test plan
- [x] `pnpm --filter @blazetrails/activemodel build`
- [x] `pnpm --filter @blazetrails/activerecord build`
- [x] `pnpm vitest run packages/activemodel/src` (1502 passed)
- [x] `pnpm vitest run packages/activerecord/src` (9274 passed, pre-existing skips unchanged)