### PR TITLE
fix(arel,activerecord): SQL datetime format + dotted GROUP BY qualification (ar-66; ar-52/ar-65 improved)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -207,6 +207,19 @@ describe("RelationTest", () => {
     expect(Order.group("1").toSql()).toContain("GROUP BY 1");
   });
 
+  it("group by dotted table.column qualifies each part", () => {
+    class Book extends Base {
+      static _tableName = "books";
+      static {
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.group("authors.name").toSql();
+    expect(sql).toContain('"authors"."name"');
+    expect(sql).not.toContain("authors.name");
+  });
+
   it("multiple selects", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -23,7 +23,13 @@ import { detectAdapterName } from "../adapter-name.js";
  */
 export function groupColumnToArel(col: string, table: Table): Nodes.Node {
   const trimmed = col.trim();
+  // Plain identifier → qualify via model table (e.g. "created_at" → "orders"."created_at").
   if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) return table.get(trimmed);
+  // Simple table.column → create a cross-table Attribute (e.g. "authors.name" → "authors"."name").
+  // Mirrors Rails' arel_columns which calls table[column] on the referenced table.
+  const dotMatch = trimmed.match(/^([A-Za-z_][\w$]*)\.([A-Za-z_][\w$]*)$/);
+  if (dotMatch) return new Table(dotMatch[1]).get(dotMatch[2]);
+  // SQL expressions, casts, positional args, etc. pass through as raw SQL.
   return new Nodes.SqlLiteral(trimmed);
 }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -24,10 +24,10 @@ import { detectAdapterName } from "../adapter-name.js";
 export function groupColumnToArel(col: string, table: Table): Nodes.Node {
   const trimmed = col.trim();
   // Plain identifier → qualify via model table (e.g. "created_at" → "orders"."created_at").
-  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) return table.get(trimmed);
+  if (/^[A-Za-z_]\w*$/.test(trimmed)) return table.get(trimmed);
   // Simple table.column → create a cross-table Attribute (e.g. "authors.name" → "authors"."name").
   // Mirrors Rails' arel_columns which calls table[column] on the referenced table.
-  const dotMatch = trimmed.match(/^([A-Za-z_][\w$]*)\.([A-Za-z_][\w$]*)$/);
+  const dotMatch = trimmed.match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)$/);
   if (dotMatch) return new Table(dotMatch[1]).get(dotMatch[2]);
   // SQL expressions, casts, positional args, etc. pass through as raw SQL.
   return new Nodes.SqlLiteral(trimmed);

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -137,6 +137,18 @@ describe("PostgresTest", () => {
       expect(sql).not.toContain("alice");
       expect(binds).toEqual([42, "alice"]);
     });
+
+    it("compileWithBinds uses $N placeholders for Quoted Date values", () => {
+      const visitor = new Visitors.PostgreSQLWithBinds();
+      const d = new Date("2020-01-02T12:00:00.000Z");
+      const node = users.get("created_at").eq(new Nodes.Quoted(d));
+      const [sql, binds] = visitor.compileWithBinds(node);
+      expect(sql).toContain("$1");
+      expect(sql).not.toContain("?");
+      expect(sql).not.toContain("2020-01-02");
+      expect(binds).toHaveLength(1);
+      expect(binds[0]).toBe(d);
+    });
   });
 
   describe("Nodes::RollUp", () => {

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -102,4 +102,9 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     }
     return this.collector;
   }
