### PR TITLE
test(parity): AR query fixtures ar-59..ar-63 — Arel.sql, nested preload, aliased select, nested or (PR 12)

### DIFF
--- a/scripts/parity/fixtures/ar-59/models.rb
+++ b/scripts/parity/fixtures/ar-59/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-59/models.ts
+++ b/scripts/parity/fixtures/ar-59/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-59/query.rb
+++ b/scripts/parity/fixtures/ar-59/query.rb
@@ -1,0 +1,1 @@
+Book.order(Arel.sql("RANDOM()"))

--- a/scripts/parity/fixtures/ar-59/query.ts
+++ b/scripts/parity/fixtures/ar-59/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.order("RANDOM()");

--- a/scripts/parity/fixtures/ar-59/schema.sql
+++ b/scripts/parity/fixtures/ar-59/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-59
+-- Query: Book.order(Arel.sql("RANDOM()"))  # trails: Book.order("RANDOM()")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-60/models.rb
+++ b/scripts/parity/fixtures/ar-60/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-60/models.ts
+++ b/scripts/parity/fixtures/ar-60/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-60/query.rb
+++ b/scripts/parity/fixtures/ar-60/query.rb
@@ -1,0 +1,1 @@
+Book.where(Arel.sql("id > 5"))

--- a/scripts/parity/fixtures/ar-60/query.ts
+++ b/scripts/parity/fixtures/ar-60/query.ts
@@ -1,0 +1,4 @@
+import { sql as arelSql } from "@blazetrails/arel";
+import { Book } from "./models.js";
+
+export default Book.where(arelSql("id > 5"));

--- a/scripts/parity/fixtures/ar-60/schema.sql
+++ b/scripts/parity/fixtures/ar-60/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-60
+-- Query: Book.where(Arel.sql("id > 5"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-61/models.rb
+++ b/scripts/parity/fixtures/ar-61/models.rb
@@ -1,0 +1,10 @@
+class Review < ActiveRecord::Base
+  belongs_to :book
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+class Author < ActiveRecord::Base
+  has_many :books
+end

--- a/scripts/parity/fixtures/ar-61/models.ts
+++ b/scripts/parity/fixtures/ar-61/models.ts
@@ -1,0 +1,24 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-61/query.rb
+++ b/scripts/parity/fixtures/ar-61/query.rb
@@ -1,0 +1,1 @@
+Author.preload(books: :reviews).limit(3)

--- a/scripts/parity/fixtures/ar-61/query.ts
+++ b/scripts/parity/fixtures/ar-61/query.ts
@@ -1,0 +1,3 @@
+import { Author } from "./models.js";
+
+export default Author.all().preload("books.reviews").limit(3);

--- a/scripts/parity/fixtures/ar-61/schema.sql
+++ b/scripts/parity/fixtures/ar-61/schema.sql
@@ -1,0 +1,17 @@
+-- Fixture for statement: ar-61
+-- Query: Author.preload(books: :reviews).limit(3)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  body TEXT
+);

--- a/scripts/parity/fixtures/ar-62/models.rb
+++ b/scripts/parity/fixtures/ar-62/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-62/models.ts
+++ b/scripts/parity/fixtures/ar-62/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-62/query.rb
+++ b/scripts/parity/fixtures/ar-62/query.rb
@@ -1,0 +1,1 @@
+Book.select("id", "title AS t")

--- a/scripts/parity/fixtures/ar-62/query.ts
+++ b/scripts/parity/fixtures/ar-62/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select("id", "title AS t");

--- a/scripts/parity/fixtures/ar-62/schema.sql
+++ b/scripts/parity/fixtures/ar-62/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-62
+-- Query: Book.select("id", "title AS t")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-63/models.rb
+++ b/scripts/parity/fixtures/ar-63/models.rb
@@ -1,0 +1,2 @@
+class Customer < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-63/models.ts
+++ b/scripts/parity/fixtures/ar-63/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Customer extends Base {
+  static {
+    this.tableName = "customers";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-63/query.rb
+++ b/scripts/parity/fixtures/ar-63/query.rb
@@ -1,0 +1,1 @@
+Customer.where(orders_count: 1).or(Customer.where(orders_count: 3).or(Customer.where(orders_count: 5)))

--- a/scripts/parity/fixtures/ar-63/query.ts
+++ b/scripts/parity/fixtures/ar-63/query.ts
@@ -1,0 +1,5 @@
+import { Customer } from "./models.js";
+
+export default Customer.where({ orders_count: 1 }).or(
+  Customer.where({ orders_count: 3 }).or(Customer.where({ orders_count: 5 })),
+);

--- a/scripts/parity/fixtures/ar-63/schema.sql
+++ b/scripts/parity/fixtures/ar-63/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-63
+-- Query: Customer.where(orders_count: 1).or(Customer.where(orders_count: 3).or(Customer.where(orders_count: 5)))
+
+CREATE TABLE customers (
+  id INTEGER PRIMARY KEY,
+  orders_count INTEGER
+);


### PR DESCRIPTION
## Summary
- Adds 5 AR query parity fixtures. All **PASS** byte-identical.

- ar-59: `Book.order(Arel.sql("RANDOM()"))` — raw SQL in ORDER BY. trails' `order()` accepts plain strings directly; `Arel.sql` wrapping isn't needed.
- ar-60: `Book.where(Arel.sql("id > 5"))` — raw SQL literal in WHERE
- ar-61: `Author.preload(books: :reviews).limit(3)` — nested hash-form preload (trails: `preload("books.reviews")`)
- ar-62: `Book.select("id", "title AS t")` — aliased column in SELECT
- ar-63: `where(...).or(where(...).or(where(...)))` — nested or chains

## Test plan
- [x] `pnpm parity:query` — all 5 PASS, no new known-gaps, no UNEXPECTED-PASS