### PR TITLE
test(parity): AR query fixtures ar-29..ar-33 — locking, projection, annotations, ordering (PR 6)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -66,5 +66,17 @@
   "ar-23": {
     "side": "diff",
     "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
+  },
+  "ar-29": {
+    "side": "diff",
+    "reason": ".lock on SQLite: trails emits 'FOR UPDATE' regardless of adapter; Rails knows SQLite has no row-level locking and emits no lock clause. trails should make Relation#lock adapter-aware (mirror Rails' AbstractAdapter#lock_clause / SQLite returning empty)."
+  },
+  "ar-32": {
+    "side": "diff",
+    "reason": "in_order_of: multiple divergences vs Rails. (1) Rails adds WHERE \"books\".\"status\" IN (values) to filter to the named set; trails omits it. (2) Rails CASE values are 1-indexed; trails 0-indexed with ELSE branch. (3) Rails appends ASC; trails leaves direction bare. (4) Rails qualifies the column ('\"books\".\"status\"'); trails leaves it bare. Real implementation gap — trails Relation#inOrderOf is incomplete vs ActiveRecord::QueryMethods#in_order_of."
+  },
+  "ar-33": {
+    "side": "diff",
+    "reason": "Relation#select with an Arel attribute As node: trails emits literal '[object Object]' because Relation#select accepts only string | SqlLiteral and toString-coerces other inputs; Rails accepts Arel nodes and renders them via the visitor. trails-missing: select() should accept Arel nodes (Attribute, As, etc.) and call toSql on them."
   }
 }

--- a/scripts/parity/fixtures/ar-29/models.rb
+++ b/scripts/parity/fixtures/ar-29/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-29/models.ts
+++ b/scripts/parity/fixtures/ar-29/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-29/query.rb
+++ b/scripts/parity/fixtures/ar-29/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).lock

--- a/scripts/parity/fixtures/ar-29/query.ts
+++ b/scripts/parity/fixtures/ar-29/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).lock();

--- a/scripts/parity/fixtures/ar-29/schema.sql
+++ b/scripts/parity/fixtures/ar-29/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-29
+-- Query: Book.where(id: 1).lock
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-30/models.rb
+++ b/scripts/parity/fixtures/ar-30/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-30/models.ts
+++ b/scripts/parity/fixtures/ar-30/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-30/query.rb
+++ b/scripts/parity/fixtures/ar-30/query.rb
@@ -1,0 +1,1 @@
+Book.select(:id, :title)

--- a/scripts/parity/fixtures/ar-30/query.ts
+++ b/scripts/parity/fixtures/ar-30/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select("id", "title");

--- a/scripts/parity/fixtures/ar-30/schema.sql
+++ b/scripts/parity/fixtures/ar-30/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-30
+-- Query: Book.select(:id, :title)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-31/models.rb
+++ b/scripts/parity/fixtures/ar-31/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-31/models.ts
+++ b/scripts/parity/fixtures/ar-31/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-31/query.rb
+++ b/scripts/parity/fixtures/ar-31/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).annotate("selecting books")

--- a/scripts/parity/fixtures/ar-31/query.ts
+++ b/scripts/parity/fixtures/ar-31/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).annotate("selecting books");

--- a/scripts/parity/fixtures/ar-31/schema.sql
+++ b/scripts/parity/fixtures/ar-31/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-31
+-- Query: Book.where(id: 1).annotate("selecting books")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-32/models.rb
+++ b/scripts/parity/fixtures/ar-32/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-32/models.ts
+++ b/scripts/parity/fixtures/ar-32/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-32/query.rb
+++ b/scripts/parity/fixtures/ar-32/query.rb
@@ -1,0 +1,1 @@
+Book.in_order_of(:status, %w[published draft archived])

--- a/scripts/parity/fixtures/ar-32/query.ts
+++ b/scripts/parity/fixtures/ar-32/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().inOrderOf("status", ["published", "draft", "archived"]);

--- a/scripts/parity/fixtures/ar-32/schema.sql
+++ b/scripts/parity/fixtures/ar-32/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-32
+-- Query: Book.in_order_of(:status, %w[published draft archived])
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-33/models.rb
+++ b/scripts/parity/fixtures/ar-33/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-33/models.ts
+++ b/scripts/parity/fixtures/ar-33/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-33/query.rb
+++ b/scripts/parity/fixtures/ar-33/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:title].as("t"))

--- a/scripts/parity/fixtures/ar-33/query.ts
+++ b/scripts/parity/fixtures/ar-33/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select(Book.arelTable.get("title").as("t"));

--- a/scripts/parity/fixtures/ar-33/schema.sql
+++ b/scripts/parity/fixtures/ar-33/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-33
+-- Query: Book.select(Book.arel_table[:title].as("t"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures around locking, projection, annotations, and custom ordering. 2 PASS byte-identical; 3 surface real trails-side gaps captured as known-gaps.

**PASS**
- ar-30: `Book.select(:id, :title)` — multi-column projection
- ar-31: `Book.where(id: 1).annotate("...")` — SQL comment

**KNOWN-GAP** (real implementation gaps)
- ar-29: `.lock` — trails emits `FOR UPDATE` on SQLite; Rails (correctly) emits no lock clause on adapters without row locking. Should mirror Rails' `AbstractAdapter#lock_clause` SQLite override.
- ar-32: `in_order_of` — multiple divergences: missing `WHERE col IN (values)` filter, 0-indexed CASE values vs Rails 1-indexed, missing `ASC` suffix, missing column qualification. Real `Relation#inOrderOf` implementation gap.
- ar-33: `select(arel_table[:c].as("alias"))` — trails renders `[object Object]` because `Relation#select` accepts only `string | SqlLiteral`. Rails accepts any Arel node and renders via the visitor. trails-missing.

## Test plan
- [x] `pnpm parity:query` — 2 PASS, 3 KNOWN-GAP, no UNEXPECTED-PASS
- [x] All known-gap reasons reference Rails source/behavior