### PR TITLE
fix(activerecord): whereNot multi-key hash → NOT(p1 AND p2) matching Rails WhereClause#invert (ar-98)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -359,6 +359,22 @@ describe("RelationTest", () => {
     }
   });
 
+  it("whereNot multi-key hash wraps in NOT(AND) not individual !=", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.whereNot({ status: "draft", active: false }).toSql();
+    // Rails: WHERE NOT ("books"."status" = 'draft' AND "books"."active" = 0)
+    expect(sql).toContain("NOT (");
+    expect(sql).toContain('"books"."status"');
+    expect(sql).toContain('"books"."active"');
+    // Must NOT be individual != predicates (wrong semantics)
+    expect(sql).not.toContain("!= 'draft' AND");
+  });
+
   it("inOrderOf emits WHERE IN filter + CASE WHEN ... ASC (Rails form)", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -367,12 +367,13 @@ describe("RelationTest", () => {
       }
     }
     const sql = Book.whereNot({ status: "draft", active: false }).toSql();
-    // Rails: WHERE NOT ("books"."status" = 'draft' AND "books"."active" = 0)
-    expect(sql).toContain("NOT (");
-    expect(sql).toContain('"books"."status"');
-    expect(sql).toContain('"books"."active"');
-    // Must NOT be individual != predicates (wrong semantics)
-    expect(sql).not.toContain("!= 'draft' AND");
+    // Exact Rails form: WHERE NOT ("books"."status" = 'draft' AND "books"."active" = 0)
+    // — a single NOT wrapping one AND containing both predicates.
+    expect(sql).toMatch(/NOT \(.*"books"\."status".*AND.*"books"\."active".*\)/);
+    // Must be exactly one NOT ( occurrence — not per-column NOTs
+    expect(sql.match(/NOT \(/g)?.length).toBe(1);
+    // Must use = (positive predicates inside NOT), not !=
+    expect(sql).not.toContain("!=");
   });
 
   it("inOrderOf emits WHERE IN filter + CASE WHEN ... ASC (Rails form)", () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -618,7 +618,19 @@ export class Relation<T extends Base> {
         ? value.map((v) => this._castWhereValue(key, v))
         : this._castWhereValue(key, value);
     }
-    rel._whereClause.predicates.push(...this.predicateBuilder.buildNegatedFromHash(castConditions));
+    // Mirrors Rails' WhereClause#invert:
+    // - single predicate → invert_predicate (NOT NULL, !=, NOT BETWEEN, etc.)
+    // - multiple predicates → NOT(p1 AND p2 AND ...) — different semantics from p1 != AND p2 !=
+    const keys = Object.keys(castConditions);
+    if (keys.length <= 1) {
+      rel._whereClause.predicates.push(
+        ...this.predicateBuilder.buildNegatedFromHash(castConditions),
+      );
+    } else {
+      const positiveNodes = this.predicateBuilder.buildFromHash(castConditions);
+      const combined = positiveNodes.length === 1 ? positiveNodes[0] : new Nodes.And(positiveNodes);
+      rel._whereClause.predicates.push(new Nodes.Not(combined));
+    }
     return rel;
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -618,18 +618,17 @@ export class Relation<T extends Base> {
         ? value.map((v) => this._castWhereValue(key, v))
         : this._castWhereValue(key, value);
     }
-    // Mirrors Rails' WhereClause#invert:
-    // - single predicate → invert_predicate (NOT NULL, !=, NOT BETWEEN, etc.)
-    // - multiple predicates → NOT(p1 AND p2 AND ...) — different semantics from p1 != AND p2 !=
-    const keys = Object.keys(castConditions);
-    if (keys.length <= 1) {
+    // Mirrors Rails' WhereClause#invert — branches on the actual predicate count,
+    // not the key count, since one key can expand to multiple predicates:
+    // - 1 predicate → invert_predicate (NOT NULL, !=, NOT BETWEEN, NOT IN, etc.)
+    // - 2+ predicates → NOT(p1 AND p2 AND ...) — semantically different from p1 != AND p2 !=
+    const positiveNodes = this.predicateBuilder.buildFromHash(castConditions);
+    if (positiveNodes.length <= 1) {
       rel._whereClause.predicates.push(
         ...this.predicateBuilder.buildNegatedFromHash(castConditions),
       );
     } else {
-      const positiveNodes = this.predicateBuilder.buildFromHash(castConditions);
-      const combined = positiveNodes.length === 1 ? positiveNodes[0] : new Nodes.And(positiveNodes);
-      rel._whereClause.predicates.push(new Nodes.Not(combined));
+      rel._whereClause.predicates.push(new Nodes.Not(new Nodes.And(positiveNodes)));
     }
     return rel;
   }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,7 +1,7 @@
 {
   "ar-01": {
     "side": "diff",
-    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date→SQL serialization to drop fractional seconds for unscaled DATETIME columns."
+    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date\u2192SQL serialization to drop fractional seconds for unscaled DATETIME columns."
   },
   "ar-52": {
     "side": "diff",
@@ -9,7 +9,7 @@
   },
   "ar-65": {
     "side": "diff",
-    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
+    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) \u2014 rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
   },
   "ar-16": {
     "side": "diff",
@@ -17,11 +17,7 @@
   },
   "ar-57": {
     "side": "diff",
-    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
-  "ar-98": {
-    "side": "diff",
-    "reason": "where.not with hash (multi-key): Rails emits WHERE NOT (\"books\".\"status\" = 'draft' AND \"books\".\"active\" = 0); trails emits individual != predicates joined with AND — logically different semantics."
+    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 \u2014 eagerLoad JOIN + column-projection behaviour is not implemented."
   },
   "ar-99": {
     "side": "diff",


### PR DESCRIPTION
## Summary

`whereNot({status: 'draft', active: false})` now emits `WHERE NOT ("books"."status" = 'draft' AND "books"."active" = 0)`, matching Rails exactly.

**Before:**
```sql
WHERE "books"."status" != 'draft' AND "books"."active" != 0
```

**After (matches Rails):**
```sql
WHERE NOT ("books"."status" = 'draft' AND "books"."active" = 0)
```

## Root cause

Rails' `WhereClause#invert` has two paths (from `where_clause.rb`):
- **Single predicate**: `invert_predicate(node)` → `!=`, `IS NOT NULL`, `NOT BETWEEN`, etc.
- **Multiple predicates**: `[Arel::Nodes::Not.new(ast)]` where `ast` is the combined AND of all positive predicates → `NOT(p1 AND p2)`

Our `whereNot` was calling `buildNegatedFromHash` for all cases, which inverts each key individually producing individual `!=` predicates. This is semantically different: `NOT a AND NOT b` ≠ `NOT(a AND b)`.

## Fix

Branch on the number of keys: single-key keeps existing `buildNegatedFromHash` behavior; multi-key builds the positive predicates, combines with `And`, and wraps in `Not`.

## Test plan

- [x] Regression test asserting `NOT (...)` grouping and no individual `!=` in multi-key whereNot
- [x] Parity: ar-98 passes; 5 gaps remain (ar-01/52/65 datetime, ar-16/57 eagerLoad)