### PR TITLE
test(parity): AR query fixtures ar-94..ar-98 — not_eq, gteq/lteq, left_outer_joins, or, where.not (PR 19)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,22 +1,54 @@
 {
-  "ar-16": {
+  "arel-17": {
     "side": "diff",
-    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
+    "reason": "is_distinct_from: trails emits 'IS DISTINCT FROM' (SQL standard); Rails on SQLite emits 'IS NOT' (SQLite extension). Both are semantically equivalent but lexically differ."
   },
-  "ar-57": {
-    "side": "diff",
-    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
-  "ar-79": {
+  "arel-24": {
     "side": "trails-missing",
-    "reason": "Relation#unscoped() not implemented as an instance method. Rails allows chaining unscoped() on a relation to discard all previously applied scopes; trails only implements it as a class method."
+    "reason": "arithmetic chain (users[:age] / 3 - employees[:time_at_company]): trails Attribute#divide returns a node without a .subtract method — predication-after-arithmetic chain is incomplete."
   },
-  "ar-82": {
+  "arel-25": {
     "side": "trails-missing",
-    "reason": "Model.optimizer_hints() class-method delegation not implemented. Rails delegates optimizer_hints() from the class to its default scope relation; trails only has it as an instance method on Relation, so Book.optimizerHints(...) throws."
+    "reason": "arithmetic predication gap — same family as arel-24 (trails arithmetic ops do not chain into further predicates)."
   },
-  "ar-87": {
+  "arel-26": {
+    "side": "trails-missing",
+    "reason": "arithmetic predication gap — same family as arel-24."
+  },
+  "arel-27": {
+    "side": "trails-missing",
+    "reason": "arithmetic predication gap — same family as arel-24."
+  },
+  "arel-28": {
+    "side": "trails-missing",
+    "reason": "arithmetic predication gap — same family as arel-24."
+  },
+  "arel-29": {
+    "side": "trails-missing",
+    "reason": "arithmetic predication gap — same family as arel-24."
+  },
+  "arel-30": {
+    "side": "trails-missing",
+    "reason": "(~users[:bitmap]).gt(0): trails Nodes.BitwiseNot does not implement predication methods (no .gt/.lt/.eq chain)."
+  },
+  "arel-36": {
     "side": "diff",
-    "reason": "Relation#joins() does not accept Arel join nodes. Rails joins() flattens its args and handles Arel::Nodes::InnerJoin entries in build_joins; trails joins() only accepts strings, coercing any non-string to [object Object]. Rails: 'SELECT \"books\".* FROM \"books\" INNER JOIN \"authors\" ON ...'; trails: 'SELECT \"books\".* FROM \"books\" [object Object]'."
+    "reason": "EXTRACT(MONTH FROM ...) vs EXTRACT(month FROM ...): trails ToSql visitor emits the EXTRACT field in the casing it was constructed with (lowercase in fixture); Rails uppercases."
+  },
+  "arel-44": {
+    "side": "diff",
+    "reason": "subquery alias quoting: Rails emits the alias bare (sub); trails emits the quoted identifier (\"sub\"). Real ToSql visitor divergence."
+  },
+  "arel-47": {
+    "side": "trails-missing",
+    "reason": "photos[:id].count.gt(5): trails Attribute#count returns a node without predication methods — HAVING aggregate-comparison chain incomplete."
+  },
+  "ar-96": {
+    "side": "diff",
+    "reason": "left_outer_joins with association: Rails resolves the association foreign key to emit ON \"reviews\".\"book_id\" = \"books\".\"id\"; trails emits ON 1=1 (no association resolution)."
+  },
+  "ar-98": {
+    "side": "diff",
+    "reason": "where.not with hash (multi-key): Rails emits WHERE NOT (...AND...), trails emits individual != predicates joined with AND — logically different semantics."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -19,10 +19,6 @@
     "side": "diff",
     "reason": "Relation#joins() does not accept Arel join nodes. Rails joins() flattens its args and handles Arel::Nodes::InnerJoin entries in build_joins; trails joins() only accepts strings, coercing any non-string to [object Object]. Rails: 'SELECT \"books\".* FROM \"books\" INNER JOIN \"authors\" ON ...'; trails: 'SELECT \"books\".* FROM \"books\" [object Object]'."
   },
-  "ar-96": {
-    "side": "diff",
-    "reason": "left_outer_joins with association: Rails resolves the association foreign key to emit ON \"reviews\".\"book_id\" = \"books\".\"id\"; trails emits ON 1=1 (no association resolution)."
-  },
   "ar-98": {
     "side": "diff",
     "reason": "where.not with hash (multi-key): Rails emits WHERE NOT (\"books\".\"status\" = 'draft' AND \"books\".\"active\" = 0); trails emits individual != predicates joined with AND — logically different semantics."

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,47 +1,23 @@
 {
-  "arel-17": {
+  "ar-16": {
     "side": "diff",
-    "reason": "is_distinct_from: trails emits 'IS DISTINCT FROM' (SQL standard); Rails on SQLite emits 'IS NOT' (SQLite extension). Both are semantically equivalent but lexically differ."
+    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
   },
-  "arel-24": {
-    "side": "trails-missing",
-    "reason": "arithmetic chain (users[:age] / 3 - employees[:time_at_company]): trails Attribute#divide returns a node without a .subtract method — predication-after-arithmetic chain is incomplete."
-  },
-  "arel-25": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24 (trails arithmetic ops do not chain into further predicates)."
-  },
-  "arel-26": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-27": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-28": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-29": {
-    "side": "trails-missing",
-    "reason": "arithmetic predication gap — same family as arel-24."
-  },
-  "arel-30": {
-    "side": "trails-missing",
-    "reason": "(~users[:bitmap]).gt(0): trails Nodes.BitwiseNot does not implement predication methods (no .gt/.lt/.eq chain)."
-  },
-  "arel-36": {
+  "ar-57": {
     "side": "diff",
-    "reason": "EXTRACT(MONTH FROM ...) vs EXTRACT(month FROM ...): trails ToSql visitor emits the EXTRACT field in the casing it was constructed with (lowercase in fixture); Rails uppercases."
+    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
   },
-  "arel-44": {
-    "side": "diff",
-    "reason": "subquery alias quoting: Rails emits the alias bare (sub); trails emits the quoted identifier (\"sub\"). Real ToSql visitor divergence."
-  },
-  "arel-47": {
+  "ar-79": {
     "side": "trails-missing",
-    "reason": "photos[:id].count.gt(5): trails Attribute#count returns a node without predication methods — HAVING aggregate-comparison chain incomplete."
+    "reason": "Relation#unscoped() not implemented as an instance method. Rails allows chaining unscoped() on a relation to discard all previously applied scopes; trails only implements it as a class method."
+  },
+  "ar-82": {
+    "side": "trails-missing",
+    "reason": "Model.optimizer_hints() class-method delegation not implemented. Rails delegates optimizer_hints() from the class to its default scope relation; trails only has it as an instance method on Relation, so Book.optimizerHints(...) throws."
+  },
+  "ar-87": {
+    "side": "diff",
+    "reason": "Relation#joins() does not accept Arel join nodes. Rails joins() flattens its args and handles Arel::Nodes::InnerJoin entries in build_joins; trails joins() only accepts strings, coercing any non-string to [object Object]. Rails: 'SELECT \"books\".* FROM \"books\" INNER JOIN \"authors\" ON ...'; trails: 'SELECT \"books\".* FROM \"books\" [object Object]'."
   },
   "ar-96": {
     "side": "diff",
@@ -49,6 +25,6 @@
   },
   "ar-98": {
     "side": "diff",
-    "reason": "where.not with hash (multi-key): Rails emits WHERE NOT (...AND...), trails emits individual != predicates joined with AND — logically different semantics."
+    "reason": "where.not with hash (multi-key): Rails emits WHERE NOT (\"books\".\"status\" = 'draft' AND \"books\".\"active\" = 0); trails emits individual != predicates joined with AND — logically different semantics."
   }
 }

--- a/scripts/parity/fixtures/ar-94/models.rb
+++ b/scripts/parity/fixtures/ar-94/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-94/models.ts
+++ b/scripts/parity/fixtures/ar-94/models.ts
@@ -1,7 +1,8 @@
-import { Base } from "@blazetrails/activerecord";
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
     this.tableName = "books";
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-94/models.ts
+++ b/scripts/parity/fixtures/ar-94/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+  }
+}

--- a/scripts/parity/fixtures/ar-94/query.rb
+++ b/scripts/parity/fixtures/ar-94/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:status].not_eq("draft"))

--- a/scripts/parity/fixtures/ar-94/query.ts
+++ b/scripts/parity/fixtures/ar-94/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("status").notEq("draft"));

--- a/scripts/parity/fixtures/ar-94/schema.sql
+++ b/scripts/parity/fixtures/ar-94/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-94
+-- Query: Book.where(Book.arel_table[:status].not_eq("draft"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-95/models.rb
+++ b/scripts/parity/fixtures/ar-95/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-95/models.ts
+++ b/scripts/parity/fixtures/ar-95/models.ts
@@ -1,7 +1,8 @@
-import { Base } from "@blazetrails/activerecord";
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
     this.tableName = "books";
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-95/models.ts
+++ b/scripts/parity/fixtures/ar-95/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+  }
+}

--- a/scripts/parity/fixtures/ar-95/query.rb
+++ b/scripts/parity/fixtures/ar-95/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:pages].gteq(200).and(Book.arel_table[:pages].lteq(400)))

--- a/scripts/parity/fixtures/ar-95/query.ts
+++ b/scripts/parity/fixtures/ar-95/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.where(
+  Book.arelTable.get("pages").gteq(200).and(Book.arelTable.get("pages").lteq(400)),
+);

--- a/scripts/parity/fixtures/ar-95/schema.sql
+++ b/scripts/parity/fixtures/ar-95/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-95
+-- Query: Book.where(Book.arel_table[:pages].gteq(200).and(Book.arel_table[:pages].lteq(400)))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  pages INTEGER
+);

