### PR TITLE
feat(activerecord): unsafe raw SQL parity — 35 new passing tests (PR 1.12)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -288,7 +288,8 @@ export function columnNameMatcher(): RegExp {
  * (SQLite3 adapter variant — used by the default in-memory test adapter)
  */
 export function columnNameWithOrderMatcher(): RegExp {
-  // Same atom as column_name_matcher but with COLLATE, ASC/DESC, NULLS modifiers.
+  // Same atom as column_name_matcher but with COLLATE and ASC/DESC modifiers.
+  // Note: NULLS FIRST/LAST is a PostgreSQL extension not included in the SQLite3 variant.
   const col = String.raw`(?:\w+|"\w+")`;
   const prefix = String.raw`(?:\w+\.|"\w+"\.)`;
   const innerArg = String.raw`(?:${prefix}?${col}|\w+\((?:|${prefix}?${col})\))`;

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -267,16 +267,16 @@ export function sanitizeAsSqlComment(value: unknown): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_matcher
  */
 export function columnNameMatcher(): RegExp {
-  // Mirrors Rails' column_name_matcher — allows:
-  //   word, "word", table.col, "table"."col", func(word), func(func(word)),
-  //   with optional AS alias.
-  // Requires balanced double-quoted identifiers and restricts function
-  // arguments to identifiers/dotted-identifiers/nested functions (no operators).
-  const quotedWord = String.raw`(?:"\w+"|'\w+'|\w+)`;
-  const innerArg = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:${quotedWord}\.)?${quotedWord}\))`;
-  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:|${innerArg})\))`;
+  // Mirrors Rails' SQLite3 adapter column_name_matcher:
+  //   ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
+  // JS lacks recursive backreferences, so function-arg nesting is approximated
+  // at 2 levels (covers length(trim(col)) and similar real-world cases).
+  const col = String.raw`(?:\w+|"\w+")`;
+  const prefix = String.raw`(?:\w+\.|"\w+"\.)`;
+  const innerArg = String.raw`(?:${prefix}?${col}|\w+\((?:|${prefix}?${col})\))`;
+  const atom = String.raw`(?:${prefix}?${col}|\w+\((?:|${innerArg})\))`;
   return new RegExp(
-    `^(${atom}(?:(?:\\s+AS)?\\s+\\w+)?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+\\w+)?)*$`,
+    `^(${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)*$`,
     "i",
   );
 }
@@ -285,14 +285,16 @@ export function columnNameMatcher(): RegExp {
  * Regexp for column names with order.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_with_order_matcher
+ * (SQLite3 adapter variant — used by the default in-memory test adapter)
  */
 export function columnNameWithOrderMatcher(): RegExp {
-  // Like column_name_matcher but with optional ASC/DESC/NULLS modifiers.
-  const quotedWord = String.raw`(?:"\w+"|'\w+'|\w+)`;
-  const innerArg = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:${quotedWord}\.)?${quotedWord}\))`;
-  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:|${innerArg})\))`;
+  // Same atom as column_name_matcher but with COLLATE, ASC/DESC, NULLS modifiers.
+  const col = String.raw`(?:\w+|"\w+")`;
+  const prefix = String.raw`(?:\w+\.|"\w+"\.)`;
+  const innerArg = String.raw`(?:${prefix}?${col}|\w+\((?:|${prefix}?${col})\))`;
+  const atom = String.raw`(?:${prefix}?${col}|\w+\((?:|${innerArg})\))`;
   return new RegExp(
-    `^(${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
+    `^(${atom}(?:\\s+COLLATE\\s+(?:\\w+|"\\w+"))?(?:\\s+ASC|\\s+DESC)?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+(?:\\w+|"\\w+"))?(?:\\s+ASC|\\s+DESC)?)*$`,
     "i",
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -267,7 +267,16 @@ export function sanitizeAsSqlComment(value: unknown): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_matcher
  */
 export function columnNameMatcher(): RegExp {
-  return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)*$/i;
+  // Mirrors Rails' column_name_matcher — allows:
+  //   word, "word", table.col, "table"."col", func(word), func(func(word)),
+  //   with optional AS alias.
+  // Approximation of Rails' recursive \g<2> pattern using 2-level nesting.
+  const quotedWord = String.raw`(?:"?\w+"?)`;
+  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:[^,()]*|\w+\([^,()]*\))*\))`;
+  return new RegExp(
+    `^(${atom}(?:(?:\\s+AS)?\\s+\\w+)?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+\\w+)?)*$`,
+    "i",
+  );
 }
 
 /**
@@ -276,7 +285,13 @@ export function columnNameMatcher(): RegExp {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_with_order_matcher
  */
 export function columnNameWithOrderMatcher(): RegExp {
-  return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+  // Like column_name_matcher but with optional ASC/DESC/NULLS modifiers.
+  const quotedWord = String.raw`(?:"?\w+"?)`;
+  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:[^,()]*|\w+\([^,()]*\))*\))`;
+  return new RegExp(
+    `^(${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
+    "i",
+  );
 }
 
 function isSqlLiteral(value: unknown): value is { value: string } {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -267,37 +267,29 @@ export function sanitizeAsSqlComment(value: unknown): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_matcher
  */
 export function columnNameMatcher(): RegExp {
-  // Mirrors Rails' SQLite3 adapter column_name_matcher:
-  //   ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
-  // JS lacks recursive backreferences, so function-arg nesting is approximated
-  // at 2 levels (covers length(trim(col)) and similar real-world cases).
-  const col = String.raw`(?:\w+|"\w+")`;
-  const prefix = String.raw`(?:\w+\.|"\w+"\.)`;
-  const innerArg = String.raw`(?:${prefix}?${col}|\w+\((?:|${prefix}?${col})\))`;
-  const atom = String.raw`(?:${prefix}?${col}|\w+\((?:|${innerArg})\))`;
-  return new RegExp(
-    `^(${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)*$`,
-    "i",
-  );
+  // Direct JS translation of Rails' abstract adapter column_name_matcher.
+  // Ruby source uses \g<2> for recursion; JS approximates at 2 levels
+  // (handles length(trim(col)) and similar real-world cases).
+  //
+  // Rails Ruby:
+  //   /((?:\w+\.)?\w+ | \w+\((?:|\g<2>)\)) (?:(?:\s+AS)?\s+\w+)?
+  //   (?:\s*,\s*\g<1>)*/ix
+  return /^((?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:(?:\s+AS)?\s+\w+)?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:(?:\s+AS)?\s+\w+)?)*$/i;
 }
 
 /**
  * Regexp for column names with order.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#column_name_with_order_matcher
- * (SQLite3 adapter variant — used by the default in-memory test adapter)
  */
 export function columnNameWithOrderMatcher(): RegExp {
-  // Same atom as column_name_matcher but with COLLATE and ASC/DESC modifiers.
-  // Note: NULLS FIRST/LAST is a PostgreSQL extension not included in the SQLite3 variant.
-  const col = String.raw`(?:\w+|"\w+")`;
-  const prefix = String.raw`(?:\w+\.|"\w+"\.)`;
-  const innerArg = String.raw`(?:${prefix}?${col}|\w+\((?:|${prefix}?${col})\))`;
-  const atom = String.raw`(?:${prefix}?${col}|\w+\((?:|${innerArg})\))`;
-  return new RegExp(
-    `^(${atom}(?:\\s+COLLATE\\s+(?:\\w+|"\\w+"))?(?:\\s+ASC|\\s+DESC)?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+(?:\\w+|"\\w+"))?(?:\\s+ASC|\\s+DESC)?)*$`,
-    "i",
-  );
+  // Direct JS translation of Rails' abstract adapter column_name_with_order_matcher.
+  // No COLLATE (abstract has none); NULLS FIRST/LAST included per Rails abstract pattern.
+  //
+  // Rails Ruby:
+  //   /((?:\w+\.)?\w+ | \w+\((?:|\g<2>)\)) (?:\s+ASC|\s+DESC)?
+  //   (?:\s+NULLS\s+(?:FIRST|LAST))? (?:\s*,\s*\g<1>)*/ix
+  return /^((?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
 }
 
 function isSqlLiteral(value: unknown): value is { value: string } {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -270,9 +270,11 @@ export function columnNameMatcher(): RegExp {
   // Mirrors Rails' column_name_matcher — allows:
   //   word, "word", table.col, "table"."col", func(word), func(func(word)),
   //   with optional AS alias.
-  // Approximation of Rails' recursive \g<2> pattern using 2-level nesting.
-  const quotedWord = String.raw`(?:"?\w+"?)`;
-  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:[^,()]*|\w+\([^,()]*\))*\))`;
+  // Requires balanced double-quoted identifiers and restricts function
+  // arguments to identifiers/dotted-identifiers/nested functions (no operators).
+  const quotedWord = String.raw`(?:"\w+"|'\w+'|\w+)`;
+  const innerArg = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:${quotedWord}\.)?${quotedWord}\))`;
+  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:|${innerArg})\))`;
   return new RegExp(
     `^(${atom}(?:(?:\\s+AS)?\\s+\\w+)?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+\\w+)?)*$`,
     "i",
@@ -286,8 +288,9 @@ export function columnNameMatcher(): RegExp {
  */
 export function columnNameWithOrderMatcher(): RegExp {
   // Like column_name_matcher but with optional ASC/DESC/NULLS modifiers.
-  const quotedWord = String.raw`(?:"?\w+"?)`;
-  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:[^,()]*|\w+\([^,()]*\))*\))`;
+  const quotedWord = String.raw`(?:"\w+"|'\w+'|\w+)`;
+  const innerArg = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:${quotedWord}\.)?${quotedWord}\))`;
+  const atom = String.raw`(?:(?:${quotedWord}\.)?${quotedWord}|\w+\((?:|${innerArg})\))`;
   return new RegExp(
     `^(${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
     "i",

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -122,31 +122,50 @@ export function castBoundValue(value: unknown): unknown {
   return value;
 }
 
-// Mirrors Rails' MySQL::Quoting.column_name_matcher. JS can't replicate Ruby's
-// recursive \g<n> back-references, so we limit function arguments to plain
-// identifiers and column references (no nested expressions), which is stricter
-// than Rails but prevents injection via function call arguments.
+// Mirrors Rails' MySQL::Quoting.column_name_matcher.
+// Rails uses recursive \g<n> back-references; JS approximates with 2-level
+// function call unrolling (handles length(trim(col)) and similar).
+// Rails MySQL COLUMN_NAME supports: integers, `backtick`, "double-quoted", \w identifiers,
+// with up to 2 qualifier prefixes (schema.table.col) and recursive function args.
 export function columnNameMatcher(): RegExp {
-  const id = String.raw`(?:\w+|` + "`" + String.raw`\w+` + "`" + String.raw`)`;
-  const col = String.raw`(?:${id}\.)?${id}`;
-  const fnArg = String.raw`(?:\*|${col})`;
-  const fnCall = String.raw`\w+\(\s*(?:${fnArg}(?:\s*,\s*${fnArg})*)?\s*\)`;
-  const expr = String.raw`(?:${col}|${fnCall})`;
+  // id: integer literal, backtick-quoted, double-quoted, or plain \w identifier
+  const id =
+    String.raw`(?:\d+|` +
+    "`" +
+    String.raw`[^` +
+    "`" +
+    String.raw`]*` +
+    "`" +
+    String.raw`|"[^"]*"|\w+)`;
+  const col = String.raw`(?:(?:${id}\.){0,2})${id}`;
+  // fnCall2: function with plain col/star args (deepest level)
+  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})(?:\s*,\s*(?:\*|${col}))*\s*\)|\w+\(\s*\)`;
+  // fnCall1: function whose args can themselves be functions (level 1)
+  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})(?:\s*,\s*(?:\*|${col}|${fnCall2}))*\s*\)|\w+\(\s*\)`;
+  const expr = String.raw`(?:${col}|${fnCall1})`;
   const aliased = String.raw`${expr}(?:(?:\s+AS)?\s+${id})?`;
   return new RegExp(`^${aliased}(?:\\s*,\\s*${aliased})*$`, "i");
 }
 
 // Mirrors Rails' MySQL::Quoting.column_name_with_order_matcher — like
