### PR TITLE
fix(activerecord): AR parity gaps ar-01, ar-09/11/19, ar-33 (join quoting, boolean literals, Arel node select)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -211,6 +211,11 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
   _onAdapterSet = hook;
 }
 
+// Mirrors Rails' AbstractAdapter#arel_visitor — routes Node#toSql() through the
+// dialect-specific visitor (e.g. SQLite booleans as 1/0, no FOR UPDATE, etc.).
+// This is process-global: the last-assigned adapter's visitor wins, matching
+// Rails' single-connection-per-process assumption. Multi-adapter processes must
+// manage visitor selection themselves.
 function _wireArelVisitor(adapter: DatabaseAdapter): void {
   const visitor = (adapter as { arelVisitor?: object }).arelVisitor;
   if (visitor) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -211,6 +211,15 @@ export function _setOnAdapterSetHook(hook: ((modelClass: any) => void) | null): 
   _onAdapterSet = hook;
 }
 
+function _wireArelVisitor(adapter: DatabaseAdapter): void {
+  const visitor = (adapter as { arelVisitor?: object }).arelVisitor;
+  if (visitor) {
+    setToSqlVisitor(
+      (visitor as object).constructor as new () => { compile(node: Nodes.Node): string },
+    );
+  }
+}
+
 /**
  * Rails' `persistence.rb#update` / `#update!` dispatch on the first arg:
  *   ":all" | nil | bare hash    → iterate `all()` and update each
@@ -645,12 +654,7 @@ export class Base extends Model {
       return;
     }
     this._adapter = adapter;
-    const visitor = (adapter as { arelVisitor?: object }).arelVisitor;
-    if (visitor) {
-      setToSqlVisitor(
-        (visitor as object).constructor as new () => { compile(node: Nodes.Node): string },
-      );
-    }
+    _wireArelVisitor(adapter);
     if (_onAdapterSet) _onAdapterSet(this);
 
     // Full schema reset on adapter swap: drops schema-sourced defs and
@@ -720,6 +724,7 @@ export class Base extends Model {
     const modelPool = this._connectionHandler.retrieveConnectionPool(this.name);
     if (modelPool) {
       this._adapter = modelPool.checkout();
+      _wireArelVisitor(this._adapter);
       if (_onAdapterSet) _onAdapterSet(this);
       return this._adapter;
     }
@@ -731,6 +736,7 @@ export class Base extends Model {
     if (connPool) {
       if (!connectionClass._adapter) {
         connectionClass._adapter = connPool.checkout();
+        _wireArelVisitor(connectionClass._adapter);
         if (_onAdapterSet) _onAdapterSet(connectionClass);
       }
       return connectionClass._adapter;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -8,6 +8,7 @@ import {
   DeleteManager,
   Nodes,
   sql as arelSql,
+  setToSqlVisitor,
 } from "@blazetrails/arel";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { Relation } from "./relation.js";
@@ -644,6 +645,12 @@ export class Base extends Model {
       return;
     }
     this._adapter = adapter;
+    const visitor = (adapter as { arelVisitor?: object }).arelVisitor;
+    if (visitor) {
+      setToSqlVisitor(
+        (visitor as object).constructor as new () => { compile(node: Nodes.Node): string },
+      );
+    }
     if (_onAdapterSet) _onAdapterSet(this);
 
     // Full schema reset on adapter swap: drops schema-sourced defs and

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -2,7 +2,6 @@ import type { Base } from "./base.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
-import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
@@ -443,14 +442,6 @@ async function establishWithConfig(
   // like register("mysql2", ...) aren't shadowed by normalization.
   // `normalized` is only used below for adapter-arg construction.
   const AdapterClass = await _loadAdapter(adapterName);
-
-  if (normalized === "sqlite") {
-    setToSqlVisitor(Visitors.SQLite);
-  } else if (normalized === "postgresql") {
-    setToSqlVisitor(Visitors.PostgreSQL);
-  } else {
-    setToSqlVisitor(Visitors.ToSql);
-  }
 
   let adapterArg: unknown;
   if (normalized === "sqlite") {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -2,6 +2,7 @@ import type { Base } from "./base.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
@@ -442,6 +443,14 @@ async function establishWithConfig(
   // like register("mysql2", ...) aren't shadowed by normalization.
   // `normalized` is only used below for adapter-arg construction.
   const AdapterClass = await _loadAdapter(adapterName);
+
+  if (normalized === "sqlite") {
+    setToSqlVisitor(Visitors.SQLite);
+  } else if (normalized === "postgresql") {
+    setToSqlVisitor(Visitors.PostgreSQL);
+  } else {
+    setToSqlVisitor(Visitors.ToSql);
+  }
 
   let adapterArg: unknown;
   if (normalized === "sqlite") {

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -131,8 +131,7 @@ export function select<T extends typeof Base>(
   this: T,
   ...columns: (string | import("@blazetrails/arel").Nodes.Node)[]
 ): Relation<InstanceType<T>> {
-  const rel = this.all();
-  return rel.select(...(columns as Parameters<typeof rel.select>));
+  return this.all().select(...columns);
 }
 
 /** Mirrors: ActiveRecord::Querying#order */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -129,9 +129,10 @@ export function from<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#select */
 export function select<T extends typeof Base>(
   this: T,
-  ...columns: string[]
+  ...columns: (string | import("@blazetrails/arel").Nodes.Node)[]
 ): Relation<InstanceType<T>> {
-  return this.all().select(...columns);
+  const rel = this.all();
+  return rel.select(...(columns as Parameters<typeof rel.select>));
 }
 
 /** Mirrors: ActiveRecord::Querying#order */

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -118,6 +118,18 @@ describe("RelationTest", () => {
     expect(sql).toContain("body");
   });
 
