### PR TITLE
fix(activerecord): whereMissing/whereAssociated emit JOIN form (ar-36, ar-37)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -287,6 +287,58 @@ describe("RelationTest", () => {
     }
   });
 
+  it("whereMissing with hasMany emits LEFT OUTER JOIN + target_pk IS NULL", () => {
+    class WmhAuthor extends Base {
+      static {
+        this.tableName = "authors";
+        this.hasMany("books");
+        registerModel("Author", this);
+      }
+    }
+    class WmhBook extends Base {
+      static {
+        this.tableName = "books";
+        registerModel("Book", this);
+      }
+    }
+    try {
+      const sql = WmhAuthor.all().whereMissing("books").toSql();
+      expect(sql).toContain("LEFT OUTER JOIN");
+      expect(sql).toContain('"books"');
+      expect(sql).toContain('"books"."id" IS NULL');
+      expect(sql).not.toContain('"authors"."id" IS NULL');
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
+    }
+  });
+
+  it("whereAssociated with hasMany emits INNER JOIN + target_pk IS NOT NULL", () => {
+    class WahAuthor extends Base {
+      static {
+        this.tableName = "authors";
+        this.hasMany("books");
+        registerModel("Author", this);
+      }
+    }
+    class WahBook extends Base {
+      static {
+        this.tableName = "books";
+        registerModel("Book", this);
+      }
+    }
+    try {
+      const sql = WahAuthor.all().whereAssociated("books").toSql();
+      expect(sql).toContain("INNER JOIN");
+      expect(sql).toContain('"books"');
+      expect(sql).toContain('"books"."id" IS NOT NULL');
+      expect(sql).not.toContain('"authors"."id" IS NOT NULL');
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
+    }
+  });
+
   it("multiple selects", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -235,6 +235,58 @@ describe("RelationTest", () => {
     expect(multiKeySql).toContain('"users"."id" DESC');
   });
 
+  it("whereMissing emits LEFT OUTER JOIN + assoc_pk IS NULL", () => {
+    class WmAuthor extends Base {
+      static {
+        this.tableName = "authors";
+        registerModel("Author", this);
+      }
+    }
+    class WmBook extends Base {
+      static {
+        this.tableName = "books";
+        this.belongsTo("author");
+        registerModel("Book", this);
+      }
+    }
+    try {
+      const sql = WmBook.all().whereMissing("author").toSql();
+      expect(sql).toContain("LEFT OUTER JOIN");
+      expect(sql).toContain('"authors"');
+      expect(sql).toContain('"authors"."id" IS NULL');
+      expect(sql).not.toContain('"books"."author_id" IS NULL');
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
+    }
+  });
+
+  it("whereAssociated emits INNER JOIN + assoc_pk IS NOT NULL", () => {
+    class WaAuthor extends Base {
+      static {
+        this.tableName = "authors";
+        registerModel("Author", this);
+      }
+    }
+    class WaBook extends Base {
+      static {
+        this.tableName = "books";
+        this.belongsTo("author");
+        registerModel("Book", this);
+      }
+    }
+    try {
+      const sql = WaBook.all().whereAssociated("author").toSql();
+      expect(sql).toContain("INNER JOIN");
+      expect(sql).toContain('"authors"');
+      expect(sql).toContain('"authors"."id" IS NOT NULL');
+      expect(sql).not.toContain('"books"."author_id" IS NOT NULL');
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
+    }
+  });
+
   it("multiple selects", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -247,6 +247,8 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated — emits an
    * INNER JOIN on the association then WHERE assoc_pk IS NOT NULL.
+   * Skips the join if an equivalent join is already present (mirrors Rails'
+   * joins_values dedup guard).
    */
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
@@ -258,15 +260,15 @@ export class Relation<T extends Base> {
         );
       }
       const cloned = rel._clone();
-      if (!cloned._joinClauses.some((j) => j.table === target.table && j.on === target.on)) {
-        cloned._joinClauses.push({
-          type: "inner",
-          table: target.table,
-          on: target.on,
-          quoted: true,
-        });
+      for (const join of target.joins) {
+        if (!cloned._joinClauses.some((j) => j.table === join.table && j.on === join.on)) {
+          cloned._joinClauses.push({ type: "inner", table: join.table, on: join.on, quoted: true });
+        }
       }
-      cloned._whereClause.predicates.push(new Table(target.table).get(target.pk).notEq(null));
+      const tgtTable = new Table(target.table);
+      for (const pk of target.pks) {
+        cloned._whereClause.predicates.push(tgtTable.get(pk).notEq(null));
+      }
       rel = cloned;
     }
     return rel;
@@ -288,21 +290,26 @@ export class Relation<T extends Base> {
         );
       }
       const cloned = rel._clone();
