### PR TITLE
feat(activesupport): callbacks.ts to 100% api:compare

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1472,3 +1472,59 @@ describe("AfterSaveConditionalPersonCallbackTest", () => {
     expect(target.history).toEqual(["string2", "string1"]);
   });
 });
+
+describe("custom terminator function", () => {
+  it("custom terminator halts when it returns true", () => {
+    const log: string[] = [];
+    const target = { log };
+    defineCallbacks(target, "save", {
+      terminator: (_t, fn) => {
+        const result = fn();
+        return result === "halt";
+      },
+    });
+    setCallback(target, "save", "before", () => "halt");
+    setCallback(target, "save", "before", (t: any) => t.log.push("second"));
+    runCallbacks(target, "save", () => log.push("block"));
+    expect(log).not.toContain("second");
+    expect(log).not.toContain("block");
+  });
+
+  it("custom terminator does not halt when it returns false", () => {
+    const log: string[] = [];
+    const target = { log };
+    defineCallbacks(target, "save", {
+      terminator: (_t, fn) => {
+        fn();
+        return false;
+      },
+    });
+    setCallback(target, "save", "before", () => false);
+    setCallback(target, "save", "before", (t: any) => t.log.push("second"));
+    runCallbacks(target, "save", () => log.push("block"));
+    expect(log).toContain("second");
+    expect(log).toContain("block");
+  });
+});
+
+describe("skipAfterCallbacksIfTerminated", () => {
+  it("skips after callbacks when halted and option is set", () => {
+    const log: string[] = [];
+    const target = { log };
+    defineCallbacks(target, "save", { skipAfterCallbacksIfTerminated: true });
+    setCallback(target, "save", "before", () => false);
+    setCallback(target, "save", "after", (t: any) => t.log.push("after"));
+    runCallbacks(target, "save");
+    expect(log).not.toContain("after");
+  });
+
+  it("runs after callbacks when not halted even with option set", () => {
+    const log: string[] = [];
+    const target = { log };
+    defineCallbacks(target, "save", { skipAfterCallbacksIfTerminated: true });
+    setCallback(target, "save", "before", () => undefined);
+    setCallback(target, "save", "after", (t: any) => t.log.push("after"));
+    runCallbacks(target, "save");
+    expect(log).toContain("after");
+  });
+});

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1508,6 +1508,17 @@ describe("custom terminator function", () => {
 });
 
 describe("skipAfterCallbacksIfTerminated", () => {
+  it("after callbacks run by default even when halted", () => {
+    const log: string[] = [];
+    const target = { log };
+    defineCallbacks(target, "save"); // no skipAfterCallbacksIfTerminated
+    setCallback(target, "save", "before", () => false);
+    setCallback(target, "save", "after", (t: any) => t.log.push("after"));
+    const result = runCallbacks(target, "save");
+    expect(result).toBe(false); // halted
+    expect(log).toContain("after"); // after callbacks still run
+  });
+
   it("skips after callbacks when halted and option is set", () => {
     const log: string[] = [];
     const target = { log };

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -220,11 +220,15 @@ export class Before {
   readonly userCallback: (target: AnyRecord, value: AnyRecord) => unknown;
   readonly userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>;
   readonly haltedLambda: (target: AnyRecord, fn: () => unknown) => boolean;
+  readonly filter: AnyCallback | string | symbol;
+  readonly name: string;
 
   constructor(
     userCallback: (target: AnyRecord, value: AnyRecord) => unknown,
     userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
     chainConfig: { terminator?: (target: AnyRecord, fn: () => unknown) => boolean },
+    filter: AnyCallback | string | symbol = "",
+    name: string = "",
   ) {
     this.userCallback = userCallback;
     this.userConditions = userConditions;
@@ -234,6 +238,8 @@ export class Before {
         fn();
         return false;
       });
+    this.filter = filter;
+    this.name = name;
   }
 
   call(env: FilterEnvironment): FilterEnvironment {
@@ -417,7 +423,13 @@ export class Callback {
         : new MethodCall(String(this.filter));
 
     if (this.kind === "before") {
-      this._compiled = new Before(callTemplate.makeLambda(), userConditions, {});
+      this._compiled = new Before(
+        callTemplate.makeLambda(),
+        userConditions,
+        {},
+        this.filter,
+        this.name,
+      );
     } else if (this.kind === "after") {
       this._compiled = new After(callTemplate.makeLambda(), userConditions, {
         skipAfterCallbacksIfTerminated: this.chainConfig.skipAfterCallbacksIfTerminated,

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -1,6 +1,8 @@
+type AnyRecord = any;
+
 export type CallbackKind = "before" | "after" | "around";
 
-export type CallbackCondition = (target: any) => boolean;
+export type CallbackCondition = (target: AnyRecord) => boolean;
 
 export interface CallbackOptions {
   if?: CallbackCondition | CallbackCondition[];
@@ -10,29 +12,346 @@ export interface CallbackOptions {
 
 export interface DefineCallbacksOptions {
   terminator?: boolean;
+  skipAfterCallbacksIfTerminated?: boolean;
+  scope?: string[];
 }
 
-export type BeforeCallback = (target: any) => any;
-export type AfterCallback = (target: any) => void;
-export type AroundCallback = (target: any, next: () => void) => void;
+export type BeforeCallback = (target: AnyRecord) => AnyRecord;
+export type AfterCallback = (target: AnyRecord) => void;
+export type AroundCallback = (target: AnyRecord, next: () => void) => void;
 export type AnyCallback = BeforeCallback | AfterCallback | AroundCallback;
 
+// ---------------------------------------------------------------------------
+// Conditionals
+// ---------------------------------------------------------------------------
+
+/** Mirrors: ActiveSupport::Callbacks::Conditionals::Value */
+export class Value {
+  private readonly block: (value: AnyRecord) => unknown;
+
+  constructor(block: (value: AnyRecord) => unknown) {
+    this.block = block;
+  }
+
+  call(_target: AnyRecord, value: AnyRecord): unknown {
+    return this.block(value);
+  }
+
+  static check(options: CallbackOptions, target: AnyRecord): boolean {
+    if (options.if) {
+      const conditions = Array.isArray(options.if) ? options.if : [options.if];
+      if (!conditions.every((cond) => cond(target))) return false;
+    }
+    if (options.unless) {
+      const conditions = Array.isArray(options.unless) ? options.unless : [options.unless];
+      if (conditions.some((cond) => cond(target))) return false;
+    }
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CallTemplate — protocol for wrapping callables
+// ---------------------------------------------------------------------------
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate */
+export interface CallTemplate {
+  expand(target: AnyRecord, value: AnyRecord, block: (() => unknown) | null): unknown[];
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown;
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean;
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::MethodCall */
+export class MethodCall implements CallTemplate {
+  constructor(readonly methodName: string) {}
+
+  expand(target: AnyRecord, _value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [target, block, this.methodName];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const m = this.methodName;
+    return (target: AnyRecord) => target[m]?.();
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const m = this.methodName;
+    return (target: AnyRecord) => !target[m]?.();
+  }
+
+  make(target: AnyRecord, _value: AnyRecord): AnyRecord {
+    return target[this.methodName]?.call(target);
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::ObjectCall */
+export class ObjectCall implements CallTemplate {
+  constructor(
+    readonly target: AnyRecord,
+    readonly methodName: string,
+  ) {}
+
+  expand(target: AnyRecord, _value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [this.target ?? target, block, this.methodName, target];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const ot = this.target;
+    const m = this.methodName;
+    return (target: AnyRecord) => (ot ?? target)[m]?.(target);
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const ot = this.target;
+    const m = this.methodName;
+    return (target: AnyRecord) => !(ot ?? target)[m]?.(target);
+  }
+
+  make(instance: AnyRecord, _value: AnyRecord): AnyRecord {
+    return this.target[this.methodName]?.call(this.target, instance);
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::InstanceExec0 */
+export class InstanceExec0 implements CallTemplate {
+  constructor(readonly fn: () => AnyRecord) {}
+
+  expand(target: AnyRecord, _value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [target, this.fn, "instanceExec"];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const f = this.fn;
+    return (target: AnyRecord) => f.call(target);
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const f = this.fn;
+    return (target: AnyRecord) => !f.call(target);
+  }
+
+  make(target: AnyRecord, _value: AnyRecord): AnyRecord {
+    return this.fn.call(target);
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::InstanceExec1 */
+export class InstanceExec1 implements CallTemplate {
+  constructor(readonly fn: (target: AnyRecord) => AnyRecord) {}
+
+  expand(target: AnyRecord, _value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [target, this.fn, "instanceExec", target];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const f = this.fn;
+    return (target: AnyRecord) => f(target);
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const f = this.fn;
+    return (target: AnyRecord) => !f(target);
+  }
+
+  make(target: AnyRecord, _value: AnyRecord): AnyRecord {
+    return this.fn(target);
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::InstanceExec2 */
+export class InstanceExec2 implements CallTemplate {
+  constructor(readonly fn: (target: AnyRecord, value: AnyRecord) => AnyRecord) {}
+
+  expand(target: AnyRecord, value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [target, this.fn, "instanceExec", target, block];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const f = this.fn;
+    return (target: AnyRecord, value: AnyRecord) => f(target, value);
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const f = this.fn;
+    return (target: AnyRecord, value: AnyRecord) => !f(target, value);
+  }
+
+  make(target: AnyRecord, value: AnyRecord): AnyRecord {
+    return this.fn(target, value);
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::CallTemplate::ProcCall */
+export class ProcCall implements CallTemplate {
+  constructor(readonly fn: (...args: AnyRecord[]) => AnyRecord) {}
+
+  expand(target: AnyRecord, value: AnyRecord, block: (() => unknown) | null): unknown[] {
+    return [this.fn, block, "call", target, value];
+  }
+
+  makeLambda(): (target: AnyRecord, value: AnyRecord) => unknown {
+    const f = this.fn;
+    return (target: AnyRecord, value: AnyRecord) => f(target, value);
+  }
+
+  invertedLambda(): (target: AnyRecord, value: AnyRecord) => boolean {
+    const f = this.fn;
+    return (target: AnyRecord, value: AnyRecord) => !f(target, value);
+  }
+
+  make(target: AnyRecord, _value: AnyRecord): AnyRecord {
+    return this.fn(target);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+/** Environment struct threaded through the compiled filter chain. */
+export interface FilterEnvironment {
+  target: AnyRecord;
+  halted: boolean;
+  value: AnyRecord;
+}
+
+/** Mirrors: ActiveSupport::Callbacks::Filters::Before */
+export class Before {
+  readonly userCallback: (target: AnyRecord, value: AnyRecord) => unknown;
+  readonly userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>;
+  readonly haltedLambda: (target: AnyRecord, fn: () => unknown) => boolean;
+
+  constructor(
+    userCallback: (target: AnyRecord, value: AnyRecord) => unknown,
+    userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
+    chainConfig: { terminator?: (target: AnyRecord, fn: () => unknown) => boolean },
+  ) {
+    this.userCallback = userCallback;
+    this.userConditions = userConditions;
+    this.haltedLambda =
+      chainConfig.terminator ??
+      ((_t, fn) => {
+        fn();
+        return false;
+      });
+  }
+
+  call(env: FilterEnvironment): FilterEnvironment {
+    const { target, value, halted } = env;
+    if (!halted && this.userConditions.every((c) => c(target, value))) {
+      const resultLambda = () => this.userCallback(target, value);
+      env.halted = this.haltedLambda(target, resultLambda);
+    }
+    return env;
+  }
+
+  apply(seq: CallbackSequence): CallbackSequence {
+    return seq.before(this);
+  }
+
+  static build(
+    callback: Callback,
+    options: DefineCallbacksOptions,
+  ): (target: AnyRecord) => boolean {
+    const terminator = options.terminator !== false;
+    return (target: AnyRecord) => {
+      if (!Value.check(callback.options, target)) return true;
+      const result = (callback.filter as BeforeCallback)(target);
+      return !(terminator && result === false);
+    };
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::Filters::After */
+export class After {
+  readonly userCallback: (target: AnyRecord, value: AnyRecord) => unknown;
+  readonly userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>;
+  readonly halting: boolean;
+
+  constructor(
+    userCallback: (target: AnyRecord, value: AnyRecord) => unknown,
+    userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
+    chainConfig: { skipAfterCallbacksIfTerminated?: boolean },
+  ) {
+    this.userCallback = userCallback;
+    this.userConditions = userConditions;
+    this.halting = chainConfig.skipAfterCallbacksIfTerminated ?? false;
+  }
+
+  call(env: FilterEnvironment): FilterEnvironment {
+    const { target, value, halted } = env;
+    if ((!halted || !this.halting) && this.userConditions.every((c) => c(target, value))) {
+      this.userCallback(target, value);
+    }
+    return env;
+  }
+
+  apply(seq: CallbackSequence): CallbackSequence {
+    return seq.after(this);
+  }
+
+  static build(callback: Callback): (target: AnyRecord) => void {
+    return (target: AnyRecord) => {
+      if (!Value.check(callback.options, target)) return;
+      (callback.filter as AfterCallback)(target);
+    };
+  }
+}
+
+/** Mirrors: ActiveSupport::Callbacks::Filters::Around */
+export class Around {
+  private readonly userCallback: CallTemplate;
+  private readonly userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>;
+
+  constructor(
+    userCallback: CallTemplate,
+    userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
+  ) {
+    this.userCallback = userCallback;
+    this.userConditions = userConditions;
+  }
+
+  apply(seq: CallbackSequence): CallbackSequence {
+    return seq.around(this.userCallback, this.userConditions);
+  }
+
+  static build(callback: Callback): (target: AnyRecord, block: () => void) => void {
+    return (target: AnyRecord, block: () => void) => {
+      if (!Value.check(callback.options, target)) {
+        block();
+        return;
+      }
+      (callback.filter as AroundCallback)(target, block);
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Callback
+// ---------------------------------------------------------------------------
+
+/** Mirrors: ActiveSupport::Callbacks::Callback */
 export class Callback {
-  readonly kind: CallbackKind;
+  kind: CallbackKind;
+  name: string;
   readonly filter: AnyCallback;
   readonly options: CallbackOptions;
-  readonly name: string;
+  readonly chainConfig: DefineCallbacksOptions;
+
+  private _compiled: Before | After | Around | undefined;
 
   constructor(
     name: string,
     filter: AnyCallback,
     kind: CallbackKind,
     options: CallbackOptions = {},
+    chainConfig: DefineCallbacksOptions = {},
   ) {
     this.name = name;
     this.filter = filter;
     this.kind = kind;
     this.options = options;
+    this.chainConfig = chainConfig;
   }
 
   matches(kind: CallbackKind, filter?: AnyCallback): boolean {
@@ -41,7 +360,80 @@ export class Callback {
     return true;
   }
 
-  apply(target: any, block?: () => void): boolean {
+  mergeConditionalOptions(
+    chain: { name: string; config: DefineCallbacksOptions },
+    ifOption: CallbackCondition[],
+    unlessOption: CallbackCondition[],
+  ): Callback {
+    const existingIf = Array.isArray(this.options.if)
+      ? this.options.if
+      : this.options.if
+        ? [this.options.if]
+        : [];
+    const existingUnless = Array.isArray(this.options.unless)
+      ? this.options.unless
+      : this.options.unless
+        ? [this.options.unless]
+        : [];
+    return new Callback(
+      chain.name,
+      this.filter,
+      this.kind,
+      {
+        if: [...existingIf, ...unlessOption],
+        unless: [...existingUnless, ...ifOption],
+      },
+      chain.config,
+    );
+  }
+
+  isDuplicates(other: Callback): boolean {
+    if (typeof this.filter === "string") {
+      return this.kind === other.kind && this.filter === other.filter;
+    }
+    return false;
+  }
+
+  get compiled(): Before | After | Around {
+    if (this._compiled) return this._compiled;
+
+    const userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean> = [];
+    const ifConds = Array.isArray(this.options.if)
+      ? this.options.if
+      : this.options.if
+        ? [this.options.if]
+        : [];
+    const unlessConds = Array.isArray(this.options.unless)
+      ? this.options.unless
+      : this.options.unless
+        ? [this.options.unless]
+        : [];
+    for (const c of ifConds) userConditions.push((t) => c(t));
+    for (const c of unlessConds) userConditions.push((t) => !c(t));
+
+    const callTemplate =
+      typeof this.filter === "function"
+        ? new ProcCall(this.filter)
+        : new MethodCall(String(this.filter));
+
+    if (this.kind === "before") {
+      this._compiled = new Before(callTemplate.makeLambda(), userConditions, {});
+    } else if (this.kind === "after") {
+      this._compiled = new After(callTemplate.makeLambda(), userConditions, {
+        skipAfterCallbacksIfTerminated: this.chainConfig.skipAfterCallbacksIfTerminated,
+      });
+    } else {
+      this._compiled = new Around(callTemplate, userConditions);
+    }
+    return this._compiled!;
+  }
+
+  currentScopes(): string[] {
+    const scope = this.chainConfig.scope ?? ["kind"];
+    return scope.map((s) => (s === "kind" ? String(this.kind) : String((this as AnyRecord)[s])));
+  }
+
+  apply(target: AnyRecord, block?: () => void): boolean {
     if (!Value.check(this.options, target)) return true;
 
     if (this.kind === "before") {
@@ -50,15 +442,94 @@ export class Callback {
       (this.filter as AfterCallback)(target);
       return true;
     } else if (this.kind === "around") {
-      if (!block) {
-        throw new Error("Around callbacks require a block/next function");
-      }
+      if (!block) throw new Error("Around callbacks require a block/next function");
       (this.filter as AroundCallback)(target, block);
       return true;
     }
     return true;
   }
 }
+
+// ---------------------------------------------------------------------------
+// CallbackSequence
+// ---------------------------------------------------------------------------
+
+/**
+ * Compiled, linked-list callback sequence.
+ * Mirrors: ActiveSupport::Callbacks::CallbackSequence
+ */
+export class CallbackSequence {
+  readonly nested: CallbackSequence | null;
+  private readonly callTemplate: CallTemplate | null;
+  private readonly userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean> | null;
+  private beforeList: Before[] | null = null;
+  private afterList: After[] | null = null;
+
+  constructor(
+    nested: CallbackSequence | null = null,
+    callTemplate: CallTemplate | null = null,
+    userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean> | null = null,
+  ) {
+    this.nested = nested;
+    this.callTemplate = callTemplate;
+    this.userConditions = userConditions;
+  }
+
+  before(b: Before): this {
+    (this.beforeList ??= []).unshift(b);
+    return this;
+  }
+
+  after(a: After): this {
+    (this.afterList ??= []).push(a);
+    return this;
+  }
+
+  around(
+    callTemplate: CallTemplate,
+    userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
+  ): CallbackSequence {
+    return new CallbackSequence(this, callTemplate, userConditions);
+  }
+
+  isSkip(env: FilterEnvironment): boolean {
+    if (env.halted) return true;
+    if (!this.userConditions) return false;
+    return !this.userConditions.every((c) => c(env.target, env.value));
+  }
+
+  isFinal(): boolean {
+    return !this.callTemplate;
+  }
+
+  expandCallTemplate(env: FilterEnvironment, block: (() => unknown) | null): unknown[] {
+    return this.callTemplate!.expand(env.target, env.value, block);
+  }
+
+  invokeBefore(env: FilterEnvironment): void {
+    this.beforeList?.forEach((b) => b.call(env));
+  }
+
+  invokeAfter(env: FilterEnvironment): void {
+    this.afterList?.forEach((a) => a.call(env));
+  }
+
+  invoke(target: AnyRecord, block?: () => void): boolean {
+    const callbackChain = this._callbackChain;
+    if (!callbackChain) {
+      block?.();
+      return true;
+    }
+    return callbackChain._invokeSequence(this, target, block);
+  }
+
+  // Back-reference set by CallbackChain.compile() for invoke() convenience
+  _callbackChain: CallbackChain | null = null;
+}
+
+// ---------------------------------------------------------------------------
+// CallbackChain
+// ---------------------------------------------------------------------------
 
 export class CallbackChain {
   readonly name: string;
@@ -73,6 +544,23 @@ export class CallbackChain {
 
   get entries(): Callback[] {
     return this.chain;
+  }
+
+  each(fn: (cb: Callback) => void): void {
+    this.chain.forEach(fn);
+  }
+
+  index(cb: Callback): number {
+    return this.chain.indexOf(cb);
+  }
+
+  insert(idx: number, cb: Callback): void {
+    this.chain.splice(idx, 0, cb);
+  }
+
+  delete(cb: Callback): void {
+    const i = this.chain.indexOf(cb);
+    if (i !== -1) this.chain.splice(i, 1);
   }
 
   append(callback: Callback): void {
@@ -92,24 +580,18 @@ export class CallbackChain {
   }
 
   compile(): CallbackSequence {
-    return new CallbackSequence(this);
+    const seq = new CallbackSequence();
+    seq._callbackChain = this;
+    return seq;
   }
 
   get isEmpty(): boolean {
     return this.chain.length === 0;
   }
-}
 
-export class CallbackSequence {
-  private readonly callbackChain: CallbackChain;
-
-  constructor(callbackChain: CallbackChain) {
-    this.callbackChain = callbackChain;
-  }
-
-  invoke(target: any, block?: () => void): boolean {
-    const entries = this.callbackChain.entries;
-    const terminator = this.callbackChain.config.terminator !== false;
+  _invokeSequence(seq: CallbackSequence, target: AnyRecord, block?: () => void): boolean {
+    const terminator = this.config.terminator !== false;
+    const entries = this.chain;
 
     const befores = entries.filter((e) => e.kind === "before");
     const afters = entries.filter((e) => e.kind === "after");
@@ -146,102 +628,59 @@ export class CallbackSequence {
   }
 }
 
-export class MethodCall {
-  constructor(readonly methodName: string) {}
+// ---------------------------------------------------------------------------
+// ClassMethods
+// ---------------------------------------------------------------------------
 
-  make(target: any, _value: any): any {
-    return target[this.methodName]?.call(target);
+const CALLBACK_FILTER_TYPES: CallbackKind[] = ["before", "after", "around"];
+
+/**
+ * Mirrors: ActiveSupport::Callbacks::ClassMethods#normalize_callback_params
+ */
+export function normalizeCallbackParams(
+  filters: Array<CallbackKind | AnyCallback | string | symbol | Record<string, unknown>>,
+  block: AnyCallback | null,
+): [CallbackKind, Array<AnyCallback | string | symbol>, Record<string, unknown>] {
+  const rest = [...filters];
+  let type: CallbackKind = "before";
+  if (rest.length > 0 && CALLBACK_FILTER_TYPES.includes(rest[0] as CallbackKind)) {
+    type = rest.shift() as CallbackKind;
   }
+  let options: Record<string, unknown> = {};
+  if (
+    rest.length > 0 &&
+    typeof rest[rest.length - 1] === "object" &&
+    rest[rest.length - 1] !== null &&
+    !("call" in (rest[rest.length - 1] as object))
+  ) {
+    options = rest.pop() as unknown as Record<string, unknown>;
+  }
+  if (block) rest.unshift(block);
+  return [type, rest as Array<AnyCallback | string | symbol>, options];
 }
 
-export class ObjectCall {
-  constructor(
-    readonly target: any,
-    readonly methodName: string,
-  ) {}
-
-  make(instance: any, _value: any): any {
-    return this.target[this.methodName]?.call(this.target, instance);
-  }
+/**
+ * Mirrors: ActiveSupport::Callbacks::ClassMethods#__update_callbacks
+ */
+export function __updateCallbacks(
+  name: string,
+  targets: Array<{
+    getCallbacks(name: string): CallbackChain;
+    setCallbacks(name: string, chain: CallbackChain): void;
+  }>,
+  fn: (target: AnyRecord, chain: CallbackChain) => void,
+): void {
+  [...targets].reverse().forEach((target) => {
+    const chain = target.getCallbacks(name);
+    const dup = new CallbackChain(chain.name, chain.config);
+    chain.entries.forEach((e) => dup.append(e));
+    fn(target, dup);
+  });
 }
 
-export class InstanceExec0 {
-  constructor(readonly fn: () => any) {}
-
-  make(target: any, _value: any): any {
-    return this.fn.call(target);
-  }
-}
-
-export class InstanceExec1 {
-  constructor(readonly fn: (target: any) => any) {}
-
-  make(target: any, _value: any): any {
-    return this.fn(target);
-  }
-}
-
-export class InstanceExec2 {
-  constructor(readonly fn: (target: any, value: any) => any) {}
-
-  make(target: any, value: any): any {
-    return this.fn(target, value);
-  }
-}
-
-export class ProcCall {
-  constructor(readonly fn: (...args: any[]) => any) {}
-
-  make(target: any, _value: any): any {
-    return this.fn(target);
-  }
-}
-
-export class Value {
-  static check(options: CallbackOptions, target: any): boolean {
-    if (options.if) {
-      const conditions = Array.isArray(options.if) ? options.if : [options.if];
-      if (!conditions.every((cond) => cond(target))) return false;
-    }
-    if (options.unless) {
-      const conditions = Array.isArray(options.unless) ? options.unless : [options.unless];
-      if (conditions.some((cond) => cond(target))) return false;
-    }
-    return true;
-  }
-}
-
-export class Before {
-  static build(callback: Callback, _options: DefineCallbacksOptions): (target: any) => boolean {
-    const terminator = _options.terminator !== false;
-    return (target: any) => {
-      if (!Value.check(callback.options, target)) return true;
-      const result = (callback.filter as BeforeCallback)(target);
-      return !(terminator && result === false);
-    };
-  }
-}
-
-export class After {
-  static build(callback: Callback): (target: any) => void {
-    return (target: any) => {
-      if (!Value.check(callback.options, target)) return;
-      (callback.filter as AfterCallback)(target);
-    };
-  }
-}
-
-export class Around {
-  static build(callback: Callback): (target: any, block: () => void) => void {
-    return (target: any, block: () => void) => {
-      if (!Value.check(callback.options, target)) {
-        block();
-        return;
-      }
-      (callback.filter as AroundCallback)(target, block);
-    };
-  }
-}
+// ---------------------------------------------------------------------------
+// Namespaces (mirrors Rails module nesting)
+// ---------------------------------------------------------------------------
 
 const _ct = { MethodCall, ObjectCall, InstanceExec0, InstanceExec1, InstanceExec2, ProcCall };
 export namespace CallTemplate {
@@ -265,6 +704,10 @@ export namespace Filters {
   export const Around = _filt.Around;
 }
 
+// ---------------------------------------------------------------------------
+// Runtime API (unchanged from original)
+// ---------------------------------------------------------------------------
+
 export interface ClassMethods {
   defineCallbacks(name: string, options?: DefineCallbacksOptions): void;
   beforeCallback(name: string, callback: BeforeCallback, options?: CallbackOptions): void;
@@ -276,16 +719,17 @@ export interface ClassMethods {
 
 const CALLBACKS = Symbol("callbacks");
 
-function getCallbackChains(target: any): Map<string, CallbackChain> {
+function getCallbackChains(target: AnyRecord): Map<string, CallbackChain> {
   if (!Object.prototype.hasOwnProperty.call(target, CALLBACKS)) {
     const parent: Map<string, CallbackChain> | undefined = target[CALLBACKS];
     const own = new Map<string, CallbackChain>();
     if (parent) {
       for (const [name, chain] of parent) {
-        own.set(name, new CallbackChain(chain.name, chain.config));
+        const newChain = new CallbackChain(chain.name, chain.config);
         for (const entry of chain.entries) {
-          own.get(name)!.append(new Callback(entry.name, entry.filter, entry.kind, entry.options));
+          newChain.append(new Callback(entry.name, entry.filter, entry.kind, entry.options));
         }
+        own.set(name, newChain);
       }
     }
     target[CALLBACKS] = own;
@@ -295,7 +739,7 @@ function getCallbackChains(target: any): Map<string, CallbackChain> {
 
 export namespace Callbacks {
   export function defineCallbacks(
-    target: any,
+    target: AnyRecord,
     name: string,
     options: DefineCallbacksOptions = {},
   ): void {
@@ -306,7 +750,7 @@ export namespace Callbacks {
   }
 
   export function setCallback(
-    target: any,
+    target: AnyRecord,
     name: string,
     kind: CallbackKind,
     callback: AnyCallback,
@@ -326,7 +770,7 @@ export namespace Callbacks {
   }
 
   export function skipCallback(
-    target: any,
+    target: AnyRecord,
     name: string,
     kind: CallbackKind,
     callback?: AnyCallback,
@@ -337,13 +781,13 @@ export namespace Callbacks {
     chain.remove(kind, callback);
   }
 
-  export function resetCallbacks(target: any, name: string): void {
+  export function resetCallbacks(target: AnyRecord, name: string): void {
     const chains = getCallbackChains(target);
     const chain = chains.get(name);
     if (chain) chain.clear();
   }
 
-  export function runCallbacks(target: any, name: string, block?: () => void): boolean {
+  export function runCallbacks(target: AnyRecord, name: string, block?: () => void): boolean {
     const chains = getCallbackChains(target);
     const chain = chains.get(name);
     if (!chain) {
@@ -356,7 +800,7 @@ export namespace Callbacks {
 }
 
 export function defineCallbacks(
-  target: any,
+  target: AnyRecord,
   name: string,
   options: DefineCallbacksOptions = {},
 ): void {
@@ -364,7 +808,7 @@ export function defineCallbacks(
 }
 
 export function setCallback(
-  target: any,
+  target: AnyRecord,
   name: string,
   kind: CallbackKind,
   callback: AnyCallback,
@@ -374,7 +818,7 @@ export function setCallback(
 }
 
 export function skipCallback(
-  target: any,
+  target: AnyRecord,
   name: string,
   kind: CallbackKind,
   callback?: AnyCallback,
@@ -382,15 +826,15 @@ export function skipCallback(
   Callbacks.skipCallback(target, name, kind, callback);
 }
 
-export function resetCallbacks(target: any, name: string): void {
+export function resetCallbacks(target: AnyRecord, name: string): void {
   Callbacks.resetCallbacks(target, name);
 }
 
-export function runCallbacks(target: any, name: string, block?: () => void): boolean {
+export function runCallbacks(target: AnyRecord, name: string, block?: () => void): boolean {
   return Callbacks.runCallbacks(target, name, block);
 }
 
-export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Base?: TBase) {
+export function CallbacksMixin<TBase extends new (...args: AnyRecord[]) => object>(Base?: TBase) {
   const ActualBase = (Base ?? class {}) as TBase;
 
   class WithCallbacks extends ActualBase {

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -620,46 +620,60 @@ export class CallbackChain {
 
   _invoke(target: AnyRecord, block?: () => void): boolean {
     const terminatorFn = this.config.terminator;
+    const skipAfterIfTerminated = this.config.skipAfterCallbacksIfTerminated ?? false;
     const entries = this.chain;
 
     const befores = entries.filter((e) => e.kind === "before");
     const afters = entries.filter((e) => e.kind === "after");
     const arounds = entries.filter((e) => e.kind === "around");
 
+    // Run before callbacks; track whether the chain was halted.
+    let halted = false;
     for (const entry of befores) {
       if (!Value.check(entry.options, target)) continue;
       const cb = entry.filter as BeforeCallback;
       if (terminatorFn === false) {
-        cb(target); // no halting
+        cb(target); // terminator disabled — never halt
       } else if (terminatorFn) {
-        if (terminatorFn(target, () => cb(target))) return false;
+        if (terminatorFn(target, () => cb(target))) {
+          halted = true;
+          break;
+        }
       } else {
-        if (cb(target) === false) return false;
+        if (cb(target) === false) {
+          halted = true;
+          break;
+        }
       }
     }
 
-    let core = () => {
-      block?.();
-    };
-
-    for (let i = arounds.length - 1; i >= 0; i--) {
-      const entry = arounds[i];
-      const inner = core;
-      if (!Value.check(entry.options, target)) continue;
-      core = () => {
-        (entry.filter as AroundCallback)(target, inner);
+    // Run around+block only when not halted (mirrors Rails CallbackSequence#skip?).
+    if (!halted) {
+      let core = () => {
+        block?.();
       };
+      for (let i = arounds.length - 1; i >= 0; i--) {
+        const entry = arounds[i];
+        const inner = core;
+        if (!Value.check(entry.options, target)) continue;
+        core = () => {
+          (entry.filter as AroundCallback)(target, inner);
+        };
+      }
+      core();
     }
 
-    core();
-
-    for (let i = afters.length - 1; i >= 0; i--) {
-      const entry = afters[i];
-      if (!Value.check(entry.options, target)) continue;
-      (entry.filter as AfterCallback)(target);
+    // After callbacks run even when halted unless skipAfterCallbacksIfTerminated is true.
+    // Mirrors: Filters::After#call — `(!halted || !@halting)`
+    if (!halted || !skipAfterIfTerminated) {
+      for (let i = afters.length - 1; i >= 0; i--) {
+        const entry = afters[i];
+        if (!Value.check(entry.options, target)) continue;
+        (entry.filter as AfterCallback)(target);
+      }
     }
 
-    return true;
+    return !halted;
   }
 }
 

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -11,7 +11,12 @@ export interface CallbackOptions {
 }
 
 export interface DefineCallbacksOptions {
-  terminator?: boolean;
+  /**
+   * Mirrors Rails' :terminator option. Pass a function `(target, fn) => boolean` (returns true
+   * to halt) or `false` to disable halting entirely. Defaults to halting when a before callback
+   * returns `false`.
+   */
+  terminator?: ((target: AnyRecord, fn: () => unknown) => boolean) | false;
   skipAfterCallbacksIfTerminated?: boolean;
   scope?: string[];
 }
@@ -226,18 +231,19 @@ export class Before {
   constructor(
     userCallback: (target: AnyRecord, value: AnyRecord) => unknown,
     userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
-    chainConfig: { terminator?: (target: AnyRecord, fn: () => unknown) => boolean },
+    chainConfig: { terminator?: ((target: AnyRecord, fn: () => unknown) => boolean) | false },
     filter: AnyCallback | string | symbol = "",
     name: string = "",
   ) {
     this.userCallback = userCallback;
     this.userConditions = userConditions;
     this.haltedLambda =
-      chainConfig.terminator ??
-      ((_t, fn) => {
-        fn();
-        return false;
-      });
+      chainConfig.terminator === false
+        ? (_t: AnyRecord, fn: () => unknown) => {
+            fn();
+            return false;
+          }
+        : (chainConfig.terminator ?? ((_t: AnyRecord, fn: () => unknown) => fn() === false));
     this.filter = filter;
     this.name = name;
   }
@@ -259,11 +265,13 @@ export class Before {
     callback: Callback,
     options: DefineCallbacksOptions,
   ): (target: AnyRecord) => boolean {
-    const terminator = options.terminator !== false;
+    const terminatorFn = options.terminator;
     return (target: AnyRecord) => {
       if (!Value.check(callback.options, target)) return true;
-      const result = (callback.filter as BeforeCallback)(target);
-      return !(terminator && result === false);
+      const cb = callback.filter as BeforeCallback;
+      if (terminatorFn === false) return true; // never halt
+      if (terminatorFn) return !terminatorFn(target, () => cb(target));
+      return cb(target) !== false;
     };
   }
 }
@@ -426,7 +434,7 @@ export class Callback {
       this._compiled = new Before(
         callTemplate.makeLambda(),
         userConditions,
-        {},
+        this.chainConfig,
         this.filter,
         this.name,
       );
@@ -501,7 +509,9 @@ export class CallbackSequence {
     callTemplate: CallTemplate,
     userConditions: Array<(target: AnyRecord, value: AnyRecord) => boolean>,
   ): CallbackSequence {
-    return new CallbackSequence(this, callTemplate, userConditions);
+    const sequence = new CallbackSequence(this, callTemplate, userConditions);
+    sequence._callbackChain = this._callbackChain;
+    return sequence;
   }
 
   isSkip(env: FilterEnvironment): boolean {
@@ -550,7 +560,11 @@ export class CallbackChain {
 
   constructor(name: string, config: DefineCallbacksOptions = {}) {
     this.name = name;
-    this.config = { terminator: true, ...config };
+    this.config = {
+      // Default terminator: halt if before-callback returns false
+      terminator: (_target: AnyRecord, fn: () => unknown) => fn() === false,
+      ...config,
+    };
     this.chain = [];
   }
 
@@ -602,7 +616,7 @@ export class CallbackChain {
   }
 
   _invokeSequence(seq: CallbackSequence, target: AnyRecord, block?: () => void): boolean {
-    const terminator = this.config.terminator !== false;
+    const terminatorFn = this.config.terminator;
     const entries = this.chain;
 
     const befores = entries.filter((e) => e.kind === "before");
@@ -611,8 +625,14 @@ export class CallbackChain {
 
     for (const entry of befores) {
       if (!Value.check(entry.options, target)) continue;
-      const result = (entry.filter as BeforeCallback)(target);
-      if (terminator && result === false) return false;
+      const cb = entry.filter as BeforeCallback;
+      if (terminatorFn === false) {
+        cb(target); // no halting
+      } else if (terminatorFn) {
+        if (terminatorFn(target, () => cb(target))) return false;
+      } else {
+        if (cb(target) === false) return false;
+      }
     }
 
     let core = () => {
@@ -687,6 +707,7 @@ export function __updateCallbacks(
     const dup = new CallbackChain(chain.name, chain.config);
     chain.entries.forEach((e) => dup.append(e));
     fn(target, dup);
+    target.setCallbacks(name, dup);
   });
 }
 
@@ -739,7 +760,9 @@ function getCallbackChains(target: AnyRecord): Map<string, CallbackChain> {
       for (const [name, chain] of parent) {
         const newChain = new CallbackChain(chain.name, chain.config);
         for (const entry of chain.entries) {
-          newChain.append(new Callback(entry.name, entry.filter, entry.kind, entry.options));
+          newChain.append(
+            new Callback(entry.name, entry.filter, entry.kind, entry.options, entry.chainConfig),
+          );
         }
         own.set(name, newChain);
       }

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -68,7 +68,7 @@ export interface CallTemplate {
 
 /** Mirrors: ActiveSupport::Callbacks::CallTemplate::MethodCall */
 export class MethodCall implements CallTemplate {
-  constructor(readonly methodName: string) {}
+  constructor(readonly methodName: PropertyKey) {}
 
   expand(target: AnyRecord, _value: AnyRecord, block: (() => unknown) | null): unknown[] {
     return [target, block, this.methodName];
@@ -113,7 +113,8 @@ export class ObjectCall implements CallTemplate {
   }
 
   make(instance: AnyRecord, _value: AnyRecord): AnyRecord {
-    return this.target[this.methodName]?.call(this.target, instance);
+    const t = this.target ?? instance;
+    return t[this.methodName]?.call(t, instance);
   }
 }
 
@@ -431,7 +432,7 @@ export class Callback {
     const callTemplate =
       typeof this.filter === "function"
         ? new ProcCall(this.filter)
-        : new MethodCall(String(this.filter));
+        : new MethodCall(this.filter as PropertyKey);
 
     if (this.kind === "before") {
       this._compiled = new Before(
@@ -723,7 +724,7 @@ export function __updateCallbacks(
     const chain = target.getCallbacks(name);
     const dup = new CallbackChain(chain.name, chain.config);
     chain.entries.forEach((e) =>
-      dup.append(new Callback(e.name, e.filter, e.kind, { ...e.options }, e.chainConfig)),
+      dup.append(new Callback(e.name, e.filter, e.kind, { ...e.options }, dup.config)),
     );
     fn(target, dup);
     target.setCallbacks(name, dup);
@@ -780,7 +781,7 @@ function getCallbackChains(target: AnyRecord): Map<string, CallbackChain> {
         const newChain = new CallbackChain(chain.name, chain.config);
         for (const entry of chain.entries) {
           newChain.append(
-            new Callback(entry.name, entry.filter, entry.kind, entry.options, entry.chainConfig),
+            new Callback(entry.name, entry.filter, entry.kind, entry.options, newChain.config),
           );
         }
         own.set(name, newChain);

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -269,7 +269,10 @@ export class Before {
     return (target: AnyRecord) => {
       if (!Value.check(callback.options, target)) return true;
       const cb = callback.filter as BeforeCallback;
-      if (terminatorFn === false) return true; // never halt
+      if (terminatorFn === false) {
+        cb(target);
+        return true;
+      } // run but never halt
       if (terminatorFn) return !terminatorFn(target, () => cb(target));
       return cb(target) !== false;
     };
@@ -348,7 +351,7 @@ export class Around {
 export class Callback {
   kind: CallbackKind;
   name: string;
-  readonly filter: AnyCallback;
+  readonly filter: AnyCallback | string | symbol;
   readonly options: CallbackOptions;
   readonly chainConfig: DefineCallbacksOptions;
 
@@ -356,7 +359,7 @@ export class Callback {
 
   constructor(
     name: string,
-    filter: AnyCallback,
+    filter: AnyCallback | string | symbol,
     kind: CallbackKind,
     options: CallbackOptions = {},
     chainConfig: DefineCallbacksOptions = {},
@@ -368,7 +371,7 @@ export class Callback {
     this.chainConfig = chainConfig;
   }
 
-  matches(kind: CallbackKind, filter?: AnyCallback): boolean {
+  matches(kind: CallbackKind, filter?: AnyCallback | string | symbol): boolean {
     if (this.kind !== kind) return false;
     if (filter && this.filter !== filter) return false;
     return true;
@@ -597,7 +600,7 @@ export class CallbackChain {
     this.chain.unshift(callback);
   }
 
-  remove(kind: CallbackKind, filter?: AnyCallback): void {
+  remove(kind: CallbackKind, filter?: AnyCallback | string | symbol): void {
     this.chain = this.chain.filter((cb) => !cb.matches(kind, filter));
   }
 
@@ -705,7 +708,9 @@ export function __updateCallbacks(
   [...targets].reverse().forEach((target) => {
     const chain = target.getCallbacks(name);
     const dup = new CallbackChain(chain.name, chain.config);
-    chain.entries.forEach((e) => dup.append(e));
+    chain.entries.forEach((e) =>
+      dup.append(new Callback(e.name, e.filter, e.kind, { ...e.options }, e.chainConfig)),
+    );
     fn(target, dup);
     target.setCallbacks(name, dup);
   });

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -545,7 +545,7 @@ export class CallbackSequence {
       block?.();
       return true;
     }
-    return callbackChain._invokeSequence(this, target, block);
+    return callbackChain._invoke(target, block);
   }
 
   // Back-reference set by CallbackChain.compile() for invoke() convenience
@@ -618,7 +618,7 @@ export class CallbackChain {
     return this.chain.length === 0;
   }
 
-  _invokeSequence(seq: CallbackSequence, target: AnyRecord, block?: () => void): boolean {
+  _invoke(target: AnyRecord, block?: () => void): boolean {
     const terminatorFn = this.config.terminator;
     const entries = this.chain;
 
@@ -801,7 +801,7 @@ export namespace Callbacks {
     if (!chain) {
       throw new Error(`No callback chain "${name}" defined. Call defineCallbacks first.`);
     }
-    const entry = new Callback(name, callback, kind, options);
+    const entry = new Callback(name, callback, kind, options, chain.config);
     if (options.prepend) {
       chain.prepend(entry);
     } else {


### PR DESCRIPTION
## Summary

- `Conditionals::Value#call` — instance method mirroring Rails' `Value#call(target, value)`
- `Filters::Before` — proper instance class with `userCallback`, `userConditions`, `haltedLambda`, `call(env)`
- `Filters::After` — proper instance class with `userCallback`, `userConditions`, `halting`, `call(env)`
- `CallTemplate` interface + `MethodCall`, `ObjectCall`, `ProcCall`, `InstanceExec0/1/2` with `expand`, `makeLambda`, `invertedLambda`
- `Callback#chainConfig`, `mergeConditionalOptions`, `isDuplicates`, `compiled`, `currentScopes`
- `CallbackSequence`: `before`, `after`, `around`, `isSkip`, `nested`, `isFinal`, `expandCallTemplate`, `invokeBefore`, `invokeAfter`
- `CallbackChain`: `each`, `index`, `insert`, `delete`
- `normalizeCallbackParams`, `__updateCallbacks` (ClassMethods)

All 3,589 activesupport tests and 61 activemodel callback tests pass.