### PR TITLE
fix(activerecord): bare subquery alias in from() (ar-99)

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -548,6 +548,18 @@ describe("RelationTest", () => {
     expect(sql).not.toContain(') "books"');
   });
 
+  it("from(rawSql, alias) emits bare alias for valid identifiers", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.from("(SELECT * FROM books WHERE active = 1) books", "books").toSql();
+    expect(sql).toMatch(/\) books/);
+    expect(sql).not.toContain(') "books"');
+  });
+
   it("relation with annotation includes comment in to sql", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -534,6 +534,20 @@ describe("RelationTest", () => {
     expect(sql).toContain("FROM");
   });
 
+  it("from(relation, alias) emits bare alias (mirrors Rails SqlLiteral unquoted path)", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    const sql = Book.from(Book.where({ active: true }), "books").toSql();
+    // Rails: FROM (SELECT "books".* FROM "books" WHERE ...) books  ← bare alias
+    expect(sql).toMatch(/FROM \(SELECT .+\) books/);
+    expect(sql).not.toContain(') "books"');
+  });
+
   it("relation with annotation includes comment in to sql", () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -102,6 +102,16 @@ function _buildOnString(...predicates: Nodes.Node[]): string {
   return new Visitors.ToSql().compile(node);
 }
 
+/**
+ * Return the alias bare if it is a valid SQL identifier (letters/digits/underscore,
+ * starting with a letter or underscore), otherwise double-quote and escape it.
+ * Mirrors Rails: aliases come from Symbol/string caller code — Rails assumes they
+ * are safe identifiers. We add a guard so malformed aliases don't produce invalid SQL.
+ */
+function _safeAlias(alias: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(alias) ? alias : `"${alias.replace(/"/g, '""')}"`;
+}
+
 function validateExplainOptions(options: ExplainOption[]): void {
   let seenHash = false;
   for (let i = 0; i < options.length; i++) {
@@ -3162,9 +3172,11 @@ export class Relation<T extends Base> {
         const subSql = raw.toSql();
         const name = alias ?? "subquery";
         // Rails wraps the alias in SqlLiteral so quote_table_name leaves it bare.
-        fromExpr = `(${subSql}) ${name}`;
+        // Only emit bare when the alias is a safe identifier; fall back to quoted
+        // for names that would produce invalid SQL or risk injection.
+        fromExpr = `(${subSql}) ${_safeAlias(name)}`;
       } else if (alias) {
-        fromExpr = `${raw} ${alias}`;
+        fromExpr = `${raw} ${_safeAlias(alias)}`;
       } else {
         fromExpr = raw;
       }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3161,9 +3161,10 @@ export class Relation<T extends Base> {
       if (raw instanceof Relation) {
         const subSql = raw.toSql();
         const name = alias ?? "subquery";
-        fromExpr = `(${subSql}) "${name.replace(/"/g, '""')}"`;
+        // Rails wraps the alias in SqlLiteral so quote_table_name leaves it bare.
+        fromExpr = `(${subSql}) ${name}`;
       } else if (alias) {
-        fromExpr = `${raw} "${alias.replace(/"/g, '""')}"`;
+        fromExpr = `${raw} ${alias}`;
       } else {
         fromExpr = raw;
       }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -18,9 +18,5 @@
   "ar-57": {
     "side": "diff",
     "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 \u2014 eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
-  "ar-99": {
-    "side": "diff",
-    "reason": "from() with subquery alias: Rails does not quote the subquery alias ('books'); trails always quotes table aliases. Rails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) books'; trails: 'SELECT \"books\".* FROM (SELECT \"books\".* FROM \"books\" WHERE \"books\".\"active\" = 1) \"books\"'. Root cause: Arel's alias quoting is unconditional; Rails' parser handles bare aliases specially in FROM clauses."
   }
 }


### PR DESCRIPTION
## Summary

`Book.from(Book.where({active: true}), "books")` now emits `FROM (SELECT ...) books` (bare alias) matching Rails, instead of `FROM (SELECT ...) "books"` (quoted).

**Root cause**: Rails wraps the alias in `SqlLiteral` before passing to `quote_table_name`, which returns `SqlLiteral` unchanged — bare, unquoted. Our implementation always double-quoted the alias with `"name"`.

**Fix**: Remove the double-quoting from both the Relation subquery case and the raw-string-with-alias case in `_applyFromToManager`.

## Test plan

- [x] Parity: ar-99 passes; 5 gaps remain (ar-01/52/65 datetime, ar-16/57 eagerLoad)
- [x] Existing relation tests pass