### PR TITLE
test(parity): AR query fixtures ar-54..ar-58 — create_with, table-keyed where, unscope, references, nested includes (PR 11)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,4 +1,12 @@
 {
+  "ar-09": {
+    "side": "diff",
+    "reason": "Boolean literal serialization: trails' ToSql renders JS booleans as the TRUE/FALSE keywords; Rails on SQLite writes 1/0 (SQLite's BOOLEAN maps to INTEGER, so Rails serialises to the integer form). Semantically equivalent but lexically differ."
+  },
+  "ar-11": {
+    "side": "diff",
+    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
+  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
@@ -19,8 +27,28 @@
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
   },
+  "ar-38": {
+    "side": "diff",
+    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 / ar-11 / ar-19 — boolean serialization is type-system-driven, not adapter-aware."
+  },
+  "ar-42": {
+    "side": "diff",
+    "reason": "Multi-column GROUP BY qualification: trails emits 'GROUP BY author_id, published_year' (bare); Rails qualifies each to '\"books\".\"author_id\", \"books\".\"published_year\"'. Same root cause as ar-17 (single-column form)."
+  },
+  "ar-51": {
+    "side": "diff",
+    "reason": "GROUP BY qualification in string-having query: trails emits 'GROUP BY status' (bare); Rails qualifies to 'GROUP BY \"orders\".\"status\"'. Same root cause as ar-17 / ar-42."
+  },
   "ar-52": {
     "side": "diff",
     "reason": "Datetime serialization in WHERE BETWEEN: trails formats Date as ISO 8601 ('1999-12-25T00:00:00.000Z'); Rails formats as SQL datetime ('1999-12-25 00:00:00'). The T separator, milliseconds, and Z suffix are wrong for standard SQL datetime literals."
+  },
+  "ar-55": {
+    "side": "diff",
+    "reason": "Nested table-keyed where hash: where({authors: {name: 'Rails'}}) — Rails expands nested hashes into table-qualified predicates ('\"authors\".\"name\" = \\'Rails\\''); trails serializes the inner object as a JSON string ('\"books\".\"authors\" = \\'{\"name\":\"Rails\"}\\'). trails-missing: PredicateBuilder should handle nested table→column hash form."
+  },
+  "ar-57": {
+    "side": "diff",
+    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,11 +1,31 @@
 {
+  "ar-01": {
+    "side": "diff",
+    "reason": "Datetime microseconds in WHERE bind: trails formats Date as '2026-04-18 12:25:55.789000' (with microseconds); Rails as '2026-04-18 12:25:55' (no sub-second). The table-quoting gap (INNER JOIN reviews vs \"reviews\") was fixed by #833, but this datetime serialization gap surfaces when frozen-at has non-zero milliseconds. Same family as ar-52."
+  },
+  "ar-09": {
+    "side": "diff",
+    "reason": "Boolean literal serialization: trails emits TRUE/FALSE in WHERE; Rails on SQLite emits 1/0. The #833 fix (setToSqlVisitor via adapter.arelVisitor) works in unit tests but not in the parity runner (tsx loads package modules in a separate module instance, so the global visitor set in ar_dump.ts does not affect the fixture's arel visitor)."
+  },
+  "ar-11": {
+    "side": "diff",
+    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09 (parity runner module isolation)."
+  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
   },
+  "ar-19": {
+    "side": "diff",
+    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09 (parity runner module isolation)."
+  },
   "ar-23": {
     "side": "diff",
     "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
+  },
+  "ar-29": {
+    "side": "diff",
+    "reason": ".lock on SQLite: trails emits 'FOR UPDATE' regardless of adapter; Rails knows SQLite has no row-level locking and emits no lock clause. trails should make Relation#lock adapter-aware (mirror Rails' AbstractAdapter#lock_clause / SQLite returning empty)."
   },
   "ar-32": {
     "side": "diff",
@@ -18,6 +38,10 @@
   "ar-37": {
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
+  },
+  "ar-38": {
+    "side": "diff",
+    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 (parity runner module isolation)."
   },
   "ar-52": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,31 +1,11 @@
 {
-  "ar-01": {
-    "side": "diff",
-    "reason": "Datetime microseconds in WHERE bind: trails formats Date as '2026-04-18 12:25:55.789000' (with microseconds); Rails as '2026-04-18 12:25:55' (no sub-second). The table-quoting gap (INNER JOIN reviews vs \"reviews\") was fixed by #833, but this datetime serialization gap surfaces when frozen-at has non-zero milliseconds. Same family as ar-52."
-  },
-  "ar-09": {
-    "side": "diff",
-    "reason": "Boolean literal serialization: trails emits TRUE/FALSE in WHERE; Rails on SQLite emits 1/0. Semantically equivalent but lexically differ."
-  },
-  "ar-11": {
-    "side": "diff",
-    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
-  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
   },
-  "ar-19": {
-    "side": "diff",
-    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09."
-  },
   "ar-23": {
     "side": "diff",
     "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
-  },
-  "ar-29": {
-    "side": "diff",
-    "reason": ".lock on SQLite: trails emits 'FOR UPDATE' regardless of adapter; Rails knows SQLite has no row-level locking and emits no lock clause. trails should make Relation#lock adapter-aware (mirror Rails' AbstractAdapter#lock_clause / SQLite returning empty)."
   },
   "ar-32": {
     "side": "diff",
@@ -38,10 +18,6 @@
   "ar-37": {
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
-  },
-  "ar-38": {
-    "side": "diff",
-    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same boolean literal serialization gap as ar-09, but occurring inside a subquery WHERE clause."
   },
   "ar-52": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -5,11 +5,11 @@
   },
   "ar-09": {
     "side": "diff",
-    "reason": "Boolean literal serialization: trails emits TRUE/FALSE in WHERE; Rails on SQLite emits 1/0. The #833 fix (setToSqlVisitor via adapter.arelVisitor) works in unit tests but not in the parity runner (tsx loads package modules in a separate module instance, so the global visitor set in ar_dump.ts does not affect the fixture's arel visitor)."
+    "reason": "Boolean literal serialization: trails emits TRUE/FALSE in WHERE; Rails on SQLite emits 1/0. Semantically equivalent but lexically differ."
   },
   "ar-11": {
     "side": "diff",
-    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09 (parity runner module isolation)."
+    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
   },
   "ar-16": {
     "side": "diff",
@@ -17,7 +17,7 @@
   },
   "ar-19": {
     "side": "diff",
-    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09 (parity runner module isolation)."
+    "reason": "Boolean literal in WHERE: trails emits 'active = TRUE', Rails on SQLite emits 'active = 1'. Same root cause as ar-09."
   },
   "ar-23": {
     "side": "diff",
@@ -41,7 +41,7 @@
   },
   "ar-38": {
     "side": "diff",
-    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 (parity runner module isolation)."
+    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same boolean literal serialization gap as ar-09, but occurring inside a subquery WHERE clause."
   },
   "ar-52": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,12 +1,4 @@
 {
-  "ar-09": {
-    "side": "diff",
-    "reason": "Boolean literal serialization: trails' ToSql renders JS booleans as the TRUE/FALSE keywords; Rails on SQLite writes 1/0 (SQLite's BOOLEAN maps to INTEGER, so Rails serialises to the integer form). Semantically equivalent but lexically differ."
-  },
-  "ar-11": {
-    "side": "diff",
-    "reason": "Boolean literal serialization in WHERE with array + nil: trails emits 'tall = FALSE OR tall IS NULL'; Rails emits 'tall = 0 OR tall IS NULL'. Same root cause as ar-09."
-  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
@@ -26,18 +18,6 @@
   "ar-37": {
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
-  },
-  "ar-38": {
-    "side": "diff",
-    "reason": "Boolean literal in subquery WHERE: trails emits 'approved = TRUE', Rails on SQLite emits 'approved = 1'. Same root cause as ar-09 / ar-11 / ar-19 — boolean serialization is type-system-driven, not adapter-aware."
-  },
-  "ar-42": {
-    "side": "diff",
-    "reason": "Multi-column GROUP BY qualification: trails emits 'GROUP BY author_id, published_year' (bare); Rails qualifies each to '\"books\".\"author_id\", \"books\".\"published_year\"'. Same root cause as ar-17 (single-column form)."
-  },
-  "ar-51": {
-    "side": "diff",
-    "reason": "GROUP BY qualification in string-having query: trails emits 'GROUP BY status' (bare); Rails qualifies to 'GROUP BY \"orders\".\"status\"'. Same root cause as ar-17 / ar-42."
   },
   "ar-52": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,4 +1,8 @@
 {
+  "ar-01": {
+    "side": "diff",
+    "reason": "Datetime microseconds in WHERE ? bind: trails serializes a Date as '2026-04-18 13:00:41.729000' (with microseconds); Rails serializes as '2026-04-18 13:00:41' (truncated to seconds). Only manifests when frozen-at has non-zero milliseconds. Same datetime serialization family as ar-52."
+  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."

--- a/scripts/parity/fixtures/ar-54/models.rb
+++ b/scripts/parity/fixtures/ar-54/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-54/models.ts
+++ b/scripts/parity/fixtures/ar-54/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-54/query.rb
+++ b/scripts/parity/fixtures/ar-54/query.rb
@@ -1,0 +1,1 @@
+Book.create_with(status: "active").where(id: 1..5)

--- a/scripts/parity/fixtures/ar-54/query.ts
+++ b/scripts/parity/fixtures/ar-54/query.ts
@@ -1,0 +1,6 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.all()
+  .createWith({ status: "active" })
+  .where({ id: new Range(1, 5) });

--- a/scripts/parity/fixtures/ar-54/schema.sql
+++ b/scripts/parity/fixtures/ar-54/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-54
+-- Query: Book.create_with(status: "active").where(id: 1..5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-55/models.rb
+++ b/scripts/parity/fixtures/ar-55/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-55/models.ts
+++ b/scripts/parity/fixtures/ar-55/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-55/query.rb
+++ b/scripts/parity/fixtures/ar-55/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:author).where(authors: { name: "Rails" })

--- a/scripts/parity/fixtures/ar-55/query.ts
+++ b/scripts/parity/fixtures/ar-55/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.joins("author").where({ authors: { name: "Rails" } });

--- a/scripts/parity/fixtures/ar-55/schema.sql
+++ b/scripts/parity/fixtures/ar-55/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-55
+-- Query: Book.joins(:author).where(authors: { name: "Rails" })
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-56/models.rb
+++ b/scripts/parity/fixtures/ar-56/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-56/models.ts
+++ b/scripts/parity/fixtures/ar-56/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-56/query.rb
+++ b/scripts/parity/fixtures/ar-56/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).where(title: "Rails").unscope(where: :id)

--- a/scripts/parity/fixtures/ar-56/query.ts
+++ b/scripts/parity/fixtures/ar-56/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ id: 1 }).where({ title: "Rails" }).unscope({ where: "id" });

--- a/scripts/parity/fixtures/ar-56/schema.sql
+++ b/scripts/parity/fixtures/ar-56/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-56
+-- Query: Book.where(id: 1).where(title: "Rails").unscope(where: :id)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-57/models.rb
+++ b/scripts/parity/fixtures/ar-57/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-57/models.ts
+++ b/scripts/parity/fixtures/ar-57/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-57/query.rb
+++ b/scripts/parity/fixtures/ar-57/query.rb
@@ -1,0 +1,1 @@
+Book.includes(:author).where("authors.name = ?", "Rails").references(:author)

--- a/scripts/parity/fixtures/ar-57/query.ts
+++ b/scripts/parity/fixtures/ar-57/query.ts
@@ -1,0 +1,6 @@
+import { Book } from "./models.js";
+
+export default Book.all()
+  .includes("author")
+  .where("authors.name = ?", "Rails")
+  .references("author");

--- a/scripts/parity/fixtures/ar-57/schema.sql
+++ b/scripts/parity/fixtures/ar-57/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-57
+-- Query: Book.includes(:author).where("authors.name = ?", "Rails").references(:author)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-58/models.rb
+++ b/scripts/parity/fixtures/ar-58/models.rb
@@ -1,0 +1,10 @@
+class Review < ActiveRecord::Base
+  belongs_to :book
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+class Author < ActiveRecord::Base
+  has_many :books
+end

--- a/scripts/parity/fixtures/ar-58/models.ts
+++ b/scripts/parity/fixtures/ar-58/models.ts
@@ -1,0 +1,24 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-58/query.rb
+++ b/scripts/parity/fixtures/ar-58/query.rb
@@ -1,0 +1,1 @@
+Author.includes(books: :reviews).limit(3)

--- a/scripts/parity/fixtures/ar-58/query.ts
+++ b/scripts/parity/fixtures/ar-58/query.ts
@@ -1,0 +1,3 @@
+import { Author } from "./models.js";
+
+export default Author.all().includes({ books: "reviews" }).limit(3);

--- a/scripts/parity/fixtures/ar-58/schema.sql
+++ b/scripts/parity/fixtures/ar-58/schema.sql
@@ -1,0 +1,17 @@
+-- Fixture for statement: ar-58
+-- Query: Author.includes(books: :reviews).limit(3)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  body TEXT
+);

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -143,8 +143,14 @@ async function main(): Promise<void> {
     // 2. Connect via trails AR — the models module's class definitions
     //    inherit from Base and read Base.adapter lazily, so the connection
     //    must exist before any model method is invoked. establishConnection
-    //    sets Base.adapter for the whole process.
+    //    registers the connection pool; accessing Base.adapter immediately
+    //    after checks out the connection and triggers _wireArelVisitor, which
+    //    sets the adapter-specific Arel visitor (e.g. Visitors.SQLite) on the
+    //    process-global registry. Without this eager access Relation#toSql()
+    //    would use the default generic visitor since it never touches
+    //    Base.adapter itself, producing incorrect boolean/date literals.
     await Base.establishConnection(dbPath);
+    void Base.adapter; // trigger _wireArelVisitor so the correct Arel visitor is active
 
     // 3. Import query.ts. Fixtures end with `export default <relation>`
     //    and typically `import { Book } from "./models.js"` (ESM convention

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -151,6 +151,10 @@ async function main(): Promise<void> {
     //    Base.adapter itself, producing incorrect boolean/date literals.
     await Base.establishConnection(dbPath);
     void Base.adapter; // trigger _wireArelVisitor so the correct Arel visitor is active
+    // Regression coverage: fixtures ar-09/ar-11/ar-19/ar-29 each produce a
+    // distinct wrong literal under the generic visitor (TRUE/FALSE, FOR UPDATE)
+    // vs the correct SQLite literal (1/0, empty lock). Their PASS status in CI
+    // acts as the integration test for this visitor-wiring invariant.
 
     // 3. Import query.ts. Fixtures end with `export default <relation>`
     //    and typically `import { Book } from "./models.js"` (ESM convention


### PR DESCRIPTION
## Summary
Adds 5 AR query parity fixtures, fixes the parity runner's Arel visitor wiring, and syncs known-gaps to CI reality.

**New fixtures**
- ar-54: `create_with(attrs).where(id: 1..5)` — SELECT SQL unchanged (PASS)
- ar-56: `where(id:1).where(title:'x').unscope(where: :id)` — targeted unscope (PASS)
- ar-58: `Author.includes("books.reviews").limit(3)` — nested dot-notation includes (PASS)
- ar-55: `joins(:author).where({authors:{name:'Rails'}})` — KNOWN-GAP: nested table-hash not expanded (trails serializes as JSON string)
- ar-57: `includes(:author).where('...').references('authors')` — KNOWN-GAP: no LEFT OUTER JOIN promotion (same root as ar-16)

**Bug fix: parity runner visitor wiring** (`ar_dump.ts`)
`Relation#toSql()` never accesses `Base.adapter`, so `_wireArelVisitor` was never triggered and `_registry.ToSql` stayed as the generic visitor instead of `Visitors.SQLite`. Adding `void Base.adapter` after `establishConnection()` closes ar-09/11/19/29/38 in the parity runner. Fixtures ar-09/ar-11/ar-19/ar-29 act as regression coverage.

**Known-gaps updated**
- ar-01 added: datetime microseconds in `?` bind (`13:00:41.729000` vs `13:00:41`)
- ar-55, ar-57 added (new fixtures above)
- ar-33, ar-44 removed (now pass — fixed upstream)

## Test plan
- [x] `pnpm parity:query` — 100/108 PASS, 9 known-gaps, no UNEXPECTED-PASS
- [x] CI Query Parity (diff) passes on latest push