### PR TITLE
test(parity): AR query fixtures ar-114..ar-118

### DIFF
--- a/scripts/parity/fixtures/ar-114/models.rb
+++ b/scripts/parity/fixtures/ar-114/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-114/models.ts
+++ b/scripts/parity/fixtures/ar-114/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-114/query.rb
+++ b/scripts/parity/fixtures/ar-114/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:title].does_not_match_any(["%draft%", "%archived%"]))

--- a/scripts/parity/fixtures/ar-114/query.ts
+++ b/scripts/parity/fixtures/ar-114/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("title").doesNotMatchAny(["%draft%", "%archived%"]));

--- a/scripts/parity/fixtures/ar-114/schema.sql
+++ b/scripts/parity/fixtures/ar-114/schema.sql
@@ -1,0 +1,7 @@
+-- Fixture for statement: ar-114
+-- Query: Book.where(Book.arel_table[:title].does_not_match_any(["%draft%", "%archived%"]))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/scripts/parity/fixtures/ar-115/models.rb
+++ b/scripts/parity/fixtures/ar-115/models.rb
@@ -1,0 +1,7 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-115/models.ts
+++ b/scripts/parity/fixtures/ar-115/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-115/query.rb
+++ b/scripts/parity/fixtures/ar-115/query.rb
@@ -1,0 +1,1 @@
+Author.joins(:books).group("authors.id").having("COUNT(books.id) >= 2")

--- a/scripts/parity/fixtures/ar-115/query.ts
+++ b/scripts/parity/fixtures/ar-115/query.ts
@@ -1,0 +1,3 @@
+import { Author } from "./models.js";
+
+export default Author.joins("books").group("authors.id").having("COUNT(books.id) >= 2");

--- a/scripts/parity/fixtures/ar-115/schema.sql
+++ b/scripts/parity/fixtures/ar-115/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-115
+-- Query: Author.joins(:books).group("authors.id").having("COUNT(books.id) >= 2")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-116/models.rb
+++ b/scripts/parity/fixtures/ar-116/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-116/models.ts
+++ b/scripts/parity/fixtures/ar-116/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-116/query.rb
+++ b/scripts/parity/fixtures/ar-116/query.rb
@@ -1,0 +1,1 @@
+Book.where(pages: 100..300)

--- a/scripts/parity/fixtures/ar-116/query.ts
+++ b/scripts/parity/fixtures/ar-116/query.ts
@@ -1,0 +1,4 @@
+import { Range } from "@blazetrails/activerecord";
+import { Book } from "./models.js";
+
+export default Book.where({ pages: new Range(100, 300) });

--- a/scripts/parity/fixtures/ar-116/schema.sql
+++ b/scripts/parity/fixtures/ar-116/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-116
+-- Query: Book.where(pages: 100..300)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  pages INTEGER
+);

--- a/scripts/parity/fixtures/ar-117/models.rb
+++ b/scripts/parity/fixtures/ar-117/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-117/models.ts
+++ b/scripts/parity/fixtures/ar-117/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-117/query.rb
+++ b/scripts/parity/fixtures/ar-117/query.rb
@@ -1,0 +1,1 @@
+Book.where(status: "draft").rewhere(status: "published")

--- a/scripts/parity/fixtures/ar-117/query.ts
+++ b/scripts/parity/fixtures/ar-117/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ status: "draft" }).rewhere({ status: "published" });

--- a/scripts/parity/fixtures/ar-117/schema.sql
+++ b/scripts/parity/fixtures/ar-117/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-117
+-- Query: Book.where(status: "draft").rewhere(status: "published")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-118/models.rb
+++ b/scripts/parity/fixtures/ar-118/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-118/models.ts
+++ b/scripts/parity/fixtures/ar-118/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-118/query.rb
+++ b/scripts/parity/fixtures/ar-118/query.rb
@@ -1,0 +1,1 @@
+Book.where(status: ["active", "featured", "new"])

--- a/scripts/parity/fixtures/ar-118/query.ts
+++ b/scripts/parity/fixtures/ar-118/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ status: ["active", "featured", "new"] });

--- a/scripts/parity/fixtures/ar-118/schema.sql
+++ b/scripts/parity/fixtures/ar-118/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-118
+-- Query: Book.where(status: ["active", "featured", "new"])
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);


### PR DESCRIPTION
5 new parity fixtures for ActiveRecord query methods:

- **ar-114**: `where` with Arel `doesNotMatchAny` (NOT LIKE OR)
- **ar-115**: `joins` with `group` + `having` on association count
- **ar-116**: `where` with range (BETWEEN inclusive)
- **ar-117**: `rewhere` (replace a where condition)
- **ar-118**: `where` with multiple values on same column (IN shorthand)

All fixtures passing parity checks.