### PR TITLE
feat(api-compare): detect file-local private helpers; split --privates / --privates-only

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -183,21 +183,27 @@ describe("methodInMode", () => {
     ...(internal ? { internal: true } : {}),
   });
 
-  it("keeps public methods when --privates is off", () => {
-    expect(methodInMode(method(false), false)).toBe(true);
-    expect(methodInMode(method(true), false)).toBe(false);
+  it("public mode keeps only public methods (default)", () => {
+    expect(methodInMode(method(false), "public")).toBe(true);
+    expect(methodInMode(method(true), "public")).toBe(false);
   });
 
-  it("keeps only internal methods when --privates is on", () => {
-    expect(methodInMode(method(true), true)).toBe(true);
-    expect(methodInMode(method(false), true)).toBe(false);
+  it("private mode keeps only internal methods (--privates-only)", () => {
+    expect(methodInMode(method(true), "private")).toBe(true);
+    expect(methodInMode(method(false), "private")).toBe(false);
+  });
+
+  it("all mode keeps both public and internal methods (--privates)", () => {
+    expect(methodInMode(method(true), "all")).toBe(true);
+    expect(methodInMode(method(false), "all")).toBe(true);
   });
 
   it("treats missing internal flag as public", () => {
     // Legacy fixture manifests may not set `internal` at all; those
     // methods must count toward the public surface, not drop out.
     const bare: MethodInfo = { name: "x", visibility: "public", params: [] };
-    expect(methodInMode(bare, false)).toBe(true);
-    expect(methodInMode(bare, true)).toBe(false);
+    expect(methodInMode(bare, "public")).toBe(true);
+    expect(methodInMode(bare, "private")).toBe(false);
+    expect(methodInMode(bare, "all")).toBe(true);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -259,13 +259,18 @@ export function superclassesMatch(
 }
 
 /**
- * Whether a given method belongs to the current comparison bucket.
- * Default mode (showPrivates=false) keeps only public API methods; with
- * `--privates` the comparison runs exclusively against internal methods.
+ * Comparison bucket a method participates in.
+ *   - "public":  default — public API only (drops `internal: true`)
+ *   - "all":     `--privates` — public + private combined
+ *   - "private": `--privates-only` — private/protected only
  * Exported so compare.test.ts can pin the filter semantics.
  */
-export function methodInMode(m: MethodInfo, showPrivates: boolean): boolean {
-  return showPrivates ? m.internal === true : m.internal !== true;
+export type CompareMode = "public" | "all" | "private";
+
+export function methodInMode(m: MethodInfo, mode: CompareMode): boolean {
+  if (mode === "all") return true;
+  if (mode === "private") return m.internal === true;
+  return m.internal !== true;
 }
 
 // ---------------------------------------------------------------------------
@@ -288,12 +293,15 @@ function main() {
   const showFiles = args.includes("--files");
   const showIncomplete = args.includes("--incomplete");
   const showInheritance = args.includes("--inheritance");
-  // When --privates is passed, the comparison runs against internal-only
-  // methods (Ruby `private`/`protected`, TS `private`/`protected`,
-  // `#`-prefixed fields). Without it, internal methods are filtered out
-  // and the numbers match the historical public-API coverage.
-  const showPrivates = args.includes("--privates");
-  const methodMatchesMode = (m: MethodInfo): boolean => methodInMode(m, showPrivates);
+  // Comparison bucket:
+  //   default        → public API only (matches historical coverage numbers)
+  //   --privates     → public + private combined (full surface)
+  //   --privates-only→ private/protected only (Ruby `private`/`protected`,
+  //                    TS `private`/`protected`, `#`-prefixed fields)
+  const privatesOnly = args.includes("--privates-only");
+  const includePrivates = args.includes("--privates");
+  const mode: CompareMode = privatesOnly ? "private" : includePrivates ? "all" : "public";
+  const methodMatchesMode = (m: MethodInfo): boolean => methodInMode(m, mode);
 
   const rubyPath = path.join(OUTPUT_DIR, "rails-api.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-api.json");
@@ -814,24 +822,21 @@ function main() {
     });
   }
 
-  // Write JSON. Separate file for the --privates run so the public artifact
-  // isn't clobbered when both run back-to-back in CI.
-  const jsonFilename = showPrivates ? "api-comparison-privates.json" : "api-comparison.json";
+  // Write JSON. Separate file per mode so artifacts don't clobber each
+  // other when multiple runs land back-to-back in CI.
+  const jsonFilename =
+    mode === "private"
+      ? "api-comparison-privates-only.json"
+      : mode === "all"
+        ? "api-comparison-privates.json"
+        : "api-comparison.json";
   const jsonPath = path.join(OUTPUT_DIR, jsonFilename);
   fs.writeFileSync(
     jsonPath,
     JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2),
   );
 
-  printReport(
-    results,
-    showMissing,
-    showFiles,
-    filterPkg,
-    showIncomplete,
-    showInheritance,
-    showPrivates,
-  );
+  printReport(results, showMissing, showFiles, filterPkg, showIncomplete, showInheritance, mode);
 }
 
 // ---------------------------------------------------------------------------
@@ -845,13 +850,15 @@ function printReport(
   filterPkg: string | null,
   showIncomplete = false,
   showInheritance = false,
-  showPrivates = false,
+  mode: CompareMode = "public",
 ) {
-  if (showPrivates) {
+  if (mode === "private") {
     console.log(
       `\n  (comparing internal/private API surface — ` +
         `Ruby private/protected, TS private/protected, TS #-prefixed fields)`,
     );
+  } else if (mode === "all") {
+    console.log(`\n  (comparing full API surface — public + private/protected combined)`);
   }
   let grandTotal = 0;
   let grandMatched = 0;

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -8,8 +8,8 @@
 
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
-import { resolveRelModule, extractClass } from "./extract-ts-api.js";
-import type { ClassInfo } from "./types.js";
+import { resolveRelModule, extractClass, extractFileLocalHelpers } from "./extract-ts-api.js";
+import type { ClassInfo, MethodInfo } from "./types.js";
 
 function extractFromSource(source: string, className = "Foo"): ClassInfo {
   const filename = "virtual.ts";
@@ -77,6 +77,67 @@ describe("resolveRelModule", () => {
     const result = resolveRelModule("dir/sub/file.ts", "./sibling.js");
     expect(result).toBe("dir/sub/sibling.ts");
     expect(result).not.toContain("\\");
+  });
+});
+
+function helpersFromSource(source: string): MethodInfo[] {
+  const sourceFile = ts.createSourceFile("virtual.ts", source, ts.ScriptTarget.Latest, true);
+  const out: MethodInfo[] = [];
+  ts.forEachChild(sourceFile, (node) => {
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isVariableStatement(node)) &&
+      !ts.getModifiers(node)?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const h of extractFileLocalHelpers(node, "virtual.ts")) out.push(h);
+    }
+  });
+  return out;
+}
+
+describe("extractFileLocalHelpers", () => {
+  it("captures non-exported function declarations as internal/private", () => {
+    const helpers = helpersFromSource(`
+      function invertPredicate(node) { return node; }
+      function exceptPredicates(cols) { return cols; }
+      export function predicatesWithWrappedSqlLiterals(p) { return p; }
+    `);
+    const names = helpers.map((h) => h.name);
+    expect(names).toEqual(["invertPredicate", "exceptPredicates"]);
+    for (const h of helpers) {
+      expect(h.visibility).toBe("private");
+      expect(h.internal).toBe(true);
+      expect(h.isStatic).toBe(false);
+    }
+  });
+
+  it("captures non-exported arrow and function-expression consts", () => {
+    const helpers = helpersFromSource(`
+      const arrowHelper = (x) => x;
+      const fnHelper = function (a, b) { return a + b; };
+      const notAFunction = 42;
+      export const exportedArrow = (x) => x;
+    `);
+    const names = helpers.map((h) => h.name);
+    expect(names).toEqual(["arrowHelper", "fnHelper"]);
+    expect(helpers[0].params.map((p) => p.name)).toEqual(["x"]);
+    expect(helpers[1].params.map((p) => p.name)).toEqual(["a", "b"]);
+    for (const h of helpers) expect(h.internal).toBe(true);
+  });
+
+  it("ignores exported declarations and non-function consts", () => {
+    const helpers = helpersFromSource(`
+      export function shouldSkip() {}
+      export const alsoSkip = () => {};
+      const literal = "string";
+      const obj = { x: 1 };
+    `);
+    expect(helpers).toEqual([]);
+  });
+
+  it("records line numbers for traceback", () => {
+    const helpers = helpersFromSource(`function first() {}\nfunction second() {}\n`);
+    expect(helpers[0].line).toBe(1);
+    expect(helpers[1].line).toBe(2);
   });
 });
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -220,6 +220,38 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
           line,
           file: relPath,
         });
