### PR TITLE
feat(encryption): frozen_encryption validation + encryption error on save

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -252,14 +252,16 @@ export function applyPendingEncryptions(klass: any): void {
     }
   }
 
-  // Register the frozen-encryption validator once per inheritance chain, mirroring
-  // Rails' `validate :cant_modify_encrypted_attributes_when_frozen` registered
-  // via the `included` hook (runs once for the root encrypted class; subclasses
-  // inherit the callback). The `in` check intentionally walks the prototype
-  // chain so subclasses don't register a duplicate — the validator already reads
-  // `record.constructor._encryptedAttributes` at call time, so it correctly
-  // handles STI subclasses with different encrypted attribute sets.
-  if (!("_frozenEncryptionValidatorInstalled" in klass) && typeof klass.validate === "function") {
+  // Register the frozen-encryption validator once per class. Own-property check
+  // so subclasses that have already snapped their callback chain don't miss it —
+  // if a subclass cloned _callbackChain before the parent installed this
+  // validator, `in` would suppress installation even though the clone lacks it.
+  // The validator reads `record.constructor._encryptedAttributes` at call time,
+  // so it correctly handles STI subclasses with different encrypted attribute sets.
+  if (
+    !Object.prototype.hasOwnProperty.call(klass, "_frozenEncryptionValidatorInstalled") &&
+    typeof klass.validate === "function"
+  ) {
     klass._frozenEncryptionValidatorInstalled = true;
     klass.validate((record: any) => {
       if (!getEncryptionContext().frozenEncryption) return;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -25,7 +25,7 @@ import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Cipher } from "./encryption/cipher/aes256-gcm.js";
 import { globalPreviousSchemesFor, EncryptableRecord } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
-import { withoutEncryption } from "./encryption/context.js";
+import { withoutEncryption, getEncryptionContext } from "./encryption/context.js";
 
 /**
  * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
@@ -250,6 +250,25 @@ export function applyPendingEncryptions(klass: any): void {
     for (const { name } of pending) {
       EncryptableRecord.validateColumnSize(klass, name);
     }
+  }
+
+  // Register the frozen-encryption validator once per class, mirroring:
+  // validate :cant_modify_encrypted_attributes_when_frozen,
+  //   if: -> { has_encrypted_attributes? && context.frozen_encryption? }
+  if (!klass._frozenEncryptionValidatorInstalled && typeof klass.validate === "function") {
+    klass._frozenEncryptionValidatorInstalled = true;
+    klass.validate((record: any) => {
+      if (!getEncryptionContext().frozenEncryption) return;
+      const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+      const changed: string[] = Array.isArray(record.changedAttributes)
+        ? record.changedAttributes
+        : [];
+      for (const attr of changed) {
+        if (encryptedAttrs.has(attr)) {
+          record.errors.add(attr, "can't be modified because it is encrypted");
+        }
+      }
+    });
   }
 }
 

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -257,10 +257,7 @@ export function applyPendingEncryptions(klass: any): void {
   //   if: -> { has_encrypted_attributes? && context.frozen_encryption? }
   // Own-property guard mirrors the pattern used for _encryptedAttributes and
   // _pendingEncryptions so inheritance doesn't re-use a parent's registration.
-  if (
-    !Object.prototype.hasOwnProperty.call(klass, "_frozenEncryptionValidatorInstalled") &&
-    typeof klass.validate === "function"
-  ) {
+  if (!("_frozenEncryptionValidatorInstalled" in klass) && typeof klass.validate === "function") {
     klass._frozenEncryptionValidatorInstalled = true;
     klass.validate((record: any) => {
       if (!getEncryptionContext().frozenEncryption) return;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -252,11 +252,13 @@ export function applyPendingEncryptions(klass: any): void {
     }
   }
 
-  // Register the frozen-encryption validator once per class, mirroring:
-  // validate :cant_modify_encrypted_attributes_when_frozen,
-  //   if: -> { has_encrypted_attributes? && context.frozen_encryption? }
-  // Own-property guard mirrors the pattern used for _encryptedAttributes and
-  // _pendingEncryptions so inheritance doesn't re-use a parent's registration.
+  // Register the frozen-encryption validator once per inheritance chain, mirroring
+  // Rails' `validate :cant_modify_encrypted_attributes_when_frozen` registered
+  // via the `included` hook (runs once for the root encrypted class; subclasses
+  // inherit the callback). The `in` check intentionally walks the prototype
+  // chain so subclasses don't register a duplicate — the validator already reads
+  // `record.constructor._encryptedAttributes` at call time, so it correctly
+  // handles STI subclasses with different encrypted attribute sets.
   if (!("_frozenEncryptionValidatorInstalled" in klass) && typeof klass.validate === "function") {
     klass._frozenEncryptionValidatorInstalled = true;
     klass.validate((record: any) => {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -255,11 +255,19 @@ export function applyPendingEncryptions(klass: any): void {
   // Register the frozen-encryption validator once per class, mirroring:
   // validate :cant_modify_encrypted_attributes_when_frozen,
   //   if: -> { has_encrypted_attributes? && context.frozen_encryption? }
-  if (!klass._frozenEncryptionValidatorInstalled && typeof klass.validate === "function") {
+  // Own-property guard mirrors the pattern used for _encryptedAttributes and
+  // _pendingEncryptions so inheritance doesn't re-use a parent's registration.
+  if (
+    !Object.prototype.hasOwnProperty.call(klass, "_frozenEncryptionValidatorInstalled") &&
+    typeof klass.validate === "function"
+  ) {
     klass._frozenEncryptionValidatorInstalled = true;
     klass.validate((record: any) => {
       if (!getEncryptionContext().frozenEncryption) return;
-      const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+      // Use record.constructor so STI subclasses consult their own
+      // encrypted_attributes list — mirrors Rails' self.class.encrypted_attributes.
+      const encryptedAttrs: Set<string> =
+        (record.constructor as any)._encryptedAttributes ?? new Set();
       const changed: string[] = Array.isArray(record.changedAttributes)
         ? record.changedAttributes
         : [];

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -33,6 +33,7 @@ export class Context {
 export interface EncryptionContext {
   encryptionDisabled?: boolean;
   protectedMode?: boolean;
+  frozenEncryption?: boolean;
   keyProvider?: unknown;
   [key: string]: unknown;
 }

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -9,6 +9,7 @@ import {
   makeEncryptedBookWithDowncaseName,
   makeEncryptedBookIgnoreCase,
   makeEncryptedAuthor,
+  makeBookThatWillFailToEncryptName,
   makeFreshModel,
   makeKeyProvider,
   assertEncryptedAttribute,
@@ -16,6 +17,7 @@ import {
   withEncryptionContext,
   withoutEncryption,
   DecryptionError,
+  EncryptionError,
   AUTHOR_NAME_LIMIT,
 } from "./test-helpers.js";
 import { Configurable } from "./configurable.js";
@@ -300,9 +302,40 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it.skip("encrypts serialized attributes", () => {});
   it.skip("encrypts serialized attributes where encrypts is declared first", () => {});
   it.skip("encrypts store attributes with accessors", () => {});
-  it.skip("encryption errors when saving records will raise the error and don't save anything", () => {});
-  it.skip("can't modify encrypted attributes when frozen_encryption is true", () => {});
-  it.skip("can only save unencrypted attributes when frozen encryption is true", () => {});
+  it("encryption errors when saving records will raise the error and don't save anything", async () => {
+    const Book = makeBookThatWillFailToEncryptName(freshAdapter());
+    new Book();
+    const countBefore = await Book.count();
+    await expect(Book.create({ name: "Dune" })).rejects.toThrow(EncryptionError);
+    expect(await Book.count()).toBe(countBefore);
+  });
+
+  it("can't modify encrypted attributes when frozen_encryption is true", async () => {
+    const Post = makeEncryptedPost(freshAdapter());
+    new Post();
+    const post = await Post.create({ title: "Original", body: "body" });
+    post.title = "Some new title";
+    expect(post.isValid()).toBe(true);
+    withEncryptionContext({ frozenEncryption: true }, () => {
+      expect(post.isValid()).toBe(false);
+    });
+  });
+
+  it("can only save unencrypted attributes when frozen encryption is true", async () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    new Book();
+    const book = await Book.create({ name: "Dune" });
+    // Updating a non-encrypted attribute succeeds even when frozen.
+    await withEncryptionContext({ frozenEncryption: true }, async () => {
+      await book.updateColumns({ id: book.id });
+    });
+    // Updating an encrypted attribute fails validation when frozen.
+    withEncryptionContext({ frozenEncryption: true }, () => {
+      book.name = "New title";
+      expect(book.isValid()).toBe(false);
+      expect(book.errors.added("name", "can't be modified because it is encrypted")).toBe(true);
+    });
+  });
   it("validate column sizes", async () => {
     const Author = makeEncryptedAuthor(freshAdapter());
     new Author();

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -322,18 +322,24 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("can only save unencrypted attributes when frozen encryption is true", async () => {
-    const Book = makeEncryptedBook(freshAdapter());
-    new Book();
-    const book = await Book.create({ name: "Dune" });
-    // Updating a non-encrypted attribute succeeds even when frozen.
+    // Build a model with one encrypted (name) and one non-encrypted (notes) attribute.
+    const adp = freshAdapter();
+    const Article = makeFreshModel(adp, { id: "integer", name: "string", notes: "string" });
+    Article.encrypts("name");
+    new Article();
+    const article = await Article.create({ name: "Dune", notes: "original" });
+    // Updating a non-encrypted attribute via save succeeds even when frozen.
     await withEncryptionContext({ frozenEncryption: true }, async () => {
-      await book.updateColumns({ id: book.id });
+      article.notes = "updated";
+      await article.save();
     });
+    const reloaded = await Article.find(article.id);
+    expect(reloaded.notes).toBe("updated");
     // Updating an encrypted attribute fails validation when frozen.
     withEncryptionContext({ frozenEncryption: true }, () => {
-      book.name = "New title";
-      expect(book.isValid()).toBe(false);
-      expect(book.errors.added("name", "can't be modified because it is encrypted")).toBe(true);
+      article.name = "New title";
+      expect(article.isValid()).toBe(false);
+      expect(article.errors.added("name", "can't be modified because it is encrypted")).toBe(true);
     });
   });
   it("validate column sizes", async () => {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -15,9 +15,10 @@ import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
-import { DecryptionError } from "./errors.js";
+import { DecryptionError, EncryptionError } from "./errors.js";
+import type { EncryptorLike } from "./encryptor.js";
 
-export { withEncryptionContext, withoutEncryption, DecryptionError };
+export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionError };
 
 // ─── Test key material ────────────────────────────────────────────────────────
 
@@ -179,6 +180,32 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
       this.attribute("name", "string", { limit: AUTHOR_NAME_LIMIT });
       this.adapter = adapter;
       this.encrypts("name");
+    }
+  } as any;
+}
+
+const _failingEncryptor: EncryptorLike = {
+  encrypt() {
+    throw new EncryptionError("deliberate encryption failure");
+  },
+  decrypt(v) {
+    return v;
+  },
+  isEncrypted() {
+    return false;
+  },
+  isBinary() {
+    return false;
+  },
+};
+
+export function makeBookThatWillFailToEncryptName(adapter: DatabaseAdapter) {
+  return class BookThatWillFailToEncryptName extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name", { encryptor: _failingEncryptor } as any);
     }
   } as any;
 }

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -16,7 +16,7 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError, EncryptionError } from "./errors.js";
-import type { EncryptorLike } from "./encryptor.js";
+import type { Encryptor } from "../encryption.js";
 
 export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionError };
 
@@ -184,7 +184,7 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
   } as any;
 }
 
-const _failingEncryptor: EncryptorLike = {
+const _failingEncryptor: Encryptor = {
   encrypt() {
     throw new EncryptionError("deliberate encryption failure");
   },
@@ -192,9 +192,6 @@ const _failingEncryptor: EncryptorLike = {
     return v;
   },
   isEncrypted() {
-    return false;
-  },
-  isBinary() {
     return false;
   },
 };
@@ -205,7 +202,7 @@ export function makeBookThatWillFailToEncryptName(adapter: DatabaseAdapter) {
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.adapter = adapter;
-      this.encrypts("name", { encryptor: _failingEncryptor } as any);
+      this.encrypts("name", { encryptor: _failingEncryptor });
     }
   } as any;
 }

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -185,13 +185,13 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
 }
 
 const _failingEncryptor: Encryptor = {
-  encrypt() {
+  encrypt(_value: string): string {
     throw new EncryptionError("deliberate encryption failure");
   },
-  decrypt(v) {
-    return v;
+  decrypt(ciphertext: string): string {
+    return ciphertext;
   },
-  isEncrypted() {
+  isEncrypted(_text: string): boolean {
     return false;
   },
 };


### PR DESCRIPTION
## Summary

- Registers a `cant_modify_encrypted_attributes_when_frozen` validation in `applyPendingEncryptions` — mirrors Rails' `validate :cant_modify_encrypted_attributes_when_frozen, if: -> { frozen_encryption? }` callback. Checks `changedAttributes` for any encrypted attribute when the `frozenEncryption` context is active.
- Guard flag `_frozenEncryptionValidatorInstalled` prevents duplicate registration across multiple `applyPendingEncryptions` calls.
- `makeBookThatWillFailToEncryptName` test helper creates a model whose encryptor throws `EncryptionError` on `encrypt`, verifying that encryption errors on save bubble up and leave the record count unchanged.
- Exports `EncryptionError` from `test-helpers.ts`.
- Unskips 3 `EncryptableRecordTest` cases: encryption errors on save, can't modify when frozen, can only save unencrypted when frozen.

## Test plan

- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/encryptable-record.test.ts` — 33 passing, 19 skipped
- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/` — 227 passing, 47 skipped