### PR TITLE
feat(activemodel): PR 15 — per-attribute Dirty generated methods

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -130,6 +130,55 @@ export function attribute(
       configurable: true,
     });
   }
+
+  defineDirtyAttributeMethods(this.prototype, name);
+}
+
+/**
+ * Generate per-attribute dirty methods on the prototype, mirroring the
+ * method cascade Rails produces via `attribute_method_suffix` /
+ * `attribute_method_affix` declarations in
+ * activemodel/lib/active_model/dirty.rb.
+ *
+ * For an attribute `name` the generated methods are:
+ *   nameChanged, nameChange, nameWas,
+ *   nameInDatabase, nameBeforeLastSave,
+ *   namePreviouslyChanged, namePreviousChange, namePreviouslyWas,
+ *   savedChangeToName, willSaveChangeToName,
+ *   restoreName
+ *
+ * Each forwards to the corresponding generic `attributeX(name, ...)` on
+ * Model, so subclasses can override the generic and have the
+ * per-attribute form pick up the change automatically. Skips any method
+ * that already exists on the prototype (e.g. user-defined).
+ */
+function defineDirtyAttributeMethods(prototype: object, attrName: string): void {
+  const cap = attrName.charAt(0).toUpperCase() + attrName.slice(1);
+  const binding: Array<[string, string]> = [
+    [`${attrName}Changed`, "attributeChanged"],
+    [`${attrName}Change`, "attributeChange"],
+    [`${attrName}Was`, "attributeWas"],
+    [`${attrName}InDatabase`, "attributeInDatabase"],
+    [`${attrName}BeforeLastSave`, "attributeBeforeLastSave"],
+    [`${attrName}PreviouslyChanged`, "attributePreviouslyChanged"],
+    [`${attrName}PreviousChange`, "attributePreviousChange"],
+    [`${attrName}PreviouslyWas`, "attributePreviouslyWas"],
+    [`savedChangeTo${cap}`, "savedChangeToAttribute"],
+    [`willSaveChangeTo${cap}`, "willSaveChangeToAttribute"],
+    [`restore${cap}`, "restoreAttribute"],
+  ];
+  for (const [methodName, target] of binding) {
+    if (Object.prototype.hasOwnProperty.call(prototype, methodName)) continue;
+    if (methodName in prototype) continue; // inherited; user/framework took it
+    Object.defineProperty(prototype, methodName, {
+      value: function (this: Record<string, unknown>, ...args: unknown[]) {
+        const fn = (this as unknown as Record<string, (...a: unknown[]) => unknown>)[target];
+        return fn.call(this, attrName, ...args);
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activemodel/src/dirty-generated-methods.test.ts
+++ b/packages/activemodel/src/dirty-generated-methods.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "./index.js";
+
+/**
+ * Covers the per-attribute dirty method cascade generated when a typed
+ * attribute is declared. Mirrors the ActiveModel::Dirty-generated
+ * methods in activemodel/lib/active_model/dirty.rb:
+ *   name_changed?, name_change, name_was, name_in_database,
+ *   name_before_last_save, name_previously_changed?, name_previous_change,
+ *   name_previously_was, saved_change_to_name, will_save_change_to_name,
+ *   restore_name!
+ */
+describe("DirtyGeneratedMethods", () => {
+  class Person extends Model {
+    static {
+      this.attribute("name", "string");
+      this.attribute("age", "integer");
+    }
+  }
+
+  it("<attr>Changed returns true after assignment", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    expect((p as any).nameChanged()).toBe(false);
+    (p as any).name = "Bob";
+    expect((p as any).nameChanged()).toBe(true);
+    expect((p as any).ageChanged()).toBe(false);
+  });
+
+  it("<attr>Change returns [old, new]", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    expect((p as any).nameChange()).toEqual(["Alice", "Bob"]);
+  });
+
+  it("<attr>Was returns the pre-change value", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    expect((p as any).nameWas()).toBe("Alice");
+  });
+
+  it("<attr>InDatabase returns the persisted value", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    expect((p as any).nameInDatabase()).toBe("Alice");
+  });
+
+  it("<attr>BeforeLastSave surfaces the prior persisted value", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    expect((p as any).nameBeforeLastSave()).toBe("Alice");
+  });
+
+  it("<attr>PreviouslyChanged and <attr>PreviousChange reflect the last save", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    expect((p as any).namePreviouslyChanged()).toBe(true);
+    expect((p as any).namePreviousChange()).toEqual(["Alice", "Bob"]);
+  });
+
+  it("<attr>PreviouslyWas is the pre-save value from the last save", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    expect((p as any).namePreviouslyWas()).toBe("Alice");
+  });
+
+  it("savedChangeTo<Attr> and willSaveChangeTo<Attr> follow save lifecycle", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    expect((p as any).willSaveChangeToName()).toBe(true);
+    expect((p as any).savedChangeToName()).toBe(false);
+    p.changesApplied();
+    expect((p as any).willSaveChangeToName()).toBe(false);
+    expect((p as any).savedChangeToName()).toBe(true);
+  });
+
+  it("restore<Attr> rolls back a single attribute only", () => {
+    const p = new Person({ name: "Alice", age: 30 });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    (p as any).age = 40;
+    (p as any).restoreName();
+    expect((p as any).name).toBe("Alice");
+    expect((p as any).nameChanged()).toBe(false);
+    expect((p as any).age).toBe(40);
+    expect((p as any).ageChanged()).toBe(true);
+  });
+
+  it("does not shadow user-defined methods of the same name", () => {
+    class Account extends Model {
+      static {
+        this.attribute("balance", "integer");
+      }
+      balanceChanged(): string {
+        return "user override";
+      }
+    }
+    const a = new Account({ balance: 100 });
+    expect((a as any).balanceChanged()).toBe("user override");
+  });
+});

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -149,14 +149,33 @@ export class DirtyTracker {
     delete?(name: string): boolean;
   }): void {
     for (const [name] of this._changedAttributes) {
-      if (!this._originalHas.has(name)) {
-        // Attribute was absent — remove it rather than setting undefined
-        attributes.delete?.(name);
-      } else {
-        const original = resolveValue(this._originalAttributes.get(name));
-        attributes.set(name, original);
-      }
+      this._restoreOne(attributes, name);
     }
     this._changedAttributes.clear();
+  }
+
+  /**
+   * Restore a single attribute to its pre-change value, matching Rails
+   * `ActiveModel::Dirty#restore_attribute!(attr)` (activemodel/lib/active_model/dirty.rb).
+   */
+  restoreAttribute(
+    attributes: { set(name: string, value: unknown): void; delete?(name: string): boolean },
+    name: string,
+  ): void {
+    if (!this._changedAttributes.has(name)) return;
+    this._restoreOne(attributes, name);
+    this._changedAttributes.delete(name);
+  }
+
+  private _restoreOne(
+    attributes: { set(name: string, value: unknown): void; delete?(name: string): boolean },
+    name: string,
+  ): void {
+    if (!this._originalHas.has(name)) {
+      attributes.delete?.(name);
+    } else {
+      const original = resolveValue(this._originalAttributes.get(name));
+      attributes.set(name, original);
+    }
   }
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1618,6 +1618,26 @@ export class Model {
     this._dirty.restore(this._attributes);
   }
 
