### PR TITLE
feat(encryption): fix supportUnencryptedData per-attribute; unskip 4 tests

### DIFF
--- a/packages/activerecord/src/encryption/concurrency.test.ts
+++ b/packages/activerecord/src/encryption/concurrency.test.ts
@@ -1,5 +1,36 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+  makeEncryptedBook,
+} from "./test-helpers.js";
 
 describe("ActiveRecord::Encryption::ConcurrencyTest", () => {
-  it.skip("models can be encrypted and decrypted in different threads concurrently", () => {});
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    configSnapshot = snapshotEncryptionConfig();
+    configureEncryption();
+  });
+
+  afterEach(() => {
+    restoreEncryptionConfig(configSnapshot);
+  });
+
+  it("models can be encrypted and decrypted in different threads concurrently", async () => {
+    // JS is single-threaded; this exercises concurrent async encrypt/decrypt operations
+    // (multiple Promises in flight) to verify no shared-state corruption occurs.
+    const Book = makeEncryptedBook(freshAdapter());
+    new Book();
+
+    const names = Array.from({ length: 10 }, (_, i) => `Concurrent Book ${i}`);
+    const created = await Promise.all(names.map((name) => Book.create({ name })));
+    const reloaded = await Promise.all(created.map((b: any) => Book.find(b.id)));
+
+    for (let i = 0; i < names.length; i++) {
+      expect((reloaded[i] as any).name).toBe(names[i]);
+    }
+  });
 });

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -253,9 +253,10 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   get supportUnencryptedData(): boolean {
     if (this._previousType) return false;
-    return (
-      Configurable.config.supportUnencryptedData === true && this.scheme.isSupportUnencryptedData()
-    );
+    // Mirrors Rails' EncryptedAttributeType#support_unencrypted_data? which delegates
+    // directly to scheme.support_unencrypted_data?. The scheme already handles the
+    // per-attribute override vs global config fallback — no extra AND-gate needed here.
+    return this.scheme.isSupportUnencryptedData();
   }
 }
 

--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -70,16 +70,71 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     expect(dup.errors.count).toBe(1);
   });
 
-  it.skip("uniqueness validations work when mixing encrypted an unencrypted data", () => {
-    // requires same adapter/table access from two different model classes
+  it("uniqueness validations work when mixing encrypted an unencrypted data", async () => {
+    // Global supportUnencryptedData = true → plain-text fallback scheme is appended to
+    // previousTypes, so the uniqueness query also searches for the unencrypted value.
+    Configurable.config.supportUnencryptedData = true;
+
+    const adp = freshAdapter();
+    const Book = makeFreshModel(adp, { id: "integer", name: "string" });
+    Book.validatesUniqueness("name");
+    Book.encrypts("name", { deterministic: true, downcase: true });
+    new Book();
+
+    // Insert unencrypted "dune" directly (simulates a row that leaked plain text).
+    const RawBook = makeFreshModel(adp, { id: "integer", name: "string" });
+    RawBook._tableName = Book._tableName;
+    new RawBook();
+    await RawBook.create({ name: "dune" });
+
+    // Creating an encrypted duplicate should fail: the query expansion includes
+    // the plain-text "dune" and finds the existing raw row.
+    const dup = await Book.create({ name: "dune" });
+    expect(dup.errors.count).toBe(1);
   });
 
-  it.skip("uniqueness validations do not work when mixing encrypted an unencrypted data and unencrypted data is opted out per-attribute", () => {
-    // needs supportUnencryptedData per-attribute option
+  it("uniqueness validations do not work when mixing encrypted an unencrypted data and unencrypted data is opted out per-attribute", async () => {
+    // Global supportUnencryptedData = true, but the attribute opts out via per-attribute
+    // supportUnencryptedData: false — so no plain-text fallback in previousTypes.
+    Configurable.config.supportUnencryptedData = true;
+
+    const adp = freshAdapter();
+    const Book = makeFreshModel(adp, { id: "integer", name: "string" });
+    Book.validatesUniqueness("name");
+    Book.encrypts("name", { deterministic: true, downcase: true, supportUnencryptedData: false });
+    new Book();
+
+    const RawBook = makeFreshModel(adp, { id: "integer", name: "string" });
+    RawBook._tableName = Book._tableName;
+    new RawBook();
+    await RawBook.create({ name: "dune" });
+
+    // Validation passes: the plain-text row is invisible to the query because
+    // the per-attribute opt-out disables the clean-text fallback scheme.
+    const book = await Book.create({ name: "dune" });
+    expect(book.errors.count).toBe(0);
   });
 
-  it.skip("uniqueness validations work when mixing encrypted an unencrypted data and unencrypted data is opted in per-attribute", () => {
-    // needs supportUnencryptedData per-attribute option
+  it("uniqueness validations work when mixing encrypted an unencrypted data and unencrypted data is opted in per-attribute", async () => {
+    // Global supportUnencryptedData = false, but the attribute explicitly opts in via
+    // supportUnencryptedData: true — so the plain-text fallback IS included.
+    Configurable.config.supportUnencryptedData = false;
+
+    const adp = freshAdapter();
+    const Book = makeFreshModel(adp, { id: "integer", name: "string" });
+    Book.validatesUniqueness("name");
+    Book.encrypts("name", { deterministic: true, downcase: true, supportUnencryptedData: true });
+    new Book();
+
+    const RawBook = makeFreshModel(adp, { id: "integer", name: "string" });
+    RawBook._tableName = Book._tableName;
+    new RawBook();
+    await RawBook.create({ name: "dune" });
+
+    // Validation fails: per-attribute opt-in adds the clean-text fallback scheme even
+    // though the global config has supportUnencryptedData = false.
+    const dup = await Book.create({ name: "dune" });
+    expect(dup.errors.count).toBe(1);
   });
 
   it("uniqueness validations work when using old encryption schemes", async () => {


### PR DESCRIPTION
## Summary

- **Bug fix**: `EncryptedAttributeType.supportUnencryptedData` incorrectly AND-gated `scheme.isSupportUnencryptedData()` with `Configurable.config.supportUnencryptedData`. This prevented per-attribute opt-in (`encrypts("name", { supportUnencryptedData: true })`) from working when the global flag was `false`. Rails delegates directly to `scheme.support_unencrypted_data?` which already handles the per-attribute-vs-global fallback — no extra gate needed.

- Unskip 4 tests:
  - `uniqueness validations work when mixing encrypted an unencrypted data` — uses table-sharing to insert a raw unencrypted row; verifies query expansion finds it when `supportUnencryptedData: true`
  - `uniqueness validations do not work when mixing encrypted an unencrypted data and unencrypted data is opted out per-attribute` — per-attribute `supportUnencryptedData: false` suppresses the plain-text fallback even when global is `true`
  - `uniqueness validations work when mixing encrypted an unencrypted data and unencrypted data is opted in per-attribute` — per-attribute `supportUnencryptedData: true` enables the fallback even when global is `false`
  - `models can be encrypted and decrypted in different threads concurrently` — concurrent `Promise.all` encrypt/decrypt round-trips (JS equivalent of Rails threads)

## Test plan

- [ ] `uniqueness-validations.test.ts` — 6 tests pass (was 3; 3 unskipped)
- [ ] `concurrency.test.ts` — 1 test passes (was 0)
- [ ] Full encryption suite — 264 passing, 17 skipped (no regressions)