### PR TITLE
feat(activerecord): PR 0.5 — fill sqlite3/pg-composite/nested-attributes gaps

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/composite.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/composite.test.ts
@@ -14,9 +14,23 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlCompositeTest", () => {
-    it.skip("column", async () => {});
-    it.skip("composite value", async () => {});
-    it.skip("composite mapping", async () => {});
-    it.skip("composite write", async () => {});
+    it.skip("column", async () => {
+      // Requires postgresql_composites table fixture with composite type.
+    });
+    it.skip("composite value", async () => {
+      // Requires postgresql_composites table fixture with composite type.
+    });
+    it.skip("composite mapping", async () => {
+      // Requires composite type registered in PostgreSQL and postgresql_composites fixture.
+    });
+    it.skip("composite write", async () => {
+      // Requires postgresql_composites table fixture with composite type.
+    });
+  });
+
+  describe("PostgresqlCompositeWithCustomOidTest", () => {
+    it.skip("composite mapping", async () => {
+      // Requires custom OID composite type fixture. PG-only.
+    });
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -348,18 +348,17 @@ describe("SQLite3AdapterTest", () => {
     expect(reqCol!.notnull).toBe(1);
   });
 
-  // null-overridden: Rails logging instrumentation
   it("indexes logs", async () => {
     const logged: string[] = [];
     const sub = Notifications.subscribe("sql.active_record", (event: any) => {
-      if (event.payload?.sql?.includes("PRAGMA")) logged.push(event.payload.sql);
+      if (event.payload?.sql) logged.push(event.payload.sql);
     });
     try {
-      await adapter.execute(`PRAGMA index_list("items")`);
+      await adapter.indexes("items");
     } finally {
       Notifications.unsubscribe(sub);
     }
-    expect(logged.some((s) => s.includes("index_list"))).toBe(true);
+    expect(logged.length).toBeGreaterThan(0);
   });
 
   it("no indexes", async () => {
@@ -574,32 +573,21 @@ describe("SQLite3AdapterTest", () => {
     fs.unlinkSync(tmpFile);
   });
 
-  // Rails tests strict_strings_by_default: whether the adapter enforces strict
-  // string/column checks. In trails the SQLite3Adapter wraps better-sqlite3 which
-  // always enforces column existence when creating indexes.
-  it("strict strings by default", async () => {
-    adapter.exec(`CREATE TABLE "strict_default" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    // Without explicit strict option: SQLite enforces column existence
-    expect(() => {
-      adapter.exec(`CREATE INDEX "idx_strict_default" ON "strict_default" ("non_existent")`);
-    }).toThrow(/no such column/i);
+  // Rails' SQLite3Adapter has a class-level `strict_strings_by_default` setting that
+  // controls whether string-typed WHERE values require exact binary matching. When
+  // disabled (default), Rails performs a loose match and assert_nothing_raised;
+  // when enabled or set true in database.yml, loose matches raise. Trails' adapter
+  // does not yet implement this config knob.
+  it.skip("strict strings by default", () => {
+    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
   });
 
-  it("strict strings by default and true in database yml", async () => {
-    // With strict: true, column validation is enforced
-    adapter.exec(`CREATE TABLE "strict_true" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    expect(() => {
-      adapter.exec(`CREATE INDEX "idx_strict_true" ON "strict_true" ("non_existent")`);
-    }).toThrow(/no such column/i);
+  it.skip("strict strings by default and true in database yml", () => {
+    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
   });
 
-  it("strict strings by default and false in database yml", async () => {
-    // With strict: false, behavior falls back to SQLite default.
-    // In SQLite, creating an index on a non-existent column raises regardless.
-    adapter.exec(`CREATE TABLE "strict_false" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    // Verify table was created correctly — plain execute confirms the table exists
-    const cols = await adapter.execute(`PRAGMA table_info("strict_false")`);
-    expect(cols.length).toBeGreaterThan(0);
+  it.skip("strict strings by default and false in database yml", () => {
+    // Requires SQLite3Adapter.strict_strings_by_default class config (not implemented)
   });
 
   it("rowid column", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
 afterEach(() => {
   adapter.close();
+  Notifications.unsubscribeAll();
 });
 
 describe("SQLite3AdapterTest", () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { Notifications } from "@blazetrails/activesupport";
 
 let adapter: SQLite3Adapter;
 
@@ -243,8 +244,19 @@ describe("SQLite3AdapterTest", () => {
     expect(rows).toHaveLength(1);
   });
 
-  // null-overridden: Rails logging instrumentation
-  // it.skip("insert logged", () => {});
+  it("insert logged", async () => {
+    const sql = `INSERT INTO "items" ("name") VALUES ('logged')`;
+    const logged: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      if (event.payload?.sql?.includes("INSERT")) logged.push(event.payload.sql);
+    });
+    try {
+      await adapter.executeMutation(sql);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(logged.some((s) => s.includes("INSERT") && s.includes("logged"))).toBe(true);
+  });
 
   it("insert id value returned", async () => {
     const id1 = await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('a')`);
@@ -272,8 +284,19 @@ describe("SQLite3AdapterTest", () => {
     expect(rows[1].name).toBe("b");
   });
 
-  // null-overridden: Rails logging instrumentation
-  // it.skip("select rows logged", () => {});
+  it("select rows logged", async () => {
+    const sql = `select * from "items"`;
+    const logged: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      if (event.payload?.sql?.toLowerCase().startsWith("select")) logged.push(event.payload.sql);
+    });
+    try {
+      await adapter.execute(sql);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(logged.some((s) => s.toLowerCase().startsWith("select"))).toBe(true);
+  });
 
   it("transaction", async () => {
     await adapter.beginTransaction();
@@ -326,7 +349,18 @@ describe("SQLite3AdapterTest", () => {
   });
 
   // null-overridden: Rails logging instrumentation
-  // it.skip("indexes logs", () => {});
+  it("indexes logs", async () => {
+    const logged: string[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (event: any) => {
+      if (event.payload?.sql?.includes("PRAGMA")) logged.push(event.payload.sql);
+    });
+    try {
+      await adapter.execute(`PRAGMA index_list("items")`);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(logged.some((s) => s.includes("index_list"))).toBe(true);
+  });
 
   it("no indexes", async () => {
     const rows = await adapter.execute(`PRAGMA index_list("items")`);
@@ -540,10 +574,33 @@ describe("SQLite3AdapterTest", () => {
     fs.unlinkSync(tmpFile);
   });
 
-  // null-overridden: Rails YAML config feature (strict_strings_mode)
-  // it.skip("strict strings by default", () => {});
-  // it.skip("strict strings by default and true in database yml", () => {});
-  // it.skip("strict strings by default and false in database yml", () => {});
+  // Rails tests strict_strings_by_default: whether the adapter enforces strict
+  // string/column checks. In trails the SQLite3Adapter wraps better-sqlite3 which
+  // always enforces column existence when creating indexes.
+  it("strict strings by default", async () => {
+    adapter.exec(`CREATE TABLE "strict_default" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    // Without explicit strict option: SQLite enforces column existence
+    expect(() => {
+      adapter.exec(`CREATE INDEX "idx_strict_default" ON "strict_default" ("non_existent")`);
+    }).toThrow(/no such column/i);
+  });
+
+  it("strict strings by default and true in database yml", async () => {
+    // With strict: true, column validation is enforced
+    adapter.exec(`CREATE TABLE "strict_true" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    expect(() => {
+      adapter.exec(`CREATE INDEX "idx_strict_true" ON "strict_true" ("non_existent")`);
+    }).toThrow(/no such column/i);
+  });
+
+  it("strict strings by default and false in database yml", async () => {
+    // With strict: false, behavior falls back to SQLite default.
+    // In SQLite, creating an index on a non-existent column raises regardless.
+    adapter.exec(`CREATE TABLE "strict_false" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    // Verify table was created correctly — plain execute confirms the table exists
+    const cols = await adapter.execute(`PRAGMA table_info("strict_false")`);
+    expect(cols.length).toBeGreaterThan(0);
+  });
 
   it("rowid column", async () => {
     adapter.exec(`CREATE TABLE "rowid_test" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -3026,6 +3026,9 @@ describe("TestNestedAttributesOnAHasManyAssociation", () => {
   beforeEach(() => {
     adapter = freshAdapter();
   });
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
 
   function makeModels() {
     class Bird extends Base {

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -2994,6 +2994,29 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
     const saved = await pirate.save();
     expect(saved).toBe(false);
   });
+
+  it("when extra records exist for associations, validate (which calls nested_records_changed_for_autosave?) should not load them up", async () => {
+    const { Pirate, Ship, Part } = makeModels();
+    const pirate = await Pirate.create({ catchphrase: "Yarr" });
+    const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
+    // Create extra parts in the DB that are NOT loaded into memory
+    await Part.create({ name: "Mast", ship_id: ship.id });
+    await Part.create({ name: "Stern", ship_id: ship.id });
+    // Nothing is cached on pirate or ship — parts association is NOT loaded
+    expect((ship as any)._cachedAssociations?.has("parts")).toBeFalsy();
+    // isValid() should not trigger a load of the parts association
+    let queryCount = 0;
+    const sub = Notifications.subscribe("sql.active_record", (evt: any) => {
+      // Count only SELECT queries (not DDL from table creation)
+      if (evt.payload?.sql?.trim().toUpperCase().startsWith("SELECT")) queryCount++;
+    });
+    try {
+      ship.isValid();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+    expect(queryCount).toBe(0);
+  });
 });
 
 // Rails: NestedAttributesOnACollectionAssociationTests is mixed into


### PR DESCRIPTION
## Summary

Fills remaining missing tests across three files.

### Changes

**`adapters/sqlite3/sqlite3-adapter.test.ts`** — 3 implemented + 3 skipped:
- `insert logged` / `select rows logged` / `indexes logs` — subscribe to `sql.active_record` and verify the notification fires
- `strict strings by default` / `strict strings by default and true/false in database yml` — skipped; Rails' `SQLite3Adapter.strict_strings_by_default` class-level config is not yet implemented in trails, so these are parity stubs only

**`adapters/postgresql/composite.test.ts`** — add `PostgresqlCompositeWithCustomOidTest` describe with `composite mapping` skip to match Rails' second test class (1 Miss → 0)

**`nested-attributes.test.ts`** — implement `TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations > when extra records exist for associations, validate ... should not load them up` (1 Miss → 0)

## Metrics

| File | Before | After |
|------|--------|-------|
| `sqlite3_adapter_test.rb` | Miss=6 | ✓ |
| `composite_test.rb` | Miss=1 | ✓ |
| `nested_attributes_test.rb` | Miss=1 | ✓ |

## Test plan

- [x] Full `pnpx vitest run packages/activerecord/src` — 0 new failures
- [x] `pnpm run test:compare -- --package activerecord` — all 3 target files 0 missing