+  /**
+   * Restore a single attribute to its pre-change value.
+   *
+   * Mirrors: ActiveModel::Dirty#restore_attribute!
+   */
+  restoreAttribute(name: string): void {
+    this._dirty.restoreAttribute(this._attributes, name);
+  }
+
+  /**
+   * Before/after tuple of a saved change for `name`, or undefined if the
+   * attribute wasn't changed in the last save.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_previous_change (returned as
+   * the hash pair by `attribute_previously_was` / `saved_change_to_attribute`).
+   */
+  attributePreviousChange(name: string): [unknown, unknown] | undefined {
+    return this._dirty.previousChanges[name];
+  }
+
   changesApplied(): void {
     this._dirty.changesApplied(this._attributes);
   }


### PR DESCRIPTION
## Summary
Rails' `ActiveModel::Dirty` generates a per-attribute method cascade via `attribute_method_suffix`/`attribute_method_affix` declarations (`activemodel/lib/active_model/dirty.rb`). Our port only exposed the generic forms (`attributeChanged`, `attributeWas`, etc.); downstream consumers expect `record.nameChanged()` / `savedChangeToName()` / `restoreName()`.

When `attribute(...)` is declared, generate 10 per-attribute forwarders on the prototype that delegate to the matching generic method:

- `nameChanged`, `nameChange`, `nameWas`
- `nameInDatabase`, `nameBeforeLastSave`
- `namePreviouslyChanged`, `namePreviousChange`, `namePreviouslyWas`
- `savedChangeToName`, `willSaveChangeToName`
- `restoreName`

New supporting methods on Model + DirtyTracker:
- `restoreAttribute(name)` — per-attribute rollback
- `attributePreviousChange(name)` — [old, new] tuple of the last save

Generation skips any method already on the prototype, so user overrides win.

PR 16 (`mutations_from_database` vs `mutations_before_last_save` split) is a separate follow-up.

## Test plan
- [x] 10 new tests in `dirty-generated-methods.test.ts`
- [x] AM 1,525 / AR 9,282 all pass
- [x] typecheck + lint clean