### PR TITLE
feat(encryption): typeForAttribute, type() delegation, normalized/attribute data tests

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -625,7 +625,6 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::ModelSchema::ClassMethods#type_for_attribute
    */
   static override typeForAttribute(name: string) {
-    (ModelSchema.loadSchema as any).call(this);
     return (this._attributeDefinitions as any)?.get(name)?.type ?? null;
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -620,6 +620,16 @@ export class Base extends Model {
   }
 
   /**
+   * Returns the type object for a named attribute.
+   *
+   * Mirrors: ActiveRecord::ModelSchema::ClassMethods#type_for_attribute
+   */
+  static override typeForAttribute(name: string) {
+    (ModelSchema.loadSchema as any).call(this);
+    return (this._attributeDefinitions as any)?.get(name)?.type ?? null;
+  }
+
+  /**
    * Get the Arel table for this model.
    *
    * Wires a TypeCasterMap so `arelTable.typeForAttribute(col)` resolves

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1,4 +1,4 @@
-import { Model } from "@blazetrails/activemodel";
+import { Model, type Type } from "@blazetrails/activemodel";
 import "./type.js"; // Register AR type overrides into AM's type registry
 import {
   Table,
@@ -624,7 +624,8 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::ModelSchema::ClassMethods#type_for_attribute
    */
-  static override typeForAttribute(name: string) {
+  static override typeForAttribute(name: string): Type | null {
+    (ModelSchema.loadSchema as any).call(this);
     return (this._attributeDefinitions as any)?.get(name)?.type ?? null;
   }
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -457,7 +457,35 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it.skip("serialized binary data can be encrypted", () => {});
   it.skip("deterministic ciphertexts remain constant", () => {});
   it.skip("can compress data with custom compressor", () => {});
-  it.skip("type method returns cast type", () => {});
-  it.skip("encrypts normalized data", () => {});
-  it.skip("encrypts attribute data", () => {});
+  it("type method returns cast type", () => {
+    const Book = makeEncryptedBook(freshAdapter());
+    new Book();
+    const Post = makeEncryptedPost(freshAdapter());
+    new Post();
+    expect((Book as any).typeForAttribute("name").type).toBe("string");
+    expect((Post as any).typeForAttribute("body").type).toBe("string");
+  });
+
+  it("encrypts normalized data", async () => {
+    // Both NormalizedFirst and NormalizedSecond use downcase:true normalization.
+    const adp = freshAdapter();
+    const BookNormalized = makeFreshModel(adp, { id: "integer", name: "string", logo: "string" });
+    BookNormalized.encrypts("name", { deterministic: true, downcase: true });
+    BookNormalized.encrypts("logo", { deterministic: true, downcase: true });
+    new BookNormalized();
+    const b1 = await BookNormalized.create({ name: "Book" });
+    assertEncryptedAttribute(await BookNormalized.find(b1.id), "name", "book");
+    const b2 = await BookNormalized.create({ logo: "Book" });
+    assertEncryptedAttribute(await BookNormalized.find(b2.id), "logo", "book");
+  });
+
+  it("encrypts attribute data", async () => {
+    // Encrypted attribute backed by a date cast type.
+    const adp = freshAdapter();
+    const BookDate = makeFreshModel(adp, { id: "integer", name: "date" });
+    BookDate.encrypts("name");
+    new BookDate();
+    const book = await BookDate.create({ name: "2024-01-01" });
+    assertEncryptedAttribute(book, "name", new Date("2024-01-01"));
+  });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -462,8 +462,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     new Book();
     const Post = makeEncryptedPost(freshAdapter());
     new Post();
-    expect((Book as any).typeForAttribute("name").type).toBe("string");
-    expect((Post as any).typeForAttribute("body").type).toBe("string");
+    expect((Book as any).typeForAttribute("name").type()).toBe("string");
+    expect((Post as any).typeForAttribute("body").type()).toBe("string");
   });
 
   it("encrypts normalized data", async () => {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -480,9 +480,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("encrypts attribute data", async () => {
-    // Encrypted attribute backed by a date cast type.
+    // The DB column stores ciphertext (text), while the cast type is date.
+    // In Rails, encrypted attribute columns are always text in the schema.
     const adp = freshAdapter();
-    const BookDate = makeFreshModel(adp, { id: "integer", name: "date" });
+    const BookDate = makeFreshModel(adp, { id: "integer", name: "string" });
+    BookDate.attribute("name", "date"); // override cast type to date
     BookDate.encrypts("name");
     new BookDate();
     const book = await BookDate.create({ name: "2024-01-01" });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -484,7 +484,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // In Rails, encrypted attribute columns are always text in the schema.
     const adp = freshAdapter();
     const BookDate = makeFreshModel(adp, { id: "integer", name: "string" });
-    new BookDate(); // create the TEXT column before changing the cast type
+    await BookDate.create({ name: "bootstrap" }); // write triggers text column creation
     BookDate.attribute("name", "date"); // override cast type to date (DB stays text)
     BookDate.encrypts("name");
     const book = await BookDate.create({ name: "2024-01-01" });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -484,9 +484,9 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // In Rails, encrypted attribute columns are always text in the schema.
     const adp = freshAdapter();
     const BookDate = makeFreshModel(adp, { id: "integer", name: "string" });
-    BookDate.attribute("name", "date"); // override cast type to date
+    new BookDate(); // create the TEXT column before changing the cast type
+    BookDate.attribute("name", "date"); // override cast type to date (DB stays text)
     BookDate.encrypts("name");
-    new BookDate();
     const book = await BookDate.create({ name: "2024-01-01" });
     assertEncryptedAttribute(book, "name", new Date("2024-01-01"));
   });

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -134,6 +134,10 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.scheme.deterministic ?? false;
   }
 
+  override type(): string {
+    return (this.castType as any).name ?? "string";
+  }
+
   get previousTypes(): EncryptedAttributeType[] {
     // Memoize on supportUnencryptedData so the clean-text scheme gets
     // recomputed if the config toggles at runtime (Rails does the same

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -135,7 +135,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   override type(): string {
-    return (this.castType as any).name ?? "string";
+    return this.castType.type();
   }
 
   get previousTypes(): EncryptedAttributeType[] {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -244,10 +244,17 @@ export function assertEncryptedAttribute(
   if (expectedValue !== null && expectedValue !== undefined) {
     const dbValues = model._attributes.valuesForDatabase();
     const dbValue = dbValues[attrName];
-    const type = model._attributes?.get?.(attrName)?.type;
-    const serializedPlaintext =
+    const type = model._attributes?.getAttribute?.(attrName)?.type;
+    const rawSerialized =
       type && typeof (type as any).castType?.serialize === "function"
         ? (type as any).castType.serialize(expectedValue)
+        : null;
+    // Normalize to string for comparison (EncryptedAttributeType calls String() before encrypting).
+    const serializedPlaintext =
+      rawSerialized != null
+        ? rawSerialized instanceof Date
+          ? rawSerialized.toISOString().split("T")[0] // date → "YYYY-MM-DD"
+          : String(rawSerialized)
         : null;
     if (
       dbValue === expectedValue ||

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -250,12 +250,7 @@ export function assertEncryptedAttribute(
         ? (type as any).castType.serialize(expectedValue)
         : null;
     // Normalize to string for comparison (EncryptedAttributeType calls String() before encrypting).
-    const serializedPlaintext =
-      rawSerialized != null
-        ? rawSerialized instanceof Date
-          ? rawSerialized.toISOString().split("T")[0] // date → "YYYY-MM-DD"
-          : String(rawSerialized)
-        : null;
+    const serializedPlaintext = rawSerialized != null ? String(rawSerialized) : null;
     if (
       dbValue === expectedValue ||
       (serializedPlaintext != null && dbValue === serializedPlaintext)

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -239,12 +239,20 @@ export function assertEncryptedAttribute(
   }
 
   // Verify the DB-bound value differs from the plaintext — confirms real encryption.
-  // Empty strings are also encrypted by EncryptedAttributeType.serialize(), so
-  // include them in this check (only skip null/undefined).
+  // For non-string types (e.g. Date), also compare against the serialized string
+  // form since dbValue is always a string while expectedValue may be an object.
   if (expectedValue !== null && expectedValue !== undefined) {
     const dbValues = model._attributes.valuesForDatabase();
     const dbValue = dbValues[attrName];
-    if (dbValue === expectedValue) {
+    const type = model._attributes?.get?.(attrName)?.type;
+    const serializedPlaintext =
+      type && typeof (type as any).castType?.serialize === "function"
+        ? (type as any).castType.serialize(expectedValue)
+        : null;
+    if (
+      dbValue === expectedValue ||
+      (serializedPlaintext != null && dbValue === serializedPlaintext)
+    ) {
       throw new Error(
         `assertEncryptedAttribute: expected ${attrName} to be encrypted ` +
           `(DB value ≠ plaintext), but valuesForDatabase() returned the plaintext unchanged.`,

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -226,7 +226,12 @@ export function assertEncryptedAttribute(
 ): void {
   // Verify the attribute reads back as the expected plaintext.
   const readValue = model[attrName];
-  if (readValue !== expectedValue) {
+  const valuesEqual =
+    readValue === expectedValue ||
+    (readValue instanceof Date &&
+      expectedValue instanceof Date &&
+      readValue.getTime() === expectedValue.getTime());
+  if (!valuesEqual) {
     throw new Error(
       `assertEncryptedAttribute: expected ${attrName} to equal ` +
         `${JSON.stringify(expectedValue)}, got ${JSON.stringify(readValue)}`,


### PR DESCRIPTION
## Summary

- `EncryptedAttributeType#type()` — delegates to `castType.name`, mirroring Rails' `delegate :type, to: :cast_type`
- `Base.typeForAttribute(name)` — static override that loads schema then returns the attribute type, mirroring `ActiveRecord::ModelSchema::ClassMethods#type_for_attribute`
- `assertEncryptedAttribute` — handles Date equality via `getTime()` comparison
- Unskips 3 `EncryptableRecordTest` cases: type method returns cast type, encrypts normalized data, encrypts attribute data

## Test plan

- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/encryptable-record.test.ts` — 40 passing, 12 skipped
- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/` — 234 passing, 40 skipped