### PR TITLE
fix(arel): uppercase EXTRACT field to match Rails (parity arel-36)

### DIFF
--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -11,6 +11,16 @@ describe("Arel::Nodes::ExtractTest", () => {
     expect(sql).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
 
+  it("uppercases a lowercase field to match Rails", () => {
+    // Rails' visit_Arel_Nodes_Extract does `o.field.to_s.upcase`, so the
+    // field identifier in the emitted SQL is always uppercased regardless
+    // of how it was constructed.
+    const createdAt = users.get("created_at");
+    const node = new Nodes.Extract(createdAt, "month");
+    const sql = new Visitors.ToSql().compile(node);
+    expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at")');
+  });
+
   describe("as", () => {
     it("should alias the extract", () => {
       const createdAt = users.get("created_at");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -991,7 +991,7 @@ export class ToSql implements NodeVisitor<SQLString> {
   // -- Extract --
 
   private visitExtract(node: Nodes.Extract): SQLString {
-    this.collector.append(`EXTRACT(${node.field} FROM `);
+    this.collector.append(`EXTRACT(${String(node.field).toUpperCase()} FROM `);
     if (node.expr instanceof Node) {
       this.visit(node.expr);
     } else if (node.expr !== null && node.expr !== undefined) {

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -31,10 +31,6 @@
     "side": "trails-missing",
     "reason": "(~users[:bitmap]).gt(0): trails Nodes.BitwiseNot does not implement predication methods (no .gt/.lt/.eq chain)."
   },
-  "arel-36": {
-    "side": "diff",
-    "reason": "EXTRACT(MONTH FROM ...) vs EXTRACT(month FROM ...): trails ToSql visitor emits the EXTRACT field in the casing it was constructed with (lowercase in fixture); Rails uppercases."
-  },
   "arel-44": {
     "side": "diff",
     "reason": "subquery alias quoting: Rails emits the alias bare (sub); trails emits the quoted identifier (\"sub\"). Real ToSql visitor divergence."


### PR DESCRIPTION
## Summary

Rails' `ToSql` visitor emits `EXTRACT(MONTH FROM ...)` — the field always uppercased. Trails was passing through the casing the field was constructed with (`EXTRACT(month FROM ...)`). One-line fix in `visitExtract` + drop `arel-36` from the parity known-gaps list.

Leaves `arel-17` (SQLite `IS NOT`) and `arel-44` (subquery alias quoting) as gaps — those need either a SQLite-routed visitor at parity-runner level or a redesign of how `Node#toSql()` picks a visitor; outside the scope of this PR.

## Test plan
- [x] `pnpm vitest run packages/arel/src` — 1000/1000 passed
- [x] `pnpm parity:query` — arel-36 flips to PASS, 43/69 overall (was 42/69)