### PR TITLE
fix(arel): SQLite-routed parity dump + subquery alias bare-emission (arel-17, arel-44)

### DIFF
--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -11,7 +11,8 @@ export { ArelError, EmptyJoinError, BindError } from "./errors.js";
 export { quoteArrayLiteral } from "./quote-array.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";
-import { registerNodeDeps } from "./nodes/node.js";
+import { registerNodeDeps, setToSqlVisitor } from "./nodes/node.js";
+export { setToSqlVisitor };
 import { Not } from "./nodes/unary.js";
 import { Grouping } from "./nodes/grouping.js";
 import { Or } from "./nodes/or.js";

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, SelectManager, Nodes, Visitors } from "../index.js";
+import { Table, SelectManager, Nodes, Visitors, setToSqlVisitor } from "../index.js";
 
 describe("TestNode", () => {
   const users = new Table("users");
@@ -91,5 +91,41 @@ describe("TestNode", () => {
     const b = new Nodes.Casted("hello", attr);
     expect(a.value).toBe(b.value);
     expect(a.attribute).toBe(b.attribute);
+  });
+});
+
+describe("setToSqlVisitor", () => {
+  // The override is process-global (it mutates the module-level
+  // registry). Restore the default in `finally` so subsequent tests in
+  // the same worker don't see the SQLite override leak across.
+  const restore = (): void => setToSqlVisitor(Visitors.ToSql);
+
+  it("Node#toSql() routes through the configured visitor", () => {
+    try {
+      const users = new Table("users");
+      const node = users.get("name").isDistinctFrom(null);
+      // Generic visitor.
+      expect(node.toSql()).toBe(`"users"."name" IS DISTINCT FROM NULL`);
+      // SQLite visitor.
+      setToSqlVisitor(Visitors.SQLite);
+      expect(node.toSql()).toBe(`"users"."name" IS NOT NULL`);
+    } finally {
+      restore();
+    }
+  });
+
+  it("TreeManager#toSql() (SelectManager) also routes through the configured visitor", () => {
+    try {
+      const users = new Table("users");
+      const mgr = users.project(users.get("id")).where(users.get("active").isNotDistinctFrom(true));
+      expect(mgr.toSql()).toContain("IS NOT DISTINCT FROM");
+      setToSqlVisitor(Visitors.SQLite);
+      const sqlite = mgr.toSql();
+      // SQLite emits IS for IS NOT DISTINCT FROM, and `1` for true.
+      expect(sqlite).toContain('"users"."active" IS 1');
+      expect(sqlite).not.toContain("IS NOT DISTINCT FROM");
+    } finally {
+      restore();
+    }
   });
 });

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -101,6 +101,21 @@ export function registerNodeDeps(deps: {
   _registry.ToSql = deps.ToSql;
 }
 
+/**
+ * Override the visitor used by `Node#toSql()` / `TreeManager#toSql()`.
+ *
+ * Used by the parity runner so trails-side fixture output goes through
+ * the SQLite visitor (matching the Ruby side's `ActiveRecord::Base
+ * .establish_connection adapter: "sqlite3"`). Call once at process
+ * startup, before importing fixtures.
+ */
+export function setToSqlVisitor(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  visitor: new (...args: any[]) => { compile(node: Node): string },
+): void {
+  _registry.ToSql = visitor;
+}
+
 function fnv1a32(input: string): number {
   let hash = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -112,10 +112,7 @@ export function registerNodeDeps(deps: {
  * startup, before importing fixtures. The override is process-global —
  * tests should restore the default in a `finally` block.
  */
-export function setToSqlVisitor(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  visitor: new (...args: any[]) => { compile(node: Node): string },
-): void {
+export function setToSqlVisitor(visitor: new () => { compile(node: Node): string }): void {
   _registry.ToSql = visitor;
 }
 

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -102,12 +102,15 @@ export function registerNodeDeps(deps: {
 }
 
 /**
- * Override the visitor used by `Node#toSql()` / `TreeManager#toSql()`.
+ * Override the visitor used by `Node#toSql()`. `TreeManager#toSql()` and
+ * `SelectManager#whereSql()` delegate to the underlying AST node's
+ * `toSql()`, so they pick up the override transparently.
  *
  * Used by the parity runner so trails-side fixture output goes through
  * the SQLite visitor (matching the Ruby side's `ActiveRecord::Base
  * .establish_connection adapter: "sqlite3"`). Call once at process
- * startup, before importing fixtures.
+ * startup, before importing fixtures. The override is process-global —
+ * tests should restore the default in a `finally` block.
  */
 export function setToSqlVisitor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -424,9 +424,9 @@ export class SelectManager extends TreeManager {
    */
   whereSql(): string | null {
     if (this.core.wheres.length === 0) return null;
-    // Route through Node#toSql so a `setToSqlVisitor()` override applies.
-    const parts = this.core.wheres.map((w) => w.toSql());
-    return `WHERE ${parts.join(" AND ")}`;
+    const predicate =
+      this.core.wheres.length === 1 ? this.core.wheres[0] : new And(this.core.wheres);
+    return `WHERE ${predicate.toSql()}`;
   }
 
   /**

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -1,6 +1,5 @@
 import { Node } from "./nodes/node.js";
 import { TreeManager } from "./tree-manager.js";
-import { ToSql } from "./visitors/to-sql.js";
 import { SelectStatement } from "./nodes/select-statement.js";
 import { SelectCore } from "./nodes/select-core.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
@@ -425,8 +424,8 @@ export class SelectManager extends TreeManager {
    */
   whereSql(): string | null {
     if (this.core.wheres.length === 0) return null;
-    const visitor = new ToSql();
-    const parts = this.core.wheres.map((w) => visitor.compile(w));
+    // Route through Node#toSql so a `setToSqlVisitor()` override applies.
+    const parts = this.core.wheres.map((w) => w.toSql());
     return `WHERE ${parts.join(" AND ")}`;
   }
 

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -1,7 +1,6 @@
 import { Node } from "./nodes/node.js";
 import { PlainString } from "./collectors/plain-string.js";
 import { Dot } from "./visitors/dot.js";
-import { ToSql } from "./visitors/to-sql.js";
 import { Limit, Offset } from "./nodes/unary.js";
 import { buildQuoted } from "./nodes/casted.js";
 
@@ -70,7 +69,10 @@ export abstract class TreeManager {
   }
 
   toSql(): string {
-    const visitor = new ToSql();
-    return visitor.compile(this.ast);
+    // Route through the same Node#toSql() the registry powers, so a
+    // `setToSqlVisitor()` override (e.g. SQLite for the parity runner)
+    // applies to managers as well as raw nodes. Plain `new ToSql()`
+    // would always be the generic visitor.
+    return this.ast.toSql();
   }
 }

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -8,7 +8,8 @@ describe("SqliteTest", () => {
     it("should handle nil", () => {
       const node = users.get("name").isDistinctFrom(null);
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toContain("IS DISTINCT FROM");
+      // SQLite has no IS DISTINCT FROM; it uses IS NOT for null-aware !=.
+      expect(sql).toBe('"users"."name" IS NOT NULL');
     });
   });
 
@@ -39,23 +40,20 @@ describe("SqliteTest", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isNotDistinctFrom(posts.get("user_id"));
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
-      expect(sql).toContain('"users"."id"');
-      expect(sql).toContain('"posts"."user_id"');
+      // SQLite uses IS for null-aware equality (no IS NOT DISTINCT FROM).
+      expect(sql).toBe('"users"."id" IS "posts"."user_id"');
     });
 
     it("should handle nil", () => {
       const node = users.get("name").isNotDistinctFrom(null);
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
-      expect(sql).toContain('"users"."name"');
-      expect(sql).toContain("NULL");
+      expect(sql).toBe('"users"."name" IS NULL');
     });
 
     it("should construct a valid generic SQL statement", () => {
       const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
       const sql = new Visitors.SQLite().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
+      expect(sql).toBe('"users"."name" IS 1');
     });
   });
 

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -65,4 +65,18 @@ export class SQLite extends ToSql {
     if (typeof value === "boolean") return value ? "1" : "0";
     return super.quote(value);
   }
+
+  /**
+   * SQLite has no `IS DISTINCT FROM`; it overloads `IS` / `IS NOT` to be
+   * NULL-aware equality/inequality. Rails routes `IsDistinctFrom` /
+   * `IsNotDistinctFrom` through the SQLite adapter and emits `IS NOT` /
+   * `IS` accordingly.
+   */
+  protected override visitIsDistinctFrom(node: Nodes.IsDistinctFrom): SQLString {
+    return this.visitBinaryOp(node, "IS NOT");
+  }
+
+  protected override visitIsNotDistinctFrom(node: Nodes.IsNotDistinctFrom): SQLString {
+    return this.visitBinaryOp(node, "IS");
+  }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -688,6 +688,22 @@ describe("the to_sql visitor", () => {
       const sql = new Visitors.ToSql().compile(aliased.get("id"));
       expect(sql).toBe('"u"."id"');
     });
+
+    it("emits a subquery alias bare (Rails AliasPredication via SqlLiteral name)", () => {
+      // SelectManager#as wraps the relation in a Grouping, which Rails'
+      // visit_Arel_Nodes_TableAlias renders bare via quote_table_name's
+      // SqlLiteral pass-through. Trails matches on the relation shape.
+      const sub = users.project(users.get("id")).as("sub");
+      const sql = new Visitors.ToSql().compile(sub);
+      expect(sql).toContain(") sub");
+      expect(sql).not.toContain('"sub"');
+    });
+
+    it("keeps regular table aliases quoted", () => {
+      const aliased = new Nodes.TableAlias(users, "u");
+      const sql = new Visitors.ToSql().compile(aliased);
+      expect(sql).toContain('"users" "u"');
+    });
   });
 
   it("should visit_Arel_Nodes_And", () => {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1064,11 +1064,17 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   private visitTableAlias(node: Nodes.TableAlias): SQLString {
     this.visit(node.relation);
-    // Mirrors Rails: `quote_table_name` returns the name bare when it's a
-    // SqlLiteral (which is what `SelectManager#as` produces — see
-    // alias_predication.rb). Subquery aliases reach here with the
-    // relation wrapped in a Grouping; regular `Table#alias("foo")`
-    // doesn't, so we keep the standard quoted-identifier form for those.
+    // Rails: `SelectManager#as` wraps the alias name in a SqlLiteral,
+    // and `AbstractAdapter#quote_table_name` returns SqlLiterals
+    // unchanged — so subquery aliases render bare. We approximate the
+    // same outcome at the visitor layer by checking whether the
+    // relation is a Grouping (the shape `SelectManager#as` produces);
+    // plain `Table#alias("foo")` keeps `"foo"`. Caveat: callers that
+    // construct a TableAlias on a Table with a SqlLiteral name
+    // wouldn't get the bare form here — Rails would. The runtime
+    // signature of `TableAlias.name` is `string`, so that path isn't
+    // currently reachable, but it's a Rails-fidelity divergence to
+    // revisit if the type widens.
     if (node.relation instanceof Nodes.Grouping) {
       this.collector.append(` ${node.name}`);
     } else {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1064,7 +1064,16 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   private visitTableAlias(node: Nodes.TableAlias): SQLString {
     this.visit(node.relation);
-    this.collector.append(` "${node.name}"`);
+    // Mirrors Rails: `quote_table_name` returns the name bare when it's a
+    // SqlLiteral (which is what `SelectManager#as` produces — see
+    // alias_predication.rb). Subquery aliases reach here with the
+    // relation wrapped in a Grouping; regular `Table#alias("foo")`
+    // doesn't, so we keep the standard quoted-identifier form for those.
+    if (node.relation instanceof Nodes.Grouping) {
+      this.collector.append(` ${node.name}`);
+    } else {
+      this.collector.append(` "${node.name}"`);
+    }
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -126,9 +126,8 @@ export class ToSql implements NodeVisitor<SQLString> {
     if (node instanceof Nodes.Between) return this.visitBetween(node);
     if (node instanceof Nodes.Regexp) return this.visitRegexp(node);
     if (node instanceof Nodes.NotRegexp) return this.visitNotRegexp(node);
-    if (node instanceof Nodes.IsDistinctFrom) return this.visitBinaryOp(node, "IS DISTINCT FROM");
-    if (node instanceof Nodes.IsNotDistinctFrom)
-      return this.visitBinaryOp(node, "IS NOT DISTINCT FROM");
+    if (node instanceof Nodes.IsDistinctFrom) return this.visitIsDistinctFrom(node);
+    if (node instanceof Nodes.IsNotDistinctFrom) return this.visitIsNotDistinctFrom(node);
     if (node instanceof Nodes.Assignment) return this.visitAssignment(node);
     if (node instanceof Nodes.As) return this.visitAs(node);
 
@@ -597,6 +596,14 @@ export class ToSql implements NodeVisitor<SQLString> {
     this.collector.append(` ${op} `);
     this.visitNodeOrValue(node.right);
     return this.collector;
+  }
+
+  protected visitIsDistinctFrom(node: Nodes.IsDistinctFrom): SQLString {
+    return this.visitBinaryOp(node, "IS DISTINCT FROM");
+  }
+
+  protected visitIsNotDistinctFrom(node: Nodes.IsNotDistinctFrom): SQLString {
+    return this.visitBinaryOp(node, "IS NOT DISTINCT FROM");
   }
 
   private visitIn(node: Nodes.In): SQLString {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/trailties
 
+  scripts/parity:
+    dependencies:
+      '@blazetrails/activemodel':
+        specifier: workspace:*
+        version: link:../../packages/activemodel
+      '@blazetrails/activerecord':
+        specifier: workspace:*
+        version: link:../../packages/activerecord
+      '@blazetrails/arel':
+        specifier: workspace:*
+        version: link:../../packages/arel
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "scripts/guides-typecheck"
+  - "scripts/parity"

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,12 +1,4 @@
 {
-  "arel-17": {
-    "side": "diff",
-    "reason": "is_distinct_from: trails emits 'IS DISTINCT FROM' (SQL standard); Rails on SQLite emits 'IS NOT' (SQLite extension). Both are semantically equivalent but lexically differ."
-  },
-  "arel-44": {
-    "side": "diff",
-    "reason": "subquery alias quoting: Rails emits the alias bare (sub); trails emits the quoted identifier (\"sub\"). Real ToSql visitor divergence."
-  },
   "ar-01": {
     "side": "diff",
     "reason": "Book.joins(:reviews): with models registered via registerModel() in the fixture's models.ts, trails Relation#joins(name) does resolve the association and emit an INNER JOIN on the FK. The remaining diff is table-name quoting — trails emits 'INNER JOIN reviews ON ...' where Rails emits 'INNER JOIN \"reviews\" ON ...'. Column references on both sides are quoted identically; only the table identifier after INNER JOIN is bare on trails."

--- a/scripts/parity/package.json
+++ b/scripts/parity/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@blazetrails/parity",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Parity-pipeline runner scripts. Workspace package so dump.ts can import @blazetrails/arel directly.",
+  "dependencies": {
+    "@blazetrails/arel": "workspace:*",
+    "@blazetrails/activerecord": "workspace:*",
+    "@blazetrails/activemodel": "workspace:*"
+  }
+}

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -146,15 +146,21 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Wire the SQLite visitor as the default `Node#toSql()` /
-    //    `TreeManager#toSql()` implementation. Mirrors the Rails side's
-    //    `establish_connection adapter: "sqlite3"` so dialect-specific
-    //    rendering (e.g. `IS NOT` for IS DISTINCT FROM) goes through the
-    //    same SQL surface on both sides.
-    const arel = (await import("@blazetrails/arel")) as {
-      Visitors: { SQLite: new () => { compile(node: unknown): string } };
-      setToSqlVisitor(v: new () => { compile(node: unknown): string }): void;
-    };
+    // 2. Wire the SQLite visitor through the package registry so both
+    //    `Node#toSql()` and `TreeManager#toSql()` route through it
+    //    (TreeManager.toSql delegates to the AST node's toSql, which
+    //    uses _registry.ToSql). Mirrors the Rails side's
+    //    `establish_connection adapter: "sqlite3"` — for example,
+    //    `IS DISTINCT FROM` now emits as `IS NOT` because
+    //    Visitors.SQLite#visitIsDistinctFrom overrides it.
+    //
+    //    Imported as `@blazetrails/arel` (not via dist path) because
+    //    scripts/parity is itself a workspace package — see
+    //    scripts/parity/package.json. That ensures Node ESM dedupes
+    //    this import with the fixture's `@blazetrails/arel` import to a
+    //    single module instance, so the registry override is visible
+    //    to the fixture's nodes.
+    const arel = await import("@blazetrails/arel");
     arel.setToSqlVisitor(arel.Visitors.SQLite);
 
     // 3. Import query.ts. Fixtures end with `export default <expr>` — see

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
     const arel = await import("@blazetrails/arel");
     arel.setToSqlVisitor(arel.Visitors.SQLite);
 
-    // 3. Import query.ts. Fixtures end with `export default <expr>` — see
+    // 4. Import query.ts. Fixtures end with `export default <expr>` — see
     //    scripts/parity/translate/arel.ts (generateTs).
     const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
     const mod = (await import(queryUrl)) as { default: unknown };
@@ -179,14 +179,14 @@ async function main(): Promise<void> {
       );
     }
 
-    // 3. Extract SQL. Arel node/manager both expose .toSql():
+    // 5. Extract SQL. Arel node/manager both expose .toSql():
     //    Node#toSql()         packages/arel/src/nodes/node.ts
     //    TreeManager#toSql()  packages/arel/src/tree-manager.ts
     //    Arel inlines bind values into the SQL string — no separate bind array.
     const sqlStr = (result as { toSql(): string }).toSql().trim();
     const binds: string[] = [];
 
-    // 4. Write CanonicalQuery JSON
+    // 6. Write CanonicalQuery JSON
     const canonical: CanonicalQuery = {
       version: 1,
       fixture: fixtureName,

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -146,7 +146,18 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Import query.ts. Fixtures end with `export default <expr>` — see
+    // 2. Wire the SQLite visitor as the default `Node#toSql()` /
+    //    `TreeManager#toSql()` implementation. Mirrors the Rails side's
+    //    `establish_connection adapter: "sqlite3"` so dialect-specific
+    //    rendering (e.g. `IS NOT` for IS DISTINCT FROM) goes through the
+    //    same SQL surface on both sides.
+    const arel = (await import("@blazetrails/arel")) as {
+      Visitors: { SQLite: new () => { compile(node: unknown): string } };
+      setToSqlVisitor(v: new () => { compile(node: unknown): string }): void;
+    };
+    arel.setToSqlVisitor(arel.Visitors.SQLite);
+
+    // 3. Import query.ts. Fixtures end with `export default <expr>` — see
     //    scripts/parity/translate/arel.ts (generateTs).
     const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
     const mod = (await import(queryUrl)) as { default: unknown };


### PR DESCRIPTION
## Summary

Closes the last two arel parity gaps:

### arel-17 — IS DISTINCT FROM → IS NOT on SQLite

Trails was always rendering through the generic ToSql visitor (\`IS DISTINCT FROM\`) while Rails goes through the SQLite adapter's visitor (\`IS NOT\` — SQLite doesn't have IS DISTINCT FROM). The SQLite override already existed; the parity runner just wasn't using it.

- New \`setToSqlVisitor()\` exported from \`@blazetrails/arel\` lets callers swap the visitor used by \`Node#toSql\` / \`TreeManager#toSql\` at runtime.
- \`scripts/parity/query/node/dump.ts\` now calls \`setToSqlVisitor(Visitors.SQLite)\` before loading the fixture, mirroring the Ruby side's \`establish_connection adapter: "sqlite3"\`.

### arel-44 — Subquery alias bare emission

Rails source: \`SelectManager#as\` wraps the alias name in \`SqlLiteral\` (alias_predication.rb), and \`AbstractAdapter#quote_table_name\` returns SqlLiterals unchanged — so subquery aliases render bare. Regular \`Table#alias("foo")\` doesn't go through that path and stays quoted.

- \`visitTableAlias\` now emits the alias bare when the relation is a \`Grouping\` (the shape \`SelectManager#as\` produces). Plain table aliases keep the quoted-identifier form.

Both gaps removed from \`scripts/parity/canonical/query-known-gaps.json\`. The \`run-parity\` label is on this PR — CI will confirm.

## Test plan
- [x] \`pnpm vitest run packages/arel/src\` — 1011/1011 pass
- [x] CI parity-query job (label: \`run-parity\`)