### PR TITLE
refactor(arel): Predications + Math mixins on expression-valued nodes (parity arel-24–30, arel-47)

### DIFF
--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -26,6 +26,25 @@ registerNodeDeps({ Not, Grouping, Or, And, ToSql });
 registerBinaryInversions({ Equality, In });
 _registerCteFactory((name, relation) => new Cte(name, relation));
 
+// Mix Predications + Math into NodeExpression (so every expression-valued
+// node — Function, Unary, Case, Casted, ...) and into InfixOperation
+// separately (it extends Binary, not NodeExpression). Done here at package
+// init rather than inside node-expression.ts / infix-operation.ts because
+// the mixin modules transitively import those files via their target-node
+// imports, creating a module-load cycle.
+import { include } from "@blazetrails/activesupport";
+import { NodeExpression } from "./nodes/node-expression.js";
+import { InfixOperation } from "./nodes/infix-operation.js";
+import { Predications } from "./predications.js";
+import { Math as MathMixin } from "./math.js";
+/* eslint-disable @typescript-eslint/no-explicit-any -- abstract class coercion for include() */
+const _NodeExpression = NodeExpression as unknown as new (...args: any[]) => NodeExpression;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+include(_NodeExpression, Predications);
+include(_NodeExpression, MathMixin);
+include(InfixOperation, Predications);
+include(InfixOperation, MathMixin);
+
 /**
  * Arel.sql() — escape hatch for raw SQL.
  *

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -1,4 +1,4 @@
-import { Node } from "./nodes/node.js";
+import type { Node } from "./nodes/node.js";
 import {
   Addition,
   Subtraction,

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -1,8 +1,52 @@
-import type { Node } from "./nodes/node.js";
+import { Node } from "./nodes/node.js";
+import {
+  Addition,
+  Subtraction,
+  Multiplication,
+  Division,
+  BitwiseAnd,
+  BitwiseOr,
+  BitwiseXor,
+  BitwiseShiftLeft,
+  BitwiseShiftRight,
+} from "./nodes/infix-operation.js";
+import { Grouping } from "./nodes/grouping.js";
+import { buildQuoted } from "./nodes/casted.js";
 
-export interface Math {
-  add(other: unknown): Node;
-  subtract(other: unknown): Node;
-  multiply(other: unknown): Node;
-  divide(other: unknown): Node;
-}
+/**
+ * Math — arithmetic mixin.
+ *
+ * Mirrors: Arel::Math (activerecord/lib/arel/math.rb). `+` and `-` wrap
+ * in Grouping so precedence is preserved when the result is further
+ * chained (`a + b - c` becomes `(a + b) - c` via nested Groupings);
+ * `*` and `/` do not — same as Rails.
+ */
+export const Math = {
+  add(this: Node, other: unknown): Grouping {
+    return new Grouping(new Addition(this, buildQuoted(other)));
+  },
+  subtract(this: Node, other: unknown): Grouping {
+    return new Grouping(new Subtraction(this, buildQuoted(other)));
+  },
+  multiply(this: Node, other: unknown): Multiplication {
+    return new Multiplication(this, buildQuoted(other));
+  },
+  divide(this: Node, other: unknown): Division {
+    return new Division(this, buildQuoted(other));
+  },
+  bitwiseAnd(this: Node, other: unknown): Grouping {
+    return new Grouping(new BitwiseAnd(this, buildQuoted(other)));
+  },
+  bitwiseOr(this: Node, other: unknown): Grouping {
+    return new Grouping(new BitwiseOr(this, buildQuoted(other)));
+  },
+  bitwiseXor(this: Node, other: unknown): Grouping {
+    return new Grouping(new BitwiseXor(this, buildQuoted(other)));
+  },
+  bitwiseShiftLeft(this: Node, other: unknown): Grouping {
+    return new Grouping(new BitwiseShiftLeft(this, buildQuoted(other)));
+  },
+  bitwiseShiftRight(this: Node, other: unknown): Grouping {
+    return new Grouping(new BitwiseShiftRight(this, buildQuoted(other)));
+  },
+};

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -1,5 +1,5 @@
 import { Node, NodeVisitor } from "./node.js";
-import { NodeExpression } from "./node-expression.js";
+import { NodeExpression, registerBuildQuoted } from "./node-expression.js";
 import type { Attribute } from "../attributes/attribute.js";
 import { ATTRIBUTE_BRAND } from "./binary.js";
 import { BindParam } from "./bind-param.js";
@@ -38,6 +38,8 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (isAttribute(attribute)) return new Casted(other, attribute as Attribute);
   return new Quoted(other);
 }