+      } else if (ts.isFunctionDeclaration(node) && node.name && !isExported(node)) {
+        // Non-exported file-local helpers map to Rails private methods
+        // per the project mixin convention (CLAUDE.md). Record them as
+        // internal so `--privates` mode can match them.
+        const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
+        fileFunctions.push({
+          name: node.name.text,
+          visibility: "private",
+          params: extractParameters(node.parameters),
+          isStatic: false,
+          line,
+          file: relPath,
+          internal: true,
+        });
+      } else if (ts.isVariableStatement(node) && !isExported(node)) {
+        // Non-exported `const fn = (...) => ...` arrow/function helpers.
+        for (const decl of node.declarationList.declarations) {
+          if (!ts.isIdentifier(decl.name)) continue;
+          const init = decl.initializer;
+          if (!init) continue;
+          if (!ts.isArrowFunction(init) && !ts.isFunctionExpression(init)) continue;
+          const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
+          fileFunctions.push({
+            name: decl.name.text,
+            visibility: "private",
+            params: extractParameters(init.parameters),
+            isStatic: false,
+            line,
+            file: relPath,
+            internal: true,
+          });
+        }
       }
     });
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -220,37 +220,15 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
           line,
           file: relPath,
         });
-      } else if (ts.isFunctionDeclaration(node) && node.name && !isExported(node)) {
+      } else if (
+        (ts.isFunctionDeclaration(node) || ts.isVariableStatement(node)) &&
+        !isExported(node)
+      ) {
         // Non-exported file-local helpers map to Rails private methods
         // per the project mixin convention (CLAUDE.md). Record them as
         // internal so `--privates` mode can match them.
-        const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
-        fileFunctions.push({
-          name: node.name.text,
-          visibility: "private",
-          params: extractParameters(node.parameters),
-          isStatic: false,
-          line,
-          file: relPath,
-          internal: true,
-        });
-      } else if (ts.isVariableStatement(node) && !isExported(node)) {
-        // Non-exported `const fn = (...) => ...` arrow/function helpers.
-        for (const decl of node.declarationList.declarations) {
-          if (!ts.isIdentifier(decl.name)) continue;
-          const init = decl.initializer;
-          if (!init) continue;
-          if (!ts.isArrowFunction(init) && !ts.isFunctionExpression(init)) continue;
-          const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
-          fileFunctions.push({
-            name: decl.name.text,
-            visibility: "private",
-            params: extractParameters(init.parameters),
-            isStatic: false,
-            line,
-            file: relPath,
-            internal: true,
-          });
+        for (const helper of extractFileLocalHelpers(node, relPath)) {
+          fileFunctions.push(helper);
         }
       }
     });
