### PR TITLE
Revert "docs(activerecord): bigint audit — document count/average precision limits and ids() runtime types"

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1558,24 +1558,6 @@ describe("BasicsTest", () => {
     expect(ids).toContain(u1.id);
     expect(ids).toContain(u2.id);
   });
-
-  it("ids returns tuples for composite primary keys", async () => {
-    class Order extends Base {
-      static {
-        this.primaryKey = ["shop_id", "id"];
-        this.attribute("shop_id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    const o1 = await Order.create({ shop_id: 1, name: "first" });
-    const o2 = await Order.create({ shop_id: 2, name: "second" });
-    const ids = await Order.ids();
-    expect(ids).toHaveLength(2);
-    // Each element is a tuple [shop_id, id]
-    expect(ids).toContainEqual([o1.readAttribute("shop_id"), o1.readAttribute("id")]);
-    expect(ids).toContainEqual([o2.readAttribute("shop_id"), o2.readAttribute("id")]);
-  });
   it("minimum returns min value", async () => {
     class User extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2182,18 +2182,9 @@ export class Relation<T extends Base> {
    * Pluck the primary key values.
    *
    * Mirrors: ActiveRecord::Relation#ids
-   *
-   * Return type is `unknown[]` in both cases:
-   * - Single-column PKs: each element is a scalar (string | number | bigint).
-   *   The concrete JS type depends on the adapter — SQLite returns bigint for
-   *   big_integer PKs (safeIntegers); PG returns decimal string for int8;
-   *   MySQL returns string for large BIGINT values and number for small ones.
-   * - Composite PKs: each element is itself an array (tuple of scalars).
    */
   async ids(): Promise<unknown[]> {
-    const pk = this._modelClass.primaryKey;
-    const cols = Array.isArray(pk) ? pk : [pk];
-    return this.pluck(...(cols as [string, ...string[]]));
+    return this.pluck(this._modelClass.primaryKey as string);
   }
 
   /**

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -204,12 +204,6 @@ async function groupedAggregate(
   return result;
 }
 
-/**
- * SQL COUNT() results are returned as JS number. This diverges from
- * Rails, which returns arbitrary-precision Integer. Tables with more
- * than 2^53-1 rows would silently lose precision; the practical risk
- * is negligible but the divergence is documented.
- */
 export async function performCount(
   this: CalculationRelation,
   column?: string,
@@ -284,11 +278,6 @@ export async function performSum(
   return ((await singleAggregate(this, "sum", column, true)) as number | bigint) ?? 0;
 }
 
-/**
- * Rails returns BigDecimal for average on integer/decimal columns.
- * We return number here — precision is lost for values whose average
- * exceeds Number.MAX_SAFE_INTEGER (2^53-1).
- */
 export async function performAverage(
   this: CalculationRelation,
   column: string,


### PR DESCRIPTION
Reverts blazetrailsdev/trails#803