### PR TITLE
fix(activerecord): inOrderOf Rails parity — WHERE IN + CASE WHEN + ASC (ar-32)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -287,6 +287,23 @@ describe("RelationTest", () => {
     }
   });
 
+  it("inOrderOf emits WHERE IN filter + CASE WHEN ... ASC (Rails form)", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.all().inOrderOf("status", ["published", "draft", "archived"]).toSql();
+    expect(sql).toContain(`"books"."status" IN ('published', 'draft', 'archived')`);
+    expect(sql).toContain(`CASE WHEN "books"."status" = 'published' THEN 1`);
+    expect(sql).toContain(`WHEN "books"."status" = 'draft' THEN 2`);
+    expect(sql).toContain(`WHEN "books"."status" = 'archived' THEN 3`);
+    expect(sql).toMatch(/END ASC/);
+    expect(sql).not.toContain("ELSE");
+    expect(sql).not.toContain("THEN 0");
+  });
+
   it("whereMissing with hasMany emits LEFT OUTER JOIN + target_pk IS NULL", () => {
     class WmhAuthor extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -304,6 +304,21 @@ describe("RelationTest", () => {
     expect(sql).not.toContain("THEN 0");
   });
 
+  it("inOrderOf with filter:false emits ELSE and no WHERE IN", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.all().inOrderOf("status", ["published", "draft"], false).toSql();
+    expect(sql).toContain(`CASE WHEN "books"."status" = 'published' THEN 1`);
+    expect(sql).toContain(`WHEN "books"."status" = 'draft' THEN 2`);
+    expect(sql).toContain("ELSE 3");
+    expect(sql).toMatch(/END ASC/);
+    expect(sql).not.toContain(" IN (");
+  });
+
   it("whereMissing with hasMany emits LEFT OUTER JOIN + target_pk IS NULL", () => {
     class WmhAuthor extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -823,7 +823,7 @@ export class Relation<T extends Base> {
     // _applyOrderToManager detects CASE-style SQL via the "(" heuristic and
     // a /\bcase\b/i check, then emits it as SqlLiteral.
     const rel = this._clone();
-    rel._orderClauses.push(new Visitors.ToSql().compile(orderNode));
+    rel._orderClauses.push(orderNode.toSql());
 
     // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
     // Values go through attribute-aware casting via the model's arelTable type-caster

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -801,9 +801,9 @@ export class Relation<T extends Base> {
   inOrderOf(column: string, values: unknown[], filter = true): Relation<T> {
     if (values.length === 0) return this.none();
 
-    // Qualify the column with the model table, mirroring Rails' order_column.
-    const tableName = (this._modelClass as any).tableName as string;
-    const arelCol = new Table(tableName).get(column);
+    // Use the model's arelTable so the attribute retains type-casting metadata,
+    // mirroring Rails' order_column which resolves through the model's arel_table.
+    const arelCol = (this._modelClass as any).arelTable.get(column);
 
     // Build CASE WHEN col = v1 THEN 1 ... END ASC (searched form, 1-indexed).
     // Mirrors Rails' build_case_for_value_position: Arel::Nodes::Case.new (no operand)

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -798,25 +798,39 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#in_order_of
    */
-  inOrderOf(column: string, values: unknown[]): Relation<T> {
+  inOrderOf(column: string, values: unknown[], filter = true): Relation<T> {
+    if (values.length === 0) return this.none();
+
+    // Qualify the column with the model table, mirroring Rails' order_column.
+    const tableName = (this._modelClass as any).tableName as string;
+    const arelCol = new Table(tableName).get(column);
+
+    // Build CASE WHEN col = v1 THEN 1 ... END ASC (searched form, 1-indexed).
+    // Mirrors Rails' build_case_for_value_position: Arel::Nodes::Case.new (no operand)
+    // with column.eq(value) predicates. No ELSE when filter=true (the default).
+    const caseNode = new Nodes.Case();
+    values.forEach((v, i) => {
+      caseNode.when(arelCol.eq(new Nodes.Quoted(v)), new Nodes.Quoted(i + 1));
+    });
+    if (!filter) {
+      caseNode.else(new Nodes.Quoted(values.length + 1));
+    }
+    const orderNode = new Nodes.Ascending(caseNode);
+
     const rel = this._clone();
-    // Generate a CASE WHEN ... expression for ordering
-    const cases = values
-      .map((v, i) => {
-        const quoted =
-          v === null
-            ? "NULL"
-            : typeof v === "number"
-              ? String(v)
-              : `'${String(v).replace(/'/g, "''")}'`;
-        return `WHEN "${column}" = ${quoted} THEN ${i}`;
-      })
-      .join(" ");
-    const caseExpr = `CASE ${cases} ELSE ${values.length} END`;
-    // Use raw SQL order — push as a string that the order manager treats as raw
     rel._orderClauses = [];
-    rel._rawOrderClauses = rel._rawOrderClauses ?? [];
-    rel._rawOrderClauses.push(caseExpr);
+    rel._rawOrderClauses = [];
+    rel._rawOrderClauses.push(new Visitors.ToSql().compile(orderNode));
+
+    // Add WHERE col IN (values) to restrict to the named set (filter=true default).
+    if (filter) {
+      const hasNull = values.includes(null) || values.includes(undefined);
+      const nonNull = values.filter((v) => v !== null && v !== undefined);
+      let whereNode: Nodes.Node = arelCol.in(nonNull);
+      if (hasNull) whereNode = new Nodes.Grouping(new Nodes.Or(whereNode, arelCol.eq(null)));
+      rel._whereClause.predicates.push(whereNode);
+    }
+
     return rel;
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -820,17 +820,20 @@ export class Relation<T extends Base> {
 
     // Push to _orderClauses (not _rawOrderClauses) so the CASE expression is
     // appended in call-order relative to any existing order clauses.
-    // _applyOrderToManager detects CASE via the "(" heuristic and emits as SqlLiteral.
+    // _applyOrderToManager detects CASE-style SQL via the "(" heuristic and
+    // a /\bcase\b/i check, then emits it as SqlLiteral.
     const rel = this._clone();
     rel._orderClauses.push(new Visitors.ToSql().compile(orderNode));
 
-    // Add WHERE col IN (values) to restrict to the named set (filter=true default).
+    // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
+    // Values go through attribute-aware casting via the model's arelTable type-caster
+    // (arelCol is from arelTable.get(column), not a bare Table).
     if (filter) {
       const hasNull = values.includes(null) || values.includes(undefined);
       const nonNull = values.filter((v) => v !== null && v !== undefined);
       let whereNode: Nodes.Node = arelCol.in(nonNull);
-      if (hasNull) whereNode = new Nodes.Grouping(new Nodes.Or(whereNode, arelCol.eq(null)));
-      rel._whereClause.predicates.push(whereNode);
+      if (hasNull) whereNode = new Nodes.Or(whereNode, arelCol.eq(null));
+      rel._whereClause.predicates.push(hasNull ? new Nodes.Grouping(whereNode) : whereNode);
     }
 
     return rel;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -817,9 +817,8 @@ export class Relation<T extends Base> {
     }
     const orderNode = new Nodes.Ascending(caseNode);
 
+    // Mirrors Rails' spawn.order!(...) — appends to existing order, doesn't replace.
     const rel = this._clone();
-    rel._orderClauses = [];
-    rel._rawOrderClauses = [];
     rel._rawOrderClauses.push(new Visitors.ToSql().compile(orderNode));
 
     // Add WHERE col IN (values) to restrict to the named set (filter=true default).

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -828,9 +828,9 @@ export class Relation<T extends Base> {
     rel._orderClauses.push(orderNode.toSql());
 
     // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
-    // Attribute#in uses buildQuoted per element; since arelCol is from the model's
-    // arelTable (not a bare Table), it carries the column type context. For typed columns
-    // requiring serialization, callers should pre-cast values before calling inOrderOf.
+    // Attribute#in uses buildQuoted (no type-caster context), matching Rails which
+    // pre-casts values via type_cast_for_database before calling in(). Callers
+    // should pre-cast for typed columns (e.g. enum integer mappings).
     if (filter) {
       const hasNull = normalized.includes(null);
       const nonNull = normalized.filter((v) => v !== null);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -805,12 +805,14 @@ export class Relation<T extends Base> {
     // mirroring Rails' order_column which resolves through the model's arel_table.
     const arelCol = this._modelClass.arelTable.get(column);
 
+    // Normalize undefined → null so eq(null) emits IS NULL (not the invalid = NULL).
+    const normalized = values.map((v) => (v === undefined ? null : v));
+
     // Build CASE WHEN col = v1 THEN 1 ... END ASC (searched form, 1-indexed).
     // Mirrors Rails' build_case_for_value_position: Arel::Nodes::Case.new (no operand)
     // with column.eq(value) predicates. No ELSE when filter=true (the default).
     const caseNode = new Nodes.Case();
-    values.forEach((v, i) => {
-      // Use arelCol.eq(v) so Arel handles casting and NULL → IS NULL semantics.
+    normalized.forEach((v, i) => {
       caseNode.when(arelCol.eq(v), new Nodes.Quoted(i + 1));
     });
     if (!filter) {
@@ -830,8 +832,8 @@ export class Relation<T extends Base> {
     // arelTable (not a bare Table), it carries the column type context. For typed columns
     // requiring serialization, callers should pre-cast values before calling inOrderOf.
     if (filter) {
-      const hasNull = values.includes(null) || values.includes(undefined);
-      const nonNull = values.filter((v) => v !== null && v !== undefined);
+      const hasNull = normalized.includes(null);
+      const nonNull = normalized.filter((v) => v !== null);
       let whereNode: Nodes.Node = arelCol.in(nonNull);
       if (hasNull) whereNode = new Nodes.Or(whereNode, arelCol.eq(null));
       rel._whereClause.predicates.push(hasNull ? new Nodes.Grouping(whereNode) : whereNode);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -810,16 +810,19 @@ export class Relation<T extends Base> {
     // with column.eq(value) predicates. No ELSE when filter=true (the default).
     const caseNode = new Nodes.Case();
     values.forEach((v, i) => {
-      caseNode.when(arelCol.eq(new Nodes.Quoted(v)), new Nodes.Quoted(i + 1));
+      // Use arelCol.eq(v) so Arel handles casting and NULL → IS NULL semantics.
+      caseNode.when(arelCol.eq(v), new Nodes.Quoted(i + 1));
     });
     if (!filter) {
       caseNode.else(new Nodes.Quoted(values.length + 1));
     }
     const orderNode = new Nodes.Ascending(caseNode);
 
-    // Mirrors Rails' spawn.order!(...) — appends to existing order, doesn't replace.
+    // Push to _orderClauses (not _rawOrderClauses) so the CASE expression is
+    // appended in call-order relative to any existing order clauses.
+    // _applyOrderToManager detects CASE via the "(" heuristic and emits as SqlLiteral.
     const rel = this._clone();
-    rel._rawOrderClauses.push(new Visitors.ToSql().compile(orderNode));
+    rel._orderClauses.push(new Visitors.ToSql().compile(orderNode));
 
     // Add WHERE col IN (values) to restrict to the named set (filter=true default).
     if (filter) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -803,7 +803,7 @@ export class Relation<T extends Base> {
 
     // Use the model's arelTable so the attribute retains type-casting metadata,
     // mirroring Rails' order_column which resolves through the model's arel_table.
-    const arelCol = (this._modelClass as any).arelTable.get(column);
+    const arelCol = this._modelClass.arelTable.get(column);
 
     // Build CASE WHEN col = v1 THEN 1 ... END ASC (searched form, 1-indexed).
     // Mirrors Rails' build_case_for_value_position: Arel::Nodes::Case.new (no operand)

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -826,8 +826,9 @@ export class Relation<T extends Base> {
     rel._orderClauses.push(orderNode.toSql());
 
     // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
-    // Values go through attribute-aware casting via the model's arelTable type-caster
-    // (arelCol is from arelTable.get(column), not a bare Table).
+    // Attribute#in uses buildQuoted per element; since arelCol is from the model's
+    // arelTable (not a bare Table), it carries the column type context. For typed columns
+    // requiring serialization, callers should pre-cast values before calling inOrderOf.
     if (filter) {
       const hasNull = values.includes(null) || values.includes(undefined);
       const nonNull = values.filter((v) => v !== null && v !== undefined);

--- a/packages/activerecord/src/relation/field-ordered-values.test.ts
+++ b/packages/activerecord/src/relation/field-ordered-values.test.ts
@@ -39,8 +39,10 @@ describe("FieldOrderedValuesTest", () => {
         this.adapter = adapter;
       }
     }
+    // Rails: return spawn.none! if values.empty? — produces WHERE (1=0), no CASE.
     const sql = Post.all().inOrderOf("status", []).toSql();
-    expect(sql).toContain("CASE");
+    expect(sql).toContain("1=0");
+    expect(sql).not.toContain("CASE");
   });
 
   it("in order of with enums values", () => {

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -15,10 +15,6 @@
     "side": "diff",
     "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
   },
-  "ar-32": {
-    "side": "diff",
-    "reason": "in_order_of: multiple divergences vs Rails. (1) Rails adds WHERE \"books\".\"status\" IN (values) to filter to the named set; trails omits it. (2) Rails CASE values are 1-indexed; trails 0-indexed with ELSE branch. (3) Rails appends ASC; trails leaves direction bare. (4) Rails qualifies the column ('\"books\".\"status\"'); trails leaves it bare. Real implementation gap — trails Relation#inOrderOf is incomplete vs ActiveRecord::QueryMethods#in_order_of."
-  },
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."


### PR DESCRIPTION
## Summary

Rewrites `inOrderOf` to match Rails' `QueryMethods#in_order_of` / `build_case_for_value_position` exactly:

**Before:**
```sql
ORDER BY CASE "status" WHEN 'published' THEN 0 WHEN 'draft' THEN 1 WHEN 'archived' THEN 2 ELSE 3 END
```

**After (matches Rails):**
```sql
WHERE "books"."status" IN ('published', 'draft', 'archived')
ORDER BY CASE WHEN "books"."status" = 'published' THEN 1 WHEN "books"."status" = 'draft' THEN 2 WHEN "books"."status" = 'archived' THEN 3 END ASC
```

## Changes

- **Searched CASE form** (`CASE WHEN col = v1 THEN 1 ...`) — mirrors Rails which uses `Arel::Nodes::Case.new` (no operand) with `column.eq(value)` predicates
- **1-indexed** THEN values (Rails uses `with_index(1)`)
- **No ELSE** when `filter: true` (default) — matches Rails `build_case_for_value_position`  
- **Table-qualified column** (`"books"."status"`) via `new Table(tableName).get(column)`
- **WHERE IN filter** (`WHERE "books"."status" IN (...)`) — mirrors Rails' `scope.where!(arel_column.in(values))`
- Added `filter` parameter (default `true`) matching Rails' `in_order_of(column, values, filter: true)`

## Test plan

- [x] Regression test verifying exact SQL shape (WHERE IN + CASE WHEN + END ASC, no ELSE, no 0-indexed values)
- [x] Parity: ar-32 now passes