+
+registerBuildQuoted(buildQuoted);
 
 function isAttribute(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -6,8 +6,6 @@ import { buildQuoted } from "./casted.js";
 import { Ascending } from "./ascending.js";
 import { Descending } from "./descending.js";
 import type { Included } from "@blazetrails/activesupport";
-import type { Predications } from "../predications.js";
-import type { Math as MathMixin } from "../math.js";
 
 /**
  * Represents a custom infix operation: left OP right.
@@ -137,5 +135,11 @@ export class Overlaps extends InfixOperation {
 // the Predications + Math method surfaces mixed in from index.ts via
 // `include()`. The runtime wiring lives there to avoid a circular module
 // cycle between infix-operation.ts and math.ts.
+// Inline `typeof import(...)` keeps the mixin modules out of this file's
+// static import graph (math.ts imports InfixOperation for its class
+// references; a static reverse import would cycle).
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface InfixOperation extends Included<typeof Predications>, Included<typeof MathMixin> {}
+export interface InfixOperation
+  extends
+    Included<typeof import("../predications.js").Predications>,
+    Included<typeof import("../math.js").Math> {}

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -2,12 +2,19 @@ import { Node, NodeVisitor } from "./node.js";
 import { Binary } from "./binary.js";
 import { As } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
+import { buildQuoted } from "./casted.js";
+import { Ascending } from "./ascending.js";
+import { Descending } from "./descending.js";
+import type { Included } from "@blazetrails/activesupport";
+import type { Predications } from "../predications.js";
+import type { Math as MathMixin } from "../math.js";
 
 /**
  * Represents a custom infix operation: left OP right.
  *
  * Mirrors: Arel::Nodes::InfixOperation
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class InfixOperation extends Binary {
   readonly operator: string;
   readonly left: Node;
@@ -20,8 +27,24 @@ export class InfixOperation extends Binary {
     this.right = right;
   }
 
+  /**
+   * Mirrors: Arel::Predications#quoted_node. No type-cast context on an
+   * InfixOperation — fall through to a plain Quoted wrap.
+   */
+  quotedNode(other: unknown): Node {
+    return buildQuoted(other, this);
+  }
+
   as(aliasName: string): As {
     return new As(this, new SqlLiteral(aliasName));
+  }
+
+  asc(): Ascending {
+    return new Ascending(this);
+  }
+
+  desc(): Descending {
+    return new Descending(this);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {
@@ -109,3 +132,10 @@ export class Overlaps extends InfixOperation {
     super("&&", left, right);
   }
 }
+
+// Declaration merging: tell TypeScript that InfixOperation instances carry
+// the Predications + Math method surfaces mixed in from index.ts via
+// `include()`. The runtime wiring lives there to avoid a circular module
+// cycle between infix-operation.ts and math.ts.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface InfixOperation extends Included<typeof Predications>, Included<typeof MathMixin> {}

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -1,18 +1,8 @@
 import { Node, NodeVisitor } from "./node.js";
 import { Function } from "./function.js";
-import { Addition, Subtraction, Multiplication, Division } from "./infix-operation.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Over } from "./over.js";
 import { NamedWindow, Window } from "./window.js";
-import { Grouping } from "./grouping.js";
-import { Quoted } from "./casted.js";
-import {
-  BitwiseAnd,
-  BitwiseOr,
-  BitwiseXor,
-  BitwiseShiftLeft,
-  BitwiseShiftRight,
-} from "./infix-operation.js";
 
 /**
  * NamedFunction — a SQL function call, e.g. COUNT(*), SUM(x).
@@ -42,47 +32,5 @@ export class NamedFunction extends Function {
 
   accept<T>(visitor: NodeVisitor<T>): T {
     return visitor.visit(this);
-  }
-
-  // -- Math --
-
-  private buildQuoted(other: unknown): Node {
-    return other instanceof Node ? other : new Quoted(other);
-  }
-
-  add(other: unknown): Grouping {
-    return new Grouping(new Addition(this, this.buildQuoted(other)));
-  }
-
-  subtract(other: unknown): Grouping {
-    return new Grouping(new Subtraction(this, this.buildQuoted(other)));
-  }
-
-  multiply(other: unknown): Multiplication {
-    return new Multiplication(this, this.buildQuoted(other));
-  }
-
-  divide(other: unknown): Division {
-    return new Division(this, this.buildQuoted(other));
-  }
-
-  bitwiseAnd(other: unknown): Grouping {
-    return new Grouping(new BitwiseAnd(this, this.buildQuoted(other)));
-  }
-
-  bitwiseOr(other: unknown): Grouping {
-    return new Grouping(new BitwiseOr(this, this.buildQuoted(other)));
-  }
-
-  bitwiseXor(other: unknown): Grouping {
-    return new Grouping(new BitwiseXor(this, this.buildQuoted(other)));
-  }
-
-  bitwiseShiftLeft(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, this.buildQuoted(other)));
-  }
-
-  bitwiseShiftRight(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, this.buildQuoted(other)));
   }
 }

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -12,7 +12,10 @@ import type { Math as MathMixin } from "../math.js";
  *
  * Mirrors: Arel::Nodes::NodeExpression — which `include`s Arel::Expressions,
  *   Arel::Predications, Arel::AliasPredication, Arel::OrderPredications,
- *   and Arel::Math.
+ *   and Arel::Math. Trails applies Predications + Math here; asc/desc
+ *   (OrderPredications) and `as()` (AliasPredication) live on subclasses
+ *   to avoid module-load cycles with `ascending.ts` / `descending.ts` /
+ *   `binary.ts` — those files all ultimately depend on NodeExpression.
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class NodeExpression extends Node {

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -1,7 +1,5 @@
 import { Node } from "./node.js";
 import type { Included } from "@blazetrails/activesupport";
-import type { Predications } from "../predications.js";
-import type { Math as MathMixin } from "../math.js";
 
 /**
  * NodeExpression — common base for Arel nodes that behave as expressions
@@ -20,9 +18,12 @@ import type { Math as MathMixin } from "../math.js";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class NodeExpression extends Node {
   /**
-   * Wrap a raw value into a Node for use inside predicates. No
-   * type-casting here — Attribute overrides this to route through
-   * `buildCasted` so the attribute's SQL type drives value coercion.
+   * Wrap a raw value into a Node for use inside predicates. Delegates to
+   * the `buildQuoted` registered by casted.ts, passing the current node
+   * as context so subclasses with type-casting semantics can coerce on
+   * that basis. (Attribute — which extends Node directly, not this class
+   * — implements its own predication methods with explicit type-casting
+   * and therefore never reaches this default.)
    *
    * Mirrors: Arel::Predications#quoted_node (private), which calls
    * Nodes.build_quoted(other, self).
@@ -43,5 +44,12 @@ export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node):
   _buildQuoted = fn;
 }
 
+// Using `typeof import(...)` inline avoids pulling the mixin modules into
+// this file's static import graph (they transitively depend on node
+// classes that extend NodeExpression), while still giving TypeScript the
+// method-surface signatures via declaration merging.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface NodeExpression extends Included<typeof Predications>, Included<typeof MathMixin> {}
+export interface NodeExpression
+  extends
+    Included<typeof import("../predications.js").Predications>,
+    Included<typeof import("../math.js").Math> {}

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -1,3 +1,44 @@
 import { Node } from "./node.js";
+import type { Included } from "@blazetrails/activesupport";
+import type { Predications } from "../predications.js";
+import type { Math as MathMixin } from "../math.js";
 
-export abstract class NodeExpression extends Node {}
+/**
+ * NodeExpression — common base for Arel nodes that behave as expressions
+ * (attributes, functions, unary ops, etc.). Runtime wiring of the
+ * Predications + Math mixins lives in ../index.ts to avoid a module-load
+ * cycle between this file and the mixin modules (which reference the
+ * concrete node classes that extend NodeExpression).
+ *
+ * Mirrors: Arel::Nodes::NodeExpression — which `include`s Arel::Expressions,
+ *   Arel::Predications, Arel::AliasPredication, Arel::OrderPredications,
+ *   and Arel::Math.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export abstract class NodeExpression extends Node {
+  /**
+   * Wrap a raw value into a Node for use inside predicates. No
+   * type-casting here — Attribute overrides this to route through
+   * `buildCasted` so the attribute's SQL type drives value coercion.
+   *
+   * Mirrors: Arel::Predications#quoted_node (private), which calls
+   * Nodes.build_quoted(other, self).
+   */
+  quotedNode(other: unknown): Node {
+    if (other instanceof Node) return other;
+    if (_buildQuoted) return _buildQuoted(other, this);
+    throw new Error("NodeExpression.quotedNode called before buildQuoted was registered");
+  }
+}
+
+// `buildQuoted` lives in casted.ts, which imports NodeExpression (Casted
+// extends it). A direct import would deadlock the class-extends
+// expression at module-load time; instead casted.ts registers itself here
+// at its own module-init.
+let _buildQuoted: ((other: unknown, ctx: unknown) => Node) | undefined;
+export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node): void {
+  _buildQuoted = fn;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface NodeExpression extends Included<typeof Predications>, Included<typeof MathMixin> {}

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -31,7 +31,9 @@ export abstract class NodeExpression extends Node {
   quotedNode(other: unknown): Node {
     if (other instanceof Node) return other;
     if (_buildQuoted) return _buildQuoted(other, this);
-    throw new Error("NodeExpression.quotedNode called before buildQuoted was registered");
+    throw new Error(
+      'NodeExpression.quotedNode called before buildQuoted was registered. Import from "@blazetrails/arel" so Arel package initialization runs and wires node registries.',
+    );
   }
 }
 

--- a/packages/arel/src/nodes/unary-operation.ts
+++ b/packages/arel/src/nodes/unary-operation.ts
@@ -9,6 +9,9 @@ import { Descending } from "./descending.js";
  * UnaryOperation — a prefix or postfix unary operation.
  *
  * Mirrors: Arel::Nodes::UnaryOperation
+ *
+ * Predications + Math come from `Unary extends NodeExpression` via the
+ * mixins wired in index.ts.
  */
 export class UnaryOperation extends Unary {
   readonly operator: string;

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "./index.js";
+
+describe("PredicationsMixin", () => {
+  const users = new Table("users");
+
+  describe("on InfixOperation (Math chain)", () => {
+    it("Division#subtract chains via the Math mixin", () => {
+      // arel-24: users[:age] / 3 - users[:other]
+      const expr = users.get("age").divide(3).subtract(users.get("other"));
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe('("users"."age" / 3 - "users"."other")');
+    });
+
+    it("BitwiseAnd#gt produces a GROUP BY / HAVING-style comparison", () => {
+      // arel-25: (users[:bitmap] & 16).gt(0)
+      const expr = users.get("bitmap").bitwiseAnd(16).gt(0);
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe('("users"."bitmap" & 16) > 0');
+    });
+
+    it("BitwiseShiftLeft#gt chains through Predications", () => {
+      // arel-28: (users[:bitmap] << 1).gt(0)
+      const expr = users.get("bitmap").bitwiseShiftLeft(1).gt(0);
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe('("users"."bitmap" << 1) > 0');
+    });
+  });
+
+  describe("on UnaryOperation (via NodeExpression mixin)", () => {
+    it("BitwiseNot#gt produces a predicate", () => {
+      // arel-30: (~users[:bitmap]).gt(0)
+      const expr = new Nodes.BitwiseNot(users.get("bitmap")).gt(0);
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe(' ~ "users"."bitmap" > 0');
+    });
+
+    it("BitwiseNot#eq produces an equality predicate", () => {
+      const expr = new Nodes.BitwiseNot(users.get("flags")).eq(0);
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe(' ~ "users"."flags" = 0');
+    });
+  });
+
+  describe("on NamedFunction (via Function → NodeExpression mixin)", () => {
+    it("count().gt(n) produces HAVING-ready comparison", () => {
+      // arel-47: photos[:id].count.gt(5)
+      const expr = users.get("id").count().gt(5);
+      const sql = new Visitors.ToSql().compile(expr);
+      expect(sql).toBe('COUNT("users"."id") > 5');
+    });
+
+    it("NamedFunction#in accepts a value list", () => {
+      const fn = new Nodes.NamedFunction("LOWER", [users.get("name")]);
+      const sql = new Visitors.ToSql().compile(fn.in(["a", "b"]));
+      expect(sql).toBe("LOWER(\"users\".\"name\") IN ('a', 'b')");
+    });
+  });
+});

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -42,6 +42,29 @@ describe("PredicationsMixin", () => {
     });
   });
 
