### PR TITLE
test(parity): AR fixtures ar-109..ar-113

### DIFF
--- a/scripts/parity/fixtures/ar-109/models.rb
+++ b/scripts/parity/fixtures/ar-109/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-109/models.ts
+++ b/scripts/parity/fixtures/ar-109/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-109/query.rb
+++ b/scripts/parity/fixtures/ar-109/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:status].not_in(["draft", "archived"]))

--- a/scripts/parity/fixtures/ar-109/query.ts
+++ b/scripts/parity/fixtures/ar-109/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("status").notIn(["draft", "archived"]));

--- a/scripts/parity/fixtures/ar-109/schema.sql
+++ b/scripts/parity/fixtures/ar-109/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-109
+-- Query: Book.where(Book.arel_table[:status].not_in(["draft", "archived"]))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-110/models.rb
+++ b/scripts/parity/fixtures/ar-110/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-110/models.ts
+++ b/scripts/parity/fixtures/ar-110/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-110/query.rb
+++ b/scripts/parity/fixtures/ar-110/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:reviews).where(reviews: { rating: 5 }).select("books.*, reviews.rating")

--- a/scripts/parity/fixtures/ar-110/query.ts
+++ b/scripts/parity/fixtures/ar-110/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.joins("reviews")
+  .where({ reviews: { rating: 5 } })
+  .select("books.*, reviews.rating");

--- a/scripts/parity/fixtures/ar-110/schema.sql
+++ b/scripts/parity/fixtures/ar-110/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-110
+-- Query: Book.joins(:reviews).where(reviews: { rating: 5 }).select("books.*, reviews.rating")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER,
+  rating INTEGER
+);

--- a/scripts/parity/fixtures/ar-111/models.rb
+++ b/scripts/parity/fixtures/ar-111/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-111/models.ts
+++ b/scripts/parity/fixtures/ar-111/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-111/query.rb
+++ b/scripts/parity/fixtures/ar-111/query.rb
@@ -1,0 +1,1 @@
+Book.select(:author_id).distinct.order(author_id: :asc)

--- a/scripts/parity/fixtures/ar-111/query.ts
+++ b/scripts/parity/fixtures/ar-111/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.select("author_id").distinct().order({ author_id: "asc" });

--- a/scripts/parity/fixtures/ar-111/schema.sql
+++ b/scripts/parity/fixtures/ar-111/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-111
+-- Query: Book.select(:author_id).distinct.order(author_id: :asc)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);

--- a/scripts/parity/fixtures/ar-112/models.rb
+++ b/scripts/parity/fixtures/ar-112/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-112/models.ts
+++ b/scripts/parity/fixtures/ar-112/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-112/query.rb
+++ b/scripts/parity/fixtures/ar-112/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:title].matches_any(["%rails%", "%ruby%"]))

--- a/scripts/parity/fixtures/ar-112/query.ts
+++ b/scripts/parity/fixtures/ar-112/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("title").matchesAny(["%rails%", "%ruby%"]));

--- a/scripts/parity/fixtures/ar-112/schema.sql
+++ b/scripts/parity/fixtures/ar-112/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-112
+-- Query: Book.where(Book.arel_table[:title].matches_any(["%rails%", "%ruby%"]))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-113/models.rb
+++ b/scripts/parity/fixtures/ar-113/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-113/models.ts
+++ b/scripts/parity/fixtures/ar-113/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-113/query.rb
+++ b/scripts/parity/fixtures/ar-113/query.rb
@@ -1,1 +1,1 @@
-Book.where(active: true).order(:title).except(:order)
+Book.where(active: true).order(:title).unscope(:order)

--- a/scripts/parity/fixtures/ar-113/query.rb
+++ b/scripts/parity/fixtures/ar-113/query.rb
@@ -1,0 +1,1 @@
+Book.where(active: true).order(:title).except(:order)

--- a/scripts/parity/fixtures/ar-113/query.ts
+++ b/scripts/parity/fixtures/ar-113/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ active: true }).order({ title: "asc" }).unscope("order");

--- a/scripts/parity/fixtures/ar-113/schema.sql
+++ b/scripts/parity/fixtures/ar-113/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-113
+-- Query: Book.where(active: true).order(:title).except(:order)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-113/schema.sql
+++ b/scripts/parity/fixtures/ar-113/schema.sql
@@ -1,5 +1,5 @@
 -- Fixture for statement: ar-113
--- Query: Book.where(active: true).order(:title).except(:order)
+-- Query: Book.where(active: true).order(:title).unscope(:order)
 
 CREATE TABLE books (
   id INTEGER PRIMARY KEY,


### PR DESCRIPTION
Add 5 new parity query fixtures:

- ar-109: where with Arel not_in
- ar-110: joins with where and select on joined table
- ar-111: select with distinct and order
- ar-112: where with Arel matches_any (multiple LIKE with OR)
- ar-113: unscope to remove query clause

All 5 fixtures pass parity checks.