--- a/scripts/parity/fixtures/ar-96/models.rb
+++ b/scripts/parity/fixtures/ar-96/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-96/models.ts
+++ b/scripts/parity/fixtures/ar-96/models.ts
@@ -1,0 +1,13 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+  }
+}

--- a/scripts/parity/fixtures/ar-96/models.ts
+++ b/scripts/parity/fixtures/ar-96/models.ts
@@ -1,13 +1,17 @@
-import { Base } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-  }
-}
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Review extends Base {
   static {
     this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-96/query.rb
+++ b/scripts/parity/fixtures/ar-96/query.rb
@@ -1,0 +1,1 @@
+Book.left_outer_joins(:reviews)

--- a/scripts/parity/fixtures/ar-96/query.ts
+++ b/scripts/parity/fixtures/ar-96/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.leftOuterJoins("reviews");

--- a/scripts/parity/fixtures/ar-96/schema.sql
+++ b/scripts/parity/fixtures/ar-96/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-96
+-- Query: Book.left_outer_joins(:reviews)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  body TEXT,
+  book_id INTEGER NOT NULL REFERENCES books(id)
+);
+CREATE INDEX idx_reviews_book_id ON reviews(book_id);

--- a/scripts/parity/fixtures/ar-97/models.rb
+++ b/scripts/parity/fixtures/ar-97/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-97/models.ts
+++ b/scripts/parity/fixtures/ar-97/models.ts
@@ -1,7 +1,8 @@
-import { Base } from "@blazetrails/activerecord";
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
     this.tableName = "books";
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-97/models.ts
+++ b/scripts/parity/fixtures/ar-97/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+  }
+}

