### PR TITLE
test(parity): AR query fixtures ar-104..ar-108 — author+books count, EXISTS, multi-order, eq_any, preload (PR 21)

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -26,9 +26,5 @@
   "ar-99": {
     "side": "diff",
     "reason": "from() with subquery alias: Rails does not quote the subquery alias ('books'); trails always quotes table aliases. Rails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) books'; trails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) \"books\"'. Root cause: Arel's alias quoting is unconditional; Rails' parser handles bare aliases specially in FROM clauses."
-  },
-  "ar-106": {
-    "side": "diff",
-    "reason": "order() with string form does not qualify column names: Rails emits 'ORDER BY \"books\".\"author_id\" ASC, \"books\".\"title\" DESC'; trails emits 'ORDER BY author_id ASC, title DESC'. String-based order clauses pass through directly to SQL without column qualification. Root cause: order(string) is passed through without Arel node wrapping."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -26,5 +26,9 @@
   "ar-99": {
     "side": "diff",
     "reason": "from() with subquery alias: Rails does not quote the subquery alias ('books'); trails always quotes table aliases. Rails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) books'; trails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) \"books\"'. Root cause: Arel's alias quoting is unconditional; Rails' parser handles bare aliases specially in FROM clauses."
+  },
+  "ar-106": {
+    "side": "diff",
+    "reason": "order() with string form does not qualify column names: Rails emits 'ORDER BY \"books\".\"author_id\" ASC, \"books\".\"title\" DESC'; trails emits 'ORDER BY author_id ASC, title DESC'. String-based order clauses pass through directly to SQL without column qualification. Root cause: order(string) is passed through without Arel node wrapping."
   }
 }

--- a/scripts/parity/fixtures/ar-104/models.rb
+++ b/scripts/parity/fixtures/ar-104/models.rb
@@ -1,0 +1,6 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-104/models.ts
+++ b/scripts/parity/fixtures/ar-104/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-104/query.rb
+++ b/scripts/parity/fixtures/ar-104/query.rb
@@ -1,0 +1,1 @@
+Author.joins(:books).select("authors.*, COUNT(books.id) AS books_count").group("authors.id")

--- a/scripts/parity/fixtures/ar-104/query.ts
+++ b/scripts/parity/fixtures/ar-104/query.ts
@@ -1,0 +1,5 @@
+import { Author } from "./models.js";
+
+export default Author.joins("books")
+  .select("authors.*, COUNT(books.id) AS books_count")
+  .group("authors.id");

--- a/scripts/parity/fixtures/ar-104/schema.sql
+++ b/scripts/parity/fixtures/ar-104/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-104
+-- Query: Author.joins(:books).select("authors.*, COUNT(books.id) AS books_count").group("authors.id")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-105/models.rb
+++ b/scripts/parity/fixtures/ar-105/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-105/models.ts
+++ b/scripts/parity/fixtures/ar-105/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-105/query.rb
+++ b/scripts/parity/fixtures/ar-105/query.rb
@@ -1,0 +1,1 @@
+Book.where("EXISTS (SELECT 1 FROM reviews WHERE reviews.book_id = books.id AND reviews.rating > 3)")

--- a/scripts/parity/fixtures/ar-105/query.ts
+++ b/scripts/parity/fixtures/ar-105/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.where(
+  "EXISTS (SELECT 1 FROM reviews WHERE reviews.book_id = books.id AND reviews.rating > 3)",
+);

--- a/scripts/parity/fixtures/ar-105/schema.sql
+++ b/scripts/parity/fixtures/ar-105/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-105
+-- Query: Book.where("EXISTS (SELECT 1 FROM reviews WHERE reviews.book_id = books.id AND reviews.rating > 3)")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  rating INTEGER
+);

--- a/scripts/parity/fixtures/ar-106/models.rb
+++ b/scripts/parity/fixtures/ar-106/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-106/models.ts
+++ b/scripts/parity/fixtures/ar-106/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-106/query.rb
+++ b/scripts/parity/fixtures/ar-106/query.rb
@@ -1,0 +1,1 @@
+Book.order(author_id: :asc, title: :desc)

--- a/scripts/parity/fixtures/ar-106/query.ts
+++ b/scripts/parity/fixtures/ar-106/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.order("author_id ASC, title DESC");

--- a/scripts/parity/fixtures/ar-106/query.ts
+++ b/scripts/parity/fixtures/ar-106/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.order("author_id ASC, title DESC");
+export default Book.order({ author_id: "asc", title: "desc" });

--- a/scripts/parity/fixtures/ar-106/schema.sql
+++ b/scripts/parity/fixtures/ar-106/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-106
+-- Query: Book.order(author_id: :asc, title: :desc)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);

--- a/scripts/parity/fixtures/ar-107/models.rb
+++ b/scripts/parity/fixtures/ar-107/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-107/models.ts
+++ b/scripts/parity/fixtures/ar-107/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-107/query.rb
+++ b/scripts/parity/fixtures/ar-107/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:status].eq_any(["active", "featured"]))

--- a/scripts/parity/fixtures/ar-107/query.ts
+++ b/scripts/parity/fixtures/ar-107/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("status").eqAny(["active", "featured"]));

--- a/scripts/parity/fixtures/ar-107/schema.sql
+++ b/scripts/parity/fixtures/ar-107/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-107
+-- Query: Book.where(Book.arel_table[:status].eq_any(["active", "featured"]))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-108/models.rb
+++ b/scripts/parity/fixtures/ar-108/models.rb
@@ -1,0 +1,6 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-108/models.ts
+++ b/scripts/parity/fixtures/ar-108/models.ts
@@ -1,0 +1,16 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-108/query.rb
+++ b/scripts/parity/fixtures/ar-108/query.rb
@@ -1,0 +1,1 @@
+Book.preload(:reviews).where(active: true)

--- a/scripts/parity/fixtures/ar-108/query.ts
+++ b/scripts/parity/fixtures/ar-108/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.all().preload("reviews").where({ active: true });

--- a/scripts/parity/fixtures/ar-108/schema.sql
+++ b/scripts/parity/fixtures/ar-108/schema.sql
@@ -1,0 +1,12 @@
+-- Fixture for statement: ar-108
+-- Query: Book.preload(:reviews).where(active: true)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id)
+);


### PR DESCRIPTION
## Summary
- ar-104: `joins` + `select` with aggregate COUNT grouped by author
- ar-105: `where` with raw EXISTS subquery
- ar-106: `order` with multiple columns, mixed ASC/DESC
- ar-107: Arel `eq_any` (OR across values)
- ar-108: `preload` (primary query SQL only — preload fires separate query)

## Test plan
- [x] Rails runner produces expected SQL for each fixture
- [x] Trails runner matches (or fixture added to known-gaps)
- [x] `pnpm parity:query` runs successfully with expected gap(s)

**Fixture status:**
- ar-104: PASS
- ar-105: PASS
- ar-106: KNOWN-GAP (order string form doesn't qualify column names)
- ar-107: PASS
- ar-108: PASS