### PR TITLE
feat(activerecord): inverse associations parity — 10 new tests + loadBelongsTo fix (PR 1.16)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -560,10 +560,10 @@ export async function loadBelongsTo(
   // Check cached (inverse_of) first, then preloaded.
   // Even for cached/preloaded hits, wire inverseOf so the parent's association
   // cache points back to this child instance (mirrors Rails behavior).
-  // Validate inverseOf before checking whether the value is null: an invalid name
-  // must throw even when the cached value is null (e.g. preloader stored null for
-  // a missing row), consistent with the cache-miss path that validates before the
-  // FK/null short-circuit.
+  // For non-polymorphic associations, validate inverseOf before checking whether
+  // the value is null: an invalid name must throw even when the cached value is
+  // null (e.g. preloader stored null for a missing row), consistent with the
+  // cache-miss path that validates before the FK/null short-circuit.
   if ((record as any)._cachedAssociations?.has(assocName)) {
     const cached = (record as any)._cachedAssociations.get(assocName) as Base | null;
     if (options.inverseOf && !options.polymorphic) {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -560,25 +560,37 @@ export async function loadBelongsTo(
   // Check cached (inverse_of) first, then preloaded.
   // Even for cached/preloaded hits, wire inverseOf so the parent's association
   // cache points back to this child instance (mirrors Rails behavior).
-  // Validate inverseOf consistently: an invalid name must throw here too, not
-  // only on a cache miss (same behavior as the main fetch path below).
-  const _wireInverse = (target: Base): void => {
-    if (!options.inverseOf) return;
-    // Validate only for non-polymorphic — matches the main fetch path.
-    if (!options.polymorphic) {
-      validateInverseOf(target.constructor as typeof Base, assocName, options.inverseOf);
-    }
-    (target as any)._cachedAssociations = (target as any)._cachedAssociations ?? new Map();
-    (target as any)._cachedAssociations.set(options.inverseOf, record);
-  };
+  // Validate inverseOf before checking whether the value is null: an invalid name
+  // must throw even when the cached value is null (e.g. preloader stored null for
+  // a missing row), consistent with the cache-miss path that validates before the
+  // FK/null short-circuit.
   if ((record as any)._cachedAssociations?.has(assocName)) {
     const cached = (record as any)._cachedAssociations.get(assocName) as Base | null;
-    if (cached) _wireInverse(cached);
+    if (options.inverseOf && !options.polymorphic) {
+      // Resolve target class from instance if available, otherwise from options.
+      const targetModel =
+        (cached?.constructor as typeof Base | undefined) ??
+        resolveModel(options.className ?? camelize(assocName));
+      validateInverseOf(targetModel, assocName, options.inverseOf);
+    }
+    if (options.inverseOf && cached) {
+      (cached as any)._cachedAssociations = (cached as any)._cachedAssociations ?? new Map();
+      (cached as any)._cachedAssociations.set(options.inverseOf, record);
+    }
     return cached;
   }
   if ((record as any)._preloadedAssociations?.has(assocName)) {
     const preloaded = (record as any)._preloadedAssociations.get(assocName) as Base | null;
-    if (preloaded) _wireInverse(preloaded);
+    if (options.inverseOf && !options.polymorphic) {
+      const targetModel =
+        (preloaded?.constructor as typeof Base | undefined) ??
+        resolveModel(options.className ?? camelize(assocName));
+      validateInverseOf(targetModel, assocName, options.inverseOf);
+    }
+    if (options.inverseOf && preloaded) {
+      (preloaded as any)._cachedAssociations = (preloaded as any)._cachedAssociations ?? new Map();
+      (preloaded as any)._cachedAssociations.set(options.inverseOf, record);
+    }
     return preloaded;
   }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -560,20 +560,25 @@ export async function loadBelongsTo(
   // Check cached (inverse_of) first, then preloaded.
   // Even for cached/preloaded hits, wire inverseOf so the parent's association
   // cache points back to this child instance (mirrors Rails behavior).
+  // Validate inverseOf consistently: an invalid name must throw here too, not
+  // only on a cache miss (same behavior as the main fetch path below).
+  const _wireInverse = (target: Base): void => {
+    if (!options.inverseOf) return;
+    // Validate only for non-polymorphic — matches the main fetch path.
+    if (!options.polymorphic) {
+      validateInverseOf(target.constructor as typeof Base, assocName, options.inverseOf);
+    }
+    (target as any)._cachedAssociations = (target as any)._cachedAssociations ?? new Map();
+    (target as any)._cachedAssociations.set(options.inverseOf, record);
+  };
   if ((record as any)._cachedAssociations?.has(assocName)) {
     const cached = (record as any)._cachedAssociations.get(assocName) as Base | null;
-    if (options.inverseOf && cached) {
-      (cached as any)._cachedAssociations = (cached as any)._cachedAssociations ?? new Map();
-      (cached as any)._cachedAssociations.set(options.inverseOf, record);
-    }
+    if (cached) _wireInverse(cached);
     return cached;
   }
   if ((record as any)._preloadedAssociations?.has(assocName)) {
     const preloaded = (record as any)._preloadedAssociations.get(assocName) as Base | null;
-    if (options.inverseOf && preloaded) {
-      (preloaded as any)._cachedAssociations = (preloaded as any)._cachedAssociations ?? new Map();
-      (preloaded as any)._cachedAssociations.set(options.inverseOf, record);
-    }
+    if (preloaded) _wireInverse(preloaded);
     return preloaded;
   }
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -557,12 +557,24 @@ export async function loadBelongsTo(
   assocName: string,
   options: AssociationOptions,
 ): Promise<Base | null> {
-  // Check cached (inverse_of) first, then preloaded
+  // Check cached (inverse_of) first, then preloaded.
+  // Even for cached/preloaded hits, wire inverseOf so the parent's association
+  // cache points back to this child instance (mirrors Rails behavior).
   if ((record as any)._cachedAssociations?.has(assocName)) {
-    return (record as any)._cachedAssociations.get(assocName) as Base | null;
+    const cached = (record as any)._cachedAssociations.get(assocName) as Base | null;
+    if (options.inverseOf && cached) {
+      (cached as any)._cachedAssociations = (cached as any)._cachedAssociations ?? new Map();
+      (cached as any)._cachedAssociations.set(options.inverseOf, record);
+    }
+    return cached;
   }
   if ((record as any)._preloadedAssociations?.has(assocName)) {
-    return (record as any)._preloadedAssociations.get(assocName) as Base | null;
+    const preloaded = (record as any)._preloadedAssociations.get(assocName) as Base | null;
+    if (options.inverseOf && preloaded) {
+      (preloaded as any)._cachedAssociations = (preloaded as any)._cachedAssociations ?? new Map();
+      (preloaded as any)._cachedAssociations.set(options.inverseOf, record);
+    }
+    return preloaded;
   }
 
   // Strict loading check: this is a lazy load

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -820,97 +820,103 @@ describe("AutomaticInverseFindingTests", () => {
   });
 
   it("has many and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
-    // Rails: with automatic_scope_inversing enabled, scoped associations still find inverse.
-    class ScopeInterest extends Base {
+    // Rails: canFindInverseOfAutomatically checks klass.automaticScopeInversing when
+    // the association has a scope. Use names that match underscore(demodulize(ClassName))
+    // and no explicit inverseOf or foreignKey so automaticInverseOf() is exercised.
+    class Work extends Base {
       static {
+        // automaticScopeInversing on the TARGET of the scoped hasMany enables scope inversing
         this.automaticScopeInversing = true;
-        this.attribute("topic", "string");
-        this.attribute("scope_man_id", "integer");
-        this.adapter = adapter;
-      }
-    }
-    class ScopeMan extends Base {
-      static {
-        this.automaticScopeInversing = true;
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    Associations.hasMany.call(ScopeMan, "scopeInterests", {
-      className: "ScopeInterest",
-      foreignKey: "scope_man_id",
-      inverseOf: "scopeMan",
-      scope: (rel: any) => rel.where({ topic: "active" }),
-    });
-    Associations.belongsTo.call(ScopeInterest, "scopeMan", {
-      className: "ScopeMan",
-      foreignKey: "scope_man_id",
-      inverseOf: "scopeInterests",
-    });
-    registerModel(ScopeMan);
-    registerModel(ScopeInterest);
-    // With explicit inverseOf, inverse is always found regardless of scope
-    const hasManyRefl = (ScopeMan as any)._reflectOnAssociation("scopeInterests");
-    expect(hasManyRefl?.inverseOf()).not.toBeNull();
-  });
-
-  it("has one and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
-    // With explicit inverseOf and automaticScopeInversing, inverse is found even with scope.
-    class ScopeFace extends Base {
-      static {
-        this.automaticScopeInversing = true;
-        this.attribute("man_id", "integer");
-        this.adapter = adapter;
-      }
-    }
-    class ScopeManHO extends Base {
-      static {
-        this.automaticScopeInversing = true;
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    Associations.hasOne.call(ScopeManHO, "scopeFace", {
-      className: "ScopeFace",
-      inverseOf: "scopeManHO",
-      scope: (rel: any) => rel.where({ man_id: 1 }),
-    });
-    Associations.belongsTo.call(ScopeFace, "scopeManHO", {
-      className: "ScopeManHO",
-      inverseOf: "scopeFace",
-    });
-    registerModel(ScopeManHO);
-    registerModel(ScopeFace);
-    const hasOneRefl = (ScopeManHO as any)._reflectOnAssociation("scopeFace");
-    expect(hasOneRefl?.inverseOf()).not.toBeNull();
-  });
-
-  it("has many with scoped belongs to does not find inverse automatically", () => {
-    // Rails: scoped belongs_to without automaticScopeInversing → no automatic inverse.
-    class ScopedBI extends Base {
-      static {
-        this.attribute("man_id", "integer");
         this.attribute("active", "boolean");
         this.adapter = adapter;
       }
     }
-    class ScopeManBI extends Base {
+    class Boss extends Base {
       static {
         this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
-    Associations.hasMany.call(ScopeManBI, "scopedBIs", { className: "ScopedBI" });
-    // Scoped belongs_to without automaticScopeInversing and no explicit inverseOf
-    Associations.belongsTo.call(ScopedBI, "scopeManBI", {
-      className: "ScopeManBI",
+    // "boss" = underscore(demodulize("Boss")) — the inverse name automaticInverseOf derives
+    Associations.hasMany.call(Boss, "works", {
+      className: "Work",
+      scope: (rel: any) => rel.where({ active: true }),
+      // no inverseOf, no foreignKey — automatic detection must find it
+    });
+    Associations.belongsTo.call(Work, "boss", {
+      className: "Boss",
+      // no inverseOf, no foreignKey
+    });
+    registerModel(Boss);
+    registerModel(Work);
+    // scopeAllowsAutomaticInverseOf checks Work.automaticScopeInversing → true
+    // inverseName = underscore("Boss") = "boss" → finds "boss" on Work ✓
+    const hasManyRefl = (Boss as any)._reflectOnAssociation("works");
+    expect(hasManyRefl?.inverseOf()?.name).toBe("boss");
+  });
+
+  it("has one and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
+    // Same as above but has_one. TARGET class must have automaticScopeInversing = true.
+    class Card extends Base {
+      static {
+        this.automaticScopeInversing = true;
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    class Deck extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    // "deck" = underscore(demodulize("Deck"))
+    Associations.hasOne.call(Deck, "card", {
+      className: "Card",
+      scope: (rel: any) => rel.where({ active: true }),
+      // no inverseOf, no foreignKey
+    });
+    Associations.belongsTo.call(Card, "deck", {
+      className: "Deck",
+      // no inverseOf, no foreignKey
+    });
+    registerModel(Deck);
+    registerModel(Card);
+    const hasOneRefl = (Deck as any)._reflectOnAssociation("card");
+    expect(hasOneRefl?.inverseOf()?.name).toBe("deck");
+  });
+
+  it("has many with scoped belongs to does not find inverse automatically", () => {
+    // Rails: scoped inverse reflection is blocked by scopeAllowsAutomaticInverseOf(refl, true=inverseReflection)
+    // which returns false when the inverse has a scope (regardless of automaticScopeInversing).
+    class Chip extends Base {
+      static {
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    class Board extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    // "board" = underscore("Board") — correct inverse name
+    Associations.hasMany.call(Board, "chips", { className: "Chip" });
+    // Scoped belongs_to: scopeAllowsAutomaticInverseOf(belongsToRefl, false) → false (scope blocks it)
+    // Also blocks the hasMany side: validInverseReflection calls canFindInverseOfAutomatically(belongsToRefl, true)
+    //   → scopeAllowsAutomaticInverseOf(belongsToRefl, true) → false (any scope blocks when inverseReflection=true)
+    Associations.belongsTo.call(Chip, "board", {
+      className: "Board",
       scope: (rel: any) => rel.where({ active: true }),
     });
-    registerModel(ScopeManBI);
-    registerModel(ScopedBI);
-    const belongsToRefl = (ScopedBI as any)._reflectOnAssociation("scopeManBI");
-    // Scoped and automaticScopeInversing is false by default → no automatic inverse
+    registerModel(Board);
+    registerModel(Chip);
+    const hasManyRefl = (Board as any)._reflectOnAssociation("chips");
+    const belongsToRefl = (Chip as any)._reflectOnAssociation("board");
+    // Scoped belongs_to: no automatic inverse from either direction
     expect(belongsToRefl?.inverseOf()).toBeNull();
+    expect(hasManyRefl?.inverseOf()).toBeNull();
   });
 
   it("has one and belongs to automatic inverse shares objects", async () => {
@@ -1045,30 +1051,35 @@ describe("AutomaticInverseFindingTests", () => {
   });
 
   it("polymorphic has one should find inverse automatically", () => {
-    // Rails: has_many with `as:` option uses the as-name as the inverse lookup key.
-    class PolyTag extends Base {
+    // Rails: has_one/has_many with `as:` uses underscore(as) as the inverse lookup name.
+    // The belongs_to :taggable, polymorphic: true matches because its name = "taggable".
+    // No explicit inverseOf — automaticInverseOf() must derive it.
+    class AutoPolyTag extends Base {
       static {
         this.attribute("taggable_id", "integer");
         this.attribute("taggable_type", "string");
         this.adapter = adapter;
       }
     }
-    class PolyPost extends Base {
+    class AutoPolyPost extends Base {
       static {
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    Associations.hasMany.call(PolyPost, "polyTags", {
-      className: "PolyTag",
+    // as: "taggable" → inverseName = underscore("taggable") = "taggable"
+    // AutoPolyTag has belongsTo named "taggable" → found ✓
+    Associations.hasOne.call(AutoPolyPost, "autoPolyTag", {
+      className: "AutoPolyTag",
       as: "taggable",
-      inverseOf: "taggable",
+      // no inverseOf — automatic detection should find "taggable" on AutoPolyTag
     });
-    Associations.belongsTo.call(PolyTag, "taggable", { polymorphic: true, inverseOf: "polyTags" });
-    registerModel(PolyPost);
-    registerModel(PolyTag);
-    const hasManyRefl = (PolyPost as any)._reflectOnAssociation("polyTags");
-    expect(hasManyRefl?.inverseOf()).not.toBeNull();
+    Associations.belongsTo.call(AutoPolyTag, "taggable", { polymorphic: true });
+    registerModel(AutoPolyPost);
+    registerModel(AutoPolyTag);
+    const hasOneRefl = (AutoPolyPost as any)._reflectOnAssociation("autoPolyTag");
+    // inverseName derived from as: "taggable" → finds "taggable" belongs_to on AutoPolyTag
+    expect(hasOneRefl?.inverseOf()?.name).toBe("taggable");
   });
 
   it.skip("has many inverse of derived automatically despite of composite foreign key", () => {
@@ -1130,16 +1141,19 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 
   it("eager loaded child instance should be shared with parent on find", async () => {
+    // Rails: eager-loaded polymorphic parent should have its inverse cache pointing
+    // back to the same child instance (object sharing, not just equal values).
     const { Man, Tag } = makeModels();
     const m = await Man.create({ name: "Gordon" });
     await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
-    // Eager-load the polymorphic belongs_to via includes
     const tags = await Tag.all().includes("taggable").toArray();
     expect(tags.length).toBe(1);
     const parent = (tags[0] as any)._preloadedAssociations?.get("taggable");
     expect(parent).not.toBeNull();
-    // The parent should exist (polymorphic eager loading is supported)
     expect((parent as any).name).toBe("Gordon");
+    // makeModels doesn't configure inverseOf, so _cachedAssociations on the parent
+    // won't be set. The test verifies the eager load correctly resolves the parent
+    // instance — inverse caching requires explicit inverseOf configuration.
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Tag } = makeModels();

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1141,19 +1141,29 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 
   it("eager loaded child instance should be shared with parent on find", async () => {
-    // Rails: eager-loaded polymorphic parent should have its inverse cache pointing
-    // back to the same child instance (object sharing, not just equal values).
+    // Rails: the child instance used to look up the parent via loadBelongsTo (with inverseOf)
+    // is stored in the parent's inverse cache — object sharing, not just equal values.
     const { Man, Tag } = makeModels();
     const m = await Man.create({ name: "Gordon" });
     await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
+
+    // Verify includes() preloads the polymorphic parent
     const tags = await Tag.all().includes("taggable").toArray();
     expect(tags.length).toBe(1);
-    const parent = (tags[0] as any)._preloadedAssociations?.get("taggable");
+    const preloadedParent = (tags[0] as any)._preloadedAssociations?.get("taggable");
+    expect(preloadedParent).not.toBeNull();
+    expect((preloadedParent as any).name).toBe("Gordon");
+
+    // Use a fresh Tag instance (not preloaded) so loadBelongsTo fetches and wires inverseOf.
+    // Preloaded instances skip the fetch and don't re-run inverse setup.
+    const freshTag = await Tag.findBy({ taggable_id: m.id });
+    const parent = await loadBelongsTo(freshTag!, "taggable", {
+      polymorphic: true,
+      inverseOf: "tags",
+    });
     expect(parent).not.toBeNull();
-    expect((parent as any).name).toBe("Gordon");
-    // makeModels doesn't configure inverseOf, so _cachedAssociations on the parent
-    // won't be set. The test verifies the eager load correctly resolves the parent
-    // instance — inverse caching requires explicit inverseOf configuration.
+    // The parent's inverse cache must reference the same freshTag instance
+    expect((parent as any)._cachedAssociations?.get("tags")).toBe(freshTag);
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Tag } = makeModels();

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1083,11 +1083,14 @@ describe("AutomaticInverseFindingTests", () => {
   });
 
   it.skip("has many inverse of derived automatically despite of composite foreign key", () => {
-    /* needs composite FK — our canFindInverseOfAutomatically returns false when foreignKey is set,
-       even for composite keys. Rails 7.x allows auto-detection with composite query_constraints. */
+    /* Composite FK associations use queryConstraints (not options.foreignKey scalar).
+       canFindInverseOfAutomatically currently checks options.foreignKey only, so composite
+       FK associations passed via queryConstraints may still auto-detect. Needs validation
+       that the right path is exercised and inverse detection works correctly for composite FKs. */
   });
   it.skip("belongs to inverse of derived automatically despite of composite foreign key", () => {
-    /* needs composite FK — same as above */
+    /* Same as above — verify canFindInverseOfAutomatically behavior for queryConstraints vs
+       scalar foreignKey, and that automatic detection works for composite FK associations. */
   });
 });
 
@@ -1237,7 +1240,8 @@ describe("InverseCachedPathTests", () => {
   it("wires inverseOf on the cached-associations fast-path", async () => {
     class CachedFace extends Base {
       static {
-        this.attribute("man_id", "integer");
+        // Default FK for belongsTo :cachedMan is cached_man_id
+        this.attribute("cached_man_id", "integer");
         this.adapter = adapter;
       }
     }
@@ -1253,7 +1257,7 @@ describe("InverseCachedPathTests", () => {
     registerModel(CachedFace);
 
     const m = await CachedMan.create({ name: "Alice" });
-    const f = await CachedFace.create({ man_id: m.id });
+    const f = await CachedFace.create({ cached_man_id: m.id });
 
     // Pre-populate _cachedAssociations so the fast-path is taken
     (f as any)._cachedAssociations = new Map();

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -762,20 +762,155 @@ describe("AutomaticInverseFindingTests", () => {
   it.skip("has many and belongs to should find inverse automatically for sti", () => {
     /* needs STI */
   });
-  it.skip("has one and belongs to with non default foreign key should not find inverse automatically", () => {
-    /* needs automatic inverse detection */
+  it("has one and belongs to with non default foreign key should not find inverse automatically", () => {
+    // Rails: options[:foreign_key] present → can_find_inverse_of_automatically? returns false.
+    class WeirdFace extends Base {
+      static {
+        this.attribute("the_man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ManA extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasOne.call(ManA, "weirdFace", {
+      className: "WeirdFace",
+      foreignKey: "the_man_id",
+    });
+    Associations.belongsTo.call(WeirdFace, "man", {
+      className: "ManA",
+      foreignKey: "the_man_id",
+    });
+    registerModel(ManA);
+    registerModel(WeirdFace);
+    const hasOneRefl = (ManA as any)._reflectOnAssociation("weirdFace");
+    const belongsToRefl = (WeirdFace as any)._reflectOnAssociation("man");
+    // Non-default foreign_key prevents automatic inverse detection
+    expect(hasOneRefl?.inverseOf()).toBeNull();
+    expect(belongsToRefl?.inverseOf()).toBeNull();
   });
-  it.skip("has one and belongs to with custom association name should not find wrong inverse automatically", () => {
-    /* needs automatic inverse detection */
+
+  it("has one and belongs to with custom association name should not find wrong inverse automatically", () => {
+    // Rails: association name doesn't match the model name → automatic detection returns nil.
+    class CustomFace extends Base {
+      static {
+        this.attribute("man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ManB extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    // "oddFace" doesn't match "CustomFace" / "manB" pattern — no auto-detection without inverseOf
+    Associations.hasOne.call(ManB, "oddFace", { className: "CustomFace" });
+    Associations.belongsTo.call(CustomFace, "faceman", { className: "ManB" });
+    registerModel(ManB);
+    registerModel(CustomFace);
+    const hasOneRefl = (ManB as any)._reflectOnAssociation("oddFace");
+    const belongsToRefl = (CustomFace as any)._reflectOnAssociation("faceman");
+    // No explicit inverseOf and automatic detection can't derive the inverse name
+    expect(hasOneRefl?.inverseOf()).toBeNull();
+    expect(belongsToRefl?.inverseOf()).toBeNull();
   });
-  it.skip("has many and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
-    /* needs automatic scope inversing */
+
+  it("has many and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
+    // Rails: with automatic_scope_inversing enabled, scoped associations still find inverse.
+    class ScopeInterest extends Base {
+      static {
+        this.automaticScopeInversing = true;
+        this.attribute("topic", "string");
+        this.attribute("scope_man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ScopeMan extends Base {
+      static {
+        this.automaticScopeInversing = true;
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(ScopeMan, "scopeInterests", {
+      className: "ScopeInterest",
+      foreignKey: "scope_man_id",
+      inverseOf: "scopeMan",
+      scope: (rel: any) => rel.where({ topic: "active" }),
+    });
+    Associations.belongsTo.call(ScopeInterest, "scopeMan", {
+      className: "ScopeMan",
+      foreignKey: "scope_man_id",
+      inverseOf: "scopeInterests",
+    });
+    registerModel(ScopeMan);
+    registerModel(ScopeInterest);
+    // With explicit inverseOf, inverse is always found regardless of scope
+    const hasManyRefl = (ScopeMan as any)._reflectOnAssociation("scopeInterests");
+    expect(hasManyRefl?.inverseOf()).not.toBeNull();
   });
-  it.skip("has one and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
-    /* needs automatic scope inversing */
+
+  it("has one and belongs to with a scope and automatic scope inversing should find inverse automatically", () => {
+    // With explicit inverseOf and automaticScopeInversing, inverse is found even with scope.
+    class ScopeFace extends Base {
+      static {
+        this.automaticScopeInversing = true;
+        this.attribute("man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class ScopeManHO extends Base {
+      static {
+        this.automaticScopeInversing = true;
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasOne.call(ScopeManHO, "scopeFace", {
+      className: "ScopeFace",
+      inverseOf: "scopeManHO",
+      scope: (rel: any) => rel.where({ man_id: 1 }),
+    });
+    Associations.belongsTo.call(ScopeFace, "scopeManHO", {
+      className: "ScopeManHO",
+      inverseOf: "scopeFace",
+    });
+    registerModel(ScopeManHO);
+    registerModel(ScopeFace);
+    const hasOneRefl = (ScopeManHO as any)._reflectOnAssociation("scopeFace");
+    expect(hasOneRefl?.inverseOf()).not.toBeNull();
   });
-  it.skip("has many with scoped belongs to does not find inverse automatically", () => {
-    /* needs automatic inverse detection */
+
+  it("has many with scoped belongs to does not find inverse automatically", () => {
+    // Rails: scoped belongs_to without automaticScopeInversing → no automatic inverse.
+    class ScopedBI extends Base {
+      static {
+        this.attribute("man_id", "integer");
+        this.attribute("active", "boolean");
+        this.adapter = adapter;
+      }
+    }
+    class ScopeManBI extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(ScopeManBI, "scopedBIs", { className: "ScopedBI" });
+    // Scoped belongs_to without automaticScopeInversing and no explicit inverseOf
+    Associations.belongsTo.call(ScopedBI, "scopeManBI", {
+      className: "ScopeManBI",
+      scope: (rel: any) => rel.where({ active: true }),
+    });
+    registerModel(ScopeManBI);
+    registerModel(ScopedBI);
+    const belongsToRefl = (ScopedBI as any)._reflectOnAssociation("scopeManBI");
+    // Scoped and automaticScopeInversing is false by default → no automatic inverse
+    expect(belongsToRefl?.inverseOf()).toBeNull();
   });
 
   it("has one and belongs to automatic inverse shares objects", async () => {
@@ -878,17 +1013,70 @@ describe("AutomaticInverseFindingTests", () => {
     expect((parent as any)._cachedAssociations?.get("interests")).toBe(i);
   });
 
-  it.skip("polymorphic and has many through relationships should not have inverses", () => {
-    /* needs automatic inverse detection */
+  it("polymorphic and has many through relationships should not have inverses", () => {
+    // Rails: through and polymorphic options prevent automatic inverse detection.
+    class Taggable extends Base {
+      static {
+        this.attribute("taggable_id", "integer");
+        this.attribute("taggable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    class TaggableParent extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    // Polymorphic belongs_to → automatic inverse detection is disabled
+    Associations.belongsTo.call(Taggable, "taggable", { polymorphic: true });
+    // Has-many-through → automatic inverse detection is disabled
+    Associations.hasMany.call(TaggableParent, "taggables", {
+      className: "Taggable",
+      through: "somejoin",
+    });
+    registerModel(Taggable);
+    registerModel(TaggableParent);
+    const belongsToRefl = (Taggable as any)._reflectOnAssociation("taggable");
+    const hasManyThruRefl = (TaggableParent as any)._reflectOnAssociation("taggables");
+    // Both should have no automatically-derived inverse
+    expect(belongsToRefl?.inverseOf()).toBeNull();
+    expect(hasManyThruRefl?.inverseOf()).toBeNull();
   });
-  it.skip("polymorphic has one should find inverse automatically", () => {
-    /* needs automatic inverse detection for polymorphic */
+
+  it("polymorphic has one should find inverse automatically", () => {
+    // Rails: has_many with `as:` option uses the as-name as the inverse lookup key.
+    class PolyTag extends Base {
+      static {
+        this.attribute("taggable_id", "integer");
+        this.attribute("taggable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    class PolyPost extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasMany.call(PolyPost, "polyTags", {
+      className: "PolyTag",
+      as: "taggable",
+      inverseOf: "taggable",
+    });
+    Associations.belongsTo.call(PolyTag, "taggable", { polymorphic: true, inverseOf: "polyTags" });
+    registerModel(PolyPost);
+    registerModel(PolyTag);
+    const hasManyRefl = (PolyPost as any)._reflectOnAssociation("polyTags");
+    expect(hasManyRefl?.inverseOf()).not.toBeNull();
   });
+
   it.skip("has many inverse of derived automatically despite of composite foreign key", () => {
-    /* needs composite FK */
+    /* needs composite FK — our canFindInverseOfAutomatically returns false when foreignKey is set,
+       even for composite keys. Rails 7.x allows auto-detection with composite query_constraints. */
   });
   it.skip("belongs to inverse of derived automatically despite of composite foreign key", () => {
-    /* needs composite FK */
+    /* needs composite FK — same as above */
   });
 });
 
@@ -941,8 +1129,17 @@ describe("InversePolymorphicBelongsToTests", () => {
     expect((parent as any)._cachedAssociations?.get("tags")).toBeTruthy();
   });
 
-  it.skip("eager loaded child instance should be shared with parent on find", () => {
-    /* needs eager loading */
+  it("eager loaded child instance should be shared with parent on find", async () => {
+    const { Man, Tag } = makeModels();
+    const m = await Man.create({ name: "Gordon" });
+    await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
+    // Eager-load the polymorphic belongs_to via includes
+    const tags = await Tag.all().includes("taggable").toArray();
+    expect(tags.length).toBe(1);
+    const parent = (tags[0] as any)._preloadedAssociations?.get("taggable");
+    expect(parent).not.toBeNull();
+    // The parent should exist (polymorphic eager loading is supported)
+    expect((parent as any).name).toBe("Gordon");
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Tag } = makeModels();

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1141,29 +1141,29 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 
   it("eager loaded child instance should be shared with parent on find", async () => {
-    // Rails: the child instance used to look up the parent via loadBelongsTo (with inverseOf)
-    // is stored in the parent's inverse cache — object sharing, not just equal values.
+    // Rails: the eagerly loaded child instance used to look up the parent via
+    // loadBelongsTo (with inverseOf) is stored in the parent's inverse cache —
+    // object sharing, not just equal values.
     const { Man, Tag } = makeModels();
     const m = await Man.create({ name: "Gordon" });
     await Tag.create({ name: "cool", taggable_id: m.id, taggable_type: "Man" });
 
-    // Verify includes() preloads the polymorphic parent
     const tags = await Tag.all().includes("taggable").toArray();
     expect(tags.length).toBe(1);
+
     const preloadedParent = (tags[0] as any)._preloadedAssociations?.get("taggable");
     expect(preloadedParent).not.toBeNull();
     expect((preloadedParent as any).name).toBe("Gordon");
 
-    // Use a fresh Tag instance (not preloaded) so loadBelongsTo fetches and wires inverseOf.
-    // Preloaded instances skip the fetch and don't re-run inverse setup.
-    const freshTag = await Tag.findBy({ taggable_id: m.id });
-    const parent = await loadBelongsTo(freshTag!, "taggable", {
+    // loadBelongsTo with inverseOf wires the inverse even for preloaded associations,
+    // so the parent's cache points back to the exact eager-loaded child instance.
+    const parent = await loadBelongsTo(tags[0] as any, "taggable", {
       polymorphic: true,
       inverseOf: "tags",
     });
     expect(parent).not.toBeNull();
-    // The parent's inverse cache must reference the same freshTag instance
-    expect((parent as any)._cachedAssociations?.get("tags")).toBe(freshTag);
+    expect(parent).toBe(preloadedParent);
+    expect((parent as any)._cachedAssociations?.get("tags")).toBe(tags[0]);
   });
   it("child instance should be shared with replaced via accessor parent", async () => {
     const { Man, Tag } = makeModels();

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1227,6 +1227,83 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 });
 
+describe("InverseCachedPathTests", () => {
+  // Tests for the _cachedAssociations / _preloadedAssociations fast-paths in loadBelongsTo.
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
+  it("wires inverseOf on the cached-associations fast-path", async () => {
+    class CachedFace extends Base {
+      static {
+        this.attribute("man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class CachedMan extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    Associations.hasOne.call(CachedMan, "cachedFace", { inverseOf: "cachedMan" });
+    Associations.belongsTo.call(CachedFace, "cachedMan", { inverseOf: "cachedFace" });
+    registerModel(CachedMan);
+    registerModel(CachedFace);
+
+    const m = await CachedMan.create({ name: "Alice" });
+    const f = await CachedFace.create({ man_id: m.id });
+
+    // Pre-populate _cachedAssociations so the fast-path is taken
+    (f as any)._cachedAssociations = new Map();
+    (f as any)._cachedAssociations.set("cachedMan", m);
+
+    const parent = await loadBelongsTo(f, "cachedMan", {
+      className: "CachedMan",
+      inverseOf: "cachedFace",
+    });
+    // Returns the cached instance
+    expect(parent).toBe(m);
+    // Inverse was wired on the parent's cache
+    expect((parent as any)._cachedAssociations?.get("cachedFace")).toBe(f);
+  });
+
+  it("throws on invalid inverseOf even when the cached value is null", async () => {
+    class NullFace extends Base {
+      static {
+        this.attribute("man_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class NullMan extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    // NullMan must have at least one association so validateInverseOf actually validates
+    // (it returns early without throwing when the target has zero associations).
+    Associations.hasOne.call(NullMan, "nullFace", { className: "NullFace" });
+    Associations.belongsTo.call(NullFace, "nullMan", { inverseOf: "nullFace" });
+    registerModel(NullMan);
+    registerModel(NullFace);
+
+    const f = new NullFace();
+    // Pre-populate cache with null (as the preloader does for missing rows)
+    (f as any)._cachedAssociations = new Map();
+    (f as any)._cachedAssociations.set("nullMan", null);
+
+    // An invalid inverseOf should throw even though the cached value is null
+    await expect(
+      loadBelongsTo(f, "nullMan", {
+        className: "NullMan",
+        inverseOf: "nonExistentAssociation",
+      }),
+    ).rejects.toThrow(/nonExistentAssociation/);
+  });
+});
+
 describe("InverseAssociationTests", () => {
   let adapter: DatabaseAdapter;
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Implements 10 previously-skipped inverse association tests and fixes a Rails fidelity gap in \`loadBelongsTo\`.

## Bug fix: \`loadBelongsTo\` cached/preloaded fast-paths

Previously, returning from the \`_cachedAssociations\` or \`_preloadedAssociations\` early-return paths in \`loadBelongsTo\` did not wire the \`inverseOf\` cache or validate the inverse name. Now:
- **Inverse wiring**: the parent's \`_cachedAssociations\` is set even when the association was already cached/preloaded — matches Rails behavior where the child instance is always shared
- **Validation**: \`validateInverseOf\` runs before the null-check for non-polymorphic associations — an invalid name throws even when the cached value is null (e.g. preloader stored null for a missing row)

## New tests (10 total, up from 8 in earlier commits)

| Test | What it proves |
|---|---|
| non-default foreign key → no auto inverse | \`foreignKey\` option → \`canFindInverseOfAutomatically()\` returns false |
| custom association name → no wrong inverse | Name mismatch → automatic detection returns null |
| scope + \`automaticScopeInversing\` (hasMany) → **auto**-finds inverse | No \`inverseOf\`/\`foreignKey\`; \`Work.automaticScopeInversing=true\` enables scope inversing |
| scope + \`automaticScopeInversing\` (hasOne) → **auto**-finds inverse | Same; asserts \`inverseOf()?.name === "deck"\` |
| scoped belongs_to → no inverse (both directions) | Scope blocks both \`belongsToRefl\` and \`hasManyRefl\` |
| polymorphic + through → no inverses | \`options.through\` + polymorphic → no auto-detection |
| polymorphic has-one → **auto**-finds inverse | \`as: "taggable"\` → \`inverseName = "taggable"\` → finds polymorphic belongs_to |
| eager loaded polymorphic child shares parent | \`includes()\` preloads + \`loadBelongsTo(inverseOf)\` caches child on parent |
| **\_cachedAssociations fast-path wires inverse** | Pre-populated cache + inverseOf → parent's cache set to child |
| **invalid inverseOf throws even for null cached value** | Preloader null pattern → validateInverseOf still fires |

## Remaining 27 skips

All require infrastructure not yet available: composite FK auto-detection, has_many inversing deduplication, callback ordering, stale detection, block-style create/build, STI parent sharing, autosave, module/namespace support.