-      cloned._joinClauses.push({ type: "left", table: target.table, on: target.on, quoted: true });
-      cloned._whereClause.predicates.push(new Table(target.table).get(target.pk).eq(null));
+      for (const join of target.joins) {
+        cloned._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
+      }
+      const tgtTable = new Table(target.table);
+      for (const pk of target.pks) {
+        cloned._whereClause.predicates.push(tgtTable.get(pk).eq(null));
+      }
       rel = cloned;
     }
     return rel;
   }
 
   /**
-   * Resolve the target table, join ON clause, and association primary key for
-   * a named association — the shared building block for whereMissing /
-   * whereAssociated.
+   * Resolve all join steps and target PK columns for a named association.
+   * Mirrors Rails' reflection.association_primary_key (Array form for composite
+   * PKs) and left_outer_joins expansion for through associations.
    */
   private _resolveAssociationTarget(
     assocName: string,
-  ): { table: string; on: string; pk: string } | null {
+  ): { joins: Array<{ table: string; on: string }>; table: string; pks: string[] } | null {
     const modelClass = this._modelClass as any;
     const associations: any[] = modelClass._associations ?? [];
     const assocDef = associations.find((a: any) => a.name === assocName);
@@ -310,26 +317,24 @@ export class Relation<T extends Base> {
 
     const resolved = this._resolveAssociationJoin(assocName);
     if (!resolved) return null;
-    // _resolveAssociationJoin can return an array for through associations;
-    // use the last join's table as the final target.
-    const joinEntry = Array.isArray(resolved) ? resolved[resolved.length - 1] : resolved;
+    const joins = Array.isArray(resolved) ? resolved : [resolved];
+    const lastJoin = joins[joins.length - 1];
 
-    let pk = "id";
+    let rawPk: string | string[] = "id";
     if (assocDef.type === "belongsTo") {
       const className = assocDef.options.className ?? _camelize(assocName);
       const targetModel = modelRegistry.get(className);
-      const rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
-      pk = Array.isArray(rawPk) ? rawPk[0] : rawPk;
+      rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
     } else {
       const className =
         assocDef.options.className ??
         _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
       const targetModel = modelRegistry.get(className);
-      const rawPk = targetModel?.primaryKey ?? "id";
-      pk = Array.isArray(rawPk) ? rawPk[0] : rawPk;
+      rawPk = targetModel?.primaryKey ?? "id";
     }
+    const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
 
-    return { table: joinEntry.table, on: joinEntry.on, pk };
+    return { joins, table: lastJoin.table, pks };
   }
 
   private _resolveHasManySubquery(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -306,6 +306,10 @@ export class Relation<T extends Base> {
    * Resolve all join steps and target PK columns for a named association.
    * Mirrors Rails' reflection.association_primary_key (Array form for composite
    * PKs) and left_outer_joins expansion for through associations.
+   *
+   * When the target model isn't in the registry (e.g. test helpers that set up
+   * associations without registering models), the table name is inferred from
+   * the association name/className and the join ON clause is built from options.
    */
   private _resolveAssociationTarget(
     assocName: string,
@@ -315,26 +319,45 @@ export class Relation<T extends Base> {
     const assocDef = associations.find((a: any) => a.name === assocName);
     if (!assocDef) return null;
 
+    // Try registry-based resolution first (handles all association types).
     const resolved = this._resolveAssociationJoin(assocName);
-    if (!resolved) return null;
-    const joins = Array.isArray(resolved) ? resolved : [resolved];
-    const lastJoin = joins[joins.length - 1];
-
-    let rawPk: string | string[] = "id";
-    if (assocDef.type === "belongsTo") {
-      const className = assocDef.options.className ?? _camelize(assocName);
-      const targetModel = modelRegistry.get(className);
-      rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
-    } else {
-      const className =
-        assocDef.options.className ??
-        _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
-      const targetModel = modelRegistry.get(className);
-      rawPk = targetModel?.primaryKey ?? "id";
+    if (resolved) {
+      const joins = Array.isArray(resolved) ? resolved : [resolved];
+      const lastJoin = joins[joins.length - 1];
+      let rawPk: string | string[] = "id";
+      if (assocDef.type === "belongsTo") {
+        const targetModel = modelRegistry.get(assocDef.options.className ?? _camelize(assocName));
+        rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
+      } else {
+        const className =
+          assocDef.options.className ??
+          _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
+        const targetModel = modelRegistry.get(className);
+        rawPk = targetModel?.primaryKey ?? "id";
+      }
+      const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
+      return { joins, table: lastJoin.table, pks };
     }
-    const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
 
-    return { joins, table: lastJoin.table, pks };
+    // Fallback: model not in registry — use the FK on the source table as a
+    // synthetic "join" with no real join table. This is data-correct for
+    // belongs_to (FK IS NULL / IS NOT NULL) even though it differs from Rails'
+    // JOIN form. The JOIN form requires knowing the target table name, which
+    // isn't available without a registered model.
+    const sourceTable = modelClass.tableName;
+    if (assocDef.type === "belongsTo") {
+      const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
+      // Emit a degenerate single-predicate check on the FK column instead of a JOIN.
+      // Callers (whereMissing/whereAssociated) will add a join + WHERE on `table.pks`,
+      // so we set table/on to the source table and pk to the FK column, which produces
+      // `source_table.fk IS NULL` without any join — matching the old behavior.
+      return {
+        joins: [],
+        table: sourceTable,
+        pks: [foreignKey],
+      };
+    }
+    return null;
   }
 
   private _resolveHasManySubquery(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -243,85 +243,93 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Filter for records WHERE the association IS present (non-null FK).
+   * Filter for records WHERE the association IS present.
    *
-   * Mirrors: ActiveRecord::Relation#where.associated
+   * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated — emits an
+   * INNER JOIN on the association then WHERE assoc_pk IS NOT NULL.
    */
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      const modelClass = rel._modelClass as any;
-      const associations: any[] = modelClass._associations ?? [];
-      const assocDef = associations.find((a: any) => a.name === assocName);
-
-      if (!assocDef) {
+      const target = rel._resolveAssociationTarget(assocName);
+      if (!target) {
         throw new Error(
-          `Association named '${assocName}' was not found on ${modelClass.name}; perhaps you misspelled it?`,
+          `Association named '${assocName}' was not found on ${(rel._modelClass as any).name}; perhaps you misspelled it?`,
         );
       }
-
-      if (assocDef.type === "belongsTo") {
-        const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
-        rel = rel.whereNot({ [foreignKey]: null });
-      } else if (assocDef.type === "hasMany" || assocDef.type === "hasOne") {
-        const { targetTable, foreignKey, typeNodes } = this._resolveHasManySubquery(
-          modelClass,
-          assocDef,
-          assocName,
-        );
-        const sourceTable = modelClass.tableName;
-        const pk = (assocDef.options.primaryKey ?? modelClass.primaryKey) as string;
-        const srcTable = new Table(sourceTable);
-        const tgtTable = new Table(targetTable);
-        const subquery = tgtTable.project(tgtTable.get(foreignKey));
-        for (const node of typeNodes) subquery.where(node);
-        const cloned = rel._clone();
-        cloned._whereClause.predicates.push(srcTable.get(pk).in(subquery));
-        rel = cloned;
+      const cloned = rel._clone();
+      if (!cloned._joinClauses.some((j) => j.table === target.table && j.on === target.on)) {
+        cloned._joinClauses.push({
+          type: "inner",
+          table: target.table,
+          on: target.on,
+          quoted: true,
+        });
       }
+      cloned._whereClause.predicates.push(new Table(target.table).get(target.pk).notEq(null));
+      rel = cloned;
     }
     return rel;
   }
 
   /**
-   * Filter for records WHERE the association IS missing (null FK).
+   * Filter for records WHERE the association IS missing.
    *
-   * Mirrors: ActiveRecord::Relation#where.missing
+   * Mirrors: ActiveRecord::QueryMethods::WhereChain#missing — emits a
+   * LEFT OUTER JOIN on the association then WHERE assoc_pk IS NULL.
    */
   whereMissing(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      const modelClass = rel._modelClass as any;
-      const associations: any[] = modelClass._associations ?? [];
-      const assocDef = associations.find((a: any) => a.name === assocName);
-
-      if (!assocDef) {
+      const target = rel._resolveAssociationTarget(assocName);
+      if (!target) {
         throw new Error(
-          `Association named '${assocName}' was not found on ${modelClass.name}; perhaps you misspelled it?`,
+          `Association named '${assocName}' was not found on ${(rel._modelClass as any).name}; perhaps you misspelled it?`,
         );
       }
-
-      if (assocDef.type === "belongsTo") {
-        const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
-        rel = rel.where({ [foreignKey]: null });
-      } else if (assocDef.type === "hasMany" || assocDef.type === "hasOne") {
-        const { targetTable, foreignKey, typeNodes } = this._resolveHasManySubquery(
-          modelClass,
-          assocDef,
-          assocName,
-        );
-        const sourceTable = modelClass.tableName;
-        const pk = (assocDef.options.primaryKey ?? modelClass.primaryKey) as string;
-        const srcTable = new Table(sourceTable);
-        const tgtTable = new Table(targetTable);
-        const subquery = tgtTable.project(tgtTable.get(foreignKey));
-        for (const node of typeNodes) subquery.where(node);
-        const cloned = rel._clone();
-        cloned._whereClause.predicates.push(srcTable.get(pk).notIn(subquery));
-        rel = cloned;
-      }
+      const cloned = rel._clone();
+      cloned._joinClauses.push({ type: "left", table: target.table, on: target.on, quoted: true });
+      cloned._whereClause.predicates.push(new Table(target.table).get(target.pk).eq(null));
+      rel = cloned;
     }
     return rel;
+  }
+
+  /**
+   * Resolve the target table, join ON clause, and association primary key for
+   * a named association — the shared building block for whereMissing /
+   * whereAssociated.
+   */
+  private _resolveAssociationTarget(
+    assocName: string,
+  ): { table: string; on: string; pk: string } | null {
+    const modelClass = this._modelClass as any;
+    const associations: any[] = modelClass._associations ?? [];
+    const assocDef = associations.find((a: any) => a.name === assocName);
+    if (!assocDef) return null;
+
+    const resolved = this._resolveAssociationJoin(assocName);
+    if (!resolved) return null;
+    // _resolveAssociationJoin can return an array for through associations;
+    // use the last join's table as the final target.
+    const joinEntry = Array.isArray(resolved) ? resolved[resolved.length - 1] : resolved;
+
+    let pk = "id";
+    if (assocDef.type === "belongsTo") {
+      const className = assocDef.options.className ?? _camelize(assocName);
+      const targetModel = modelRegistry.get(className);
+      const rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
+      pk = Array.isArray(rawPk) ? rawPk[0] : rawPk;
+    } else {
+      const className =
+        assocDef.options.className ??
+        _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
+      const targetModel = modelRegistry.get(className);
+      const rawPk = targetModel?.primaryKey ?? "id";
+      pk = Array.isArray(rawPk) ? rawPk[0] : rawPk;
+    }
+
+    return { table: joinEntry.table, on: joinEntry.on, pk };
   }
 
   private _resolveHasManySubquery(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -66,6 +66,34 @@ export type LoadedRelation<R> = Omit<R, "then">;
  * `EXPLAIN FORMAT=X ANALYZE` is invalid) from receiving orderings they
  * can't render.
  */
+/**
+ * Add a join clause to `clauses` for whereMissing/whereAssociated.
+ * - Skip if an identical (type + table + on) entry already exists.
+ * - Throw if a different join to the same table exists — that would require
+ *   aliasing which we don't support, and silently skipping would apply the
+ *   WHERE predicate against the wrong join.
+ */
+function _addAssocJoin(
+  clauses: Array<{ type: "inner" | "left"; table: string; on: string; quoted?: boolean }>,
+  type: "inner" | "left",
+  join: { table: string; on: string },
+  assocName: string,
+  modelClass: any,
+): void {
+  const equivalent = clauses.some(
+    (j) => j.type === type && j.table === join.table && j.on === join.on,
+  );
+  if (equivalent) return;
+  const conflicting = clauses.some((j) => j.table === join.table);
+  if (conflicting) {
+    throw new Error(
+      `where${type === "inner" ? "Associated" : "Missing"}: cannot add ${type.toUpperCase()} JOIN for '${assocName}' on ${modelClass.name} ` +
+        `— a different join to '${join.table}' already exists and cannot be represented without aliasing.`,
+    );
+  }
+  clauses.push({ type, table: join.table, on: join.on, quoted: true });
+}
+
 function validateExplainOptions(options: ExplainOption[]): void {
   let seenHash = false;
   for (let i = 0; i < options.length; i++) {
@@ -263,11 +291,7 @@ export class Relation<T extends Base> {
       }
       const cloned = rel._clone();
       for (const join of target.joins) {
-        // Dedup by table name: skip if a join to this table already exists
-        // (regardless of ON clause) to avoid invalid duplicate-table SQL.
-        if (!cloned._joinClauses.some((j) => j.table === join.table)) {
-          cloned._joinClauses.push({ type: "inner", table: join.table, on: join.on, quoted: true });
-        }
+        _addAssocJoin(cloned._joinClauses, "inner", join, assocName, rel._modelClass as any);
       }
       const tgtTable = new Table(target.table);
       for (const pk of target.pks) {
@@ -297,11 +321,7 @@ export class Relation<T extends Base> {
       }
       const cloned = rel._clone();
       for (const join of target.joins) {
-        // Dedup by table name to avoid duplicate-table SQL if the same
-        // association is applied twice or already joined via leftOuterJoins.
-        if (!cloned._joinClauses.some((j) => j.table === join.table)) {
-          cloned._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
-        }
+        _addAssocJoin(cloned._joinClauses, "left", join, assocName, rel._modelClass as any);
       }
       const tgtTable = new Table(target.table);
       for (const pk of target.pks) {
@@ -367,16 +387,28 @@ export class Relation<T extends Base> {
         const targetModel = modelRegistry.get(className);
         rawPk = targetModel?.primaryKey ?? "id";
       }
+      // Composite PKs are supported at the WHERE level (one IS NULL per column)
+      // but the JOIN ON clause from _resolveAssociationJoin uses a single string;
+      // if the association itself has a composite FK that would stringify to "a,b",
+      // throw a clear error rather than emitting broken SQL.
+      if (Array.isArray(assocDef.options.foreignKey)) {
+        throw new Error(
+          `whereMissing/whereAssociated: composite foreignKey on '${assocName}' is not yet supported.`,
+        );
+      }
       const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
       return { joins, table: lastJoin.table, pks };
     }
 
     // Fallback: target model not in registry — derive JOIN from options.
+    // NOTE: for belongsTo, the target table name is not reliably inferrable
+    // without a registered model (the actual tableName may differ from the
+    // class-name convention). We fall back to a source-table FK predicate
+    // (WHERE source.fk IS NULL) which is data-correct for belongs_to but
+    // does not match Rails' JOIN form. Register the model to get the JOIN form.
     const sourceTable = modelClass.tableName;
     if (assocDef.type === "belongsTo") {
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
-      // No JOIN needed: emit WHERE source_table.fk IS NULL instead.
-      // Data-correct for belongs_to even though it differs from Rails' JOIN form.
       return { joins: [], table: sourceTable, pks: [foreignKey] };
     }
     if (assocDef.type === "hasOne" || assocDef.type === "hasMany") {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -68,10 +68,12 @@ export type LoadedRelation<R> = Omit<R, "then">;
  */
 /**
  * Add a join clause to `clauses` for whereMissing/whereAssociated.
- * - Skip if an identical (type + table + on) entry already exists.
- * - Throw if a different join to the same table exists — that would require
- *   aliasing which we don't support, and silently skipping would apply the
- *   WHERE predicate against the wrong join.
+ * - Skip if a join with the same table+ON already exists regardless of type
+ *   (e.g. leftJoins(:assoc).whereAssociated(:assoc) is valid — the existing
+ *   LEFT OUTER JOIN already covers the table; the IS NOT NULL predicate
+ *   provides the restriction).
+ * - Throw if a join to the same table with a *different* ON clause exists —
+ *   that would require aliasing which is not supported.
  */
 function _addAssocJoin(
   clauses: Array<{ type: "inner" | "left"; table: string; on: string; quoted?: boolean }>,
@@ -80,12 +82,9 @@ function _addAssocJoin(
   assocName: string,
   modelClass: any,
 ): void {
-  const equivalent = clauses.some(
-    (j) => j.type === type && j.table === join.table && j.on === join.on,
-  );
-  if (equivalent) return;
-  const conflicting = clauses.some((j) => j.table === join.table);
-  if (conflicting) {
+  const sameTableOn = clauses.find((j) => j.table === join.table);
+  if (sameTableOn) {
+    if (sameTableOn.on === join.on) return; // compatible existing join — skip
     throw new Error(
       `where${type === "inner" ? "Associated" : "Missing"}: cannot add ${type.toUpperCase()} JOIN for '${assocName}' on ${modelClass.name} ` +
         `— a different join to '${join.table}' already exists and cannot be represented without aliasing.`,
@@ -281,7 +280,7 @@ export class Relation<T extends Base> {
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      this._requireAssociation(assocName);
+      rel._requireAssociation(assocName);
       const target = rel._resolveAssociationTarget(assocName);
       if (!target) {
         throw new Error(
@@ -311,7 +310,7 @@ export class Relation<T extends Base> {
   whereMissing(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      this._requireAssociation(assocName);
+      rel._requireAssociation(assocName);
       const target = rel._resolveAssociationTarget(assocName);
       if (!target) {
         throw new Error(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -253,15 +253,13 @@ export class Relation<T extends Base> {
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      const target = rel._resolveAssociationTarget(assocName);
-      if (!target) {
-        throw new Error(
-          `Association named '${assocName}' was not found on ${(rel._modelClass as any).name}; perhaps you misspelled it?`,
-        );
-      }
+      this._requireAssociation(assocName);
+      const target = rel._resolveAssociationTarget(assocName)!;
       const cloned = rel._clone();
       for (const join of target.joins) {
-        if (!cloned._joinClauses.some((j) => j.table === join.table && j.on === join.on)) {
+        // Dedup by table name: skip if a join to this table already exists
+        // (regardless of ON clause) to avoid invalid duplicate-table SQL.
+        if (!cloned._joinClauses.some((j) => j.table === join.table)) {
           cloned._joinClauses.push({ type: "inner", table: join.table, on: join.on, quoted: true });
         }
       }
@@ -283,15 +281,15 @@ export class Relation<T extends Base> {
   whereMissing(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
-      const target = rel._resolveAssociationTarget(assocName);
-      if (!target) {
-        throw new Error(
-          `Association named '${assocName}' was not found on ${(rel._modelClass as any).name}; perhaps you misspelled it?`,
-        );
-      }
+      this._requireAssociation(assocName);
+      const target = rel._resolveAssociationTarget(assocName)!;
       const cloned = rel._clone();
       for (const join of target.joins) {
-        cloned._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
+        // Dedup by table name to avoid duplicate-table SQL if the same
+        // association is applied twice or already joined via leftOuterJoins.
+        if (!cloned._joinClauses.some((j) => j.table === join.table)) {
+          cloned._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
+        }
       }
       const tgtTable = new Table(target.table);
       for (const pk of target.pks) {
@@ -300,6 +298,16 @@ export class Relation<T extends Base> {
       rel = cloned;
     }
     return rel;
+  }
+
+  private _requireAssociation(assocName: string): void {
+    const modelClass = this._modelClass as any;
+    const associations: any[] = modelClass._associations ?? [];
+    if (!associations.some((a: any) => a.name === assocName)) {
+      throw new Error(
+        `Association named '${assocName}' was not found on ${modelClass.name}; perhaps you misspelled it?`,
+      );
+    }
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -357,9 +357,13 @@ export class Relation<T extends Base> {
         const targetModel = modelRegistry.get(assocDef.options.className ?? _camelize(assocName));
         rawPk = assocDef.options.primaryKey ?? targetModel?.primaryKey ?? "id";
       } else {
+        // Singularize for all plural collection association types.
+        const isPlural =
+          assocDef.type === "hasMany" ||
+          assocDef.type === "hasAndBelongsToMany" ||
+          (assocDef.type as string) === "hasManyThrough";
         const className =
-          assocDef.options.className ??
-          _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
+          assocDef.options.className ?? _camelize(isPlural ? _singularize(assocName) : assocName);
         const targetModel = modelRegistry.get(className);
         rawPk = targetModel?.primaryKey ?? "id";
       }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1140,11 +1140,14 @@ export class Relation<T extends Base> {
 
     if (assocDef.type === "belongsTo") {
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(name)}_id`;
+      if (Array.isArray(foreignKey)) return null;
       const className = assocDef.options.className ?? _camelize(name);
       const targetModel = modelRegistry.get(className);
       if (!targetModel) return null;
       const targetTable = targetModel.tableName;
-      const targetPk = assocDef.options.primaryKey ?? targetModel.primaryKey ?? "id";
+      const rawTargetPk = assocDef.options.primaryKey ?? targetModel.primaryKey ?? "id";
+      if (Array.isArray(rawTargetPk)) return null;
+      const targetPk = rawTargetPk;
       const tgt = new Table(targetTable);
       const src = new Table(sourceTable);
       const predicates: Nodes.Node[] = [tgt.get(targetPk).eq(src.get(foreignKey))];
@@ -1174,8 +1177,11 @@ export class Relation<T extends Base> {
       const targetModel = modelRegistry.get(className);
       if (!targetModel) return null;
       const targetTable = targetModel.tableName;
-      const primaryKey = assocDef.options.primaryKey ?? sourcePk;
+      const rawPk = assocDef.options.primaryKey ?? sourcePk;
+      if (Array.isArray(rawPk)) return null;
+      const primaryKey = rawPk;
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`;
+      if (Array.isArray(foreignKey)) return null;
       const tgt = new Table(targetTable);
       const src = new Table(sourceTable);
       const predicates: Nodes.Node[] = [tgt.get(foreignKey).eq(src.get(primaryKey))];
@@ -1287,7 +1293,18 @@ export class Relation<T extends Base> {
         ? (sourceAssocDef?.options?.foreignKey ?? `${_toUnderscore(sourceAsName)}_id`)
         : (sourceAssocDef?.options?.foreignKey ?? `${_toUnderscore(throughClassName)}_id`);
       const rawThroughPk = throughModel.primaryKey ?? "id";
-      const throughPkCol = Array.isArray(rawThroughPk) ? rawThroughPk[0] : rawThroughPk;
+      let throughPkCol: string;
+      if (Array.isArray(rawThroughPk)) {
+        if (rawThroughPk.includes("id")) {
+          throughPkCol = "id";
+        } else if (rawThroughPk.length === 1) {
+          throughPkCol = rawThroughPk[0];
+        } else {
+          return null;
+        }
+      } else {
+        throughPkCol = rawThroughPk;
+      }
       targetPredicates.push(tgtTable.get(sourceFk).eq(thrTable.get(throughPkCol)));
       if (sourceAsName) {
         targetPredicates.push(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -254,7 +254,13 @@ export class Relation<T extends Base> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       this._requireAssociation(assocName);
-      const target = rel._resolveAssociationTarget(assocName)!;
+      const target = rel._resolveAssociationTarget(assocName);
+      if (!target) {
+        throw new Error(
+          `whereAssociated: cannot resolve join for '${assocName}' on ${(rel._modelClass as any).name} — ` +
+            `through/HABTM associations require the intermediate model to be registered.`,
+        );
+      }
       const cloned = rel._clone();
       for (const join of target.joins) {
         // Dedup by table name: skip if a join to this table already exists
@@ -282,7 +288,13 @@ export class Relation<T extends Base> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       this._requireAssociation(assocName);
-      const target = rel._resolveAssociationTarget(assocName)!;
+      const target = rel._resolveAssociationTarget(assocName);
+      if (!target) {
+        throw new Error(
+          `whereMissing: cannot resolve join for '${assocName}' on ${(rel._modelClass as any).name} — ` +
+            `through/HABTM associations require the intermediate model to be registered.`,
+        );
+      }
       const cloned = rel._clone();
       for (const join of target.joins) {
         // Dedup by table name to avoid duplicate-table SQL if the same
@@ -318,9 +330,14 @@ export class Relation<T extends Base> {
    * PKs are handled at the WHERE-predicate level (one IS NULL per PK column)
    * but not yet in the ON clause itself.
    *
-   * When the target model isn't in the registry (e.g. test helpers that set up
-   * associations without registering models), the table name is inferred from
-   * the association name/className and the join ON clause is built from options.
+   * When the target model isn't in the modelRegistry, falls back to deriving
+   * the JOIN from association options alone. For `belongsTo` the FK is known,
+   * so the fallback emits a source-table FK predicate (no JOIN) which is
+   * data-correct. For `hasOne`/`hasMany` the target table name is inferred
+   * from the className/association name and a JOIN ON is built from options.
+   *
+   * Returns null only when the association type is unsupported in the fallback
+   * path (e.g. through/HABTM without a registered model).
    */
   private _resolveAssociationTarget(
     assocName: string,
@@ -330,7 +347,7 @@ export class Relation<T extends Base> {
     const assocDef = associations.find((a: any) => a.name === assocName);
     if (!assocDef) return null;
 
-    // Try registry-based resolution first (handles all association types).
+    // Primary path: registry-based resolution handles all association types.
     const resolved = this._resolveAssociationJoin(assocName);
     if (resolved) {
       const joins = Array.isArray(resolved) ? resolved : [resolved];
@@ -350,23 +367,23 @@ export class Relation<T extends Base> {
       return { joins, table: lastJoin.table, pks };
     }
 
-    // Fallback: model not in registry — use the FK on the source table as a
-    // synthetic "join" with no real join table. This is data-correct for
-    // belongs_to (FK IS NULL / IS NOT NULL) even though it differs from Rails'
-    // JOIN form. The JOIN form requires knowing the target table name, which
-    // isn't available without a registered model.
+    // Fallback: target model not in registry — derive JOIN from options.
     const sourceTable = modelClass.tableName;
     if (assocDef.type === "belongsTo") {
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
-      // Emit a degenerate single-predicate check on the FK column instead of a JOIN.
-      // Callers (whereMissing/whereAssociated) will add a join + WHERE on `table.pks`,
-      // so we set table/on to the source table and pk to the FK column, which produces
-      // `source_table.fk IS NULL` without any join — matching the old behavior.
-      return {
-        joins: [],
-        table: sourceTable,
-        pks: [foreignKey],
-      };
+      // No JOIN needed: emit WHERE source_table.fk IS NULL instead.
+      // Data-correct for belongs_to even though it differs from Rails' JOIN form.
+      return { joins: [], table: sourceTable, pks: [foreignKey] };
+    }
+    if (assocDef.type === "hasOne" || assocDef.type === "hasMany") {
+      const className =
+        assocDef.options.className ??
+        _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
+      const targetTable = assocDef.options.tableName ?? _pluralize(_toUnderscore(className));
+      const sourcePk = assocDef.options.primaryKey ?? modelClass.primaryKey ?? "id";
+      const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`;
+      const on = `"${targetTable}"."${foreignKey}" = "${sourceTable}"."${sourcePk}"`;
+      return { joins: [{ table: targetTable, on }], table: targetTable, pks: ["id"] };
     }
     return null;
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -275,8 +275,8 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated — emits an
    * INNER JOIN on the association then WHERE assoc_pk IS NOT NULL.
-   * Skips the join if an equivalent join is already present (mirrors Rails'
-   * joins_values dedup guard).
+   * Skips if an identical (type+table+ON) join already exists; throws if a
+   * different join to the same table is present (aliasing not supported).
    */
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
@@ -344,20 +344,25 @@ export class Relation<T extends Base> {
 
   /**
    * Resolve all join steps and target PK columns for a named association.
-   * The `pks` array mirrors Rails' `Array(reflection.association_primary_key)`
-   * — multiple entries for composite-PK models. Note: the JOIN ON clauses from
-   * `_resolveAssociationJoin` interpolate PK values as strings, so composite
-   * PKs are handled at the WHERE-predicate level (one IS NULL per PK column)
-   * but not yet in the ON clause itself.
    *
-   * When the target model isn't in the modelRegistry, falls back to deriving
-   * the JOIN from association options alone. For `belongsTo` the FK is known,
-   * so the fallback emits a source-table FK predicate (no JOIN) which is
-   * data-correct. For `hasOne`/`hasMany` the target table name is inferred
-   * from the className/association name and a JOIN ON is built from options.
+   * `pks` mirrors Rails' `Array(reflection.association_primary_key)` — one
+   * entry per PK column so callers emit one IS NULL/NOT NULL predicate each.
+   * The ON clause produced by `_resolveAssociationJoin` is a column-to-column
+   * expression (e.g. `"authors"."id" = "books"."author_id"`); if an array FK
+   * were used it would stringify to `"a,b"` — an invalid column reference.
+   * We guard against that before returning (see composite-FK check below).
    *
-   * Returns null only when the association type is unsupported in the fallback
-   * path (e.g. through/HABTM without a registered model).
+   * When the target model is not in `modelRegistry` the fallback behavior
+   * differs by association type:
+   * - `belongsTo`: target table name is not safe to infer — Rails always has
+   *   a registered model class, so `tableName` is always available; without
+   *   registration the inferred name (e.g. "authors") may differ from the real
+   *   table (e.g. "wm_authors"). Falls back to WHERE source.fk IS NULL which
+   *   is data-correct but not the Rails JOIN form. **Register the model** to
+   *   get the JOIN form.
+   * - `hasOne`/`hasMany`: target table is inferred from className + pluralise,
+   *   and a JOIN ON is built from association options.
+   * - through/HABTM: returns null (caller throws).
    */
   private _resolveAssociationTarget(
     assocName: string,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -275,7 +275,9 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated — emits an
    * INNER JOIN on the association then WHERE assoc_pk IS NOT NULL.
    * Skips if an identical (type+table+ON) join already exists; throws if a
-   * different join to the same table is present (aliasing not supported).
+   * Skips if an identical (table+ON) join already exists, regardless of join
+   * type; throws if a different join to the same table is present (aliasing
+   * not supported).
    */
   whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
@@ -284,8 +286,9 @@ export class Relation<T extends Base> {
       const target = rel._resolveAssociationTarget(assocName);
       if (!target) {
         throw new Error(
-          `whereAssociated: cannot resolve join for '${assocName}' on ${(rel._modelClass as any).name} — ` +
-            `through/HABTM associations require the intermediate model to be registered.`,
+          `whereAssociated: association resolution failed for '${assocName}' on ${(rel._modelClass as any).name} — ` +
+            `through/HABTM associations may require a registered intermediate model, ` +
+            `and some join shapes (such as composite primary/foreign keys) are not supported.`,
         );
       }
       const cloned = rel._clone();
@@ -314,8 +317,9 @@ export class Relation<T extends Base> {
       const target = rel._resolveAssociationTarget(assocName);
       if (!target) {
         throw new Error(
-          `whereMissing: cannot resolve join for '${assocName}' on ${(rel._modelClass as any).name} — ` +
-            `through/HABTM associations require the intermediate model to be registered.`,
+          `whereMissing: association resolution failed for '${assocName}' on ${(rel._modelClass as any).name} — ` +
+            `through/HABTM associations may require a registered intermediate model, ` +
+            `and some join shapes (such as composite primary/foreign keys) are not supported.`,
         );
       }
       const cloned = rel._clone();
@@ -410,15 +414,16 @@ export class Relation<T extends Base> {
     // class-name convention). We fall back to a source-table FK null/non-null
     // predicate, which is data-correct but not the Rails JOIN form. **Register
     // the model** to get the JOIN form.
+    const sourceTable = modelClass.tableName;
+    if (assocDef.type === "belongsTo") {
+      const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
+      const pks = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
+      return { joins: [], table: sourceTable, pks };
+    }
     if (Array.isArray(assocDef.options.foreignKey)) {
       throw new Error(
         `whereMissing/whereAssociated: composite foreignKey on '${assocName}' is not yet supported in fallback path.`,
       );
-    }
-    const sourceTable = modelClass.tableName;
-    if (assocDef.type === "belongsTo") {
-      const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
-      return { joins: [], table: sourceTable, pks: [foreignKey] };
     }
     if (assocDef.type === "hasOne" || assocDef.type === "hasMany") {
       const className =

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -312,8 +312,11 @@ export class Relation<T extends Base> {
 
   /**
    * Resolve all join steps and target PK columns for a named association.
-   * Mirrors Rails' reflection.association_primary_key (Array form for composite
-   * PKs) and left_outer_joins expansion for through associations.
+   * The `pks` array mirrors Rails' `Array(reflection.association_primary_key)`
+   * — multiple entries for composite-PK models. Note: the JOIN ON clauses from
+   * `_resolveAssociationJoin` interpolate PK values as strings, so composite
+   * PKs are handled at the WHERE-predicate level (one IS NULL per PK column)
+   * but not yet in the ON clause itself.
    *
    * When the target model isn't in the registry (e.g. test helpers that set up
    * associations without registering models), the table name is inferred from

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -274,7 +274,6 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated — emits an
    * INNER JOIN on the association then WHERE assoc_pk IS NOT NULL.
-   * Skips if an identical (type+table+ON) join already exists; throws if a
    * Skips if an identical (table+ON) join already exists, regardless of join
    * type; throws if a different join to the same table is present (aliasing
    * not supported).
@@ -396,12 +395,16 @@ export class Relation<T extends Base> {
         rawPk = targetModel?.primaryKey ?? "id";
       }
       // Composite PKs are supported at the WHERE level (one IS NULL per column)
-      // but the JOIN ON clause from _resolveAssociationJoin uses a single string;
-      // if the association itself has a composite FK that would stringify to "a,b",
-      // throw a clear error rather than emitting broken SQL.
+      // but the JOIN ON clause from _resolveAssociationJoin is a raw SQL string;
+      // composite FK or PK options would stringify to "a,b" → invalid SQL.
       if (Array.isArray(assocDef.options.foreignKey)) {
         throw new Error(
           `whereMissing/whereAssociated: composite foreignKey on '${assocName}' is not yet supported.`,
+        );
+      }
+      if (Array.isArray(assocDef.options.primaryKey)) {
+        throw new Error(
+          `whereMissing/whereAssociated: composite primaryKey on '${assocName}' is not yet supported.`,
         );
       }
       const pks = Array.isArray(rawPk) ? rawPk : [rawPk];
@@ -430,7 +433,13 @@ export class Relation<T extends Base> {
         assocDef.options.className ??
         _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
       const targetTable = assocDef.options.tableName ?? _pluralize(_toUnderscore(className));
-      const sourcePk = assocDef.options.primaryKey ?? modelClass.primaryKey ?? "id";
+      const rawSourcePk = assocDef.options.primaryKey ?? modelClass.primaryKey ?? "id";
+      if (Array.isArray(rawSourcePk)) {
+        throw new Error(
+          `whereMissing/whereAssociated: composite primaryKey on '${assocName}' is not yet supported in fallback path.`,
+        );
+      }
+      const sourcePk = rawSourcePk;
       const foreignKey = assocDef.options.as
         ? (assocDef.options.foreignKey ?? `${_toUnderscore(assocDef.options.as)}_id`)
         : (assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -443,12 +443,15 @@ export class Relation<T extends Base> {
       const foreignKey = assocDef.options.as
         ? (assocDef.options.foreignKey ?? `${_toUnderscore(assocDef.options.as)}_id`)
         : (assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`);
-      const onParts = [`"${targetTable}"."${foreignKey}" = "${sourceTable}"."${sourcePk}"`];
+      const tgt = new Table(targetTable);
+      const src = new Table(sourceTable);
+      const onPredicates: Nodes.Node[] = [tgt.get(foreignKey).eq(src.get(sourcePk))];
       if (assocDef.options.as) {
         const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
-        onParts.push(`"${targetTable}"."${typeCol}" = '${modelClass.name}'`);
+        onPredicates.push(tgt.get(typeCol).eq(modelClass.name));
       }
-      const on = onParts.join(" AND ");
+      const onNode = onPredicates.length === 1 ? onPredicates[0] : new Nodes.And(onPredicates);
+      const on = new Visitors.ToSql().compile(onNode);
       return { joins: [{ table: targetTable, on }], table: targetTable, pks: ["id"] };
     }
     return null;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -407,9 +407,14 @@ export class Relation<T extends Base> {
     // Fallback: target model not in registry — derive JOIN from options.
     // NOTE: for belongsTo, the target table name is not reliably inferrable
     // without a registered model (the actual tableName may differ from the
-    // class-name convention). We fall back to a source-table FK predicate
-    // (WHERE source.fk IS NULL) which is data-correct for belongs_to but
-    // does not match Rails' JOIN form. Register the model to get the JOIN form.
+    // class-name convention). We fall back to a source-table FK null/non-null
+    // predicate, which is data-correct but not the Rails JOIN form. **Register
+    // the model** to get the JOIN form.
+    if (Array.isArray(assocDef.options.foreignKey)) {
+      throw new Error(
+        `whereMissing/whereAssociated: composite foreignKey on '${assocName}' is not yet supported in fallback path.`,
+      );
+    }
     const sourceTable = modelClass.tableName;
     if (assocDef.type === "belongsTo") {
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(assocName)}_id`;
@@ -421,8 +426,15 @@ export class Relation<T extends Base> {
         _camelize(assocDef.type === "hasMany" ? _singularize(assocName) : assocName);
       const targetTable = assocDef.options.tableName ?? _pluralize(_toUnderscore(className));
       const sourcePk = assocDef.options.primaryKey ?? modelClass.primaryKey ?? "id";
-      const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`;
-      const on = `"${targetTable}"."${foreignKey}" = "${sourceTable}"."${sourcePk}"`;
+      const foreignKey = assocDef.options.as
+        ? (assocDef.options.foreignKey ?? `${_toUnderscore(assocDef.options.as)}_id`)
+        : (assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`);
+      const onParts = [`"${targetTable}"."${foreignKey}" = "${sourceTable}"."${sourcePk}"`];
+      if (assocDef.options.as) {
+        const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
+        onParts.push(`"${targetTable}"."${typeCol}" = '${modelClass.name}'`);
+      }
+      const on = onParts.join(" AND ");
       return { joins: [{ table: targetTable, on }], table: targetTable, pks: ["id"] };
     }
     return null;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -82,9 +82,9 @@ function _addAssocJoin(
   assocName: string,
   modelClass: any,
 ): void {
-  const sameTableOn = clauses.find((j) => j.table === join.table);
-  if (sameTableOn) {
-    if (sameTableOn.on === join.on) return; // compatible existing join — skip
+  const sameTableJoins = clauses.filter((j) => j.table === join.table);
+  if (sameTableJoins.length > 0) {
+    if (sameTableJoins.every((j) => j.on === join.on)) return; // all compatible — skip
     throw new Error(
       `where${type === "inner" ? "Associated" : "Missing"}: cannot add ${type.toUpperCase()} JOIN for '${assocName}' on ${modelClass.name} ` +
         `— a different join to '${join.table}' already exists and cannot be represented without aliasing.`,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -93,6 +93,12 @@ function _addAssocJoin(
   clauses.push({ type, table: join.table, on: join.on, quoted: true });
 }
 
+/** Compile one or more Arel predicate nodes to the ON string used in _joinClauses. */
+function _buildOnString(...predicates: Nodes.Node[]): string {
+  const node = predicates.length === 1 ? predicates[0] : new Nodes.And(predicates);
+  return new Visitors.ToSql().compile(node);
+}
+
 function validateExplainOptions(options: ExplainOption[]): void {
   let seenHash = false;
   for (let i = 0; i < options.length; i++) {
@@ -1139,7 +1145,9 @@ export class Relation<T extends Base> {
       if (!targetModel) return null;
       const targetTable = targetModel.tableName;
       const targetPk = assocDef.options.primaryKey ?? targetModel.primaryKey ?? "id";
-      let onClause = `"${targetTable}"."${targetPk}" = "${sourceTable}"."${foreignKey}"`;
+      const tgt = new Table(targetTable);
+      const src = new Table(sourceTable);
+      const predicates: Nodes.Node[] = [tgt.get(targetPk).eq(src.get(foreignKey))];
 
       // STI type condition on target
       const inheritanceCol = getInheritanceColumn(targetModel);
@@ -1148,11 +1156,10 @@ export class Relation<T extends Base> {
           targetModel.name,
           ...(targetModel.descendants ?? []).map((d: any) => d.name),
         ];
-        const inList = stiNames.map((n: string) => `'${n}'`).join(", ");
-        onClause += ` AND "${targetTable}"."${inheritanceCol}" IN (${inList})`;
+        predicates.push(tgt.get(inheritanceCol).in(stiNames));
       }
 
-      return { table: targetTable, on: onClause };
+      return { table: targetTable, on: _buildOnString(...predicates) };
     }
 
     if (assocDef.type === "hasOne" || assocDef.type === "hasMany") {
@@ -1169,12 +1176,14 @@ export class Relation<T extends Base> {
       const targetTable = targetModel.tableName;
       const primaryKey = assocDef.options.primaryKey ?? sourcePk;
       const foreignKey = assocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`;
-      let onClause = `"${targetTable}"."${foreignKey}" = "${sourceTable}"."${primaryKey}"`;
+      const tgt = new Table(targetTable);
+      const src = new Table(sourceTable);
+      const predicates: Nodes.Node[] = [tgt.get(foreignKey).eq(src.get(primaryKey))];
 
       // Polymorphic type condition
       if (assocDef.options.as) {
         const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
-        onClause += ` AND "${targetTable}"."${typeCol}" = '${modelClass.name}'`;
+        predicates.push(tgt.get(typeCol).eq(modelClass.name));
       }
 
       // STI type condition on target
@@ -1184,11 +1193,10 @@ export class Relation<T extends Base> {
           targetModel.name,
           ...(targetModel.descendants ?? []).map((d: any) => d.name),
         ];
-        const inList = stiNames.map((n: string) => `'${n}'`).join(", ");
-        onClause += ` AND "${targetTable}"."${inheritanceCol}" IN (${inList})`;
+        predicates.push(tgt.get(inheritanceCol).in(stiNames));
       }
 
-      return { table: targetTable, on: onClause };
+      return { table: targetTable, on: _buildOnString(...predicates) };
     }
 
     // hasManyThrough (test-data style where type is literally "hasManyThrough")
@@ -1231,23 +1239,25 @@ export class Relation<T extends Base> {
     const throughTable = (throughModel as any).tableName;
 
     // Build the first JOIN: source -> through
-    let throughOn: string;
+    const srcTable = new Table(sourceTable);
+    const thrTable = new Table(throughTable);
+    const throughPredicates: Nodes.Node[] = [];
 
     if (throughAssocDef.type === "belongsTo") {
       const throughFk = throughAssocDef.options.foreignKey ?? `${_toUnderscore(throughName)}_id`;
       const throughTargetPk = throughAssocDef.options.primaryKey ?? throughModel.primaryKey ?? "id";
-      throughOn = `"${throughTable}"."${throughTargetPk}" = "${sourceTable}"."${throughFk}"`;
+      throughPredicates.push(thrTable.get(throughTargetPk).eq(srcTable.get(throughFk)));
     } else {
-      // hasMany or hasOne
       const throughPk = throughAssocDef.options.primaryKey ?? sourcePk;
       const throughAsName = throughAssocDef.options.as;
       const throughFk = throughAsName
         ? (throughAssocDef.options.foreignKey ?? `${_toUnderscore(throughAsName)}_id`)
         : (throughAssocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`);
-      throughOn = `"${throughTable}"."${throughFk}" = "${sourceTable}"."${throughPk}"`;
+      throughPredicates.push(thrTable.get(throughFk).eq(srcTable.get(throughPk)));
       if (throughAsName) {
-        const typeCol = `${_toUnderscore(throughAsName)}_type`;
-        throughOn += ` AND "${throughTable}"."${typeCol}" = '${modelClass.name}'`;
+        throughPredicates.push(
+          thrTable.get(`${_toUnderscore(throughAsName)}_type`).eq(modelClass.name),
+        );
       }
     }
 
@@ -1262,31 +1272,33 @@ export class Relation<T extends Base> {
     const targetModel = modelRegistry.get(targetClassName);
     if (!targetModel) return null;
     const targetTable = (targetModel as any).tableName;
+    const tgtTable = new Table(targetTable);
 
     const sourceType = sourceAssocDef?.type ?? "belongsTo";
-    let targetOn: string;
+    const targetPredicates: Nodes.Node[] = [];
 
     if (sourceType === "belongsTo") {
       const targetFk = sourceAssocDef?.options?.foreignKey ?? `${_toUnderscore(sourceName)}_id`;
       const targetPk = sourceAssocDef?.options?.primaryKey ?? targetModel.primaryKey ?? "id";
-      targetOn = `"${targetTable}"."${targetPk}" = "${throughTable}"."${targetFk}"`;
+      targetPredicates.push(tgtTable.get(targetPk).eq(thrTable.get(targetFk)));
     } else {
-      // hasMany or hasOne: target has FK pointing to through
       const sourceAsName = sourceAssocDef?.options?.as;
       const sourceFk = sourceAsName
         ? (sourceAssocDef?.options?.foreignKey ?? `${_toUnderscore(sourceAsName)}_id`)
         : (sourceAssocDef?.options?.foreignKey ?? `${_toUnderscore(throughClassName)}_id`);
-      const throughPkCol = throughModel.primaryKey ?? "id";
-      targetOn = `"${targetTable}"."${sourceFk}" = "${throughTable}"."${throughPkCol}"`;
+      const rawThroughPk = throughModel.primaryKey ?? "id";
+      const throughPkCol = Array.isArray(rawThroughPk) ? rawThroughPk[0] : rawThroughPk;
+      targetPredicates.push(tgtTable.get(sourceFk).eq(thrTable.get(throughPkCol)));
       if (sourceAsName) {
-        const typeCol = `${_toUnderscore(sourceAsName)}_type`;
-        targetOn += ` AND "${targetTable}"."${typeCol}" = '${throughClassName}'`;
+        targetPredicates.push(
+          tgtTable.get(`${_toUnderscore(sourceAsName)}_type`).eq(throughClassName),
+        );
       }
     }
 
     return [
-      { table: throughTable, on: throughOn },
-      { table: targetTable, on: targetOn },
+      { table: throughTable, on: _buildOnString(...throughPredicates) },
+      { table: targetTable, on: _buildOnString(...targetPredicates) },
     ];
   }
 
@@ -1322,14 +1334,14 @@ export class Relation<T extends Base> {
     const ownerFk: string = fkOption ?? `${_toUnderscore(modelClass.name)}_id`;
     const targetFk = `${_toUnderscore(_singularize(assocDef.name))}_id`;
 
+    const srcT = new Table(sourceTable);
+    const joinT = new Table(joinTable);
+    const tgtT = new Table(targetTable);
     return [
-      {
-        table: joinTable,
-        on: `"${joinTable}"."${ownerFk}" = "${sourceTable}"."${sourcePk}"`,
-      },
+      { table: joinTable, on: _buildOnString(joinT.get(ownerFk).eq(srcT.get(sourcePk))) },
       {
         table: targetTable,
-        on: `"${targetTable}"."${targetPk}" = "${joinTable}"."${targetFk}"`,
+        on: _buildOnString(tgtT.get(targetPk as string).eq(joinT.get(targetFk))),
       },
     ];
   }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -19,14 +19,6 @@
     "side": "diff",
     "reason": "in_order_of: multiple divergences vs Rails. (1) Rails adds WHERE \"books\".\"status\" IN (values) to filter to the named set; trails omits it. (2) Rails CASE values are 1-indexed; trails 0-indexed with ELSE branch. (3) Rails appends ASC; trails leaves direction bare. (4) Rails qualifies the column ('\"books\".\"status\"'); trails leaves it bare. Real implementation gap — trails Relation#inOrderOf is incomplete vs ActiveRecord::QueryMethods#in_order_of."
   },
-  "ar-36": {
-    "side": "diff",
-    "reason": "where.missing(:assoc): Rails emits LEFT OUTER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NULL (works for any association type). trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NULL — equivalent for belongs_to but diverges from Rails' SQL and won't work for has_one/has_many. Real trails-missing: whereMissing should emit the JOIN form."
-  },
-  "ar-37": {
-    "side": "diff",
-    "reason": "where.associated(:assoc): Rails emits INNER JOIN \"authors\" ON ... WHERE \"authors\".\"id\" IS NOT NULL. trails shortcuts a belongs_to to WHERE \"books\".\"author_id\" IS NOT NULL. Same shape gap as ar-36 — whereAssociated should emit the INNER JOIN + assoc-side IS NOT NULL form."
-  },
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."


### PR DESCRIPTION
## Summary

- **ar-36/ar-37**: `whereMissing` and `whereAssociated` now emit the JOIN form that Rails uses, matching `WhereChain#missing` / `#associated` exactly.

**Before (belongsTo shortcut):**
```sql
-- whereMissing(:author)
WHERE "books"."author_id" IS NULL
-- whereAssociated(:author)
WHERE "books"."author_id" IS NOT NULL
```

**After (Rails JOIN form):**
```sql
-- whereMissing(:author)
LEFT OUTER JOIN "authors" ON "authors"."id" = "books"."author_id" WHERE "authors"."id" IS NULL
-- whereAssociated(:author)
INNER JOIN "authors" ON "authors"."id" = "books"."author_id" WHERE "authors"."id" IS NOT NULL
```

## Registry requirement

The JOIN form requires the target model to be registered in `modelRegistry` so the correct `tableName` is available. Without registration, `belongs_to` falls back to `WHERE source.fk IS NULL/NOT NULL` (data-correct but not the Rails JOIN form); `has_one`/`has_many` fall back to inferring the table name from the class name convention. Rails always has registered models, so this only affects test helpers that set up associations without `registerModel`.

## Implementation

- `_resolveAssociationTarget` reuses `_resolveAssociationJoin` (handles all association types including through/HABTM) and extracts target PK column(s) (composite PK aware — one IS NULL predicate per column).
- `_addAssocJoin` helper deduplicates by table+ON (skips if same ON regardless of join type; throws if same table but different ON — aliasing not supported).
- `_requireAssociation` called on `rel` (not `this`) for correctness.

Removes ar-36 and ar-37 from `query-known-gaps.json`; 5 gaps remain (ar-01/52/65 datetime, ar-16 eagerLoad, ar-32 inOrderOf, ar-57 includes+references).

## Test plan

- [x] `whereMissing` + `whereAssociated` for `belongsTo`: LEFT/INNER JOIN + assoc PK IS NULL/NOT NULL, no FK in WHERE
- [x] `whereMissing` + `whereAssociated` for `hasMany`: LEFT/INNER JOIN + target PK IS NULL/NOT NULL
- [x] Parity: `122/128 passed, 5 known gap(s)` (ar-36, ar-37 now pass)
- [x] All existing `where.test.ts` tests pass (unregistered-model FK fallback preserved)