### PR TITLE
test(parity): AR query fixtures ar-34..ar-38 — CTE, optimizer hints, where.missing/associated, subquery (PR 7)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -46,5 +46,17 @@
   "ar-33": {
     "side": "diff",
     "reason": "Relation#select with an Arel attribute As node: trails emits literal '[object Object]' because Relation#select accepts only string | SqlLiteral and toString-coerces other inputs; Rails accepts Arel nodes and renders them via the visitor. trails-missing: select() should accept Arel nodes (Attribute, As, etc.) and call toSql on them."
+  },
+  "ar-36": {
+    "side": "diff",
+    "reason": "where.missing(:assoc): Rails emits LEFT OUTER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NULL (works for any association type). trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NULL — equivalent for belongs_to but diverges from Rails' SQL and won't work for has_one/has_many. Real trails-missing: whereMissing should emit the JOIN form."
+  },
+  "ar-37": {
+    "side": "diff",
+    "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
+  },
+  "ar-38": {
+    "side": "diff",
+    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 / ar-11 / ar-19 — boolean serialization is type-system-driven, not adapter-aware."
   }
 }

--- a/scripts/parity/fixtures/ar-34/models.rb
+++ b/scripts/parity/fixtures/ar-34/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-34/models.ts
+++ b/scripts/parity/fixtures/ar-34/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-34/query.rb
+++ b/scripts/parity/fixtures/ar-34/query.rb
@@ -1,0 +1,1 @@
+Book.with(recent: Book.where("published_year >= ?", 2020)).from("recent AS books")

--- a/scripts/parity/fixtures/ar-34/query.ts
+++ b/scripts/parity/fixtures/ar-34/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.all()
+  .with({ recent: Book.where("published_year >= ?", 2020) })
+  .from("recent AS books");

--- a/scripts/parity/fixtures/ar-34/schema.sql
+++ b/scripts/parity/fixtures/ar-34/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-34
+-- Query: Book.with(recent: Book.where("published_year >= ?", 2020)).from("recent AS books")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  published_year INTEGER
+);

--- a/scripts/parity/fixtures/ar-35/models.rb
+++ b/scripts/parity/fixtures/ar-35/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-35/models.ts
+++ b/scripts/parity/fixtures/ar-35/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-35/query.rb
+++ b/scripts/parity/fixtures/ar-35/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).optimizer_hints("USE_INDEX(books, idx_title)")

--- a/scripts/parity/fixtures/ar-35/query.ts
+++ b/scripts/parity/fixtures/ar-35/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).optimizerHints("USE_INDEX(books, idx_title)");

--- a/scripts/parity/fixtures/ar-35/schema.sql
+++ b/scripts/parity/fixtures/ar-35/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-35
+-- Query: Book.optimizer_hints("USE_INDEX(books, idx_title)").where(id: 1)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-35/schema.sql
+++ b/scripts/parity/fixtures/ar-35/schema.sql
@@ -1,5 +1,5 @@
 -- Fixture for statement: ar-35
--- Query: Book.optimizer_hints("USE_INDEX(books, idx_title)").where(id: 1)
+-- Query: Book.where(id: 1).optimizer_hints("USE_INDEX(books, idx_title)")
 
 CREATE TABLE books (
   id INTEGER PRIMARY KEY,

--- a/scripts/parity/fixtures/ar-36/models.rb
+++ b/scripts/parity/fixtures/ar-36/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-36/models.ts
+++ b/scripts/parity/fixtures/ar-36/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-36/query.rb
+++ b/scripts/parity/fixtures/ar-36/query.rb
@@ -1,0 +1,1 @@
+Book.where.missing(:author)

--- a/scripts/parity/fixtures/ar-36/query.ts
+++ b/scripts/parity/fixtures/ar-36/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().whereMissing("author");

--- a/scripts/parity/fixtures/ar-36/schema.sql
+++ b/scripts/parity/fixtures/ar-36/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-36
+-- Query: Book.where.missing(:author)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-37/models.rb
+++ b/scripts/parity/fixtures/ar-37/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-37/models.ts
+++ b/scripts/parity/fixtures/ar-37/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-37/query.rb
+++ b/scripts/parity/fixtures/ar-37/query.rb
@@ -1,0 +1,1 @@
+Book.where.associated(:author)

--- a/scripts/parity/fixtures/ar-37/query.ts
+++ b/scripts/parity/fixtures/ar-37/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().whereAssociated("author");

--- a/scripts/parity/fixtures/ar-37/schema.sql
+++ b/scripts/parity/fixtures/ar-37/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-37
+-- Query: Book.where.associated(:author)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-38/models.rb
+++ b/scripts/parity/fixtures/ar-38/models.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+end
+class Comment < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-38/models.ts
+++ b/scripts/parity/fixtures/ar-38/models.ts
@@ -1,0 +1,14 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}
+export class Comment extends Base {
+  static {
+    this.tableName = "comments";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-38/query.rb
+++ b/scripts/parity/fixtures/ar-38/query.rb
@@ -1,0 +1,1 @@
+User.where(id: Comment.select(:user_id).where(approved: true))

--- a/scripts/parity/fixtures/ar-38/query.ts
+++ b/scripts/parity/fixtures/ar-38/query.ts
@@ -1,0 +1,3 @@
+import { User, Comment } from "./models.js";
+
+export default User.where({ id: Comment.select("user_id").where({ approved: true }) });

--- a/scripts/parity/fixtures/ar-38/schema.sql
+++ b/scripts/parity/fixtures/ar-38/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-38
+-- Query: User.where(id: Comment.select(:user_id).where(approved: true))
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  approved BOOLEAN
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures. 2 PASS byte-identical; 3 surface real trails-side gaps captured as known-gaps.

**PASS**
- ar-34: `Book.with(recent: ...).from("recent AS books")` — CTE composition
- ar-35: `Book.where(id: 1).optimizer_hints("USE_INDEX(...)")` — optimizer hint append

**KNOWN-GAP**
- ar-36: `where.missing(:author)` — trails shortcuts a `belongs_to` to `WHERE fk IS NULL`; Rails always emits `LEFT OUTER JOIN ... WHERE assoc.id IS NULL` (works for any association type). trails-missing.
- ar-37: `where.associated(:author)` — same shape gap: trails uses FK-not-null shortcut, Rails uses `INNER JOIN ... WHERE assoc.id IS NOT NULL`.
- ar-38: subquery `where(id: rel.where(approved: true))` — boolean `TRUE/FALSE` vs SQLite `1/0`. Same root cause as ar-09/11/19.

## Test plan
- [x] `pnpm parity:query` — 2 PASS, 3 KNOWN-GAP, no UNEXPECTED-PASS