### PR TITLE
feat(activemodel): PR 22d — String cast true/false to "t"/"f"

### DIFF
--- a/packages/activemodel/src/misc.test.ts
+++ b/packages/activemodel/src/misc.test.ts
@@ -387,9 +387,13 @@ describe("ActiveModel", () => {
 
     // -- Acceptance --
     describe("acceptance", () => {
+      // Rails' equivalent uses a virtual attribute; boolean here so `"1"` /
+      // `true` round-trip through cast as `true` and match the default accept
+      // list `["1", true]`, whereas a string-typed attr would cast `true` to
+      // "t" (per type/immutable_string.rb) and rightly fail.
       class Terms extends Model {
         static {
-          this.attribute("accepted", "string");
+          this.attribute("accepted", "boolean");
           this.validates("accepted", { acceptance: true });
         }
       }

--- a/packages/activemodel/src/type/immutable-string.test.ts
+++ b/packages/activemodel/src/type/immutable-string.test.ts
@@ -9,6 +9,14 @@ describe("ImmutableStringTest", () => {
     expect(Object.isFrozen(result)).toBe(true);
   });
 
+  it("casts booleans to the PG literal form", () => {
+    // Rails type/immutable_string.rb#cast_value:
+    //   case value when true then "t"; when false then "f"; else value.to_s
+    const type = Types.typeRegistry.lookup("immutable_string");
+    expect(type.cast(true)).toBe("t");
+    expect(type.cast(false)).toBe("f");
+  });
+
   it("immutable strings are not duped coming out", () => {
     const type = Types.typeRegistry.lookup("immutable_string");
     const a = type.cast("hello");

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -9,6 +9,14 @@ export class ImmutableStringType extends ValueType<string> {
 
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;
+    // Rails type/immutable_string.rb#cast_value:
+    //   case value
+    //   when true  then "t"
+    //   when false then "f"
+    //   else value.to_s
+    //   end
+    if (value === true) return Object.freeze("t") as string;
+    if (value === false) return Object.freeze("f") as string;
     const str = String(value);
     return Object.freeze(str) as string;
   }

--- a/packages/activemodel/src/type/string.test.ts
+++ b/packages/activemodel/src/type/string.test.ts
@@ -4,8 +4,10 @@ import { Types } from "../index.js";
 describe("StringTest", () => {
   it("type casting", () => {
     const type = new Types.StringType();
-    expect(type.cast(true)).toBe("true");
-    expect(type.cast(false)).toBe("false");
+    // Rails type/string.rb inherits from type/immutable_string.rb#cast_value,
+    // which maps true/false to the PG literal form "t"/"f".
+    expect(type.cast(true)).toBe("t");
+    expect(type.cast(false)).toBe("f");
     expect(type.cast(123)).toBe("123");
   });
 

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -5,6 +5,11 @@ export class StringType extends ImmutableStringType {
 
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;
+    // StringType inherits the boolean-literal casting from
+    // ImmutableStringType (type/string.rb subclasses immutable_string.rb):
+    // `true` -> "t", `false` -> "f".
+    if (value === true) return "t";
+    if (value === false) return "f";
     return String(value);
   }
 

--- a/packages/activemodel/src/type/string.ts
+++ b/packages/activemodel/src/type/string.ts
@@ -5,11 +5,11 @@ export class StringType extends ImmutableStringType {
 
   cast(value: unknown): string | null {
     if (value === null || value === undefined) return null;
-    // StringType inherits the boolean-literal casting from
-    // ImmutableStringType (type/string.rb subclasses immutable_string.rb):
-    // `true` -> "t", `false` -> "f".
-    if (value === true) return "t";
-    if (value === false) return "f";
+    // Rails type/string.rb subclasses immutable_string.rb, so the
+    // boolean `true -> "t"` / `false -> "f"` mapping lives in the
+    // superclass. Freezing is a no-op on primitive strings, so there's
+    // no behavior lost by delegating the bool branch.
+    if (typeof value === "boolean") return super.cast(value);
     return String(value);
   }
 

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -119,6 +119,19 @@ describe("AcceptanceValidationTest", () => {
     expect(p2.isValid()).toBe(true);
   });
 
+  it("validates acceptance with a scalar accept option", () => {
+    // Rails' `acceptable_option?` does `Array(options[:accept]).include?(value)`,
+    // so a non-array `accept:` is normalized to a one-element list.
+    class Terms extends Model {
+      static {
+        this.attribute("terms", "string");
+        this.validates("terms", { acceptance: { accept: "yes" } });
+      }
+    }
+    expect(new Terms({ terms: "yes" }).isValid()).toBe(true);
+    expect(new Terms({ terms: "y" }).isValid()).toBe(false);
+  });
+
   it("setup! auto-defines attribute when not explicitly declared", () => {
     class Agreement extends Model {
       static {

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -94,9 +94,15 @@ describe("AcceptanceValidationTest", () => {
   });
 
   it("validates acceptance of true", () => {
+    // Rails' Topic uses `attr_accessor :terms_of_service`, preserving the
+    // assigned value without casting; its tests rely on `true` matching the
+    // default accept list `["1", true]`. Our Model requires a declared
+    // attribute, so use `boolean` here — `true` round-trips through cast.
+    // A `string`-typed attribute would cast `true` to "t" (per
+    // type/immutable_string.rb) and rightly not match the default list.
     class Terms extends Model {
       static {
-        this.attribute("terms", "string");
+        this.attribute("terms", "boolean");
         this.validates("terms", { acceptance: true });
       }
     }

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -132,6 +132,20 @@ describe("AcceptanceValidationTest", () => {
     expect(new Terms({ terms: "y" }).isValid()).toBe(false);
   });
 
+  it("validates acceptance with an iterable (Set) accept option", () => {
+    // Rails' `Array(options[:accept])` coerces via `to_a`, so a Set/Enumerator
+    // should be spread into the list of accepted values.
+    class Terms extends Model {
+      static {
+        this.attribute("terms", "string");
+        this.validates("terms", { acceptance: { accept: new Set(["yes", "ok"]) } });
+      }
+    }
+    expect(new Terms({ terms: "yes" }).isValid()).toBe(true);
+    expect(new Terms({ terms: "ok" }).isValid()).toBe(true);
+    expect(new Terms({ terms: "no" }).isValid()).toBe(false);
+  });
+
   it("setup! auto-defines attribute when not explicitly declared", () => {
     class Agreement extends Model {
       static {

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -28,6 +28,16 @@ export class LazilyDefineAttributes {
   }
 }
 
+/**
+ * Ruby `Array()` coerces any object with `to_a`/`to_ary` (Set, Enumerator,
+ * Hash, etc.) into an array, but leaves strings wrapped as `[str]`. Match
+ * that: if the value is iterable but not a string, spread it.
+ */
+function isNonStringIterable(value: unknown): value is Iterable<unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  return typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function";
+}
+
 export class AcceptanceValidator extends EachValidator {
   static readonly lazilyDefineAttributes = new LazilyDefineAttributes([]);
 
@@ -48,6 +58,7 @@ export class AcceptanceValidator extends EachValidator {
       const rawAccept = this.options.accept;
       if (rawAccept === null || rawAccept === undefined) accepted = [];
       else if (Array.isArray(rawAccept)) accepted = rawAccept;
+      else if (isNonStringIterable(rawAccept)) accepted = Array.from(rawAccept);
       else accepted = [rawAccept];
     }
     if (!accepted.includes(value)) {

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -34,7 +34,9 @@ export class AcceptanceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
-    const accepted = (this.options.accept as unknown[]) ?? ["1", "true", true];
+    // Rails activemodel/lib/active_model/validations/acceptance.rb initializer:
+    //   super({ allow_nil: true, accept: ["1", true] }.merge!(options))
+    const accepted = (this.options.accept as unknown[]) ?? ["1", true];
     if (!accepted.includes(value)) {
       record.errors.add(attribute, "accepted", { message: this.options.message });
     }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -38,8 +38,12 @@ export class AcceptanceValidator extends EachValidator {
     // `acceptable_option?` calls `Array(options[:accept]).include?(value)`,
     // so a scalar `accept:` still works. Normalize here with the same shape.
     const rawAccept = this.options.accept;
-    const accepted: unknown[] =
-      rawAccept === undefined ? ["1", true] : Array.isArray(rawAccept) ? rawAccept : [rawAccept];
+    let accepted: unknown[];
+    if (rawAccept === undefined) accepted = ["1", true];
+    else if (rawAccept === null)
+      accepted = []; // Rails `Array(nil) #=> []`
+    else if (Array.isArray(rawAccept)) accepted = rawAccept;
+    else accepted = [rawAccept];
     if (!accepted.includes(value)) {
       record.errors.add(attribute, "accepted", { message: this.options.message });
     }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -34,9 +34,12 @@ export class AcceptanceValidator extends EachValidator {
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
-    // Rails activemodel/lib/active_model/validations/acceptance.rb initializer:
-    //   super({ allow_nil: true, accept: ["1", true] }.merge!(options))
-    const accepted = (this.options.accept as unknown[]) ?? ["1", true];
+    // Rails activemodel/lib/active_model/validations/acceptance.rb
+    // `acceptable_option?` calls `Array(options[:accept]).include?(value)`,
+    // so a scalar `accept:` still works. Normalize here with the same shape.
+    const rawAccept = this.options.accept;
+    const accepted: unknown[] =
+      rawAccept === undefined ? ["1", true] : Array.isArray(rawAccept) ? rawAccept : [rawAccept];
     if (!accepted.includes(value)) {
       record.errors.add(attribute, "accepted", { message: this.options.message });
     }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -35,6 +35,9 @@ export class LazilyDefineAttributes {
  */
 function isNonStringIterable(value: unknown): value is Iterable<unknown> {
   if (typeof value !== "object" || value === null) return false;
+  // Boxed strings (`new String("yes")`) are iterable by char; Ruby's
+  // `Array("yes")` still wraps as `["yes"]`, so treat them as scalars.
+  if (value instanceof String) return false;
   return typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function";
 }
 

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -37,13 +37,19 @@ export class AcceptanceValidator extends EachValidator {
     // Rails activemodel/lib/active_model/validations/acceptance.rb
     // `acceptable_option?` calls `Array(options[:accept]).include?(value)`,
     // so a scalar `accept:` still works. Normalize here with the same shape.
-    const rawAccept = this.options.accept;
+    // Rails checks key presence via `options.key?(:accept)`, so an explicit
+    // `accept: nil` is treated as `Array(nil) #=> []` (rejects everything)
+    // rather than falling back to the default. Mirror that with a hasOwn
+    // check on this.options.
+    const hasAccept = Object.prototype.hasOwnProperty.call(this.options, "accept");
     let accepted: unknown[];
-    if (rawAccept === undefined) accepted = ["1", true];
-    else if (rawAccept === null)
-      accepted = []; // Rails `Array(nil) #=> []`
-    else if (Array.isArray(rawAccept)) accepted = rawAccept;
-    else accepted = [rawAccept];
+    if (!hasAccept) accepted = ["1", true];
+    else {
+      const rawAccept = this.options.accept;
+      if (rawAccept === null || rawAccept === undefined) accepted = [];
+      else if (Array.isArray(rawAccept)) accepted = rawAccept;
+      else accepted = [rawAccept];
+    }
     if (!accepted.includes(value)) {
       record.errors.add(attribute, "accepted", { message: this.options.message });
     }


### PR DESCRIPTION
## Summary
Closes the remaining gap from the audit's PR 22 cluster:

- `ImmutableString`/`String` `cast(true)` now returns `"t"` and `cast(false)` returns `"f"`, mirroring `activemodel/lib/active_model/type/immutable_string.rb:19-26`.
- `AcceptanceValidator` default accept list realigned to Rails' `["1", true]` (activemodel/lib/active_model/validations/acceptance.rb initializer). The prior `["1", "true", true]` was a workaround for our old (wrong) string cast.
- Two tests that set `terms: true` against a `string`-typed attribute switched to `boolean` — the Rails originals use plain `attr_accessor` so `true` round-trips; a `string`-typed attribute here would (correctly) cast to `"t"` and miss the accept list.

## Test plan
- [x] AM 1,494 / AR 9,274 all pass
- [x] typecheck + lint clean