### PR TITLE
test(parity): AR query fixtures ar-24..ar-28 — Range/NULL + relation transformers (PR 5)

### DIFF
--- a/scripts/parity/fixtures/ar-24/models.rb
+++ b/scripts/parity/fixtures/ar-24/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-24/models.ts
+++ b/scripts/parity/fixtures/ar-24/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-24/query.rb
+++ b/scripts/parity/fixtures/ar-24/query.rb
@@ -1,0 +1,1 @@
+Book.where(title: nil)

--- a/scripts/parity/fixtures/ar-24/query.ts
+++ b/scripts/parity/fixtures/ar-24/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ title: null });

--- a/scripts/parity/fixtures/ar-24/schema.sql
+++ b/scripts/parity/fixtures/ar-24/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-24
+-- Query: Book.where(title: nil)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-25/models.rb
+++ b/scripts/parity/fixtures/ar-25/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-25/models.ts
+++ b/scripts/parity/fixtures/ar-25/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-25/query.rb
+++ b/scripts/parity/fixtures/ar-25/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1..5)

--- a/scripts/parity/fixtures/ar-25/query.ts
+++ b/scripts/parity/fixtures/ar-25/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ id: new Range(1, 5) });

--- a/scripts/parity/fixtures/ar-25/schema.sql
+++ b/scripts/parity/fixtures/ar-25/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-25
+-- Query: Book.where(id: 1..5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-26/models.rb
+++ b/scripts/parity/fixtures/ar-26/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-26/models.ts
+++ b/scripts/parity/fixtures/ar-26/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-26/query.rb
+++ b/scripts/parity/fixtures/ar-26/query.rb
@@ -1,0 +1,1 @@
+Customer.where(last_name: "Smith").rewhere(last_name: "Jones")

--- a/scripts/parity/fixtures/ar-26/query.ts
+++ b/scripts/parity/fixtures/ar-26/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.where({ last_name: "Smith" }).rewhere({ last_name: "Jones" });

--- a/scripts/parity/fixtures/ar-26/schema.sql
+++ b/scripts/parity/fixtures/ar-26/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-26
+-- Query: Customer.where(last_name: "Smith").rewhere(last_name: "Jones")
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  last_name TEXT,
+  orders_count INTEGER
+);

--- a/scripts/parity/fixtures/ar-27/models.rb
+++ b/scripts/parity/fixtures/ar-27/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-27/models.ts
+++ b/scripts/parity/fixtures/ar-27/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-27/query.rb
+++ b/scripts/parity/fixtures/ar-27/query.rb
@@ -1,0 +1,1 @@
+Book.none

--- a/scripts/parity/fixtures/ar-27/query.ts
+++ b/scripts/parity/fixtures/ar-27/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.none();

--- a/scripts/parity/fixtures/ar-27/schema.sql
+++ b/scripts/parity/fixtures/ar-27/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-27
+-- Query: Book.none
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-28/models.rb
+++ b/scripts/parity/fixtures/ar-28/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-28/models.ts
+++ b/scripts/parity/fixtures/ar-28/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-28/query.rb
+++ b/scripts/parity/fixtures/ar-28/query.rb
@@ -1,0 +1,1 @@
+Customer.where(last_name: "Smith").merge(Customer.where(orders_count: 5))

--- a/scripts/parity/fixtures/ar-28/query.ts
+++ b/scripts/parity/fixtures/ar-28/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.where({ last_name: "Smith" }).merge(Customer.where({ orders_count: 5 }));

--- a/scripts/parity/fixtures/ar-28/schema.sql
+++ b/scripts/parity/fixtures/ar-28/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-28
+-- Query: Customer.where(last_name: "Smith").merge(Customer.where(orders_count: 5))
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  last_name TEXT,
+  orders_count INTEGER
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures around Range/NULL handling and relation transformers — all **PASS** byte-identical against Rails.
- ar-24: `where(title: nil)` → `IS NULL`
- ar-25: `where(id: 1..5)` → `BETWEEN 1 AND 5` (uses trails `Range`)
- ar-26: `where(...).rewhere(...)` replaces same-attr predicate
- ar-27: `Book.none` → impossible WHERE clause
- ar-28: `where(...).merge(other.where(...))` composes predicates

## Test plan
- [x] `pnpm parity:query` — ar-24..ar-28 all PASS
- [x] No new known-gaps; no UNEXPECTED-PASS