### PR TITLE
feat(activemodel): PR 16 — mutations_from_database vs mutations_before_last_save

### DIFF
--- a/packages/activemodel/src/dirty-mutations.test.ts
+++ b/packages/activemodel/src/dirty-mutations.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "./index.js";
+
+/**
+ * Covers the Rails-canonical names exposed by
+ * activemodel/lib/active_model/dirty.rb +
+ * attribute_mutation_tracker.rb: `mutations_from_database`,
+ * `mutations_before_last_save`, `forget_attribute_assignments`,
+ * `clear_attribute_change`.
+ */
+describe("DirtyMutations", () => {
+  class Person extends Model {
+    static {
+      this.attribute("name", "string");
+      this.attribute("age", "integer");
+    }
+  }
+
+  it("mutationsFromDatabase tracks pending writes vs the loaded values", () => {
+    const p = new Person({ name: "Alice", age: 30 });
+    p.changesApplied();
+    expect(p.mutationsFromDatabase).toEqual({});
+    (p as any).name = "Bob";
+    expect(p.mutationsFromDatabase).toEqual({ name: ["Alice", "Bob"] });
+  });
+
+  it("mutationsFromDatabase clears after changesApplied", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    expect(p.mutationsFromDatabase).toEqual({});
+  });
+
+  it("mutationsBeforeLastSave snapshots pending changes at save time", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    expect(p.mutationsBeforeLastSave).toEqual({});
+    (p as any).name = "Bob";
+    p.changesApplied();
+    expect(p.mutationsBeforeLastSave).toEqual({ name: ["Alice", "Bob"] });
+  });
+
+  it("mutationsBeforeLastSave is replaced on the next save", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    (p as any).name = "Carol";
+    p.changesApplied();
+    expect(p.mutationsBeforeLastSave).toEqual({ name: ["Bob", "Carol"] });
+  });
+
+  it("forgetAttributeAssignments drops pending tracking without reverting values", () => {
+    // Matches Rails transactional rollback: the in-memory value stays, but
+    // the record no longer reports it as changed.
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    (p as any).age = 40;
+    p.forgetAttributeAssignments();
+    expect(p.mutationsFromDatabase).toEqual({});
+    expect((p as any).name).toBe("Bob");
+    expect((p as any).age).toBe(40);
+  });
+
+  it("clearAttributeChange drops a single attribute's pending change", () => {
+    const p = new Person({ name: "Alice", age: 30 });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    (p as any).age = 40;
+    p.clearAttributeChange("name");
+    expect(p.mutationsFromDatabase).toEqual({ age: [30, 40] });
+    // The value stays — only the tracking was cleared.
+    expect((p as any).name).toBe("Bob");
+  });
+});

--- a/packages/activemodel/src/dirty-mutations.test.ts
+++ b/packages/activemodel/src/dirty-mutations.test.ts
@@ -64,6 +64,28 @@ describe("DirtyMutations", () => {
     expect((p as any).age).toBe(40);
   });
 