+
+  protected override addDateBind(value: unknown): void {
+    this.bindIndex += 1;
+    this.collector.addBind(value, () => `$${this.bindIndex}`);
+  }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -753,13 +753,20 @@ describe("the to_sql visitor", () => {
   it("should visit_Date", () => {
     const d = new Date("2020-01-02T12:00:00.000Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
-    expect(sql).toBe("'2020-01-02T12:00:00.000Z'");
+    // Mirrors Rails' AbstractAdapter#quoted_date: space separator, seconds precision.
+    expect(sql).toBe("'2020-01-02 12:00:00'");
   });
 
   it("should visit_DateTime", () => {
     const dt = { toISOString: () => "2020-01-02T03:04:05.000Z" };
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(dt));
-    expect(sql).toBe("'2020-01-02T03:04:05.000Z'");
+    expect(sql).toBe("'2020-01-02 03:04:05'");
+  });
+
+  it("should visit_Date with fractional seconds strips to whole seconds", () => {
+    const d = new Date("2026-04-18T13:00:41.729Z");
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
+    expect(sql).toBe("'2026-04-18 13:00:41'");
   });
 
   it("should visit_Float", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -791,6 +791,18 @@ describe("the to_sql visitor", () => {
     expect(sql).not.toContain("Z");
   });
 
+  it("should extract Date as bind param in compileWithBinds", () => {
+    const users = new Table("users");
+    const d = new Date("2020-01-02T12:00:00.000Z");
+    const node = users.get("created_at").eq(new Nodes.Quoted(d));
+    const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
+    // Placeholder in SQL, actual Date in binds array.
+    expect(sql).toContain("?");
+    expect(sql).not.toContain("2020-01-02");
+    expect(binds).toHaveLength(1);
+    expect(binds[0]).toBe(d);
+  });
+
   it("should visit_Float", () => {
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(1.5));
     expect(sql).toBe("1.5");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -766,8 +766,15 @@ describe("the to_sql visitor", () => {
   it("should visit_Date with fractional seconds retains microseconds", () => {
     const d = new Date("2026-04-18T13:00:41.729Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
-    // ms=729 → 729000 microseconds
+    // "729" → padded to "729000" microseconds
     expect(sql).toBe("'2026-04-18 13:00:41.729000'");
+  });
+
+  it("should visit_Date-like with 1-digit fraction normalises to microseconds", () => {
+    // "7" → "700000" μs (not "007000" which the old ms*1000 approach produced)
+    const obj = { toISOString: () => "2020-01-02T03:04:05.7Z" };
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj as unknown as Date));
+    expect(sql).toBe("'2020-01-02 03:04:05.700000'");
   });
 
   it("should visit_Date with zero ms emits bare seconds (Rails quoted_date format)", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -763,10 +763,17 @@ describe("the to_sql visitor", () => {
     expect(sql).toBe("'2020-01-02 03:04:05'");
   });
 
-  it("should visit_Date with fractional seconds strips to whole seconds", () => {
+  it("should visit_Date with fractional seconds retains microseconds", () => {
     const d = new Date("2026-04-18T13:00:41.729Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
-    expect(sql).toBe("'2026-04-18 13:00:41'");
+    // ms=729 → 729000 microseconds
+    expect(sql).toBe("'2026-04-18 13:00:41.729000'");
+  });
+
+  it("should visit_Date with zero ms emits bare seconds (Rails quoted_date format)", () => {
+    const d = new Date("2000-01-01T00:00:00.000Z");
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
+    expect(sql).toBe("'2000-01-01 00:00:00'");
   });
 
   it("should visit_Float", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -776,6 +776,14 @@ describe("the to_sql visitor", () => {
     expect(sql).toBe("'2000-01-01 00:00:00'");
   });
 
+  it("should visit_Date-like with no fractional part (no trailing Z artifact)", () => {
+    // Handles objects whose toISOString() omits the fractional part, e.g. "...T00:00:00Z".
+    const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj as unknown as Date));
+    expect(sql).toBe("'2026-01-01 00:00:00'");
+    expect(sql).not.toContain("Z");
+  });
+
   it("should visit_Float", () => {
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(1.5));
     expect(sql).toBe("1.5");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1369,20 +1369,23 @@ export class ToSql implements NodeVisitor<SQLString> {
     }
   }
 
-  // Formats a date-like value as a SQL datetime string: 'YYYY-MM-DD HH:MM:SS'.
-  // Mirrors Rails' AbstractAdapter#quoted_date (space separator, seconds precision).
+  // Formats a date-like value as a SQL datetime string matching Rails'
+  // AbstractAdapter#quoted_date: 'YYYY-MM-DD HH:MM:SS[.microseconds]'.
+  // When ms > 0 the fractional part is emitted as 6-digit microseconds,
+  // matching AR quoting.ts and preserving sub-second DB precision. When ms = 0
+  // the bare seconds form is used — matching Rails' default output for midnight/
+  // whole-second values and closing ar-52/ar-65.
   //
-  // This visitor always uses UTC because JS Date#toISOString() is UTC-only and
-  // the Arel layer has no access to AR's defaultTimezone setting. Adapter-level
-  // quoting (packages/activerecord/src/connection-adapters/abstract/quoting.ts)
-  // honours defaultTimezone and is the authoritative path for bound values —
-  // this method covers Arel-inlined literals (Quoted/Casted nodes).
+  // Always UTC: JS Date#toISOString() is UTC-only and the Arel layer has no
+  // access to AR's defaultTimezone. Adapter-level quoting in
+  // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
+  // authoritative path for timezone-aware bound values.
   protected quotedDate(d: { toISOString(): string }): string {
-    const iso = d.toISOString(); // always "YYYY-MM-DDTHH:MM:SS.mmmZ"
-    return `'${iso
-      .replace("T", " ")
-      .replace(/\.\d+Z$/, "")
-      .replace(/Z$/, "")}'`;
+    const iso = d.toISOString(); // "YYYY-MM-DDTHH:MM:SS.mmmZ"
+    const [base, fracZ] = iso.split(".");
+    const ms = parseInt(fracZ ?? "0", 10);
+    const datetime = base.replace("T", " ");
+    return ms > 0 ? `'${datetime}.${String(ms * 1000).padStart(6, "0")}'` : `'${datetime}'`;
   }
 
   protected quote(value: unknown): string {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1369,13 +1369,15 @@ export class ToSql implements NodeVisitor<SQLString> {
     }
   }
 
-  // Mirrors Rails' AbstractAdapter#quoted_date: 'YYYY-MM-DD HH:MM:SS'
-  // (space separator, no T, no milliseconds, no Z).
+  // Mirrors Rails' AbstractAdapter#quoted_date — 'YYYY-MM-DD HH:MM:SS'
+  // (space separator, seconds precision, no T, no fractional seconds, no Z).
+  // JS Date#toISOString() always returns UTC so the UTC form is authoritative.
   protected quotedDate(d: { toISOString(): string }): string {
-    return `'${d
-      .toISOString()
+    const iso = d.toISOString(); // "YYYY-MM-DDTHH:MM:SS.mmmZ"
+    return `'${iso
       .replace("T", " ")
-      .replace(/\.\d+Z$/, "")}'`;
+      .replace(/\.\d+Z$/, "")
+      .replace(/Z$/, "")}'`;
   }
 
   protected quote(value: unknown): string {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1355,7 +1355,7 @@ export class ToSql implements NodeVisitor<SQLString> {
       "toISOString" in v &&
       typeof (v as { toISOString: unknown }).toISOString === "function"
     ) {
-      this.collector.append(`'${(v as { toISOString: () => string }).toISOString()}'`);
+      this.collector.append(this.quotedDate(v as { toISOString(): string }));
     } else {
       this.collector.append(String(v));
     }
@@ -1369,6 +1369,15 @@ export class ToSql implements NodeVisitor<SQLString> {
     }
   }
 
+  // Mirrors Rails' AbstractAdapter#quoted_date: 'YYYY-MM-DD HH:MM:SS'
+  // (space separator, no T, no milliseconds, no Z).
+  protected quotedDate(d: { toISOString(): string }): string {
+    return `'${d
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d+Z$/, "")}'`;
+  }
+
   protected quote(value: unknown): string {
     if (value === null || value === undefined) return "NULL";
     if (typeof value === "number") return String(value);
@@ -1380,7 +1389,7 @@ export class ToSql implements NodeVisitor<SQLString> {
       "toISOString" in value &&
       typeof (value as { toISOString: unknown }).toISOString === "function"
     ) {
-      return `'${(value as { toISOString: () => string }).toISOString()}'`;
+      return this.quotedDate(value as { toISOString(): string });
     }
     if (typeof value === "object" && value !== null) {
       const proto = Object.getPrototypeOf(value);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1383,7 +1383,7 @@ export class ToSql implements NodeVisitor<SQLString> {
   protected quotedDate(d: { toISOString(): string }): string {
     // Parse "YYYY-MM-DDTHH:MM:SS.mmmZ" or "YYYY-MM-DDTHH:MM:SSZ" (no fractional part).
     const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
-    if (!match) return `'${d.toISOString()}'`;
+    if (!match) return `'${d.toISOString().replace(/'/g, "''")}'`;
     const [, date, time, frac] = match;
     // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
     // "729" → "729000" (μs), "7" → "700000", "1234" → "123400", "729000" → "729000".

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1291,7 +1291,18 @@ export class ToSql implements NodeVisitor<SQLString> {
   }
 
   private visitQuoted(node: Nodes.Quoted): SQLString {
-    this.collector.append(this.quote(node.value));
+    if (
+      this._extractBinds &&
+      node.value !== null &&
+      node.value !== undefined &&
+      typeof node.value === "object" &&
+      "toISOString" in node.value &&
+      typeof (node.value as { toISOString: unknown }).toISOString === "function"
+    ) {
+      this.collector.addBind(node.value);
+    } else {
+      this.collector.append(this.quote(node.value));
+    }
     return this.collector;
   }
 
@@ -1355,7 +1366,11 @@ export class ToSql implements NodeVisitor<SQLString> {
       "toISOString" in v &&
       typeof (v as { toISOString: unknown }).toISOString === "function"
     ) {
-      this.collector.append(this.quotedDate(v as { toISOString(): string }));
+      if (this._extractBinds) {
+        this.collector.addBind(v);
+      } else {
+        this.collector.append(this.quotedDate(v as { toISOString(): string }));
+      }
     } else {
       this.collector.append(String(v));
     }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1299,7 +1299,14 @@ export class ToSql implements NodeVisitor<SQLString> {
       "toISOString" in node.value &&
       typeof (node.value as { toISOString: unknown }).toISOString === "function"
     ) {
-      this.collector.addBind(node.value);
+      // Bind real Date instances directly (drivers handle them natively).
+      // For non-Date date-like objects, bind the formatted string so drivers
+      // don't receive an unsupported object type.
+      const bind =
+        node.value instanceof Date
+          ? node.value
+          : this.quotedDate(node.value as { toISOString(): string }).slice(1, -1);
+      this.collector.addBind(bind);
     } else {
       this.collector.append(this.quote(node.value));
     }
@@ -1367,7 +1374,9 @@ export class ToSql implements NodeVisitor<SQLString> {
       typeof (v as { toISOString: unknown }).toISOString === "function"
     ) {
       if (this._extractBinds) {
-        this.collector.addBind(v);
+        const bind =
+          v instanceof Date ? v : this.quotedDate(v as { toISOString(): string }).slice(1, -1);
+        this.collector.addBind(bind);
       } else {
         this.collector.append(this.quotedDate(v as { toISOString(): string }));
       }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1381,11 +1381,12 @@ export class ToSql implements NodeVisitor<SQLString> {
   // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
   // authoritative path for timezone-aware bound values.
   protected quotedDate(d: { toISOString(): string }): string {
-    const iso = d.toISOString(); // "YYYY-MM-DDTHH:MM:SS.mmmZ"
-    const [base, fracZ] = iso.split(".");
-    const ms = parseInt(fracZ ?? "0", 10);
-    const datetime = base.replace("T", " ");
-    return ms > 0 ? `'${datetime}.${String(ms * 1000).padStart(6, "0")}'` : `'${datetime}'`;
+    // Parse "YYYY-MM-DDTHH:MM:SS.mmmZ" or "YYYY-MM-DDTHH:MM:SSZ" (no fractional part).
+    const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
+    if (!match) return `'${d.toISOString()}'`;
+    const [, date, time, frac] = match;
+    const ms = frac ? parseInt(frac.slice(0, 3).padEnd(3, "0"), 10) : 0;
+    return ms > 0 ? `'${date} ${time}.${String(ms * 1000).padStart(6, "0")}'` : `'${date} ${time}'`;
   }
 
   protected quote(value: unknown): string {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -960,6 +960,12 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   // -- BindParam --
 
+  // Overridable hook for date bind insertion so PostgreSQLWithBinds can
+  // emit $N placeholders instead of ?.
+  protected addDateBind(value: unknown): void {
+    this.collector.addBind(value);
+  }
+
   protected visitBindParam(node: Nodes.BindParam): SQLString {
     if (this._extractBinds) {
       this.collector.addBind(node.value !== undefined ? node.value : node);
@@ -1306,7 +1312,7 @@ export class ToSql implements NodeVisitor<SQLString> {
         node.value instanceof Date
           ? node.value
           : this.quotedDate(node.value as { toISOString(): string }).slice(1, -1);
-      this.collector.addBind(bind);
+      this.addDateBind(bind);
     } else {
       this.collector.append(this.quote(node.value));
     }
@@ -1376,7 +1382,7 @@ export class ToSql implements NodeVisitor<SQLString> {
       if (this._extractBinds) {
         const bind =
           v instanceof Date ? v : this.quotedDate(v as { toISOString(): string }).slice(1, -1);
-        this.collector.addBind(bind);
+        this.addDateBind(bind);
       } else {
         this.collector.append(this.quotedDate(v as { toISOString(): string }));
       }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1385,8 +1385,12 @@ export class ToSql implements NodeVisitor<SQLString> {
     const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
     if (!match) return `'${d.toISOString()}'`;
     const [, date, time, frac] = match;
-    const ms = frac ? parseInt(frac.slice(0, 3).padEnd(3, "0"), 10) : 0;
-    return ms > 0 ? `'${date} ${time}.${String(ms * 1000).padStart(6, "0")}'` : `'${date} ${time}'`;
+    // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
+    // "729" → "729000" (μs), "7" → "700000", "1234" → "123400", "729000" → "729000".
+    const micros = frac ? parseInt((frac + "000000").slice(0, 6), 10) : 0;
+    return micros > 0
+      ? `'${date} ${time}.${String(micros).padStart(6, "0")}'`
+      : `'${date} ${time}'`;
   }
 
   protected quote(value: unknown): string {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1388,15 +1388,18 @@ export class ToSql implements NodeVisitor<SQLString> {
   // AbstractAdapter#quoted_date: 'YYYY-MM-DD HH:MM:SS[.microseconds]'.
   // When ms > 0 the fractional part is emitted as 6-digit microseconds,
   // matching AR quoting.ts and preserving sub-second DB precision. When ms = 0
-  // the bare seconds form is used — matching Rails' default output for midnight/
-  // whole-second values and closing ar-52/ar-65.
+  // the bare seconds form is used — matching Rails' default output for
+  // whole-second values.
   //
-  // Always UTC: JS Date#toISOString() is UTC-only and the Arel layer has no
-  // access to AR's defaultTimezone. Adapter-level quoting in
+  // UTC handling: JS Date#toISOString() always appends Z; the regex also
+  // accepts strings without a trailing Z (treating absent timezone as UTC),
+  // which covers non-standard date-like objects. The Arel layer has no access
+  // to AR's defaultTimezone — adapter-level quoting in
   // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
   // authoritative path for timezone-aware bound values.
   protected quotedDate(d: { toISOString(): string }): string {
-    // Parse "YYYY-MM-DDTHH:MM:SS.mmmZ" or "YYYY-MM-DDTHH:MM:SSZ" (no fractional part).
+    // Matches "YYYY-MM-DDTHH:MM:SS.mmmZ", "YYYY-MM-DDTHH:MM:SSZ", or
+    // the same without trailing Z (treated as UTC).
     const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
     if (!match) return `'${d.toISOString().replace(/'/g, "''")}'`;
     const [, date, time, frac] = match;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1369,11 +1369,16 @@ export class ToSql implements NodeVisitor<SQLString> {
     }
   }
 
-  // Mirrors Rails' AbstractAdapter#quoted_date — 'YYYY-MM-DD HH:MM:SS'
-  // (space separator, seconds precision, no T, no fractional seconds, no Z).
-  // JS Date#toISOString() always returns UTC so the UTC form is authoritative.
+  // Formats a date-like value as a SQL datetime string: 'YYYY-MM-DD HH:MM:SS'.
+  // Mirrors Rails' AbstractAdapter#quoted_date (space separator, seconds precision).
+  //
+  // This visitor always uses UTC because JS Date#toISOString() is UTC-only and
+  // the Arel layer has no access to AR's defaultTimezone setting. Adapter-level
+  // quoting (packages/activerecord/src/connection-adapters/abstract/quoting.ts)
+  // honours defaultTimezone and is the authoritative path for bound values —
+  // this method covers Arel-inlined literals (Quoted/Casted nodes).
   protected quotedDate(d: { toISOString(): string }): string {
-    const iso = d.toISOString(); // "YYYY-MM-DDTHH:MM:SS.mmmZ"
+    const iso = d.toISOString(); // always "YYYY-MM-DDTHH:MM:SS.mmmZ"
     return `'${iso
       .replace("T", " ")
       .replace(/\.\d+Z$/, "")

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,7 +1,15 @@
 {
   "ar-01": {
     "side": "diff",
-    "reason": "Datetime microseconds in WHERE ? bind: trails serializes a Date as '2026-04-18 13:00:41.729000' (with microseconds); Rails serializes as '2026-04-18 13:00:41' (truncated to seconds). Only manifests when frozen-at has non-zero milliseconds. Same datetime serialization family as ar-52."
+    "reason": "Datetime microseconds in WHERE ? bind: trails serializes a Date as '2026-04-18 13:00:41.729000' (with microseconds); Rails serializes as '2026-04-18 13:00:41' (truncated to seconds). Only manifests when frozen-at has non-zero milliseconds. Same datetime serialization family as ar-52/ar-65."
+  },
+  "ar-52": {
+    "side": "diff",
+    "reason": "Datetime precision in WHERE BETWEEN: trails emits '2026-04-18 17:53:16.175000' (microseconds) when the frozen clock has non-zero ms; Rails truncates to '2026-04-18 17:53:16'. Root cause: Rails uses bind params for Date values so the DB driver handles precision natively; trails inlines dates as SQL literals. Truncating to seconds fixes parity but breaks DB timestamp precision (cache-key, touch tests). Will be fully resolved once INSERT/UPDATE uses bind params."
+  },
+  "ar-65": {
+    "side": "diff",
+    "reason": "Datetime precision in WHERE = (single value): same root cause as ar-52 — microseconds in inline literal vs Rails' seconds-only format. Manifests when frozen-at has non-zero milliseconds."
   },
   "ar-16": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -19,10 +19,6 @@
     "side": "diff",
     "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
   },
-  "ar-52": {
-    "side": "diff",
-    "reason": "Datetime serialization in WHERE BETWEEN: trails formats Date as ISO 8601 ('1999-12-25T00:00:00.000Z'); Rails formats as SQL datetime ('1999-12-25 00:00:00'). The T separator, milliseconds, and Z suffix are wrong for standard SQL datetime literals."
-  },
   "ar-55": {
     "side": "diff",
     "reason": "Nested table-keyed where hash: where({authors: {name: 'Rails'}}) — Rails expands nested hashes into table-qualified predicates ('\"authors\".\"name\" = \\'Rails\\''); trails serializes the inner object as a JSON string ('\"books\".\"authors\" = \\'{\"name\":\"Rails\"}\\'). trails-missing: PredicateBuilder should handle nested table→column hash form."
@@ -30,13 +26,5 @@
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
-  "ar-65": {
-    "side": "diff",
-    "reason": "Datetime serialization in WHERE = for a single value: trails formats Date as ISO 8601 ('2000-01-01T00:00:00.000Z'); Rails formats as SQL datetime ('2000-01-01 00:00:00'). Same root cause as ar-52 (BETWEEN) and ar-01 (? bind microseconds)."
-  },
-  "ar-66": {
-    "side": "diff",
-    "reason": "GROUP BY qualification on a cross-join column: trails emits 'GROUP BY authors.name' (bare dotted form); Rails qualifies to 'GROUP BY \"authors\".\"name\"'. Same root cause as ar-17 / ar-42 / ar-51."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -5,11 +5,11 @@
   },
   "ar-52": {
     "side": "diff",
-    "reason": "Datetime precision in WHERE BETWEEN: trails emits '2026-04-18 17:53:16.175000' (microseconds) when the frozen clock has non-zero ms; Rails truncates to '2026-04-18 17:53:16'. Root cause: Rails uses bind params for Date values so the DB driver handles precision natively; trails inlines dates as SQL literals. Truncating to seconds fixes parity but breaks DB timestamp precision (cache-key, touch tests). Will be fully resolved once INSERT/UPDATE uses bind params."
+    "reason": "Datetime precision in WHERE BETWEEN: trails inlines dates as SQL literals via toSql(), emitting '2026-04-18 17:53:16.175000' (microseconds) when frozen-at has non-zero ms; Rails' quoted_date truncates to seconds. INSERT/UPDATE already uses bind params (PR #845), but the parity runner calls toSql() which still inlines. Will close once the parity runner or WHERE predicates also use bind params (matching Rails' BindParam-first architecture)."
   },
   "ar-65": {
     "side": "diff",
-    "reason": "Datetime precision in WHERE = (single value): same root cause as ar-52 — microseconds in inline literal vs Rails' seconds-only format. Manifests when frozen-at has non-zero milliseconds."
+    "reason": "Datetime precision in WHERE = (single value): same root cause as ar-52 — toSql() inline literal includes microseconds when frozen-at ms > 0, while Rails emits bare seconds via quoted_date."
   },
   "ar-16": {
     "side": "diff",


### PR DESCRIPTION
## Summary

- **ar-66** — `groupColumnToArel`: handles `table.column` dotted form by creating a cross-table `Attribute` node, emitting `"authors"."name"` instead of bare `authors.name`. Fully closed.
- **ar-52, ar-65** (improved, not fully closed): datetime literals now emit `'YYYY-MM-DD HH:MM:SS[.microseconds]'` (space separator, no T, no Z) instead of ISO 8601. The remaining gap: when the frozen clock has non-zero milliseconds, trails emits `.175000` microseconds while Rails truncates to seconds. Root cause: Rails uses bind params for Date values so the DB driver handles precision natively; trails inlines dates as SQL literals in `toSql()`. **Bind param fix also added**: `visitQuoted` and `visitNodeOrValue` now extract date values as bind params when using `compileWithBinds` (INSERT/UPDATE execution path), preserving full millisecond precision in the DB.
- **ar-01** — same datetime family, still in known-gaps.

## Test plan

- [ ] `pnpm --filter @blazetrails/arel test` passes
- [ ] `pnpm --filter @blazetrails/activerecord test` passes (cache-key / touch tests pass with bind-param fix)
- [ ] AR query parity CI: ar-66 green; ar-52/ar-65 still in known-gaps (inline toSql with frozen ms > 0)