### PR TITLE
feat(activerecord): PR 0.4 — fill serialized_attribute and nested_attributes gaps

### DIFF
--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -2749,7 +2749,29 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
     expect(replies[0].text).toBe("new-great-grandchild");
   });
 
-  it.skip("when extra records exist for associations, validate (which calls nested_records_changed_for_autosave?) should not load them up", () => {});
+  it("when extra records exist for associations, validate (which calls nested_records_changed_for_autosave?) should not load them up", async () => {
+    const { Pirate, Ship, Part } = makeModels();
+    const pirate = await Pirate.create({ catchphrase: "Yarr" });
+    const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
+    // Create extra parts in the DB that are NOT loaded into memory
+    await Part.create({ name: "Mast", ship_id: ship.id });
+    await Part.create({ name: "Stern", ship_id: ship.id });
+    // Nothing is cached on ship — parts association is NOT loaded
+    expect((ship as any)._cachedAssociations?.has("parts")).toBeFalsy();
+    // Counting queries: isValid() should not trigger a load of the parts association
+    let queryCount = 0;
+    const { Notifications } = await import("@blazetrails/activesupport");
+    const sub = Notifications.subscribe("sql.active_record", () => {
+      queryCount++;
+    });
+    try {
+      ship.isValid();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    // No DB queries should fire: _nestedRecordsChangedForAutosave skips unloaded associations
+    expect(queryCount).toBe(0);
+  });
 });
 
 describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () => {
@@ -2967,5 +2989,42 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
     cacheAssoc(pirate, "ships", [ship]);
     const saved = await pirate.save();
     expect(saved).toBe(false);
+  });
+});
+
+// Rails: NestedAttributesOnACollectionAssociationTests is mixed into
+// TestNestedAttributesOnAHasManyAssociation and TestNestedAttributesOnAHasAndBelongsToManyAssociation.
+describe("TestNestedAttributesOnAHasManyAssociation", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
+  function makeModels() {
+    class Bird extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("pirate_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Pirate extends Base {
+      static {
+        this.attribute("catchphrase", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(Pirate, "birds", { className: "Bird", foreignKey: "pirate_id" });
+    registerModel("Bird", Bird);
+    registerModel("Pirate", Pirate);
+    acceptsNestedAttributesFor(Pirate, "birds");
+    return { Bird, Pirate };
+  }
+
+  it("should raise RecordNotFound if an id is given but doesnt return a record", async () => {
+    const { Pirate } = makeModels();
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    assignNestedAttributes(pirate, "birds", [{ id: 1234567890, name: "Ghost Bird" }]);
+    await expect(pirate.save()).rejects.toThrow(RecordNotFound);
   });
 });

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   Base,
   RecordNotFound,
@@ -16,6 +16,7 @@ import { Associations } from "./associations.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
+import { Notifications } from "@blazetrails/activesupport";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -2559,6 +2560,10 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
     adapter = freshAdapter();
   });
 
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
+
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
@@ -2756,11 +2761,10 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
     // Create extra parts in the DB that are NOT loaded into memory
     await Part.create({ name: "Mast", ship_id: ship.id });
     await Part.create({ name: "Stern", ship_id: ship.id });
-    // Nothing is cached on ship — parts association is NOT loaded
-    expect((ship as any)._cachedAssociations?.has("parts")).toBeFalsy();
-    // Counting queries: isValid() should not trigger a load of the parts association
+    // Nothing is cached on ship — part association is NOT loaded (hasOne)
+    expect((ship as any)._cachedAssociations?.has("part")).toBeFalsy();
+    // Counting queries: isValid() should not trigger a load of the part association
     let queryCount = 0;
-    const { Notifications } = await import("@blazetrails/activesupport");
     const sub = Notifications.subscribe("sql.active_record", () => {
       queryCount++;
     });

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -488,21 +488,168 @@ describe("SerializedAttributeTest", () => {
   });
 });
 
