### PR TITLE
test(parity): AR query fixtures ar-49..ar-53 — IS NOT NULL, multi-includes, having, datetime range, chained whereNot (PR 10)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       '@blazetrails/activerecord':
         specifier: workspace:*
         version: link:../../packages/activerecord
+      '@blazetrails/activesupport':
+        specifier: workspace:*
+        version: link:../../packages/activesupport
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../../packages/arel

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -58,5 +58,13 @@
   "ar-44": {
     "side": "diff",
     "reason": "LEFT OUTER JOIN table-name quoting: trails emits 'LEFT OUTER JOIN authors ON ...' (bare table identifier); Rails emits 'LEFT OUTER JOIN \"authors\" ON ...'. Same root cause as ar-01's INNER JOIN quoting gap."
+  },
+  "ar-51": {
+    "side": "diff",
+    "reason": "GROUP BY qualification in string-having query: trails emits 'GROUP BY status' (bare); Rails qualifies to 'GROUP BY \"orders\".\"status\"'. Same root cause as ar-17 / ar-42."
+  },
+  "ar-52": {
+    "side": "diff",
+    "reason": "Datetime serialization in WHERE BETWEEN: trails formats Date as ISO 8601 ('1999-12-25T00:00:00.000Z'); Rails formats as SQL datetime ('1999-12-25 00:00:00'). The T separator, milliseconds, and Z suffix are wrong for standard SQL datetime literals."
   }
 }

--- a/scripts/parity/fixtures/ar-49/models.rb
+++ b/scripts/parity/fixtures/ar-49/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-49/models.ts
+++ b/scripts/parity/fixtures/ar-49/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-49/query.rb
+++ b/scripts/parity/fixtures/ar-49/query.rb
@@ -1,0 +1,1 @@
+Customer.where.not(last_name: nil)

--- a/scripts/parity/fixtures/ar-49/query.ts
+++ b/scripts/parity/fixtures/ar-49/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.whereNot({ last_name: null });

--- a/scripts/parity/fixtures/ar-49/schema.sql
+++ b/scripts/parity/fixtures/ar-49/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-49
+-- Query: Customer.where.not(last_name: nil)
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  last_name TEXT,
+  email TEXT
+);

--- a/scripts/parity/fixtures/ar-50/models.rb
+++ b/scripts/parity/fixtures/ar-50/models.rb
@@ -1,0 +1,10 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Review < ActiveRecord::Base
+  belongs_to :book
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end

--- a/scripts/parity/fixtures/ar-50/models.ts
+++ b/scripts/parity/fixtures/ar-50/models.ts
@@ -1,0 +1,24 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-50/query.rb
+++ b/scripts/parity/fixtures/ar-50/query.rb
@@ -1,0 +1,1 @@
+Book.includes(:author, :reviews).limit(5)

--- a/scripts/parity/fixtures/ar-50/query.ts
+++ b/scripts/parity/fixtures/ar-50/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().includes("author", "reviews").limit(5);

--- a/scripts/parity/fixtures/ar-50/schema.sql
+++ b/scripts/parity/fixtures/ar-50/schema.sql
@@ -1,0 +1,17 @@
+-- Fixture for statement: ar-50
+-- Query: Book.includes(:author, :reviews).limit(5)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  body TEXT
+);

