### PR TITLE
fix(activerecord): qualify GROUP BY columns + retire gaps fixed by #833 (ar-17, ar-42, ar-51)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -128,10 +128,14 @@ describe("RelationTest", () => {
         this.adapter = adapter;
       }
     }
-    // Function expressions pass through as raw SQL
-    expect(Order.group("DATE(created_at)").toSql()).toContain("DATE(created_at)");
+    // Function expressions pass through as raw SQL (not quoted as identifier)
+    const fnSql = Order.group("DATE(created_at)").toSql();
+    expect(fnSql).toContain("GROUP BY DATE(created_at)");
+    expect(fnSql).not.toContain('"orders"."DATE(created_at)"');
     // Cast expressions pass through as raw SQL (not quoted as identifier)
-    expect(Order.group("created_at::date").toSql()).toContain("created_at::date");
+    const castSql = Order.group("created_at::date").toSql();
+    expect(castSql).toContain("GROUP BY created_at::date");
+    expect(castSql).not.toContain('"orders"."created_at::date"');
     // Positional GROUP BY passes through as raw SQL
     expect(Order.group("1").toSql()).toContain("GROUP BY 1");
   });

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -128,9 +128,12 @@ describe("RelationTest", () => {
         this.adapter = adapter;
       }
     }
-    const sql = Order.group("DATE(created_at)").toSql();
-    expect(sql).toContain("DATE(created_at)");
-    expect(sql).not.toContain('"orders"."DATE(created_at)"');
+    // Function expressions pass through as raw SQL
+    expect(Order.group("DATE(created_at)").toSql()).toContain("DATE(created_at)");
+    // Cast expressions pass through as raw SQL (not quoted as identifier)
+    expect(Order.group("created_at::date").toSql()).toContain("created_at::date");
+    // Positional GROUP BY passes through as raw SQL
+    expect(Order.group("1").toSql()).toContain("GROUP BY 1");
   });
 
   it("multiple selects", () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -106,6 +106,33 @@ describe("RelationTest", () => {
     expect(post.isPersisted()).toBe(true);
   });
 
+  it("group by bare column name qualifies via table", () => {
+    class Order extends Base {
+      static _tableName = "orders";
+      static {
+        this.attribute("created_at", "string");
+        this.attribute("total", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Order.group("created_at").toSql();
+    expect(sql).toContain('"orders"."created_at"');
+    expect(sql).not.toMatch(/GROUP BY created_at[^"]/);
+  });
+
+  it("group by SQL expression passes through unqualified", () => {
+    class Order extends Base {
+      static _tableName = "orders";
+      static {
+        this.attribute("created_at", "string");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Order.group("DATE(created_at)").toSql();
+    expect(sql).toContain("DATE(created_at)");
+    expect(sql).not.toContain('"orders"."DATE(created_at)"');
+  });
+
   it("multiple selects", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -120,6 +120,22 @@ describe("RelationTest", () => {
     expect(sql).not.toMatch(/GROUP BY created_at[^"]/);
   });
 
+  it("group by multiple bare columns qualifies each via table", () => {
+    class Book extends Base {
+      static _tableName = "books";
+      static {
+        this.attribute("author_id", "integer");
+        this.attribute("published_year", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.group("author_id", "published_year").toSql();
+    expect(sql).toContain('"books"."author_id"');
+    expect(sql).toContain('"books"."published_year"');
+    expect(sql).not.toMatch(/GROUP BY author_id[^"]/);
+    expect(sql).not.toMatch(/,\s*published_year[^"]/);
+  });
+
   it("group by SQL expression passes through unqualified", () => {
     class Order extends Base {
       static _tableName = "orders";

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2887,7 +2887,7 @@ export class Relation<T extends Base> {
   // table; pass SQL expressions (containing parens, spaces, dots, etc.) through
   // as raw SqlLiteral, matching ActiveRecord::Relation#build_group behaviour.
   private _groupColumnToArel(col: string, table: Table): Nodes.Node {
-    if (/[(\s*]/.test(col) || col.includes(".")) return new Nodes.SqlLiteral(col);
+    if (/[(\s]/.test(col) || col.includes(".")) return new Nodes.SqlLiteral(col);
     return table.get(col);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -37,7 +37,7 @@ import { InsertAll } from "./insert-all.js";
 import { ScopeRegistry } from "./scoping.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { include, type Included } from "@blazetrails/activesupport";
-import { Calculations } from "./relation/calculations.js";
+import { Calculations, groupColumnToArel } from "./relation/calculations.js";
 import { FinderMethods } from "./relation/finder-methods.js";
 import { SpawnMethods } from "./relation/spawn-methods.js";
 import { FromClause } from "./relation/from-clause.js";
@@ -1662,7 +1662,7 @@ export class Relation<T extends Base> {
     this._applyOrderToManager(manager, table);
 
     if (this._isDistinct) manager.distinct();
-    for (const col of this._groupColumns) manager.group(this._groupColumnToArel(col, table));
+    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
     if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
     if (this._lockValue) manager.lock(this._lockValue);
 
@@ -2054,7 +2054,7 @@ export class Relation<T extends Base> {
     const manager = table.project(new Nodes.SqlLiteral("1 AS one"));
     rel._applyJoinsToManager(manager);
     rel._applyWheresToManager(manager, table);
-    for (const col of rel._groupColumns) manager.group(rel._groupColumnToArel(col, table));
+    for (const col of rel._groupColumns) manager.group(groupColumnToArel(col, table));
     if (!rel._havingClause.isEmpty()) manager.having(rel._havingClause.ast);
     manager.take(1);
     const rows = await rel._modelClass.adapter.execute(manager.toSql());
@@ -2761,7 +2761,7 @@ export class Relation<T extends Base> {
     if (this._limitValue !== null) manager.take(this._limitValue);
     if (this._offsetValue !== null) manager.skip(this._offsetValue);
     for (const col of this._groupColumns) {
-      manager.group(this._groupColumnToArel(col, table));
+      manager.group(groupColumnToArel(col, table));
     }
     return manager;
   }
@@ -2813,7 +2813,7 @@ export class Relation<T extends Base> {
     if (this._offsetValue !== null) manager.skip(this._offsetValue);
 
     for (const col of this._groupColumns) {
-      manager.group(this._groupColumnToArel(col, table));
+      manager.group(groupColumnToArel(col, table));
     }
 
     if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
@@ -2881,14 +2881,6 @@ export class Relation<T extends Base> {
 
   private _compileArelNode(node: Nodes.Node): string {
     return new Visitors.ToSql().compile(node);
-  }
-
-  // Mirrors Rails' arel_columns: qualify a bare column name via the model
-  // table; pass SQL expressions (containing parens, spaces, dots, etc.) through
-  // as raw SqlLiteral, matching ActiveRecord::Relation#build_group behaviour.
-  private _groupColumnToArel(col: string, table: Table): Nodes.Node {
-    if (/[(\s]/.test(col) || col.includes(".")) return new Nodes.SqlLiteral(col);
-    return table.get(col);
   }
 
   private _applyOrderToManager(manager: SelectManager, table: Table): void {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1662,7 +1662,7 @@ export class Relation<T extends Base> {
     this._applyOrderToManager(manager, table);
 
     if (this._isDistinct) manager.distinct();
-    for (const col of this._groupColumns) manager.group(col);
+    for (const col of this._groupColumns) manager.group(this._groupColumnToArel(col, table));
     if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
     if (this._lockValue) manager.lock(this._lockValue);
 
@@ -2054,7 +2054,7 @@ export class Relation<T extends Base> {
     const manager = table.project(new Nodes.SqlLiteral("1 AS one"));
     rel._applyJoinsToManager(manager);
     rel._applyWheresToManager(manager, table);
-    for (const col of rel._groupColumns) manager.group(col);
+    for (const col of rel._groupColumns) manager.group(rel._groupColumnToArel(col, table));
     if (!rel._havingClause.isEmpty()) manager.having(rel._havingClause.ast);
     manager.take(1);
     const rows = await rel._modelClass.adapter.execute(manager.toSql());
@@ -2761,7 +2761,7 @@ export class Relation<T extends Base> {
     if (this._limitValue !== null) manager.take(this._limitValue);
     if (this._offsetValue !== null) manager.skip(this._offsetValue);
     for (const col of this._groupColumns) {
-      manager.group(col);
+      manager.group(this._groupColumnToArel(col, table));
     }
     return manager;
   }
@@ -2813,7 +2813,7 @@ export class Relation<T extends Base> {
     if (this._offsetValue !== null) manager.skip(this._offsetValue);
 
     for (const col of this._groupColumns) {
-      manager.group(col);
+      manager.group(this._groupColumnToArel(col, table));
     }
 
     if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
@@ -2881,6 +2881,14 @@ export class Relation<T extends Base> {
 
   private _compileArelNode(node: Nodes.Node): string {
     return new Visitors.ToSql().compile(node);
+  }
+
+  // Mirrors Rails' arel_columns: qualify a bare column name via the model
+  // table; pass SQL expressions (containing parens, spaces, dots, etc.) through
+  // as raw SqlLiteral, matching ActiveRecord::Relation#build_group behaviour.
+  private _groupColumnToArel(col: string, table: Table): Nodes.Node {
+    if (/[(\s*]/.test(col) || col.includes(".")) return new Nodes.SqlLiteral(col);
+    return table.get(col);
   }
 
   private _applyOrderToManager(manager: SelectManager, table: Table): void {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -8,9 +8,24 @@
  * Mirrors: ActiveRecord::Calculations
  */
 
-import { Nodes } from "@blazetrails/arel";
+import { Nodes, Table } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import { detectAdapterName } from "../adapter-name.js";
+
+/**
+ * Qualify a GROUP BY column string as an Arel attribute node when it is a
+ * plain SQL identifier (letters, digits, underscores), mirroring Rails'
+ * `arel_columns` / `build_group` behaviour. Positional args ("1"), cast
+ * expressions ("created_at::date"), and SQL expressions pass through as
+ * SqlLiteral.
+ *
+ * @internal exported so Relation can share the implementation.
+ */
+export function groupColumnToArel(col: string, table: Table): Nodes.Node {
+  const trimmed = col.trim();
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) return table.get(trimmed);
+  return new Nodes.SqlLiteral(trimmed);
+}
 
 interface CalculationRelation {
   _modelClass: {
@@ -178,7 +193,7 @@ async function groupedAggregate(
   const manager = table.project(table.get(groupCol).as("group_key"), aggNode.as("val"));
   rel._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
-  manager.group(groupCol);
+  manager.group(groupColumnToArel(groupCol, table));
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -189,11 +189,13 @@ async function groupedAggregate(
 ): Promise<Record<string, unknown>> {
   const table = rel._modelClass.arelTable;
   const groupCol = rel._groupColumns[0];
+  const groupNode = groupColumnToArel(groupCol, table);
   const aggNode = buildAggNode(table, fn, column, rel._isDistinct);
-  const manager = table.project(table.get(groupCol).as("group_key"), aggNode.as("val"));
+  const groupKeyAlias = new Nodes.As(groupNode, new Nodes.SqlLiteral("group_key"));
+  const manager = table.project(groupKeyAlias, aggNode.as("val"));
   rel._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
-  manager.group(groupColumnToArel(groupCol, table));
+  manager.group(groupNode);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,43 +1,15 @@
 {
-  "ar-01": {
-    "side": "diff",
-    "reason": "Book.joins(:reviews): with models registered via registerModel() in the fixture's models.ts, trails Relation#joins(name) does resolve the association and emit an INNER JOIN on the FK. The remaining diff is table-name quoting — trails emits 'INNER JOIN reviews ON ...' where Rails emits 'INNER JOIN \"reviews\" ON ...'. Column references on both sides are quoted identically; only the table identifier after INNER JOIN is bare on trails."
-  },
-  "ar-09": {
-    "side": "diff",
-    "reason": "Boolean literal serialization: trails' ToSql renders JS booleans as the TRUE/FALSE keywords; Rails on SQLite writes 1/0 (SQLite's BOOLEAN maps to INTEGER, so Rails serialises to the integer form). Semantically equivalent but lexically differ."
-  },
-  "ar-11": {
-    "side": "diff",
-    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
-  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
-  },
-  "ar-17": {
-    "side": "diff",
-    "reason": "GROUP BY column qualification: trails emits 'GROUP BY created_at' (bare); Rails qualifies to 'GROUP BY \"orders\".\"created_at\"'. Same SQL semantic, lexically differ."
-  },
-  "ar-19": {
-    "side": "diff",
-    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09 / ar-11."
   },
   "ar-23": {
     "side": "diff",
     "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
   },
-  "ar-29": {
-    "side": "diff",
-    "reason": ".lock on SQLite: trails emits 'FOR UPDATE' regardless of adapter; Rails knows SQLite has no row-level locking and emits no lock clause. trails should make Relation#lock adapter-aware (mirror Rails' AbstractAdapter#lock_clause / SQLite returning empty)."
-  },
   "ar-32": {
     "side": "diff",
     "reason": "in_order_of: multiple divergences vs Rails. (1) Rails adds WHERE \"books\".\"status\" IN (values) to filter to the named set; trails omits it. (2) Rails CASE values are 1-indexed; trails 0-indexed with ELSE branch. (3) Rails appends ASC; trails leaves direction bare. (4) Rails qualifies the column ('\"books\".\"status\"'); trails leaves it bare. Real implementation gap — trails Relation#inOrderOf is incomplete vs ActiveRecord::QueryMethods#in_order_of."
-  },
-  "ar-33": {
-    "side": "diff",
-    "reason": "Relation#select with an Arel attribute As node: trails emits literal '[object Object]' because Relation#select accepts only string | SqlLiteral and toString-coerces other inputs; Rails accepts Arel nodes and renders them via the visitor. trails-missing: select() should accept Arel nodes (Attribute, As, etc.) and call toSql on them."
   },
   "ar-36": {
     "side": "diff",
@@ -46,22 +18,6 @@
   "ar-37": {
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
-  },
-  "ar-38": {
-    "side": "diff",
-    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 / ar-11 / ar-19 — boolean serialization is type-system-driven, not adapter-aware."
-  },
-  "ar-42": {
-    "side": "diff",
-    "reason": "Multi-column GROUP BY qualification: trails emits 'GROUP BY author_id, published_year' (bare); Rails qualifies each to '\"books\".\"author_id\", \"books\".\"published_year\"'. Same root cause as ar-17 (single-column form)."
-  },
-  "ar-44": {
-    "side": "diff",
-    "reason": "LEFT OUTER JOIN table-name quoting: trails emits 'LEFT OUTER JOIN authors ON ...' (bare table identifier); Rails emits 'LEFT OUTER JOIN \"authors\" ON ...'. Same root cause as ar-01's INNER JOIN quoting gap."
-  },
-  "ar-51": {
-    "side": "diff",
-    "reason": "GROUP BY qualification in string-having query: trails emits 'GROUP BY status' (bare); Rails qualifies to 'GROUP BY \"orders\".\"status\"'. Same root cause as ar-17 / ar-42."
   },
   "ar-52": {
     "side": "diff",


### PR DESCRIPTION
## Summary

- **ar-17, ar-42, ar-51** — GROUP BY column qualification: bare string column names in `.group(col)` now route through `_groupColumnToArel` which qualifies them as `table["col"]` (emitting `"orders"."created_at"`) while passing SQL expressions (containing parens, spaces, dots) through as `SqlLiteral`. Matches Rails' `arel_columns`/`build_group` behaviour.

- **query-known-gaps.json** — retire gaps closed by PR #833 (ar-01, ar-09/11/19/33, ar-29, ar-38, ar-44) and by this PR (ar-17, ar-42, ar-51). Remaining: ar-16, ar-23, ar-32, ar-36, ar-37, ar-52.

## Test plan

- [ ] `pnpm --filter @blazetrails/activerecord test` passes
- [ ] AR query parity CI: ar-17, ar-42, ar-51 now green; ar-29, ar-38, ar-44 confirmed green from #833