--- a/scripts/parity/fixtures/ar-97/query.rb
+++ b/scripts/parity/fixtures/ar-97/query.rb
@@ -1,0 +1,1 @@
+Book.where(status: "active").or(Book.where(status: "featured"))

--- a/scripts/parity/fixtures/ar-97/query.ts
+++ b/scripts/parity/fixtures/ar-97/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ status: "active" }).or(Book.where({ status: "featured" }));

--- a/scripts/parity/fixtures/ar-97/schema.sql
+++ b/scripts/parity/fixtures/ar-97/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-97
+-- Query: Book.where(status: "active").or(Book.where(status: "featured"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-98/models.rb
+++ b/scripts/parity/fixtures/ar-98/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-98/models.ts
+++ b/scripts/parity/fixtures/ar-98/models.ts
@@ -1,7 +1,8 @@
-import { Base } from "@blazetrails/activerecord";
+import { Base, registerModel } from "@blazetrails/activerecord";
 
 export class Book extends Base {
   static {
     this.tableName = "books";
+    registerModel(this);
   }
 }

--- a/scripts/parity/fixtures/ar-98/models.ts
+++ b/scripts/parity/fixtures/ar-98/models.ts
@@ -1,0 +1,7 @@
+import { Base } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+  }
+}

--- a/scripts/parity/fixtures/ar-98/query.rb
+++ b/scripts/parity/fixtures/ar-98/query.rb
@@ -1,0 +1,1 @@
+Book.where.not(status: "draft", active: false)

--- a/scripts/parity/fixtures/ar-98/query.ts
+++ b/scripts/parity/fixtures/ar-98/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.whereNot({ status: "draft", active: false });

--- a/scripts/parity/fixtures/ar-98/schema.sql
+++ b/scripts/parity/fixtures/ar-98/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-98
+-- Query: Book.where.not(status: "draft", active: false)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT,
+  active BOOLEAN
+);


### PR DESCRIPTION
## Summary
- ar-94: Arel `not_eq` predicate in `where`
- ar-95: Arel `gteq`/`lteq` combined with `.and()`
- ar-96: `left_outer_joins` with association name
- ar-97: `or` combining two `where` scopes
- ar-98: `where.not` with hash (multi-key)

## Test plan
- [x] Rails runner produces expected SQL for each fixture
- [x] Trails runner matches (or fixture added to known-gaps)
- [x] `pnpm parity:query` passes with expected results