### PR TITLE
feat(encryption): unskip 4 EncryptionSchemesTest cases (custom encryptor, previous contexts, decrypt fallback, Decryption errors)

### DIFF
--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -13,6 +13,7 @@ import {
   restoreEncryptionConfig,
   makeEncryptedAuthor,
   makeFreshModel,
+  makeKeyProvider,
   withoutEncryption,
 } from "./test-helpers.js";
 
@@ -68,18 +69,21 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
   it("can decrypt encrypted_value encrypted with a different encryption scheme", async () => {
     Configurable.config.supportUnencryptedData = false;
-    // Configure a previous scheme so the author type has previousTypes.
-    Configurable.config.previous = [{ deterministic: false }] as SchemeOptions[];
+    // Use a distinct key for the previous scheme so current-scheme decryption
+    // fails and the fallback path is actually exercised.
+    const prevKeyProvider = makeKeyProvider("prev-key-for-schemes-test-32bytes!!");
+    Configurable.config.previous = [{ keyProvider: prevKeyProvider }] as SchemeOptions[];
     const Author = makeEncryptedAuthor(freshAdapter());
     new Author();
     const author = await Author.create({ name: "david" });
     const currentType = (Author as any).typeForAttribute("name") as EncryptedAttributeType;
     const prevType = currentType.previousTypes[0];
     expect(prevType).toBeDefined();
-    // Overwrite the DB row with a ciphertext produced by the previous scheme.
+    // Write the ciphertext produced by the previous scheme directly — bypass
+    // validations (length validator) with updateColumns.
     const oldCiphertext = prevType.serialize("dhh") as string;
     await withoutEncryption(async () => {
-      await author.update({ name: oldCiphertext });
+      await author.updateColumns({ name: oldCiphertext });
     });
     const reloaded = await Author.find(author.id);
     expect(reloaded.name).toBe("dhh");
@@ -88,6 +92,11 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
   it("when defining previous encryption schemes, you still get Decryption errors when using invalid clear values", async () => {
     Configurable.config.supportUnencryptedData = false;
+    // Configure a previous scheme — the test verifies that even with previous
+    // schemes, an unencrypted plaintext raises DecryptionError.
+    Configurable.config.previous = [
+      { keyProvider: makeKeyProvider("prev-key-for-decryption-error-32b!") },
+    ] as SchemeOptions[];
     const Author = makeEncryptedAuthor(freshAdapter());
     new Author();
     const author = await withoutEncryption(() => Author.create({ name: "unencrypted author" }));
@@ -114,7 +123,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     const EncryptedAuthor2 = makeFreshModel(adp, { id: "integer", name: "string" });
     EncryptedAuthor2.encrypts("name", {
       encryptor: new TestEncryptor({ "2": "3" }),
-      previous: [{ encryptor: new TestEncryptor({ "1": "2" }) }] as any,
+      previousSchemes: [new Scheme({ encryptor: new TestEncryptor({ "1": "2" }) })],
     });
     new EncryptedAuthor2();
     const author = await EncryptedAuthor2.create({ name: "2" });

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -121,6 +121,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     expect(author.name).toBe("2");
     const found = await EncryptedAuthor2.findBy({ name: "2" });
     expect(found).not.toBeNull();
+    // Reload to verify DB ciphertext — encryptedAttribute checks the raw DB value.
     const authorReloaded = await EncryptedAuthor2.find(author.id);
     expect(authorReloaded.encryptedAttribute("name")).toBe(true);
     // Write plaintext directly to DB (simulates an unencrypted legacy row).
@@ -131,6 +132,10 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     await rawRecord.update({ name: "1" });
     const reloaded = await EncryptedAuthor2.find(author.id);
     expect(reloaded.name).toBe("1");
+    // findBy plaintext also works because TestEncryptor.encrypt("1") returns "1"
+    // (not in map), so the WHERE clause matches the raw value.
+    const foundByPlaintext = await EncryptedAuthor2.findBy({ name: "1" });
+    expect(foundByPlaintext).not.toBeNull();
     expect(reloaded.encryptedAttribute("name")).toBe(false);
   });
 

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -6,6 +6,15 @@ import { Decryption as DecryptionError } from "./errors.js";
 import type { EncryptorLike } from "./encryptor.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import type { SchemeOptions } from "./scheme.js";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+  makeEncryptedAuthor,
+  makeFreshModel,
+  withoutEncryption,
+} from "./test-helpers.js";
 
 class TestEncryptor implements EncryptorLike {
   constructor(private readonly map: Record<string, string>) {}
@@ -44,19 +53,86 @@ function makeType(
 
 describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   let savedSupportUnencryptedData: boolean;
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
 
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
+    configSnapshot = snapshotEncryptionConfig();
+    configureEncryption();
   });
 
   afterEach(() => {
     Configurable.config.supportUnencryptedData = savedSupportUnencryptedData;
+    restoreEncryptionConfig(configSnapshot);
   });
 
-  it.skip("can decrypt encrypted_value encrypted with a different encryption scheme", () => {});
-  it.skip("when defining previous encryption schemes, you still get Decryption errors when using invalid clear values", () => {});
-  it.skip("use a custom encryptor", () => {});
-  it.skip("support previous contexts", () => {});
+  it("can decrypt encrypted_value encrypted with a different encryption scheme", async () => {
+    Configurable.config.supportUnencryptedData = false;
+    // Configure a previous scheme so the author type has previousTypes.
+    Configurable.config.previous = [{ deterministic: false }] as SchemeOptions[];
+    const Author = makeEncryptedAuthor(freshAdapter());
+    new Author();
+    const author = await Author.create({ name: "david" });
+    const currentType = (Author as any).typeForAttribute("name") as EncryptedAttributeType;
+    const prevType = currentType.previousTypes[0];
+    expect(prevType).toBeDefined();
+    // Overwrite the DB row with a ciphertext produced by the previous scheme.
+    const oldCiphertext = prevType.serialize("dhh") as string;
+    await withoutEncryption(async () => {
+      await author.update({ name: oldCiphertext });
+    });
+    const reloaded = await Author.find(author.id);
+    expect(reloaded.name).toBe("dhh");
+    expect(reloaded.encryptedAttribute("name")).toBe(true);
+  });
+
+  it("when defining previous encryption schemes, you still get Decryption errors when using invalid clear values", async () => {
+    Configurable.config.supportUnencryptedData = false;
+    const Author = makeEncryptedAuthor(freshAdapter());
+    new Author();
+    const author = await withoutEncryption(() => Author.create({ name: "unencrypted author" }));
+    const reloaded = await Author.find(author.id);
+    expect(() => reloaded.name).toThrow(DecryptionError);
+  });
+
+  it("use a custom encryptor", async () => {
+    const adp = freshAdapter();
+    const EncryptedAuthor1 = makeFreshModel(adp, { id: "integer", name: "string" });
+    EncryptedAuthor1.encrypts("name", { encryptor: new TestEncryptor({ "1": "2" }) });
+    new EncryptedAuthor1();
+    const author = await EncryptedAuthor1.create({ name: "1" });
+    expect(author.name).toBe("1");
+    // Reload to get DB ciphertext in memory so encryptedAttribute returns true.
+    const reloaded = await EncryptedAuthor1.find(author.id);
+    expect(reloaded.name).toBe("1");
+    expect(reloaded.encryptedAttribute("name")).toBe(true);
+  });
+
+  it("support previous contexts", async () => {
+    Configurable.config.supportUnencryptedData = true;
+    const adp = freshAdapter();
+    const EncryptedAuthor2 = makeFreshModel(adp, { id: "integer", name: "string" });
+    EncryptedAuthor2.encrypts("name", {
+      encryptor: new TestEncryptor({ "2": "3" }),
+      previous: [{ encryptor: new TestEncryptor({ "1": "2" }) }] as any,
+    });
+    new EncryptedAuthor2();
+    const author = await EncryptedAuthor2.create({ name: "2" });
+    expect(author.name).toBe("2");
+    const found = await EncryptedAuthor2.findBy({ name: "2" });
+    expect(found).not.toBeNull();
+    const authorReloaded = await EncryptedAuthor2.find(author.id);
+    expect(authorReloaded.encryptedAttribute("name")).toBe(true);
+    // Write plaintext directly to DB (simulates an unencrypted legacy row).
+    const RawModel = makeFreshModel(adp, { id: "integer", name: "string" });
+    RawModel._tableName = (EncryptedAuthor2 as any)._tableName;
+    new RawModel();
+    const rawRecord = await RawModel.find(author.id);
+    await rawRecord.update({ name: "1" });
+    const reloaded = await EncryptedAuthor2.find(author.id);
+    expect(reloaded.name).toBe("1");
+    expect(reloaded.encryptedAttribute("name")).toBe(false);
+  });
 
   it("use global previous schemes to decrypt data encrypted with previous schemes", () => {
     Configurable.config.supportUnencryptedData = false;


### PR DESCRIPTION
## Summary

Unskips 4 `EncryptionSchemesTest` cases that require DB-backed model tests:

- **can decrypt encrypted_value encrypted with a different encryption scheme** — creates a record with the current scheme, overwrites the DB row with a previous-scheme ciphertext, verifies fallback decryption
- **when defining previous encryption schemes, you still get Decryption errors when using invalid clear values** — verifies that unencrypted plaintext raises `DecryptionError` when `support_unencrypted_data = false`
- **use a custom encryptor** — verifies `encrypts(:name, encryptor: TestEncryptor)` stores ciphertext and decrypts correctly
- **support previous contexts** — verifies that a record with a current-scheme ciphertext and a previous-scheme fallback also handles unencrypted legacy rows when `support_unencrypted_data = true`

## Test plan

- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/encryption-schemes.test.ts` — 10 passing, 5 skipped
- [ ] `pnpm exec vitest run packages/activerecord/src/encryption/` — 238 passing, 36 skipped