### PR TITLE
test(parity): AR query fixtures ar-89..ar-93 — Arel matches, does_not_match, in, between, group+having (PR 18)

### DIFF
--- a/scripts/parity/fixtures/ar-89/models.rb
+++ b/scripts/parity/fixtures/ar-89/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-89/models.ts
+++ b/scripts/parity/fixtures/ar-89/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-89/query.rb
+++ b/scripts/parity/fixtures/ar-89/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:title].matches("%rails%"))

--- a/scripts/parity/fixtures/ar-89/query.ts
+++ b/scripts/parity/fixtures/ar-89/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("title").matches("%rails%"));

--- a/scripts/parity/fixtures/ar-89/schema.sql
+++ b/scripts/parity/fixtures/ar-89/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-89
+-- Query: Book.where(Book.arel_table[:title].matches("%rails%"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-90/models.rb
+++ b/scripts/parity/fixtures/ar-90/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-90/models.ts
+++ b/scripts/parity/fixtures/ar-90/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-90/query.rb
+++ b/scripts/parity/fixtures/ar-90/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:title].does_not_match("%draft%"))

--- a/scripts/parity/fixtures/ar-90/query.ts
+++ b/scripts/parity/fixtures/ar-90/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("title").doesNotMatch("%draft%"));

--- a/scripts/parity/fixtures/ar-90/schema.sql
+++ b/scripts/parity/fixtures/ar-90/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-90
+-- Query: Book.where(Book.arel_table[:title].does_not_match("%draft%"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-91/models.rb
+++ b/scripts/parity/fixtures/ar-91/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-91/models.ts
+++ b/scripts/parity/fixtures/ar-91/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-91/query.rb
+++ b/scripts/parity/fixtures/ar-91/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:status].in(["active", "archived"]))

--- a/scripts/parity/fixtures/ar-91/query.ts
+++ b/scripts/parity/fixtures/ar-91/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("status").in(["active", "archived"]));

--- a/scripts/parity/fixtures/ar-91/schema.sql
+++ b/scripts/parity/fixtures/ar-91/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-91
+-- Query: Book.where(Book.arel_table[:status].in(["active", "archived"]))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-92/models.rb
+++ b/scripts/parity/fixtures/ar-92/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-92/models.ts
+++ b/scripts/parity/fixtures/ar-92/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-92/query.rb
+++ b/scripts/parity/fixtures/ar-92/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:pages].between(100..500))

--- a/scripts/parity/fixtures/ar-92/query.ts
+++ b/scripts/parity/fixtures/ar-92/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.where(Book.arelTable.get("pages").between(100, 500));
+export default Book.where(Book.arelTable.get("pages").between({ begin: 100, end: 500 }));

--- a/scripts/parity/fixtures/ar-92/query.ts
+++ b/scripts/parity/fixtures/ar-92/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("pages").between(100, 500));

--- a/scripts/parity/fixtures/ar-92/schema.sql
+++ b/scripts/parity/fixtures/ar-92/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-92
+-- Query: Book.where(Book.arel_table[:pages].between(100..500))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  pages INTEGER
+);

--- a/scripts/parity/fixtures/ar-93/models.rb
+++ b/scripts/parity/fixtures/ar-93/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-93/models.ts
+++ b/scripts/parity/fixtures/ar-93/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-93/query.rb
+++ b/scripts/parity/fixtures/ar-93/query.rb
@@ -1,0 +1,1 @@
+Book.select(:author_id, Arel.sql("COUNT(*) AS book_count")).group(:author_id).having(Arel.sql("COUNT(*) > 2"))

--- a/scripts/parity/fixtures/ar-93/query.ts
+++ b/scripts/parity/fixtures/ar-93/query.ts
@@ -1,0 +1,6 @@
+import { Book } from "./models.js";
+import { sql } from "@blazetrails/arel";
+
+export default Book.select("author_id", sql("COUNT(*) AS book_count"))
+  .group("author_id")
+  .having(sql("COUNT(*) > 2"));

--- a/scripts/parity/fixtures/ar-93/query.ts
+++ b/scripts/parity/fixtures/ar-93/query.ts
@@ -1,5 +1,5 @@
-import { Book } from "./models.js";
 import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
 
 export default Book.select("author_id", sql("COUNT(*) AS book_count"))
   .group("author_id")

--- a/scripts/parity/fixtures/ar-93/schema.sql
+++ b/scripts/parity/fixtures/ar-93/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-93
+-- Query: Book.select(:author_id, Arel.sql("COUNT(*) AS book_count")).group(:author_id).having(Arel.sql("COUNT(*) > 2"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);


### PR DESCRIPTION
## Summary
- ar-89: Arel `matches` (LIKE) in `where`
- ar-90: Arel `does_not_match` (NOT LIKE) in `where`
- ar-91: Arel `in` (IN array) in `where`
- ar-92: Arel `between` (BETWEEN range) in `where`
- ar-93: `select` + `group` + `having` with Arel.sql count

## Test plan
- [x] Rails runner produces expected SQL for each fixture
- [x] Trails runner matches (or fixture added to known-gaps)
- [x] `pnpm parity:query` passes with 0 failures