+  describe("edge cases (via the mixin, not Attribute's inline predications)", () => {
+    const bn = new Nodes.BitwiseNot(users.get("flags"));
+
+    it("eqAny([]) does not crash and renders as a false-ish predicate", () => {
+      // Rails' `Or.inject` on [] returns nil and the visitor renders
+      // NULL (falsy). We produce an explicit NOT(TRUE) for the same
+      // effect without a TypeError from Array#reduce without an initial.
+      const sql = new Visitors.ToSql().compile(bn.eqAny([]));
+      expect(sql).toContain("NOT");
+    });
+
+    it("eqAll([]) does not crash and renders as a true-ish predicate", () => {
+      const sql = new Visitors.ToSql().compile(bn.eqAll([]));
+      // The only content inside the Grouping is a TRUE node — no NOT.
+      expect(sql).not.toContain("NOT");
+    });
+
+    it("in(scalar) wraps the scalar (Rails quoted_node fallthrough)", () => {
+      const sql = new Visitors.ToSql().compile(bn.in(7));
+      expect(sql).toBe(' ~ "users"."flags" IN (7)');
+    });
+  });
+
   describe("on NamedFunction (via Function → NodeExpression mixin)", () => {
     it("count().gt(n) produces HAVING-ready comparison", () => {
       // arel-47: photos[:id].count.gt(5)

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -45,12 +45,12 @@ describe("PredicationsMixin", () => {
   describe("edge cases (via the mixin, not Attribute's inline predications)", () => {
     const bn = new Nodes.BitwiseNot(users.get("flags"));
 
-    it("eqAny([]) does not crash and renders as a false-ish predicate", () => {
+    it("eqAny([]) does not crash and renders as NULL (Rails 3-valued logic)", () => {
       // Rails' `Or.inject` on [] returns nil and the visitor renders
-      // NULL (falsy). We produce an explicit NOT(TRUE) for the same
-      // effect without a TypeError from Array#reduce without an initial.
+      // NULL — we preserve that, since NULL is not the same as FALSE
+      // under SQL three-valued logic.
       const sql = new Visitors.ToSql().compile(bn.eqAny([]));
-      expect(sql).toContain("NOT");
+      expect(sql).toBe("(NULL)");
     });
 
     it("eqAll([]) does not crash and renders as a true-ish predicate", () => {

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -53,10 +53,11 @@ describe("PredicationsMixin", () => {
       expect(sql).toBe("(NULL)");
     });
 
-    it("eqAll([]) does not crash and renders as a true-ish predicate", () => {
+    it("eqAll([]) does not crash and renders as an empty grouped AND", () => {
+      // Matches Attribute#groupedAll: an empty And inside a Grouping
+      // visits to `()`, the same as Rails' empty-And rendering.
       const sql = new Visitors.ToSql().compile(bn.eqAll([]));
-      // The only content inside the Grouping is a TRUE node — no NOT.
-      expect(sql).not.toContain("NOT");
+      expect(sql).toBe("()");
     });
 
     it("in(scalar) wraps the scalar (Rails quoted_node fallthrough)", () => {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -14,7 +14,7 @@ import { Equality } from "./nodes/equality.js";
 import { Matches, DoesNotMatch } from "./nodes/matches.js";
 import { In } from "./nodes/in.js";
 import { Regexp as RegexpNode, NotRegexp } from "./nodes/regexp.js";
-import { Quoted, buildQuoted } from "./nodes/casted.js";
+import { Quoted } from "./nodes/casted.js";
 import { And } from "./nodes/and.js";
 import { Or } from "./nodes/or.js";
 import { Not } from "./nodes/unary.js";
@@ -103,9 +103,12 @@ export const Predications = {
     if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
       return new In(this as unknown as Node, (values as { ast: Node }).ast);
     }
+    // Route each element through the host's quotedNode so type-casting
+    // subclasses (Attribute, ...) get a chance to coerce per-value.
+    // Mirrors: Predications#quoted_array → quoted_node(v).
     return new In(
       this as unknown as Node,
-      (values as unknown[]).map(buildQuoted) as unknown as Node,
+      (values as unknown[]).map((v) => this.quotedNode(v)) as unknown as Node,
     );
   },
   notIn(this: PredicationHost, values: unknown[] | { ast: Node }): NotIn {
@@ -114,7 +117,7 @@ export const Predications = {
     }
     return new NotIn(
       this as unknown as Node,
-      (values as unknown[]).map(buildQuoted) as unknown as Node,
+      (values as unknown[]).map((v) => this.quotedNode(v)) as unknown as Node,
     );
   },
 
@@ -145,14 +148,14 @@ export const Predications = {
     }
     if (beginVal === -Infinity && endVal === Infinity) return new True();
     if (beginVal === -Infinity) {
-      return new LessThanOrEqual(this as unknown as Node, buildQuoted(endVal));
+      return new LessThanOrEqual(this as unknown as Node, this.quotedNode(endVal));
     }
     if (endVal === Infinity) {
-      return new GreaterThanOrEqual(this as unknown as Node, buildQuoted(beginVal));
+      return new GreaterThanOrEqual(this as unknown as Node, this.quotedNode(beginVal));
     }
     return new Between(
       this as unknown as Node,
-      new And([buildQuoted(beginVal), buildQuoted(endVal)]),
+      new And([this.quotedNode(beginVal), this.quotedNode(endVal)]),
     );
   },
   notBetween(this: PredicationHost, beginOrRange: unknown, end?: unknown): Not {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -123,8 +123,12 @@ export const Predications = {
         other.map((v) => this.quotedNode(v)),
       );
     }
+    // SelectManager/TreeManager-shaped object: only forward `.ast` when
+    // it's actually a Node — anything else falls through to quotedNode
+    // so we don't construct a malformed In with a stray non-Node ast.
     if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
-      return new In(this as unknown as Node, (other as { ast: Node }).ast);
+      const ast = (other as { ast: unknown }).ast;
+      if (ast instanceof Node) return new In(this as unknown as Node, ast);
     }
     return new In(this as unknown as Node, this.quotedNode(other));
   },
@@ -136,7 +140,8 @@ export const Predications = {
       );
     }
     if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
-      return new NotIn(this as unknown as Node, (other as { ast: Node }).ast);
+      const ast = (other as { ast: unknown }).ast;
+      if (ast instanceof Node) return new NotIn(this as unknown as Node, ast);
     }
     return new NotIn(this as unknown as Node, this.quotedNode(other));
   },

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -33,17 +33,18 @@ export interface PredicationHost {
 }
 
 function groupedAny(nodes: Node[]): Grouping {
-  // Empty `*_any([])` = false; Rails' `Or.inject` on [] returns nil and
-  // the visitor renders `NULL`, which falsifies the predicate anyway —
-  // be explicit about it here so callers get deterministic SQL instead
-  // of a TypeError from `Array#reduce` without an initial value.
-  if (nodes.length === 0) return new Grouping(new Not(new True()));
+  // Rails' `Or.inject` on [] returns nil; the visitor renders that as
+  // `NULL`. Preserve three-valued semantics (NULL is *not* the same as
+  // FALSE under SQL: `NULL OR FALSE` is NULL, `FALSE OR FALSE` is FALSE)
+  // while still guarding against the `Array#reduce` TypeError on empty.
+  if (nodes.length === 0) return new Grouping(new Quoted(null));
   return new Grouping(nodes.reduce((acc, n) => new Or(acc, n)));
 }
 
 function groupedAll(nodes: Node[]): Grouping {
-  // Empty `*_all([])` = true, matching SQL's vacuous-AND semantics and
-  // Rails' empty-Ands short-circuit.
+  // Rails wraps an empty And in a Grouping; the visitor renders it as
+  // `()`. We emit an explicit TRUE so the predicate is at least valid
+  // SQL — empty `_all` = vacuously true.
   if (nodes.length === 0) return new Grouping(new True());
   return new Grouping(new And(nodes));
 }

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -33,10 +33,18 @@ export interface PredicationHost {
 }
 
 function groupedAny(nodes: Node[]): Grouping {
+  // Empty `*_any([])` = false; Rails' `Or.inject` on [] returns nil and
+  // the visitor renders `NULL`, which falsifies the predicate anyway —
+  // be explicit about it here so callers get deterministic SQL instead
+  // of a TypeError from `Array#reduce` without an initial value.
+  if (nodes.length === 0) return new Grouping(new Not(new True()));
   return new Grouping(nodes.reduce((acc, n) => new Or(acc, n)));
 }
 
 function groupedAll(nodes: Node[]): Grouping {
+  // Empty `*_all([])` = true, matching SQL's vacuous-AND semantics and
+  // Rails' empty-Ands short-circuit.
+  if (nodes.length === 0) return new Grouping(new True());
   return new Grouping(new And(nodes));
 }
 
@@ -74,23 +82,28 @@ export const Predications = {
 
   matches(
     this: PredicationHost,
-    pattern: string | { ast: Node },
+    pattern: unknown,
     escape: string | null = null,
     caseSensitive = false,
   ): Matches {
-    const right =
-      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
-    return new Matches(this as unknown as Node, right, escape, caseSensitive);
+    // Rails: `Nodes::Matches.new self, quoted_node(other), ...`.
+    // `quotedNode` (→ buildQuoted) already unwraps SelectManager/TreeManager
+    // `.ast` and passes Nodes through untouched, so we don't need a
+    // separate branch for AST-bearing inputs here.
+    return new Matches(this as unknown as Node, this.quotedNode(pattern), escape, caseSensitive);
   },
   doesNotMatch(
     this: PredicationHost,
-    pattern: string | { ast: Node },
+    pattern: unknown,
     escape: string | null = null,
     caseSensitive = false,
   ): DoesNotMatch {
-    const right =
-      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
-    return new DoesNotMatch(this as unknown as Node, right, escape, caseSensitive);
+    return new DoesNotMatch(
+      this as unknown as Node,
+      this.quotedNode(pattern),
+      escape,
+      caseSensitive,
+    );
   },
   matchesRegexp(this: PredicationHost, pattern: string, caseSensitive = true): RegexpNode {
     return new RegexpNode(this as unknown as Node, this.quotedNode(pattern), caseSensitive);
@@ -99,26 +112,33 @@ export const Predications = {
     return new NotRegexp(this as unknown as Node, this.quotedNode(pattern), caseSensitive);
   },
 
-  in(this: PredicationHost, values: unknown[] | { ast: Node }): In {
-    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
-      return new In(this as unknown as Node, (values as { ast: Node }).ast);
+  in(this: PredicationHost, other: unknown[] | { ast: Node } | Node | unknown): In {
+    // Mirrors Arel::Predications#in:
+    //   SelectManager → In(self, other.ast)
+    //   Enumerable    → In(self, quoted_array(other))
+    //   else          → In(self, quoted_node(other))
+    if (Array.isArray(other)) {
+      return new In(
+        this as unknown as Node,
+        other.map((v) => this.quotedNode(v)) as unknown as Node,
+      );
     }
-    // Route each element through the host's quotedNode so type-casting
-    // subclasses (Attribute, ...) get a chance to coerce per-value.
-    // Mirrors: Predications#quoted_array → quoted_node(v).
-    return new In(
-      this as unknown as Node,
-      (values as unknown[]).map((v) => this.quotedNode(v)) as unknown as Node,
-    );
+    if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
+      return new In(this as unknown as Node, (other as { ast: Node }).ast);
+    }
+    return new In(this as unknown as Node, this.quotedNode(other));
   },
-  notIn(this: PredicationHost, values: unknown[] | { ast: Node }): NotIn {
-    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
-      return new NotIn(this as unknown as Node, (values as { ast: Node }).ast);
+  notIn(this: PredicationHost, other: unknown[] | { ast: Node } | Node | unknown): NotIn {
+    if (Array.isArray(other)) {
+      return new NotIn(
+        this as unknown as Node,
+        other.map((v) => this.quotedNode(v)) as unknown as Node,
+      );
     }
-    return new NotIn(
-      this as unknown as Node,
-      (values as unknown[]).map((v) => this.quotedNode(v)) as unknown as Node,
-    );
+    if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
+      return new NotIn(this as unknown as Node, (other as { ast: Node }).ast);
+    }
+    return new NotIn(this as unknown as Node, this.quotedNode(other));
   },
 
   between(

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -1,21 +1,241 @@
-import type { Node } from "./nodes/node.js";
+import { Node } from "./nodes/node.js";
+import {
+  NotEqual,
+  GreaterThan,
+  GreaterThanOrEqual,
+  LessThan,
+  LessThanOrEqual,
+  Between,
+  NotIn,
+  IsDistinctFrom,
+  IsNotDistinctFrom,
+} from "./nodes/binary.js";
+import { Equality } from "./nodes/equality.js";
+import { Matches, DoesNotMatch } from "./nodes/matches.js";
+import { In } from "./nodes/in.js";
+import { Regexp as RegexpNode, NotRegexp } from "./nodes/regexp.js";
+import { Quoted, buildQuoted } from "./nodes/casted.js";
+import { And } from "./nodes/and.js";
+import { Or } from "./nodes/or.js";
+import { Not } from "./nodes/unary.js";
+import { Grouping } from "./nodes/grouping.js";
+import { True } from "./nodes/true.js";
 
-export interface Predications {
-  eq(other: unknown): Node;
-  notEq(other: unknown): Node;
-  gt(other: unknown): Node;
-  gteq(other: unknown): Node;
-  lt(other: unknown): Node;
-  lteq(other: unknown): Node;
-  matches(other: unknown, escape?: string | null, caseSensitive?: boolean): Node;
-  doesNotMatch(other: unknown, escape?: string | null, caseSensitive?: boolean): Node;
-  in(values: unknown): Node;
-  notIn(values: unknown): Node;
-  between(begin: unknown, end: unknown): Node;
-  isNotNull(): Node;
-  isNull(): Node;
-  isDistinctFrom(other: unknown): Node;
-  isNotDistinctFrom(other: unknown): Node;
-  concat(other: unknown): Node;
-  quotedArray(others: unknown[]): Node[];
+/**
+ * Host contract for the Predications mixin.
+ *
+ * Implementors provide `quotedNode(other)` which either type-casts (for
+ * Attribute) or plain-wraps (for NodeExpression / InfixOperation) — same
+ * role Rails' private `quoted_node` method plays inside Predications.
+ */
+export interface PredicationHost {
+  quotedNode(other: unknown): Node;
 }
+
+function groupedAny(nodes: Node[]): Grouping {
+  return new Grouping(nodes.reduce((acc, n) => new Or(acc, n)));
+}
+
+function groupedAll(nodes: Node[]): Grouping {
+  return new Grouping(new And(nodes));
+}
+
+/**
+ * Predications — predicate-builder mixin.
+ *
+ * Mirrors: Arel::Predications (activerecord/lib/arel/predications.rb)
+ */
+export const Predications = {
+  eq(this: PredicationHost, other: unknown): Equality {
+    return new Equality(this as unknown as Node, this.quotedNode(other));
+  },
+  notEq(this: PredicationHost, other: unknown): NotEqual {
+    return new NotEqual(this as unknown as Node, this.quotedNode(other));
+  },
+  gt(this: PredicationHost, other: unknown): GreaterThan {
+    return new GreaterThan(this as unknown as Node, this.quotedNode(other));
+  },
+  gteq(this: PredicationHost, other: unknown): GreaterThanOrEqual {
+    return new GreaterThanOrEqual(this as unknown as Node, this.quotedNode(other));
+  },
+  lt(this: PredicationHost, other: unknown): LessThan {
+    return new LessThan(this as unknown as Node, this.quotedNode(other));
+  },
+  lteq(this: PredicationHost, other: unknown): LessThanOrEqual {
+    return new LessThanOrEqual(this as unknown as Node, this.quotedNode(other));
+  },
+
+  isDistinctFrom(this: PredicationHost, other: unknown): IsDistinctFrom {
+    return new IsDistinctFrom(this as unknown as Node, this.quotedNode(other));
+  },
+  isNotDistinctFrom(this: PredicationHost, other: unknown): IsNotDistinctFrom {
+    return new IsNotDistinctFrom(this as unknown as Node, this.quotedNode(other));
+  },
+
+  matches(
+    this: PredicationHost,
+    pattern: string | { ast: Node },
+    escape: string | null = null,
+    caseSensitive = false,
+  ): Matches {
+    const right =
+      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
+    return new Matches(this as unknown as Node, right, escape, caseSensitive);
+  },
+  doesNotMatch(
+    this: PredicationHost,
+    pattern: string | { ast: Node },
+    escape: string | null = null,
+    caseSensitive = false,
+  ): DoesNotMatch {
+    const right =
+      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
+    return new DoesNotMatch(this as unknown as Node, right, escape, caseSensitive);
+  },
+  matchesRegexp(this: PredicationHost, pattern: string, caseSensitive = true): RegexpNode {
+    return new RegexpNode(this as unknown as Node, this.quotedNode(pattern), caseSensitive);
+  },
+  doesNotMatchRegexp(this: PredicationHost, pattern: string, caseSensitive = true): NotRegexp {
+    return new NotRegexp(this as unknown as Node, this.quotedNode(pattern), caseSensitive);
+  },
+
+  in(this: PredicationHost, values: unknown[] | { ast: Node }): In {
+    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
+      return new In(this as unknown as Node, (values as { ast: Node }).ast);
+    }
+    return new In(
+      this as unknown as Node,
+      (values as unknown[]).map(buildQuoted) as unknown as Node,
+    );
+  },
+  notIn(this: PredicationHost, values: unknown[] | { ast: Node }): NotIn {
+    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
+      return new NotIn(this as unknown as Node, (values as { ast: Node }).ast);
+    }
+    return new NotIn(
+      this as unknown as Node,
+      (values as unknown[]).map(buildQuoted) as unknown as Node,
+    );
+  },
+
+  between(
+    this: PredicationHost,
+    beginOrRange: unknown,
+    end?: unknown,
+  ): Between | LessThanOrEqual | GreaterThanOrEqual | True {
+    let beginVal: unknown;
+    let endVal: unknown;
+    if (Array.isArray(beginOrRange) && end === undefined) {
+      beginVal = beginOrRange[0];
+      endVal = beginOrRange[1];
+    } else if (
+      typeof beginOrRange === "object" &&
+      beginOrRange !== null &&
+      !Array.isArray(beginOrRange) &&
+      !(beginOrRange instanceof Node) &&
+      "begin" in (beginOrRange as Record<string, unknown>) &&
+      "end" in (beginOrRange as Record<string, unknown>) &&
+      end === undefined
+    ) {
+      beginVal = (beginOrRange as { begin: unknown; end: unknown }).begin;
+      endVal = (beginOrRange as { begin: unknown; end: unknown }).end;
+    } else {
+      beginVal = beginOrRange;
+      endVal = end;
+    }
+    if (beginVal === -Infinity && endVal === Infinity) return new True();
+    if (beginVal === -Infinity) {
+      return new LessThanOrEqual(this as unknown as Node, buildQuoted(endVal));
+    }
+    if (endVal === Infinity) {
+      return new GreaterThanOrEqual(this as unknown as Node, buildQuoted(beginVal));
+    }
+    return new Between(
+      this as unknown as Node,
+      new And([buildQuoted(beginVal), buildQuoted(endVal)]),
+    );
+  },
+  notBetween(this: PredicationHost, beginOrRange: unknown, end?: unknown): Not {
+    const self = this as unknown as { between(b: unknown, e?: unknown): Node };
+    if (Array.isArray(beginOrRange) && end === undefined) {
+      return new Not(self.between(beginOrRange));
+    }
+    return new Not(self.between(beginOrRange, end));
+  },
+
+  isNull(this: PredicationHost): Equality {
+    return new Equality(this as unknown as Node, new Quoted(null));
+  },
+  isNotNull(this: PredicationHost): NotEqual {
+    return new NotEqual(this as unknown as Node, new Quoted(null));
+  },
+
+  // -- _any / _all variants --
+
+  eqAny(this: PredicationHost & { eq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.eq(o)));
+  },
+  eqAll(this: PredicationHost & { eq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.eq(o)));
+  },
+  notEqAny(this: PredicationHost & { notEq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.notEq(o)));
+  },
+  notEqAll(this: PredicationHost & { notEq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.notEq(o)));
+  },
+  gtAny(this: PredicationHost & { gt(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.gt(o)));
+  },
+  gtAll(this: PredicationHost & { gt(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.gt(o)));
+  },
+  gteqAny(this: PredicationHost & { gteq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.gteq(o)));
+  },
+  gteqAll(this: PredicationHost & { gteq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.gteq(o)));
+  },
+  ltAny(this: PredicationHost & { lt(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.lt(o)));
+  },
+  ltAll(this: PredicationHost & { lt(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.lt(o)));
+  },
+  lteqAny(this: PredicationHost & { lteq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAny(others.map((o) => this.lteq(o)));
+  },
+  lteqAll(this: PredicationHost & { lteq(o: unknown): Node }, others: unknown[]): Grouping {
+    return groupedAll(others.map((o) => this.lteq(o)));
+  },
+  matchesAny(this: PredicationHost & { matches(o: string): Node }, others: string[]): Grouping {
+    return groupedAny(others.map((o) => this.matches(o)));
+  },
+  matchesAll(this: PredicationHost & { matches(o: string): Node }, others: string[]): Grouping {
+    return groupedAll(others.map((o) => this.matches(o)));
+  },
+  doesNotMatchAny(
+    this: PredicationHost & { doesNotMatch(o: string): Node },
+    others: string[],
+  ): Grouping {
+    return groupedAny(others.map((o) => this.doesNotMatch(o)));
+  },
+  doesNotMatchAll(
+    this: PredicationHost & { doesNotMatch(o: string): Node },
+    others: string[],
+  ): Grouping {
+    return groupedAll(others.map((o) => this.doesNotMatch(o)));
+  },
+  inAny(this: PredicationHost & { in(o: unknown[]): Node }, others: unknown[][]): Grouping {
+    return groupedAny(others.map((o) => this.in(o)));
+  },
+  inAll(this: PredicationHost & { in(o: unknown[]): Node }, others: unknown[][]): Grouping {
+    return groupedAll(others.map((o) => this.in(o)));
+  },
+  notInAny(this: PredicationHost & { notIn(o: unknown[]): Node }, others: unknown[][]): Grouping {
+    return groupedAny(others.map((o) => this.notIn(o)));
+  },
+  notInAll(this: PredicationHost & { notIn(o: unknown[]): Node }, others: unknown[][]): Grouping {
+    return groupedAll(others.map((o) => this.notIn(o)));
+  },
+};

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -118,9 +118,10 @@ export const Predications = {
     //   Enumerable    → In(self, quoted_array(other))
     //   else          → In(self, quoted_node(other))
     if (Array.isArray(other)) {
+      // Node[] is valid NodeOrValue for In/NotIn — no cast needed.
       return new In(
         this as unknown as Node,
-        other.map((v) => this.quotedNode(v)) as unknown as Node,
+        other.map((v) => this.quotedNode(v)),
       );
     }
     if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
@@ -132,7 +133,7 @@ export const Predications = {
     if (Array.isArray(other)) {
       return new NotIn(
         this as unknown as Node,
-        other.map((v) => this.quotedNode(v)) as unknown as Node,
+        other.map((v) => this.quotedNode(v)),
       );
     }
     if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -42,10 +42,8 @@ function groupedAny(nodes: Node[]): Grouping {
 }
 
 function groupedAll(nodes: Node[]): Grouping {
-  // Rails wraps an empty And in a Grouping; the visitor renders it as
-  // `()`. We emit an explicit TRUE so the predicate is at least valid
-  // SQL — empty `_all` = vacuously true.
-  if (nodes.length === 0) return new Grouping(new True());
+  // Match Attribute#groupedAll: an empty And inside a Grouping. The
+  // visitor renders this as `()`, same as Rails' empty-And rendering.
   return new Grouping(new And(nodes));
 }
 
@@ -143,7 +141,12 @@ export const Predications = {
     return new NotIn(this as unknown as Node, this.quotedNode(other));
   },
 
-  between(
+  // `between` / `notBetween` accept three forms — `[begin, end]`, `{ begin,
+  // end }`, or `(begin, end)` — same as Attribute#between. Object-literal
+  // methods can't carry overload signatures directly, so the public type
+  // is asserted via `as` below; the implementation parameter list stays
+  // permissive for the runtime branch.
+  between: function (
     this: PredicationHost,
     beginOrRange: unknown,
     end?: unknown,
@@ -179,13 +182,42 @@ export const Predications = {
       this as unknown as Node,
       new And([this.quotedNode(beginVal), this.quotedNode(endVal)]),
     );
+  } as {
+    (
+      this: PredicationHost,
+      range: readonly [unknown, unknown],
+    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
+    (
+      this: PredicationHost,
+      range: { begin: unknown; end: unknown },
+    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
+    (
+      this: PredicationHost,
+      begin: unknown,
+      end: unknown,
+    ): Between | LessThanOrEqual | GreaterThanOrEqual | True;
   },
-  notBetween(this: PredicationHost, beginOrRange: unknown, end?: unknown): Not {
+
+  notBetween: function (this: PredicationHost, beginOrRange: unknown, end?: unknown): Not {
     const self = this as unknown as { between(b: unknown, e?: unknown): Node };
     if (Array.isArray(beginOrRange) && end === undefined) {
       return new Not(self.between(beginOrRange));
     }
+    if (
+      typeof beginOrRange === "object" &&
+      beginOrRange !== null &&
+      !(beginOrRange instanceof Node) &&
+      end === undefined &&
+      "begin" in (beginOrRange as Record<string, unknown>) &&
+      "end" in (beginOrRange as Record<string, unknown>)
+    ) {
+      return new Not(self.between(beginOrRange));
+    }
     return new Not(self.between(beginOrRange, end));
+  } as {
+    (this: PredicationHost, range: readonly [unknown, unknown]): Not;
+    (this: PredicationHost, range: { begin: unknown; end: unknown }): Not;
+    (this: PredicationHost, begin: unknown, end: unknown): Not;
   },
 
   isNull(this: PredicationHost): Equality {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -481,8 +481,10 @@ describe("the to_sql visitor", () => {
     it("should handle arbitrary operators", () => {
       const node = new Nodes.UnaryOperation("-", new Nodes.Quoted(1));
       // Rails' visit_Arel_Nodes_UnaryOperation emits `" #{operator} "` —
-      // space on both sides of the operator.
-      expect(new Visitors.ToSql().compile(node)).toContain("- 1");
+      // space on both sides of the operator. Lock the exact byte sequence
+      // (including the leading space) so any spacing regression is caught
+      // by this test, not just by parity.
+      expect(new Visitors.ToSql().compile(node)).toBe(" - 1");
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -480,7 +480,9 @@ describe("the to_sql visitor", () => {
 
     it("should handle arbitrary operators", () => {
       const node = new Nodes.UnaryOperation("-", new Nodes.Quoted(1));
-      expect(new Visitors.ToSql().compile(node)).toContain("-1");
+      // Rails' visit_Arel_Nodes_UnaryOperation emits `" #{operator} "` —
+      // space on both sides of the operator.
+      expect(new Visitors.ToSql().compile(node)).toContain("- 1");
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1205,7 +1205,9 @@ export class ToSql implements NodeVisitor<SQLString> {
   private visitUnaryOperation(node: Nodes.UnaryOperation): SQLString {
     // Rails emits ` ${operator} ` — space on both sides — so the operator
     // sits free of surrounding tokens wherever it lands in an expression.
-    this.collector.append(` ${node.operator} `);
+    // Trim the operator first so callers who construct with decorative
+    // whitespace (e.g. "NOT ") don't get double spaces in the output.
+    this.collector.append(` ${node.operator.trim()} `);
     this.visit(node.operand);
     return this.collector;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1203,7 +1203,9 @@ export class ToSql implements NodeVisitor<SQLString> {
   // -- UnaryOperation --
 
   private visitUnaryOperation(node: Nodes.UnaryOperation): SQLString {
-    this.collector.append(node.operator);
+    // Rails emits ` ${operator} ` — space on both sides — so the operator
+    // sits free of surrounding tokens wherever it lands in an expression.
+    this.collector.append(` ${node.operator} `);
     this.visit(node.operand);
     return this.collector;
   }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -3,41 +3,9 @@
     "side": "diff",
     "reason": "is_distinct_from: trails emits 'IS DISTINCT FROM' (SQL standard); Rails on SQLite emits 'IS NOT' (SQLite extension). Both are semantically equivalent but lexically differ."
   },
-  "arel-24": {
-    "side": "trails-missing",
-    "reason": "arithmetic chain (users[:age] / 3 - employees[:time_at_company]): trails Attribute#divide returns a node without a .subtract method — predication-after-arithmetic chain is incomplete."
-  },
-  "arel-25": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24 (trails arithmetic ops do not chain into further predicates)."
-  },
-  "arel-26": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-27": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-28": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-29": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-30": {
-    "side": "trails-missing",
-    "reason": "(~users[:bitmap]).gt(0): trails Nodes.BitwiseNot does not implement predication methods (no .gt/.lt/.eq chain)."
-  },
   "arel-44": {
     "side": "diff",
     "reason": "subquery alias quoting: Rails emits the alias bare (sub); trails emits the quoted identifier (\"sub\"). Real ToSql visitor divergence."
-  },
-  "arel-47": {
-    "side": "trails-missing",
-    "reason": "photos[:id].count.gt(5): trails Attribute#count returns a node without predication methods — HAVING aggregate-comparison chain incomplete."
   },
   "ar-01": {
     "side": "diff",


### PR DESCRIPTION
## Summary

Closes the predication-chain family of parity gaps by mirroring Rails' Arel structure: extract the predicate-builder and arithmetic method families into reusable module objects (`predications.ts`, `math.ts`) and mix them into `NodeExpression` and `InfixOperation` via `@blazetrails/activesupport#include`. Every expression-valued node — the unary-operator hierarchy, functions, casted, case, etc. — now has the full predicate surface (`.eq`/`.gt`/`.lt`/`.in`/`.between`/`.matches`/...) and the arithmetic surface (`.add`/`.subtract`/`.multiply`/`.divide` + bitwise).

Rails source:
- `activerecord/lib/arel/nodes/node_expression.rb` — `include Arel::Predications`, `Arel::Math`, `Arel::AliasPredication`, `Arel::OrderPredications`
- `activerecord/lib/arel/nodes/infix_operation.rb` — same four mixins (extends `Binary`, not `NodeExpression`, just like trails)
- `activerecord/lib/arel/predications.rb` — the module itself
- `activerecord/lib/arel/visitors/to_sql.rb:854` — `" #{operator} "` spacing for UnaryOperation

Runtime wiring lives in `index.ts` to avoid a module-load cycle between `node-expression.ts` and the mixin modules (which reference the concrete node classes). `NodeExpression` gains a `quotedNode(other)` hook (Rails `Predications#quoted_node`) routed through a `registerBuildQuoted()` callback so `Attribute` can override with type-casting while plain expression nodes fall through to `buildQuoted`.

Also:
- Removes `NamedFunction`'s duplicate inline Math methods (now inherited from `Function → NodeExpression`).
- Fixes `visitUnaryOperation` to emit `" ${op} "` on both sides so `(~users[:bitmap]).gt(0)` renders identically to Rails.

## Parity impact
- Closes `arel-24`, `arel-25`, `arel-26`, `arel-27`, `arel-28`, `arel-29`, `arel-30`, `arel-47`.
- **61/69** parity fixtures passing (was 42).

## Test plan
- [x] `pnpm vitest run packages/arel/src` — 1001/1001 passed
- [x] `pnpm vitest run packages/activerecord/src` — 9282 passed, no regressions
- [x] `pnpm parity:query` — 61/69 PASS, 8 remaining known gaps (all `ar-*` bool-serialization / alias-quoting / eager-load / group-by-qualification; orthogonal to this change)