--- a/scripts/parity/fixtures/ar-51/models.rb
+++ b/scripts/parity/fixtures/ar-51/models.rb
@@ -1,0 +1,2 @@
+class Order < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-51/models.ts
+++ b/scripts/parity/fixtures/ar-51/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Order extends Base {
+  static {
+    this.tableName = "orders";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-51/query.rb
+++ b/scripts/parity/fixtures/ar-51/query.rb
@@ -1,0 +1,1 @@
+Order.group(:status).having("SUM(total) > ?", 200)

--- a/scripts/parity/fixtures/ar-51/query.ts
+++ b/scripts/parity/fixtures/ar-51/query.ts
@@ -1,0 +1,3 @@
+import { Order } from "./models.js";
+
+export default Order.group("status").having("SUM(total) > ?", 200);

--- a/scripts/parity/fixtures/ar-51/schema.sql
+++ b/scripts/parity/fixtures/ar-51/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-51
+-- Query: Order.group(:status).having("SUM(total) > ?", 200)
+
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY,
+  status TEXT,
+  total INTEGER
+);

--- a/scripts/parity/fixtures/ar-52/models.rb
+++ b/scripts/parity/fixtures/ar-52/models.rb
@@ -1,0 +1,2 @@
+class Order < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-52/models.ts
+++ b/scripts/parity/fixtures/ar-52/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Order extends Base {
+  static {
+    this.tableName = "orders";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-52/query.rb
+++ b/scripts/parity/fixtures/ar-52/query.rb
@@ -1,0 +1,1 @@
+Order.where(created_at: 1.week.ago..Time.now)

--- a/scripts/parity/fixtures/ar-52/query.ts
+++ b/scripts/parity/fixtures/ar-52/query.ts
@@ -1,0 +1,6 @@
+import { Range } from "@blazetrails/activerecord";
+import { Order } from "./models.js";
+
+const now = new Date();
+const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+export default Order.where({ created_at: new Range(weekAgo, now) });

--- a/scripts/parity/fixtures/ar-52/query.ts
+++ b/scripts/parity/fixtures/ar-52/query.ts
@@ -1,6 +1,7 @@
+import { weeks } from "@blazetrails/activesupport";
 import { Range } from "@blazetrails/activerecord";
 import { Order } from "./models.js";
 
 const now = new Date();
-const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+const weekAgo = weeks(1).ago(now);
 export default Order.where({ created_at: new Range(weekAgo, now) });

--- a/scripts/parity/fixtures/ar-52/schema.sql
+++ b/scripts/parity/fixtures/ar-52/schema.sql
@@ -3,5 +3,5 @@
 
 CREATE TABLE orders (
   id INTEGER PRIMARY KEY,
-  created_at TEXT
+  created_at DATETIME
 );

--- a/scripts/parity/fixtures/ar-52/schema.sql
+++ b/scripts/parity/fixtures/ar-52/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-52
+-- Query: Order.where(created_at: 1.week.ago..Time.now)
+
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY,
+  created_at TEXT
+);

--- a/scripts/parity/fixtures/ar-53/models.rb
+++ b/scripts/parity/fixtures/ar-53/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-53/models.ts
+++ b/scripts/parity/fixtures/ar-53/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-53/query.rb
+++ b/scripts/parity/fixtures/ar-53/query.rb
@@ -1,0 +1,1 @@
+Customer.where.not(last_name: nil).where.not(email: nil)

--- a/scripts/parity/fixtures/ar-53/query.ts
+++ b/scripts/parity/fixtures/ar-53/query.ts
@@ -1,0 +1,3 @@
+import { Customer } from "./models.js";
+
+export default Customer.whereNot({ last_name: null }).whereNot({ email: null });

--- a/scripts/parity/fixtures/ar-53/schema.sql
+++ b/scripts/parity/fixtures/ar-53/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-53
+-- Query: Customer.where.not(last_name: nil).where.not(email: nil)
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  last_name TEXT,
+  email TEXT
+);

--- a/scripts/parity/package.json
+++ b/scripts/parity/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "description": "Parity-pipeline runner scripts. Workspace package so dump.ts can import @blazetrails/arel directly.",
   "dependencies": {
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/activemodel": "workspace:*",
     "@blazetrails/arel": "workspace:*",
-    "@blazetrails/activerecord": "workspace:*",
-    "@blazetrails/activemodel": "workspace:*"
+    "@blazetrails/activerecord": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures. **3 PASS** byte-identical; 2 KNOWN-GAP.

**PASS**
- ar-49: `whereNot({ col: null })` → `IS NOT NULL`
- ar-50: `includes("author", "reviews").limit(5)` — multiple association preload
- ar-53: chained `whereNot(a: null).whereNot(b: null)`

**KNOWN-GAP**
- ar-51: `group(:status).having("SUM(...) > ?", n)` — GROUP BY qualification; same root cause as ar-17/ar-42
- ar-52: `where(created_at: weekAgo..now)` — trails formats Date as ISO 8601 (`'1999-12-25T00:00:00.000Z'`); Rails uses SQL datetime (`'1999-12-25 00:00:00'`). New gap category — datetime serialization needs adapter-aware formatting.

## Test plan
- [x] `pnpm parity:query` — 3 PASS, 2 KNOWN-GAP, no UNEXPECTED-PASS