### PR TITLE
test(parity): AR query fixtures ar-119..ar-123 — Arel eq, joins+Arel where, multi-attr select, IS NULL, IS NOT NULL (PR 24)

### DIFF
--- a/scripts/parity/fixtures/ar-119/models.rb
+++ b/scripts/parity/fixtures/ar-119/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-119/models.ts
+++ b/scripts/parity/fixtures/ar-119/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-119/query.rb
+++ b/scripts/parity/fixtures/ar-119/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:status].eq("published"))

--- a/scripts/parity/fixtures/ar-119/query.ts
+++ b/scripts/parity/fixtures/ar-119/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where(Book.arelTable.get("status").eq("published"));

--- a/scripts/parity/fixtures/ar-119/schema.sql
+++ b/scripts/parity/fixtures/ar-119/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-119
+-- Query: Book.where(Book.arel_table[:status].eq("published"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-120/models.rb
+++ b/scripts/parity/fixtures/ar-120/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-120/models.ts
+++ b/scripts/parity/fixtures/ar-120/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-120/query.rb
+++ b/scripts/parity/fixtures/ar-120/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:reviews).where(Review.arel_table[:rating].gteq(4))

--- a/scripts/parity/fixtures/ar-120/query.ts
+++ b/scripts/parity/fixtures/ar-120/query.ts
@@ -1,0 +1,3 @@
+import { Book, Review } from "./models.js";
+
+export default Book.joins("reviews").where(Review.arelTable.get("rating").gteq(4));

--- a/scripts/parity/fixtures/ar-120/schema.sql
+++ b/scripts/parity/fixtures/ar-120/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-120
+-- Query: Book.joins(:reviews).where(Review.arel_table[:rating].gteq(4))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER,
+  rating INTEGER
+);

--- a/scripts/parity/fixtures/ar-121/models.rb
+++ b/scripts/parity/fixtures/ar-121/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-121/models.ts
+++ b/scripts/parity/fixtures/ar-121/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-121/query.rb
+++ b/scripts/parity/fixtures/ar-121/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:id], Book.arel_table[:title], Book.arel_table[:status]).where(active: true)

--- a/scripts/parity/fixtures/ar-121/query.ts
+++ b/scripts/parity/fixtures/ar-121/query.ts
@@ -1,0 +1,7 @@
+import { Book } from "./models.js";
+
+export default Book.select(
+  Book.arelTable.get("id"),
+  Book.arelTable.get("title"),
+  Book.arelTable.get("status"),
+).where({ active: true });

--- a/scripts/parity/fixtures/ar-121/schema.sql
+++ b/scripts/parity/fixtures/ar-121/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-121
+-- Query: Book.select(Book.arel_table[:id], Book.arel_table[:title], Book.arel_table[:status]).where(active: true)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-122/models.rb
+++ b/scripts/parity/fixtures/ar-122/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-122/models.ts
+++ b/scripts/parity/fixtures/ar-122/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-122/query.rb
+++ b/scripts/parity/fixtures/ar-122/query.rb
@@ -1,0 +1,1 @@
+Book.where(author_id: nil)

--- a/scripts/parity/fixtures/ar-122/query.ts
+++ b/scripts/parity/fixtures/ar-122/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ author_id: null });

--- a/scripts/parity/fixtures/ar-122/schema.sql
+++ b/scripts/parity/fixtures/ar-122/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-122
+-- Query: Book.where(author_id: nil)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);

--- a/scripts/parity/fixtures/ar-123/models.rb
+++ b/scripts/parity/fixtures/ar-123/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-123/models.ts
+++ b/scripts/parity/fixtures/ar-123/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-123/query.rb
+++ b/scripts/parity/fixtures/ar-123/query.rb
@@ -1,0 +1,1 @@
+Book.where.not(author_id: nil)

--- a/scripts/parity/fixtures/ar-123/query.ts
+++ b/scripts/parity/fixtures/ar-123/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.whereNot({ author_id: null });

--- a/scripts/parity/fixtures/ar-123/schema.sql
+++ b/scripts/parity/fixtures/ar-123/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-123
+-- Query: Book.where.not(author_id: nil)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER
+);


### PR DESCRIPTION
5 new AR query parity fixtures

- ar-119: where with Arel eq predicate
- ar-120: joins with Arel where on joined table
- ar-121: select with multiple Arel attributes + where
- ar-122: where with nil (IS NULL)
- ar-123: where.not with nil (IS NOT NULL)

All fixtures passing parity:query, 168/173 passed.