-// columnNameMatcher but also allows COLLATE and ASC/DESC suffixes.
+// columnNameMatcher but also allows COLLATE and ASC/DESC/NULLS suffixes.
 export function columnNameWithOrderMatcher(): RegExp {
-  const id = String.raw`(?:\w+|` + "`" + String.raw`\w+` + "`" + String.raw`)`;
-  const col = String.raw`(?:${id}\.)?${id}`;
-  const fnArg = String.raw`(?:\*|${col})`;
-  const fnCall = String.raw`\w+\(\s*(?:${fnArg}(?:\s*,\s*${fnArg})*)?\s*\)`;
-  const expr = String.raw`(?:${col}|${fnCall})`;
-  const collate = String.raw`(?:\s+COLLATE\s+(?:\w+|"\w+"))?`;
+  const id =
+    String.raw`(?:\d+|` +
+    "`" +
+    String.raw`[^` +
+    "`" +
+    String.raw`]*` +
+    "`" +
+    String.raw`|"[^"]*"|\w+)`;
+  const col = String.raw`(?:(?:${id}\.){0,2})${id}`;
+  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})(?:\s*,\s*(?:\*|${col}))*\s*\)|\w+\(\s*\)`;
+  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})(?:\s*,\s*(?:\*|${col}|${fnCall2}))*\s*\)|\w+\(\s*\)`;
+  const expr = String.raw`(?:${col}|${fnCall1})`;
+  const collate = String.raw`(?:\s+COLLATE\s+\S+)?`;
   const dir = String.raw`(?:\s+ASC|\s+DESC)?`;
-  const ordered = String.raw`${expr}${collate}${dir}`;
+  const nulls = String.raw`(?:\s+NULLS\s+(?:FIRST|LAST))?`;
+  const ordered = String.raw`${expr}${collate}${dir}${nulls}`;
   return new RegExp(`^${ordered}(?:\\s*,\\s*${ordered})*$`, "i");
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -163,7 +163,7 @@ export function columnNameWithOrderMatcher(): RegExp {
   const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
   const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})?\s*\)`;
   const expr = String.raw`(?:${col}|${fnCall1})`;
-  const collate = String.raw`(?:\s+COLLATE\s+\S+)?`;
+  const collate = String.raw`(?:\s+COLLATE\s+\w+)?`;
   const dir = String.raw`(?:\s+ASC|\s+DESC)?`;
   const nulls = String.raw`(?:\s+NULLS\s+(?:FIRST|LAST))?`;
   const ordered = String.raw`${expr}${collate}${dir}${nulls}`;

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -138,10 +138,11 @@ export function columnNameMatcher(): RegExp {
     "`" +
     String.raw`|"[^"]*"|\w+)`;
   const col = String.raw`(?:(?:${id}\.){0,2})${id}`;
-  // fnCall2: function with plain col/star args (deepest level)
-  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})(?:\s*,\s*(?:\*|${col}))*\s*\)|\w+\(\s*\)`;
-  // fnCall1: function whose args can themselves be functions (level 1)
-  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})(?:\s*,\s*(?:\*|${col}|${fnCall2}))*\s*\)|\w+\(\s*\)`;
+  // Rails uses \w+\((?:|\g<2>)\) — 0 or 1 arg (no comma-separated multi-arg).
+  // fnCall2: function with 0 or 1 plain col/star arg (deepest level)
+  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
+  // fnCall1: function with 0 or 1 arg (which can itself be a function)
+  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})?\s*\)`;
   const expr = String.raw`(?:${col}|${fnCall1})`;
   const aliased = String.raw`${expr}(?:(?:\s+AS)?\s+${id})?`;
   return new RegExp(`^${aliased}(?:\\s*,\\s*${aliased})*$`, "i");
@@ -159,8 +160,8 @@ export function columnNameWithOrderMatcher(): RegExp {
     "`" +
     String.raw`|"[^"]*"|\w+)`;
   const col = String.raw`(?:(?:${id}\.){0,2})${id}`;
-  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})(?:\s*,\s*(?:\*|${col}))*\s*\)|\w+\(\s*\)`;
-  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})(?:\s*,\s*(?:\*|${col}|${fnCall2}))*\s*\)|\w+\(\s*\)`;
+  const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
+  const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})?\s*\)`;
   const expr = String.raw`(?:${col}|${fnCall1})`;
   const collate = String.raw`(?:\s+COLLATE\s+\S+)?`;
   const dir = String.raw`(?:\s+ASC|\s+DESC)?`;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -16,6 +16,8 @@ import {
   quoteColumnName as pgQuoteColumnName,
   quoteString as pgQuoteString,
   quoteDefaultExpression as pgQuoteDefaultExpression,
+  columnNameMatcher as pgColumnNameMatcher,
+  columnNameWithOrderMatcher as pgColumnNameWithOrderMatcher,
 } from "./postgresql/quoting.js";
 import { TypeMapInitializer, type PgTypeRow } from "./postgresql/oid/type-map-initializer.js";
 import {
@@ -78,31 +80,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   static columnNameMatcher(): RegExp {
-    // Rails PostgreSQL adapter column_name_matcher:
-    //   (col(?:::\w+)? | func(arg?)(?:::\w+)?) with optional AS alias.
-    // Both branches carry their own (?:::\w+)? so backtracking from col→func works.
-    // 2-level approximation of Ruby's recursive \g<2>.
-    //
-    // col_branch: (?:\w+\.|"\w+"\.){0,2}(?:\w+|"\w+")(?:::\w+)?
-    // func_branch: \w+\((?:|col_branch|func(col_branch))\)(?:::\w+)?
-    const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
-    const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
-    const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
-    return new RegExp(
-      `^(${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)*$`,
-      "i",
-    );
+    return pgColumnNameMatcher();
   }
 
   static columnNameWithOrderMatcher(): RegExp {
-    // Same atom as columnNameMatcher plus COLLATE, ASC/DESC, NULLS FIRST/LAST.
-    const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
-    const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
-    const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
-    return new RegExp(
-      `^(${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
-      "i",
-    );
+    return pgColumnNameWithOrderMatcher();
   }
 
   override get active(): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -77,6 +77,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return "PostgreSQL";
   }
 
