### PR TITLE
feat(activerecord): query_methods private helpers PR 1/2 — 20 helpers (2% → 47%)

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1112,7 +1112,7 @@ function checkIfMethodHasArgumentsBang(
   message?: string,
 ): void {
   if (!args || args.length === 0) {
-    throw new ArgumentError(message ?? `The method .${methodName}() must contain arguments.`);
+    throw argumentError(message ?? `The method .${methodName}() must contain arguments.`);
   }
   const flat = flattenedArgs(args);
   args.length = 0;
@@ -1150,7 +1150,15 @@ function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
 function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string, unknown>[] {
   return args.flatMap((arg) => {
     if (!isPlainObject(arg)) {
-      throw new ArgumentError(`Unsupported argument type: ${String(arg)} ${typeof arg}`);
+      const desc =
+        arg === null
+          ? "null"
+          : Array.isArray(arg)
+            ? "Array"
+            : typeof arg !== "object"
+              ? `${String(arg)} (${typeof arg})`
+              : ((arg as any).constructor?.name ?? "object");
+      throw argumentError(`Unsupported argument type: ${desc}. Expected a plain object/hash.`);
     }
     return Object.entries(arg).map(([k, v]) => ({ [k]: v }));
   });
@@ -1287,7 +1295,7 @@ function extractTableNameFrom(orderTerm: string): string | null {
 function symbolToName(s: symbol): string {
   const name = Symbol.keyFor(s) ?? s.description;
   if (name === undefined || name.trim() === "") {
-    throw new ArgumentError("Order symbols must have a non-blank name");
+    throw argumentError("Order symbols must have a non-blank name");
   }
   return name;
 }
@@ -1304,10 +1312,15 @@ function columnReferences(orderArgs: unknown[]): string[] {
     } else if (arg instanceof Nodes.Ordering) {
       const expr = (arg as any).expr;
       if (expr instanceof Nodes.Attribute) refs.push(expr.relation.name);
-    } else if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
-      for (const [key] of Object.entries(arg as Record<string, unknown>)) {
-        const t = extractTableNameFrom(String(key));
-        if (t) refs.push(t);
+    } else if (isPlainObject(arg)) {
+      for (const [key, value] of Object.entries(arg)) {
+        if (isPlainObject(value)) {
+          // Nested hash { table: { col: dir } } — key is the table name.
+          refs.push(key);
+        } else {
+          const t = extractTableNameFrom(String(key));
+          if (t) refs.push(t);
+        }
       }
     }
   }
@@ -1350,19 +1363,26 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
       mapped.push(new Nodes.Ascending(arelSql(symbolToName(arg))));
-    } else if (
-      arg !== null &&
-      typeof arg === "object" &&
-      !Array.isArray(arg) &&
-      !(arg instanceof Nodes.Node)
-    ) {
-      for (const [key, dir] of Object.entries(arg as Record<string, unknown>)) {
-        const expr: Nodes.Node = arelSql(key);
-        mapped.push(
-          String(dir).toLowerCase() === "desc"
-            ? new Nodes.Descending(expr)
-            : new Nodes.Ascending(expr),
-        );
+    } else if (isPlainObject(arg)) {
+      for (const [key, value] of Object.entries(arg)) {
+        if (isPlainObject(value)) {
+          // Nested hash: { table: { col: dir } } → table.col DESC/ASC
+          for (const [field, dir] of Object.entries(value)) {
+            const expr = arelSql(`${key}.${field}`);
+            mapped.push(
+              String(dir).toLowerCase() === "desc"
+                ? new Nodes.Descending(expr)
+                : new Nodes.Ascending(expr),
+            );
+          }
+        } else {
+          const expr: Nodes.Node = arelSql(key);
+          mapped.push(
+            String(value).toLowerCase() === "desc"
+              ? new Nodes.Descending(expr)
+              : new Nodes.Ascending(expr),
+          );
+        }
       }
     } else {
       mapped.push(arg);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -4,7 +4,7 @@
  *
  * Mirrors: ActiveRecord::QueryMethods
  */
-import { Nodes, SelectManager, sql as arelSql } from "@blazetrails/arel";
+import { Nodes, SelectManager, Table as ArelTable, sql as arelSql } from "@blazetrails/arel";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
@@ -1100,7 +1100,7 @@ function async(this: QueryMethodsHost): QueryMethodsHost {
 }
 
 function assertModifiableBang(this: QueryMethodsHost): void {
-  if ((this as any)._loaded || (this as any)._arel) {
+  if ((this as any)._loaded) {
     throw new ActiveRecordError("can't modify a loaded relation");
   }
 }
@@ -1132,7 +1132,7 @@ function flattenedArgs(args: unknown[]): unknown[] {
   });
 }
 
-const VALID_DIRECTIONS = new Set(["asc", "desc", "ASC", "DESC"]);
+const VALID_DIRECTIONS = new Set(["asc", "desc"]);
 
 function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
   for (const arg of args) {
@@ -1140,10 +1140,8 @@ function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
     for (const [, value] of Object.entries(arg)) {
       if (isPlainObject(value)) {
         validateOrderArgs.call(this, [value]);
-      } else if (!VALID_DIRECTIONS.has(value as string)) {
-        throw new ArgumentError(
-          `Direction "${value}" is invalid. Valid directions are: ${[...VALID_DIRECTIONS].join(", ")}`,
-        );
+      } else if (!VALID_DIRECTIONS.has(String(value).toLowerCase())) {
+        throw new ArgumentError(`Direction "${value}" is invalid. Valid directions are: asc, desc`);
       }
     }
   }
@@ -1287,7 +1285,11 @@ function extractTableNameFrom(orderTerm: string): string | null {
 }
 
 function symbolToName(s: symbol): string {
-  return Symbol.keyFor(s) ?? s.description ?? "";
+  const name = Symbol.keyFor(s) ?? s.description;
+  if (name === undefined || name.trim() === "") {
+    throw new ArgumentError("Order symbols must have a non-blank name");
+  }
+  return name;
 }
 
 function columnReferences(orderArgs: unknown[]): string[] {
@@ -1397,12 +1399,12 @@ function buildCaseForValuePosition(
   options: { filter?: boolean } = {},
 ): unknown {
   const filter = options.filter !== false;
-  const node: any = new (Nodes as any).Case();
+  const node = new Nodes.Case();
   values.forEach((value, i) => {
     node.when((column as any).eq(value), i + 1);
   });
-  if (!filter) node.else(values.length + 1);
-  return new (Nodes as any).Ascending(node);
+  if (!filter) (node as any).else(values.length + 1);
+  return new Nodes.Ascending(node);
 }
 
 function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]): unknown[] {
@@ -1417,14 +1419,14 @@ function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]): unknow
         return (Array.isArray(columns) ? columns : [columns]).map(
           (col) =>
             builder?.resolveArelAttribute?.(tableName, String(col)) ??
-            arelSql(`${tableName}.${String(col)}`),
+            new ArelTable(tableName).get(String(col)),
         );
       });
     }
     const s = String(attr);
     if (s.includes(".")) {
       const [table, col] = s.split(".", 2);
-      return [builder?.resolveArelAttribute?.(table, col) ?? arelSql(s)];
+      return [builder?.resolveArelAttribute?.(table, col) ?? new ArelTable(table).get(col)];
     }
     return [s];
   });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1347,7 +1347,7 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
       !(arg instanceof Nodes.Node)
     ) {
       for (const [key, dir] of Object.entries(arg as Record<string, unknown>)) {
-        const expr: Nodes.Node = key instanceof Nodes.Node ? key : arelSql(key);
+        const expr: Nodes.Node = arelSql(key);
         mapped.push(
           String(dir).toLowerCase() === "desc"
             ? new Nodes.Descending(expr)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1265,8 +1265,8 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
   });
 }
 
