### PR TITLE
ci: run parity jobs on schedule + main merge + `run-parity` label only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
+      parity_relevant: ${{ steps.filter.outputs.parity_relevant }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,24 +40,41 @@ jobs:
           # reliably compute a diff — fall back to running the full matrix.
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Changed files:"
           echo "$files"
           if [ -z "$files" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Any line that does NOT start with `docs/` flips the switch.
+          # docs_only: any line NOT starting with `docs/` flips the switch.
           if echo "$files" | grep -qv '^docs/'; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           else
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          fi
+          # parity_relevant: true when any change could shift Rails↔trails
+          # SQL output. Covers the parity harness itself, fixtures, the TS
+          # packages whose compiled output the runners import, the bin
+          # shims, pnpm lock (dep graph), and the workflow file itself
+          # (changing build steps is a reason to re-run). Everything else
+          # (rack, actionpack, actionview, trailties, website, top-level
+          # docs, eslint plugin, etc.) cannot affect introspection or query
+          # serialization and is skipped.
+          parity_paths='^scripts/parity/|^packages/activesupport/src/|^packages/activemodel/src/|^packages/arel/src/|^packages/activerecord/src/|^packages/activerecord/bin/|^packages/activerecord/package\.json$|^packages/activesupport/package\.json$|^packages/activemodel/package\.json$|^packages/arel/package\.json$|^package\.json$|^pnpm-lock\.yaml$|^\.github/workflows/ci\.yml$'
+          if echo "$files" | grep -qE "$parity_paths"; then
+            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
           fi
 
   build-and-typecheck:
@@ -330,7 +348,9 @@ jobs:
   schema-parity-rails:
     name: Schema Parity (Rails side)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -372,7 +392,9 @@ jobs:
   schema-parity-trails:
     name: Schema Parity (trails side)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -402,6 +424,7 @@ jobs:
       - schema-parity-trails
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true' &&
       needs.schema-parity-rails.result == 'success' &&
       needs.schema-parity-trails.result == 'success'
     runs-on: ubuntu-latest
@@ -429,7 +452,9 @@ jobs:
   query-parity-frozen-at:
     name: Query Parity (compute frozen-at)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true'
     runs-on: ubuntu-latest
     outputs:
       # Minted once per workflow run and consumed by both dump jobs so they
@@ -448,7 +473,9 @@ jobs:
     needs:
       - changes
       - query-parity-frozen-at
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true'
     runs-on: ubuntu-latest
     env:
       PARITY_FROZEN_AT: ${{ needs.query-parity-frozen-at.outputs.value }}
@@ -487,7 +514,9 @@ jobs:
     needs:
       - changes
       - query-parity-frozen-at
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true'
     runs-on: ubuntu-latest
     env:
       PARITY_FROZEN_AT: ${{ needs.query-parity-frozen-at.outputs.value }}
@@ -528,6 +557,7 @@ jobs:
       - query-parity-trails
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.parity_relevant == 'true' &&
       needs.query-parity-rails.result == 'success' &&
       needs.query-parity-trails.result == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,15 @@ jobs:
           fi
           # parity_relevant: true when any change could shift Rails↔trails
           # SQL output. Covers the parity harness itself, fixtures, the TS
-          # packages whose compiled output the runners import, the bin
-          # shims, pnpm lock (dep graph), and the workflow file itself
-          # (changing build steps is a reason to re-run). Everything else
-          # (rack, actionpack, actionview, trailties, website, top-level
-          # docs, eslint plugin, etc.) cannot affect introspection or query
-          # serialization and is skipped.
-          parity_paths='^scripts/parity/|^packages/activesupport/src/|^packages/activemodel/src/|^packages/arel/src/|^packages/activerecord/src/|^packages/activerecord/bin/|^packages/activerecord/package\.json$|^packages/activesupport/package\.json$|^packages/activemodel/package\.json$|^packages/arel/package\.json$|^package\.json$|^pnpm-lock\.yaml$|^\.github/workflows/ci\.yml$'
+          # packages whose compiled output the runners import, their build
+          # configs (root + per-package tsconfig — tsconfig edits change
+          # emitted JS and can break the runners), the bin shims, pnpm lock
+          # (dep graph), and the workflow file itself (changing build steps
+          # is a reason to re-run). Everything else (rack, actionpack,
+          # actionview, trailties, website, top-level docs, eslint plugin,
+          # etc.) cannot affect introspection or query serialization and
+          # is skipped.
+          parity_paths='^scripts/parity/|^packages/activesupport/src/|^packages/activemodel/src/|^packages/arel/src/|^packages/activerecord/src/|^packages/activerecord/bin/|^packages/activesupport/package\.json$|^packages/activemodel/package\.json$|^packages/arel/package\.json$|^packages/activerecord/package\.json$|^packages/activesupport/tsconfig\.json$|^packages/activemodel/tsconfig\.json$|^packages/arel/tsconfig\.json$|^packages/activerecord/tsconfig\.json$|^package\.json$|^tsconfig\.json$|^pnpm-lock\.yaml$|^\.github/workflows/ci\.yml$'
           if echo "$files" | grep -qE "$parity_paths"; then
             echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
-    # parity-relevant PRs. Monday 06:00 UTC is off-peak on a ubuntu runner.
+    # parity-relevant PRs. Monday 06:00 UTC is off-peak on an Ubuntu runner.
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
@@ -83,7 +83,11 @@ jobs:
               echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
               ;;
             pull_request)
-              if echo "$PR_LABELS" | jq -e '.[].name == "run-parity"' >/dev/null; then
+              # `any(.[]; ...)` rather than `.[].name == "..."` because the
+              # latter emits one boolean per label and `jq -e`'s exit status
+              # reflects only the last element — so a PR with labels
+              # ["run-parity", "bug"] would miss.
+              if echo "$PR_LABELS" | jq -e 'any(.[]; .name == "run-parity")' >/dev/null; then
                 echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
               else
                 echo "parity_relevant=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `labeled` fires so parity jobs can be opted in via a PR label
+    # without pushing a new commit. `run-parity` is the label name
+    # matched in the `changes` job below.
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # Weekly post-merge sweep so slow regressions can't hide between
+    # parity-relevant PRs. Monday 06:00 UTC is off-peak on a ubuntu runner.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 jobs:
   # Preflight that sets `docs_only=true` when every changed path is under
@@ -26,6 +35,10 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          # Labels live on the PR even when the firing event is `labeled`,
+          # `synchronize`, etc., so we can scan them uniformly.
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -40,44 +53,46 @@ jobs:
           # reliably compute a diff — fall back to running the full matrix.
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
+          elif ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Changed files:"
-          echo "$files"
-          if [ -z "$files" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # docs_only: any line NOT starting with `docs/` flips the switch.
-          if echo "$files" | grep -qv '^docs/'; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
           else
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            echo "$files"
+            # docs_only: any line NOT starting with `docs/` flips the switch.
+            if [ -z "$files" ]; then
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            elif echo "$files" | grep -qv '^docs/'; then
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
-          # parity_relevant: true when any change could shift Rails↔trails
-          # SQL output. Covers the parity harness itself, fixtures, the TS
-          # packages whose compiled output the runners import, their build
-          # configs (root + per-package tsconfig — tsconfig edits change
-          # emitted JS and can break the runners), the bin shims, pnpm lock
-          # (dep graph), and the workflow file itself (changing build steps
-          # is a reason to re-run). Everything else (rack, actionpack,
-          # actionview, trailties, website, top-level docs, eslint plugin,
-          # etc.) cannot affect introspection or query serialization and
-          # is skipped.
-          parity_paths='^scripts/parity/|^packages/activesupport/src/|^packages/activemodel/src/|^packages/arel/src/|^packages/activerecord/src/|^packages/activerecord/bin/|^packages/activesupport/package\.json$|^packages/activemodel/package\.json$|^packages/arel/package\.json$|^packages/activerecord/package\.json$|^packages/activesupport/tsconfig\.json$|^packages/activemodel/tsconfig\.json$|^packages/arel/tsconfig\.json$|^packages/activerecord/tsconfig\.json$|^package\.json$|^tsconfig\.json$|^pnpm-lock\.yaml$|^\.github/workflows/ci\.yml$'
-          if echo "$files" | grep -qE "$parity_paths"; then
-            echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
-          fi
+          # parity_relevant: the Rails↔trails parity sweep is expensive
+          # (~15-20 CI minutes of setup across 7 jobs), and almost every
+          # PR touches `packages/*/src/**`, so a path filter would still
+          # run it nearly every time. Instead run on:
+          #   - `push` to main (catches regressions immediately after merge)
+          #   - weekly `schedule` cron (catches slow drifts between pushes)
+          #   - manual `workflow_dispatch` (debugging)
+          #   - PRs carrying the `run-parity` label (opt-in per PR when
+          #     the author knows their change could shift SQL output)
+          # Plain PRs without the label skip all 7 parity jobs.
+          case "${{ github.event_name }}" in
+            push|schedule|workflow_dispatch)
+              echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
+              ;;
+            pull_request)
+              if echo "$PR_LABELS" | jq -e '.[].name == "run-parity"' >/dev/null; then
+                echo "parity_relevant=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "parity_relevant=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
   build-and-typecheck:
     name: Build & Type Check


