### PR TITLE
feat(activesupport): Railtie base class (PR 21 — ActiveModel::Railtie inheritance)

### DIFF
--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -60,7 +60,11 @@ describe("RailtieTest", () => {
       Railtie.runInitializers();
       expect(SecurePassword.minCost).toBe(true);
     } finally {
-      process.env.NODE_ENV = prev;
+      if (prev === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = prev;
+      }
     }
   });
 });

--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Railtie } from "./railtie.js";
+import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
 
@@ -33,5 +34,23 @@ describe("RailtieTest", () => {
   it("i18n customize full message can be enabled", () => {
     Railtie.initialize({ i18nCustomizeFullMessage: true });
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
+  });
+
+  it("ActiveModel::Railtie is registered in the global subclasses list", () => {
+    // Mirrors Rails::Railtie.subclasses which auto-populates via `inherited`.
+    expect(BaseRailtie.subclasses).toContain(Railtie);
+  });
+
+  it("runInitializers applies the active_model.secure_password setting", () => {
+    // Simulate a test environment via NODE_ENV so the initializer fires
+    // the min_cost branch.
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+    try {
+      Railtie.runInitializers();
+      expect(SecurePassword.minCost).toBe(true);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
   });
 });

--- a/packages/activemodel/src/railtie.test.ts
+++ b/packages/activemodel/src/railtie.test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { Railtie } from "./railtie.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
 
 describe("RailtieTest", () => {
+  // Snapshot the global subclasses list so activesupport tests that
+  // truncate it can't make this suite order-dependent.
+  let savedSubclasses: (typeof BaseRailtie)[];
+
+  beforeEach(() => {
+    savedSubclasses = [...BaseRailtie.subclasses];
+  });
+
   afterEach(() => {
     SecurePassword.minCost = false;
     ActiveModelError.i18nCustomizeFullMessage = false;
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
   });
 
   it("secure password min_cost is false in the development environment", () => {

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -13,16 +13,16 @@ export interface RailtieConfig {
  * Mirrors: ActiveModel::Railtie < ::Rails::Railtie
  * (activemodel/lib/active_model/railtie.rb)
  *
- * Extends the trailties base Railtie (matching the Rails inheritance) and
- * registers itself so it participates in the global initialization pipeline.
+ * Extends the base Railtie exported from `@blazetrails/activesupport`,
+ * matching the Rails inheritance pattern, and registers itself so it
+ * participates in the global initialization pipeline.
  */
 export class Railtie extends BaseRailtie {
   static {
     registerRailtie(this);
 
     this.initializer("active_model.secure_password", () => {
-      const env = (typeof process !== "undefined" && process.env?.NODE_ENV) || "development";
-      SecurePassword.minCost = env === "test";
+      SecurePassword.minCost = Railtie.detectEnv() === "test";
     });
   }
 

--- a/packages/activemodel/src/railtie.ts
+++ b/packages/activemodel/src/railtie.ts
@@ -1,3 +1,4 @@
+import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
 import { SecurePassword } from "./secure-password.js";
 import { Error as ActiveModelError } from "./error.js";
 
@@ -9,21 +10,29 @@ export interface RailtieConfig {
 /**
  * Railtie — initialization hooks for ActiveModel.
  *
- * Mirrors: ActiveModel::Railtie
+ * Mirrors: ActiveModel::Railtie < ::Rails::Railtie
+ * (activemodel/lib/active_model/railtie.rb)
  *
- * In Rails, the Railtie sets:
- *   - ActiveModel::SecurePassword.min_cost based on environment
- *   - ActiveModel::Error.i18n_customize_full_message from config
- *
- * Since we don't have a full Rails application context, the Railtie
- * exposes a static `initialize` method that applies the same defaults.
+ * Extends the trailties base Railtie (matching the Rails inheritance) and
+ * registers itself so it participates in the global initialization pipeline.
  */
-export class Railtie {
+export class Railtie extends BaseRailtie {
+  static {
+    registerRailtie(this);
+
+    this.initializer("active_model.secure_password", () => {
+      const env = (typeof process !== "undefined" && process.env?.NODE_ENV) || "development";
+      SecurePassword.minCost = env === "test";
+    });
+  }
+
+  /**
+   * One-shot configuration helper (non-Rails convenience kept for
+   * backwards-compat with existing callers).
+   */
   static initialize(config?: RailtieConfig): void {
     const env = config?.env ?? Railtie.detectEnv();
-
     SecurePassword.minCost = env === "test";
-
     ActiveModelError.i18nCustomizeFullMessage = config?.i18nCustomizeFullMessage ?? false;
   }
 

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -434,3 +434,4 @@ export { NumberToPercentageConverter } from "./number-helper/number-to-percentag
 export { NumberToHumanConverter } from "./number-helper/number-to-human-converter.js";
 export { NumberToHumanSizeConverter } from "./number-helper/number-to-human-size-converter.js";
 export { RoundingHelper } from "./number-helper/rounding-helper.js";
+export { Railtie, registerRailtie } from "./railtie.js";

--- a/packages/activesupport/src/railtie.test.ts
+++ b/packages/activesupport/src/railtie.test.ts
@@ -4,7 +4,7 @@ import { Railtie, registerRailtie } from "./railtie.js";
 describe("Railtie", () => {
   // Snapshot and restore global singletons so these tests don't interfere
   // with other test files (e.g. ActiveModel::Railtie expects to remain
-  // registered in BaseRailtie.subclasses after module init).
+  // registered in Railtie.subclasses after module init).
   let savedSubclasses: (typeof Railtie)[];
   let savedConfig: Record<string, unknown>;
 

--- a/packages/activesupport/src/railtie.test.ts
+++ b/packages/activesupport/src/railtie.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Railtie, registerRailtie } from "./railtie.js";
+
+describe("Railtie", () => {
+  beforeEach(() => {
+    // Reset the subclasses list and test stubs between tests.
+    (Railtie.subclasses as (typeof Railtie)[]).length = 0;
+  });
+
+  it("initializer registers a named block", () => {
+    class TestRailtie extends Railtie {}
+    const log: string[] = [];
+    TestRailtie.initializer("test.hello", () => log.push("hello"));
+    TestRailtie.runInitializers();
+    expect(log).toEqual(["hello"]);
+  });
+
+  it("runInitializers runs blocks in registration order", () => {
+    class OrderRailtie extends Railtie {}
+    const log: string[] = [];
+    OrderRailtie.initializer("a", () => log.push("a"));
+    OrderRailtie.initializer("b", () => log.push("b"));
+    OrderRailtie.runInitializers();
+    expect(log).toEqual(["a", "b"]);
+  });
+
+  it("initializers are isolated per subclass", () => {
+    class R1 extends Railtie {}
+    class R2 extends Railtie {}
+    const log: string[] = [];
+    R1.initializer("r1", () => log.push("r1"));
+    R2.initializer("r2", () => log.push("r2"));
+    R1.runInitializers();
+    expect(log).toEqual(["r1"]);
+  });
+
+  it("registerRailtie adds subclass to registry", () => {
+    class MyRailtie extends Railtie {
+      static {
+        registerRailtie(this);
+      }
+    }
+    expect(Railtie.subclasses).toContain(MyRailtie);
+  });
+
+  it("runAllInitializers fires every registered subclass", () => {
+    class A extends Railtie {
+      static {
+        registerRailtie(this);
+      }
+    }
+    class B extends Railtie {
+      static {
+        registerRailtie(this);
+      }
+    }
+    const log: string[] = [];
+    A.initializer("a", () => log.push("A"));
+    B.initializer("b", () => log.push("B"));
+    Railtie.runAllInitializers();
+    expect(log).toContain("A");
+    expect(log).toContain("B");
+  });
+
+  it("config is isolated per subclass (copy-on-first-write)", () => {
+    class Child extends Railtie {}
+    Railtie.config["shared"] = "base";
+    Child.config["own"] = "child";
+    expect(Child.config["shared"]).toBe("base");
+    expect(Railtie.config["own"]).toBeUndefined();
+  });
+});

--- a/packages/activesupport/src/railtie.test.ts
+++ b/packages/activesupport/src/railtie.test.ts
@@ -1,14 +1,29 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Railtie, registerRailtie } from "./railtie.js";
 
 describe("Railtie", () => {
+  // Snapshot and restore global singletons so these tests don't interfere
+  // with other test files (e.g. ActiveModel::Railtie expects to remain
+  // registered in BaseRailtie.subclasses after module init).
+  let savedSubclasses: (typeof Railtie)[];
+  let savedConfig: Record<string, unknown>;
+
   beforeEach(() => {
-    // Reset shared static state between tests.
+    savedSubclasses = [...Railtie.subclasses];
+    savedConfig = { ...Railtie.config };
     (Railtie.subclasses as (typeof Railtie)[]).length = 0;
-    // Clear the base config so mutations from one test don't leak into others.
     for (const key of Object.keys(Railtie.config)) {
       delete (Railtie.config as Record<string, unknown>)[key];
     }
+  });
+
+  afterEach(() => {
+    (Railtie.subclasses as (typeof Railtie)[]).length = 0;
+    (Railtie.subclasses as (typeof Railtie)[]).push(...savedSubclasses);
+    for (const key of Object.keys(Railtie.config)) {
+      delete (Railtie.config as Record<string, unknown>)[key];
+    }
+    Object.assign(Railtie.config, savedConfig);
   });
 
   it("initializer registers a named block", () => {

--- a/packages/activesupport/src/railtie.test.ts
+++ b/packages/activesupport/src/railtie.test.ts
@@ -80,7 +80,7 @@ describe("Railtie", () => {
     expect(log).toEqual(["A", "B"]);
   });
 
-  it("config is isolated per subclass (copy-on-first-write)", () => {
+  it("config is isolated per subclass (copy-on-first-access)", () => {
     class Child extends Railtie {}
     Railtie.config["shared"] = "base";
     Child.config["own"] = "child";

--- a/packages/activesupport/src/railtie.test.ts
+++ b/packages/activesupport/src/railtie.test.ts
@@ -3,8 +3,12 @@ import { Railtie, registerRailtie } from "./railtie.js";
 
 describe("Railtie", () => {
   beforeEach(() => {
-    // Reset the subclasses list and test stubs between tests.
+    // Reset shared static state between tests.
     (Railtie.subclasses as (typeof Railtie)[]).length = 0;
+    // Clear the base config so mutations from one test don't leak into others.
+    for (const key of Object.keys(Railtie.config)) {
+      delete (Railtie.config as Record<string, unknown>)[key];
+    }
   });
 
   it("initializer registers a named block", () => {
@@ -58,8 +62,7 @@ describe("Railtie", () => {
     A.initializer("a", () => log.push("A"));
     B.initializer("b", () => log.push("B"));
     Railtie.runAllInitializers();
-    expect(log).toContain("A");
-    expect(log).toContain("B");
+    expect(log).toEqual(["A", "B"]);
   });
 
   it("config is isolated per subclass (copy-on-first-write)", () => {

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -31,15 +31,10 @@ export class Railtie {
     if (!Object.prototype.hasOwnProperty.call(host, "_config")) {
       const parent = Object.getPrototypeOf(host)._config ?? {};
       // Best-effort deep-clone so nested objects/arrays are isolated per
-      // subclass. Falls through to a shallow copy when the config contains
-      // values that aren't clone-safe (functions, class instances, cycles,
-      // BigInt) — config is expected to hold plain scalar/object settings
-      // in normal Rails-style usage.
-      // subclass when the runtime supports it. Falls back to a shallow copy
-      // when structuredClone is unavailable or the config contains values
-      // that aren't clone-safe (functions, class instances, cycles, BigInt)
-      // — config is expected to hold plain scalar/object settings in normal
-      // Rails-style usage.
+      // subclass. Falls back to a shallow copy when structuredClone is
+      // unavailable or the config contains non-clone-safe values (functions,
+      // class instances, cycles, BigInt) — config is expected to hold plain
+      // scalar/object settings in normal Rails-style usage.
       try {
         host._config =
           typeof structuredClone === "function" ? structuredClone(parent) : { ...parent };

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -30,12 +30,19 @@ export class Railtie {
     const host = this as any;
     if (!Object.prototype.hasOwnProperty.call(host, "_config")) {
       const parent = Object.getPrototypeOf(host)._config ?? {};
-      // Deep-clone so nested objects/arrays are isolated per subclass
-      // (structuredClone is available in Node 17+ and modern browsers).
-      host._config =
-        typeof structuredClone === "function"
-          ? structuredClone(parent)
-          : JSON.parse(JSON.stringify(parent));
+      // Best-effort deep-clone so nested objects/arrays are isolated per
+      // subclass. Falls through to a shallow copy when the config contains
+      // values that aren't clone-safe (functions, class instances, cycles,
+      // BigInt) — config is expected to hold plain scalar/object settings
+      // in normal Rails-style usage.
+      try {
+        host._config =
+          typeof structuredClone === "function"
+            ? structuredClone(parent)
+            : JSON.parse(JSON.stringify(parent));
+      } catch {
+        host._config = { ...parent };
+      }
     }
     return host._config as Record<string, unknown>;
   }

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -20,9 +20,10 @@ export class Railtie {
   private static _config: Record<string, unknown> = {};
 
   /**
-   * Per-class config object. Each subclass gets its own deep-cloned copy
-   * on first access, so parent defaults propagate until the subclass
-   * config is read (copy-on-first-access).
+   * Per-class config object. Each subclass gets its own copy on first
+   * access — deep-cloned when possible, otherwise shallow-copied — so
+   * parent defaults propagate until the subclass config is read
+   * (copy-on-first-access).
    *
    * Mirrors: Rails::Railtie.config
    */

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -1,0 +1,95 @@
+/**
+ * Base Railtie class — mirrors Rails::Railtie.
+ *
+ * Each engine/component (ActiveModel, ActionController, etc.) subclasses
+ * Railtie to register named initializer blocks and a shared configuration
+ * object. The application runner calls `Railtie.runAllInitializers()` to
+ * fire them in registration order.
+ *
+ * Mirrors: Rails::Railtie (railties/lib/rails/railtie.rb)
+ */
+export class Railtie {
+  /**
+   * All registered subclasses — tracked so the application can enumerate
+   * all railties at boot.
+   *
+   * Mirrors: Rails::Railtie.subclasses
+   */
+  static readonly subclasses: Array<typeof Railtie> = [];
+
+  private static _config: Record<string, unknown> = {};
+
+  /**
+   * Per-class config object. Each subclass gets its own copy on first
+   * access (copy-on-first-write so parent defaults propagate).
+   *
+   * Mirrors: Rails::Railtie.config
+   */
+  static get config(): Record<string, unknown> {
+    const host = this as any;
+    if (!Object.prototype.hasOwnProperty.call(host, "_config")) {
+      host._config = { ...Object.getPrototypeOf(host)._config };
+    }
+    return host._config as Record<string, unknown>;
+  }
+
+  private static _initializers: Array<{ name: string; block: () => void }> = [];
+
+  /**
+   * Register a named initializer block.
+   *
+   * Mirrors: Rails::Railtie.initializer
+   */
+  static initializer(name: string, block: () => void): void {
+    const host = this as any;
+    if (!Object.prototype.hasOwnProperty.call(host, "_initializers")) {
+      host._initializers = [];
+    }
+    host._initializers.push({ name, block });
+  }
+
+  /**
+   * Run all initializers registered on this class (in registration order).
+   *
+   * Mirrors: Rails::Railtie#run_initializers
+   */
+  static runInitializers(): void {
+    const host = this as any;
+    const own: Array<{ name: string; block: () => void }> = Object.prototype.hasOwnProperty.call(
+      host,
+      "_initializers",
+    )
+      ? host._initializers
+      : [];
+    for (const { block } of own) {
+      block();
+    }
+  }
+
+  /**
+   * Run initializers for every registered subclass.
+   *
+   * Mirrors: Rails application initialization pipeline.
+   */
+  static runAllInitializers(): void {
+    for (const sub of Railtie.subclasses) {
+      sub.runInitializers();
+    }
+  }
+}
+
+/**
+ * Register `subclass` with the Railtie registry.
+ *
+ * Call this in each subclass's static init block:
+ *   static { registerRailtie(this); }
+ *
+ * Mirrors: Rails::Railtie.inherited (called automatically by Ruby when
+ * a class subclasses Railtie; we replicate it with an explicit call since
+ * JavaScript has no `inherited` hook).
+ */
+export function registerRailtie(subclass: typeof Railtie): void {
+  if (!Railtie.subclasses.includes(subclass)) {
+    Railtie.subclasses.push(subclass);
+  }
+}

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -35,11 +35,14 @@ export class Railtie {
       // values that aren't clone-safe (functions, class instances, cycles,
       // BigInt) — config is expected to hold plain scalar/object settings
       // in normal Rails-style usage.
+      // subclass when the runtime supports it. Falls back to a shallow copy
+      // when structuredClone is unavailable or the config contains values
+      // that aren't clone-safe (functions, class instances, cycles, BigInt)
+      // — config is expected to hold plain scalar/object settings in normal
+      // Rails-style usage.
       try {
         host._config =
-          typeof structuredClone === "function"
-            ? structuredClone(parent)
-            : JSON.parse(JSON.stringify(parent));
+          typeof structuredClone === "function" ? structuredClone(parent) : { ...parent };
       } catch {
         host._config = { ...parent };
       }

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -20,8 +20,9 @@ export class Railtie {
   private static _config: Record<string, unknown> = {};
 
   /**
-   * Per-class config object. Each subclass gets its own copy on first
-   * access (copy-on-first-write so parent defaults propagate).
+   * Per-class config object. Each subclass gets its own deep-cloned copy
+   * on first access, so parent defaults propagate until the subclass
+   * config is read (copy-on-first-access).
    *
    * Mirrors: Rails::Railtie.config
    */

--- a/packages/activesupport/src/railtie.ts
+++ b/packages/activesupport/src/railtie.ts
@@ -28,7 +28,13 @@ export class Railtie {
   static get config(): Record<string, unknown> {
     const host = this as any;
     if (!Object.prototype.hasOwnProperty.call(host, "_config")) {
-      host._config = { ...Object.getPrototypeOf(host)._config };
+      const parent = Object.getPrototypeOf(host)._config ?? {};
+      // Deep-clone so nested objects/arrays are isolated per subclass
+      // (structuredClone is available in Node 17+ and modern browsers).
+      host._config =
+        typeof structuredClone === "function"
+          ? structuredClone(parent)
+          : JSON.parse(JSON.stringify(parent));
     }
     return host._config as Record<string, unknown>;
   }


### PR DESCRIPTION
## Summary
Rails' \`ActiveModel::Railtie < ::Rails::Railtie\` — our port had no superclass (\`api:compare\` reported an inheritance mismatch). This PR fixes that.

**Why activesupport, not trailties:** putting base Railtie in trailties would create a circular dependency (trailties → activerecord → activemodel → trailties). ActiveSupport has no such deps and is already the foundation for all packages.

## What's added

### \`@blazetrails/activesupport\` — \`Railtie\` base class
Mirrors \`Rails::Railtie\` (railties/lib/rails/railtie.rb):
- \`Railtie.subclasses\` — registry of registered subclasses
- \`Railtie.config\` — per-class config (copy-on-first-write)
- \`Railtie.initializer(name, block)\` — register named initializer
- \`Railtie.runInitializers()\` — fire this class's blocks
- \`Railtie.runAllInitializers()\` — fire all registered subclasses
- \`registerRailtie(cls)\` — explicit \`inherited\` equivalent (JS has no hook)

### \`ActiveModel::Railtie\` now extends the base
Registers itself via \`registerRailtie\` and wires \`active_model.secure_password\` as a named initializer. Backwards-compat \`Railtie.initialize\` helper preserved.

## Test plan
- [x] 6 Railtie unit tests (initializer order, subclass isolation, registry, runAll, config isolation)
- [x] All AS/AM/AR tests pass
- [x] typecheck + lint clean