### PR TITLE
feat(encryption): unskip 2 tests — custom metadata and dump/load

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -415,7 +415,24 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   it.skip("loading records with encrypted attributes defined on columns with default values", () => {
     // requires upsert/insert_on_duplicate_update support
   });
-  it.skip("can dump and load records that use encryption", () => {});
+  it("can dump and load records that use encryption", async () => {
+    // Mirrors Rails' Marshal.dump/Marshal.load test: after serializing a model's raw
+    // attribute state (ciphertexts) and reconstructing a new instance via the DB-load
+    // path, the encrypted attribute should decrypt correctly on read.
+    const Book = makeEncryptedBook(freshAdapter());
+    new Book();
+
+    const book = await Book.create({ name: "Dune" });
+
+    // Capture raw DB values (ciphertexts) — equivalent to what Marshal.dump preserves.
+    const rawValues = book._attributes.valuesForDatabase();
+
+    // Reconstruct via _instantiate (the DB-load path) so writeFromDatabase → deserialize
+    // is invoked, matching how Rails Marshal.load reconstructs AR objects.
+    const loadedBook = (Book as any)._instantiate(rawValues);
+
+    expect(loadedBook.name).toBe("Dune");
+  });
   it("supports decrypting data encrypted non deterministically with SHA1 when digest class is SHA256", async () => {
     Configurable.configure({
       primaryKey: "the primary key",

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Encryptor } from "./encryptor.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
 import { MessageSerializer } from "./message-serializer.js";
+import { Message } from "./message.js";
 import { defaultCompressor } from "./config.js";
 import * as crypto from "crypto";
 
@@ -121,7 +122,7 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
 
   it("store custom metadata with the encrypted data, accessible by the key provider", () => {
     const secret = generateKey();
-    let receivedMessage: unknown = null;
+    let receivedMessage: Message | null = null;
 
     // Key provider that stores publicTags in the message headers and reads them back
     // during decryption. Mirrors Rails: key_provider.encryption_key.public_tags are
@@ -130,7 +131,7 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
       encryptionKey() {
         return { secret, publicTags: { model: "User", attr: "email" } };
       },
-      decryptionKeys(message: unknown) {
+      decryptionKeys(message: Message) {
         receivedMessage = message;
         return [{ secret }];
       },
@@ -148,10 +149,10 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     expect(message.headers.get("model")).toBe("User");
     expect(message.headers.get("attr")).toBe("email");
 
-    // Verify the key provider received a message with the custom metadata headers during decryption.
-    const received = receivedMessage as typeof message;
-    expect(received.headers.get("model")).toBe("User");
-    expect(received.headers.get("attr")).toBe("email");
+    // Verify the key provider received a Message with the custom metadata headers during decryption.
+    expect(receivedMessage).not.toBeNull();
+    expect(receivedMessage!.headers.get("model")).toBe("User");
+    expect(receivedMessage!.headers.get("attr")).toBe("email");
   });
 
   it("compress? returns the compress setting", () => {

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -119,8 +119,39 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     expect(() => enc.encrypt({} as any, { key: generateKey() })).toThrow(ForbiddenClass);
   });
 
-  it.skip("store custom metadata with the encrypted data, accessible by the key provider", () => {
-    /* needs key provider integration with metadata */
+  it("store custom metadata with the encrypted data, accessible by the key provider", () => {
+    const secret = generateKey();
+    let receivedMessage: unknown = null;
+
+    // Key provider that stores publicTags in the message headers and reads them back
+    // during decryption. Mirrors Rails: key_provider.encryption_key.public_tags are
+    // serialized into the message, and decryption_keys receives the full Message.
+    const keyProvider = {
+      encryptionKey() {
+        return { secret, publicTags: { model: "User", attr: "email" } };
+      },
+      decryptionKeys(message: unknown) {
+        receivedMessage = message;
+        return [{ secret }];
+      },
+    };
+
+    const enc = new Encryptor();
+    const encrypted = enc.encrypt("test@example.com", { keyProvider });
+    const decrypted = enc.decrypt(encrypted, { keyProvider });
+
+    expect(decrypted).toBe("test@example.com");
+
+    // Verify the custom metadata was stored in the message headers.
+    const serializer = new MessageSerializer();
+    const message = serializer.load(encrypted);
+    expect(message.headers.get("model")).toBe("User");
+    expect(message.headers.get("attr")).toBe("email");
+
+    // Verify the key provider received a message with the custom metadata headers during decryption.
+    const received = receivedMessage as typeof message;
+    expect(received.headers.get("model")).toBe("User");
+    expect(received.headers.get("attr")).toBe("email");
   });
 
   it("compress? returns the compress setting", () => {


### PR DESCRIPTION
## Summary

- **"store custom metadata with the encrypted data, accessible by the key provider"** (EncryptorTest): `publicTags` from `encryptionKey()` are already stored in message headers by `Encryptor.encrypt`. The test verifies the end-to-end flow: custom tags are written into the message, serialized with the ciphertext, and the key provider's `decryptionKeys(message)` receives the full message (including those headers) during decryption.

- **"can dump and load records that use encryption"** (EncryptableRecordTest): Rails tests `Marshal.dump(book)` / `Marshal.load(dumped)`, which preserves raw ciphertexts in `@attributes` and re-runs `deserialize` on access. JS equivalent: extract raw DB values via `valuesForDatabase()`, then reconstruct via `_instantiate` (the `writeFromDatabase` → `deserialize` path), verifying the encrypted attribute decrypts correctly.

## Test plan

- [ ] `encryptor.test.ts` — 16 tests pass (was 15; 1 unskipped)
- [ ] `encryptable-record.test.ts` — 43 tests pass, 9 skipped (was 10 skipped; 1 unskipped)
- [ ] Full encryption suite — 270 passing, 12 skipped (no regressions)