### PR TITLE
test(parity): AR query fixtures ar-124..ar-128

### DIFF
--- a/scripts/parity/fixtures/ar-124/models.rb
+++ b/scripts/parity/fixtures/ar-124/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-124/models.ts
+++ b/scripts/parity/fixtures/ar-124/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-124/query.rb
+++ b/scripts/parity/fixtures/ar-124/query.rb
@@ -1,0 +1,1 @@
+Book.where(active: true)

--- a/scripts/parity/fixtures/ar-124/query.ts
+++ b/scripts/parity/fixtures/ar-124/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ active: true });

--- a/scripts/parity/fixtures/ar-124/schema.sql
+++ b/scripts/parity/fixtures/ar-124/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-124
+-- Query: Book.where(active: true)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-125/models.rb
+++ b/scripts/parity/fixtures/ar-125/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-125/models.ts
+++ b/scripts/parity/fixtures/ar-125/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-125/query.rb
+++ b/scripts/parity/fixtures/ar-125/query.rb
@@ -1,0 +1,1 @@
+Book.where(active: false)

--- a/scripts/parity/fixtures/ar-125/query.ts
+++ b/scripts/parity/fixtures/ar-125/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ active: false });

--- a/scripts/parity/fixtures/ar-125/schema.sql
+++ b/scripts/parity/fixtures/ar-125/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-125
+-- Query: Book.where(active: false)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);

--- a/scripts/parity/fixtures/ar-126/models.rb
+++ b/scripts/parity/fixtures/ar-126/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-126/models.ts
+++ b/scripts/parity/fixtures/ar-126/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-126/query.rb
+++ b/scripts/parity/fixtures/ar-126/query.rb
@@ -1,0 +1,1 @@
+Book.order(Arel.sql("CASE WHEN status = 'featured' THEN 0 ELSE 1 END"))

--- a/scripts/parity/fixtures/ar-126/query.ts
+++ b/scripts/parity/fixtures/ar-126/query.ts
@@ -1,4 +1,4 @@
-import { Book } from "./models.js";
 import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
 
 export default Book.order(sql("CASE WHEN status = 'featured' THEN 0 ELSE 1 END"));

--- a/scripts/parity/fixtures/ar-126/query.ts
+++ b/scripts/parity/fixtures/ar-126/query.ts
@@ -1,0 +1,4 @@
+import { Book } from "./models.js";
+import { sql } from "@blazetrails/arel";
+
+export default Book.order(sql("CASE WHEN status = 'featured' THEN 0 ELSE 1 END"));

--- a/scripts/parity/fixtures/ar-126/schema.sql
+++ b/scripts/parity/fixtures/ar-126/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-126
+-- Query: Book.order(Arel.sql("CASE WHEN status = 'featured' THEN 0 ELSE 1 END"))
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  status TEXT
+);

--- a/scripts/parity/fixtures/ar-127/models.rb
+++ b/scripts/parity/fixtures/ar-127/models.rb
@@ -1,0 +1,12 @@
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-127/models.ts
+++ b/scripts/parity/fixtures/ar-127/models.ts
@@ -1,0 +1,26 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-127/query.rb
+++ b/scripts/parity/fixtures/ar-127/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:author).joins(:reviews).where("reviews.rating > 3")

--- a/scripts/parity/fixtures/ar-127/query.ts
+++ b/scripts/parity/fixtures/ar-127/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.joins("author").joins("reviews").where("reviews.rating > 3");

--- a/scripts/parity/fixtures/ar-127/schema.sql
+++ b/scripts/parity/fixtures/ar-127/schema.sql
@@ -1,0 +1,17 @@
+-- Fixture for statement: ar-127
+-- Query: Book.joins(:author).joins(:reviews).where("reviews.rating > 3")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author_id INTEGER REFERENCES authors(id)
+);
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER NOT NULL REFERENCES books(id),
+  rating INTEGER
+);

--- a/scripts/parity/fixtures/ar-128/models.rb
+++ b/scripts/parity/fixtures/ar-128/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-128/models.ts
+++ b/scripts/parity/fixtures/ar-128/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-128/query.rb
+++ b/scripts/parity/fixtures/ar-128/query.rb
@@ -1,0 +1,1 @@
+Book.where(active: true).select("COUNT(*) AS total")

--- a/scripts/parity/fixtures/ar-128/query.ts
+++ b/scripts/parity/fixtures/ar-128/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+
+export default Book.where({ active: true }).select("COUNT(*) AS total");

--- a/scripts/parity/fixtures/ar-128/schema.sql
+++ b/scripts/parity/fixtures/ar-128/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-128
+-- Query: Book.where(active: true).select("COUNT(*) AS total")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  active BOOLEAN
+);


### PR DESCRIPTION
## Summary

Five new ActiveRecord query parity fixtures validating SQLite query generation:

- **ar-124**: `where(active: true)` — boolean true coerced to 1
- **ar-125**: `where(active: false)` — boolean false coerced to 0
- **ar-126**: `order(Arel.sql("CASE WHEN..."))` — inlined SQL expressions in ORDER BY
- **ar-127**: `joins(:author).joins(:reviews).where(...)` — chained association joins with multiple INNER JOINs
- **ar-128**: `select("COUNT(*) AS total")` — aggregate functions in SELECT clause

All fixtures pass 100% SQL parity (rails vs trails output).

## Status

- Parity check: all 5 fixtures **PASS**
- Known gaps: no new gaps added, unchanged baseline from origin/main
- Exit code: 1 (expected due to pre-existing UNEXPECTED-PASS for ar-01/ar-52/ar-65 whole-second flakiness)