### PR TITLE
test(parity): AR query fixtures ar-39..ar-43 — chained order, ranges, multi-col group, named placeholders (PR 8)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -58,5 +58,9 @@
   "ar-38": {
     "side": "diff",
     "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 / ar-11 / ar-19 — boolean serialization is type-system-driven, not adapter-aware."
+  },
+  "ar-42": {
+    "side": "diff",
+    "reason": "Multi-column GROUP BY qualification: trails emits 'GROUP BY author_id, published_year' (bare); Rails qualifies each to '\"books\".\"author_id\", \"books\".\"published_year\"'. Same root cause as ar-17 (single-column form)."
   }
 }

--- a/scripts/parity/fixtures/ar-39/models.rb
+++ b/scripts/parity/fixtures/ar-39/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-39/models.ts
+++ b/scripts/parity/fixtures/ar-39/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-39/query.rb
+++ b/scripts/parity/fixtures/ar-39/query.rb
@@ -1,0 +1,1 @@
+Book.order(id: :asc).order(title: :desc)

--- a/scripts/parity/fixtures/ar-39/query.ts
+++ b/scripts/parity/fixtures/ar-39/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.order({ id: "asc" }).order({ title: "desc" });

--- a/scripts/parity/fixtures/ar-39/schema.sql
+++ b/scripts/parity/fixtures/ar-39/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-39
+-- Query: Book.order(id: :asc).order(title: :desc)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-40/models.rb
+++ b/scripts/parity/fixtures/ar-40/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-40/models.ts
+++ b/scripts/parity/fixtures/ar-40/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-40/query.rb
+++ b/scripts/parity/fixtures/ar-40/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 5..)

--- a/scripts/parity/fixtures/ar-40/query.ts
+++ b/scripts/parity/fixtures/ar-40/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ id: new Range(5, null) });

--- a/scripts/parity/fixtures/ar-40/schema.sql
+++ b/scripts/parity/fixtures/ar-40/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-40
+-- Query: Book.where(id: 5..)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-41/models.rb
+++ b/scripts/parity/fixtures/ar-41/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-41/models.ts
+++ b/scripts/parity/fixtures/ar-41/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-41/query.rb
+++ b/scripts/parity/fixtures/ar-41/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: ..10)

--- a/scripts/parity/fixtures/ar-41/query.ts
+++ b/scripts/parity/fixtures/ar-41/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ id: new Range(null, 10) });

--- a/scripts/parity/fixtures/ar-41/schema.sql
+++ b/scripts/parity/fixtures/ar-41/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-41
+-- Query: Book.where(id: ..10)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-42/models.rb
+++ b/scripts/parity/fixtures/ar-42/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-42/models.ts
+++ b/scripts/parity/fixtures/ar-42/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-42/query.rb
+++ b/scripts/parity/fixtures/ar-42/query.rb
@@ -1,0 +1,1 @@
+Book.group(:author_id, :published_year).select("author_id, published_year, COUNT(*) AS c")

--- a/scripts/parity/fixtures/ar-42/query.ts
+++ b/scripts/parity/fixtures/ar-42/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.group("author_id", "published_year").select(
+  "author_id, published_year, COUNT(*) AS c",
+);

--- a/scripts/parity/fixtures/ar-42/schema.sql
+++ b/scripts/parity/fixtures/ar-42/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-42
+-- Query: Book.group(:author_id, :published_year).select("author_id, published_year, COUNT(*) AS c")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER,
+  published_year INTEGER
+);

--- a/scripts/parity/fixtures/ar-43/models.rb
+++ b/scripts/parity/fixtures/ar-43/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-43/models.ts
+++ b/scripts/parity/fixtures/ar-43/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-43/query.rb
+++ b/scripts/parity/fixtures/ar-43/query.rb
@@ -1,0 +1,1 @@
+Book.where("title = :t AND id > :min", t: "Rails", min: 5)

--- a/scripts/parity/fixtures/ar-43/query.ts
+++ b/scripts/parity/fixtures/ar-43/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where("title = :t AND id > :min", { t: "Rails", min: 5 });

--- a/scripts/parity/fixtures/ar-43/schema.sql
+++ b/scripts/parity/fixtures/ar-43/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-43
+-- Query: Book.where("title = :t AND id > :min", t: "Rails", min: 5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures. **4 PASS** byte-identical; 1 KNOWN-GAP.

**PASS**
- ar-39: `.order(...).order(...)` — appended ORDER BY clauses
- ar-40: `where(id: 5..)` — endless range → `>=` predicate
- ar-41: `where(id: ..10)` — beginless range → `<=` predicate
- ar-43: `where("title = :t AND id > :min", t: ..., min: ...)` — named placeholder binds (trails accepts the hash form)

**KNOWN-GAP**
- ar-42: `.group(:a, :b)` — multi-col GROUP BY qualification (trails bare; Rails qualified). Same root cause as ar-17's single-column case.

## Test plan
- [x] `pnpm parity:query` — 4 PASS, 1 KNOWN-GAP, no UNEXPECTED-PASS