### PR TITLE
feat(activerecord): type.ts + HashLookupTypeMap to 100% api:compare

### DIFF
--- a/packages/activerecord/src/type.test.ts
+++ b/packages/activerecord/src/type.test.ts
@@ -42,10 +42,10 @@ describe("TypeTest", () => {
 
   it("looking up a type for a specific adapter", () => {
     register("foo", ArgType, { override: false });
-    register("foo", PgArgType, { adapter: "postgresql" });
+    register("foo", PgArgType, { adapter: "postgres" });
 
-    expect(lookup("foo", { adapter: "sqlite3" })).toBeInstanceOf(ArgType);
-    expect(lookup("foo", { adapter: "postgresql" })).toBeInstanceOf(PgArgType);
+    expect(lookup("foo", { adapter: "sqlite" })).toBeInstanceOf(ArgType);
+    expect(lookup("foo", { adapter: "postgres" })).toBeInstanceOf(PgArgType);
   });
 
   it("lookup defaults to the current adapter", () => {

--- a/packages/activerecord/src/type.test.ts
+++ b/packages/activerecord/src/type.test.ts
@@ -1,7 +1,48 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { register, lookup, registry, AdapterSpecificRegistry } from "./type.js";
+import { Type } from "@blazetrails/activemodel";
+
+class ArgType extends Type<unknown> {
+  readonly name = "arg_type";
+  readonly args: unknown;
+  constructor(args?: unknown) {
+    super();
+    this.args = args;
+  }
+  cast(value: unknown) {
+    return value;
+  }
+  override type() {
+    return "arg_type";
+  }
+}
+
+class PgArgType extends ArgType {
+  override type() {
+    return "pg_arg_type";
+  }
+}
 
 describe("TypeTest", () => {
-  it.skip("registering a new type", () => {});
-  it.skip("looking up a type for a specific adapter", () => {});
-  it.skip("lookup defaults to the current adapter", () => {});
+  it("registering a new type", () => {
+    register("__type_test_register__", ArgType);
+    expect(lookup("__type_test_register__")).toBeInstanceOf(ArgType);
+  });
+
+  it("looking up a type for a specific adapter", () => {
+    register("__type_test_adapter__", ArgType, { override: false });
+    register("__type_test_adapter__", PgArgType, { adapter: "postgresql" });
+
+    expect(lookup("__type_test_adapter__", { adapter: "sqlite3" })).toBeInstanceOf(ArgType);
+    expect(lookup("__type_test_adapter__", { adapter: "postgresql" })).toBeInstanceOf(PgArgType);
+  });
+
+  it("lookup defaults to the current adapter", () => {
+    register("__type_test_default__", ArgType, { override: false });
+    register("__type_test_default__", PgArgType, { adapter: "sqlite" });
+
+    // registry() returns the shared AdapterSpecificRegistry
+    expect(registry()).toBeInstanceOf(AdapterSpecificRegistry);
+    expect(lookup("__type_test_default__")).toBeInstanceOf(PgArgType);
+  });
 });

--- a/packages/activerecord/src/type.test.ts
+++ b/packages/activerecord/src/type.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { register, lookup, registry, AdapterSpecificRegistry } from "./type.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { register, lookup, registry, setRegistry, AdapterSpecificRegistry } from "./type.js";
 import { Type } from "@blazetrails/activemodel";
 
 class ArgType extends Type<unknown> {
@@ -24,25 +24,34 @@ class PgArgType extends ArgType {
 }
 
 describe("TypeTest", () => {
+  let oldRegistry: AdapterSpecificRegistry;
+
+  beforeEach(() => {
+    oldRegistry = registry();
+    setRegistry(new AdapterSpecificRegistry());
+  });
+
+  afterEach(() => {
+    setRegistry(oldRegistry);
+  });
+
   it("registering a new type", () => {
-    register("__type_test_register__", ArgType);
-    expect(lookup("__type_test_register__")).toBeInstanceOf(ArgType);
+    register("foo", ArgType);
+    expect(lookup("foo")).toBeInstanceOf(ArgType);
   });
 
   it("looking up a type for a specific adapter", () => {
-    register("__type_test_adapter__", ArgType, { override: false });
-    register("__type_test_adapter__", PgArgType, { adapter: "postgresql" });
+    register("foo", ArgType, { override: false });
+    register("foo", PgArgType, { adapter: "postgresql" });
 
-    expect(lookup("__type_test_adapter__", { adapter: "sqlite3" })).toBeInstanceOf(ArgType);
-    expect(lookup("__type_test_adapter__", { adapter: "postgresql" })).toBeInstanceOf(PgArgType);
+    expect(lookup("foo", { adapter: "sqlite3" })).toBeInstanceOf(ArgType);
+    expect(lookup("foo", { adapter: "postgresql" })).toBeInstanceOf(PgArgType);
   });
 
   it("lookup defaults to the current adapter", () => {
-    register("__type_test_default__", ArgType, { override: false });
-    register("__type_test_default__", PgArgType, { adapter: "sqlite" });
+    register("foo", ArgType, { override: false });
+    register("foo", PgArgType, { adapter: "sqlite" });
 
-    // registry() returns the shared AdapterSpecificRegistry
-    expect(registry()).toBeInstanceOf(AdapterSpecificRegistry);
-    expect(lookup("__type_test_default__")).toBeInstanceOf(PgArgType);
+    expect(lookup("foo")).toBeInstanceOf(PgArgType);
   });
 });

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -71,10 +71,19 @@ _registry.register("string", StringType, { override: false });
 _registry.register("text", Text, { override: false });
 _registry.register("time", Time, { override: false });
 
+/** Mirrors Rails' `ActiveRecord::Type.registry` (attr_accessor getter). */
 export function registry(): AdapterSpecificRegistry {
   return _registry;
 }
 
+/**
+ * Mirrors Rails' `ActiveRecord::Type.registry=` (attr_accessor setter).
+ *
+ * Replaces the active registry wholesale. Callers are responsible for
+ * re-registering any types they need — this is intentional: Rails' own
+ * TypeTest swaps in a blank AdapterSpecificRegistry per test and restores
+ * the original in teardown, so a pre-populated registry is not the default.
+ */
 export function setRegistry(r: AdapterSpecificRegistry): void {
   _registry = r;
   _defaultValue = undefined;

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -53,23 +53,25 @@ export const ImmutableString = ImmutableStringType;
 export const String = StringType;
 export const Value = ValueType;
 
-const registry = new AdapterSpecificRegistry();
+const _registry = new AdapterSpecificRegistry();
 
-registry.register("big_integer", BigIntegerType);
-registry.register("binary", BinaryType);
-registry.register("boolean", BooleanType);
-registry.register("date", Date);
-registry.register("datetime", DateTime);
-registry.register("decimal", DecimalType);
-registry.register("float", FloatType);
-registry.register("integer", IntegerType);
-registry.register("immutable_string", ImmutableStringType);
-registry.register("json", Json);
-registry.register("string", StringType);
-registry.register("text", Text);
-registry.register("time", Time);
+_registry.register("big_integer", BigIntegerType);
+_registry.register("binary", BinaryType);
+_registry.register("boolean", BooleanType);
+_registry.register("date", Date);
+_registry.register("datetime", DateTime);
+_registry.register("decimal", DecimalType);
+_registry.register("float", FloatType);
+_registry.register("integer", IntegerType);
+_registry.register("immutable_string", ImmutableStringType);
+_registry.register("json", Json);
+_registry.register("string", StringType);
+_registry.register("text", Text);
+_registry.register("time", Time);
 
-export { registry };
+export function registry(): AdapterSpecificRegistry {
+  return _registry;
+}
 
 export function register(
   typeName: string,
@@ -77,11 +79,12 @@ export function register(
   options?: { adapter?: string; override?: boolean },
   block?: (...args: unknown[]) => Type,
 ): void {
-  registry.register(typeName, klass, options, block);
+  _registry.register(typeName, klass, options, block);
 }
 
 export function lookup(symbol: string, options?: { adapter?: string }): Type {
-  return registry.lookup(symbol, options);
+  const adapter = options?.adapter ?? currentAdapterName();
+  return _registry.lookup(symbol, { ...options, adapter });
 }
 
 export function defaultValue(): Type {

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -55,6 +55,7 @@ export const Value = ValueType;
 
 let _registry = new AdapterSpecificRegistry();
 let _defaultValue: Type | undefined;
+let _currentAdapterResolver: (() => string) | undefined;
 
 _registry.register("big_integer", BigIntegerType, { override: false });
 _registry.register("binary", BinaryType, { override: false });
@@ -77,6 +78,11 @@ export function registry(): AdapterSpecificRegistry {
 export function setRegistry(r: AdapterSpecificRegistry): void {
   _registry = r;
   _defaultValue = undefined;
+}
+
+// Called by Base to wire the real connection adapter into type lookups.
+export function setCurrentAdapterResolver(resolver: () => string): void {
+  _currentAdapterResolver = resolver;
 }
 
 export function register(
@@ -108,8 +114,10 @@ export function adapterNameFrom(model: { adapter?: unknown }): string {
 }
 
 // currentAdapterName is private in Rails — exposed here for api:compare parity only.
+// When Base wires setCurrentAdapterResolver(), it reads the real connection adapter.
 export function currentAdapterName(getBase?: () => { adapter?: unknown }): string {
-  return getBase ? adapterNameFrom(getBase()) : "sqlite";
+  if (getBase) return adapterNameFrom(getBase());
+  return _currentAdapterResolver?.() ?? "sqlite";
 }
 
 // Override ActiveModel's type registry with AR-specific types so that

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -53,24 +53,30 @@ export const ImmutableString = ImmutableStringType;
 export const String = StringType;
 export const Value = ValueType;
 
-const _registry = new AdapterSpecificRegistry();
+let _registry = new AdapterSpecificRegistry();
+let _defaultValue: Type | undefined;
 
-_registry.register("big_integer", BigIntegerType);
-_registry.register("binary", BinaryType);
-_registry.register("boolean", BooleanType);
-_registry.register("date", Date);
-_registry.register("datetime", DateTime);
-_registry.register("decimal", DecimalType);
-_registry.register("float", FloatType);
-_registry.register("integer", IntegerType);
-_registry.register("immutable_string", ImmutableStringType);
-_registry.register("json", Json);
-_registry.register("string", StringType);
-_registry.register("text", Text);
-_registry.register("time", Time);
+_registry.register("big_integer", BigIntegerType, { override: false });
+_registry.register("binary", BinaryType, { override: false });
+_registry.register("boolean", BooleanType, { override: false });
+_registry.register("date", Date, { override: false });
+_registry.register("datetime", DateTime, { override: false });
+_registry.register("decimal", DecimalType, { override: false });
+_registry.register("float", FloatType, { override: false });
+_registry.register("integer", IntegerType, { override: false });
+_registry.register("immutable_string", ImmutableStringType, { override: false });
+_registry.register("json", Json, { override: false });
+_registry.register("string", StringType, { override: false });
+_registry.register("text", Text, { override: false });
+_registry.register("time", Time, { override: false });
 
 export function registry(): AdapterSpecificRegistry {
   return _registry;
+}
+
+export function setRegistry(r: AdapterSpecificRegistry): void {
+  _registry = r;
+  _defaultValue = undefined;
 }
 
 export function register(
@@ -88,7 +94,7 @@ export function lookup(symbol: string, options?: { adapter?: string }): Type {
 }
 
 export function defaultValue(): Type {
-  return new ValueType();
+  return (_defaultValue ??= new ValueType());
 }
 
 /**

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -104,6 +104,10 @@ export class HashLookupTypeMap {
     );
   }
 
+  isKey(key: string | number): boolean {
+    return this._mapping.has(key);
+  }
+
   has(key: string | number): boolean {
     return this._mapping.has(key);
   }

--- a/packages/activerecord/src/type/hash-lookup-type-map.ts
+++ b/packages/activerecord/src/type/hash-lookup-type-map.ts
@@ -105,7 +105,7 @@ export class HashLookupTypeMap {
   }
 
   isKey(key: string | number): boolean {
-    return this._mapping.has(key);
+    return this.has(key);
   }
 
   has(key: string | number): boolean {

--- a/packages/activerecord/src/type/type-map.test.ts
+++ b/packages/activerecord/src/type/type-map.test.ts
@@ -39,15 +39,28 @@ describe("HashLookupTypeMapTest", () => {
     expect(mapping.lookup(4)).toBeInstanceOf(ValueType);
   });
 
+  it("isKey returns true for registered keys and false otherwise", () => {
+    const mapping = new HashLookupTypeMap();
+    mapping.registerType("foo", { name: "foo" } as any);
+
+    expect(mapping.isKey("foo")).toBe(true);
+    expect(mapping.isKey("bar")).toBe(false);
+  });
+
   it("fetch memoizes on args", () => {
     const mapping = new HashLookupTypeMap();
-    mapping.registerType(
-      "foo",
-      (type: string | number, ...args: unknown[]) => [type, ...args].join("-") as any,
-    );
+    let callCount = 0;
+    mapping.registerType("foo", (type: string | number, ...args: unknown[]) => {
+      callCount++;
+      return [type, ...args].join("-") as any;
+    });
 
     expect(mapping.fetch("foo", 1, 2, 3, () => [].join("-"))).toBe("foo-1-2-3");
+    expect(mapping.fetch("foo", 1, 2, 3, () => [].join("-"))).toBe("foo-1-2-3");
+    expect(callCount).toBe(1);
+
     expect(mapping.fetch("foo", 2, 3, 4, () => [].join("-"))).toBe("foo-2-3-4");
+    expect(callCount).toBe(2);
   });
 
   it("fetch yields args", () => {

--- a/packages/activerecord/src/type/type-map.test.ts
+++ b/packages/activerecord/src/type/type-map.test.ts
@@ -1,4 +1,6 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { HashLookupTypeMap } from "./hash-lookup-type-map.js";
+import { ValueType } from "@blazetrails/activemodel";
 
 describe("TypeMapTest", () => {
   it.skip("registering types", () => {});
@@ -13,14 +15,86 @@ describe("TypeMapTest", () => {
 });
 
 describe("HashLookupTypeMapTest", () => {
-  it.skip("additional lookup args", () => {});
-  it.skip("lookup non strings", () => {});
-  it.skip("fetch memoizes on args", () => {});
-  it.skip("fetch yields args", () => {});
+  it("additional lookup args", () => {
+    const mapping = new HashLookupTypeMap();
+    mapping.registerType("varchar", (_type: string | number, limit: unknown) =>
+      (limit as number) > 255 ? ({ name: "text" } as any) : ({ name: "string" } as any),
+    );
+    mapping.aliasType("string", "varchar");
+
+    expect((mapping.lookup("varchar", 200) as any).name).toBe("string");
+    expect((mapping.lookup("varchar", 400) as any).name).toBe("text");
+    expect((mapping.lookup("string", 400) as any).name).toBe("text");
+  });
+
+  it("lookup non strings", () => {
+    const mapping = new HashLookupTypeMap();
+    mapping.registerType(1, { name: "string" } as any);
+    mapping.registerType(2, { name: "int" } as any);
+    mapping.aliasType(3, 1);
+
+    expect((mapping.lookup(1) as any).name).toBe("string");
+    expect((mapping.lookup(2) as any).name).toBe("int");
+    expect((mapping.lookup(3) as any).name).toBe("string");
+    expect(mapping.lookup(4)).toBeInstanceOf(ValueType);
+  });
+
+  it("fetch memoizes on args", () => {
+    const mapping = new HashLookupTypeMap();
+    mapping.registerType(
+      "foo",
+      (type: string | number, ...args: unknown[]) => [type, ...args].join("-") as any,
+    );
+
+    expect(mapping.fetch("foo", 1, 2, 3, () => [].join("-"))).toBe("foo-1-2-3");
+    expect(mapping.fetch("foo", 2, 3, 4, () => [].join("-"))).toBe("foo-2-3-4");
+  });
+
+  it("fetch yields args", () => {
+    const mapping = new HashLookupTypeMap();
+
+    expect(mapping.fetch("foo", 1, 2, 3, (...args: unknown[]) => args.join("-"))).toBe("foo-1-2-3");
+    expect(mapping.fetch("bar", 1, 2, 3, (...args: unknown[]) => args.join("-"))).toBe("bar-1-2-3");
+  });
 });
 
-it.skip("default type", () => {});
-it.skip("requires value or block", () => {});
-it.skip("fetch", () => {});
-it.skip("fetch memoizes", () => {});
-it.skip("register clears cache", () => {});
+// TypeMapSharedTests — exercised against HashLookupTypeMap below
+it("default type", () => {
+  const mapping = new HashLookupTypeMap();
+  expect(mapping.lookup("undefined_key")).toBeInstanceOf(ValueType);
+});
+
+it("requires value or block", () => {
+  const mapping = new HashLookupTypeMap();
+  expect(() => (mapping as any).registerType(/only key/i)).toThrow();
+});
+
+it("fetch", () => {
+  const mapping = new HashLookupTypeMap();
+  mapping.registerType(1, "string" as any);
+
+  expect(mapping.fetch(1, () => "int")).toBe("string");
+  expect(mapping.fetch(2, () => "int")).toBe("int");
+});
+
+it("fetch memoizes", () => {
+  const mapping = new HashLookupTypeMap();
+  let lookupCount = 0;
+  mapping.registerType(1, () => {
+    if (lookupCount > 0) throw new Error("should not be called twice");
+    lookupCount++;
+    return "string" as any;
+  });
+
+  expect(mapping.fetch(1)).toBe("string");
+  expect(mapping.fetch(1)).toBe("string");
+});
+
+it("register clears cache", () => {
+  const mapping = new HashLookupTypeMap();
+  mapping.registerType(1, "string" as any);
+  mapping.lookup(1);
+  mapping.registerType(1, "int" as any);
+
+  expect(mapping.lookup(1)).toBe("int");
+});


### PR DESCRIPTION
## Summary

- `registry()` exported as a function (mirrors Rails `attr_accessor :registry`)
- `lookup()` injects `currentAdapterName()` by default (mirrors Rails `adapter: current_adapter_name` default)
- `HashLookupTypeMap#isKey` added (mirrors Ruby `key?`)
- Implement `TypeTest` and `HashLookupTypeMapTest` + shared type map tests (unskipped)