### PR TITLE
test(parity): AR query fixtures ar-20..ar-23 — Arel interop + raw SQL composition (PR 4)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -65,6 +65,6 @@
   },
   "ar-23": {
     "side": "diff",
-    "reason": "ORDER BY column qualification with .from(rawSql, alias): trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
+    "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -62,5 +62,9 @@
   "ar-19": {
     "side": "diff",
     "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09 / ar-11."
+  },
+  "ar-23": {
+    "side": "diff",
+    "reason": "ORDER BY column qualification with .from(rawSql, alias): trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
   }
 }

--- a/scripts/parity/fixtures/ar-20/models.rb
+++ b/scripts/parity/fixtures/ar-20/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-20/models.ts
+++ b/scripts/parity/fixtures/ar-20/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-20/query.rb
+++ b/scripts/parity/fixtures/ar-20/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:title].matches("%rails%"))

--- a/scripts/parity/fixtures/ar-20/query.ts
+++ b/scripts/parity/fixtures/ar-20/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("title").matches("%rails%"));

--- a/scripts/parity/fixtures/ar-20/schema.sql
+++ b/scripts/parity/fixtures/ar-20/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-20
+-- Query: Book.where(Book.arel_table[:title].matches("%rails%"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-21/models.rb
+++ b/scripts/parity/fixtures/ar-21/models.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  has_many :posts
+end
+class Post < ActiveRecord::Base
+  belongs_to :user
+end

--- a/scripts/parity/fixtures/ar-21/models.ts
+++ b/scripts/parity/fixtures/ar-21/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    this.hasMany("posts");
+    registerModel(this);
+  }
+}
+export class Post extends Base {
+  static {
+    this.tableName = "posts";
+    this.belongsTo("user");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-21/query.rb
+++ b/scripts/parity/fixtures/ar-21/query.rb
@@ -1,0 +1,2 @@
+posts = Post.arel_table
+User.where(Post.where(posts[:user_id].eq(User.arel_table[:id])).arel.exists.not)

--- a/scripts/parity/fixtures/ar-21/query.ts
+++ b/scripts/parity/fixtures/ar-21/query.ts
@@ -1,0 +1,9 @@
+import { User, Post } from "./models.js";
+
+const posts = Post.arelTable;
+export default User.where(
+  Post.where(posts.get("user_id").eq(User.arelTable.get("id")))
+    .arel()
+    .exists()
+    .not(),
+);

--- a/scripts/parity/fixtures/ar-21/schema.sql
+++ b/scripts/parity/fixtures/ar-21/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-21
+-- Query: User.where(Post.where(posts[:user_id].eq(User.arel_table[:id])).arel.exists.not)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-22/models.rb
+++ b/scripts/parity/fixtures/ar-22/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-22/models.ts
+++ b/scripts/parity/fixtures/ar-22/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-22/query.rb
+++ b/scripts/parity/fixtures/ar-22/query.rb
@@ -1,0 +1,2 @@
+User.select("users.*, RANK() OVER (ORDER BY comments_count DESC) as rank")
+  .joins("LEFT JOIN (SELECT user_id, COUNT(*) as comments_count FROM comments GROUP BY user_id) comments ON comments.user_id = users.id")

--- a/scripts/parity/fixtures/ar-22/query.ts
+++ b/scripts/parity/fixtures/ar-22/query.ts
@@ -1,7 +1,5 @@
 import { User } from "./models.js";
 
-export default User.all()
-  .select("users.*, RANK() OVER (ORDER BY comments_count DESC) as rank")
-  .joins(
-    "LEFT JOIN (SELECT user_id, COUNT(*) as comments_count FROM comments GROUP BY user_id) comments ON comments.user_id = users.id",
-  );
+export default User.select("users.*, RANK() OVER (ORDER BY comments_count DESC) as rank").joins(
+  "LEFT JOIN (SELECT user_id, COUNT(*) as comments_count FROM comments GROUP BY user_id) comments ON comments.user_id = users.id",
+);

--- a/scripts/parity/fixtures/ar-22/query.ts
+++ b/scripts/parity/fixtures/ar-22/query.ts
@@ -1,0 +1,7 @@
+import { User } from "./models.js";
+
+export default User.all()
+  .select("users.*, RANK() OVER (ORDER BY comments_count DESC) as rank")
+  .joins(
+    "LEFT JOIN (SELECT user_id, COUNT(*) as comments_count FROM comments GROUP BY user_id) comments ON comments.user_id = users.id",
+  );

--- a/scripts/parity/fixtures/ar-22/schema.sql
+++ b/scripts/parity/fixtures/ar-22/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-22
+-- Query: User.select("users.*, RANK() OVER (ORDER BY comments_count DESC) as rank")...
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  body TEXT
+);

--- a/scripts/parity/fixtures/ar-23/models.rb
+++ b/scripts/parity/fixtures/ar-23/models.rb
@@ -1,0 +1,2 @@
+class Developer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-23/models.ts
+++ b/scripts/parity/fixtures/ar-23/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Developer extends Base {
+  static {
+    this.tableName = "developers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-23/query.rb
+++ b/scripts/parity/fixtures/ar-23/query.rb
@@ -1,0 +1,2 @@
+RANKED_DEV_SQL = "(SELECT id, name, commits AS hotness FROM developers ORDER BY commits DESC) developers"
+Developer.from(RANKED_DEV_SQL).order(hotness: :desc).limit(10)

--- a/scripts/parity/fixtures/ar-23/query.ts
+++ b/scripts/parity/fixtures/ar-23/query.ts
@@ -1,0 +1,6 @@
+import { Developer } from "./models.js";
+
+const RANKED_DEV_SQL =
+  "(SELECT id, name, commits AS hotness FROM developers ORDER BY commits DESC) developers";
+
+export default Developer.all().from(RANKED_DEV_SQL).order({ hotness: "desc" }).limit(10);

--- a/scripts/parity/fixtures/ar-23/query.ts
+++ b/scripts/parity/fixtures/ar-23/query.ts
@@ -3,4 +3,4 @@ import { Developer } from "./models.js";
 const RANKED_DEV_SQL =
   "(SELECT id, name, commits AS hotness FROM developers ORDER BY commits DESC) developers";
 
-export default Developer.all().from(RANKED_DEV_SQL).order({ hotness: "desc" }).limit(10);
+export default Developer.from(RANKED_DEV_SQL).order({ hotness: "desc" }).limit(10);

--- a/scripts/parity/fixtures/ar-23/schema.sql
+++ b/scripts/parity/fixtures/ar-23/schema.sql
@@ -1,5 +1,5 @@
 -- Fixture for statement: ar-23
--- Query: Developer.from("(<ranked sql>) as developers").order(hotness: :desc).limit(10)
+-- Query: Developer.from("(<ranked sql>) developers").order(hotness: :desc).limit(10)
 
 CREATE TABLE developers (
   id INTEGER PRIMARY KEY,

--- a/scripts/parity/fixtures/ar-23/schema.sql
+++ b/scripts/parity/fixtures/ar-23/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-23
+-- Query: Developer.from("(<ranked sql>) as developers").order(hotness: :desc).limit(10)
+
+CREATE TABLE developers (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  commits INTEGER
+);


### PR DESCRIPTION
## Summary
- Adds 4 AR query parity fixtures covering Arel interop and raw-SQL composition.
- ar-20: Arel `matches()` LIKE predicate — **PASS** byte-identical
- ar-21: NOT EXISTS via `Relation.arel().exists().not()` — **PASS**
- ar-22: window function with raw-SQL JOIN subquery — **PASS**
- ar-23: `.from(rawSql, alias)` with ORDER BY — **KNOWN-GAP**: trails qualifies the order column (`"developers"."hotness"`); Rails leaves it bare (`"hotness"`). Inverse direction from ar-17's GROUP BY case.

## Test plan
- [x] `pnpm parity:query` — ar-20..ar-22 PASS, ar-23 logged as KNOWN-GAP
- [x] No unexpected passes / no new failures