### PR TITLE
feat(activemodel): PR 24 — Lint as a Vitest-friendly mixin

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -109,3 +109,4 @@ export {
 } from "./secure-password.js";
 export { SerializeCastValue } from "./type/serialize-cast-value.js";
 export { Builder as AttributeSetBuilder } from "./attribute-set/builder.js";
+export { Tests as LintTests, lintTests, describeLint } from "./lint.js";

--- a/packages/activemodel/src/lint.test.ts
+++ b/packages/activemodel/src/lint.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { Model, lintTests, describeLint } from "./index.js";
+
+class Post extends Model {
+  static {
+    this.attribute("id", "integer");
+  }
+}
+
+// Self-application — exactly the Rails idiom of `include ActiveModel::Lint::Tests`
+// (lint.rb), but driven through Vitest via describeLint.
+describeLint({ describe, it }, () => new Post({ id: 1 }), { label: "Post lint" });
+
+describe("Lint registry", () => {
+  it("exposes the Rails-canonical test_* set", () => {
+    // Mirrors lint.rb's `test_to_key`, `test_to_param`, `test_to_partial_path`,
+    // `test_persisted?`, `test_model_naming`, `test_errors_aref`, `test_errors`.
+    expect(lintTests.map((t) => t.name).sort()).toEqual(
+      [
+        "errors",
+        "errors_aref",
+        "model_naming",
+        "persisted?",
+        "to_key",
+        "to_param",
+        "to_partial_path",
+      ].sort(),
+    );
+  });
+
+  it("each registered test runs against a compliant model", () => {
+    const model = new Post({ id: 1 });
+    for (const t of lintTests) {
+      expect(() => t.run(model)).not.toThrow();
+    }
+  });
+
+  it("flags non-compliant models with a clear error", () => {
+    const broken = {
+      toKey: () => "not an array",
+      isPersisted: () => true,
+    };
+    expect(() => lintTests.find((t) => t.name === "to_key")!.run(broken)).toThrow(
+      /toKey must return null or an array/,
+    );
+  });
+});

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -95,3 +95,51 @@ export const {
   testModelNaming,
   testErrorsAref,
 } = Tests;
+
+/**
+ * The Rails-canonical Lint::Tests as a name -> assertion list.
+ *
+ * Mirrors the discoverable `test_*` methods on `ActiveModel::Lint::Tests`,
+ * allowing a test framework to enumerate and dispatch them — same role
+ * as MiniTest's `include ActiveModel::Lint::Tests` (lint.rb).
+ */
+export const lintTests: ReadonlyArray<{ name: string; run(model: unknown): void }> = [
+  { name: "to_key", run: (m) => Tests.testToKey(m as never) },
+  { name: "to_param", run: (m) => Tests.testToParam(m as never) },
+  { name: "to_partial_path", run: (m) => Tests.testToPartialPath(m as never) },
+  { name: "persisted?", run: (m) => Tests.testPersisted(m as never) },
+  { name: "model_naming", run: (m) => Tests.testModelNaming(m as never) },
+  { name: "errors_aref", run: (m) => Tests.testErrorsAref(m as never) },
+  { name: "errors", run: (m) => Tests.testErrors(m as never) },
+];
+
+interface MinimalDescribe {
+  (label: string, body: () => void): void;
+}
+interface MinimalIt {
+  (label: string, body: () => void): void;
+}
+
+/**
+ * Vitest-friendly translation of Rails' `include ActiveModel::Lint::Tests`.
+ * Pass in your testing framework's `describe`/`it` and a factory that
+ * builds a fresh model for each assertion; emits one `it` per Rails
+ * `test_*` method, mirroring how MiniTest discovers them.
+ *
+ * Example:
+ *   import { describe, it } from "vitest";
+ *   import { describeLint } from "@blazetrails/activemodel";
+ *   describeLint({ describe, it }, () => new Post());
+ */
+export function describeLint(
+  framework: { describe: MinimalDescribe; it: MinimalIt },
+  buildModel: () => unknown,
+  options: { label?: string } = {},
+): void {
+  const label = options.label ?? "ActiveModel::Lint";
+  framework.describe(label, () => {
+    for (const t of lintTests) {
+      framework.it(t.name, () => t.run(buildModel()));
+    }
+  });
+}

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -104,13 +104,25 @@ export const {
  * as MiniTest's `include ActiveModel::Lint::Tests` (lint.rb).
  */
 export const lintTests: ReadonlyArray<{ name: string; run(model: unknown): void }> = [
-  { name: "to_key", run: (m) => Tests.testToKey(m as never) },
-  { name: "to_param", run: (m) => Tests.testToParam(m as never) },
-  { name: "to_partial_path", run: (m) => Tests.testToPartialPath(m as never) },
-  { name: "persisted?", run: (m) => Tests.testPersisted(m as never) },
-  { name: "model_naming", run: (m) => Tests.testModelNaming(m as never) },
-  { name: "errors_aref", run: (m) => Tests.testErrorsAref(m as never) },
-  { name: "errors", run: (m) => Tests.testErrors(m as never) },
+  { name: "to_key", run: (m) => Tests.testToKey(m as Parameters<typeof Tests.testToKey>[0]) },
+  { name: "to_param", run: (m) => Tests.testToParam(m as Parameters<typeof Tests.testToParam>[0]) },
+  {
+    name: "to_partial_path",
+    run: (m) => Tests.testToPartialPath(m as Parameters<typeof Tests.testToPartialPath>[0]),
+  },
+  {
+    name: "persisted?",
+    run: (m) => Tests.testPersisted(m as Parameters<typeof Tests.testPersisted>[0]),
+  },
+  {
+    name: "model_naming",
+    run: (m) => Tests.testModelNaming(m as Parameters<typeof Tests.testModelNaming>[0]),
+  },
+  {
+    name: "errors_aref",
+    run: (m) => Tests.testErrorsAref(m as Parameters<typeof Tests.testErrorsAref>[0]),
+  },
+  { name: "errors", run: (m) => Tests.testErrors(m as Parameters<typeof Tests.testErrors>[0]) },
 ];
 
 interface MinimalDescribe {


### PR DESCRIPTION
## Summary
Rails' `ActiveModel::Lint::Tests` is a MiniTest module: `include` it and its `test_*` methods become discoverable test cases. Our `lint.ts` only exposed free assertion functions; users couldn't inherit the suite into their own test scope.

This PR adds a registry-shaped equivalent that maps to Vitest's `describe`/`it` via DI:

- `lintTests` — name + `run()` per Rails-canonical `test_*` method (`to_key`, `to_param`, `to_partial_path`, `persisted?`, `model_naming`, `errors_aref`, `errors`).
- `describeLint({ describe, it }, makeModel, { label? })` — emits one `it` per registered test against a fresh model. Mirrors `include ActiveModel::Lint::Tests`.

DI shape avoids making Vitest a runtime import of `@blazetrails/activemodel`.

## Test plan
- [x] 10 tests in `lint.test.ts` (3 explicit + 7 emitted by `describeLint`)
- [x] AM 1,535 / AR 9,283 all pass
- [x] typecheck + lint clean