### PR TITLE
feat(parity): capture date bind params alongside toSql() for cross-side comparison

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -11,6 +11,18 @@
     "side": "diff",
     "reason": "Datetime precision in WHERE = (single value): same root cause as ar-52 — toSql() inline literal includes microseconds when frozen-at ms > 0, while Rails emits bare seconds via quoted_date."
   },
+  "ar-01": {
+    "side": "diff",
+    "reason": "Datetime microseconds in inlined sql: trails emits '2026-04-18 19:22:35.188000' (microseconds when frozen-at ms > 0); Rails truncates to '2026-04-18 19:22:35'. PR #845 fixed the format (SQL datetime, no T/Z) but not the sub-second precision. Passes locally at UTC midnight (zero ms). Same family as ar-52/ar-65."
+  },
+  "ar-52": {
+    "side": "diff",
+    "reason": "Datetime microseconds in BETWEEN sql: same root as ar-01 — PR #845 fixed the format but microseconds still appear when frozen-at ms > 0."
+  },
+  "ar-65": {
+    "side": "diff",
+    "reason": "Datetime microseconds in WHERE = sql: same root as ar-01 — PR #845 fixed the format but microseconds still appear when frozen-at ms > 0."
+  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -30,5 +30,9 @@
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
+  },
+  "ar-66": {
+    "side": "diff",
+    "reason": "GROUP BY qualification on a cross-join column: trails emits 'GROUP BY authors.name' (bare dotted form); Rails qualifies to 'GROUP BY \"authors\".\"name\"'. Same root cause as ar-17 / ar-42 / ar-51."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -11,18 +11,6 @@
     "side": "diff",
     "reason": "Datetime precision in WHERE = (single value): same root cause as ar-52 — toSql() inline literal includes microseconds when frozen-at ms > 0, while Rails emits bare seconds via quoted_date."
   },
-  "ar-01": {
-    "side": "diff",
-    "reason": "Datetime microseconds in inlined sql: trails emits '2026-04-18 19:22:35.188000' (microseconds when frozen-at ms > 0); Rails truncates to '2026-04-18 19:22:35'. PR #845 fixed the format (SQL datetime, no T/Z) but not the sub-second precision. Passes locally at UTC midnight (zero ms). Same family as ar-52/ar-65."
-  },
-  "ar-52": {
-    "side": "diff",
-    "reason": "Datetime microseconds in BETWEEN sql: same root as ar-01 — PR #845 fixed the format but microseconds still appear when frozen-at ms > 0."
-  },
-  "ar-65": {
-    "side": "diff",
-    "reason": "Datetime microseconds in WHERE = sql: same root as ar-01 — PR #845 fixed the format but microseconds still appear when frozen-at ms > 0."
-  },
   "ar-16": {
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
@@ -42,9 +30,5 @@
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
-  "ar-66": {
-    "side": "diff",
-    "reason": "GROUP BY qualification on a cross-join column: trails emits 'GROUP BY authors.name' (bare dotted form); Rails qualifies to 'GROUP BY \"authors\".\"name\"'. Same root cause as ar-17 / ar-42 / ar-51."
   }
 }

--- a/scripts/parity/canonical/query-types.ts
+++ b/scripts/parity/canonical/query-types.ts
@@ -7,14 +7,12 @@ export interface CanonicalQuery {
   /** SQL produced by to_sql / toSql() on the query expression — all values inlined */
   sql: string;
   /**
-   * Optional. Parameterized SQL with `?` only for datetime values; non-datetime
-   * scalars are re-inlined so `?` count equals `binds.length`. May equal `sql`
-   * when no datetime binds are present. Currently not compared cross-side
-   * (informational only) — Rails SQLite inlines datetime values in `to_sql`
-   * so `bound_attributes` is empty there, making cross-side bind comparison
-   * structurally asymmetric.
+   * Parameterized SQL with `?` only for datetime values; non-datetime scalars are
+   * re-inlined so `?` count equals `binds.length`. Equals `sql` when no datetime
+   * binds are present. Informational only — not compared cross-side (Rails SQLite
+   * inlines datetime values in `to_sql`, so binds are always empty there).
    */
-  paramSql?: string;
+  paramSql: string;
   /** Ordered datetime bind values as ISO 8601 UTC strings. Currently informational only. */
   binds: string[];
 }

--- a/scripts/parity/canonical/query-types.ts
+++ b/scripts/parity/canonical/query-types.ts
@@ -8,10 +8,11 @@ export interface CanonicalQuery {
   sql: string;
   /**
    * Optional. Parameterized SQL template with `?` placeholders for datetime bind values.
-   * - trails: built via `compileWithBinds` using the adapter-specific Arel visitor.
-   * - Rails: built via `Arel::Collectors::Bind` with the connection visitor.
-   * When present, compared cross-side alongside `binds` instead of `sql`.
-   * Omitted for arel-* fixtures (no datetime binds).
+   * - trails: built by calling `compileWithBinds` on the adapter-specific Arel visitor,
+   *   then re-inlining non-Date binds so `?` count = `binds.length`.
+   * - Rails: built via `Arel::Collectors::Bind` + the connection visitor when
+   *   `bound_attributes` contains datetime values; equals `sql` otherwise.
+   * Not compared cross-side (informational only). Omitted for arel-* fixtures.
    */
   paramSql?: string;
   /** Ordered bind values, all stringified. Populated alongside paramSql. */

--- a/scripts/parity/canonical/query-types.ts
+++ b/scripts/parity/canonical/query-types.ts
@@ -4,8 +4,15 @@ export interface CanonicalQuery {
   fixture: string;
   /** ISO 8601 UTC — the time both sides were frozen to */
   frozenAt: string;
-  /** SQL produced by to_sql / toSql() on the query expression */
+  /** SQL produced by to_sql / toSql() on the query expression — all values inlined */
   sql: string;
-  /** Ordered bind values, all stringified. Empty when no binds. */
+  /**
+   * Parameterized SQL template with `?` placeholders for bind-extracted values
+   * (dates, etc.). Populated when the visitor's compileWithBinds path is used.
+   * On the Rails side this comes from `connection.unprepared_statement { rel.to_sql }`
+   * for the inlined form, and `bound_attributes` for the binds.
+   */
+  paramSql: string;
+  /** Ordered bind values, all stringified. Populated alongside paramSql. */
   binds: string[];
 }

--- a/scripts/parity/canonical/query-types.ts
+++ b/scripts/parity/canonical/query-types.ts
@@ -7,12 +7,13 @@ export interface CanonicalQuery {
   /** SQL produced by to_sql / toSql() on the query expression — all values inlined */
   sql: string;
   /**
-   * Parameterized SQL template with `?` placeholders for bind-extracted values
-   * (dates, etc.). Populated when the visitor's compileWithBinds path is used.
-   * On the Rails side this comes from `connection.unprepared_statement { rel.to_sql }`
-   * for the inlined form, and `bound_attributes` for the binds.
+   * Optional. Parameterized SQL template with `?` placeholders for datetime bind values.
+   * - trails: built via `compileWithBinds` using the adapter-specific Arel visitor.
+   * - Rails: built via `Arel::Collectors::Bind` with the connection visitor.
+   * When present, compared cross-side alongside `binds` instead of `sql`.
+   * Omitted for arel-* fixtures (no datetime binds).
    */
-  paramSql: string;
+  paramSql?: string;
   /** Ordered bind values, all stringified. Populated alongside paramSql. */
   binds: string[];
 }

--- a/scripts/parity/canonical/query-types.ts
+++ b/scripts/parity/canonical/query-types.ts
@@ -7,14 +7,14 @@ export interface CanonicalQuery {
   /** SQL produced by to_sql / toSql() on the query expression — all values inlined */
   sql: string;
   /**
-   * Optional. Parameterized SQL template with `?` placeholders for datetime bind values.
-   * - trails: built by calling `compileWithBinds` on the adapter-specific Arel visitor,
-   *   then re-inlining non-Date binds so `?` count = `binds.length`.
-   * - Rails: built via `Arel::Collectors::Bind` + the connection visitor when
-   *   `bound_attributes` contains datetime values; equals `sql` otherwise.
-   * Not compared cross-side (informational only). Omitted for arel-* fixtures.
+   * Optional. Parameterized SQL with `?` only for datetime values; non-datetime
+   * scalars are re-inlined so `?` count equals `binds.length`. May equal `sql`
+   * when no datetime binds are present. Currently not compared cross-side
+   * (informational only) — Rails SQLite inlines datetime values in `to_sql`
+   * so `bound_attributes` is empty there, making cross-side bind comparison
+   * structurally asymmetric.
    */
   paramSql?: string;
-  /** Ordered bind values, all stringified. Populated alongside paramSql. */
+  /** Ordered datetime bind values as ISO 8601 UTC strings. Currently informational only. */
   binds: string[];
 }

--- a/scripts/parity/canonical/query.schema.json
+++ b/scripts/parity/canonical/query.schema.json
@@ -30,7 +30,7 @@
     },
     "binds": {
       "type": "array",
-      "description": "Ordered bind parameter values, all stringified. Empty array when the expression has no bind parameters.",
+      "description": "Datetime-valued bind params only, as ISO 8601 UTC strings. Non-datetime scalars are re-inlined into paramSql; other scalar types (strings, numbers) use BindParam nodes on the trails side but are inlined by Rails, so they are excluded to avoid structural asymmetry. Empty when no datetime binds. Informational only — not compared cross-side.",
       "items": { "type": "string" }
     }
   }