-function extractTableNameFrom(string: string): string | null {
-  const match = string.match(/^\W?(\w+)\W?\./);
+function extractTableNameFrom(orderTerm: string): string | null {
+  const match = orderTerm.match(/^\W?(\w+)\W?\./);
   return match ? match[1] : null;
 }
 
@@ -1348,7 +1348,7 @@ function buildCaseForValuePosition(
   const filter = options.filter !== false;
   const node: any = new (Nodes as any).Case();
   values.forEach((value, i) => {
-    node.when((column as any).eq(value)).then(i + 1);
+    node.when((column as any).eq(value), i + 1);
   });
   if (!filter) node.else(values.length + 1);
   return new (Nodes as any).Ascending(node);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1209,8 +1209,8 @@ function buildSubquery(
   subqueryAlias: string,
   selectValue: unknown,
 ): SelectManager {
-  // Rails: except(:optimizer_hints).arel.as(alias) → new SelectManager(subquery).project(selectValue)
-  const relation = (this as any).except?.("optimizerHints") ?? this;
+  // Rails: except(:optimizer_hints).arel.as(alias) — use unscope (our except is SQL EXCEPT, not query-part removal)
+  const relation = (this as any).unscope?.("optimizerHints") ?? this;
   const aliasedSubquery = (relation as any).toArel?.().as(subqueryAlias);
   const sm = new SelectManager();
   if (aliasedSubquery) (sm as any).from(aliasedSubquery);
@@ -1312,9 +1312,7 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
 }
 
 function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void {
-  const model = (this as any)._modelClass;
-  const permit = model?.adapterClass?.columnNameWithOrderMatcher?.();
-  if (permit) disallowRawSqlBang(flattenedOrderKeysForRawSqlCheck(orderArgs), permit);
+  disallowRawSqlBang(flattenedOrderKeysForRawSqlCheck(orderArgs), resolveOrderMatcher(this));
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
   if (refs.length > 0)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1141,7 +1141,7 @@ function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
       if (isPlainObject(value)) {
         validateOrderArgs.call(this, [value]);
       } else if (!VALID_DIRECTIONS.has(String(value).toLowerCase())) {
-        throw new ArgumentError(`Direction "${value}" is invalid. Valid directions are: asc, desc`);
+        throw argumentError(`Direction "${value}" is invalid. Valid directions are: asc, desc`);
       }
     }
   }
@@ -1222,9 +1222,7 @@ function buildSubquery(
     throw new ActiveRecordError("Cannot build subquery: relation does not support toArel()");
   }
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(subqueryAlias)) {
-    throw new ArgumentError(
-      `Invalid subquery alias "${subqueryAlias}": must be a safe SQL identifier`,
-    );
+    throw argumentError(`Invalid subquery alias "${subqueryAlias}": must be a safe SQL identifier`);
   }
   const aliasedSubquery = (relation as any).toArel().as(subqueryAlias);
   const sm = new SelectManager();