+  it("forgetAttributeAssignments resets the baseline so later writes diff from current", () => {
+    // Rails `@attributes.map(&:forgotten_change)` rebinds each Attribute's
+    // original value to its current cast value, so a later A->B->forget->C
+    // reports [B, C] — not [A, C].
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.forgetAttributeAssignments();
+    (p as any).name = "Carol";
+    expect(p.mutationsFromDatabase).toEqual({ name: ["Bob", "Carol"] });
+  });
+
+  it("forgetAttributeAssignments preserves mutationsBeforeLastSave", () => {
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.changesApplied();
+    (p as any).name = "Carol";
+    p.forgetAttributeAssignments();
+    expect(p.mutationsBeforeLastSave).toEqual({ name: ["Alice", "Bob"] });
+  });
+
   it("clearAttributeChange drops a single attribute's pending change", () => {
     const p = new Person({ name: "Alice", age: 30 });
     p.changesApplied();
@@ -73,5 +95,16 @@ describe("DirtyMutations", () => {
     expect(p.mutationsFromDatabase).toEqual({ age: [30, 40] });
     // The value stays — only the tracking was cleared.
     expect((p as any).name).toBe("Bob");
+  });
+
+  it("clearAttributeChange rebinds the baseline for the cleared attribute", () => {
+    // Rails `mutation_tracker.forget_change(name)` treats the current cast
+    // value as the new clean state, so a later write reports [current, next].
+    const p = new Person({ name: "Alice" });
+    p.changesApplied();
+    (p as any).name = "Bob";
+    p.clearAttributeChange("name");
+    (p as any).name = "Carol";
+    expect(p.mutationsFromDatabase).toEqual({ name: ["Bob", "Carol"] });
   });
 });

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -173,14 +173,10 @@ export class DirtyTracker {
   forgetAttributeAssignments(
     attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
   ): void {
-    if (attributes instanceof Map) {
-      this._originalAttributes = new Map(attributes);
-      this._originalHas = new Set(attributes.keys());
-    } else {
-      this._originalAttributes = attributes.snapshotValues();
-      this._originalHas = new Set(this._originalAttributes.keys());
-    }
-    this._changedAttributes.clear();
+    // Same shape as snapshot(): reset baseline + clear pending changes.
+    // `snapshot` also clears `_changedAttributes`, so the single call
+    // covers both sides of Rails' `forget_attribute_assignments`.
+    this.snapshot(attributes);
   }
 
   /**
@@ -192,13 +188,33 @@ export class DirtyTracker {
    * -> `mutation_tracker.forget_change(name)`.
    */
   clearAttributeChange(
-    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+    attributes:
+      | Map<string, unknown>
+      | { has(name: string): boolean; fetchValue(name: string): unknown }
+      | { snapshotValues(): Map<string, unknown> },
     name: string,
   ): void {
     this._changedAttributes.delete(name);
-    const snap = attributes instanceof Map ? attributes : attributes.snapshotValues();
-    if (snap.has(name)) {
-      this._originalAttributes.set(name, snap.get(name));
+    // Fast path: avoid snapshotting every attribute when only one baseline
+    // needs rebinding. AttributeSet exposes has/fetchValue per-attribute;
+    // fall back to the full snapshot for plain Maps / other shapes.
+    let has: boolean;
+    let value: unknown;
+    const perAttr = attributes as { has?: unknown; fetchValue?: unknown };
+    if (typeof perAttr.has === "function" && typeof perAttr.fetchValue === "function") {
+      const src = attributes as { has(n: string): boolean; fetchValue(n: string): unknown };
+      has = src.has(name);
+      value = has ? src.fetchValue(name) : undefined;
+    } else {
+      const snap =
+        attributes instanceof Map
+          ? attributes
+          : (attributes as { snapshotValues(): Map<string, unknown> }).snapshotValues();
+      has = snap.has(name);
+      value = snap.get(name);
+    }
+    if (has) {
+      this._originalAttributes.set(name, value);
       this._originalHas.add(name);
     } else {
       this._originalAttributes.delete(name);

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -12,6 +12,8 @@ export interface Dirty {
   readonly changedAttributes: string[];
   readonly changes: Record<string, [unknown, unknown]>;
   readonly previousChanges: Record<string, [unknown, unknown]>;
+  readonly mutationsFromDatabase: Record<string, [unknown, unknown]>;
+  readonly mutationsBeforeLastSave: Record<string, [unknown, unknown]>;
   attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean;
   attributeWas(name: string): unknown;
   attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean;
@@ -21,6 +23,8 @@ export interface Dirty {
   clearChangesInformation(): void;
   clearAttributeChanges(attributes: string[]): void;
   attributeChangedInPlace(name: string): boolean;
+  forgetAttributeAssignments(): void;
+  clearAttributeChange(name: string): void;
 }
 
 function resolveValue(value: unknown): unknown {
@@ -156,24 +160,50 @@ export class DirtyTracker {
   }
 
   /**
-   * Drop all pending assignment tracking without reverting values. Used
-   * by transactional rollback: the in-memory values stay, but the record
-   * no longer reports them as changed.
+   * Drop all pending assignment tracking and reset the baseline to the
+   * current in-memory values. Subsequent writes diff from the new baseline.
+   *
+   * Rails' `forget_attribute_assignments` replaces `@attributes` with
+   * `@attributes.map(&:forgotten_change)`, which rebinds each Attribute's
+   * `@original_attribute` to its current cast value. Mirror that by
+   * re-snapshotting (while preserving `_previousChanges` from the last save).
    *
    * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
    */
-  forgetAttributeAssignments(): void {
+  forgetAttributeAssignments(
+    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+  ): void {
+    if (attributes instanceof Map) {
+      this._originalAttributes = new Map(attributes);
+      this._originalHas = new Set(attributes.keys());
+    } else {
+      this._originalAttributes = attributes.snapshotValues();
+      this._originalHas = new Set(this._originalAttributes.keys());
+    }
     this._changedAttributes.clear();
   }
 
   /**
-   * Drop a single attribute's pending change without reverting its value.
+   * Drop a single attribute's pending change and rebind its baseline to
+   * the current value, so a later write reports `[current, next]` instead
+   * of `[originalFromFirstSnapshot, next]`.
    *
    * Mirrors: ActiveModel::Dirty#clear_attribute_change
-   * (-> mutation_tracker.forget_change(name)).
+   * -> `mutation_tracker.forget_change(name)`.
    */
-  clearAttributeChange(name: string): void {
+  clearAttributeChange(
+    attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
+    name: string,
+  ): void {
     this._changedAttributes.delete(name);
+    const snap = attributes instanceof Map ? attributes : attributes.snapshotValues();
+    if (snap.has(name)) {
+      this._originalAttributes.set(name, snap.get(name));
+      this._originalHas.add(name);
+    } else {
+      this._originalAttributes.delete(name);
+      this._originalHas.delete(name);
+    }
   }
 
   initAttributes(

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -134,6 +134,48 @@ export class DirtyTracker {
     }
   }
 
+  /**
+   * Pending changes diff against the values loaded from the database —
+   * what will be written on the next save. Cleared by `changesApplied()`.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_from_database
+   * (activemodel/lib/active_model/dirty.rb + attribute_mutation_tracker.rb).
+   */
+  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
+    return this.changes;
+  }
+
+  /**
+   * Snapshot of `mutations_from_database` at the moment of the last save.
+   * Lives until the next save.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_before_last_save
+   */
+  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
+    return this.previousChanges;
+  }
+
+  /**
+   * Drop all pending assignment tracking without reverting values. Used
+   * by transactional rollback: the in-memory values stay, but the record
+   * no longer reports them as changed.
+   *
+   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
+   */
+  forgetAttributeAssignments(): void {
+    this._changedAttributes.clear();
+  }
+
+  /**
+   * Drop a single attribute's pending change without reverting its value.
+   *
+   * Mirrors: ActiveModel::Dirty#clear_attribute_change
+   * (-> mutation_tracker.forget_change(name)).
+   */
+  clearAttributeChange(name: string): void {
+    this._changedAttributes.delete(name);
+  }
+
   initAttributes(
     attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
   ): void {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1665,7 +1665,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
    */
   forgetAttributeAssignments(): void {
-    this._dirty.forgetAttributeAssignments();
+    this._dirty.forgetAttributeAssignments(this._attributes);
   }
 
   /**
@@ -1674,7 +1674,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#clear_attribute_change
    */
   clearAttributeChange(name: string): void {
-    this._dirty.clearAttributeChange(name);
+    this._dirty.clearAttributeChange(this._attributes, name);
   }
 
   // -- Serialization --

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1640,6 +1640,43 @@ export class Model {
     this._dirty.clearAttributeChanges(attributes);
   }
 
+  /**
+   * Pending changes diff against the values loaded from the database.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_from_database
+   */
+  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
+    return this._dirty.mutationsFromDatabase;
+  }
+
+  /**
+   * Snapshot of the pending changes at the moment of the last save.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_before_last_save
+   */
+  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
+    return this._dirty.mutationsBeforeLastSave;
+  }
+
+  /**
+   * Drop all pending assignment tracking without reverting values.
+   * Used by transactional rollback paths.
+   *
+   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
+   */
+  forgetAttributeAssignments(): void {
+    this._dirty.forgetAttributeAssignments();
+  }
+
+  /**
+   * Drop a single attribute's pending change without reverting its value.
+   *
+   * Mirrors: ActiveModel::Dirty#clear_attribute_change
+   */
+  clearAttributeChange(name: string): void {
+    this._dirty.clearAttributeChange(name);
+  }
+
   // -- Serialization --
 
   serializableHash(options?: SerializeOptions): Record<string, unknown> {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -290,7 +290,7 @@ type TouchOption = boolean | string | string[];
 /** Class-level updateCounters + dirty-tracking needed by incrementBang. */
 interface CounterBangRecord extends AttributeIO {
   id: unknown;
-  clearAttributeChanges(attributes: string[]): void;
+  clearAttributeChange(name: string): void;
   constructor: {
     updateCounters(
       id: unknown,
@@ -348,8 +348,11 @@ export async function incrementBang<T extends CounterBangRecord>(
   await this.constructor.updateCounters(this.id, { [attribute]: by }, { touch: options.touch });
   // Rails: `public_send(:"clear_#{attribute}_change")` — the in-memory
   // increment is now durably persisted, so the attribute should no longer
-  // appear dirty (otherwise a later save() would re-persist it).
-  this.clearAttributeChanges([attribute]);
+  // appear dirty (otherwise a later save() would re-persist it). Use the
+  // per-attribute form so the baseline is rebound to the current value —
+  // otherwise a later write would still diff against the pre-increment
+  // original.
+  this.clearAttributeChange(attribute);
   return this;
 }
 

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -144,7 +144,11 @@ export async function beforeCommittedBang(this: Base): Promise<void> {
 function surreptitiouslyTouch(record: Base, attrNames: string[], time: Date): void {
   for (const attr of attrNames) {
     (record as any).writeAttribute(attr, time);
-    if (typeof (record as any).clearAttributeChanges === "function") {
+    // Per-attribute clear so the baseline rebinds to the touched value;
+    // otherwise a later write would diff against the pre-touch original.
+    if (typeof (record as any).clearAttributeChange === "function") {
+      (record as any).clearAttributeChange(attr);
+    } else if (typeof (record as any).clearAttributeChanges === "function") {
       (record as any).clearAttributeChanges([attr]);
     }
   }


### PR DESCRIPTION
## Summary
Our `DirtyTracker` already kept the two states separate internally (`_changedAttributes` = pre-save diff, `_previousChanges` = last-save snapshot), but only exposed them under the generic `changes` / `previousChanges` names. Rails' `attribute_mutation_tracker.rb` + `dirty.rb` export them under mutation-tracker-canonical names, and add two pending-assignment dropping methods used by transactional rollback.

Adds on Model + `DirtyTracker`:
- `mutationsFromDatabase` → current pending changes
- `mutationsBeforeLastSave` → snapshot from the last save
- `forgetAttributeAssignments()` — drop all pending tracking, rebind baseline to current values (matches Rails' `@attributes.map(&:forgotten_change)`)
- `clearAttributeChange(name)` — drop one pending change, rebind baseline for that name

## Test plan
- [x] 9 tests in `dirty-mutations.test.ts` (incl. baseline-reset regression cases after review)
- [x] AM 1,525 / AR all pass
- [x] typecheck + lint clean