### PR DESCRIPTION
## Problem

The 7 parity jobs (`schema-parity-{rails,trails,diff}` and `query-parity-{frozen-at,rails,trails,diff}`) pay ~15–20 CI minutes of setup per PR before doing any work. Path filtering was the initial fix, but almost every PR touches `packages/{activesupport,activemodel,arel,activerecord}/src/**`, so the filter would still fire on nearly every push.

## Fix

Run parity jobs on these triggers only:

| Trigger | When | Why |
|---|---|---|
| `push` to `main` | post-merge | Catches regressions immediately after they land |
| `schedule` weekly cron (Mon 06:00 UTC) | always | Catches slow drifts between pushes; off-peak runner time |
| `workflow_dispatch` | manual | Debugging |
| `pull_request` with `run-parity` label | opt-in | Author knows their change could shift SQL output |

The `pull_request` trigger type list now includes `labeled`, so adding the `run-parity` label to a PR fires the sweep without needing a new commit.

Regular PRs skip all 7 parity jobs by default.

## Branch protection stays green

Aggregator `CI` job treats `skipped` as success. Branch protection points at `CI`, not the individual parity jobs.

## Recovery

If a slow drift sneaks in between the weekly runs, `workflow_dispatch` runs the sweep manually on any ref. Add `run-parity` to any PR for a pre-merge check.