### PR TITLE
test(parity): AR query fixtures ar-69..ar-73 — exclusive range, reorder, multi-joins, select+distinct, NOT BETWEEN (PR 14)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,4 +1,16 @@
 {
+  "ar-12": {
+    "side": "diff",
+    "reason": "ORDER BY hash-column qualification: #839 fixed ar-23 (ORDER BY in .from() context) but introduced a partial regression — hash-order columns that are not the primary key (e.g. created_at, title) are emitted bare ('\"created_at\" DESC') while Rails qualifies them ('\"users\".\"created_at\" DESC'). The `id` column is qualified because it matches the PK; other columns are not."
+  },
+  "ar-39": {
+    "side": "diff",
+    "reason": "ORDER BY multi-column partial qualification: first column in multi-key order hash is qualified ('\"books\".\"id\" ASC') but second is bare ('\"title\" DESC'). Same root cause as ar-12 — only pk-matching columns get the table qualifier from #839's fix."
+  },
+  "ar-64": {
+    "side": "diff",
+    "reason": "ORDER BY multi-column partial qualification (reverse order): first column bare ('\"title\" ASC'), second qualified ('\"books\".\"id\" DESC'). Same root cause as ar-12 and ar-39 — the id column is qualified regardless of position."
+  },
   "ar-01": {
     "side": "diff",
     "reason": "Datetime microseconds in WHERE ? bind: trails serializes a Date as '2026-04-18 13:00:41.729000' (with microseconds); Rails serializes as '2026-04-18 13:00:41' (truncated to seconds). Only manifests when frozen-at has non-zero milliseconds. Same datetime serialization family as ar-52."

--- a/scripts/parity/fixtures/ar-69/models.rb
+++ b/scripts/parity/fixtures/ar-69/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-69/models.ts
+++ b/scripts/parity/fixtures/ar-69/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-69/query.rb
+++ b/scripts/parity/fixtures/ar-69/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1...5)

--- a/scripts/parity/fixtures/ar-69/query.ts
+++ b/scripts/parity/fixtures/ar-69/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ id: new Range(1, 5, true) });

--- a/scripts/parity/fixtures/ar-69/schema.sql
+++ b/scripts/parity/fixtures/ar-69/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-69
+-- Query: Book.where(id: 1...5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-70/models.rb
+++ b/scripts/parity/fixtures/ar-70/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-70/models.ts
+++ b/scripts/parity/fixtures/ar-70/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-70/query.rb
+++ b/scripts/parity/fixtures/ar-70/query.rb
@@ -1,0 +1,1 @@
+Book.order(title: :desc).reorder(id: :asc)

--- a/scripts/parity/fixtures/ar-70/query.ts
+++ b/scripts/parity/fixtures/ar-70/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.order({ title: "desc" }).reorder({ id: "asc" });

--- a/scripts/parity/fixtures/ar-70/schema.sql
+++ b/scripts/parity/fixtures/ar-70/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-70
+-- Query: Book.order(title: :desc).reorder(id: :asc)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-71/models.rb
+++ b/scripts/parity/fixtures/ar-71/models.rb
@@ -1,0 +1,10 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Review < ActiveRecord::Base
+  belongs_to :book
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end

--- a/scripts/parity/fixtures/ar-71/models.ts
+++ b/scripts/parity/fixtures/ar-71/models.ts
@@ -1,0 +1,24 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-71/query.rb
+++ b/scripts/parity/fixtures/ar-71/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:author, :reviews)

--- a/scripts/parity/fixtures/ar-71/query.ts
+++ b/scripts/parity/fixtures/ar-71/query.ts
@@ -1,3 +1,7 @@
 import { Book } from "./models.js";
 
+// Rails: joins(:author, :reviews) — variadic single call.
+// trails Relation#joins(assocName, on?) accepts only one association per call;
+// passing a second string is treated as a raw ON clause, not a second assoc.
+// Chaining is the correct workaround until joins() is made variadic.
 export default Book.joins("author").joins("reviews");

--- a/scripts/parity/fixtures/ar-71/query.ts
+++ b/scripts/parity/fixtures/ar-71/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.joins("author").joins("reviews");

--- a/scripts/parity/fixtures/ar-71/schema.sql
+++ b/scripts/parity/fixtures/ar-71/schema.sql
@@ -1,0 +1,17 @@
+-- Fixture for statement: ar-71
+-- Query: Book.joins(:author, :reviews)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  body TEXT
+);

--- a/scripts/parity/fixtures/ar-72/models.rb
+++ b/scripts/parity/fixtures/ar-72/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-72/models.ts
+++ b/scripts/parity/fixtures/ar-72/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-72/query.rb
+++ b/scripts/parity/fixtures/ar-72/query.rb
@@ -1,0 +1,1 @@
+User.select(:id).distinct.where(active: true)

--- a/scripts/parity/fixtures/ar-72/query.ts
+++ b/scripts/parity/fixtures/ar-72/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.select("id").distinct().where({ active: true });

--- a/scripts/parity/fixtures/ar-72/schema.sql
+++ b/scripts/parity/fixtures/ar-72/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-72
+-- Query: User.select(:id).distinct.where(active: true)
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-73/models.rb
+++ b/scripts/parity/fixtures/ar-73/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-73/models.ts
+++ b/scripts/parity/fixtures/ar-73/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-73/query.rb
+++ b/scripts/parity/fixtures/ar-73/query.rb
@@ -1,0 +1,1 @@
+Book.where.not(id: 1..5)

--- a/scripts/parity/fixtures/ar-73/query.ts
+++ b/scripts/parity/fixtures/ar-73/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.whereNot({ id: new Range(1, 5) });

--- a/scripts/parity/fixtures/ar-73/schema.sql
+++ b/scripts/parity/fixtures/ar-73/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-73
+-- Query: Book.where.not(id: 1..5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
Adds 5 AR query parity fixtures (all **PASS**) and documents 3 ORDER BY regression gaps introduced by upstream #839.

**PASS (new fixtures)**
- ar-69: `where(id: 1...5)` — exclusive Range → `id >= 1 AND id < 5`
- ar-70: `order(title: :desc).reorder(id: :asc)` — `reorder` clears prior ORDER BY
- ar-71: `Book.joins(:author, :reviews)` — two association joins (trails chains: `.joins("author").joins("reviews")`)
- ar-72: `User.select(:id).distinct.where(active: true)` — chained projection+distinct+where
- ar-73: `Book.where.not(id: 1..5)` — NOT BETWEEN with inclusive Range

**KNOWN-GAP (ORDER BY regression from #839)**
- ar-12, ar-39, ar-64: `#839` fixed ar-23's ORDER BY qualification in `.from()` context but partially regressed hash-order qualification — the `id` column (matches PK) gets table-qualified but other columns (`created_at`, `title`) don't. Single-column and multi-column forms affected.

## Test plan
- [x] `pnpm parity:query` — 5 PASS, 3 regression KNOWN-GAP, no UNEXPECTED-PASS