### PR TITLE
test(parity): AR query fixtures ar-84..ar-88 — create_with, Arel gt, Arel lt, Arel join, Arel as alias (PR 17)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -18,5 +18,9 @@
   "ar-82": {
     "side": "trails-missing",
     "reason": "Model.optimizer_hints() class-method delegation not implemented. Rails delegates optimizer_hints() from the class to its default scope relation; trails only has it as an instance method on Relation, so Book.optimizerHints(...) throws."
+  },
+  "ar-87": {
+    "side": "diff",
+    "reason": "Relation#joins() does not accept Arel join nodes. Rails joins() flattens its args and handles Arel::Nodes::InnerJoin entries in build_joins; trails joins() only accepts strings, coercing any non-string to [object Object]. Rails: 'SELECT \"books\".* FROM \"books\" INNER JOIN \"authors\" ON ...'; trails: 'SELECT \"books\".* FROM \"books\" [object Object]'."
   }
 }

--- a/scripts/parity/fixtures/ar-84/models.rb
+++ b/scripts/parity/fixtures/ar-84/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-84/models.ts
+++ b/scripts/parity/fixtures/ar-84/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-84/query.rb
+++ b/scripts/parity/fixtures/ar-84/query.rb
@@ -1,0 +1,1 @@
+Book.create_with(active: true).where(title: "Moby Dick")

--- a/scripts/parity/fixtures/ar-84/query.ts
+++ b/scripts/parity/fixtures/ar-84/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().createWith({ active: true }).where({ title: "Moby Dick" });

--- a/scripts/parity/fixtures/ar-84/schema.sql
+++ b/scripts/parity/fixtures/ar-84/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-84
+-- Query: Book.create_with(active: true).where(title: "Moby Dick")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-85/models.rb
+++ b/scripts/parity/fixtures/ar-85/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-85/models.ts
+++ b/scripts/parity/fixtures/ar-85/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-85/query.rb
+++ b/scripts/parity/fixtures/ar-85/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:pages].gt(100))

--- a/scripts/parity/fixtures/ar-85/query.ts
+++ b/scripts/parity/fixtures/ar-85/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("pages").gt(100));

--- a/scripts/parity/fixtures/ar-85/schema.sql
+++ b/scripts/parity/fixtures/ar-85/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-85
+-- Query: Book.where(Book.arel_table[:pages].gt(100))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  pages INTEGER
+);

--- a/scripts/parity/fixtures/ar-86/models.rb
+++ b/scripts/parity/fixtures/ar-86/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-86/models.ts
+++ b/scripts/parity/fixtures/ar-86/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-86/query.rb
+++ b/scripts/parity/fixtures/ar-86/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:rating].lt(5))

--- a/scripts/parity/fixtures/ar-86/query.ts
+++ b/scripts/parity/fixtures/ar-86/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("rating").lt(5));

--- a/scripts/parity/fixtures/ar-86/schema.sql
+++ b/scripts/parity/fixtures/ar-86/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-86
+-- Query: Book.where(Book.arel_table[:rating].lt(5))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  rating INTEGER
+);

--- a/scripts/parity/fixtures/ar-87/models.rb
+++ b/scripts/parity/fixtures/ar-87/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  belongs_to :author
+end
+
+class Author < ActiveRecord::Base
+  has_many :books
+end

--- a/scripts/parity/fixtures/ar-87/models.ts
+++ b/scripts/parity/fixtures/ar-87/models.ts
@@ -1,0 +1,15 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-87/query.rb
+++ b/scripts/parity/fixtures/ar-87/query.rb
@@ -1,0 +1,4 @@
+authors = Author.arel_table
+books   = Book.arel_table
+join_node = books.join(authors).on(books[:author_id].eq(authors[:id])).join_sources
+Book.joins(join_node)

--- a/scripts/parity/fixtures/ar-87/query.ts
+++ b/scripts/parity/fixtures/ar-87/query.ts
@@ -1,4 +1,4 @@
-import { Nodes } from "@blazetrails/arel";
+import type { Nodes } from "@blazetrails/arel";
 import { Author, Book } from "./models.js";
 
 const authors = Author.arelTable;

