### PR TITLE
test(parity): AR query fixtures ar-44..ar-48 — left join, readonly, empty-array, and, strict_loading (PR 9)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -54,5 +54,9 @@
   "ar-42": {
     "side": "diff",
     "reason": "Multi-column GROUP BY qualification: trails emits 'GROUP BY author_id, published_year' (bare); Rails qualifies each to '\"books\".\"author_id\", \"books\".\"published_year\"'. Same root cause as ar-17 (single-column form)."
+  },
+  "ar-44": {
+    "side": "diff",
+    "reason": "LEFT OUTER JOIN table-name quoting: trails emits 'LEFT OUTER JOIN authors ON ...' (bare table identifier); Rails emits 'LEFT OUTER JOIN \"authors\" ON ...'. Same root cause as ar-01's INNER JOIN quoting gap."
   }
 }

--- a/scripts/parity/fixtures/ar-44/models.rb
+++ b/scripts/parity/fixtures/ar-44/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-44/models.ts
+++ b/scripts/parity/fixtures/ar-44/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-44/query.rb
+++ b/scripts/parity/fixtures/ar-44/query.rb
@@ -1,0 +1,1 @@
+Book.left_outer_joins(:author)

--- a/scripts/parity/fixtures/ar-44/query.ts
+++ b/scripts/parity/fixtures/ar-44/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.all().leftOuterJoins("authors", '"authors"."id" = "books"."author_id"');
+export default Book.leftOuterJoins("author");

--- a/scripts/parity/fixtures/ar-44/query.ts
+++ b/scripts/parity/fixtures/ar-44/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().leftOuterJoins("authors", '"authors"."id" = "books"."author_id"');

--- a/scripts/parity/fixtures/ar-44/schema.sql
+++ b/scripts/parity/fixtures/ar-44/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-44
+-- Query: Book.left_outer_joins(:author)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-45/models.rb
+++ b/scripts/parity/fixtures/ar-45/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-45/models.ts
+++ b/scripts/parity/fixtures/ar-45/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-45/query.rb
+++ b/scripts/parity/fixtures/ar-45/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).readonly

--- a/scripts/parity/fixtures/ar-45/query.ts
+++ b/scripts/parity/fixtures/ar-45/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).readonly();

--- a/scripts/parity/fixtures/ar-45/schema.sql
+++ b/scripts/parity/fixtures/ar-45/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-45
+-- Query: Book.where(id: 1).readonly
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-46/models.rb
+++ b/scripts/parity/fixtures/ar-46/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-46/models.ts
+++ b/scripts/parity/fixtures/ar-46/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-46/query.rb
+++ b/scripts/parity/fixtures/ar-46/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: [])

--- a/scripts/parity/fixtures/ar-46/query.ts
+++ b/scripts/parity/fixtures/ar-46/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: [] });

--- a/scripts/parity/fixtures/ar-46/schema.sql
+++ b/scripts/parity/fixtures/ar-46/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-46
+-- Query: Book.where(id: [])
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-47/models.rb
+++ b/scripts/parity/fixtures/ar-47/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-47/models.ts
+++ b/scripts/parity/fixtures/ar-47/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-47/query.rb
+++ b/scripts/parity/fixtures/ar-47/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1..5).and(Book.where(title: "Rails"))

--- a/scripts/parity/fixtures/ar-47/query.ts
+++ b/scripts/parity/fixtures/ar-47/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ id: new Range(1, 5) }).and(Book.where({ title: "Rails" }));

--- a/scripts/parity/fixtures/ar-47/schema.sql
+++ b/scripts/parity/fixtures/ar-47/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-47
+-- Query: Book.where(id: 1..5).and(Book.where(title: "Rails"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-48/models.rb
+++ b/scripts/parity/fixtures/ar-48/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-48/models.ts
+++ b/scripts/parity/fixtures/ar-48/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-48/query.rb
+++ b/scripts/parity/fixtures/ar-48/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).strict_loading

--- a/scripts/parity/fixtures/ar-48/query.ts
+++ b/scripts/parity/fixtures/ar-48/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).strictLoading();

--- a/scripts/parity/fixtures/ar-48/schema.sql
+++ b/scripts/parity/fixtures/ar-48/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-48
+-- Query: Book.where(id: 1).strict_loading
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures. **4 PASS** byte-identical; 1 KNOWN-GAP.

**PASS**
- ar-45: `where(...).readonly` — SQL unchanged (readonly is a load-time flag only)
- ar-46: `where(id: [])` — empty array → `WHERE 1=0`
- ar-47: `where(id: 1..5).and(Book.where(title: "Rails"))` — relation intersection
- ar-48: `where(...).strict_loading` — SQL unchanged (strict_loading is a load-time flag)

**KNOWN-GAP**
- ar-44: `left_outer_joins(:author)` — bare table name `authors` vs Rails' `"authors"`. Same root cause as ar-01's INNER JOIN quoting gap.

## Test plan
- [x] `pnpm parity:query` — 4 PASS, 1 KNOWN-GAP, no UNEXPECTED-PASS