### PR TITLE
test(parity): AR query fixtures ar-64..ar-68 — mixed order, datetime, join+group, multi-CTE, Arel.sql select (PR 13)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -34,5 +34,13 @@
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
+  },
+  "ar-65": {
+    "side": "diff",
+    "reason": "Datetime serialization in WHERE = for a single value: trails formats Date as ISO 8601 ('2000-01-01T00:00:00.000Z'); Rails formats as SQL datetime ('2000-01-01 00:00:00'). Same root cause as ar-52 (BETWEEN) and ar-01 (? bind microseconds)."
+  },
+  "ar-66": {
+    "side": "diff",
+    "reason": "GROUP BY qualification on a cross-join column: trails emits 'GROUP BY authors.name' (bare dotted form); Rails qualifies to 'GROUP BY \"authors\".\"name\"'. Same root cause as ar-17 / ar-42 / ar-51."
   }
 }

--- a/scripts/parity/fixtures/ar-64/models.rb
+++ b/scripts/parity/fixtures/ar-64/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-64/models.ts
+++ b/scripts/parity/fixtures/ar-64/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-64/query.rb
+++ b/scripts/parity/fixtures/ar-64/query.rb
@@ -1,0 +1,1 @@
+Book.order(title: :asc, id: :desc)

--- a/scripts/parity/fixtures/ar-64/query.ts
+++ b/scripts/parity/fixtures/ar-64/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.order({ title: "asc", id: "desc" });

--- a/scripts/parity/fixtures/ar-64/schema.sql
+++ b/scripts/parity/fixtures/ar-64/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-64
+-- Query: Book.order(title: :asc, id: :desc)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-65/models.rb
+++ b/scripts/parity/fixtures/ar-65/models.rb
@@ -1,0 +1,2 @@
+class Order < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-65/models.ts
+++ b/scripts/parity/fixtures/ar-65/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Order extends Base {
+  static {
+    this.tableName = "orders";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-65/query.rb
+++ b/scripts/parity/fixtures/ar-65/query.rb
@@ -1,0 +1,1 @@
+Order.where(created_at: Time.now)

--- a/scripts/parity/fixtures/ar-65/query.ts
+++ b/scripts/parity/fixtures/ar-65/query.ts
@@ -1,0 +1,3 @@
+import { Order } from "./models.js";
+
+export default Order.where({ created_at: new Date() });

--- a/scripts/parity/fixtures/ar-65/schema.sql
+++ b/scripts/parity/fixtures/ar-65/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-65
+-- Query: Order.where(created_at: Time.now)
+
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY,
+  created_at DATETIME
+);

--- a/scripts/parity/fixtures/ar-66/models.rb
+++ b/scripts/parity/fixtures/ar-66/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-66/models.ts
+++ b/scripts/parity/fixtures/ar-66/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-66/query.rb
+++ b/scripts/parity/fixtures/ar-66/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:author).group("authors.name").select("authors.name, COUNT(*) AS c")

--- a/scripts/parity/fixtures/ar-66/query.ts
+++ b/scripts/parity/fixtures/ar-66/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.joins("author").group("authors.name").select("authors.name, COUNT(*) AS c");

--- a/scripts/parity/fixtures/ar-66/schema.sql
+++ b/scripts/parity/fixtures/ar-66/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-66
+-- Query: Book.joins(:author).group("authors.name").select("authors.name, COUNT(*) AS c")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-67/models.rb
+++ b/scripts/parity/fixtures/ar-67/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-67/models.ts
+++ b/scripts/parity/fixtures/ar-67/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-67/query.rb
+++ b/scripts/parity/fixtures/ar-67/query.rb
@@ -1,0 +1,1 @@
+User.with(active: User.where(active: true), admins: User.where(role: "admin")).from("active")

--- a/scripts/parity/fixtures/ar-67/query.ts
+++ b/scripts/parity/fixtures/ar-67/query.ts
@@ -1,0 +1,5 @@
+import { User } from "./models.js";
+
+export default User.all()
+  .with({ active: User.where({ active: true }), admins: User.where({ role: "admin" }) })
+  .from("active");

--- a/scripts/parity/fixtures/ar-67/schema.sql
+++ b/scripts/parity/fixtures/ar-67/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-67
+-- Query: User.with(active: User.where(active: true), admins: User.where(role: "admin")).from("active")
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  active BOOLEAN,
+  role TEXT
+);

--- a/scripts/parity/fixtures/ar-68/models.rb
+++ b/scripts/parity/fixtures/ar-68/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-68/models.ts
+++ b/scripts/parity/fixtures/ar-68/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-68/query.rb
+++ b/scripts/parity/fixtures/ar-68/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel.sql("id, title")).limit(5)

--- a/scripts/parity/fixtures/ar-68/query.ts
+++ b/scripts/parity/fixtures/ar-68/query.ts
@@ -1,0 +1,4 @@
+import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
+
+export default Book.select(sql("id, title")).limit(5);

--- a/scripts/parity/fixtures/ar-68/schema.sql
+++ b/scripts/parity/fixtures/ar-68/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-68
+-- Query: Book.select(Arel.sql("id, title")).limit(5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
Adds 5 AR query parity fixtures. 3 PASS byte-identical; 2 KNOWN-GAP.

**PASS**
- ar-64: `order(title: :asc, id: :desc)` — multi-column mixed-direction ORDER BY
- ar-67: `with(cte1: ..., cte2: ...).from("cte1")` — multiple named CTEs
- ar-68: `select(Arel.sql("id, title")).limit(5)` — `SqlLiteral` node in select projection

**KNOWN-GAP**
- ar-65: `where(created_at: Time.now)` — datetime = single value: trails formats as ISO 8601 (`'2000-01-01T00:00:00.000Z'`); Rails as SQL datetime (`'2000-01-01 00:00:00'`). Same family as ar-52.
- ar-66: `joins(:author).group("authors.name")` — GROUP BY on cross-join column: trails emits bare `authors.name`; Rails qualifies to `"authors"."name"`. Same family as ar-17/42/51.

## Test plan
- [x] `pnpm parity:query` — 3 PASS, 2 KNOWN-GAP, no UNEXPECTED-PASS