--- a/scripts/parity/fixtures/ar-87/query.ts
+++ b/scripts/parity/fixtures/ar-87/query.ts
@@ -1,4 +1,3 @@
-import type { Nodes } from "@blazetrails/arel";
 import { Author, Book } from "./models.js";
 
 const authors = Author.arelTable;
@@ -7,4 +6,4 @@ const joinSources = books
   .join(authors)
   .on(books.get("author_id").eq(authors.get("id"))).joinSources;
 
-export default Book.joins(joinSources.map((j: Nodes.Node) => j.toSql()).join(" "));
+export default Book.joins(...joinSources);

--- a/scripts/parity/fixtures/ar-87/query.ts
+++ b/scripts/parity/fixtures/ar-87/query.ts
@@ -1,7 +1,10 @@
+import { Nodes } from "@blazetrails/arel";
 import { Author, Book } from "./models.js";
 
 const authors = Author.arelTable;
 const books = Book.arelTable;
-const joinNode = books.join(authors).on(books.get("author_id").eq(authors.get("id"))).joinSources;
+const joinSources = books
+  .join(authors)
+  .on(books.get("author_id").eq(authors.get("id"))).joinSources;
 
-export default Book.joins(joinNode.map((j: any) => j.toSql()).join(" "));
+export default Book.joins(joinSources.map((j: Nodes.Node) => j.toSql()).join(" "));

--- a/scripts/parity/fixtures/ar-87/query.ts
+++ b/scripts/parity/fixtures/ar-87/query.ts
@@ -1,0 +1,7 @@
+import { Author, Book } from "./models.js";
+
+const authors = Author.arelTable;
+const books = Book.arelTable;
+const joinNode = books.join(authors).on(books.get("author_id").eq(authors.get("id"))).joinSources;
+
+export default Book.joins(joinNode.map((j: any) => j.toSql()).join(" "));

--- a/scripts/parity/fixtures/ar-87/schema.sql
+++ b/scripts/parity/fixtures/ar-87/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-87
+-- Query: authors = Author.arel_table; books = Book.arel_table; join_node = books.join(authors).on(books[:author_id].eq(authors[:id])).join_sources; Book.joins(join_node)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);

--- a/scripts/parity/fixtures/ar-88/models.rb
+++ b/scripts/parity/fixtures/ar-88/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-88/models.ts
+++ b/scripts/parity/fixtures/ar-88/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-88/query.rb
+++ b/scripts/parity/fixtures/ar-88/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:title].as("book_title"), Book.arel_table[:id])

--- a/scripts/parity/fixtures/ar-88/query.ts
+++ b/scripts/parity/fixtures/ar-88/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select(Book.arelTable.get("title").as("book_title"), Book.arelTable.get("id"));

--- a/scripts/parity/fixtures/ar-88/schema.sql
+++ b/scripts/parity/fixtures/ar-88/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-88
+-- Query: Book.select(Book.arel_table[:title].as("book_title"), Book.arel_table[:id])
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);


### PR DESCRIPTION
## Summary
- ar-84: \`create_with\` — scoped defaults for new records; does not add WHERE (PASS)
- ar-85: Arel \`gt\` predicate in \`where\` (PASS)
- ar-86: Arel \`lt\` predicate in \`where\` (PASS)
- ar-87: Arel join nodes passed directly to \`joins()\` (KNOWN-GAP diff) — Rails \`joins()\` handles \`Arel::Nodes::InnerJoin\` entries in \`build_joins\`; trails \`joins()\` only accepts strings and coerces nodes to \`[object Object]\`
- ar-88: \`select\` with Arel \`as\` column alias (PASS)

## Test plan
- [x] Rails runner produces expected SQL for each fixture
- [x] Trails runner matches for ar-84/85/86/88; ar-87 classified as diff known gap
- [x] \`pnpm parity:query\` passes: 132/138 PASS, 6 known gaps, 0 failures