@@ -383,7 +361,11 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
 
     // If a file has exported functions but no class/interface/namespace,
     // also create a module entry from the file name for backward compat.
-    if (!fileHasClassOrModule && fileFunctions.length > 0) {
+    // Only count public functions: a file with only non-exported helpers
+    // (all `internal: true`) shouldn't fabricate a module — there's no
+    // public surface for the module to represent.
+    const hasPublicFn = fileFunctions.some((fn) => !fn.internal);
+    if (!fileHasClassOrModule && hasPublicFn) {
       const baseName = path.basename(relPath, ".ts");
       const moduleName = baseName
         .split("-")
@@ -435,6 +417,60 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
  * null if the specifier doesn't target a local file. Caller must
  * already have POSIX-normalized `fromRel`.
  */
+/**
+ * Extract file-local (non-exported) function helpers from a top-level
+ * statement. These map to Rails private methods under the project's
+ * mixin convention (CLAUDE.md): file-local helpers next to the class
+ * that owns the Rails port. Returns one MethodInfo per helper found,
+ * each tagged `internal: true` so `--privates` mode picks them up and
+ * public mode filters them out.
+ *
+ * Handles two shapes:
+ *   - `function helper(...) {}`
+ *   - `const helper = (...) => {}` / `const helper = function (...) {}`
+ *
+ * Caller must already have ensured `node` is not exported.
+ */
+export function extractFileLocalHelpers(
+  node: ts.FunctionDeclaration | ts.VariableStatement,
+  relPath: string,
+): MethodInfo[] {
+  const out: MethodInfo[] = [];
+
+  if (ts.isFunctionDeclaration(node)) {
+    if (!node.name) return out;
+    const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
+    out.push({
+      name: node.name.text,
+      visibility: "private",
+      params: extractParameters(node.parameters),
+      isStatic: false,
+      line,
+      file: relPath,
+      internal: true,
+    });
+    return out;
+  }
+
+  for (const decl of node.declarationList.declarations) {
+    if (!ts.isIdentifier(decl.name)) continue;
+    const init = decl.initializer;
+    if (!init) continue;
+    if (!ts.isArrowFunction(init) && !ts.isFunctionExpression(init)) continue;
+    const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
+    out.push({
+      name: decl.name.text,
+      visibility: "private",
+      params: extractParameters(init.parameters),
+      isStatic: false,
+      line,
+      file: relPath,
+      internal: true,
+    });
+  }
+  return out;
+}
+
 export function resolveRelModule(fromRel: string, spec: string): string | null {
   if (!spec.startsWith("./") && !spec.startsWith("../")) return null;
   const fromDir = path.posix.dirname(fromRel);


### PR DESCRIPTION
## Summary

Two related changes to `pnpm api:compare`:

### 1. Detect non-exported file-local helpers as private methods

Under the project mixin convention (CLAUDE.md), many Rails private methods map to non-exported top-level helpers in the corresponding TS file. The extractor previously only emitted exported declarations, so these helpers never entered the comparison set.

`extract-ts-api.ts` now walks file-level non-exported `function` declarations and arrow/function-expression `const` declarations and emits them under `fileFunctions[relPath]` with `internal: true`. Detection is factored into an exported `extractFileLocalHelpers(node, relPath)` so it can be unit-tested via `ts.createSourceFile`.

The auto-module backwards-compat fallback is now gated on the presence of at least one **public** file function — a file with only non-exported helpers no longer fabricates a module entry.

### 2. Split `--privates` into all-surface vs `--privates-only`

Three comparison modes:

| Flag                | Bucket                                         |
|---------------------|------------------------------------------------|
| _(default)_         | public API only (historical behavior)          |
| `--privates`        | public + private/protected combined (full surface) |
| `--privates-only`   | private/protected only (was `--privates`)      |

The old `--privates` was useful for triaging the private gap in isolation, but for measuring overall API parity the more natural question is "what fraction of Rails' total surface do we cover?" Splitting the flags lets callers ask either question.

JSON artifacts:
- `api-comparison.json` — public
- `api-comparison-privates.json` — all surface (was internal-only)
- `api-comparison-privates-only.json` — internal-only (new)

## Impact (activerecord)

| Mode                | Coverage              |
|---------------------|-----------------------|
| public              | 2705/2811 (96.2%)     |
| `--privates`        | 2934/4214 (69.6%)     |
| `--privates-only`   | 136/1429 (9.5%) — was 114/1429 (8.0%) on main |

Example: `relation/where_clause.rb` 0/12 → 4/12 in `--privates-only` mode. Helpers `equalities`, `extractNodeValue`, `exceptPredicates`, `invertPredicate` now match their Rails counterparts.

This is the first step of `docs/private-api-parity-100-plan.md`; the remaining ~90% of the private-method gap is real implementation work.

## Test plan

- [x] `pnpm vitest run scripts/api-compare/` — 41 tests pass (4 new for file-local helpers, 1 new for "all" mode)
- [x] `pnpm api:compare --package activerecord` — public unchanged at 96.2%
- [x] `pnpm api:compare --package activerecord --privates` — full surface 69.6%
- [x] `pnpm api:compare --package activerecord --privates-only` — internal-only moves 8.0% → 9.5%
- [x] `pnpm typecheck` (via pre-commit hook)