+  static columnNameMatcher(): RegExp {
+    // Rails PostgreSQL adapter column_name_matcher:
+    //   ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)? | \w+\((?:|\g<2>)\)(?:::\w+)?)
+    //   with optional AS alias. 2-level \g<2> approximation.
+    return /^((?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)*$/i;
+  }
+
+  static columnNameWithOrderMatcher(): RegExp {
+    // Rails PostgreSQL adapter column_name_with_order_matcher:
+    //   same atom + COLLATE "\w+" + ASC/DESC + NULLS FIRST/LAST
+    return /^((?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:::\w+)?)(?:\s+COLLATE\s+"?\w+"?)?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:::\w+)?)(?:\s+COLLATE\s+"?\w+"?)?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+  }
+
   override get active(): boolean {
     return this._driverPool != null;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -79,15 +79,30 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   static columnNameMatcher(): RegExp {
     // Rails PostgreSQL adapter column_name_matcher:
-    //   ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)? | \w+\((?:|\g<2>)\)(?:::\w+)?)
-    //   with optional AS alias. 2-level \g<2> approximation.
-    return /^((?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)*$/i;
+    //   (col(?:::\w+)? | func(arg?)(?:::\w+)?) with optional AS alias.
+    // Both branches carry their own (?:::\w+)? so backtracking from col→func works.
+    // 2-level approximation of Ruby's recursive \g<2>.
+    //
+    // col_branch: (?:\w+\.|"\w+"\.){0,2}(?:\w+|"\w+")(?:::\w+)?
+    // func_branch: \w+\((?:|col_branch|func(col_branch))\)(?:::\w+)?
+    const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
+    const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
+    const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
+    return new RegExp(
+      `^(${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+(?:\\w+|"\\w+"))?)*$`,
+      "i",
+    );
   }
 
   static columnNameWithOrderMatcher(): RegExp {
-    // Rails PostgreSQL adapter column_name_with_order_matcher:
-    //   same atom + COLLATE "\w+" + ASC/DESC + NULLS FIRST/LAST
-    return /^((?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:::\w+)?)(?:\s+COLLATE\s+"?\w+"?)?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?|\w+\((?:|(?:(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?)\)))\))(?:::\w+)?)(?:\s+COLLATE\s+"?\w+"?)?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+    // Same atom as columnNameMatcher plus COLLATE, ASC/DESC, NULLS FIRST/LAST.
+    const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
+    const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
+    const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
+    return new RegExp(
+      `^(${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
+      "i",
+    );
   }
 
   override get active(): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -65,9 +65,9 @@ describe("PostgreSQL quoting", () => {
     expect(quoteDefaultExpression(["a", "b"], column, typeMap)).toBe(" DEFAULT '{a,b}'");
   });
 
-  it("documents the JavaScript regexp limitation for nested functions", () => {
+  it("supports nested function calls up to 2 levels deep", () => {
     expect(columnNameMatcher().test("lower(name)")).toBe(true);
-    expect(columnNameMatcher().test("lower(trim(name))")).toBe(false);
+    expect(columnNameMatcher().test("lower(trim(name))")).toBe(true);
   });
 
   it("unescapes hex bytea values we now own locally", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -315,7 +315,7 @@ export function columnNameWithOrderMatcher(): RegExp {
   const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
   const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
   return new RegExp(
-    `^(${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
+    `^(${atom}(?:\\s+COLLATE\\s+"\\w+")?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+"\\w+")?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
     "i",
   );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -292,21 +292,32 @@ export function unescapeBytea(value: string): Buffer {
 }
 
 export function columnNameMatcher(): RegExp {
-  // Rails uses recursive regexp syntax for nested function calls. JavaScript
-  // RegExp cannot express that directly, so this mirrors the current abstract
-  // limitation and only allows a bare identifier inside function calls.
-  return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:(?:\s+AS)?\s+\w+)?)*$/i;
+  // Mirrors Rails PostgreSQL column_name_matcher.
+  // Supports "schema"."table"."col" quoted identifiers, ::type casts, and
+  // 0-or-1-arg function calls (2-level unrolling of Ruby's recursive \g<2>).
+  // col branch carries its own (?:::\w+)? so backtracking col→func works.
+  const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
+  const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
+  const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
+  const id = String.raw`(?:\w+|"\w+")`;
+  return new RegExp(
+    `^(${atom}(?:(?:\\s+AS)?\\s+${id})?)(?:\\s*,\\s*${atom}(?:(?:\\s+AS)?\\s+${id})?)*$`,
+    "i",
+  );
 }
 
 /**
  * Mirrors: PostgreSQL::Quoting::ClassMethods#column_name_with_order_matcher.
- * Same core expression as columnNameMatcher plus optional COLLATE/ASC/DESC/
- * NULLS ordering suffixes. Rails only accepts quoted collation names
- * (`"\w+"`), so this does too — unquoted `COLLATE C` is rejected, matching
- * Rails exactly.
+ * Same atom as columnNameMatcher plus COLLATE, ASC/DESC, NULLS FIRST/LAST.
  */
 export function columnNameWithOrderMatcher(): RegExp {
-  return /^((?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+COLLATE\s+"\w+")?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|\w+)\))(?:\s+COLLATE\s+"\w+")?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+  const col0 = String.raw`(?:(?:\w+|"\w+")\.){0,2}(?:\w+|"\w+")(?:::\w+)?`;
+  const col1 = String.raw`(?:${col0}|\w+\((?:|${col0})\)(?:::\w+)?)`;
+  const atom = String.raw`(?:${col0}|\w+\((?:|${col1})\)(?:::\w+)?)`;
+  return new RegExp(
+    `^(${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)(?:\\s*,\\s*${atom}(?:\\s+COLLATE\\s+"?\\w+"?)?(?:\\s+ASC|\\s+DESC)?(?:\\s+NULLS\\s+(?:FIRST|LAST))?)*$`,
+    "i",
+  );
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -47,6 +47,10 @@ import {
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
+import {
+  columnNameMatcher as sqlite3ColumnNameMatcher,
+  columnNameWithOrderMatcher as sqlite3ColumnNameWithOrderMatcher,
+} from "./sqlite3/quoting.js";
 
 /**
  * SQLite adapter — connects ActiveRecord to a real SQLite database.
@@ -59,16 +63,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   static columnNameMatcher(): RegExp {
-    // Rails: SQLite3 adapter column_name_matcher — adds "word" double-quote support.
-    // ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\)) with optional AS alias
-    return /^((?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)*$/i;
+    return sqlite3ColumnNameMatcher();
   }
 
   static columnNameWithOrderMatcher(): RegExp {
-    // Rails: SQLite3 adapter column_name_with_order_matcher — double-quote support + COLLATE.
-    // SQLite supports NULLS FIRST/LAST (3.30.0+) even though Rails SQLite3 matcher omits it;
-    // we include it here for reverseOrder() compatibility.
-    return /^((?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
+    return sqlite3ColumnNameWithOrderMatcher();
   }
 
   override get arelVisitor(): Visitors.ToSql {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1,4 +1,5 @@
 import Database from "better-sqlite3";
+import { columnNameMatcher, columnNameWithOrderMatcher } from "./abstract/quoting.js";
 import { Visitors } from "@blazetrails/arel";
 import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
@@ -56,6 +57,14 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
 export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override get adapterName(): string {
     return "SQLite";
+  }
+
+  static columnNameMatcher(): RegExp {
+    return columnNameMatcher();
+  }
+
+  static columnNameWithOrderMatcher(): RegExp {
+    return columnNameWithOrderMatcher();
   }
 
   override get arelVisitor(): Visitors.ToSql {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -60,9 +60,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   static columnNameMatcher(): RegExp {
     // Mirrors Rails SQLite3 column_name_matcher. Uses "..." quoted identifiers
-    // (SQLite-style, supports escaped "" inside). Strict 0-or-1 function arg
-    // matching Rails \w+\((?:|\g<2>)\) — multi-arg functions are rejected.
-    const id = String.raw`(?:\w+|"[^"]*")`;
+    // (SQLite double-quote escaping: "" inside quotes). Strict 0-or-1 function
+    // arg matching Rails \w+\((?:|\g<2>)\) — multi-arg functions are rejected.
+    const id = String.raw`(?:\w+|"(?:[^"]|"")*")`;
     const col = String.raw`(?:${id}\.)?${id}`;
     const fn2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
     const fn1 = String.raw`\w+\(\s*(?:\*|${col}|${fn2})?\s*\)`;
@@ -74,7 +74,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   static columnNameWithOrderMatcher(): RegExp {
     // Mirrors Rails SQLite3 column_name_with_order_matcher. Adds COLLATE and
     // ASC/DESC; includes NULLS FIRST/LAST for reverseOrder() compatibility.
-    const id = String.raw`(?:\w+|"[^"]*")`;
+    const id = String.raw`(?:\w+|"(?:[^"]|"")*")`;
     const col = String.raw`(?:${id}\.)?${id}`;
     const fn2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
     const fn1 = String.raw`\w+\(\s*(?:\*|${col}|${fn2})?\s*\)`;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1,5 +1,4 @@
 import Database from "better-sqlite3";
-import { columnNameMatcher, columnNameWithOrderMatcher } from "./abstract/quoting.js";
 import { Visitors } from "@blazetrails/arel";
 import type { DatabaseAdapter, ExplainOption, TrailsAdapterOptions } from "../adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
@@ -60,11 +59,16 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   static columnNameMatcher(): RegExp {
-    return columnNameMatcher();
+    // Rails: SQLite3 adapter column_name_matcher — adds "word" double-quote support.
+    // ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\)) with optional AS alias
+    return /^((?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:(?:\s+AS)?\s+(?:\w+|"\w+"))?)*$/i;
   }
 
   static columnNameWithOrderMatcher(): RegExp {
-    return columnNameWithOrderMatcher();
+    // Rails: SQLite3 adapter column_name_with_order_matcher — double-quote support + COLLATE.
+    // SQLite supports NULLS FIRST/LAST (3.30.0+) even though Rails SQLite3 matcher omits it;
+    // we include it here for reverseOrder() compatibility.
+    return /^((?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+")|\w+\((?:|(?:(?:\w+|"\w+")\.)?(?:\w+|"\w+"))\)))\))(?:\s+COLLATE\s+(?:\w+|"\w+"))?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
   }
 
   override get arelVisitor(): Visitors.ToSql {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -47,10 +47,6 @@ import {
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
-import {
-  columnNameMatcher as sqlite3ColumnNameMatcher,
-  columnNameWithOrderMatcher as sqlite3ColumnNameWithOrderMatcher,
-} from "./sqlite3/quoting.js";
 
 /**
  * SQLite adapter — connects ActiveRecord to a real SQLite database.
@@ -63,11 +59,28 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   static columnNameMatcher(): RegExp {
-    return sqlite3ColumnNameMatcher();
+    // Mirrors Rails SQLite3 column_name_matcher. Uses "..." quoted identifiers
+    // (SQLite-style, supports escaped "" inside). Strict 0-or-1 function arg
+    // matching Rails \w+\((?:|\g<2>)\) — multi-arg functions are rejected.
+    const id = String.raw`(?:\w+|"[^"]*")`;
+    const col = String.raw`(?:${id}\.)?${id}`;
+    const fn2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
+    const fn1 = String.raw`\w+\(\s*(?:\*|${col}|${fn2})?\s*\)`;
+    const expr = String.raw`(?:${col}|${fn1})`;
+    const aliased = String.raw`${expr}(?:(?:\s+AS)?\s+${id})?`;
+    return new RegExp(`^${aliased}(?:\\s*,\\s*${aliased})*$`, "i");
   }
 
   static columnNameWithOrderMatcher(): RegExp {
-    return sqlite3ColumnNameWithOrderMatcher();
+    // Mirrors Rails SQLite3 column_name_with_order_matcher. Adds COLLATE and
+    // ASC/DESC; includes NULLS FIRST/LAST for reverseOrder() compatibility.
+    const id = String.raw`(?:\w+|"[^"]*")`;
+    const col = String.raw`(?:${id}\.)?${id}`;
+    const fn2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
+    const fn1 = String.raw`\w+\(\s*(?:\*|${col}|${fn2})?\s*\)`;
+    const expr = String.raw`(?:${col}|${fn1})`;
+    const ordered = String.raw`${expr}(?:\s+COLLATE\s+\w+)?(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?`;
+    return new RegExp(`^${ordered}(?:\\s*,\\s*${ordered})*$`, "i");
   }
 
   override get arelVisitor(): Visitors.ToSql {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -536,6 +536,22 @@ export class SQLWarning extends AdapterError {
   }
 }
 
+/**
+ * Raised when a query method is called with a non-attribute argument that
+ * would be used as raw SQL without sanitization.
+ *
+ * Mirrors: ActiveRecord::UnknownAttributeReference
+ */
+export class UnknownAttributeReference extends ActiveRecordError {
+  constructor(message?: string) {
+    super(
+      message ??
+        "Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s)",
+    );
+    this.name = "UnknownAttributeReference";
+  }
+}
+
 export class MultiparameterAssignmentErrors extends ActiveRecordError {
   readonly errors: Error[];
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -210,6 +210,7 @@ export {
   AttributeAssignmentError,
   TransactionIsolationError,
   IrreversibleOrderError,
+  UnknownAttributeReference,
 } from "./errors.js";
 export {
   ReadonlyAttributeError,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -12,10 +12,7 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import {
-  columnNameMatcher,
-  columnNameWithOrderMatcher,
-} from "./connection-adapters/abstract/quoting.js";
+import { columnNameMatcher } from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -535,8 +532,10 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#order
    */
-  order(...args: Array<string | Record<string, "asc" | "desc">>): Relation<T> {
-    return this._clone().orderBang(...args);
+  order(
+    ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+  ): Relation<T> {
+    return this._clone().orderBang(...(args as any));
   }
 
   /**
@@ -646,8 +645,10 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#reorder
    */
-  reorder(...args: Array<string | Record<string, "asc" | "desc">>): Relation<T> {
-    return this._clone().reorderBang(...args);
+  reorder(
+    ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+  ): Relation<T> {
+    return this._clone().reorderBang(...(args as any));
   }
 
   /**
@@ -2943,9 +2944,6 @@ export class Relation<T extends Base> {
     for (const clause of this._orderClauses) {
       if (typeof clause === "string") {
         const trimmed = clause.trim();
-        // Validate plain string clauses against column_name_with_order_matcher.
-        // This is called inside async execution methods so exceptions become rejected promises.
-        disallowRawSqlBang([trimmed], columnNameWithOrderMatcher());
         // Detect SQL expressions (functions, parens, operators) and pass as raw SQL
         if (trimmed.includes("(") || /\bcase\b/i.test(trimmed) || trimmed.includes("||")) {
           manager.order(new Nodes.SqlLiteral(trimmed));
@@ -2981,11 +2979,6 @@ export class Relation<T extends Base> {
         }
       } else {
         const [col, dir] = clause;
-        // Validate column name and direction for hash-style { col: dir } clauses.
-        disallowRawSqlBang([col], columnNameWithOrderMatcher());
-        if (!/^(asc|desc)$/i.test(String(dir))) {
-          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
-        }
         // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
         // from .from()) get a bare quoted name, not a table-qualified attribute.
         // Dotted keys (e.g. "comments.body") pass through as raw SQL with direction.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -11,6 +11,11 @@ import {
 import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
+import { disallowRawSqlBang } from "./sanitization.js";
+import {
+  columnNameMatcher,
+  columnNameWithOrderMatcher,
+} from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2176,11 +2181,34 @@ export class Relation<T extends Base> {
   ): Promise<unknown[]> {
     if (this._isNone) return [];
 
+    // Mirrors Rails' disallow_raw_sql! check on pluck arguments.
+    // Uses the broader column_name_matcher (allows functions like UPPER(col))
+    // rather than column_name_with_order_matcher (which is stricter, for order).
+    const stringColumns = columns.filter((c): c is string => typeof c === "string");
+    if (stringColumns.length > 0) {
+      disallowRawSqlBang(stringColumns, columnNameMatcher());
+    }
+
     const table = this._modelClass.arelTable;
-    const projections = columns.map((c) => (typeof c === "string" ? table.get(c) : c));
+    const projections = columns.map((c) => {
+      if (typeof c !== "string") return c;
+      // Table-qualified ("table.col"), quoted ('"table"."col"'), or function expressions
+      // must pass through as raw SQL rather than being wrapped in a table attribute node.
+      const isComplex =
+        c.includes(".") || c.includes("(") || c.includes('"') || /\s+AS\s+/i.test(c);
+      return isComplex ? new Nodes.SqlLiteral(c) : table.get(c);
+    });
     // Extract column names for result mapping
     const columnNames = columns.map((c) => {
-      if (typeof c === "string") return c;
+      if (typeof c === "string") {
+        // For table-qualified ("posts.title") or complex expressions, extract the alias
+        // or last segment as the result key.
+        const asMatch = c.match(/\s+AS\s+(\w+)\s*$/i);
+        if (asMatch) return asMatch[1];
+        const dotMatch = c.match(/(?:"?\w+"?\.)?"?(\w+)"?\s*$/);
+        if (dotMatch) return dotMatch[1];
+        return c;
+      }
       if (c instanceof Nodes.Attribute) return c.name;
       // For functions/literals, use the SQL representation
       return null;
@@ -2915,6 +2943,9 @@ export class Relation<T extends Base> {
     for (const clause of this._orderClauses) {
       if (typeof clause === "string") {
         const trimmed = clause.trim();
+        // Validate plain string clauses against column_name_with_order_matcher.
+        // This is called inside async execution methods so exceptions become rejected promises.
+        disallowRawSqlBang([trimmed], columnNameWithOrderMatcher());
         // Detect SQL expressions (functions, parens, operators) and pass as raw SQL
         if (trimmed.includes("(") || /\bcase\b/i.test(trimmed) || trimmed.includes("||")) {
           manager.order(new Nodes.SqlLiteral(trimmed));
@@ -2950,6 +2981,11 @@ export class Relation<T extends Base> {
         }
       } else {
         const [col, dir] = clause;
+        // Validate column name and direction for hash-style { col: dir } clauses.
+        disallowRawSqlBang([col], columnNameWithOrderMatcher());
+        if (!/^(asc|desc)$/i.test(String(dir))) {
+          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
+        }
         // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
         // from .from()) get a bare quoted name, not a table-qualified attribute.
         // Dotted keys (e.g. "comments.body") pass through as raw SQL with direction.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,10 +13,6 @@ import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.j
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
 import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
-
-function resolveColumnNameMatcher(adapter: any): RegExp {
-  return adapter?.constructor?.columnNameMatcher?.() ?? abstractColumnNameMatcher();
-}
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -102,6 +98,19 @@ function validateExplainOptions(options: ExplainOption[]): void {
  *
  * Mirrors: ActiveRecord::Relation
  */
+
+function resolveColumnNameMatcher(adapter: any): RegExp {
+  // Walk adapter → inner (SchemaAdapter wraps the real adapter) to find a
+  // static columnNameMatcher on the concrete adapter class.
+  let a = adapter;
+  while (a) {
+    const matcher = (a.constructor as any)?.columnNameMatcher?.();
+    if (matcher) return matcher;
+    a = a.inner;
+  }
+  return abstractColumnNameMatcher();
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Relation<T extends Base> {
   private _modelClass: typeof Base;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2221,7 +2221,11 @@ export class Relation<T extends Base> {
         );
       }
       const isComplex =
-        c.includes(".") || c.includes("(") || c.includes('"') || /\s+AS\s+/i.test(c);
+        c.includes(".") ||
+        c.includes("(") ||
+        c.includes('"') ||
+        c.includes("`") ||
+        /\s+AS\s+/i.test(c);
       return isComplex ? new Nodes.SqlLiteral(c) : table.get(c);
     });
     // Extract column names for result mapping
@@ -2234,7 +2238,7 @@ export class Relation<T extends Base> {
         // can't be reliably predicted — use positional fallback (return null).
         if (c.includes("(")) return null;
         // Table-qualified or quoted identifiers: extract the last plain identifier segment.
-        const dotMatch = c.match(/(?:"?\w+"?\.)?"?(\w+)"?\s*$/);
+        const dotMatch = c.match(/(?:["`]?\w+["`]?\.)? *["`]?(\w+)["`]?\s*$/);
         if (dotMatch) return dotMatch[1];
         return c;
       }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2201,10 +2201,14 @@ export class Relation<T extends Base> {
     const table = this._modelClass.arelTable;
     const projections = columns.map((c) => {
       if (typeof c !== "string") return c;
-      // Table-qualified ("table.col"), quoted ('"table"."col"'), or function expressions
-      // must pass through as raw SQL rather than being wrapped in a table attribute node.
+      // Table-qualified ("table.col"), quoted ('"table"."col"'), function expressions,
+      // or comma-separated lists must pass through as raw SQL.
       const isComplex =
-        c.includes(".") || c.includes("(") || c.includes('"') || /\s+AS\s+/i.test(c);
+        c.includes(".") ||
+        c.includes("(") ||
+        c.includes('"') ||
+        c.includes(",") ||
+        /\s+AS\s+/i.test(c);
       return isComplex ? new Nodes.SqlLiteral(c) : table.get(c);
     });
     // Extract column names for result mapping

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2212,12 +2212,16 @@ export class Relation<T extends Base> {
       if (typeof c !== "string") return c;
       // Table-qualified ("table.col"), quoted ('"table"."col"'), function expressions,
       // or comma-separated lists must pass through as raw SQL.
+      // Comma-separated lists are not allowed in a single pluck argument —
+      // each column must be passed as a separate argument for correct result mapping.
+      if (c.includes(",")) {
+        throw new Error(
+          `pluck does not allow comma-separated column lists in a single argument. ` +
+            `Pass each column as a separate argument: pluck("col1", "col2")`,
+        );
+      }
       const isComplex =
-        c.includes(".") ||
-        c.includes("(") ||
-        c.includes('"') ||
-        c.includes(",") ||
-        /\s+AS\s+/i.test(c);
+        c.includes(".") || c.includes("(") || c.includes('"') || /\s+AS\s+/i.test(c);
       return isComplex ? new Nodes.SqlLiteral(c) : table.get(c);
     });
     // Extract column names for result mapping

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -101,7 +101,26 @@ function validateExplainOptions(options: ExplainOption[]): void {
 
 function hasTopLevelComma(s: string): boolean {
   let depth = 0;
-  for (const ch of s) {
+  let quote: '"' | "'" | "`" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quote) {
+      if (ch === "\\") {
+        i++;
+        continue;
+      }
+      // SQL doubled-quote escape ("" or ``)
+      if (ch === quote && s[i + 1] === quote) {
+        i++;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
     if (ch === "(") depth++;
     else if (ch === ")") depth--;
     else if (ch === "," && depth === 0) return true;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -576,7 +576,11 @@ export class Relation<T extends Base> {
    */
   order(
     ...args: Array<
-      string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+      | string
+      | Record<string, "asc" | "desc" | "ASC" | "DESC">
+      | Nodes.Node
+      | string[]
+      | [Nodes.Node, ...unknown[]]
     >
   ): Relation<T> {
     return this._clone().orderBang(...(args as any));
@@ -691,7 +695,11 @@ export class Relation<T extends Base> {
    */
   reorder(
     ...args: Array<
-      string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+      | string
+      | Record<string, "asc" | "desc" | "ASC" | "DESC">
+      | Nodes.Node
+      | string[]
+      | [Nodes.Node, ...unknown[]]
     >
   ): Relation<T> {
     return this._clone().reorderBang(...(args as any));
@@ -3039,10 +3047,9 @@ export class Relation<T extends Base> {
         }
       } else {
         const [col, dir] = clause;
-        // Mirrors Rails' arel_column: unknown columns (e.g. subquery aliases
-        // from .from()) get a bare quoted name, not a table-qualified attribute.
-        // Dotted keys (e.g. "comments.body") pass through as raw SQL with direction.
-        if (/^[\w$]+(\.[\w$]+)+$/.test(col)) {
+        // Function expressions, quoted identifiers, and dotted names must be
+        // emitted as raw SQL — table.get() would double-quote them incorrectly.
+        if (/[()"`]/.test(col) || /^[\w$]+(\.[\w$]+)+$/.test(col)) {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2242,8 +2242,8 @@ export class Relation<T extends Base> {
     const columnNames = columns.map((c) => {
       if (typeof c === "string") {
         // Explicit AS alias is reliable on all adapters.
-        const asMatch = c.match(/\s+AS\s+(\w+)\s*$/i);
-        if (asMatch) return asMatch[1];
+        const asMatch = c.match(/\s+AS\s+(?:"([^"]+)"|`([^`]+)`|(\w+))\s*$/i);
+        if (asMatch) return asMatch[1] ?? asMatch[2] ?? asMatch[3];
         // Function expressions: the result column label is adapter-specific and
         // can't be reliably predicted — use positional fallback (return null).
         if (c.includes("(")) return null;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2262,6 +2262,7 @@ export class Relation<T extends Base> {
         c.includes("(") ||
         c.includes('"') ||
         c.includes("`") ||
+        c.includes("::") ||
         /\s+AS\s+/i.test(c);
       return isComplex ? new Nodes.SqlLiteral(c) : table.get(c);
     });
@@ -3049,7 +3050,7 @@ export class Relation<T extends Base> {
         const [col, dir] = clause;
         // Function expressions, quoted identifiers, and dotted names must be
         // emitted as raw SQL — table.get() would double-quote them incorrectly.
-        if (/[()"`]/.test(col) || /^[\w$]+(\.[\w$]+)+$/.test(col)) {
+        if (/[()"`]|::/.test(col) || /^[\w$]+(\.[\w$]+)+$/.test(col)) {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -99,6 +99,16 @@ function validateExplainOptions(options: ExplainOption[]): void {
  * Mirrors: ActiveRecord::Relation
  */
 
+function hasTopLevelComma(s: string): boolean {
+  let depth = 0;
+  for (const ch of s) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === "," && depth === 0) return true;
+  }
+  return false;
+}
+
 function resolveColumnNameMatcher(adapter: any): RegExp {
   // Walk adapter → inner (SchemaAdapter wraps the real adapter) to find a
   // static columnNameMatcher on the concrete adapter class.
@@ -2214,7 +2224,7 @@ export class Relation<T extends Base> {
       // or comma-separated lists must pass through as raw SQL.
       // Comma-separated lists are not allowed in a single pluck argument —
       // each column must be passed as a separate argument for correct result mapping.
-      if (c.includes(",")) {
+      if (hasTopLevelComma(c)) {
         throw argumentError(
           `pluck does not allow comma-separated column lists in a single argument. ` +
             `Pass each column as a separate argument: pluck("col1", "col2")`,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -12,7 +12,11 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import { columnNameMatcher } from "./connection-adapters/abstract/quoting.js";
+import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
+
+function resolveColumnNameMatcher(adapter: any): RegExp {
+  return adapter?.constructor?.columnNameMatcher?.() ?? abstractColumnNameMatcher();
+}
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -533,7 +537,9 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#order
    */
   order(
-    ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+    ...args: Array<
+      string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+    >
   ): Relation<T> {
     return this._clone().orderBang(...(args as any));
   }
@@ -646,7 +652,9 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reorder
    */
   reorder(
-    ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+    ...args: Array<
+      string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+    >
   ): Relation<T> {
     return this._clone().reorderBang(...(args as any));
   }
@@ -2187,7 +2195,7 @@ export class Relation<T extends Base> {
     // rather than column_name_with_order_matcher (which is stricter, for order).
     const stringColumns = columns.filter((c): c is string => typeof c === "string");
     if (stringColumns.length > 0) {
-      disallowRawSqlBang(stringColumns, columnNameMatcher());
+      disallowRawSqlBang(stringColumns, resolveColumnNameMatcher(this._modelClass.adapter));
     }
 
     const table = this._modelClass.arelTable;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2215,7 +2215,7 @@ export class Relation<T extends Base> {
       // Comma-separated lists are not allowed in a single pluck argument —
       // each column must be passed as a separate argument for correct result mapping.
       if (c.includes(",")) {
-        throw new Error(
+        throw argumentError(
           `pluck does not allow comma-separated column lists in a single argument. ` +
             `Pass each column as a separate argument: pluck("col1", "col2")`,
         );
@@ -2227,16 +2227,18 @@ export class Relation<T extends Base> {
     // Extract column names for result mapping
     const columnNames = columns.map((c) => {
       if (typeof c === "string") {
-        // For table-qualified ("posts.title") or complex expressions, extract the alias
-        // or last segment as the result key.
+        // Explicit AS alias is reliable on all adapters.
         const asMatch = c.match(/\s+AS\s+(\w+)\s*$/i);
         if (asMatch) return asMatch[1];
+        // Function expressions: the result column label is adapter-specific and
+        // can't be reliably predicted — use positional fallback (return null).
+        if (c.includes("(")) return null;
+        // Table-qualified or quoted identifiers: extract the last plain identifier segment.
         const dotMatch = c.match(/(?:"?\w+"?\.)?"?(\w+)"?\s*$/);
         if (dotMatch) return dotMatch[1];
         return c;
       }
       if (c instanceof Nodes.Attribute) return c.name;
-      // For functions/literals, use the SQL representation
       return null;
     });
     const manager = table.project(...projections);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -120,10 +120,21 @@ interface QueryMethodsHost {
 // ---------------------------------------------------------------------------
 
 function resolveOrderMatcher(host: QueryMethodsHost): RegExp {
-  return (
-    (host._modelClass?.adapter?.constructor as any)?.columnNameWithOrderMatcher?.() ??
-    abstractOrderMatcher()
-  );
+  // Walk adapter → inner (SchemaAdapter wraps the real adapter) to find a
+  // static columnNameWithOrderMatcher on the concrete adapter class.
+  // Use _connection/_adapter private fields to avoid triggering connection-pool lookup.
+  try {
+    let adapter = (host._modelClass as any)?._adapter;
+    if (!adapter) return abstractOrderMatcher();
+    while (adapter) {
+      const matcher = (adapter.constructor as any)?.columnNameWithOrderMatcher?.();
+      if (matcher) return matcher;
+      adapter = (adapter as any).inner;
+    }
+  } catch {
+    // No adapter set — fall back to abstract pattern.
+  }
+  return abstractOrderMatcher();
 }
 
 // ---------------------------------------------------------------------------
@@ -265,7 +276,7 @@ function orderBang(
         // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check
         const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
+        if (interpolated.trim() !== "") this._orderClauses.push(interpolated);
       } else {
         // Plain string array: all elements must be strings; validate each immediately.
         if (!(arg as unknown[]).every((e) => typeof e === "string")) {
@@ -279,7 +290,7 @@ function orderBang(
     } else if (arg instanceof Nodes.Node) {
       // Arel node (e.g. Arel.sql("title")) — store raw SQL directly.
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push(rawSql);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -326,7 +337,7 @@ function reorderBang(
       if (first instanceof Nodes.Node) {
         const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
+        if (interpolated.trim() !== "") this._orderClauses.push(interpolated);
       } else {
         if (!(arg as unknown[]).every((e) => typeof e === "string")) {
           throw argumentError("Order arguments passed as an array must contain only strings");
@@ -338,7 +349,7 @@ function reorderBang(
       }
     } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push(rawSql);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -9,7 +9,10 @@ import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
 import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
-import { quote, columnNameWithOrderMatcher } from "../connection-adapters/abstract/quoting.js";
+import {
+  quote,
+  columnNameWithOrderMatcher as abstractOrderMatcher,
+} from "../connection-adapters/abstract/quoting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 
 /**
@@ -110,6 +113,17 @@ interface QueryMethodsHost {
   _modelClass: any;
   predicateBuilder: import("./predicate-builder.js").PredicateBuilder;
   _castWhereValue(key: string, value: unknown): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveOrderMatcher(host: QueryMethodsHost): RegExp {
+  return (
+    (host._modelClass?.adapter?.constructor as any)?.columnNameWithOrderMatcher?.() ??
+    abstractOrderMatcher()
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -238,7 +252,9 @@ function regroupBang(this: QueryMethodsHost, ...columns: string[]): any {
 
 function orderBang(
   this: QueryMethodsHost,
-  ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+  ...args: Array<
+    string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+  >
 ): any {
   let i = 0;
   while (i < args.length) {
@@ -247,12 +263,12 @@ function orderBang(
       const [first, ...rest] = arg as unknown[];
       if (first instanceof Nodes.Node) {
         // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check
-        const rawSql = (first as any).value ?? first.toString();
+        const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
       } else {
         // Plain string array: validate each element immediately.
-        disallowRawSqlBang(arg as string[], columnNameWithOrderMatcher());
+        disallowRawSqlBang(arg as string[], resolveOrderMatcher(this));
         for (const elem of arg as string[]) {
           if (typeof elem === "string" && elem.trim() !== "") {
             this._orderClauses.push(elem);
@@ -261,7 +277,7 @@ function orderBang(
       }
     } else if (arg instanceof Nodes.Node) {
       // Arel node (e.g. Arel.sql("title")) — store raw SQL directly.
-      const rawSql = (arg as any).value ?? arg.toString();
+      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
       if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
@@ -270,7 +286,7 @@ function orderBang(
         continue;
       }
       // Validate immediately — mirrors Rails raising on order("invalid") at call time.
-      disallowRawSqlBang([arg], columnNameWithOrderMatcher());
+      disallowRawSqlBang([arg], resolveOrderMatcher(this));
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
@@ -281,7 +297,7 @@ function orderBang(
     } else if (arg !== null && typeof arg === "object") {
       // Hash form { col: "asc"|"desc" } — validate column and direction immediately.
       for (const [col, dir] of Object.entries(arg)) {
-        disallowRawSqlBang([col], columnNameWithOrderMatcher());
+        disallowRawSqlBang([col], resolveOrderMatcher(this));
         if (!/^(asc|desc)$/i.test(String(dir))) {
           throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
         }
@@ -295,7 +311,9 @@ function orderBang(
 
 function reorderBang(
   this: QueryMethodsHost,
-  ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
+  ...args: Array<
+    string | Record<string, "asc" | "desc"> | Nodes.Node | string[] | [Nodes.Node, ...unknown[]]
+  >
 ): any {
   this._orderClauses = [];
   this._rawOrderClauses = [];
@@ -305,17 +323,17 @@ function reorderBang(
     if (Array.isArray(arg)) {
       const [first, ...rest] = arg as unknown[];
       if (first instanceof Nodes.Node) {
-        const rawSql = (first as any).value ?? first.toString();
+        const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
       } else {
-        disallowRawSqlBang(arg as string[], columnNameWithOrderMatcher());
+        disallowRawSqlBang(arg as string[], resolveOrderMatcher(this));
         for (const elem of arg as string[]) {
           if (typeof elem === "string" && elem.trim() !== "") this._orderClauses.push(elem);
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      const rawSql = (arg as any).value ?? arg.toString();
+      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
       if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
@@ -323,7 +341,7 @@ function reorderBang(
         i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
         continue;
       }
-      disallowRawSqlBang([arg], columnNameWithOrderMatcher());
+      disallowRawSqlBang([arg], resolveOrderMatcher(this));
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
@@ -333,7 +351,7 @@ function reorderBang(
       this._orderClauses.push(arg);
     } else if (arg !== null && typeof arg === "object") {
       for (const [col, dir] of Object.entries(arg as Record<string, string>)) {
-        disallowRawSqlBang([col], columnNameWithOrderMatcher());
+        disallowRawSqlBang([col], resolveOrderMatcher(this));
         if (!/^(asc|desc)$/i.test(String(dir))) {
           throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
         }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -317,7 +317,8 @@ function orderBang(
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
     } else {
-      throw argumentError(`Unsupported order argument: ${typeof arg}`);
+      const argType = arg === null ? "null" : typeof arg;
+      throw argumentError(`Unsupported order argument: ${argType}`);
     }
     i++;
   }
@@ -376,7 +377,8 @@ function reorderBang(
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
     } else {
-      throw argumentError(`Unsupported order argument: ${typeof arg}`);
+      const argType = arg === null ? "null" : typeof arg;
+      throw argumentError(`Unsupported order argument: ${argType}`);
     }
     i++;
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -120,19 +120,20 @@ interface QueryMethodsHost {
 // ---------------------------------------------------------------------------
 
 function resolveOrderMatcher(host: QueryMethodsHost): RegExp {
-  // Walk adapter → inner (SchemaAdapter wraps the real adapter) to find a
-  // static columnNameWithOrderMatcher on the concrete adapter class.
-  // Use _connection/_adapter private fields to avoid triggering connection-pool lookup.
+  // Use the public .adapter getter so establishConnection() models get their
+  // concrete adapter's matcher. Walk adapter → inner to handle SchemaAdapter.
+  // Also check the instance method in case the adapter exposes it directly.
   try {
-    let adapter = (host._modelClass as any)?._adapter;
-    if (!adapter) return abstractOrderMatcher();
+    let adapter = (host._modelClass as any)?.adapter ?? (host._modelClass as any)?._adapter;
     while (adapter) {
-      const matcher = (adapter.constructor as any)?.columnNameWithOrderMatcher?.();
+      const matcher =
+        (adapter as any)?.columnNameWithOrderMatcher?.() ??
+        (adapter.constructor as any)?.columnNameWithOrderMatcher?.();
       if (matcher) return matcher;
       adapter = (adapter as any).inner;
     }
   } catch {
-    // No adapter set — fall back to abstract pattern.
+    // No adapter configured — fall back to abstract pattern.
   }
   return abstractOrderMatcher();
 }
@@ -315,6 +316,8 @@ function orderBang(
         }
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
+    } else {
+      throw argumentError(`Unsupported order argument: ${typeof arg}`);
     }
     i++;
   }
@@ -372,6 +375,8 @@ function reorderBang(
         }
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
+    } else {
+      throw argumentError(`Unsupported order argument: ${typeof arg}`);
     }
     i++;
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -243,7 +243,27 @@ function orderBang(
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    if (typeof arg === "string") {
+    if (Array.isArray(arg)) {
+      const [first, ...rest] = arg as unknown[];
+      if (first instanceof Nodes.Node) {
+        // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check
+        const rawSql = (first as any).value ?? first.toString();
+        const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
+        if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
+      } else {
+        // Plain string array: each element is a separate ORDER BY term.
+        // Join and store in _orderClauses for later validation at execution time.
+        for (const elem of arg as string[]) {
+          if (typeof elem === "string" && elem.trim() !== "") {
+            this._orderClauses.push(elem);
+          }
+        }
+      }
+    } else if (arg instanceof Nodes.Node) {
+      // Arel node (e.g. Arel.sql("title")) — store raw SQL directly.
+      const rawSql = (arg as any).value ?? arg.toString();
+      if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
+    } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
         i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
@@ -256,7 +276,8 @@ function orderBang(
         continue;
       }
       this._orderClauses.push(arg);
-    } else {
+    } else if (arg !== null && typeof arg === "object") {
+      // Hash form { col: "asc"|"desc" } — direction validation deferred to execution
       for (const [col, dir] of Object.entries(arg)) {
         this._orderClauses.push([col, dir]);
       }
@@ -271,10 +292,14 @@ function reorderBang(
   ...args: Array<string | Record<string, "asc" | "desc">>
 ): any {
   this._orderClauses = [];
+  this._rawOrderClauses = [];
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    if (typeof arg === "string") {
+    if (arg instanceof Nodes.Node) {
+      const rawSql = (arg as any).value ?? arg.toString();
+      if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
+    } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
         i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -267,12 +267,13 @@ function orderBang(
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
       } else {
-        // Plain string array: validate each element immediately.
+        // Plain string array: all elements must be strings; validate each immediately.
+        if (!(arg as unknown[]).every((e) => typeof e === "string")) {
+          throw argumentError("Order arguments passed as an array must contain only strings");
+        }
         disallowRawSqlBang(arg as string[], resolveOrderMatcher(this));
         for (const elem of arg as string[]) {
-          if (typeof elem === "string" && elem.trim() !== "") {
-            this._orderClauses.push(elem);
-          }
+          if (elem.trim() !== "") this._orderClauses.push(elem);
         }
       }
     } else if (arg instanceof Nodes.Node) {
@@ -299,7 +300,7 @@ function orderBang(
       for (const [col, dir] of Object.entries(arg)) {
         disallowRawSqlBang([col], resolveOrderMatcher(this));
         if (!/^(asc|desc)$/i.test(String(dir))) {
-          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
+          throw argumentError(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
         }
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
@@ -327,9 +328,12 @@ function reorderBang(
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
       } else {
+        if (!(arg as unknown[]).every((e) => typeof e === "string")) {
+          throw argumentError("Order arguments passed as an array must contain only strings");
+        }
         disallowRawSqlBang(arg as string[], resolveOrderMatcher(this));
         for (const elem of arg as string[]) {
-          if (typeof elem === "string" && elem.trim() !== "") this._orderClauses.push(elem);
+          if (elem.trim() !== "") this._orderClauses.push(elem);
         }
       }
     } else if (arg instanceof Nodes.Node) {
@@ -353,7 +357,7 @@ function reorderBang(
       for (const [col, dir] of Object.entries(arg as Record<string, string>)) {
         disallowRawSqlBang([col], resolveOrderMatcher(this));
         if (!/^(asc|desc)$/i.test(String(dir))) {
-          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
+          throw argumentError(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
         }
         this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -8,8 +8,8 @@ import { Nodes } from "@blazetrails/arel";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
-import { sanitizeSqlArray } from "../sanitization.js";
-import { quote } from "../connection-adapters/abstract/quoting.js";
+import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
+import { quote, columnNameWithOrderMatcher } from "../connection-adapters/abstract/quoting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 
 /**
@@ -238,7 +238,7 @@ function regroupBang(this: QueryMethodsHost, ...columns: string[]): any {
 
 function orderBang(
   this: QueryMethodsHost,
-  ...args: Array<string | Record<string, "asc" | "desc">>
+  ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
 ): any {
   let i = 0;
   while (i < args.length) {
@@ -251,8 +251,8 @@ function orderBang(
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
       } else {
-        // Plain string array: each element is a separate ORDER BY term.
-        // Join and store in _orderClauses for later validation at execution time.
+        // Plain string array: validate each element immediately.
+        disallowRawSqlBang(arg as string[], columnNameWithOrderMatcher());
         for (const elem of arg as string[]) {
           if (typeof elem === "string" && elem.trim() !== "") {
             this._orderClauses.push(elem);
@@ -269,6 +269,8 @@ function orderBang(
         i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
         continue;
       }
+      // Validate immediately — mirrors Rails raising on order("invalid") at call time.
+      disallowRawSqlBang([arg], columnNameWithOrderMatcher());
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
@@ -277,9 +279,13 @@ function orderBang(
       }
       this._orderClauses.push(arg);
     } else if (arg !== null && typeof arg === "object") {
-      // Hash form { col: "asc"|"desc" } — direction validation deferred to execution
+      // Hash form { col: "asc"|"desc" } — validate column and direction immediately.
       for (const [col, dir] of Object.entries(arg)) {
-        this._orderClauses.push([col, dir]);
+        disallowRawSqlBang([col], columnNameWithOrderMatcher());
+        if (!/^(asc|desc)$/i.test(String(dir))) {
+          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
+        }
+        this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
     }
     i++;
@@ -289,14 +295,26 @@ function orderBang(
 
 function reorderBang(
   this: QueryMethodsHost,
-  ...args: Array<string | Record<string, "asc" | "desc">>
+  ...args: Array<string | Record<string, "asc" | "desc"> | Nodes.Node | unknown[]>
 ): any {
   this._orderClauses = [];
   this._rawOrderClauses = [];
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    if (arg instanceof Nodes.Node) {
+    if (Array.isArray(arg)) {
+      const [first, ...rest] = arg as unknown[];
+      if (first instanceof Nodes.Node) {
+        const rawSql = (first as any).value ?? first.toString();
+        const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
+        if (interpolated.trim() !== "") this._rawOrderClauses.push(interpolated);
+      } else {
+        disallowRawSqlBang(arg as string[], columnNameWithOrderMatcher());
+        for (const elem of arg as string[]) {
+          if (typeof elem === "string" && elem.trim() !== "") this._orderClauses.push(elem);
+        }
+      }
+    } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? arg.toString();
       if (rawSql && rawSql.trim() !== "") this._rawOrderClauses.push(rawSql);
     } else if (typeof arg === "string") {
@@ -305,6 +323,7 @@ function reorderBang(
         i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
         continue;
       }
+      disallowRawSqlBang([arg], columnNameWithOrderMatcher());
       const next = args[i + 1];
       if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
         this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
@@ -312,9 +331,13 @@ function reorderBang(
         continue;
       }
       this._orderClauses.push(arg);
-    } else {
-      for (const [col, dir] of Object.entries(arg)) {
-        this._orderClauses.push([col, dir]);
+    } else if (arg !== null && typeof arg === "object") {
+      for (const [col, dir] of Object.entries(arg as Record<string, string>)) {
+        disallowRawSqlBang([col], columnNameWithOrderMatcher());
+        if (!/^(asc|desc)$/i.test(String(dir))) {
+          throw new Error(`Direction "${dir}" is invalid. Valid directions are: asc, desc`);
+        }
+        this._orderClauses.push([col, (dir as string).toLowerCase() as "asc" | "desc"]);
       }
     }
     i++;

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -6,7 +6,7 @@
 
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
-import { PreparedStatementInvalid } from "./errors.js";
+import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js";
 
 /**
  * Sanitize a SQL template with bind parameters.
@@ -120,7 +120,7 @@ export function disallowRawSqlBang(args: (string | symbol | Nodes.Node)[], permi
     }
   }
   if (unexpected.length > 0) {
-    throw new Error(
+    throw new UnknownAttributeReference(
       `Dangerous query method (method whose arguments are used as raw SQL) ` +
         `called with non-attribute argument(s): ${unexpected.map((a) => `"${a}"`).join(", ")}`,
     );

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -1,41 +1,273 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors: activerecord/test/cases/unsafe_raw_sql_test.rb
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, UnknownAttributeReference } from "./index.js";
+import { sql as arelSql } from "@blazetrails/arel";
+import { createTestAdapter } from "./test-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+
+function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
 
 describe("UnsafeRawSqlTest", () => {
-  it.skip("order: allows string column name", () => {});
-  it.skip("order: allows symbol column name", () => {});
-  it.skip("order: allows downcase symbol direction", () => {});
-  it.skip("order: allows upcase symbol direction", () => {});
-  it.skip("order: allows string direction", () => {});
-  it.skip("order: allows multiple columns", () => {});
-  it.skip("order: allows mixed", () => {});
-  it.skip("order: allows table and column names", () => {});
-  it.skip("order: allows quoted table and column names", () => {});
-  it.skip("order: allows column name and direction in string", () => {});
-  it.skip("order: allows table name, column name and direction in string", () => {});
-  it.skip("order: allows NULLS FIRST and NULLS LAST too", () => {});
-  it.skip("order: disallows invalid column name", () => {});
-  it.skip("order: disallows invalid direction", () => {});
-  it.skip("order: disallows invalid column with direction", () => {});
-  it.skip("order: always allows Arel", () => {});
-  it.skip("order: allows Arel.sql with binds", () => {});
-  it.skip("order: disallows invalid bind statement", () => {});
-  it.skip("order: disallows invalid Array arguments", () => {});
-  it.skip("order: allows valid Array arguments", () => {});
-  it.skip("order: allows valid arguments with COLLATE", () => {});
-  it.skip("order: allows nested functions", () => {});
-  it.skip("order: disallows dangerous query method", () => {});
-  it.skip("pluck: allows string column name", () => {});
-  it.skip("pluck: allows string column name with function and alias", () => {});
-  it.skip("pluck: allows symbol column name", () => {});
-  it.skip("pluck: allows multiple column names", () => {});
-  it.skip("pluck: allows column names with includes", () => {});
-  it.skip("pluck: allows auto-generated attributes", () => {});
-  it.skip("pluck: allows table and column names", () => {});
-  it.skip("pluck: allows quoted table and column names", () => {});
-  it.skip("pluck: allows nested functions", () => {});
-  it.skip("pluck: disallows invalid column name", () => {});
-  it.skip("pluck: disallows invalid column name amongst valid names", () => {});
-  it.skip("pluck: disallows invalid column names with includes", () => {});
-  it.skip("pluck: always allows Arel", () => {});
-  it.skip("pluck: disallows dangerous query method", () => {});
+  let adapter: DatabaseAdapter;
+  let Post: typeof Base;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+
+    class UrsPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        this.attribute("type", "string");
+        this.attribute("tags_count", "integer");
+        this.adapter = adapter;
+      }
+    }
+    Post = UrsPost;
+
+    await Post.create({ title: "Alpha", author_id: 2, tags_count: 3 });
+    await Post.create({ title: "Beta", author_id: 1, tags_count: 1 });
+    await Post.create({ title: "Gamma", author_id: 1, tags_count: 2 });
+  });
+
+  it("order: allows string column name", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title")).pluck("id");
+    const ids = await (Post as any).order("title").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows symbol column name", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title")).pluck("id");
+    const ids = await (Post as any).order("title").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows downcase symbol direction", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title asc")).pluck("id");
+    const ids = await (Post as any).order({ title: "asc" }).pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows upcase symbol direction", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title ASC")).pluck("id");
+    const ids = await (Post as any).order({ title: "ASC" }).pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows string direction", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title asc")).pluck("id");
+    const ids = await (Post as any).order({ title: "asc" }).pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows multiple columns", async () => {
+    const idsExpected = await (Post as any)
+      .order(arelSql("author_id"), arelSql("title"))
+      .pluck("id");
+    const ids = await (Post as any).order("author_id", "title").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows mixed", async () => {
+    const idsExpected = await (Post as any)
+      .order(arelSql("author_id"), arelSql("title asc"))
+      .pluck("id");
+    const ids = await (Post as any).order("author_id", { title: "asc" }).pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows table and column names", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title")).pluck("id");
+    const ids = await (Post as any).order("urs_posts.title").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows quoted table and column names", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title")).pluck("id");
+    const ids = await (Post as any).order('"urs_posts"."title"').pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows column name and direction in string", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title desc")).pluck("id");
+    const ids = await (Post as any).order("title desc").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: allows table name, column name and direction in string", async () => {
+    const idsExpected = await (Post as any).order(arelSql("title desc")).pluck("id");
+    const ids = await (Post as any).order("urs_posts.title desc").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it.skip("order: allows NULLS FIRST and NULLS LAST too", () => {
+    // PostgreSQL-only (type cast syntax `::text`); skip for in-memory adapter.
+  });
+
+  it("order: disallows invalid column name", async () => {
+    await expect(
+      (Post as any).order("REPLACE(title, 'misc', 'zzzz') asc").pluck("id"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("order: disallows invalid direction", async () => {
+    await expect((Post as any).order({ title: "foo" }).pluck("id")).rejects.toThrow();
+  });
+
+  it("order: disallows invalid column with direction", async () => {
+    await expect(
+      (Post as any).order({ "REPLACE(title, 'misc', 'zzzz')": "asc" }).pluck("id"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("order: always allows Arel", async () => {
+    const titles = await (Post as any).order(arelSql("length(title)")).pluck("title");
+    expect(titles.length).toBeGreaterThan(0);
+  });
+
+  it("order: allows Arel.sql with binds", async () => {
+    const idsExpected = await (Post as any)
+      .order(arelSql("REPLACE(title, 'Alpha', 'Zeta'), id"))
+      .pluck("id");
+    const ids = await (Post as any)
+      .order([arelSql("REPLACE(title, ?, ?), id"), "Alpha", "Zeta"])
+      .pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: disallows invalid bind statement", async () => {
+    await expect(
+      (Post as any).order(["REPLACE(title, ?, ?), id", "misc", "zzzz"]).pluck("id"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("order: disallows invalid Array arguments", async () => {
+    await expect(
+      (Post as any).order(["author_id", "REPLACE(title, 'misc', 'zzzz')"]).pluck("id"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("order: allows valid Array arguments", async () => {
+    const idsExpected = await (Post as any).order(arelSql("author_id, length(title)")).pluck("id");
+    const ids = await (Post as any).order(["author_id", "length(title)"]).pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it.skip("order: allows valid arguments with COLLATE", () => {
+    // COLLATE syntax is adapter-specific.
+  });
+
+  it("order: allows nested functions", async () => {
+    const idsExpected = await (Post as any)
+      .order(arelSql("author_id, length(trim(title))"))
+      .pluck("id");
+    const ids = await (Post as any).order("author_id, length(trim(title))").pluck("id");
+    expect(ids).toEqual(idsExpected);
+  });
+
+  it("order: disallows dangerous query method", async () => {
+    let error: unknown;
+    try {
+      await (Post as any).order("REPLACE(title, 'misc', 'zzzz')").pluck("id");
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(UnknownAttributeReference);
+    expect((error as UnknownAttributeReference).message).toMatch(
+      /Dangerous query method.*called with non-attribute argument\(s\):/,
+    );
+  });
+
+  it("pluck: allows string column name", async () => {
+    const titlesExpected = await (Post as any).pluck(arelSql("title"));
+    const titles = await (Post as any).pluck("title");
+    expect(titles).toEqual(titlesExpected);
+  });
+
+  it("pluck: allows string column name with function and alias", async () => {
+    const titlesExpected = await (Post as any).pluck(arelSql("UPPER(title)"));
+    const titles = await (Post as any).pluck("UPPER(title) AS title");
+    expect(titles).toEqual(titlesExpected);
+  });
+
+  it("pluck: allows symbol column name", async () => {
+    const titlesExpected = await (Post as any).pluck(arelSql("title"));
+    const titles = await (Post as any).pluck("title");
+    expect(new Set(titles)).toEqual(new Set(titlesExpected));
+  });
+
+  it("pluck: allows multiple column names", async () => {
+    const valuesExpected = await (Post as any).pluck(arelSql("title"), arelSql("id"));
+    const values = await (Post as any).pluck("title", "id");
+    expect(values).toEqual(valuesExpected);
+  });
+
+  it("pluck: allows column names with includes", async () => {
+    const valuesExpected = await (Post as any).pluck(arelSql("title"), arelSql("id"));
+    const values = await (Post as any).all().pluck("title", "id");
+    expect(values).toEqual(valuesExpected);
+  });
+
+  it("pluck: allows auto-generated attributes", async () => {
+    const values = await (Post as any).pluck("tags_count");
+    expect(values.length).toBeGreaterThan(0);
+  });
+
+  it("pluck: allows table and column names", async () => {
+    const titlesExpected = await (Post as any).pluck(arelSql("title"));
+    const titles = await (Post as any).pluck("urs_posts.title");
+    expect(titles).toEqual(titlesExpected);
+  });
+
+  it("pluck: allows quoted table and column names", async () => {
+    const titlesExpected = await (Post as any).pluck(arelSql("title"));
+    const titles = await (Post as any).pluck('"urs_posts"."title"');
+    expect(titles).toEqual(titlesExpected);
+  });
+
+  it("pluck: allows nested functions", async () => {
+    const lengths = await (Post as any).pluck("length(trim(title))");
+    expect(lengths.length).toBeGreaterThan(0);
+  });
+
+  it("pluck: disallows invalid column name", async () => {
+    await expect((Post as any).pluck("REPLACE(title, 'misc', 'zzzz')")).rejects.toBeInstanceOf(
+      UnknownAttributeReference,
+    );
+  });
+
+  it("pluck: disallows invalid column name amongst valid names", async () => {
+    await expect(
+      (Post as any).pluck("title", "REPLACE(title, 'misc', 'zzzz')"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("pluck: disallows invalid column names with includes", async () => {
+    await expect(
+      (Post as any).all().pluck("title", "REPLACE(title, 'misc', 'zzzz')"),
+    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+  });
+
+  it("pluck: always allows Arel", async () => {
+    const values = await (Post as any).pluck("title", arelSql("length(title)"));
+    expect(values.length).toBeGreaterThan(0);
+    expect(Array.isArray(values[0])).toBe(true);
+  });
+
+  it("pluck: disallows dangerous query method", async () => {
+    let error: unknown;
+    try {
+      await (Post as any).pluck("title", "REPLACE(title, 'misc', 'zzzz')");
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(UnknownAttributeReference);
+    expect((error as UnknownAttributeReference).message).toMatch(
+      /Dangerous query method.*called with non-attribute argument\(s\):/,
+    );
+  });
 });

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -109,19 +109,22 @@ describe("UnsafeRawSqlTest", () => {
   });
 
   it("order: disallows invalid column name", async () => {
-    await expect(
-      (Post as any).order("REPLACE(title, 'misc', 'zzzz') asc").pluck("id"),
-    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+    // order() raises immediately (Rails-faithful); wrap in async fn so .rejects works.
+    await expect(async () => {
+      await (Post as any).order("REPLACE(title, 'misc', 'zzzz') asc").pluck("id");
+    }).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
   it("order: disallows invalid direction", async () => {
-    await expect((Post as any).order({ title: "foo" }).pluck("id")).rejects.toThrow();
+    await expect(async () => {
+      await (Post as any).order({ title: "foo" }).pluck("id");
+    }).rejects.toThrow();
   });
 
   it("order: disallows invalid column with direction", async () => {
-    await expect(
-      (Post as any).order({ "REPLACE(title, 'misc', 'zzzz')": "asc" }).pluck("id"),
-    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+    await expect(async () => {
+      await (Post as any).order({ "REPLACE(title, 'misc', 'zzzz')": "asc" }).pluck("id");
+    }).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
   it("order: always allows Arel", async () => {
@@ -140,15 +143,15 @@ describe("UnsafeRawSqlTest", () => {
   });
 
   it("order: disallows invalid bind statement", async () => {
-    await expect(
-      (Post as any).order(["REPLACE(title, ?, ?), id", "misc", "zzzz"]).pluck("id"),
-    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+    await expect(async () => {
+      await (Post as any).order(["REPLACE(title, ?, ?), id", "misc", "zzzz"]).pluck("id");
+    }).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
   it("order: disallows invalid Array arguments", async () => {
-    await expect(
-      (Post as any).order(["author_id", "REPLACE(title, 'misc', 'zzzz')"]).pluck("id"),
-    ).rejects.toBeInstanceOf(UnknownAttributeReference);
+    await expect(async () => {
+      await (Post as any).order(["author_id", "REPLACE(title, 'misc', 'zzzz')"]).pluck("id");
+    }).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
   it("order: allows valid Array arguments", async () => {

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -255,6 +255,15 @@ describe("UnsafeRawSqlTest", () => {
     ).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
+  it("pluck: rejects comma-separated column list in a single argument", async () => {
+    // trails-specific guard: pluck("id, title") has ambiguous result mapping.
+    // Pass each column as a separate argument instead: pluck("id", "title").
+    await expect((Post as any).pluck("id, title")).rejects.toMatchObject({
+      name: "ArgumentError",
+      message: /pluck does not allow comma-separated/,
+    });
+  });
+
   it("pluck: always allows Arel", async () => {
     const values = await (Post as any).pluck("title", arelSql("length(title)"));
     expect(values.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Implements \`unsafe_raw_sql_test.rb\` — 37 tests total, 35 passing, 2 skipped.

**New error class:**
- \`UnknownAttributeReference\` — mirrors \`ActiveRecord::UnknownAttributeReference\`. \`disallowRawSqlBang\` now throws this instead of a plain \`Error\`.

**New validation:**
- \`pluck()\` calls \`disallowRawSqlBang\` with \`columnNameMatcher()\` (the broader pattern — allows \`UPPER(col)\`, \`length(trim(col))\`)
- \`orderBang\`/\`reorderBang\` validate string clauses and \`{ col: dir }\` hash clauses with \`columnNameWithOrderMatcher()\` — validation happens **synchronously at call time** (i.e. \`order("bad")\` throws immediately, not on \`await\`)

**New \`orderBang\`/\`reorderBang\` features:**
- Arel \`Node\` arguments (e.g. \`order(Arel.sql("length(title)"))\`) now extract raw SQL instead of being treated as hash objects
- Array bind form: \`[Arel.sql("col = ?"), bind1]\` interpolates binds; \`["col1", "col2"]\` validates each element independently

**Updated column matchers** (\`columnNameMatcher\` / \`columnNameWithOrderMatcher\`):
- Each adapter's matchers live in its quoting module and are delegated to from the adapter static methods (PG: \`postgresql/quoting.ts\`, MySQL: \`mysql/quoting.ts\`, SQLite3: inline in adapter using the strict 0-or-1-arg shape)
- Allow nested function calls: \`length(trim(col))\` ✓
- Allow quoted identifiers: \`"table"."col"\`, \`\`table\`.\`col\`\` ✓
- Allow multi-level qualifiers and \`::type\` casts (PG): \`"schema"."table"."col"::text\` ✓
- Reject multi-arg functions: \`REPLACE(a, b, c)\` ✗ (0-or-1 arg, mirroring Rails \`\\w+((?:|\\g<2>))\`)
- Note: \`sqlite3/quoting.ts\` \`ColumnMatcher\` is intentionally more permissive (accepts \`COALESCE(a,b)\` etc.) for query use-cases; \`SQLite3Adapter\` statics use a separate strict implementation matching Rails

**\`pluck()\` projection fix:**
- Table-qualified (\`table.col\`), quoted (\`"table"."col"\`), backtick-quoted, and function expressions use \`SqlLiteral\` for projection, not \`table.get(col)\`
- Result column mapping: function expressions without explicit AS alias use positional \`Object.values(row)[i]\` fallback; AS alias extraction handles plain, double-quoted, and backtick-quoted forms

## Skipped tests
- \`order: allows NULLS FIRST and NULLS LAST too\` — PostgreSQL-only (\`::text\` cast syntax)
- \`order: allows valid arguments with COLLATE\` — adapter-specific collation names