### PR TITLE
test(parity): AR query fixtures ar-74..ar-78 — array+nil, multi-Arel select, limit(0), Arel.sql having, extending (PR 15)

### DIFF
--- a/scripts/parity/fixtures/ar-74/models.rb
+++ b/scripts/parity/fixtures/ar-74/models.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-74/models.ts
+++ b/scripts/parity/fixtures/ar-74/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  static {
+    this.tableName = "users";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-74/query.rb
+++ b/scripts/parity/fixtures/ar-74/query.rb
@@ -1,0 +1,1 @@
+User.where(name: ["Alice", nil])

--- a/scripts/parity/fixtures/ar-74/query.ts
+++ b/scripts/parity/fixtures/ar-74/query.ts
@@ -1,0 +1,3 @@
+import { User } from "./models.js";
+
+export default User.where({ name: ["Alice", null] });

--- a/scripts/parity/fixtures/ar-74/schema.sql
+++ b/scripts/parity/fixtures/ar-74/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-74
+-- Query: User.where(name: ["Alice", nil])
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);

--- a/scripts/parity/fixtures/ar-75/models.rb
+++ b/scripts/parity/fixtures/ar-75/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-75/models.ts
+++ b/scripts/parity/fixtures/ar-75/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-75/query.rb
+++ b/scripts/parity/fixtures/ar-75/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:id], Book.arel_table[:title]).limit(3)

--- a/scripts/parity/fixtures/ar-75/query.ts
+++ b/scripts/parity/fixtures/ar-75/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select(Book.arelTable.get("id"), Book.arelTable.get("title")).limit(3);

--- a/scripts/parity/fixtures/ar-75/schema.sql
+++ b/scripts/parity/fixtures/ar-75/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-75
+-- Query: Book.select(Book.arel_table[:id], Book.arel_table[:title]).limit(3)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-76/models.rb
+++ b/scripts/parity/fixtures/ar-76/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-76/models.ts
+++ b/scripts/parity/fixtures/ar-76/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-76/query.rb
+++ b/scripts/parity/fixtures/ar-76/query.rb
@@ -1,0 +1,1 @@
+Book.limit(0)

--- a/scripts/parity/fixtures/ar-76/query.ts
+++ b/scripts/parity/fixtures/ar-76/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.limit(0);

--- a/scripts/parity/fixtures/ar-76/schema.sql
+++ b/scripts/parity/fixtures/ar-76/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-76
+-- Query: Book.limit(0)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-77/models.rb
+++ b/scripts/parity/fixtures/ar-77/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-77/models.ts
+++ b/scripts/parity/fixtures/ar-77/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-77/query.rb
+++ b/scripts/parity/fixtures/ar-77/query.rb
@@ -1,0 +1,1 @@
+Book.group(:author_id).having(Arel.sql("COUNT(*) > 1"))

--- a/scripts/parity/fixtures/ar-77/query.ts
+++ b/scripts/parity/fixtures/ar-77/query.ts
@@ -1,0 +1,4 @@
+import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
+
+export default Book.group("author_id").having(sql("COUNT(*) > 1"));

--- a/scripts/parity/fixtures/ar-77/schema.sql
+++ b/scripts/parity/fixtures/ar-77/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-77
+-- Query: Book.group(:author_id).having(Arel.sql("COUNT(*) > 1"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);

--- a/scripts/parity/fixtures/ar-78/models.rb
+++ b/scripts/parity/fixtures/ar-78/models.rb
@@ -1,0 +1,8 @@
+module Pagination
+  def per_page(n)
+    limit(n)
+  end
+end
+
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-78/models.ts
+++ b/scripts/parity/fixtures/ar-78/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-78/query.rb
+++ b/scripts/parity/fixtures/ar-78/query.rb
@@ -1,0 +1,1 @@
+Book.where(id: 1).extending(Pagination)

--- a/scripts/parity/fixtures/ar-78/query.ts
+++ b/scripts/parity/fixtures/ar-78/query.ts
@@ -1,7 +1,7 @@
 import { Book } from "./models.js";
 
 const Pagination = {
-  perPage(n: number) {
+  per_page(n: number) {
     return (this as any).limit(n);
   },
 };

--- a/scripts/parity/fixtures/ar-78/query.ts
+++ b/scripts/parity/fixtures/ar-78/query.ts
@@ -1,0 +1,9 @@
+import { Book } from "./models.js";
+
+const Pagination = {
+  perPage(n: number) {
+    return (this as any).limit(n);
+  },
+};
+
+export default Book.where({ id: 1 }).extending(Pagination);

--- a/scripts/parity/fixtures/ar-78/schema.sql
+++ b/scripts/parity/fixtures/ar-78/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-78
+-- Query: Book.where(id: 1).extending(Pagination)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
Adds 5 AR query parity fixtures. All **PASS** byte-identical.

- ar-74: `where(name: ["Alice", nil])` — array with nil → `IN ('Alice') OR name IS NULL`
- ar-75: `select(arel_table[:id], arel_table[:title]).limit(3)` — multiple Arel attribute nodes in select (exercises #833's Arel-node-in-select fix)
- ar-76: `Book.limit(0)` — zero-limit edge case
- ar-77: `group(:author_id).having(Arel.sql("COUNT(*) > 1"))` — `SqlLiteral` in HAVING clause
- ar-78: `where(id: 1).extending(Pagination)` — SQL unchanged; `extending` mixes extra methods into the relation

## Test plan
- [x] `pnpm parity:query` — all 5 PASS, no new known-gaps, no UNEXPECTED-PASS