@@ -1265,7 +1263,8 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
   return orderQuery.flatMap((o) => {
     // Match Rails: Arel::Attribute → .desc, Arel::Nodes::Ordering → .reverse,
     // other Arel nodes → .desc. Skip arrays (Array#reverse would mutate them).
-    if (o instanceof Nodes.Ordering) return [(o as any).reverse()];
+    if (o instanceof Nodes.Ordering && typeof (o as any).reverse === "function")
+      return [(o as any).reverse()];
     if (o instanceof Nodes.Attribute) return [o.desc()];
     if (o instanceof Nodes.Node && typeof (o as any).desc === "function") {
       return [(o as any).desc()];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1181,8 +1181,8 @@ function buildNamedBoundSqlLiteral(
 ): Nodes.BoundSqlLiteral {
   const namedBinds: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(values)) {
-    if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
-      namedBinds[key] = arelSql((value as any).toSql());
+    if (value instanceof Nodes.Node) {
+      namedBinds[key] = arelSql(value.toSql());
     } else {
       namedBinds[key] = value;
     }
@@ -1200,8 +1200,8 @@ function buildBoundSqlLiteral(
   values: unknown[],
 ): Nodes.BoundSqlLiteral {
   const positionalBinds = values.map((value) => {
-    if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
-      return arelSql((value as any).toSql());
+    if (value instanceof Nodes.Node) {
+      return arelSql(value.toSql());
     }
     return value;
   });
@@ -1256,7 +1256,15 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
         );
       }
       const table: any = (this as any)._modelClass?.arelTable;
-      return [table ? table.get(pk).desc() : arelSql(`${pk} DESC`)];
+      const modelClass: any = (this as any)._modelClass;
+      const arelTable =
+        modelClass?.arelTable ??
+        (modelClass?.tableName ? new ArelTable(modelClass.tableName) : null);
+      return [
+        arelTable
+          ? new Nodes.Descending(arelTable.get(pk))
+          : new Nodes.Descending(new Nodes.SqlLiteral(pk)),
+      ];
     }
     throw new IrreversibleOrderError(
       "Relation has no current order and table has no primary key to be used as default order",

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1365,25 +1365,29 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
-      mapped.push(new Nodes.Ascending(arelSql(symbolToName(arg))));
+      const name = symbolToName(arg);
+      const attr = this.predicateBuilder?.resolveArelAttribute?.(name, name) ?? arelSql(name);
+      mapped.push(new Nodes.Ascending(attr));
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
         if (isPlainObject(value)) {
-          // Nested hash: { table: { col: dir } } → table.col DESC/ASC
+          // Nested hash: { table: { col: dir } } → table.col DESC/ASC (quoted via ArelTable)
           for (const [field, dir] of Object.entries(value)) {
-            const expr = arelSql(`${key}.${field}`);
+            const attr = new ArelTable(key).get(field);
             mapped.push(
               String(dir).toLowerCase() === "desc"
-                ? new Nodes.Descending(expr)
-                : new Nodes.Ascending(expr),
+                ? new Nodes.Descending(attr)
+                : new Nodes.Ascending(attr),
             );
           }
         } else {
-          const expr: Nodes.Node = arelSql(key);
+          // Flat hash: { col: dir } — resolve via predicate builder for quoting
+          const attr =
+            this.predicateBuilder?.resolveArelAttribute?.(key, key) ?? new ArelTable(key).get(key);
           mapped.push(
             String(value).toLowerCase() === "desc"
-              ? new Nodes.Descending(expr)
-              : new Nodes.Ascending(expr),
+              ? new Nodes.Descending(attr)
+              : new Nodes.Ascending(attr),
           );
         }
       }
@@ -1398,14 +1402,23 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
 function buildOrderNode(clause: unknown): unknown {
   if (clause instanceof Nodes.Node) return clause;
   if (typeof clause === "string") return new Nodes.SqlLiteral(clause);
+  if (typeof clause === "symbol") return new Nodes.SqlLiteral(symbolToName(clause));
   if (Array.isArray(clause) && clause.length === 2) {
     const [col, dir] = clause;
-    const expr = col instanceof Nodes.Node ? col : new Nodes.SqlLiteral(String(col));
-    return String(dir).toLowerCase() === "desc"
-      ? new Nodes.Descending(expr)
-      : new Nodes.Ascending(expr);
+    if (col instanceof Nodes.Node) {
+      return String(dir).toLowerCase() === "desc"
+        ? new Nodes.Descending(col)
+        : new Nodes.Ascending(col);
+    }
+    if (typeof col === "string" || typeof col === "symbol") {
+      const expr = new Nodes.SqlLiteral(typeof col === "symbol" ? symbolToName(col) : col);
+      return String(dir).toLowerCase() === "desc"
+        ? new Nodes.Descending(expr)
+        : new Nodes.Ascending(expr);
+    }
+    throw argumentError(`Unsupported order column type: ${Object.prototype.toString.call(col)}`);
   }
-  return new Nodes.SqlLiteral(String(clause));
+  throw argumentError(`Unsupported order clause type: ${Object.prototype.toString.call(clause)}`);
 }
 
 function buildOrder(this: QueryMethodsHost, arel: any): void {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1261,13 +1261,12 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
     );
   }
   return orderQuery.flatMap((o) => {
-    // Match Rails: Arel::Attribute → .desc, Arel::Nodes::Ordering → .reverse,
-    // other Arel nodes → .desc. Skip arrays (Array#reverse would mutate them).
-    if (o instanceof Nodes.Ordering && typeof (o as any).reverse === "function")
-      return [(o as any).reverse()];
-    if (o instanceof Nodes.Attribute) return [o.desc()];
-    if (o instanceof Nodes.Node && typeof (o as any).desc === "function") {
-      return [(o as any).desc()];
+    // Use reverse() when available (Ascending, Descending, NullsFirst, NullsLast),
+    // fall back to desc() for other Arel nodes (Attribute, NodeExpression, etc.).
+    // Guard instanceof Nodes.Node to avoid matching arrays which also have reverse().
+    if (o instanceof Nodes.Node) {
+      if (typeof (o as any).reverse === "function") return [(o as any).reverse()];
+      if (typeof (o as any).desc === "function") return [(o as any).desc()];
     }
     if (typeof o === "string") {
       if (isDoesNotSupportReverse(o)) {
@@ -1350,7 +1349,12 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbo
 }
 
 function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void {
-  disallowRawSqlBang(flattenedOrderKeysForRawSqlCheck(orderArgs), resolveOrderMatcher(this));
+  // disallowRawSqlBang skips symbols — resolve symbol names to strings first
+  // so their descriptions are validated against the column-name matcher.
+  const keysForCheck = flattenedOrderKeysForRawSqlCheck(orderArgs).map((k) =>
+    typeof k === "symbol" ? symbolToName(k) : k,
+  );
+  disallowRawSqlBang(keysForCheck, resolveOrderMatcher(this));
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
   if (refs.length > 0) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -5,7 +5,7 @@
  * Mirrors: ActiveRecord::QueryMethods
  */
 import { Nodes, SelectManager, Table as ArelTable, sql as arelSql } from "@blazetrails/arel";
-import { ArgumentError, Attribute, ValueType } from "@blazetrails/activemodel";
+import { Attribute, ValueType } from "@blazetrails/activemodel";
 import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1257,10 +1257,12 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
     );
   }
   return orderQuery.flatMap((o) => {
-    if (o !== null && typeof o === "object") {
-      const node = o as any;
-      if (typeof node.desc === "function") return [node.desc()];
-      if (typeof node.reverse === "function") return [node.reverse()];
+    // Match Rails: Arel::Attribute → .desc, Arel::Nodes::Ordering → .reverse,
+    // other Arel nodes → .desc. Skip arrays (Array#reverse would mutate them).
+    if (o instanceof Nodes.Ordering) return [(o as any).reverse()];
+    if (o instanceof Nodes.Attribute) return [o.desc()];
+    if (o instanceof Nodes.Node && typeof (o as any).desc === "function") {
+      return [(o as any).desc()];
     }
     if (typeof o === "string") {
       if (isDoesNotSupportReverse(o)) {
@@ -1314,13 +1316,13 @@ function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknown[]): u
   return orderArgs.map((arg) => (this as any)._modelClass?.sanitizeSqlForOrder?.(arg) ?? arg);
 }
 
-function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
-  const result: string[] = [];
+function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbol)[] {
+  const result: (string | symbol)[] = [];
   for (const arg of orderArgs) {
     if (Array.isArray(arg)) {
       result.push(...flattenedOrderKeysForRawSqlCheck(arg));
     } else if (typeof arg === "string" || typeof arg === "symbol") {
-      result.push(typeof arg === "symbol" ? symbolToName(arg) : arg);
+      result.push(arg);
     } else if (arg instanceof Nodes.Node) {
       // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
     } else if (isPlainObject(arg)) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -4,9 +4,9 @@
  *
  * Mirrors: ActiveRecord::QueryMethods
  */
-import { Nodes, SelectManager, Table, sql as arelSql } from "@blazetrails/arel";
+import { Nodes, SelectManager, sql as arelSql } from "@blazetrails/arel";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { PreparedStatementInvalid } from "../errors.js";
+import { ActiveRecordError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
@@ -1095,12 +1095,14 @@ function asyncBang(this: QueryMethodsHost): QueryMethodsHost {
 }
 
 function async(this: QueryMethodsHost): QueryMethodsHost {
-  return (this as any).spawn().asyncBang();
+  const rel = (this as any).spawn();
+  rel._async = true;
+  return rel;
 }
 
 function assertModifiableBang(this: QueryMethodsHost): void {
   if ((this as any)._loaded || (this as any)._arel) {
-    throw new Error("UnmodifiableRelation");
+    throw new ActiveRecordError("can't modify a loaded relation");
   }
 }
 
@@ -1167,17 +1169,17 @@ function buildNamedBoundSqlLiteral(
   this: QueryMethodsHost,
   statement: string,
   values: Record<string, unknown>,
-): Nodes.Node {
-  const boundValues: Record<string, unknown> = {};
+): Nodes.BoundSqlLiteral {
+  const namedBinds: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(values)) {
     if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
-      boundValues[key] = arelSql((value as any).toSql());
+      namedBinds[key] = arelSql((value as any).toSql());
     } else {
-      boundValues[key] = value;
+      namedBinds[key] = value;
     }
   }
   try {
-    return new (Nodes as any).BoundSqlLiteral(`(${statement})`, null, boundValues);
+    return new Nodes.BoundSqlLiteral(`(${statement})`, [], namedBinds);
   } catch (e: any) {
     throw new PreparedStatementInvalid(e?.message ?? String(e));
   }
@@ -1187,15 +1189,15 @@ function buildBoundSqlLiteral(
   this: QueryMethodsHost,
   statement: string,
   values: unknown[],
-): Nodes.Node {
-  const boundValues = values.map((value) => {
+): Nodes.BoundSqlLiteral {
+  const positionalBinds = values.map((value) => {
     if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
       return arelSql((value as any).toSql());
     }
     return value;
   });
   try {
-    return new (Nodes as any).BoundSqlLiteral(`(${statement})`, boundValues, null);
+    return new Nodes.BoundSqlLiteral(`(${statement})`, positionalBinds, {});
   } catch (e: any) {
     throw new PreparedStatementInvalid(e?.message ?? String(e));
   }
@@ -1206,10 +1208,11 @@ function buildSubquery(
   subqueryAlias: string,
   selectValue: unknown,
 ): SelectManager {
+  // Rails: except(:optimizer_hints).arel.as(alias) → new SelectManager(subquery).project(selectValue)
   const relation = (this as any).except?.("optimizerHints") ?? this;
-  const subquery = (relation as any).toArel?.().as(subqueryAlias);
-  const sm = new SelectManager(new Table(subqueryAlias));
-  if (subquery) sm.from(subquery);
+  const aliasedSubquery = (relation as any).toArel?.().as(subqueryAlias);
+  const sm = new SelectManager();
+  if (aliasedSubquery) (sm as any).from(aliasedSubquery);
   sm.project(selectValue as any);
   const hints: string[] = (this as any)._optimizerHints ?? [];
   if (hints.length > 0) (sm as any).optimizerHints?.(...hints);
@@ -1246,7 +1249,9 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
     }
     if (typeof o === "string") {
       if (isDoesNotSupportReverse(o)) {
-        throw new IrreversibleOrderError(`Order ${JSON.stringify(o)} cannot be reversed automatically`);
+        throw new IrreversibleOrderError(
+          `Order ${JSON.stringify(o)} cannot be reversed automatically`,
+        );
       }
       return o.split(",").map((s) => {
         s = s.trim();
@@ -1273,8 +1278,16 @@ function columnReferences(orderArgs: unknown[]): string[] {
         const t = extractTableNameFrom(String(key));
         if (t) refs.push(t);
       }
-    } else if (arg !== null && typeof arg === "object" && typeof (arg as any).relation === "object") {
-      refs.push((arg as any).relation.name);
+    } else if (arg !== null && typeof arg === "object") {
+      const node = arg as any;
+      // Arel::Attribute → node.relation.name
+      if (typeof node.relation === "object" && node.relation?.name) {
+        refs.push(node.relation.name);
+      } else if (typeof node.expr === "object" && typeof node.expr?.relation === "object") {
+        // Arel::Nodes::Ordering wrapping an Attribute → node.expr.relation.name
+        const rel = node.expr.relation;
+        if (rel?.name) refs.push(rel.name);
+      }
     }
   }
   return refs;
@@ -1290,7 +1303,8 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   if (permit) disallowRawSqlBang(flattenedArgs(orderArgs) as string[], permit);
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
-  if (refs.length > 0) (this as any)._referencesValues = [...((this as any)._referencesValues ?? []), ...refs];
+  if (refs.length > 0)
+    (this as any)._referencesValues = [...((this as any)._referencesValues ?? []), ...refs];
 }
 
 function buildOrder(this: QueryMethodsHost, arel: any): void {
@@ -1324,8 +1338,10 @@ function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]): unknow
     if (attr !== null && typeof attr === "object" && !Array.isArray(attr)) {
       return Object.entries(attr as Record<string, unknown>).flatMap(([table, columns]) => {
         const tableName = String(table);
-        return (Array.isArray(columns) ? columns : [columns]).map((col) =>
-          builder?.resolveArelAttribute?.(tableName, String(col)) ?? arelSql(`${tableName}.${String(col)}`),
+        return (Array.isArray(columns) ? columns : [columns]).map(
+          (col) =>
+            builder?.resolveArelAttribute?.(tableName, String(col)) ??
+            arelSql(`${tableName}.${String(col)}`),
         );
       });
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1117,7 +1117,9 @@ function checkIfMethodHasArgumentsBang(
   const flat = flattenedArgs(args);
   args.length = 0;
   for (const a of flat) {
-    if (a !== null && a !== undefined && a !== "") args.push(a);
+    if (a === null || a === undefined) continue;
+    if (typeof a === "string" && a.trim() === "") continue;
+    args.push(a);
   }
 }
 
@@ -1220,10 +1222,10 @@ function buildSubquery(
   }
   const aliasedSubquery = (relation as any).toArel().as(subqueryAlias);
   const sm = new SelectManager();
-  (sm as any).from(aliasedSubquery);
+  sm.from(aliasedSubquery);
   sm.project(selectValue as any);
   const hints: string[] = (this as any)._optimizerHints ?? [];
-  if (hints.length > 0) (sm as any).optimizerHints?.(...hints);
+  if (hints.length > 0) sm.optimizerHints(...hints);
   return sm;
 }
 
@@ -1334,12 +1336,13 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
     const existing: string[] = (this as any)._referencesValues ?? [];
     (this as any)._referencesValues = [...new Set([...existing, ...refs])];
   }
-  // Rails maps Symbol args to Ascending nodes and Hash args to directional nodes
-  // (Arel::Nodes::SqlLiteral / Arel::Nodes::Node keys get their dir method called directly).
+  // Rails maps Symbol args to Ascending nodes and Hash args to directional nodes.
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
-      mapped.push(new Nodes.Ascending(arelSql(String(arg))));
+      // Use .description to get the symbol name ("id" not "Symbol(id)").
+      const name = arg.description ?? String(arg);
+      mapped.push(new Nodes.Ascending(arelSql(name)));
     } else if (
       arg !== null &&
       typeof arg === "object" &&

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -5,7 +5,11 @@
  * Mirrors: ActiveRecord::QueryMethods
  */
 import { Nodes, SelectManager, Table as ArelTable, sql as arelSql } from "@blazetrails/arel";
-import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  ArgumentError,
+  Attribute,
+  defaultValue as defaultAttributeType,
+} from "@blazetrails/activemodel";
 import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
@@ -1170,12 +1174,8 @@ function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string
   });
 }
 
-function buildCastValue(
-  name: string,
-  value: unknown,
-): { name: string; value: unknown; valueForDatabase(): unknown } {
-  if (!name) throw new ArgumentError("attribute name must be provided");
-  return { name, value, valueForDatabase: () => value };
+function buildCastValue(name: string, value: unknown): Attribute {
+  return Attribute.withCastValue(name, value, defaultAttributeType());
 }
 
 function buildNamedBoundSqlLiteral(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1210,10 +1210,14 @@ function buildSubquery(
   selectValue: unknown,
 ): SelectManager {
   // Rails: except(:optimizer_hints).arel.as(alias) — use unscope (our except is SQL EXCEPT, not query-part removal)
-  const relation = (this as any).unscope?.("optimizerHints") ?? this;
-  const aliasedSubquery = (relation as any).toArel?.().as(subqueryAlias);
+  const relation =
+    typeof (this as any).unscope === "function" ? (this as any).unscope("optimizerHints") : this;
+  if (typeof (relation as any).toArel !== "function") {
+    throw new ActiveRecordError("Cannot build subquery: relation does not support toArel()");
+  }
+  const aliasedSubquery = (relation as any).toArel().as(subqueryAlias);
   const sm = new SelectManager();
-  if (aliasedSubquery) (sm as any).from(aliasedSubquery);
+  (sm as any).from(aliasedSubquery);
   sm.project(selectValue as any);
   const hints: string[] = (this as any)._optimizerHints ?? [];
   if (hints.length > 0) (sm as any).optimizerHints?.(...hints);
@@ -1302,9 +1306,20 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
       result.push(...flattenedOrderKeysForRawSqlCheck(arg));
     } else if (typeof arg === "string" || typeof arg === "symbol") {
       result.push(String(arg));
-    } else if (arg !== null && typeof arg === "object" && !(arg instanceof Nodes.SqlLiteral)) {
-      for (const key of Object.keys(arg as Record<string, unknown>)) {
+    } else if (arg instanceof Nodes.Node) {
+      // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
+    } else if (arg !== null && typeof arg === "object") {
+      for (const [key, value] of Object.entries(arg as Record<string, unknown>)) {
         result.push(key);
+        // Recurse into nested hash values so { table: { col: "asc" } } is fully validated.
+        if (
+          value !== null &&
+          typeof value === "object" &&
+          !Array.isArray(value) &&
+          !(value instanceof Nodes.Node)
+        ) {
+          result.push(...flattenedOrderKeysForRawSqlCheck([value]));
+        }
       }
     }
   }
@@ -1315,8 +1330,36 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   disallowRawSqlBang(flattenedOrderKeysForRawSqlCheck(orderArgs), resolveOrderMatcher(this));
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
-  if (refs.length > 0)
-    (this as any)._referencesValues = [...((this as any)._referencesValues ?? []), ...refs];
+  if (refs.length > 0) {
+    const existing: string[] = (this as any)._referencesValues ?? [];
+    (this as any)._referencesValues = [...new Set([...existing, ...refs])];
+  }
+  // Rails maps Symbol args to Ascending nodes and Hash args to directional nodes
+  // (Arel::Nodes::SqlLiteral / Arel::Nodes::Node keys get their dir method called directly).
+  const mapped: unknown[] = [];
+  for (const arg of orderArgs) {
+    if (typeof arg === "symbol") {
+      mapped.push(new Nodes.Ascending(arelSql(String(arg))));
+    } else if (
+      arg !== null &&
+      typeof arg === "object" &&
+      !Array.isArray(arg) &&
+      !(arg instanceof Nodes.Node)
+    ) {
+      for (const [key, dir] of Object.entries(arg as Record<string, unknown>)) {
+        const expr: Nodes.Node = key instanceof Nodes.Node ? key : arelSql(key);
+        mapped.push(
+          String(dir).toLowerCase() === "desc"
+            ? new Nodes.Descending(expr)
+            : new Nodes.Ascending(expr),
+        );
+      }
+    } else {
+      mapped.push(arg);
+    }
+  }
+  orderArgs.length = 0;
+  orderArgs.push(...mapped);
 }
 
 function buildOrderNode(clause: unknown): unknown {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1365,8 +1365,10 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
+      // Resolve against the current relation's table, not a table named after the column.
       const name = symbolToName(arg);
-      const attr = this.predicateBuilder?.resolveArelAttribute?.(name, name) ?? arelSql(name);
+      const modelTable = (this as any)._modelClass?.arelTable;
+      const attr = modelTable ? modelTable.get(name) : arelSql(name);
       mapped.push(new Nodes.Ascending(attr));
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
@@ -1381,9 +1383,9 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
             );
           }
         } else {
-          // Flat hash: { col: dir } — resolve via predicate builder for quoting
-          const attr =
-            this.predicateBuilder?.resolveArelAttribute?.(key, key) ?? new ArelTable(key).get(key);
+          // Flat hash: { col: dir } — resolve against the current table.
+          const modelTable = (this as any)._modelClass?.arelTable;
+          const attr = modelTable ? modelTable.get(key) : arelSql(key);
           mapped.push(
             String(value).toLowerCase() === "desc"
               ? new Nodes.Descending(attr)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1122,28 +1122,26 @@ function checkIfMethodHasArgumentsBang(
 }
 
 function flattenedArgs(args: unknown[]): unknown[] {
-  return args.flatMap((e) =>
-    e !== null && typeof e === "object" && !Array.isArray(e)
-      ? flattenedArgs(Object.entries(e as object).flat())
-      : Array.isArray(e)
-        ? flattenedArgs(e)
-        : e,
-  );
+  return args.flatMap((e) => {
+    if (Array.isArray(e)) return flattenedArgs(e);
+    // Only expand plain objects — leave class instances (Arel nodes, Dates, …) as-is.
+    if (isPlainObject(e)) return flattenedArgs(Object.entries(e).flat());
+    return e;
+  });
 }
 
 const VALID_DIRECTIONS = new Set(["asc", "desc", "ASC", "DESC"]);
 
 function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
   for (const arg of args) {
-    if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
-      for (const [, value] of Object.entries(arg as Record<string, unknown>)) {
-        if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-          validateOrderArgs.call(this, [value]);
-        } else if (!VALID_DIRECTIONS.has(value as string)) {
-          throw new ArgumentError(
-            `Direction "${value}" is invalid. Valid directions are: ${[...VALID_DIRECTIONS].join(", ")}`,
-          );
-        }
+    if (!isPlainObject(arg)) continue;
+    for (const [, value] of Object.entries(arg)) {
+      if (isPlainObject(value)) {
+        validateOrderArgs.call(this, [value]);
+      } else if (!VALID_DIRECTIONS.has(value as string)) {
+        throw new ArgumentError(
+          `Direction "${value}" is invalid. Valid directions are: ${[...VALID_DIRECTIONS].join(", ")}`,
+        );
       }
     }
   }
@@ -1151,10 +1149,10 @@ function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
 
 function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string, unknown>[] {
   return args.flatMap((arg) => {
-    if (arg === null || typeof arg !== "object" || Array.isArray(arg)) {
+    if (!isPlainObject(arg)) {
       throw new ArgumentError(`Unsupported argument type: ${String(arg)} ${typeof arg}`);
     }
-    return Object.entries(arg as Record<string, unknown>).map(([k, v]) => ({ [k]: v }));
+    return Object.entries(arg).map(([k, v]) => ({ [k]: v }));
   });
 }
 
@@ -1182,7 +1180,7 @@ function buildNamedBoundSqlLiteral(
   try {
     return new Nodes.BoundSqlLiteral(`(${statement})`, [], namedBinds);
   } catch (e: any) {
-    throw new PreparedStatementInvalid(e?.message ?? String(e));
+    throw new PreparedStatementInvalid(e?.message ?? String(e), { cause: e });
   }
 }
 
@@ -1200,7 +1198,7 @@ function buildBoundSqlLiteral(
   try {
     return new Nodes.BoundSqlLiteral(`(${statement})`, positionalBinds, {});
   } catch (e: any) {
-    throw new PreparedStatementInvalid(e?.message ?? String(e));
+    throw new PreparedStatementInvalid(e?.message ?? String(e), { cause: e });
   }
 }
 
@@ -1214,6 +1212,11 @@ function buildSubquery(
     typeof (this as any).unscope === "function" ? (this as any).unscope("optimizerHints") : this;
   if (typeof (relation as any).toArel !== "function") {
     throw new ActiveRecordError("Cannot build subquery: relation does not support toArel()");
+  }
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(subqueryAlias)) {
+    throw new ArgumentError(
+      `Invalid subquery alias "${subqueryAlias}": must be a safe SQL identifier`,
+    );
   }
   const aliasedSubquery = (relation as any).toArel().as(subqueryAlias);
   const sm = new SelectManager();
@@ -1239,6 +1242,11 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
   if (orderQuery.length === 0) {
     const pk = (this as any)._modelClass?.primaryKey;
     if (pk) {
+      if (Array.isArray(pk)) {
+        throw new IrreversibleOrderError(
+          "Relation has no current order and table has a composite primary key; cannot determine default reverse order",
+        );
+      }
       const table: any = (this as any)._modelClass?.arelTable;
       return [table ? table.get(pk).desc() : arelSql(`${pk} DESC`)];
     }
@@ -1308,18 +1316,10 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
       result.push(String(arg));
     } else if (arg instanceof Nodes.Node) {
       // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
-    } else if (arg !== null && typeof arg === "object") {
-      for (const [key, value] of Object.entries(arg as Record<string, unknown>)) {
+    } else if (isPlainObject(arg)) {
+      for (const [key, value] of Object.entries(arg)) {
         result.push(key);
-        // Recurse into nested hash values so { table: { col: "asc" } } is fully validated.
-        if (
-          value !== null &&
-          typeof value === "object" &&
-          !Array.isArray(value) &&
-          !(value instanceof Nodes.Node)
-        ) {
-          result.push(...flattenedOrderKeysForRawSqlCheck([value]));
-        }
+        if (isPlainObject(value)) result.push(...flattenedOrderKeysForRawSqlCheck([value]));
       }
     }
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -4,7 +4,9 @@
  *
  * Mirrors: ActiveRecord::QueryMethods
  */
-import { Nodes } from "@blazetrails/arel";
+import { Nodes, SelectManager, Table, sql as arelSql } from "@blazetrails/arel";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { IrreversibleOrderError } from "../errors.js";
@@ -1080,6 +1082,260 @@ function constructJoinDependency(
     }
   }
   return jd;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers — mirrors ActiveRecord::QueryMethods private block.
+// Non-exported so the extractor marks them internal: true.
+// ---------------------------------------------------------------------------
+
+function asyncBang(this: QueryMethodsHost): QueryMethodsHost {
+  (this as any)._async = true;
+  return this;
+}
+
+function async(this: QueryMethodsHost): QueryMethodsHost {
+  return (this as any).spawn().asyncBang();
+}
+
+function assertModifiableBang(this: QueryMethodsHost): void {
+  if ((this as any)._loaded || (this as any)._arel) {
+    throw new Error("UnmodifiableRelation");
+  }
+}
+
+function checkIfMethodHasArgumentsBang(
+  this: QueryMethodsHost,
+  methodName: string,
+  args: unknown[],
+  message?: string,
+): void {
+  if (!args || args.length === 0) {
+    throw new ArgumentError(message ?? `The method .${methodName}() must contain arguments.`);
+  }
+  const flat = flattenedArgs(args);
+  args.length = 0;
+  for (const a of flat) {
+    if (a !== null && a !== undefined && a !== "") args.push(a);
+  }
+}
+
+function flattenedArgs(args: unknown[]): unknown[] {
+  return args.flatMap((e) =>
+    e !== null && typeof e === "object" && !Array.isArray(e)
+      ? flattenedArgs(Object.entries(e as object).flat())
+      : Array.isArray(e)
+        ? flattenedArgs(e)
+        : e,
+  );
+}
+
+const VALID_DIRECTIONS = new Set(["asc", "desc", "ASC", "DESC"]);
+
+function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
+  for (const arg of args) {
+    if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
+      for (const [, value] of Object.entries(arg as Record<string, unknown>)) {
+        if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+          validateOrderArgs.call(this, [value]);
+        } else if (!VALID_DIRECTIONS.has(value as string)) {
+          throw new ArgumentError(
+            `Direction "${value}" is invalid. Valid directions are: ${[...VALID_DIRECTIONS].join(", ")}`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string, unknown>[] {
+  return args.flatMap((arg) => {
+    if (arg === null || typeof arg !== "object" || Array.isArray(arg)) {
+      throw new ArgumentError(`Unsupported argument type: ${String(arg)} ${typeof arg}`);
+    }
+    return Object.entries(arg as Record<string, unknown>).map(([k, v]) => ({ [k]: v }));
+  });
+}
+
+function buildCastValue(name: string, value: unknown): unknown {
+  // Wraps a bound SQL parameter in an ActiveModel::Attribute-like shape.
+  // The adapter reads .value_for_database from the result.
+  return { name, value, valueForDatabase: () => value };
+}
+
+function buildNamedBoundSqlLiteral(
+  this: QueryMethodsHost,
+  statement: string,
+  values: Record<string, unknown>,
+): Nodes.Node {
+  const boundValues: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
+      boundValues[key] = arelSql((value as any).toSql());
+    } else {
+      boundValues[key] = value;
+    }
+  }
+  try {
+    return new (Nodes as any).BoundSqlLiteral(`(${statement})`, null, boundValues);
+  } catch (e: any) {
+    throw new PreparedStatementInvalid(e?.message ?? String(e));
+  }
+}
+
+function buildBoundSqlLiteral(
+  this: QueryMethodsHost,
+  statement: string,
+  values: unknown[],
+): Nodes.Node {
+  const boundValues = values.map((value) => {
+    if (value !== null && typeof value === "object" && typeof (value as any).toSql === "function") {
+      return arelSql((value as any).toSql());
+    }
+    return value;
+  });
+  try {
+    return new (Nodes as any).BoundSqlLiteral(`(${statement})`, boundValues, null);
+  } catch (e: any) {
+    throw new PreparedStatementInvalid(e?.message ?? String(e));
+  }
+}
+
+function buildSubquery(
+  this: QueryMethodsHost,
+  subqueryAlias: string,
+  selectValue: unknown,
+): SelectManager {
+  const relation = (this as any).except?.("optimizerHints") ?? this;
+  const subquery = (relation as any).toArel?.().as(subqueryAlias);
+  const sm = new SelectManager(new Table(subqueryAlias));
+  if (subquery) sm.from(subquery);
+  sm.project(selectValue as any);
+  const hints: string[] = (this as any)._optimizerHints ?? [];
+  if (hints.length > 0) (sm as any).optimizerHints?.(...hints);
+  return sm;
+}
+
+function isDoesNotSupportReverse(order: string): boolean {
+  const plain = String(order);
+  if (
+    plain.includes(",") &&
+    plain.split(",").some((s) => s.split("(").length !== s.split(")").length)
+  ) {
+    return true;
+  }
+  return /\bnulls\s+(?:first|last)\b/i.test(plain);
+}
+
+function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown[] {
+  if (orderQuery.length === 0) {
+    const pk = (this as any)._modelClass?.primaryKey;
+    if (pk) {
+      const table: any = (this as any)._modelClass?.arelTable;
+      return [table ? table.get(pk).desc() : arelSql(`${pk} DESC`)];
+    }
+    throw new IrreversibleOrderError(
+      "Relation has no current order and table has no primary key to be used as default order",
+    );
+  }
+  return orderQuery.flatMap((o) => {
+    if (o !== null && typeof o === "object") {
+      const node = o as any;
+      if (typeof node.desc === "function") return [node.desc()];
+      if (typeof node.reverse === "function") return [node.reverse()];
+    }
+    if (typeof o === "string") {
+      if (isDoesNotSupportReverse(o)) {
+        throw new IrreversibleOrderError(`Order ${JSON.stringify(o)} cannot be reversed automatically`);
+      }
+      return o.split(",").map((s) => {
+        s = s.trim();
+        return s.replace(/\sasc$/i, " DESC").replace(/\sdesc$/i, " ASC") || s + " DESC";
+      });
+    }
+    return [o];
+  });
+}
+
+function extractTableNameFrom(string: string): string | null {
+  const match = string.match(/^\W?(\w+)\W?\./);
+  return match ? match[1] : null;
+}
+
+function columnReferences(orderArgs: unknown[]): string[] {
+  const refs: string[] = [];
+  for (const arg of orderArgs) {
+    if (typeof arg === "string" || typeof arg === "symbol") {
+      const t = extractTableNameFrom(String(arg));
+      if (t) refs.push(t);
+    } else if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
+      for (const [key] of Object.entries(arg as Record<string, unknown>)) {
+        const t = extractTableNameFrom(String(key));
+        if (t) refs.push(t);
+      }
+    } else if (arg !== null && typeof arg === "object" && typeof (arg as any).relation === "object") {
+      refs.push((arg as any).relation.name);
+    }
+  }
+  return refs;
+}
+
+function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknown[]): unknown[] {
+  return orderArgs.map((arg) => (this as any)._modelClass?.sanitizeSqlForOrder?.(arg) ?? arg);
+}
+
+function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void {
+  const model = (this as any)._modelClass;
+  const permit = model?.adapterClass?.columnNameWithOrderMatcher?.();
+  if (permit) disallowRawSqlBang(flattenedArgs(orderArgs) as string[], permit);
+  validateOrderArgs.call(this, orderArgs);
+  const refs = columnReferences(orderArgs);
+  if (refs.length > 0) (this as any)._referencesValues = [...((this as any)._referencesValues ?? []), ...refs];
+}
+
+function buildOrder(this: QueryMethodsHost, arel: any): void {
+  const orders: unknown[] = ((this as any)._orderClauses ?? []).filter(
+    (o: unknown) => o !== null && o !== undefined && o !== "",
+  );
+  if (orders.length > 0) arel.order?.(...orders);
+}
+
+function buildCaseForValuePosition(
+  this: QueryMethodsHost,
+  column: unknown,
+  values: unknown[],
+  options: { filter?: boolean } = {},
+): unknown {
+  const filter = options.filter !== false;
+  const node: any = new (Nodes as any).Case();
+  values.forEach((value, i) => {
+    node.when((column as any).eq(value)).then(i + 1);
+  });
+  if (!filter) node.else(values.length + 1);
+  return new (Nodes as any).Ascending(node);
+}
+
+function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]): unknown[] {
+  const builder = (this as any).predicateBuilder;
+  return attrs.flatMap((attr) => {
+    if (attr !== null && typeof attr === "object" && typeof (attr as any).eq === "function") {
+      return [attr];
+    }
+    if (attr !== null && typeof attr === "object" && !Array.isArray(attr)) {
+      return Object.entries(attr as Record<string, unknown>).flatMap(([table, columns]) => {
+        const tableName = String(table);
+        return (Array.isArray(columns) ? columns : [columns]).map((col) =>
+          builder?.resolveArelAttribute?.(tableName, String(col)) ?? arelSql(`${tableName}.${String(col)}`),
+        );
+      });
+    }
+    const s = String(attr);
+    if (s.includes(".")) {
+      const [table, col] = s.split(".", 2);
+      return [builder?.resolveArelAttribute?.(table, col) ?? arelSql(s)];
+    }
+    return [s];
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -5,11 +5,7 @@
  * Mirrors: ActiveRecord::QueryMethods
  */
 import { Nodes, SelectManager, Table as ArelTable, sql as arelSql } from "@blazetrails/arel";
-import {
-  ArgumentError,
-  Attribute,
-  defaultValue as defaultAttributeType,
-} from "@blazetrails/activemodel";
+import { ArgumentError, Attribute, ValueType } from "@blazetrails/activemodel";
 import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
@@ -1175,7 +1171,7 @@ function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string
 }
 
 function buildCastValue(name: string, value: unknown): Attribute {
-  return Attribute.withCastValue(name, value, defaultAttributeType());
+  return Attribute.withCastValue(name, value, new ValueType());
 }
 
 function buildNamedBoundSqlLiteral(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1301,8 +1301,8 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
     if (Array.isArray(arg)) {
       result.push(...flattenedOrderKeysForRawSqlCheck(arg));
     } else if (typeof arg === "string" || typeof arg === "symbol") {
-      if (!(arg instanceof Nodes.SqlLiteral)) result.push(String(arg));
-    } else if (arg !== null && typeof arg === "object") {
+      result.push(String(arg));
+    } else if (arg !== null && typeof arg === "object" && !(arg instanceof Nodes.SqlLiteral)) {
       for (const key of Object.keys(arg as Record<string, unknown>)) {
         result.push(key);
       }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -6,10 +6,9 @@
  */
 import { Nodes, SelectManager, sql as arelSql } from "@blazetrails/arel";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { ActiveRecordError, PreparedStatementInvalid } from "../errors.js";
+import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
-import { IrreversibleOrderError } from "../errors.js";
 import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
 import {
   quote,
@@ -1159,9 +1158,11 @@ function processWithArgs(this: QueryMethodsHost, args: unknown[]): Record<string
   });
 }
 
-function buildCastValue(name: string, value: unknown): unknown {
-  // Wraps a bound SQL parameter in an ActiveModel::Attribute-like shape.
-  // The adapter reads .value_for_database from the result.
+function buildCastValue(
+  name: string,
+  value: unknown,
+): { name: string; value: unknown; valueForDatabase(): unknown } {
+  if (!name) throw new ArgumentError("attribute name must be provided");
   return { name, value, valueForDatabase: () => value };
 }
 
@@ -1255,7 +1256,9 @@ function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown
       }
       return o.split(",").map((s) => {
         s = s.trim();
-        return s.replace(/\sasc$/i, " DESC").replace(/\sdesc$/i, " ASC") || s + " DESC";
+        if (/\sasc$/i.test(s)) return s.replace(/\sasc$/i, " DESC");
+        if (/\sdesc$/i.test(s)) return s.replace(/\sdesc$/i, " ASC");
+        return `${s} DESC`;
       });
     }
     return [o];
@@ -1273,20 +1276,15 @@ function columnReferences(orderArgs: unknown[]): string[] {
     if (typeof arg === "string" || typeof arg === "symbol") {
       const t = extractTableNameFrom(String(arg));
       if (t) refs.push(t);
+    } else if (arg instanceof Nodes.Attribute) {
+      refs.push((arg as any).relation.name);
+    } else if (arg instanceof Nodes.Ordering) {
+      const expr = (arg as any).expr;
+      if (expr instanceof Nodes.Attribute) refs.push(expr.relation.name);
     } else if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
       for (const [key] of Object.entries(arg as Record<string, unknown>)) {
         const t = extractTableNameFrom(String(key));
         if (t) refs.push(t);
-      }
-    } else if (arg !== null && typeof arg === "object") {
-      const node = arg as any;
-      // Arel::Attribute → node.relation.name
-      if (typeof node.relation === "object" && node.relation?.name) {
-        refs.push(node.relation.name);
-      } else if (typeof node.expr === "object" && typeof node.expr?.relation === "object") {
-        // Arel::Nodes::Ordering wrapping an Attribute → node.expr.relation.name
-        const rel = node.expr.relation;
-        if (rel?.name) refs.push(rel.name);
       }
     }
   }
@@ -1297,20 +1295,49 @@ function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknown[]): u
   return orderArgs.map((arg) => (this as any)._modelClass?.sanitizeSqlForOrder?.(arg) ?? arg);
 }
 
+function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
+  const result: string[] = [];
+  for (const arg of orderArgs) {
+    if (Array.isArray(arg)) {
+      result.push(...flattenedOrderKeysForRawSqlCheck(arg));
+    } else if (typeof arg === "string" || typeof arg === "symbol") {
+      if (!(arg instanceof Nodes.SqlLiteral)) result.push(String(arg));
+    } else if (arg !== null && typeof arg === "object") {
+      for (const key of Object.keys(arg as Record<string, unknown>)) {
+        result.push(key);
+      }
+    }
+  }
+  return result;
+}
+
 function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void {
   const model = (this as any)._modelClass;
   const permit = model?.adapterClass?.columnNameWithOrderMatcher?.();
-  if (permit) disallowRawSqlBang(flattenedArgs(orderArgs) as string[], permit);
+  if (permit) disallowRawSqlBang(flattenedOrderKeysForRawSqlCheck(orderArgs), permit);
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
   if (refs.length > 0)
     (this as any)._referencesValues = [...((this as any)._referencesValues ?? []), ...refs];
 }
 
+function buildOrderNode(clause: unknown): unknown {
+  if (clause instanceof Nodes.Node) return clause;
+  if (typeof clause === "string") return new Nodes.SqlLiteral(clause);
+  if (Array.isArray(clause) && clause.length === 2) {
+    const [col, dir] = clause;
+    const expr = col instanceof Nodes.Node ? col : new Nodes.SqlLiteral(String(col));
+    return String(dir).toLowerCase() === "desc"
+      ? new Nodes.Descending(expr)
+      : new Nodes.Ascending(expr);
+  }
+  return new Nodes.SqlLiteral(String(clause));
+}
+
 function buildOrder(this: QueryMethodsHost, arel: any): void {
-  const orders: unknown[] = ((this as any)._orderClauses ?? []).filter(
-    (o: unknown) => o !== null && o !== undefined && o !== "",
-  );
+  const orders = ((this as any)._orderClauses ?? [])
+    .filter((o: unknown) => o !== null && o !== undefined && o !== "")
+    .map(buildOrderNode);
   if (orders.length > 0) arel.order?.(...orders);
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1284,11 +1284,16 @@ function extractTableNameFrom(orderTerm: string): string | null {
   return match ? match[1] : null;
 }
 
+function symbolToName(s: symbol): string {
+  return Symbol.keyFor(s) ?? s.description ?? "";
+}
+
 function columnReferences(orderArgs: unknown[]): string[] {
   const refs: string[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "string" || typeof arg === "symbol") {
-      const t = extractTableNameFrom(String(arg));
+      const term = typeof arg === "symbol" ? symbolToName(arg) : arg;
+      const t = extractTableNameFrom(term);
       if (t) refs.push(t);
     } else if (arg instanceof Nodes.Attribute) {
       refs.push((arg as any).relation.name);
@@ -1315,7 +1320,7 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
     if (Array.isArray(arg)) {
       result.push(...flattenedOrderKeysForRawSqlCheck(arg));
     } else if (typeof arg === "string" || typeof arg === "symbol") {
-      result.push(String(arg));
+      result.push(typeof arg === "symbol" ? symbolToName(arg) : arg);
     } else if (arg instanceof Nodes.Node) {
       // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
     } else if (isPlainObject(arg)) {
@@ -1340,9 +1345,7 @@ function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]): void
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
-      // Use .description to get the symbol name ("id" not "Symbol(id)").
-      const name = arg.description ?? String(arg);
-      mapped.push(new Nodes.Ascending(arelSql(name)));
+      mapped.push(new Nodes.Ascending(arelSql(symbolToName(arg))));
     } else if (
       arg !== null &&
       typeof arg === "object" &&

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1105,6 +1105,14 @@ function assertModifiableBang(this: QueryMethodsHost): void {
   }
 }
 
+function isBlankArgument(value: unknown): boolean {
+  if (value === null || value === undefined || value === false) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (Array.isArray(value)) return value.length === 0;
+  if (isPlainObject(value)) return Object.keys(value).length === 0;
+  return false;
+}
+
 function checkIfMethodHasArgumentsBang(
   this: QueryMethodsHost,
   methodName: string,
@@ -1117,9 +1125,7 @@ function checkIfMethodHasArgumentsBang(
   const flat = flattenedArgs(args);
   args.length = 0;
   for (const a of flat) {
-    if (a === null || a === undefined) continue;
-    if (typeof a === "string" && a.trim() === "") continue;
-    args.push(a);
+    if (!isBlankArgument(a)) args.push(a);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds 20 file-local non-exported functions in \`relation/query-methods.ts\` mirroring the first half of the Rails \`ActiveRecord::QueryMethods\` private block. Advances \`relation/query_methods.rb\` from **2% → 47%** (1/45 → 21/45). Overall private parity: **11.6% → 13%** (166 → 186 / 1429).

**State / modifiability:**
\`asyncBang\` (sets \`_async = true\`), \`async\` (spawn + set flag), \`assertModifiableBang\` (raises \`ActiveRecordError\` if loaded)

**Argument validation:**
\`checkIfMethodHasArgumentsBang\`, \`flattenedArgs\`, \`validateOrderArgs\`, \`processWithArgs\`

**SQL literal construction:**
\`buildCastValue\` (attribute-like wrapper for bound SQL params), \`buildNamedBoundSqlLiteral\` (\`BoundSqlLiteral\` with named \`:placeholder\` binds), \`buildBoundSqlLiteral\` (\`BoundSqlLiteral\` with positional \`?\` binds), \`buildSubquery\` (builds subquery \`SelectManager\` via \`toArel().as(alias)\`)

**Order helpers:**
\`isDoesNotSupportReverse\` (multi-arg functions / NULLS FIRST|LAST), \`reverseSqlOrder\` (flip ASC/DESC on each term), \`extractTableNameFrom\` (regex-extract from \`table.column\`), \`columnReferences\` (table names from order args, including Arel::Attribute and Arel::Nodes::Ordering), \`sanitizeOrderArguments\`, \`preprocessOrderArgs\` (disallow raw SQL, validate, collect references), \`buildOrder\` (apply compact orders to Arel manager), \`buildCaseForValuePosition\` (CASE node for \`in_order_of\`)

**Attribute resolution:**
\`resolveArelAttributes\` (Arel::Predications, Hash, String with dot notation)

PR 2/2 adds the remaining 24: \`buildWhereClause\`, \`buildArel\`, \`buildJoins\`, \`buildSelect\`, \`buildFrom\`, \`buildWith*\`, \`arelColumn*\`, \`orderColumn\`, join dependency helpers, and \`scopeAssociationReflection\`.

## Test plan
- [x] \`pnpm api:compare --package activerecord --privates-only\` → \`relation/query_methods.rb  21/45  47%\`
- [x] Build + typecheck clean
- [x] Prettier passes