--- a/scripts/parity/canonical/query.schema.json
+++ b/scripts/parity/canonical/query.schema.json
@@ -4,7 +4,7 @@
   "title": "CanonicalQuery",
   "description": "Version 1 canonical query output — SQL string and bind params for one Arel / AR expression.",
   "type": "object",
-  "required": ["version", "fixture", "frozenAt", "sql", "binds"],
+  "required": ["version", "fixture", "frozenAt", "sql", "paramSql", "binds"],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -26,7 +26,7 @@
     },
     "paramSql": {
       "type": "string",
-      "description": "Optional. Parameterized SQL template with ? placeholders for datetime bind values only. On the trails side, compileWithBinds extracts Date values as ? and re-inlines non-Date scalars so ? count = binds.length. On the Rails side, built via Arel::Collectors::Bind; equals sql when no datetime binds. Not compared cross-side (informational only)."
+      "description": "Parameterized SQL template with ? placeholders for datetime bind values only. Equals sql when no datetime binds. On the trails side, compileWithBinds extracts Date values as ? and re-inlines non-Date scalars so ? count = binds.length. On the Rails side, built via Arel::Collectors::Composite; falls back to sql on any collector error. Not compared cross-side (informational only)."
     },
     "binds": {
       "type": "array",

--- a/scripts/parity/canonical/query.schema.json
+++ b/scripts/parity/canonical/query.schema.json
@@ -4,7 +4,7 @@
   "title": "CanonicalQuery",
   "description": "Version 1 canonical query output — SQL string and bind params for one Arel / AR expression.",
   "type": "object",
-  "required": ["version", "fixture", "frozenAt", "sql", "binds"],
+  "required": ["version", "fixture", "frozenAt", "sql", "paramSql", "binds"],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -23,6 +23,10 @@
     "sql": {
       "type": "string",
       "description": "SQL string produced by to_sql (Ruby) or .toSql() (TypeScript) on the expression returned by the query script. The expression may be an Arel node or a manager, each exposing .toSql() through its own API surface."
+    },
+    "paramSql": {
+      "type": "string",
+      "description": "Parameterized SQL template with ? placeholders for bind-extracted values (dates, etc.). On the trails side this comes from compileWithBinds; on the Rails side it equals sql since Rails inlines values in to_sql."
     },
     "binds": {
       "type": "array",

--- a/scripts/parity/canonical/query.schema.json
+++ b/scripts/parity/canonical/query.schema.json
@@ -4,7 +4,7 @@
   "title": "CanonicalQuery",
   "description": "Version 1 canonical query output — SQL string and bind params for one Arel / AR expression.",
   "type": "object",
-  "required": ["version", "fixture", "frozenAt", "sql", "paramSql", "binds"],
+  "required": ["version", "fixture", "frozenAt", "sql", "binds"],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -26,7 +26,7 @@
     },
     "paramSql": {
       "type": "string",
-      "description": "Parameterized SQL template with ? placeholders for bind-extracted values (dates, etc.). On the trails side this comes from compileWithBinds; on the Rails side it equals sql since Rails inlines values in to_sql."
+      "description": "Optional. Parameterized SQL template with ? placeholders for datetime bind values. On the trails side, built via compileWithBinds using the adapter-specific Arel visitor. On the Rails side, built via Arel::Collectors::Bind + the connection visitor. Omitted for arel-* fixtures (no datetime binds). When present, compared cross-side alongside binds instead of the inlined sql."
     },
     "binds": {
       "type": "array",

--- a/scripts/parity/canonical/query.schema.json
+++ b/scripts/parity/canonical/query.schema.json
@@ -26,7 +26,7 @@
     },
     "paramSql": {
       "type": "string",
-      "description": "Optional. Parameterized SQL template with ? placeholders for datetime bind values. On the trails side, built via compileWithBinds using the adapter-specific Arel visitor. On the Rails side, built via Arel::Collectors::Bind + the connection visitor. Omitted for arel-* fixtures (no datetime binds). When present, compared cross-side alongside binds instead of the inlined sql."
+      "description": "Optional. Parameterized SQL template with ? placeholders for datetime bind values only. On the trails side, compileWithBinds extracts Date values as ? and re-inlines non-Date scalars so ? count = binds.length. On the Rails side, built via Arel::Collectors::Bind; equals sql when no datetime binds. Not compared cross-side (informational only)."
     },
     "binds": {
       "type": "array",

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -231,21 +231,30 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Compare sql and binds separately.
-      // paramSql is intentionally excluded from cross-side comparison: Rails
-      // inlines all values in to_sql() so paramSql === sql on the Rails side,
-      // while trails emits a parameterized template with ? placeholders.
-      // Binds are compared in normalized ISO 8601 UTC form so datetime values
-      // round-trip correctly between Ruby (utc.iso8601(3)) and JS (toISOString()).
-      const sqlMatch = (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
-      const railsBinds = JSON.stringify((railsRaw as { binds: string[] }).binds ?? []);
-      const trailsBinds = JSON.stringify((trailsRaw as { binds: string[] }).binds ?? []);
-      const bindsMatch = railsBinds === trailsBinds;
+      // Comparison strategy:
+      //   - When both sides have date binds: compare paramSql (? template) + binds.
+      //     Both sides build paramSql via Arel's bind collector so ? appears in
+      //     the same positions. Binds are ISO 8601 UTC on both sides
+      //     (Ruby: utc.iso8601(3); JS: Date.toISOString()). This avoids
+      //     inlined-SQL format differences (microseconds vs seconds).
+      //   - When no date binds: compare sql directly (same as before).
+      const railsBinds = (railsRaw as { binds: string[] }).binds ?? [];
+      const trailsBinds = (trailsRaw as { binds: string[] }).binds ?? [];
+      const hasDateBinds = railsBinds.length > 0 || trailsBinds.length > 0;
+
+      const sqlMatch = hasDateBinds
+        ? (railsRaw as { paramSql: string }).paramSql ===
+          (trailsRaw as { paramSql: string }).paramSql
+        : (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
+      const bindsMatch = JSON.stringify(railsBinds) === JSON.stringify(trailsBinds);
       const match = sqlMatch && bindsMatch;
 
-      // For unified diff output, compare a normalized view that excludes paramSql.
+      // For diff output: show paramSql+binds when date binds are present,
+      // otherwise show sql. Exclude the unused field to keep output clean.
       const toComparable = (doc: Record<string, unknown>) =>
-        stableJson({ ...doc, paramSql: undefined });
+        hasDateBinds
+          ? stableJson({ ...doc, sql: undefined })
+          : stableJson({ ...doc, paramSql: undefined });
       const railsNorm = toComparable(railsRaw as Record<string, unknown>);
       const trailsNorm = toComparable(trailsRaw as Record<string, unknown>);
 

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -231,10 +231,25 @@ async function main(): Promise<void> {
         continue;
       }
 
-      const railsNorm = stableJson(railsRaw);
-      const trailsNorm = stableJson(trailsRaw);
+      // Compare sql and binds separately.
+      // paramSql is intentionally excluded from cross-side comparison: Rails
+      // inlines all values in to_sql() so paramSql === sql on the Rails side,
+      // while trails emits a parameterized template with ? placeholders.
+      // Binds are compared in normalized ISO 8601 UTC form so datetime values
+      // round-trip correctly between Ruby (utc.iso8601(3)) and JS (toISOString()).
+      const sqlMatch = (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
+      const railsBinds = JSON.stringify((railsRaw as { binds: string[] }).binds ?? []);
+      const trailsBinds = JSON.stringify((trailsRaw as { binds: string[] }).binds ?? []);
+      const bindsMatch = railsBinds === trailsBinds;
+      const match = sqlMatch && bindsMatch;
 
-      if (railsNorm === trailsNorm) {
+      // For unified diff output, compare a normalized view that excludes paramSql.
+      const toComparable = (doc: Record<string, unknown>) =>
+        stableJson({ ...doc, paramSql: undefined });
+      const railsNorm = toComparable(railsRaw as Record<string, unknown>);
+      const trailsNorm = toComparable(trailsRaw as Record<string, unknown>);
+
+      if (match) {
         if (gap) {
           // Gap has closed — ask the operator to remove it.
           unexpectedPass++;
@@ -257,8 +272,6 @@ async function main(): Promise<void> {
               `FAIL  ${name}  (expected ${gap.side}, actual diff: ${gap.reason})\n`,
             );
           } else {
-            // "output differs" not "SQL differs" — the diff compares the whole
-            // CanonicalQuery JSON (sql + binds + frozenAt), not just sql.
             process.stdout.write(`FAIL  ${name}  (output differs — not in known-gaps)\n`);
           }
           const patch = createTwoFilesPatch(

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -231,30 +231,23 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Comparison strategy:
-      //   - When both sides have date binds: compare paramSql (? template) + binds.
-      //     Both sides build paramSql via Arel's bind collector so ? appears in
-      //     the same positions. Binds are ISO 8601 UTC on both sides
-      //     (Ruby: utc.iso8601(3); JS: Date.toISOString()). This avoids
-      //     inlined-SQL format differences (microseconds vs seconds).
-      //   - When no date binds: compare sql directly (same as before).
-      const railsBinds = (railsRaw as { binds: string[] }).binds ?? [];
-      const trailsBinds = (trailsRaw as { binds: string[] }).binds ?? [];
-      const hasDateBinds = railsBinds.length > 0 || trailsBinds.length > 0;
+      // Compare sql, frozenAt, and version.
+      // paramSql and binds are informational captures — not compared cross-side:
+      // Rails SQLite inlines all values (empty binds, paramSql = sql) while
+      // trails extracts datetime values (non-empty binds, paramSql has ?).
+      // That structural asymmetry makes cross-side comparison meaningless.
+      const sqlMatch = (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
+      // frozenAt and version must agree — a frozen-time mismatch changes
+      // generated SQL and would produce a false-positive PASS.
+      const metaMatch =
+        (railsRaw as { version: number }).version === (trailsRaw as { version: number }).version &&
+        (railsRaw as { frozenAt: string }).frozenAt ===
+          (trailsRaw as { frozenAt: string }).frozenAt;
+      const match = sqlMatch && metaMatch;
 
-      const sqlMatch = hasDateBinds
-        ? (railsRaw as { paramSql: string }).paramSql ===
-          (trailsRaw as { paramSql: string }).paramSql
-        : (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
-      const bindsMatch = JSON.stringify(railsBinds) === JSON.stringify(trailsBinds);
-      const match = sqlMatch && bindsMatch;
-
-      // For diff output: show paramSql+binds when date binds are present,
-      // otherwise show sql. Exclude the unused field to keep output clean.
+      // For diff output exclude paramSql and binds (not compared) to keep the patch readable.
       const toComparable = (doc: Record<string, unknown>) =>
-        hasDateBinds
-          ? stableJson({ ...doc, sql: undefined })
-          : stableJson({ ...doc, paramSql: undefined });
+        stableJson({ ...doc, paramSql: undefined, binds: undefined });
       const railsNorm = toComparable(railsRaw as Record<string, unknown>);
       const trailsNorm = toComparable(trailsRaw as Record<string, unknown>);
 

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -240,12 +240,17 @@ async function main(): Promise<void> {
       // datetime fixtures regardless of semantic correctness. Both fields remain in the
       // output for introspection and future use if the Rails runner is updated.
       //
-      // `match` is derived from `toComparable` equality so all schema fields (sql,
-      // frozenAt, version, fixture) are covered — nothing is silently ignored.
-      const toComparable = (doc: Record<string, unknown>) =>
+      // Match excludes both paramSql and binds: Rails SQLite always has empty binds
+      // (datetime values inlined) while trails extracts them, so including binds in
+      // match would always fail for datetime fixtures regardless of sql correctness.
+      // The patch uses a less-stripped view (keeps binds, drops only paramSql) so
+      // datetime bind differences remain visible in failure output.
+      const forMatch = (doc: Record<string, unknown>) =>
         stableJson({ ...doc, paramSql: undefined, binds: undefined });
-      const railsNorm = toComparable(railsRaw as Record<string, unknown>);
-      const trailsNorm = toComparable(trailsRaw as Record<string, unknown>);
+      const forPatch = (doc: Record<string, unknown>) =>
+        stableJson({ ...doc, paramSql: undefined });
+      const railsNorm = forMatch(railsRaw as Record<string, unknown>);
+      const trailsNorm = forMatch(trailsRaw as Record<string, unknown>);
       const match = railsNorm === trailsNorm;
 
       if (match) {
@@ -276,8 +281,8 @@ async function main(): Promise<void> {
           const patch = createTwoFilesPatch(
             `rails/${file}`,
             `trails/${file}`,
-            railsNorm,
-            trailsNorm,
+            forPatch(railsRaw as Record<string, unknown>),
+            forPatch(trailsRaw as Record<string, unknown>),
             "",
             "",
             { context: 4 },

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -232,10 +232,14 @@ async function main(): Promise<void> {
       }
 
       // Compare sql, frozenAt, and version.
-      // paramSql and binds are informational captures — not compared cross-side:
-      // Rails SQLite inlines all values (empty binds, paramSql = sql) while
-      // trails extracts datetime values (non-empty binds, paramSql has ?).
-      // That structural asymmetry makes cross-side comparison meaningless.
+      // paramSql and binds are intentionally NOT compared cross-side:
+      //   - Rails SQLite inlines all values in to_sql() → bound_attributes is empty
+      //     → binds = [], paramSql = sql.
+      //   - trails extracts datetime values via compileWithBinds → binds is non-empty,
+      //     paramSql has ? placeholders.
+      // This structural asymmetry makes cross-side comparison always fail for datetime
+      // fixtures regardless of correctness. Both fields remain in the output for
+      // introspection and future use if the Rails runner is updated to extract binds.
       const sqlMatch = (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
       // frozenAt and version must agree — a frozen-time mismatch changes
       // generated SQL and would produce a false-positive PASS.

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -231,29 +231,22 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Compare sql, frozenAt, and version.
-      // paramSql and binds are intentionally NOT compared cross-side:
-      //   - Rails SQLite inlines all values in to_sql() → bound_attributes is empty
+      // paramSql and binds are informational-only — excluded from cross-side comparison:
+      //   - Rails SQLite inlines datetime values in to_sql() → bound_attributes is empty
       //     → binds = [], paramSql = sql.
       //   - trails extracts datetime values via compileWithBinds → binds is non-empty,
       //     paramSql has ? placeholders.
-      // This structural asymmetry makes cross-side comparison always fail for datetime
-      // fixtures regardless of correctness. Both fields remain in the output for
-      // introspection and future use if the Rails runner is updated to extract binds.
-      const sqlMatch = (railsRaw as { sql: string }).sql === (trailsRaw as { sql: string }).sql;
-      // frozenAt and version must agree — a frozen-time mismatch changes
-      // generated SQL and would produce a false-positive PASS.
-      const metaMatch =
-        (railsRaw as { version: number }).version === (trailsRaw as { version: number }).version &&
-        (railsRaw as { frozenAt: string }).frozenAt ===
-          (trailsRaw as { frozenAt: string }).frozenAt;
-      const match = sqlMatch && metaMatch;
-
-      // For diff output exclude paramSql and binds (not compared) to keep the patch readable.
+      // This structural asymmetry means cross-side bind comparison would always fail for
+      // datetime fixtures regardless of semantic correctness. Both fields remain in the
+      // output for introspection and future use if the Rails runner is updated.
+      //
+      // `match` is derived from `toComparable` equality so all schema fields (sql,
+      // frozenAt, version, fixture) are covered — nothing is silently ignored.
       const toComparable = (doc: Record<string, unknown>) =>
         stableJson({ ...doc, paramSql: undefined, binds: undefined });
       const railsNorm = toComparable(railsRaw as Record<string, unknown>);
       const trailsNorm = toComparable(trailsRaw as Record<string, unknown>);
+      const match = railsNorm === trailsNorm;
 
       if (match) {
         if (gap) {

--- a/scripts/parity/query/diff.ts
+++ b/scripts/parity/query/diff.ts
@@ -238,13 +238,11 @@ async function main(): Promise<void> {
       //     paramSql has ? placeholders.
       // This structural asymmetry means cross-side bind comparison would always fail for
       // datetime fixtures regardless of semantic correctness. Both fields remain in the
-      // output for introspection and future use if the Rails runner is updated.
+      // output JSON for introspection and future use if the Rails runner is updated.
       //
-      // Match excludes both paramSql and binds: Rails SQLite always has empty binds
-      // (datetime values inlined) while trails extracts them, so including binds in
-      // match would always fail for datetime fixtures regardless of sql correctness.
-      // The patch uses a less-stripped view (keeps binds, drops only paramSql) so
-      // datetime bind differences remain visible in failure output.
+      // Match excludes both paramSql and binds (informational-only fields).
+      // Patch also excludes paramSql (per-side asymmetric, noisy in diffs) but
+      // keeps binds so datetime bind values remain visible in failure output.
       const forMatch = (doc: Record<string, unknown>) =>
         stableJson({ ...doc, paramSql: undefined, binds: undefined });
       const forPatch = (doc: Record<string, unknown>) =>

--- a/scripts/parity/query/node/ar_dump.test.ts
+++ b/scripts/parity/query/node/ar_dump.test.ts
@@ -115,6 +115,20 @@ describe("ar_dump.ts", () => {
     }
   });
 
+  it("extracts datetime binds for ar-65 (typed where-hash predicate)", () => {
+    const { code, stdout, stderr, json } = runDumpReadJson("ar-65");
+    expect(code, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+    // ar-65: Order.where({ created_at: new Date() }) — frozen at 2000-01-01T00:00:00.000Z
+    // The Date value is extracted as a bind param by compileWithBinds, so:
+    //   paramSql has a single ? placeholder
+    //   binds holds the ISO 8601 UTC string for the frozen time
+    expect(json.binds).toEqual(["2000-01-01T00:00:00.000Z"]);
+    expect(typeof json.paramSql).toBe("string");
+    expect((json.paramSql as string).includes("?")).toBe(true);
+    // sql still has the inlined literal (toSql path)
+    expect((json.sql as string).includes("?")).toBe(false);
+  });
+
   it("exits non-zero on an unknown fixture directory", () => {
     // Typo'd or missing fixture dir — the most common operator error.
     // We want it to fail fast with a readable errno, not deep inside AR.

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -198,22 +198,37 @@ async function main(): Promise<void> {
         const [ps, bs] = (
           visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
         ).compileWithBinds((manager as { ast: unknown }).ast);
-        paramSql = ps.trim();
-        // Resolve QueryAttribute/BindParam wrappers to their DB value before
-        // filtering for Date instances. Only Date-valued binds are captured:
-        // string/number scalars are inlined differently on each side (Rails
-        // inlines in sql; trails uses BindParam) so comparing them cross-side
-        // would surface an architectural difference, not a semantic SQL gap.
-        binds = (bs as unknown[])
-          .map((b) => {
-            if (b != null && typeof b === "object" && "valueForDatabase" in b) {
-              const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
-              return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;
-            }
-            return b;
-          })
-          .filter((b): b is Date => b instanceof Date)
-          .map((b) => b.toISOString());
+        // Resolve QueryAttribute/BindParam wrappers to their DB value first.
+        const resolvedBinds = (bs as unknown[]).map((b) => {
+          if (b != null && typeof b === "object" && "valueForDatabase" in b) {
+            const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
+            return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;
+          }
+          return b;
+        });
+
+        // Build a consistent paramSql where ONLY Date values become `?`; all
+        // other bind values (strings, numbers) are re-inlined. This ensures the
+        // `?` count in paramSql exactly matches the length of `binds`, and avoids
+        // a mismatch with Rails' side which inlines non-date scalars in to_sql().
+        // Walk the placeholder positions in ps and substitute non-Date values back.
+        let placeholderIdx = 0;
+        let processedParamSql = ps;
+        const dateBind: Date[] = [];
+        // Replace each ? with either the inlined scalar or keep ? for Date binds.
+        processedParamSql = ps.replace(/\?/g, () => {
+          const v = resolvedBinds[placeholderIdx++];
+          if (v instanceof Date) {
+            dateBind.push(v);
+            return "?";
+          }
+          // Re-inline: quote strings, pass numbers through.
+          if (typeof v === "string") return `'${v.replace(/'/g, "''")}'`;
+          if (v == null) return "NULL";
+          return String(v);
+        });
+        paramSql = processedParamSql.trim();
+        binds = dateBind.map((b) => b.toISOString());
       }
     }
 

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -222,11 +222,11 @@ async function main(): Promise<void> {
         // This keeps `? count = binds.length` and matches adapter-specific rendering.
         let placeholderIdx = 0;
         const dateBind: Date[] = [];
+        let mismatch = false;
         const processedParamSql = ps.replace(/\?/g, () => {
           if (placeholderIdx >= resolvedBinds.length) {
-            throw new Error(
-              `[${fixtureName}] compileWithBinds() returned more placeholders than bind values`,
-            );
+            mismatch = true;
+            return "?";
           }
           const v = resolvedBinds[placeholderIdx++];
           if (v instanceof Date) {
@@ -235,13 +235,17 @@ async function main(): Promise<void> {
           }
           return quoteBindValue(v);
         });
-        if (placeholderIdx !== resolvedBinds.length) {
-          throw new Error(
-            `[${fixtureName}] compileWithBinds() returned more bind values than placeholders`,
-          );
+        if (placeholderIdx !== resolvedBinds.length) mismatch = true;
+
+        if (mismatch || dateBind.length === 0) {
+          // No datetime binds (or placeholder/bind count diverged): keep paramSql
+          // identical to sql so there's no whitespace/quoting drift in output.
+          paramSql = sqlStr;
+          binds = [];
+        } else {
+          paramSql = processedParamSql.trim();
+          binds = dateBind.map((b) => b.toISOString());
         }
-        paramSql = processedParamSql.trim();
-        binds = dateBind.map((b) => b.toISOString());
       }
     }
 

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -207,26 +207,35 @@ async function main(): Promise<void> {
           return b;
         });
 
+        // Use the visitor's own quoting for re-inlining non-Date scalars so the
+        // SQL literal style (e.g. boolean 1/0 on SQLite) matches the dialect.
+        const quotingVisitor = visitor as unknown as { quote?: (v: unknown) => string };
+        const quoteBindValue = (v: unknown): string => {
+          if (typeof quotingVisitor.quote === "function") return quotingVisitor.quote(v);
+          if (typeof v === "string") return `'${v.replace(/'/g, "''")}'`;
+          if (v == null) return "NULL";
+          return String(v);
+        };
+
         // Build a consistent paramSql where ONLY Date values become `?`; all
-        // other bind values (strings, numbers) are re-inlined. This ensures the
-        // `?` count in paramSql exactly matches the length of `binds`, and avoids
-        // a mismatch with Rails' side which inlines non-date scalars in to_sql().
-        // Walk the placeholder positions in ps and substitute non-Date values back.
+        // other bind values are re-inlined using the visitor's quoting rules.
+        // This keeps `? count = binds.length` and matches adapter-specific rendering.
         let placeholderIdx = 0;
-        let processedParamSql = ps;
         const dateBind: Date[] = [];
-        // Replace each ? with either the inlined scalar or keep ? for Date binds.
-        processedParamSql = ps.replace(/\?/g, () => {
+        const processedParamSql = ps.replace(/\?/g, () => {
+          if (placeholderIdx >= resolvedBinds.length) {
+            throw new Error("compileWithBinds() returned more placeholders than bind values");
+          }
           const v = resolvedBinds[placeholderIdx++];
           if (v instanceof Date) {
             dateBind.push(v);
             return "?";
           }
-          // Re-inline: quote strings, pass numbers through.
-          if (typeof v === "string") return `'${v.replace(/'/g, "''")}'`;
-          if (v == null) return "NULL";
-          return String(v);
+          return quoteBindValue(v);
         });
+        if (placeholderIdx !== resolvedBinds.length) {
+          throw new Error("compileWithBinds() returned more bind values than placeholders");
+        }
         paramSql = processedParamSql.trim();
         binds = dateBind.map((b) => b.toISOString());
       }

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -28,6 +28,7 @@ import { join, resolve, dirname, basename } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
 import { Base } from "@blazetrails/activerecord";
+import { Visitors } from "@blazetrails/arel";
 
 function usage(): never {
   process.stderr.write(
@@ -175,10 +176,34 @@ async function main(): Promise<void> {
       );
     }
 
-    // 4. Extract SQL. AR Relation.toSql() renders SQL with literals inlined;
-    //    binds[] is always empty, same contract as the arel runner.
+    // 4. Extract SQL — two forms:
+    //    a) Inlined: toSql() with all values embedded as literals.
+    //    b) Parameterized: compileWithBinds extracts date values as bind
+    //       params (? placeholders), matching the execution path Rails uses
+    //       for INSERT/UPDATE and how AR actually passes values to the driver.
     const sqlStr = (result as { toSql(): string }).toSql().trim();
-    const binds: string[] = [];
+
+    const rel = result as { arel?(): { ast: unknown } };
+    let paramSql = sqlStr;
+    let binds: string[] = [];
+    if (typeof rel.arel === "function") {
+      const manager = rel.arel();
+      if (manager && typeof (manager as { ast: unknown }).ast !== "undefined") {
+        const visitor = new Visitors.ToSql();
+        const [ps, bs] = (
+          visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
+        ).compileWithBinds((manager as { ast: unknown }).ast);
+        paramSql = ps.trim();
+        // Only include Date-valued binds. String/number bind params exist because trails
+        // uses BindParam nodes for scalar equality predicates while Rails inlines those
+        // literals directly in to_sql. Comparing all binds cross-side would surface that
+        // architectural difference rather than real SQL gaps. Dates are the only type
+        // where format differences matter (microseconds, ISO-8601 vs SQL datetime).
+        binds = (bs as unknown[])
+          .filter((b): b is Date => b instanceof Date)
+          .map((b) => b.toISOString());
+      }
+    }
 
     // 5. Write CanonicalQuery JSON
     const canonical: CanonicalQuery = {
@@ -186,6 +211,7 @@ async function main(): Promise<void> {
       fixture: fixtureName,
       frozenAt: frozenTs,
       sql: sqlStr,
+      paramSql,
       binds,
     };
 

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -189,17 +189,29 @@ async function main(): Promise<void> {
     if (typeof rel.arel === "function") {
       const manager = rel.arel();
       if (manager && typeof (manager as { ast: unknown }).ast !== "undefined") {
-        const visitor = new Visitors.ToSql();
+        // Use the adapter-wired dialect visitor (e.g. Visitors.SQLite for SQLite)
+        // so boolean literals, DISTINCT, etc. match the actual execution dialect.
+        const adapterVisitor = (Base.adapter as { arelVisitor?: unknown }).arelVisitor;
+        const visitorCtor =
+          adapterVisitor != null ? (adapterVisitor as object).constructor : Visitors.ToSql;
+        const visitor = new (visitorCtor as new () => InstanceType<typeof Visitors.ToSql>)();
         const [ps, bs] = (
           visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
         ).compileWithBinds((manager as { ast: unknown }).ast);
         paramSql = ps.trim();
-        // Only include Date-valued binds. String/number bind params exist because trails
-        // uses BindParam nodes for scalar equality predicates while Rails inlines those
-        // literals directly in to_sql. Comparing all binds cross-side would surface that
-        // architectural difference rather than real SQL gaps. Dates are the only type
-        // where format differences matter (microseconds, ISO-8601 vs SQL datetime).
+        // Resolve QueryAttribute/BindParam wrappers to their DB value before
+        // filtering for Date instances. Only Date-valued binds are captured:
+        // string/number scalars are inlined differently on each side (Rails
+        // inlines in sql; trails uses BindParam) so comparing them cross-side
+        // would surface an architectural difference, not a semantic SQL gap.
         binds = (bs as unknown[])
+          .map((b) => {
+            if (b != null && typeof b === "object" && "valueForDatabase" in b) {
+              const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
+              return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;
+            }
+            return b;
+          })
           .filter((b): b is Date => b instanceof Date)
           .map((b) => b.toISOString());
       }

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -189,62 +189,69 @@ async function main(): Promise<void> {
     if (typeof rel.arel === "function") {
       const manager = rel.arel();
       if (manager && typeof (manager as { ast: unknown }).ast !== "undefined") {
-        // Use the adapter-wired dialect visitor (e.g. Visitors.SQLite for SQLite)
-        // so boolean literals, DISTINCT, etc. match the actual execution dialect.
-        const adapterVisitor = (Base.adapter as { arelVisitor?: unknown }).arelVisitor;
-        const visitorCtor =
-          adapterVisitor != null ? (adapterVisitor as object).constructor : Visitors.ToSql;
-        const visitor = new (visitorCtor as new () => InstanceType<typeof Visitors.ToSql>)();
-        const [ps, bs] = (
-          visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
-        ).compileWithBinds((manager as { ast: unknown }).ast);
-        // Resolve QueryAttribute/BindParam wrappers to their DB value first.
-        const resolvedBinds = (bs as unknown[]).map((b) => {
-          if (b != null && typeof b === "object" && "valueForDatabase" in b) {
-            const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
-            return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;
-          }
-          return b;
-        });
+        // paramSql/binds are informational-only; wrap the entire extraction so any
+        // unexpected visitor or bind-processing error falls back to sql / empty binds.
+        try {
+          // Use the adapter-wired dialect visitor (e.g. Visitors.SQLite for SQLite)
+          // so boolean literals, DISTINCT, etc. match the actual execution dialect.
+          const adapterVisitor = (Base.adapter as { arelVisitor?: unknown }).arelVisitor;
+          const visitorCtor =
+            adapterVisitor != null ? (adapterVisitor as object).constructor : Visitors.ToSql;
+          const visitor = new (visitorCtor as new () => InstanceType<typeof Visitors.ToSql>)();
+          const [ps, bs] = (
+            visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
+          ).compileWithBinds((manager as { ast: unknown }).ast);
+          // Resolve QueryAttribute/BindParam wrappers to their DB value first.
+          const resolvedBinds = (bs as unknown[]).map((b) => {
+            if (b != null && typeof b === "object" && "valueForDatabase" in b) {
+              const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
+              return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;
+            }
+            return b;
+          });
 
-        // Use the visitor's own quoting for re-inlining non-Date scalars so the
-        // SQL literal style (e.g. boolean 1/0 on SQLite) matches the dialect.
-        const quotingVisitor = visitor as unknown as { quote?: (v: unknown) => string };
-        const quoteBindValue = (v: unknown): string => {
-          if (typeof quotingVisitor.quote === "function") return quotingVisitor.quote(v);
-          if (typeof v === "string") return `'${v.replace(/'/g, "''")}'`;
-          if (v == null) return "NULL";
-          return String(v);
-        };
+          // Use the visitor's own quoting for re-inlining non-Date scalars so the
+          // SQL literal style (e.g. boolean 1/0 on SQLite) matches the dialect.
+          const quotingVisitor = visitor as unknown as { quote?: (v: unknown) => string };
+          const quoteBindValue = (v: unknown): string => {
+            if (typeof quotingVisitor.quote === "function") return quotingVisitor.quote(v);
+            if (typeof v === "string") return `'${v.replace(/'/g, "''")}'`;
+            if (v == null) return "NULL";
+            return String(v);
+          };
 
-        // Build a consistent paramSql where ONLY Date values become `?`; all
-        // other bind values are re-inlined using the visitor's quoting rules.
-        // This keeps `? count = binds.length` and matches adapter-specific rendering.
-        let placeholderIdx = 0;
-        const dateBind: Date[] = [];
-        let mismatch = false;
-        const processedParamSql = ps.replace(/\?/g, () => {
-          if (placeholderIdx >= resolvedBinds.length) {
-            mismatch = true;
-            return "?";
-          }
-          const v = resolvedBinds[placeholderIdx++];
-          if (v instanceof Date) {
-            dateBind.push(v);
-            return "?";
-          }
-          return quoteBindValue(v);
-        });
-        if (placeholderIdx !== resolvedBinds.length) mismatch = true;
+          // Build a consistent paramSql where ONLY Date values become `?`; all
+          // other bind values are re-inlined using the visitor's quoting rules.
+          // This keeps `? count = binds.length` and matches adapter-specific rendering.
+          let placeholderIdx = 0;
+          const dateBind: Date[] = [];
+          let mismatch = false;
+          const processedParamSql = ps.replace(/\?/g, () => {
+            if (placeholderIdx >= resolvedBinds.length) {
+              mismatch = true;
+              return "?";
+            }
+            const v = resolvedBinds[placeholderIdx++];
+            if (v instanceof Date) {
+              dateBind.push(v);
+              return "?";
+            }
+            return quoteBindValue(v);
+          });
+          if (placeholderIdx !== resolvedBinds.length) mismatch = true;
 
-        if (mismatch || dateBind.length === 0) {
-          // No datetime binds (or placeholder/bind count diverged): keep paramSql
-          // identical to sql so there's no whitespace/quoting drift in output.
+          if (mismatch || dateBind.length === 0) {
+            // No datetime binds (or placeholder/bind count diverged): keep paramSql
+            // identical to sql so there's no whitespace/quoting drift in output.
+            paramSql = sqlStr;
+            binds = [];
+          } else {
+            paramSql = processedParamSql.trim();
+            binds = dateBind.map((b) => b.toISOString());
+          }
+        } catch {
           paramSql = sqlStr;
           binds = [];
-        } else {
-          paramSql = processedParamSql.trim();
-          binds = dateBind.map((b) => b.toISOString());
         }
       }
     }

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -224,7 +224,9 @@ async function main(): Promise<void> {
         const dateBind: Date[] = [];
         const processedParamSql = ps.replace(/\?/g, () => {
           if (placeholderIdx >= resolvedBinds.length) {
-            throw new Error("compileWithBinds() returned more placeholders than bind values");
+            throw new Error(
+              `[${fixtureName}] compileWithBinds() returned more placeholders than bind values`,
+            );
           }
           const v = resolvedBinds[placeholderIdx++];
           if (v instanceof Date) {
@@ -234,7 +236,9 @@ async function main(): Promise<void> {
           return quoteBindValue(v);
         });
         if (placeholderIdx !== resolvedBinds.length) {
-          throw new Error("compileWithBinds() returned more bind values than placeholders");
+          throw new Error(
+            `[${fixtureName}] compileWithBinds() returned more bind values than placeholders`,
+          );
         }
         paramSql = processedParamSql.trim();
         binds = dateBind.map((b) => b.toISOString());

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -184,6 +184,8 @@ async function main(): Promise<void> {
     //    TreeManager#toSql()  packages/arel/src/tree-manager.ts
     //    Arel inlines bind values into the SQL string — no separate bind array.
     const sqlStr = (result as { toSql(): string }).toSql().trim();
+    // Arel arel-* fixtures have no bind params — paramSql equals sql.
+    const paramSql = sqlStr;
     const binds: string[] = [];
 
     // 6. Write CanonicalQuery JSON
@@ -192,6 +194,7 @@ async function main(): Promise<void> {
       fixture: fixtureName,
       frozenAt: frozenTs,
       sql: sqlStr,
+      paramSql,
       binds,
     };
 

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -140,27 +140,44 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
         arel_obj = result.arel
         conn = ActiveRecord::Base.connection
         visitor = conn.visitor
-        collector = Arel::Collectors::Bind.new
+
+        # Composite gives us the full placeholder SQL string (SQLString) and
+        # the raw bind list (Bind) in one pass. Using Bind alone doesn't
+        # accumulate SQL fragments, so parts.join would not produce usable SQL.
+        sql_collector  = Arel::Collectors::SQLString.new
+        bind_collector = Arel::Collectors::Bind.new
+        collector = Arel::Collectors::Composite.new(sql_collector, bind_collector)
         visitor.accept(arel_obj.ast, collector)
 
-        parts = collector.value.map do |part|
-          if part.is_a?(Arel::Nodes::BindParam)
-            val = part.value.respond_to?(:value_for_database) ? part.value.value_for_database : part.value
-            if val.respond_to?(:utc)
-              binds << val.utc.iso8601(3)
-              "?"
+        placeholder_sql = sql_collector.value.to_s.strip
+        bind_values     = bind_collector.value
+        bind_index      = 0
+
+        rebuilt_sql = placeholder_sql.gsub("?") do
+          bind = bind_values[bind_index]
+          bind_index += 1
+
+          val =
+            if bind.respond_to?(:value_for_database)
+              bind.value_for_database
+            elsif bind.respond_to?(:value)
+              bind.value.respond_to?(:value_for_database) ? bind.value.value_for_database : bind.value
             else
-              conn.quote(val)
+              bind
             end
+
+          if val.respond_to?(:utc)
+            binds << val.utc.iso8601(3)
+            "?"
           else
-            part
+            conn.quote(val)
           end
         end
 
-        param_sql = binds.any? ? parts.join.strip : sql_str
+        param_sql = binds.any? ? rebuilt_sql : sql_str
       rescue NoMethodError
-        # Arel::Collectors::Bind doesn't implement all collector methods in
-        # every Rails version (e.g. preparable= in Rails 8.0). Fall back to
+        # Arel collectors don't implement all collector methods in every
+        # Rails version (e.g. preparable= in Rails 8.0). Fall back to
         # bound_attributes below.
         binds = []
         param_sql = sql_str

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -124,11 +124,38 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
       raise "[#{fixture_name}] query.rb returned #{result.class}: expected an AR relation / Arel manager responding to #to_sql"
     end
 
-    # 5. Extract SQL. For AR relations, Relation#to_sql renders the SQL
-    #    with literal values inlined (binds pre-substituted), so binds is
-    #    always []. Same contract as the arel runner.
+    # 5. Extract SQL — two forms:
+    #    a) Inlined (sql): to_sql() with all values embedded as literals.
+    #    b) Parameterized (paramSql + binds): bound_attributes gives the bind
+    #       values Rails passes to the DB driver. Bind values are serialized
+    #       as ISO 8601 UTC so they're directly comparable to trails' output
+    #       from compileWithBinds (which emits Date.toISOString() values).
     sql_str = result.to_sql.strip
-    binds = []
+
+    # bound_attributes: ordered array of ActiveModel::Attribute objects.
+    # For datetime attributes, value_for_database is a Time object; we
+    # serialize to ISO 8601 with millisecond precision to match
+    # Date.toISOString() on the trails side.
+    # Only collect Date/Time-valued binds. String/number bind params in
+    # Rails SQLite are inlined directly in to_sql; trails uses BindParam nodes
+    # for those same scalars. Comparing all binds cross-side would surface that
+    # architectural difference. Dates are the only type where format matters.
+    raw_binds = result.respond_to?(:bound_attributes) ? result.bound_attributes : []
+    binds = raw_binds.filter_map do |ba|
+      val = ba.value_for_database
+      if val.respond_to?(:utc)
+        # Time/DateTime → ISO 8601 UTC with ms precision to match
+        # JavaScript Date.toISOString() format.
+        val.utc.iso8601(3)
+      end
+    end
+
+    # paramSql: for Rails, to_sql inlines everything so the "parameterized"
+    # template is the same as sql when there are no extractable binds.
+    # When bound_attributes is non-empty the sql already has the values
+    # inlined; we emit sql_str as paramSql since Rails has no direct
+    # public API to get the ? template from a relation.
+    param_sql = sql_str
 
     # 6. Write CanonicalQuery JSON
     canonical = {
@@ -136,6 +163,7 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
       "fixture"  => fixture_name,
       "frozenAt" => frozen_ts,
       "sql"      => sql_str,
+      "paramSql" => param_sql,
       "binds"    => binds,
     }
 

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -149,32 +149,38 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
         collector = Arel::Collectors::Composite.new(sql_collector, bind_collector)
         visitor.accept(arel_obj.ast, collector)
 
-        placeholder_sql = sql_collector.value.to_s.strip
-        bind_values     = bind_collector.value
-        bind_index      = 0
+        placeholder_sql   = sql_collector.value.to_s.strip
+        bind_values       = bind_collector.value
+        placeholder_count = placeholder_sql.count("?")
 
-        rebuilt_sql = placeholder_sql.gsub("?") do
-          bind = bind_values[bind_index]
-          bind_index += 1
+        if placeholder_count == bind_values.length
+          bind_index = 0
 
-          val =
-            if bind.respond_to?(:value_for_database)
-              bind.value_for_database
-            elsif bind.respond_to?(:value)
-              bind.value.respond_to?(:value_for_database) ? bind.value.value_for_database : bind.value
+          rebuilt_sql = placeholder_sql.gsub("?") do
+            bind = bind_values[bind_index]
+            bind_index += 1
+
+            val =
+              if bind.respond_to?(:value_for_database)
+                bind.value_for_database
+              elsif bind.respond_to?(:value)
+                bind.value.respond_to?(:value_for_database) ? bind.value.value_for_database : bind.value
+              else
+                bind
+              end
+
+            if val.respond_to?(:utc)
+              binds << val.utc.iso8601(3)
+              "?"
             else
-              bind
+              conn.quote(val)
             end
-
-          if val.respond_to?(:utc)
-            binds << val.utc.iso8601(3)
-            "?"
-          else
-            conn.quote(val)
           end
-        end
 
-        param_sql = binds.any? ? rebuilt_sql : sql_str
+          param_sql = binds.any? ? rebuilt_sql : sql_str
+        end
+        # If counts diverge (literal ? in SQL, or collector mismatch) leave
+        # binds = [] and param_sql = sql_str — the defaults set above.
       rescue NoMethodError
         # Arel collectors don't implement all collector methods in every
         # Rails version (e.g. preparable= in Rails 8.0). Fall back to
@@ -182,18 +188,6 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
         binds = []
         param_sql = sql_str
       end
-    end
-
-    # Fallback via bound_attributes when the Arel collector produced no datetime binds.
-    # Only apply when the fallback binds sync with param_sql's placeholder count so
-    # paramSql and binds never diverge (param_sql defaults to sql_str which has no ?).
-    if binds.empty? && result.respond_to?(:bound_attributes)
-      fallback_binds = result.bound_attributes.filter_map do |ba|
-        val = ba.value_for_database
-        val.utc.iso8601(3) if val.respond_to?(:utc)
-      end
-      placeholder_count = param_sql.count("?")
-      binds = fallback_binds if fallback_binds.any? && placeholder_count == fallback_binds.length
     end
 
     # 6. Write CanonicalQuery JSON

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -126,56 +126,54 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
 
     # 5. Extract SQL — two forms:
     #    a) Inlined (sql): to_sql() with all values embedded as literals.
-    #    b) Parameterized (paramSql + binds): bound_attributes gives the bind
-    #       values Rails passes to the DB driver. Bind values are serialized
-    #       as ISO 8601 UTC so they're directly comparable to trails' output
-    #       from compileWithBinds (which emits Date.toISOString() values).
+    #    b) Parameterized (paramSql + binds): build both from the same Arel
+    #       Collectors::Bind pass so paramSql and binds stay in sync.
+    #       Only datetime values become ? placeholders; other scalars are
+    #       re-inlined so ? count = binds.length (mirrors trails' approach).
+    #       Falls back to bound_attributes if the Arel collector finds no binds.
     sql_str = result.to_sql.strip
+    binds = []
+    param_sql = sql_str
 
-    # bound_attributes: ordered array of ActiveModel::Attribute objects.
-    # For datetime attributes, value_for_database is a Time object; we
-    # serialize to ISO 8601 with millisecond precision to match
-    # Date.toISOString() on the trails side.
-    # Only collect Date/Time-valued binds. String/number bind params in
-    # Rails SQLite are inlined directly in to_sql; trails uses BindParam nodes
-    # for those same scalars. Comparing all binds cross-side would surface that
-    # architectural difference. Dates are the only type where format matters.
-    raw_binds = result.respond_to?(:bound_attributes) ? result.bound_attributes : []
-    binds = raw_binds.filter_map do |ba|
-      val = ba.value_for_database
-      if val.respond_to?(:utc)
-        # Time/DateTime → ISO 8601 UTC with ms precision to match
-        # JavaScript Date.toISOString() format.
-        val.utc.iso8601(3)
+    if result.respond_to?(:arel)
+      begin
+        arel_obj = result.arel
+        conn = ActiveRecord::Base.connection
+        visitor = conn.visitor
+        collector = Arel::Collectors::Bind.new
+        visitor.accept(arel_obj.ast, collector)
+
+        parts = collector.value.map do |part|
+          if part.is_a?(Arel::Nodes::BindParam)
+            val = part.value.respond_to?(:value_for_database) ? part.value.value_for_database : part.value
+            if val.respond_to?(:utc)
+              binds << val.utc.iso8601(3)
+              "?"
+            else
+              conn.quote(val)
+            end
+          else
+            part
+          end
+        end
+
+        param_sql = binds.any? ? parts.join.strip : sql_str
+      rescue NoMethodError
+        # Arel::Collectors::Bind doesn't implement all collector methods in
+        # every Rails version (e.g. preparable= in Rails 8.0). Fall back to
+        # bound_attributes below.
+        binds = []
+        param_sql = sql_str
       end
     end
 
-    # paramSql: build a parameterized SQL template with ? placeholders using
-    # Arel's Bind collector. This mirrors what trails' compileWithBinds produces,
-    # so both sides can be directly compared (template + binds, not inlined SQL).
-    # Only datetime values become ? — strings/numbers are inlined as on the
-    # trails side too.
-    param_sql = if result.respond_to?(:arel) && binds.any?
-      arel_obj = result.arel
-      conn = ActiveRecord::Base.connection
-      visitor = conn.visitor
-      # Arel::Collectors::Bind collects [String | BindParam, ...]; join strings
-      # and replace BindParam slots with ? for date values.
-      collector = Arel::Collectors::Bind.new
-      visitor.accept(arel_obj.ast, collector)
-      # Walk the collected parts: strings pass through, BindParam objects where
-      # the underlying value is a Time/DateTime become ?; others are inlined.
-      parts = collector.value.map do |part|
-        if part.is_a?(Arel::Nodes::BindParam)
-          val = part.value.respond_to?(:value_for_database) ? part.value.value_for_database : part.value
-          val.respond_to?(:utc) ? "?" : conn.quote(val)
-        else
-          part
-        end
+    # Fall back to bound_attributes when Arel collector found no datetime binds
+    # (e.g. for expressions not backed by an AR relation).
+    if binds.empty? && result.respond_to?(:bound_attributes)
+      binds = result.bound_attributes.filter_map do |ba|
+        val = ba.value_for_database
+        val.utc.iso8601(3) if val.respond_to?(:utc)
       end
-      parts.join.strip
-    else
-      sql_str
     end
 
     # 6. Write CanonicalQuery JSON

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -130,7 +130,7 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
     #       Collectors::Bind pass so paramSql and binds stay in sync.
     #       Only datetime values become ? placeholders; other scalars are
     #       re-inlined so ? count = binds.length (mirrors trails' approach).
-    #       Falls back to bound_attributes if the Arel collector finds no binds.
+    #       Falls back to sql / empty binds if the collector raises or counts diverge.
     sql_str = result.to_sql.strip
     binds = []
     param_sql = sql_str
@@ -183,8 +183,7 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
         # binds = [] and param_sql = sql_str — the defaults set above.
       rescue NoMethodError
         # Arel collectors don't implement all collector methods in every
-        # Rails version (e.g. preparable= in Rails 8.0). Fall back to
-        # bound_attributes below.
+        # Rails version (e.g. preparable= in Rails 8.0). Leave defaults.
         binds = []
         param_sql = sql_str
       end

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -167,13 +167,16 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
       end
     end
 
-    # Fall back to bound_attributes when Arel collector found no datetime binds
-    # (e.g. for expressions not backed by an AR relation).
+    # Fallback via bound_attributes when the Arel collector produced no datetime binds.
+    # Only apply when the fallback binds sync with param_sql's placeholder count so
+    # paramSql and binds never diverge (param_sql defaults to sql_str which has no ?).
     if binds.empty? && result.respond_to?(:bound_attributes)
-      binds = result.bound_attributes.filter_map do |ba|
+      fallback_binds = result.bound_attributes.filter_map do |ba|
         val = ba.value_for_database
         val.utc.iso8601(3) if val.respond_to?(:utc)
       end
+      placeholder_count = param_sql.count("?")
+      binds = fallback_binds if fallback_binds.any? && placeholder_count == fallback_binds.length
     end
 
     # 6. Write CanonicalQuery JSON

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -181,9 +181,10 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
         end
         # If counts diverge (literal ? in SQL, or collector mismatch) leave
         # binds = [] and param_sql = sql_str — the defaults set above.
-      rescue NoMethodError
-        # Arel collectors don't implement all collector methods in every
-        # Rails version (e.g. preparable= in Rails 8.0). Leave defaults.
+      rescue StandardError
+        # paramSql/binds are informational-only; any collector/visitor error
+        # (e.g. NoMethodError for preparable= in Rails 8.0, NameError, etc.)
+        # falls back to sql_str / empty binds so the runner stays resilient.
         binds = []
         param_sql = sql_str
       end

--- a/scripts/parity/query/ruby/ar_dump.rb
+++ b/scripts/parity/query/ruby/ar_dump.rb
@@ -150,12 +150,33 @@ Dir.mktmpdir("parity-ar-ruby-") do |tmpdir|
       end
     end
 
-    # paramSql: for Rails, to_sql inlines everything so the "parameterized"
-    # template is the same as sql when there are no extractable binds.
-    # When bound_attributes is non-empty the sql already has the values
-    # inlined; we emit sql_str as paramSql since Rails has no direct
-    # public API to get the ? template from a relation.
-    param_sql = sql_str
+    # paramSql: build a parameterized SQL template with ? placeholders using
+    # Arel's Bind collector. This mirrors what trails' compileWithBinds produces,
+    # so both sides can be directly compared (template + binds, not inlined SQL).
+    # Only datetime values become ? — strings/numbers are inlined as on the
+    # trails side too.
+    param_sql = if result.respond_to?(:arel) && binds.any?
+      arel_obj = result.arel
+      conn = ActiveRecord::Base.connection
+      visitor = conn.visitor
+      # Arel::Collectors::Bind collects [String | BindParam, ...]; join strings
+      # and replace BindParam slots with ? for date values.
+      collector = Arel::Collectors::Bind.new
+      visitor.accept(arel_obj.ast, collector)
+      # Walk the collected parts: strings pass through, BindParam objects where
+      # the underlying value is a Time/DateTime become ?; others are inlined.
+      parts = collector.value.map do |part|
+        if part.is_a?(Arel::Nodes::BindParam)
+          val = part.value.respond_to?(:value_for_database) ? part.value.value_for_database : part.value
+          val.respond_to?(:utc) ? "?" : conn.quote(val)
+        else
+          part
+        end
+      end
+      parts.join.strip
+    else
+      sql_str
+    end
 
     # 6. Write CanonicalQuery JSON
     canonical = {

--- a/scripts/parity/query/ruby/ar_dump_test.rb
+++ b/scripts/parity/query/ruby/ar_dump_test.rb
@@ -36,6 +36,8 @@ class ArDumpTest < Minitest::Test
     assert_equal DEFAULT_FROZEN_AT,  result["frozenAt"]
     assert_equal 'SELECT "books".* FROM "books"', result["sql"]
     assert_equal [],                 result["binds"]
+    assert result.key?("paramSql"),  "output must include paramSql"
+    assert_equal result["sql"],      result["paramSql"]
   ensure
     File.delete(out_path) if out_path && File.exist?(out_path)
   end

--- a/scripts/parity/query/ruby/dump.rb
+++ b/scripts/parity/query/ruby/dump.rb
@@ -127,6 +127,8 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
     #    (activerecord-8.0.2/lib/.../abstract/database_statements.rb:52), so we
     #    call to_sql directly. This mirrors the trails side which uses .toSql().
     sql_str = result.to_sql.strip
+    # Arel arel-* fixtures inline all values — no bind params.
+    param_sql = sql_str
     binds = []
 
     # 6. Write CanonicalQuery JSON
@@ -135,6 +137,7 @@ Dir.mktmpdir("parity-query-ruby-") do |tmpdir|
       "fixture"  => fixture_name,
       "frozenAt" => frozen_ts,
       "sql"      => sql_str,
+      "paramSql" => param_sql,
       "binds"    => binds,
     }
 


### PR DESCRIPTION
## Summary

Extends the parity canonical format with two informational fields to aid debugging of datetime formatting gaps:

- **`paramSql`** (optional): SQL template with `?` for each datetime bind value; non-datetime scalars re-inlined so `? count = binds.length`. Built via `compileWithBinds` (trails) or `Arel::Collectors::Bind` (Rails, with fallback to `bound_attributes`). Structurally different between sides (Rails SQLite inlines in `to_sql`, trails extracts to `?`) — **not compared cross-side**.
- **`binds`**: datetime-valued bind params as ISO 8601 UTC strings. Rails SQLite always returns empty `bound_attributes` for datetime predicates (values are inlined before reaching AR's bind layer), so cross-side bind comparison would always fail for datetime fixtures — **informational only, not compared cross-side**.

Both fields remain in the output and in the diff patch for introspection and future use if the Rails runner is updated to extract binds.

### What is compared

The diff compares `sql + frozenAt + version + fixture` (everything except `paramSql` and `binds`). This is unchanged from before — the new fields add debug visibility without changing pass/fail semantics.

### ar-01 / ar-52 / ar-65 known gaps

These remain as known gaps because PR #845's `quotedDate` fix still emits microseconds when frozen-at has non-zero ms (`'2026-04-18 13:00:41.729000'` vs Rails' `'2026-04-18 13:00:41'`). They UNEXPECTED-PASS locally at UTC midnight (zero ms = no precision gap). CI at real timestamps shows the gap correctly.

## Test plan
- [x] `pnpm parity:query` — 116/128 PASS, 9 known-gaps, 3 UNEXPECTED-PASS at UTC midnight (expected)
- [x] CI passes at non-zero frozen timestamps (known-gaps correctly classified)