+  it("select with arel node emits SQL alias", () => {
+    class Book extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.select(Book.arelTable.get("title").as("t")).toSql();
+    expect(sql).toContain('"title" AS t');
+    expect(sql).not.toContain("[object Object]");
+  });
+
   it("find_by with hash conditions returns the first matching record", async () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
-import { Associations, registerModel } from "./associations.js";
+import { Associations, registerModel, modelRegistry } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -387,8 +387,12 @@ describe("RelationTest", () => {
       }
     }
     registerModel("Comment", Comment);
-    const sql = Post.joins("comments").toSql();
-    expect(sql).toContain('INNER JOIN "comments"');
+    try {
+      const sql = Post.joins("comments").toSql();
+      expect(sql).toContain('INNER JOIN "comments"');
+    } finally {
+      modelRegistry.delete("Comment");
+    }
   });
 
   it("joins with string array", () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
+import { Associations, registerModel } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -363,6 +364,31 @@ describe("RelationTest", () => {
     }
     const sql = Post.all().annotate("counting").toSql();
     expect(sql).toContain("counting");
+  });
+
+  it("association join quotes the table name", () => {
+    const adp = freshAdapter();
+    class Comment extends Base {
+      static _tableName = "comments";
+      static {
+        this.attribute("post_id", "integer");
+        this.adapter = adp;
+      }
+    }
+    class Post extends Base {
+      static _tableName = "posts";
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+        Associations.hasMany.call(this, "comments", {
+          className: "Comment",
+          foreignKey: "post_id",
+        });
+      }
+    }
+    registerModel("Comment", Comment);
+    const sql = Post.joins("comments").toSql();
+    expect(sql).toContain('INNER JOIN "comments"');
   });
 
   it("joins with string array", () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1989,7 +1989,14 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     for (const join of this._joinClauses) {
-      const tableNode = join.quoted ? new Table(join.table) : join.table;
+      const tableNode = join.quoted
+        ? new Nodes.SqlLiteral(
+            join.table
+              .split(".")
+              .map((p) => `"${p}"`)
+              .join("."),
+          )
+        : join.table;
       const onNode = new Nodes.SqlLiteral(join.on);
       if (join.type === "inner") {
         manager.join(tableNode, onNode);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -557,12 +557,16 @@ export class Relation<T extends Base> {
    *   select(record => record.active)   // block form (returns array)
    */
   select(fn: (record: T) => boolean): Promise<T[]>;
-  select(...columns: (string | Nodes.SqlLiteral)[]): Relation<T>;
+  select(...columns: (string | Nodes.Node)[]): Relation<T>;
   select(...args: any[]): Relation<T> | Promise<T[]> {
     if (args.length === 1 && typeof args[0] === "function") {
       return this.toArray().then((records) => records.filter(args[0]));
     }
-    const columns = args.map((a: any) => (a instanceof Nodes.SqlLiteral ? a : String(a)));
+    const columns = args.map((a: any) => {
+      if (a instanceof Nodes.Node) return a;
+      if (a instanceof Nodes.SqlLiteral) return a;
+      return String(a);
+    });
     return this._clone()._selectBang(...columns);
   }
 
@@ -571,7 +575,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#reselect
    */
-  reselect(...columns: (string | Nodes.SqlLiteral)[]): Relation<T> {
+  reselect(...columns: (string | Nodes.Node)[]): Relation<T> {
     return this._clone().reselectBang(...columns);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -116,7 +116,12 @@ export class Relation<T extends Base> {
     type: "union" | "unionAll" | "intersect" | "except";
     other: Relation<T>;
   } | null = null;
-  private _joinClauses: Array<{ type: "inner" | "left"; table: string; on: string }> = [];
+  private _joinClauses: Array<{
+    type: "inner" | "left";
+    table: string;
+    on: string;
+    quoted?: boolean;
+  }> = [];
   private _rawJoins: string[] = [];
   private _includesAssociations: string[] = [];
   private _preloadAssociations: string[] = [];
@@ -921,10 +926,15 @@ export class Relation<T extends Base> {
       if (resolved) {
         if (Array.isArray(resolved)) {
           for (const join of resolved) {
-            rel._joinClauses.push({ type: "inner", table: join.table, on: join.on });
+            rel._joinClauses.push({ type: "inner", table: join.table, on: join.on, quoted: true });
           }
         } else {
-          rel._joinClauses.push({ type: "inner", table: resolved.table, on: resolved.on });
+          rel._joinClauses.push({
+            type: "inner",
+            table: resolved.table,
+            on: resolved.on,
+            quoted: true,
+          });
         }
       } else {
         rel._rawJoins.push(tableOrSql);
@@ -948,10 +958,15 @@ export class Relation<T extends Base> {
       if (resolved) {
         if (Array.isArray(resolved)) {
           for (const join of resolved) {
-            rel._joinClauses.push({ type: "left", table: join.table, on: join.on });
+            rel._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
           }
         } else {
-          rel._joinClauses.push({ type: "left", table: resolved.table, on: resolved.on });
+          rel._joinClauses.push({
+            type: "left",
+            table: resolved.table,
+            on: resolved.on,
+            quoted: true,
+          });
         }
       } else {
         rel._joinClauses.push({ type: "left", table, on: "1=1" });
@@ -1978,7 +1993,7 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     for (const join of this._joinClauses) {
-      const tableNode = new Table(join.table);
+      const tableNode = join.quoted ? new Table(join.table) : join.table;
       const onNode = new Nodes.SqlLiteral(join.on);
       if (join.type === "inner") {
         manager.join(tableNode, onNode);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -104,7 +104,7 @@ export class Relation<T extends Base> {
   private _rawOrderClauses: string[] = [];
   private _limitValue: number | null = null;
   private _offsetValue: number | null = null;
-  private _selectColumns: (string | Nodes.SqlLiteral)[] | null = null;
+  private _selectColumns: (string | Nodes.Node)[] | null = null;
   private _isDistinct = false;
   private _distinctOnColumns: string[] = [];
   private _groupColumns: string[] = [];
@@ -708,7 +708,11 @@ export class Relation<T extends Base> {
     }
     if (this._selectColumns !== null) {
       const cols = this._selectColumns.map((c) =>
-        c instanceof Nodes.SqlLiteral ? `sql(${JSON.stringify(c.value)})` : JSON.stringify(c),
+        c instanceof Nodes.SqlLiteral
+          ? `sql(${JSON.stringify(c.value)})`
+          : c instanceof Nodes.Node
+            ? `sql(${JSON.stringify(c.toSql())})`
+            : JSON.stringify(c),
       );
       parts.push(`.select(${cols.join(", ")})`);
     }
@@ -1970,11 +1974,12 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     for (const join of this._joinClauses) {
+      const tableNode = new Table(join.table);
       const onNode = new Nodes.SqlLiteral(join.on);
       if (join.type === "inner") {
-        manager.join(join.table, onNode);
+        manager.join(tableNode, onNode);
       } else {
-        manager.outerJoin(join.table, onNode);
+        manager.outerJoin(tableNode, onNode);
       }
     }
     for (const rawJoin of this._rawJoins) {
@@ -2475,7 +2480,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#select_values
    */
-  get selectValues(): (string | Nodes.SqlLiteral)[] {
+  get selectValues(): (string | Nodes.Node)[] {
     return this._selectColumns ?? [];
   }
 
@@ -2694,7 +2699,7 @@ export class Relation<T extends Base> {
   private _buildProjections(table: Table): any[] {
     if (this._selectColumns) {
       return this._selectColumns.map((c) => {
-        if (c instanceof Nodes.SqlLiteral) return c;
+        if (c instanceof Nodes.Node) return c;
         if (/[(*\s]/.test(c)) return new Nodes.SqlLiteral(c);
         return table.get(c);
       });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -567,11 +567,7 @@ export class Relation<T extends Base> {
     if (args.length === 1 && typeof args[0] === "function") {
       return this.toArray().then((records) => records.filter(args[0]));
     }
-    const columns = args.map((a: any) => {
-      if (a instanceof Nodes.Node) return a;
-      if (a instanceof Nodes.SqlLiteral) return a;
-      return String(a);
-    });
+    const columns = args.map((a: any) => (a instanceof Nodes.Node ? a : String(a)));
     return this._clone()._selectBang(...columns);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1989,14 +1989,7 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     for (const join of this._joinClauses) {
-      const tableNode = join.quoted
-        ? new Nodes.SqlLiteral(
-            join.table
-              .split(".")
-              .map((p) => `"${p}"`)
-              .join("."),
-          )
-        : join.table;
+      const tableNode = join.quoted ? new Table(join.table) : join.table;
       const onNode = new Nodes.SqlLiteral(join.on);
       if (join.type === "inner") {
         manager.join(tableNode, onNode);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -152,9 +152,11 @@ function withRecursiveBang(this: QueryMethodsHost, ...ctes: Array<Record<string,
 }
 
 function reselectBang(this: QueryMethodsHost, ...columns: any[]): any {
-  this._selectColumns = columns.map((c: any) =>
-    typeof c === "object" && c !== null && "value" in c ? c : String(c),
-  );
+  this._selectColumns = columns.map((c: any) => {
+    if (c instanceof Nodes.Node) return c;
+    if (typeof c === "object" && c !== null && "value" in c) return c;
+    return String(c);
+  });
   return this;
 }
 
@@ -166,11 +168,17 @@ function reselectBang(this: QueryMethodsHost, ...columns: any[]): any {
  */
 function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const flat = columns.flat(Infinity);
-  const normalized = flat.map((c: any) =>
-    typeof c === "object" && c !== null && "value" in c ? c : String(c),
-  );
+  const normalized = flat.map((c: any) => {
+    if (c instanceof Nodes.Node) return c;
+    if (typeof c === "object" && c !== null && "value" in c) return c;
+    return String(c);
+  });
   if (this._selectColumns === null) this._selectColumns = [];
-  const keyOf = (c: unknown) => (typeof c === "string" ? c : (c as { value: string }).value);
+  const keyOf = (c: unknown) => {
+    if (typeof c === "string") return c;
+    if (c instanceof Nodes.Node) return c.toSql();
+    return (c as { value: string }).value;
+  };
   const seen = new Set(this._selectColumns.map(keyOf));
   for (const col of normalized) {
     const key = keyOf(col);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -175,10 +175,22 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   });
   if (this._selectColumns === null) this._selectColumns = [];
   const seenStrings = new Set<string>();
-  const seenNodes = new WeakSet<object>();
+  const seenNodeHashes = new Map<number, Nodes.Node[]>();
+  const nodeIsDuplicate = (node: Nodes.Node): boolean => {
+    const h = node.hash();
+    const bucket = seenNodeHashes.get(h);
+    if (!bucket) return false;
+    return bucket.some((n) => n.eql(node));
+  };
+  const addNodeToSeen = (node: Nodes.Node): void => {
+    const h = node.hash();
+    const bucket = seenNodeHashes.get(h);
+    if (bucket) bucket.push(node);
+    else seenNodeHashes.set(h, [node]);
+  };
   for (const existing of this._selectColumns) {
     if (typeof existing === "string") seenStrings.add(existing);
-    else if (existing instanceof Nodes.Node) seenNodes.add(existing);
+    else if (existing instanceof Nodes.Node) addNodeToSeen(existing);
     else seenStrings.add((existing as { value: string }).value);
   }
   for (const col of normalized) {
@@ -188,9 +200,9 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
         seenStrings.add(col);
       }
     } else if (col instanceof Nodes.Node) {
-      if (!seenNodes.has(col)) {
+      if (!nodeIsDuplicate(col)) {
         this._selectColumns.push(col);
-        seenNodes.add(col);
+        addNodeToSeen(col);
       }
     } else {
       const key = (col as { value: string }).value;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -174,17 +174,30 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
     return String(c);
   });
   if (this._selectColumns === null) this._selectColumns = [];
-  const keyOf = (c: unknown) => {
-    if (typeof c === "string") return c;
-    if (c instanceof Nodes.Node) return c.toSql();
-    return (c as { value: string }).value;
-  };
-  const seen = new Set(this._selectColumns.map(keyOf));
+  const seenStrings = new Set<string>();
+  const seenNodes = new WeakSet<object>();
+  for (const existing of this._selectColumns) {
+    if (typeof existing === "string") seenStrings.add(existing);
+    else if (existing instanceof Nodes.Node) seenNodes.add(existing);
+    else seenStrings.add((existing as { value: string }).value);
+  }
   for (const col of normalized) {
-    const key = keyOf(col);
-    if (!seen.has(key)) {
-      this._selectColumns.push(col);
-      seen.add(key);
+    if (typeof col === "string") {
+      if (!seenStrings.has(col)) {
+        this._selectColumns.push(col);
+        seenStrings.add(col);
+      }
+    } else if (col instanceof Nodes.Node) {
+      if (!seenNodes.has(col)) {
+        this._selectColumns.push(col);
+        seenNodes.add(col);
+      }
+    } else {
+      const key = (col as { value: string }).value;
+      if (!seenStrings.has(key)) {
+        this._selectColumns.push(col);
+        seenStrings.add(key);
+      }
     }
   }
   return this;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -154,7 +154,8 @@ function withRecursiveBang(this: QueryMethodsHost, ...ctes: Array<Record<string,
 function reselectBang(this: QueryMethodsHost, ...columns: any[]): any {
   this._selectColumns = columns.map((c: any) => {
     if (c instanceof Nodes.Node) return c;
-    if (typeof c === "object" && c !== null && "value" in c) return c;
+    if (typeof c === "object" && c !== null && "value" in c)
+      return new Nodes.SqlLiteral((c as { value: string }).value);
     return String(c);
   });
   return this;
@@ -170,7 +171,8 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const flat = columns.flat(Infinity);
   const normalized = flat.map((c: any) => {
     if (c instanceof Nodes.Node) return c;
-    if (typeof c === "object" && c !== null && "value" in c) return c;
+    if (typeof c === "object" && c !== null && "value" in c)
+      return new Nodes.SqlLiteral((c as { value: string }).value);
     return String(c);
   });
   if (this._selectColumns === null) this._selectColumns = [];

--- a/packages/activerecord/src/test-setup.ts
+++ b/packages/activerecord/src/test-setup.ts
@@ -1,0 +1,11 @@
+import { afterEach } from "vitest";
+import { setToSqlVisitor, Visitors } from "@blazetrails/arel";
+
+// Restore the default Arel visitor after each test so AR tests that set a
+// SQLite (or other dialect) adapter via `Base.adapter = ...` don't leak the
+// dialect-specific visitor into unrelated arel tests running in the same
+// process. Tests that need a dialect visitor for their duration already
+// manage it themselves (see node.test.ts's try/finally pattern).
+afterEach(() => {
+  setToSqlVisitor(Visitors.ToSql);
+});

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1252,10 +1252,14 @@ export class ToSql implements NodeVisitor<SQLString> {
   }
 
   private visitTable(node: Table): SQLString {
+    const quoted = node.name
+      .split(".")
+      .map((p) => `"${p}"`)
+      .join(".");
     if (node.tableAlias) {
-      this.collector.append(`"${node.name}" "${node.tableAlias}"`);
+      this.collector.append(`${quoted} "${node.tableAlias}"`);
     } else {
-      this.collector.append(`"${node.name}"`);
+      this.collector.append(quoted);
     }
     return this.collector;
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,8 +39,9 @@ export default defineConfig({
       "scripts/parity/**/*.test.ts",
     ],
     exclude: ["**/node_modules/**", "**/dist/**", "packages/website/**", "packages/*/dx-tests/**"],
-    setupFiles: process.env.MYSQL_TEST_URL
-      ? ["./packages/activerecord/src/test-setup-mysql.ts"]
-      : [],
+    setupFiles: [
+      "./packages/activerecord/src/test-setup.ts",
+      ...(process.env.MYSQL_TEST_URL ? ["./packages/activerecord/src/test-setup-mysql.ts"] : []),
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- **ar-09, ar-11, ar-19** — Boolean literals: `establishConnection` now calls `setToSqlVisitor(Visitors.SQLite)` when connecting to SQLite, so booleans in WHERE clauses emit as `1`/`0` instead of `TRUE`/`FALSE`, matching Rails' adapter-driven visitor dispatch via `AbstractAdapter#arel_visitor`.
- **ar-01** — Join table quoting: `_applyJoinsToManager` now passes `new Table(join.table)` instead of a bare string so the visitor double-quotes the table name (`"reviews"` vs `reviews`), matching Rails.
- **ar-33** — Arel nodes in `select()`: `Relation#select`, `_selectBang`, and `reselectBang` now preserve `Nodes.Node` instances through the pipeline; `_buildProjections` passes them directly to the manager instead of `toString()`-coercing them.

## Test plan

- [ ] `pnpm --filter @blazetrails/activerecord test` passes
- [ ] AR query parity CI: ar-01, ar-09, ar-11, ar-19, ar-33 now green