### PR TITLE
feat(encryption): implement ignore_case dual-column storage with original_ attribute

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -229,13 +229,26 @@ function _preserveOriginalEncrypted(klass: any, name: string, options: EncryptsO
   const { ignoreCase: _ic, downcase: _dc, ...originalOptions } = options;
   encrypts(klass, originalAttrName, originalOptions);
 
-  // Before each save, copy the in-memory value of `name` (original case, since
-  // attribute values are stored as plaintext in memory before serialization)
-  // into `original_name`. Using `readAttribute` bypasses the prototype getter so
-  // we read directly from the attribute store, not from `original_name`.
-  // Mirrors Rails' name= setter which calls `self.original_name = value`.
+  // Before each save, copy the in-memory value of `name` into `original_name`
+  // when `name` has been written (is dirty). Using `readAttribute` bypasses
+  // the prototype getter so we read directly from the attribute store, not from
+  // `original_name`. Only syncing when dirty prevents a freshly-loaded record
+  // whose `readAttribute(name)` would return the decrypted downcased value from
+  // overwriting the original-cased `original_name` on an unrelated save.
+  // Mirrors Rails' `name= { self.original_name = value; super(value) }`.
   if (typeof klass.beforeSave === "function") {
     klass.beforeSave((record: any) => {
+      // For new records, always sync — changedAttributes is empty because attrs
+      // were assigned before the dirty snapshot in the constructor.
+      // For persisted records, only sync when `name` was actually written to
+      // avoid overwriting original_name with the downcased decrypted value on
+      // unrelated saves.
+      const isNew =
+        typeof record.isNewRecord === "function" ? record.isNewRecord() : !record.isPersisted?.();
+      const changed: string[] = Array.isArray(record.changedAttributes)
+        ? record.changedAttributes
+        : [];
+      if (!isNew && !changed.includes(name)) return;
       const plaintext = record.readAttribute(name);
       if (plaintext != null) {
         record.writeAttribute(originalAttrName, plaintext);
@@ -243,13 +256,22 @@ function _preserveOriginalEncrypted(klass: any, name: string, options: EncryptsO
     });
   }
 
-  // Override the reader on the prototype so `record.name` returns the
-  // original-cased value from `original_name`.
-  // Mirrors Rails' `define_method(name) { send(original_attribute_name) }`.
+  // Override the reader on the prototype. Mirrors Rails:
+  //   return original_name if attribute is encrypted or support_unencrypted_data is false
+  //   return name (raw value) when not encrypted and support_unencrypted_data is true
   Object.defineProperty(klass.prototype, name, {
     configurable: true,
     enumerable: true,
     get(this: any) {
+      const rawValue = this.readAttribute(name);
+      if (Configurable.config.supportUnencryptedData) {
+        const type = klass._attributeDefinitions?.get(name)?.type;
+        const isEncrypted =
+          typeof type?.isEncrypted === "function"
+            ? type.isEncrypted(this._attributes?.get?.(name)?.valueBeforeTypeCast ?? rawValue)
+            : true;
+        if (!isEncrypted) return rawValue;
+      }
       return this.readAttribute(originalAttrName);
     },
     set(this: any, value: unknown) {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -250,32 +250,28 @@ function _preserveOriginalEncrypted(klass: any, name: string, options: EncryptsO
         : [];
       if (!isNew && !changed.includes(name)) return;
       const plaintext = record.readAttribute(name);
-      if (plaintext != null) {
-        record.writeAttribute(originalAttrName, plaintext);
-      }
+      record.writeAttribute(originalAttrName, plaintext);
     });
   }
 
-  // Override the reader on the prototype. Mirrors Rails:
-  //   return original_name if attribute is encrypted or support_unencrypted_data is false
-  //   return name (raw value) when not encrypted and support_unencrypted_data is true
+  // Override the accessor on the prototype. Mirrors Rails'
+  // override_accessors_to_preserve_original:
+  //   - getter returns original_name when present, falls back to name for
+  //     legacy rows that predate the original_name column
+  //   - setter writes both name (for downcased query) and original_name
+  //     (for case-preserving reads) immediately, so in-memory reads see
+  //     the new value before the record is saved
   Object.defineProperty(klass.prototype, name, {
     configurable: true,
-    enumerable: true,
     get(this: any) {
-      const rawValue = this.readAttribute(name);
-      if (Configurable.config.supportUnencryptedData) {
-        const type = klass._attributeDefinitions?.get(name)?.type;
-        const isEncrypted =
-          typeof type?.isEncrypted === "function"
-            ? type.isEncrypted(this._attributes?.get?.(name)?.valueBeforeTypeCast ?? rawValue)
-            : true;
-        if (!isEncrypted) return rawValue;
-      }
-      return this.readAttribute(originalAttrName);
+      const originalValue = this.readAttribute(originalAttrName);
+      if (originalValue != null) return originalValue;
+      // Fallback for legacy rows where original_name is absent.
+      return this.readAttribute(name);
     },
     set(this: any, value: unknown) {
       this.writeAttribute(name, value);
+      this.writeAttribute(originalAttrName, value);
     },
   });
 }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -206,11 +206,56 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
     if (Configurable.config.validateColumnSize) {
       EncryptableRecord.validateColumnSize(klass, name);
     }
+    if (options.ignoreCase) {
+      _preserveOriginalEncrypted(klass, name, options);
+    }
   }
 
   if (klass._attributeDefinitions?.size > 0) {
     applyPendingEncryptions(klass);
   }
+}
+
+/**
+ * Mirrors Rails' EncryptableRecord::ClassMethods#preserve_original_encrypted.
+ * When ignore_case: true, stores the original-cased value in an additional
+ * `original_<name>` encrypted attribute, and overrides the reader so reads
+ * return the original-cased value rather than the downcased one.
+ */
+function _preserveOriginalEncrypted(klass: any, name: string, options: EncryptsOptions): void {
+  const originalAttrName = `original_${name}`;
+
+  // Register the original-case column as encrypted (without ignoreCase/downcase).
+  const { ignoreCase: _ic, downcase: _dc, ...originalOptions } = options;
+  encrypts(klass, originalAttrName, originalOptions);
+
+  // Before each save, copy the in-memory value of `name` (original case, since
+  // attribute values are stored as plaintext in memory before serialization)
+  // into `original_name`. Using `readAttribute` bypasses the prototype getter so
+  // we read directly from the attribute store, not from `original_name`.
+  // Mirrors Rails' name= setter which calls `self.original_name = value`.
+  if (typeof klass.beforeSave === "function") {
+    klass.beforeSave((record: any) => {
+      const plaintext = record.readAttribute(name);
+      if (plaintext != null) {
+        record.writeAttribute(originalAttrName, plaintext);
+      }
+    });
+  }
+
+  // Override the reader on the prototype so `record.name` returns the
+  // original-cased value from `original_name`.
+  // Mirrors Rails' `define_method(name) { send(original_attribute_name) }`.
+  Object.defineProperty(klass.prototype, name, {
+    configurable: true,
+    enumerable: true,
+    get(this: any) {
+      return this.readAttribute(originalAttrName);
+    },
+    set(this: any, value: unknown) {
+      this.writeAttribute(name, value);
+    },
+  });
 }
 
 /**

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -422,6 +422,12 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const book = await Book.create({ name: "Dune" });
     assertEncryptedAttribute(book, "name", "Dune");
     assertEncryptedAttribute(book, "original_name", "Dune");
+    // In-memory read before save reflects the assigned value immediately.
+    const unsaved = new Book({ name: "Arrakis" });
+    expect(unsaved.name).toBe("Arrakis");
+    // Null-clearing: assigning null clears original_name and returns null.
+    unsaved.name = null;
+    expect(unsaved.name).toBeNull();
   });
 
   it("when ignore_case: true, it returns the actual value when not encrypted", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -257,8 +257,13 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect(found!.name).toBe("dune");
   });
 
-  it.skip("when ignore_case: true, it ignores case in queries but keep it when reading the attribute", () => {
-    // requires dual-column storage (name + original_name) not yet implemented
+  it("when ignore_case: true, it ignores case in queries but keep it when reading the attribute", async () => {
+    const Book = makeEncryptedBookIgnoreCase(freshAdapter());
+    new Book();
+    await Book.create({ name: "Dune" });
+    const book = await Book.findBy({ name: "dune" });
+    expect(book).not.toBeNull();
+    expect(book!.name).toBe("Dune");
   });
 
   it("when ignore_case: true, it lets you update attributes normally", async () => {
@@ -411,9 +416,36 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
   it.skip("can dump and load records that use encryption", () => {});
   it.skip("supports decrypting data encrypted non deterministically with SHA1 when digest class is SHA256", () => {});
-  it.skip("when ignore_case: true, it keeps both the attribute and the _original counterpart encrypted", () => {});
-  it.skip("when ignore_case: true, it returns the actual value when not encrypted", () => {});
-  it.skip("when ignore_case: true, users can override accessors and call super", () => {});
+  it("when ignore_case: true, it keeps both the attribute and the _original counterpart encrypted", async () => {
+    const Book = makeEncryptedBookIgnoreCase(freshAdapter());
+    new Book();
+    const book = await Book.create({ name: "Dune" });
+    assertEncryptedAttribute(book, "name", "Dune");
+    assertEncryptedAttribute(book, "original_name", "Dune");
+  });
+
+  it("when ignore_case: true, it returns the actual value when not encrypted", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const Book = makeEncryptedBookIgnoreCase(freshAdapter());
+    new Book();
+    const book = await withoutEncryption(async () => Book.create({ name: "Dune" }));
+    expect(book.name).toBe("Dune");
+  });
+
+  it("when ignore_case: true, users can override accessors and call super", async () => {
+    const Book = makeEncryptedBookIgnoreCase(freshAdapter());
+    const OverridingBook = class extends Book {
+      get name() {
+        return `${super.name}-overridden`;
+      }
+    };
+    new Book();
+    await Book.create({ name: "Dune" });
+    const found = await Book.findBy({ name: "dune" });
+    expect(found).not.toBeNull();
+    const overridingInstance = Object.assign(Object.create(OverridingBook.prototype), found);
+    expect(overridingInstance.name).toBe("Dune-overridden");
+  });
   it.skip("binary data can be encrypted", () => {});
   it.skip("binary data can be encrypted uncompressed", () => {});
   it.skip("serialized binary data can be encrypted", () => {});

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -443,7 +443,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     await Book.create({ name: "Dune" });
     const found = await Book.findBy({ name: "dune" });
     expect(found).not.toBeNull();
-    const overridingInstance = Object.assign(Object.create(OverridingBook.prototype), found);
+    const overridingInstance = found!.becomes(OverridingBook);
     expect(overridingInstance.name).toBe("Dune-overridden");
   });
   it.skip("binary data can be encrypted", () => {});

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -165,6 +165,7 @@ export function makeEncryptedBookIgnoreCase(adapter: DatabaseAdapter) {
     static {
       this.attribute("id", "integer");
       this.attribute("name", "string");
+      this.attribute("original_name", "string");
       this.adapter = adapter;
       this.encrypts("name", { deterministic: true, ignoreCase: true });
     }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -723,7 +723,12 @@ function applyColumnsHash(
       continue;
     }
     const proto = (host as unknown as { prototype: object }).prototype;
-    if (!Object.prototype.hasOwnProperty.call(proto, name)) {
+    // Skip if this class or any parent prototype already has a custom accessor —
+    // prevents schema reflection from overwriting an ignore_case (or other)
+    // override that was installed on a parent class.
+    const parentProto = Object.getPrototypeOf(proto);
+    const inheritedFromParent = parentProto != null && name in (parentProto as object);
+    if (!Object.prototype.hasOwnProperty.call(proto, name) && !inheritedFromParent) {
       Object.defineProperty(proto, name, {
         get(this: { readAttribute(n: string): unknown }) {
           return this.readAttribute(name);


### PR DESCRIPTION
## Summary

- Implements `ignore_case: true` dual-column storage: when encrypting an attribute with `ignore_case: true`, an additional `original_<name>` encrypted attribute preserves the original-cased value while `name` is stored downcased for case-insensitive queries.
- `_preserveOriginalEncrypted` mirrors Rails' `preserve_original_encrypted` + `override_accessors_to_preserve_original`: registers `original_name` as an encrypted attribute, installs a `beforeSave` callback to sync the in-memory plaintext into `original_name` before serialization, and overrides the `name` prototype reader to return `readAttribute("original_name")`.
- `makeEncryptedBookIgnoreCase` test helper gains the required `original_name` column.
- Unskips 4 `EncryptableRecordTest` cases: ignore_case queries preserve case on read, both attributes are encrypted, returns actual value when not encrypted, users can override accessors and call super.

## Test plan

- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/encryptable-record.test.ts` — 37 passing, 15 skipped
- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/` — 231 passing, 43 skipped