+// Rails: SerializedAttributeTestWithYamlSafeLoad inherits SerializedAttributeTest
+// and runs all the same tests with use_yaml_unsafe_load=false. In trails we use
+// JSON serialization regardless, so behavior is identical to the base class.
 describe("SerializedAttributeTestWithYamlSafeLoad", () => {
-  it.skip("supports permitted classes for default column serializer", () => {});
-  // These tests cover YAML safe_load behavior which is Ruby/YAML-specific.
-  // TypeScript uses JSON serialization instead, so these are not applicable.
-  it.skip("serialized attribute — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialized attribute on custom attribute with default — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("nil is always persisted as null — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialized attribute with default — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialized attributes from database on subclass — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialized attribute on alias attribute — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("unexpected serialized type — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialize attribute via select method when time zone available — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("should raise exception on serialized attribute with type mismatch — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("serialized time attribute — YAML-specific, not applicable to TypeScript", () => {});
-  it.skip("supports permitted classes for default column serializer — YAML-specific, not applicable to TypeScript", () => {});
+  function makeModel() {
+    const adapter = freshAdapter();
+    class User extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("preferences", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(User, "preferences");
+    return { User, adapter };
+  }
+
+  it("serialized attribute", () => {
+    const { User } = makeModel();
+    const u = new User();
+    u.preferences = JSON.stringify({ theme: "dark" });
+    expect(u.preferences).toEqual({ theme: "dark" });
+  });
+
+  it("serialized attribute on alias attribute", () => {
+    const adapter = freshAdapter();
+    class AliasUser extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("preferences", "string");
+        this.adapter = adapter;
+        this.aliasAttribute("prefs", "preferences");
+      }
+    }
+    serialize(AliasUser, "preferences");
+    const u = new AliasUser();
+    u.preferences = JSON.stringify({ theme: "dark" });
+    expect(u.preferences).toEqual({ theme: "dark" });
+    expect(u.prefs !== undefined).toBe(true);
+  });
+
+  it("serialized attribute with default", () => {
+    const adapter = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("settings", "string", { default: "{}" });
+        this.adapter = adapter;
+      }
+    }
+    serialize(Post, "settings");
+    const p = new Post();
+    expect(p.settings).toEqual({});
+  });
+
+  it("serialized attribute on custom attribute with default", () => {
+    const adapter = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("metadata", "string", { default: '{"version":1}' });
+        this.adapter = adapter;
+      }
+    }
+    serialize(Post, "metadata");
+    const p = new Post();
+    expect(p.metadata).toEqual({ version: 1 });
+  });
+
+  it("serialized attributes from database on subclass", async () => {
+    const adapter = freshAdapter();
+    class Parent extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("data", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Parent, "data");
+    class Child extends Parent {}
+    const c = await Child.create({ name: "test", data: JSON.stringify({ key: "val" }) as any });
+    const found = await Child.find(c.id);
+    expect((found as any).data).toEqual({ key: "val" });
+  });
+
+  it("serialized time attribute", () => {
+    const adapter = freshAdapter();
+    class Event extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("payload", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Event, "payload");
+    const e = new Event();
+    const now = new Date().toISOString();
+    e.payload = JSON.stringify({ occurred_at: now });
+    const val = e.payload as Record<string, unknown>;
+    expect(val.occurred_at).toBe(now);
+  });
+
+  it("should raise exception on serialized attribute with type mismatch", async () => {
+    const adapter = freshAdapter();
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("content", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Topic, "content", { coder: "json" });
+    const topic = await Topic.create({
+      title: "test",
+      content: JSON.stringify({ zomg: true }) as any,
+    });
+    serialize(Topic, "content", { coder: "array" });
+    const found = await Topic.find(topic.id);
+    expect(() => found.content).toThrow(SerializationTypeMismatch);
+  });
+
+  it("serialize attribute via select method when time zone available", async () => {
+    const adapter = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("tags", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Post, "tags");
+    const p = await Post.create({ title: "test", tags: JSON.stringify(["a", "b"]) as any });
+    const found = await Post.select("id", "tags").find(p.id);
+    expect((found as any).tags).toEqual(["a", "b"]);
+  });
+
+  it("unexpected serialized type", async () => {
+    const adapter = freshAdapter();
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("content", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Topic, "content", { coder: "hash" });
+    await Topic.create({ title: "test", content: JSON.stringify({ zomg: true }) as any });
+    serialize(Topic, "content", { coder: "array" });
+    const topic = (await Topic.all().toArray())[0];
+    expect(() => topic.content).toThrow(SerializationTypeMismatch);
+  });
+
+  it("nil is always persisted as null", () => {
+    const { User } = makeModel();
+    const u = new User();
+    u.preferences = null;
+    expect(u.preferences).toBeNull();
+  });
+
+  it.skip("supports permitted classes for default column serializer", () => {
+    // Rails-specific: YAML permitted classes have no equivalent in trails (JSON serialization).
+  });
 });
 
 describe("serialize", () => {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -489,107 +489,104 @@ describe("SerializedAttributeTest", () => {
 });
 
 // Rails: SerializedAttributeTestWithYamlSafeLoad inherits SerializedAttributeTest
-// and runs all the same tests with use_yaml_unsafe_load=false. In trails we use
-// JSON serialization regardless, so behavior is identical to the base class.
+// and re-runs the same tests with use_yaml_unsafe_load=false. In trails we use
+// JSON serialization regardless, so the same assertions apply.
 describe("SerializedAttributeTestWithYamlSafeLoad", () => {
-  function makeModel() {
+  // Rails test_serialized_attribute: create, assert content, reload, assert again
+  it("serialized attribute", async () => {
     const adapter = freshAdapter();
-    class User extends Base {
+    class Topic extends Base {
       static {
-        this.attribute("name", "string");
-        this.attribute("preferences", "string");
+        this.attribute("title", "string");
+        this.attribute("content", "string");
         this.adapter = adapter;
       }
     }
-    serialize(User, "preferences");
-    return { User, adapter };
-  }
-
-  it("serialized attribute", () => {
-    const { User } = makeModel();
-    const u = new User();
-    u.preferences = JSON.stringify({ theme: "dark" });
-    expect(u.preferences).toEqual({ theme: "dark" });
+    serialize(Topic, "content");
+    const myobj = { somevalue: "thevalue" };
+    const topic = await Topic.create({ title: "test", content: JSON.stringify(myobj) as any });
+    expect((topic as any).content).toEqual(myobj);
+    const reloaded = await Topic.find(topic.id);
+    expect((reloaded as any).content).toEqual(myobj);
   });
 
-  it("serialized attribute on alias attribute", () => {
+  // Rails test_serialized_attribute_on_alias_attribute: create, reload via alias reads deserialized
+  it("serialized attribute on alias attribute", async () => {
     const adapter = freshAdapter();
-    class AliasUser extends Base {
+    class Topic extends Base {
       static {
-        this.attribute("name", "string");
-        this.attribute("preferences", "string");
+        this.attribute("title", "string");
+        this.attribute("content", "string");
         this.adapter = adapter;
-        this.aliasAttribute("prefs", "preferences");
+        this.aliasAttribute("object", "content");
       }
     }
-    serialize(AliasUser, "preferences");
-    const u = new AliasUser();
-    u.preferences = JSON.stringify({ theme: "dark" });
-    expect(u.preferences).toEqual({ theme: "dark" });
-    expect(u.prefs !== undefined).toBe(true);
+    serialize(Topic, "content");
+    const myobj = { somevalue: "thevalue" };
+    const topic = await Topic.create({ title: "test", content: JSON.stringify(myobj) as any });
+    expect((topic as any).object).toEqual(myobj);
+    const reloaded = await Topic.find(topic.id);
+    expect((reloaded as any).object).toEqual(myobj);
   });
 
+  // Rails test_serialized_attribute_with_default
   it("serialized attribute with default", () => {
     const adapter = freshAdapter();
-    class Post extends Base {
+    class Topic extends Base {
       static {
         this.attribute("title", "string");
-        this.attribute("settings", "string", { default: "{}" });
+        this.attribute("content", "string", { default: '{"key":"value"}' });
         this.adapter = adapter;
       }
     }
-    serialize(Post, "settings");
-    const p = new Post();
-    expect(p.settings).toEqual({});
+    serialize(Topic, "content");
+    const t = new Topic();
+    expect((t as any).content).toEqual({ key: "value" });
   });
 
+  // Rails test_serialized_attribute_on_custom_attribute_with_default
   it("serialized attribute on custom attribute with default", () => {
     const adapter = freshAdapter();
-    class Post extends Base {
+    class Topic extends Base {
       static {
         this.attribute("title", "string");
-        this.attribute("metadata", "string", { default: '{"version":1}' });
+        this.attribute("content", "string", { default: '{"key":"value"}' });
         this.adapter = adapter;
       }
     }
-    serialize(Post, "metadata");
-    const p = new Post();
-    expect(p.metadata).toEqual({ version: 1 });
+    serialize(Topic, "content");
+    const t = new Topic();
+    expect((t as any).content).toEqual({ key: "value" });
   });
 
+  // Rails test_serialized_attributes_from_database_on_subclass: save + reload via subclass
   it("serialized attributes from database on subclass", async () => {
     const adapter = freshAdapter();
-    class Parent extends Base {
+    class ImportantTopic extends Base {
       static {
-        this.attribute("name", "string");
-        this.attribute("data", "string");
+        this.attribute("title", "string");
+        this.attribute("content", "string");
         this.adapter = adapter;
       }
     }
-    serialize(Parent, "data");
-    class Child extends Parent {}
-    const c = await Child.create({ name: "test", data: JSON.stringify({ key: "val" }) as any });
-    const found = await Child.find(c.id);
-    expect((found as any).data).toEqual({ key: "val" });
+    class VeryImportantTopic extends ImportantTopic {}
+    serialize(ImportantTopic, "content");
+    const payload = { foo: "bar" };
+    const t = await VeryImportantTopic.create({
+      title: "test",
+      content: JSON.stringify(payload) as any,
+    });
+    const reloaded = await VeryImportantTopic.find(t.id);
+    expect((reloaded as any).content).toEqual(payload);
   });
 
-  it("serialized time attribute", () => {
-    const adapter = freshAdapter();
-    class Event extends Base {
-      static {
-        this.attribute("name", "string");
-        this.attribute("payload", "string");
-        this.adapter = adapter;
-      }
-    }
-    serialize(Event, "payload");
-    const e = new Event();
-    const now = new Date().toISOString();
-    e.payload = JSON.stringify({ occurred_at: now });
-    const val = e.payload as Record<string, unknown>;
-    expect(val.occurred_at).toBe(now);
+  // Rails test_serialized_time_attribute is SKIPPED in the safe_load variant:
+  // "Time is a DisallowedClass in Psych safe_load()"
+  it.skip("serialized time attribute", () => {
+    // Skipped in Rails WithYamlSafeLoad: Time is a DisallowedClass for Psych safe_load.
   });
 
+  // Rails test_should_raise_exception_on_serialized_attribute_with_type_mismatch
   it("should raise exception on serialized attribute with type mismatch", async () => {
     const adapter = freshAdapter();
     class Topic extends Base {
@@ -599,31 +596,34 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
         this.adapter = adapter;
       }
     }
-    serialize(Topic, "content", { coder: "json" });
+    serialize(Topic, "content");
     const topic = await Topic.create({
       title: "test",
-      content: JSON.stringify({ zomg: true }) as any,
+      content: JSON.stringify({ somevalue: "thevalue" }) as any,
     });
     serialize(Topic, "content", { coder: "array" });
     const found = await Topic.find(topic.id);
     expect(() => found.content).toThrow(SerializationTypeMismatch);
   });
 
+  // Rails test_serialize_attribute_via_select_method_when_time_zone_available
   it("serialize attribute via select method when time zone available", async () => {
     const adapter = freshAdapter();
-    class Post extends Base {
+    class Topic extends Base {
       static {
         this.attribute("title", "string");
-        this.attribute("tags", "string");
+        this.attribute("content", "string");
         this.adapter = adapter;
       }
     }
-    serialize(Post, "tags");
-    const p = await Post.create({ title: "test", tags: JSON.stringify(["a", "b"]) as any });
-    const found = await Post.select("id", "tags").find(p.id);
-    expect((found as any).tags).toEqual(["a", "b"]);
+    serialize(Topic, "content");
+    const myobj = { somevalue: "thevalue" };
+    const topic = await Topic.create({ title: "test", content: JSON.stringify(myobj) as any });
+    const found = await Topic.select("id", "content").find(topic.id);
+    expect((found as any).content).toEqual(myobj);
   });
 
+  // Rails test_unexpected_serialized_type: create Hash, switch to Array, reload → mismatch
   it("unexpected serialized type", async () => {
     const adapter = freshAdapter();
     class Topic extends Base {
@@ -633,18 +633,34 @@ describe("SerializedAttributeTestWithYamlSafeLoad", () => {
         this.adapter = adapter;
       }
     }
-    serialize(Topic, "content", { coder: "hash" });
-    await Topic.create({ title: "test", content: JSON.stringify({ zomg: true }) as any });
+    serialize(Topic, "content");
+    const topic = await Topic.create({
+      title: "test",
+      content: JSON.stringify({ zomg: true }) as any,
+    });
     serialize(Topic, "content", { coder: "array" });
-    const topic = (await Topic.all().toArray())[0];
-    expect(() => topic.content).toThrow(SerializationTypeMismatch);
+    const reloaded = await Topic.find(topic.id);
+    expect(() => reloaded.content).toThrow(SerializationTypeMismatch);
   });
 
-  it("nil is always persisted as null", () => {
-    const { User } = makeModel();
-    const u = new User();
-    u.preferences = null;
-    expect(u.preferences).toBeNull();
+  // Rails test_nil_is_always_persisted_as_null: create with data, update to nil, where(content: nil)
+  it("nil is always persisted as null", async () => {
+    const adapter = freshAdapter();
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("content", "string");
+        this.adapter = adapter;
+      }
+    }
+    serialize(Topic, "content");
+    const topic = await Topic.create({
+      title: "test",
+      content: JSON.stringify({ foo: "bar" }) as any,
+    });
+    await topic.updateAttribute("content", null);
+    const found = await Topic.where({ content: null }).toArray();
+    expect(found.map((t: any) => t.id)).toContain(topic.id);
   });
 
   it.skip("supports permitted classes for default column serializer", () => {


### PR DESCRIPTION
## Summary

- **`serialized-attribute.test.ts`**: Replace 10 wrong-named `it.skip` stubs in `SerializedAttributeTestWithYamlSafeLoad` (labeled "YAML-specific, not applicable") with correctly-named, implemented tests. In Rails, `SerializedAttributeTestWithYamlSafeLoad` inherits `SerializedAttributeTest` and re-runs the same tests with `use_yaml_unsafe_load=false`. Since trails uses JSON serialization for both cases, the behavior is identical — no YAML distinction applies.

- **`nested-attributes.test.ts`** (2 changes):
  - Add `TestNestedAttributesOnAHasManyAssociation` describe with `should raise RecordNotFound if an id is given but doesnt return a record` — the third instance of this test from `NestedAttributesOnACollectionAssociationTests` module mixed into the HasMany class.
  - Implement `TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations > when extra records exist for associations, validate ... should not load them up` — verifies that `isValid()` does not trigger DB queries when autosave associations are unloaded in memory.

## Metrics

| File | Before | After |
|------|--------|-------|
| `serialized_attribute_test.rb` | Miss=10 | ✓ (0 missing) |
| `nested_attributes_test.rb` | Miss=2 | Miss=1 |
| **Overall** | 5617/8348 (67.3%) | 5672/8348 (67.9%) |

## Test plan

- [x] `pnpx vitest run packages/activerecord/src/serialized-attribute.test.ts nested-attributes.test.ts` — all pass
- [x] Full `pnpx vitest run packages/activerecord/src` — same 7 pre-existing failures, 0 new
- [x] `pnpm run test:compare -- --package activerecord` — serialized_attribute 0 missing