### PR TITLE
fix(activerecord): bare-quote unknown hash-order columns, matching Rails arel_column fallback (ar-23)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -106,6 +106,32 @@ describe("RelationTest", () => {
     expect(post.isPersisted()).toBe(true);
   });
 
+  it("order by unknown column (subquery alias) uses bare quoted name", () => {
+    class Developer extends Base {
+      static _tableName = "developers";
+      static {
+        this.attribute("commits", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const RANKED = "(SELECT id, commits AS hotness FROM developers) developers";
+    const sql = Developer.from(RANKED).order({ hotness: "desc" }).limit(10).toSql();
+    expect(sql).toContain('"hotness" DESC');
+    expect(sql).not.toContain('"developers"."hotness"');
+  });
+
+  it("order by known column uses table-qualified attribute", () => {
+    class Developer extends Base {
+      static _tableName = "developers";
+      static {
+        this.attribute("commits", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Developer.order({ commits: "desc" }).toSql();
+    expect(sql).toContain('"developers"."commits" DESC');
+  });
+
   it("group by bare column name qualifies via table", () => {
     class Order extends Base {
       static _tableName = "orders";

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -106,6 +106,18 @@ describe("RelationTest", () => {
     expect(post.isPersisted()).toBe(true);
   });
 
+  it("order by primary key stays table-qualified even before schema reflection", () => {
+    // The PK (`id`) may not be in _attributeDefinitions before schema loads,
+    // but must remain table-qualified to avoid ambiguous-column errors on JOINs.
+    class Post extends Base {
+      static _tableName = "posts";
+      static {
+        this.adapter = adapter;
+      }
+    }
+    expect(Post.order({ id: "desc" }).toSql()).toContain('"posts"."id" DESC');
+  });
+
   it("order by unknown column (subquery alias) uses bare quoted name", () => {
     class Developer extends Base {
       static _tableName = "developers";

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -106,6 +106,19 @@ describe("RelationTest", () => {
     expect(post.isPersisted()).toBe(true);
   });
 
+  it("dotted string order passes through as raw SQL (Rails treats all string orders as SqlLiteral)", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    // Rails never strips or re-qualifies cross-table references in string form.
+    expect(Post.order("comments.body ASC").toSql()).toContain("ORDER BY comments.body ASC");
+    expect(Post.order("posts.id DESC").toSql()).toContain("ORDER BY posts.id DESC");
+  });
+
   it("order by primary key stays table-qualified even before schema reflection", () => {
     // The PK (`id`) may not be in _attributeDefinitions before schema loads,
     // but must remain table-qualified to avoid ambiguous-column errors on JOINs.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2910,7 +2910,14 @@ export class Relation<T extends Base> {
         }
       } else {
         const [col, dir] = clause;
-        manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
+        // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
+        // from .from()) get a bare quoted name, not a table-qualified attribute.
+        if (this._modelClass._attributeDefinitions.has(col)) {
+          manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
+        } else {
+          const lit = new Nodes.SqlLiteral(`"${col}"`);
+          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
+        }
       }
     }
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2900,18 +2900,19 @@ export class Relation<T extends Base> {
     }
     for (const clause of this._orderClauses) {
       if (typeof clause === "string") {
+        const trimmed = clause.trim();
         // Detect SQL expressions (functions, parens, operators) and pass as raw SQL
-        if (clause.includes("(") || /\bcase\b/i.test(clause) || clause.includes("||")) {
-          manager.order(new Nodes.SqlLiteral(clause));
+        if (trimmed.includes("(") || /\bcase\b/i.test(trimmed) || trimmed.includes("||")) {
+          manager.order(new Nodes.SqlLiteral(trimmed));
         } else {
           // Parse "column ASC/DESC" or "table.column ASC/DESC" strings
-          const match = clause.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
+          const match = trimmed.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
           if (match) {
             const rawCol = match[1];
             const dir = match[2].toUpperCase();
             // Any dotted identifier (one or more dots) passes through as raw SQL.
             if (rawCol.includes(".")) {
-              manager.order(new Nodes.SqlLiteral(clause));
+              manager.order(new Nodes.SqlLiteral(trimmed));
             } else {
               const node = this._isKnownColumn(rawCol)
                 ? table.get(rawCol)
@@ -2923,13 +2924,13 @@ export class Relation<T extends Base> {
           } else {
             // Not "col DIR" form. Only wrap plain letter-start identifiers;
             // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
-            if (/^[A-Za-z_$][\w$]*$/.test(clause)) {
-              const node = this._isKnownColumn(clause)
-                ? table.get(clause)
-                : new Nodes.UnqualifiedColumn(table.get(clause));
+            if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+              const node = this._isKnownColumn(trimmed)
+                ? table.get(trimmed)
+                : new Nodes.UnqualifiedColumn(table.get(trimmed));
               manager.order(new Nodes.Ascending(node));
             } else {
-              manager.order(new Nodes.SqlLiteral(clause));
+              manager.order(new Nodes.SqlLiteral(trimmed));
             }
           }
         }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2905,15 +2905,12 @@ export class Relation<T extends Base> {
           manager.order(new Nodes.SqlLiteral(clause));
         } else {
           // Parse "column ASC/DESC" or "table.column ASC/DESC" strings
-          const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);
+          const match = clause.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
           if (match) {
             const rawCol = match[1];
             const dir = match[2].toUpperCase();
-            // Dotted simple identifiers (table.column) pass through as raw SQL —
-            // Rails treats string-form orders as SqlLiteral and never re-qualifies
-            // cross-table references. Restrict to safe identifier patterns to avoid
-            // bypassing sanitization for arbitrary dotted strings.
-            if (/^[\w$]+\.[\w$]+$/.test(rawCol)) {
+            // Any dotted identifier (one or more dots) passes through as raw SQL.
+            if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
               const node = this._isKnownColumn(rawCol)
@@ -2924,10 +2921,9 @@ export class Relation<T extends Base> {
               );
             }
           } else {
-            // Not "col DIR" form. Pass through as raw SQL unless it's a plain
-            // single identifier — multi-column strings, NULLS FIRST, commas, etc.
-            // must not be wrapped in an Arel node.
-            if (/^[\w$]+$/.test(clause)) {
+            // Not "col DIR" form. Only wrap plain letter-start identifiers;
+            // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
+            if (/^[A-Za-z_$][\w$]*$/.test(clause)) {
               const node = this._isKnownColumn(clause)
                 ? table.get(clause)
                 : new Nodes.UnqualifiedColumn(table.get(clause));
@@ -2942,7 +2938,7 @@ export class Relation<T extends Base> {
         // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
         // from .from()) get a bare quoted name, not a table-qualified attribute.
         // Dotted keys (e.g. "comments.body") pass through as raw SQL with direction.
-        if (/^[\w$]+\.[\w$]+$/.test(col)) {
+        if (/^[\w$]+(\.[\w$]+)+$/.test(col)) {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (this._isKnownColumn(col)) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -10,6 +10,7 @@ import {
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
+import { quoteColumnName } from "./connection-adapters/abstract/quoting.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
@@ -2898,18 +2899,30 @@ export class Relation<T extends Base> {
           const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);
           if (match) {
             const rawCol = match[1];
-            const col = rawCol.includes(".") ? rawCol.split(".").pop()! : rawCol;
             const dir = match[2].toUpperCase();
-            const node = this._modelClass._attributeDefinitions.has(col)
-              ? table.get(col)
-              : new Nodes.SqlLiteral(`"${col}"`);
-            manager.order(dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node));
+            // Dotted string (e.g. "comments.body") with an unknown column: keep
+            // as raw SQL to avoid silently dropping the qualifier.
+            if (rawCol.includes(".") && !this._modelClass._attributeDefinitions.has(rawCol)) {
+              manager.order(new Nodes.SqlLiteral(`${clause}`));
+            } else {
+              const col = rawCol.includes(".") ? rawCol.split(".").pop()! : rawCol;
+              const node = this._modelClass._attributeDefinitions.has(col)
+                ? table.get(col)
+                : new Nodes.SqlLiteral(quoteColumnName(col));
+              manager.order(
+                dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node),
+              );
+            }
           } else {
-            const col = clause.includes(".") ? clause.split(".").pop()! : clause;
-            const node = this._modelClass._attributeDefinitions.has(col)
-              ? table.get(col)
-              : new Nodes.SqlLiteral(`"${col}"`);
-            manager.order(new Nodes.Ascending(node));
+            if (clause.includes(".") && !this._modelClass._attributeDefinitions.has(clause)) {
+              manager.order(new Nodes.SqlLiteral(clause));
+            } else {
+              const col = clause.includes(".") ? clause.split(".").pop()! : clause;
+              const node = this._modelClass._attributeDefinitions.has(col)
+                ? table.get(col)
+                : new Nodes.SqlLiteral(quoteColumnName(col));
+              manager.order(new Nodes.Ascending(node));
+            }
           }
         }
       } else {
@@ -2919,7 +2932,7 @@ export class Relation<T extends Base> {
         if (this._modelClass._attributeDefinitions.has(col)) {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
         } else {
-          const lit = new Nodes.SqlLiteral(`"${col}"`);
+          const lit = new Nodes.SqlLiteral(quoteColumnName(col));
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         }
       }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -10,7 +10,6 @@ import {
 } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
-import { quoteColumnName } from "./connection-adapters/abstract/quoting.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
@@ -2910,27 +2909,28 @@ export class Relation<T extends Base> {
           if (match) {
             const rawCol = match[1];
             const dir = match[2].toUpperCase();
-            // Dotted identifiers (e.g. "comments.body ASC") pass through as raw
-            // SQL — Rails treats all string-form orders as Arel::Nodes::SqlLiteral
-            // and never strips or re-qualifies a cross-table prefix.
-            if (rawCol.includes(".")) {
+            // Dotted simple identifiers (table.column) pass through as raw SQL —
+            // Rails treats string-form orders as SqlLiteral and never re-qualifies
+            // cross-table references. Restrict to safe identifier patterns to avoid
+            // bypassing sanitization for arbitrary dotted strings.
+            if (/^[\w$]+\.[\w$]+$/.test(rawCol)) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
               const node = this._isKnownColumn(rawCol)
                 ? table.get(rawCol)
-                : new Nodes.SqlLiteral(quoteColumnName(rawCol));
+                : new Nodes.UnqualifiedColumn(table.get(rawCol));
               manager.order(
                 dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node),
               );
             }
           } else {
-            // Dotted bare clause (no direction) → raw SQL passthrough.
-            if (clause.includes(".")) {
+            // Dotted simple identifier (no direction) → raw SQL passthrough.
+            if (/^[\w$]+\.[\w$]+$/.test(clause)) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
               const node = this._isKnownColumn(clause)
                 ? table.get(clause)
-                : new Nodes.SqlLiteral(quoteColumnName(clause));
+                : new Nodes.UnqualifiedColumn(table.get(clause));
               manager.order(new Nodes.Ascending(node));
             }
           }
@@ -2942,8 +2942,10 @@ export class Relation<T extends Base> {
         if (this._isKnownColumn(col)) {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
         } else {
-          const lit = new Nodes.SqlLiteral(quoteColumnName(col));
-          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
+          const unqual = new Nodes.UnqualifiedColumn(table.get(col));
+          manager.order(
+            dir === "desc" ? new Nodes.Descending(unqual) : new Nodes.Ascending(unqual),
+          );
         }
       }
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2897,15 +2897,19 @@ export class Relation<T extends Base> {
           // Parse "column ASC/DESC" or "table.column ASC/DESC" strings
           const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);
           if (match) {
-            // Strip table prefix if present (e.g. "posts.score" → "score")
             const rawCol = match[1];
             const col = rawCol.includes(".") ? rawCol.split(".").pop()! : rawCol;
             const dir = match[2].toUpperCase();
-            manager.order(dir === "DESC" ? table.get(col).desc() : table.get(col).asc());
+            const node = this._modelClass._attributeDefinitions.has(col)
+              ? table.get(col)
+              : new Nodes.SqlLiteral(`"${col}"`);
+            manager.order(dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node));
           } else {
-            // Strip table prefix if present
             const col = clause.includes(".") ? clause.split(".").pop()! : clause;
-            manager.order(table.get(col).asc());
+            const node = this._modelClass._attributeDefinitions.has(col)
+              ? table.get(col)
+              : new Nodes.SqlLiteral(`"${col}"`);
+            manager.order(new Nodes.Ascending(node));
           }
         }
       } else {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2884,6 +2884,16 @@ export class Relation<T extends Base> {
     return new Visitors.ToSql().compile(node);
   }
 
+  // Returns true when `col` is a known schema attribute OR is (part of) the
+  // model's primary key. The PK check is needed because `_attributeDefinitions`
+  // may not yet contain `id` (before schema reflection), but it must still be
+  // table-qualified to avoid ambiguous-column errors on joined relations.
+  private _isKnownColumn(col: string): boolean {
+    if (this._modelClass._attributeDefinitions.has(col)) return true;
+    const pk = this._modelClass.primaryKey;
+    return Array.isArray(pk) ? pk.includes(col) : pk === col;
+  }
+
   private _applyOrderToManager(manager: SelectManager, table: Table): void {
     // Raw order clauses (from inOrderOf)
     for (const rawClause of this._rawOrderClauses) {
@@ -2906,7 +2916,7 @@ export class Relation<T extends Base> {
             if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
-              const node = this._modelClass._attributeDefinitions.has(rawCol)
+              const node = this._isKnownColumn(rawCol)
                 ? table.get(rawCol)
                 : new Nodes.SqlLiteral(quoteColumnName(rawCol));
               manager.order(
@@ -2918,7 +2928,7 @@ export class Relation<T extends Base> {
             if (clause.includes(".")) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
-              const node = this._modelClass._attributeDefinitions.has(clause)
+              const node = this._isKnownColumn(clause)
                 ? table.get(clause)
                 : new Nodes.SqlLiteral(quoteColumnName(clause));
               manager.order(new Nodes.Ascending(node));
@@ -2929,7 +2939,7 @@ export class Relation<T extends Base> {
         const [col, dir] = clause;
         // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
         // from .from()) get a bare quoted name, not a table-qualified attribute.
-        if (this._modelClass._attributeDefinitions.has(col)) {
+        if (this._isKnownColumn(col)) {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
         } else {
           const lit = new Nodes.SqlLiteral(quoteColumnName(col));

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2924,14 +2924,16 @@ export class Relation<T extends Base> {
               );
             }
           } else {
-            // Dotted simple identifier (no direction) → raw SQL passthrough.
-            if (/^[\w$]+\.[\w$]+$/.test(clause)) {
-              manager.order(new Nodes.SqlLiteral(clause));
-            } else {
+            // Not "col DIR" form. Pass through as raw SQL unless it's a plain
+            // single identifier — multi-column strings, NULLS FIRST, commas, etc.
+            // must not be wrapped in an Arel node.
+            if (/^[\w$]+$/.test(clause)) {
               const node = this._isKnownColumn(clause)
                 ? table.get(clause)
                 : new Nodes.UnqualifiedColumn(table.get(clause));
               manager.order(new Nodes.Ascending(node));
+            } else {
+              manager.order(new Nodes.SqlLiteral(clause));
             }
           }
         }
@@ -2939,7 +2941,11 @@ export class Relation<T extends Base> {
         const [col, dir] = clause;
         // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
         // from .from()) get a bare quoted name, not a table-qualified attribute.
-        if (this._isKnownColumn(col)) {
+        // Dotted keys (e.g. "comments.body") pass through as raw SQL with direction.
+        if (/^[\w$]+\.[\w$]+$/.test(col)) {
+          const lit = new Nodes.SqlLiteral(col);
+          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
+        } else if (this._isKnownColumn(col)) {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
         } else {
           const unqual = new Nodes.UnqualifiedColumn(table.get(col));

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2900,27 +2900,27 @@ export class Relation<T extends Base> {
           if (match) {
             const rawCol = match[1];
             const dir = match[2].toUpperCase();
-            // Dotted string (e.g. "comments.body") with an unknown column: keep
-            // as raw SQL to avoid silently dropping the qualifier.
-            if (rawCol.includes(".") && !this._modelClass._attributeDefinitions.has(rawCol)) {
-              manager.order(new Nodes.SqlLiteral(`${clause}`));
+            // Dotted identifiers (e.g. "comments.body ASC") pass through as raw
+            // SQL — Rails treats all string-form orders as Arel::Nodes::SqlLiteral
+            // and never strips or re-qualifies a cross-table prefix.
+            if (rawCol.includes(".")) {
+              manager.order(new Nodes.SqlLiteral(clause));
             } else {
-              const col = rawCol.includes(".") ? rawCol.split(".").pop()! : rawCol;
-              const node = this._modelClass._attributeDefinitions.has(col)
-                ? table.get(col)
-                : new Nodes.SqlLiteral(quoteColumnName(col));
+              const node = this._modelClass._attributeDefinitions.has(rawCol)
+                ? table.get(rawCol)
+                : new Nodes.SqlLiteral(quoteColumnName(rawCol));
               manager.order(
                 dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node),
               );
             }
           } else {
-            if (clause.includes(".") && !this._modelClass._attributeDefinitions.has(clause)) {
+            // Dotted bare clause (no direction) → raw SQL passthrough.
+            if (clause.includes(".")) {
               manager.order(new Nodes.SqlLiteral(clause));
             } else {
-              const col = clause.includes(".") ? clause.split(".").pop()! : clause;
-              const node = this._modelClass._attributeDefinitions.has(col)
-                ? table.get(col)
-                : new Nodes.SqlLiteral(quoteColumnName(col));
+              const node = this._modelClass._attributeDefinitions.has(clause)
+                ? table.get(clause)
+                : new Nodes.SqlLiteral(quoteColumnName(clause));
               manager.order(new Nodes.Ascending(node));
             }
           }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -8,7 +8,7 @@ import { Nodes } from "@blazetrails/arel";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
-import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
+import { sanitizeSqlArray } from "../sanitization.js";
 import { quote } from "../connection-adapters/abstract/quoting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 
@@ -235,7 +235,6 @@ function orderBang(
   while (i < args.length) {
     const arg = args[i];
     if (typeof arg === "string") {
-      disallowRawSqlBang([arg]);
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -8,7 +8,7 @@ import { Nodes } from "@blazetrails/arel";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
-import { sanitizeSqlArray } from "../sanitization.js";
+import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
 import { quote } from "../connection-adapters/abstract/quoting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 
@@ -235,6 +235,7 @@ function orderBang(
   while (i < args.length) {
     const arg = args[i];
     if (typeof arg === "string") {
+      disallowRawSqlBang([arg]);
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1265,7 +1265,9 @@ export class ToSql implements NodeVisitor<SQLString> {
   }
 
   private visitAttribute(node: Nodes.Attribute): SQLString {
-    this.collector.append(`"${node.relation.tableAlias || node.relation.name}"."${node.name}"`);
+    const tbl = (node.relation.tableAlias || node.relation.name).replace(/"/g, '""');
+    const col = node.name.replace(/"/g, '""');
+    this.collector.append(`"${tbl}"."${col}"`);
     return this.collector;
   }
 
@@ -1276,7 +1278,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     if (!attr || typeof attr.name !== "string") {
       throw new UnsupportedVisitError("UnqualifiedColumn must wrap an Attribute node with a name");
     }
-    this.collector.append(`"${attr.name}"`);
+    this.collector.append(`"${attr.name.replace(/"/g, '""')}"`);
     return this.collector;
   }
 

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -3,10 +3,6 @@
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
   },
-  "ar-23": {
-    "side": "diff",
-    "reason": "ORDER BY column qualification with .from(...) using a single raw SQL string that already includes the alias: trails qualifies the order column to '\"developers\".\"hotness\"'; Rails leaves it bare as '\"hotness\"'. Same SQL semantic, lexically differ. Inverse direction from ar-17's GROUP BY case."
-  },
   "ar-32": {
     "side": "diff",
     "reason": "in_order_of: multiple divergences vs Rails. (1) Rails adds WHERE \"books\".\"status\" IN (values) to filter to the named set; trails omits it. (2) Rails CASE values are 1-indexed; trails 0-indexed with ELSE branch. (3) Rails appends ASC; trails leaves direction bare. (4) Rails qualifies the column ('\"books\".\"status\"'); trails leaves it bare. Real implementation gap — trails Relation#inOrderOf is incomplete vs ActiveRecord::QueryMethods#in_order_of."


### PR DESCRIPTION
## Summary

When `order(col: dir)` is called and `col` is not in `_attributeDefinitions` (e.g. a subquery alias from `.from()`), trails now emits `"col" DESC` rather than `"table"."col" DESC`.

Mirrors Rails' `arel_column` method which falls back to `connection.quote_column_name(field)` when the field is absent from `columns_hash` — producing a bare quoted identifier with no table prefix.

**Example (ar-23):**
```ruby
Developer.from("(subquery) developers").order(hotness: :desc).limit(10)
# Rails: ORDER BY "hotness" DESC   ← hotness not in schema
# Trails before: ORDER BY "developers"."hotness" DESC
# Trails after:  ORDER BY "hotness" DESC ✓
```

Known columns (in `_attributeDefinitions`) still emit the full `"table"."col"` form.

## Test plan

- [ ] `pnpm --filter @blazetrails/activerecord test` passes
- [ ] AR query parity CI: ar-23 now green