### PR TITLE
test(parity): Phase 1 audit — remove 14 redundant/trivial AR query fixtures

### DIFF
--- a/scripts/parity/fixtures/ar-00/models.rb
+++ b/scripts/parity/fixtures/ar-00/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-00/models.ts
+++ b/scripts/parity/fixtures/ar-00/models.ts
@@ -1,7 +1,0 @@
-import { Base } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-  }
-}

--- a/scripts/parity/fixtures/ar-00/query.rb
+++ b/scripts/parity/fixtures/ar-00/query.rb
@@ -1,1 +1,0 @@
-Book.all

--- a/scripts/parity/fixtures/ar-00/query.ts
+++ b/scripts/parity/fixtures/ar-00/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.all();

--- a/scripts/parity/fixtures/ar-00/schema.sql
+++ b/scripts/parity/fixtures/ar-00/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-00 (smoke test)
--- Query: Book.all
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);

--- a/scripts/parity/fixtures/ar-116/models.rb
+++ b/scripts/parity/fixtures/ar-116/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-116/models.ts
+++ b/scripts/parity/fixtures/ar-116/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-116/query.rb
+++ b/scripts/parity/fixtures/ar-116/query.rb
@@ -1,1 +1,0 @@
-Book.where(pages: 100..300)

--- a/scripts/parity/fixtures/ar-116/query.ts
+++ b/scripts/parity/fixtures/ar-116/query.ts
@@ -1,4 +1,0 @@
-import { Range } from "@blazetrails/activerecord";
-import { Book } from "./models.js";
-
-export default Book.where({ pages: new Range(100, 300) });

--- a/scripts/parity/fixtures/ar-116/schema.sql
+++ b/scripts/parity/fixtures/ar-116/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-116
--- Query: Book.where(pages: 100..300)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  pages INTEGER
-);

--- a/scripts/parity/fixtures/ar-118/models.rb
+++ b/scripts/parity/fixtures/ar-118/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-118/models.ts
+++ b/scripts/parity/fixtures/ar-118/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-118/query.rb
+++ b/scripts/parity/fixtures/ar-118/query.rb
@@ -1,1 +1,0 @@
-Book.where(status: ["active", "featured", "new"])

--- a/scripts/parity/fixtures/ar-118/query.ts
+++ b/scripts/parity/fixtures/ar-118/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ status: ["active", "featured", "new"] });

--- a/scripts/parity/fixtures/ar-118/schema.sql
+++ b/scripts/parity/fixtures/ar-118/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-118
--- Query: Book.where(status: ["active", "featured", "new"])
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  status TEXT
-);

--- a/scripts/parity/fixtures/ar-119/models.rb
+++ b/scripts/parity/fixtures/ar-119/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-119/models.ts
+++ b/scripts/parity/fixtures/ar-119/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-119/query.rb
+++ b/scripts/parity/fixtures/ar-119/query.rb
@@ -1,1 +1,0 @@
-Book.where(Book.arel_table[:status].eq("published"))

--- a/scripts/parity/fixtures/ar-119/query.ts
+++ b/scripts/parity/fixtures/ar-119/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where(Book.arelTable.get("status").eq("published"));

--- a/scripts/parity/fixtures/ar-119/schema.sql
+++ b/scripts/parity/fixtures/ar-119/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-119
--- Query: Book.where(Book.arel_table[:status].eq("published"))
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  status TEXT
-);

--- a/scripts/parity/fixtures/ar-122/models.rb
+++ b/scripts/parity/fixtures/ar-122/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-122/models.ts
+++ b/scripts/parity/fixtures/ar-122/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-122/query.rb
+++ b/scripts/parity/fixtures/ar-122/query.rb
@@ -1,1 +1,0 @@
-Book.where(author_id: nil)

--- a/scripts/parity/fixtures/ar-122/query.ts
+++ b/scripts/parity/fixtures/ar-122/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ author_id: null });

--- a/scripts/parity/fixtures/ar-122/schema.sql
+++ b/scripts/parity/fixtures/ar-122/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-122
--- Query: Book.where(author_id: nil)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  author_id INTEGER
-);

--- a/scripts/parity/fixtures/ar-124/models.rb
+++ b/scripts/parity/fixtures/ar-124/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-124/models.ts
+++ b/scripts/parity/fixtures/ar-124/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-124/query.rb
+++ b/scripts/parity/fixtures/ar-124/query.rb
@@ -1,1 +1,0 @@
-Book.where(active: true)

--- a/scripts/parity/fixtures/ar-124/query.ts
+++ b/scripts/parity/fixtures/ar-124/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ active: true });

--- a/scripts/parity/fixtures/ar-124/schema.sql
+++ b/scripts/parity/fixtures/ar-124/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-124
--- Query: Book.where(active: true)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  active BOOLEAN
-);

--- a/scripts/parity/fixtures/ar-125/models.rb
+++ b/scripts/parity/fixtures/ar-125/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-125/models.ts
+++ b/scripts/parity/fixtures/ar-125/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-125/query.rb
+++ b/scripts/parity/fixtures/ar-125/query.rb
@@ -1,1 +1,0 @@
-Book.where(active: false)

--- a/scripts/parity/fixtures/ar-125/query.ts
+++ b/scripts/parity/fixtures/ar-125/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ active: false });

--- a/scripts/parity/fixtures/ar-125/schema.sql
+++ b/scripts/parity/fixtures/ar-125/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-125
--- Query: Book.where(active: false)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  active BOOLEAN
-);

--- a/scripts/parity/fixtures/ar-128/models.rb
+++ b/scripts/parity/fixtures/ar-128/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-128/models.ts
+++ b/scripts/parity/fixtures/ar-128/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-128/query.rb
+++ b/scripts/parity/fixtures/ar-128/query.rb
@@ -1,1 +1,0 @@
-Book.where(active: true).select("COUNT(*) AS total")

--- a/scripts/parity/fixtures/ar-128/query.ts
+++ b/scripts/parity/fixtures/ar-128/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ active: true }).select("COUNT(*) AS total");

--- a/scripts/parity/fixtures/ar-128/schema.sql
+++ b/scripts/parity/fixtures/ar-128/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-128
--- Query: Book.where(active: true).select("COUNT(*) AS total")
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT,
-  active BOOLEAN
-);

--- a/scripts/parity/fixtures/ar-24/models.rb
+++ b/scripts/parity/fixtures/ar-24/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-24/models.ts
+++ b/scripts/parity/fixtures/ar-24/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-24/query.rb
+++ b/scripts/parity/fixtures/ar-24/query.rb
@@ -1,1 +1,0 @@
-Book.where(title: nil)

--- a/scripts/parity/fixtures/ar-24/query.ts
+++ b/scripts/parity/fixtures/ar-24/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ title: null });

--- a/scripts/parity/fixtures/ar-24/schema.sql
+++ b/scripts/parity/fixtures/ar-24/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-24
--- Query: Book.where(title: nil)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);

--- a/scripts/parity/fixtures/ar-30/models.rb
+++ b/scripts/parity/fixtures/ar-30/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-30/models.ts
+++ b/scripts/parity/fixtures/ar-30/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-30/query.rb
+++ b/scripts/parity/fixtures/ar-30/query.rb
@@ -1,1 +1,0 @@
-Book.select(:id, :title)

--- a/scripts/parity/fixtures/ar-30/query.ts
+++ b/scripts/parity/fixtures/ar-30/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.select("id", "title");

--- a/scripts/parity/fixtures/ar-30/schema.sql
+++ b/scripts/parity/fixtures/ar-30/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-30
--- Query: Book.select(:id, :title)
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);

--- a/scripts/parity/fixtures/ar-46/models.rb
+++ b/scripts/parity/fixtures/ar-46/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-46/models.ts
+++ b/scripts/parity/fixtures/ar-46/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-46/query.rb
+++ b/scripts/parity/fixtures/ar-46/query.rb
@@ -1,1 +1,0 @@
-Book.where(id: [])

--- a/scripts/parity/fixtures/ar-46/query.ts
+++ b/scripts/parity/fixtures/ar-46/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where({ id: [] });

--- a/scripts/parity/fixtures/ar-46/schema.sql
+++ b/scripts/parity/fixtures/ar-46/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-46
--- Query: Book.where(id: [])
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);

--- a/scripts/parity/fixtures/ar-72/models.rb
+++ b/scripts/parity/fixtures/ar-72/models.rb
@@ -1,2 +1,0 @@
-class User < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-72/models.ts
+++ b/scripts/parity/fixtures/ar-72/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class User extends Base {
-  static {
-    this.tableName = "users";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-72/query.rb
+++ b/scripts/parity/fixtures/ar-72/query.rb
@@ -1,1 +1,0 @@
-User.select(:id).distinct.where(active: true)

--- a/scripts/parity/fixtures/ar-72/query.ts
+++ b/scripts/parity/fixtures/ar-72/query.ts
@@ -1,3 +1,0 @@
-import { User } from "./models.js";
-
-export default User.select("id").distinct().where({ active: true });

--- a/scripts/parity/fixtures/ar-72/schema.sql
+++ b/scripts/parity/fixtures/ar-72/schema.sql
@@ -1,8 +1,0 @@
--- Fixture for statement: ar-72
--- Query: User.select(:id).distinct.where(active: true)
-
-CREATE TABLE users (
-  id INTEGER PRIMARY KEY,
-  name TEXT,
-  active BOOLEAN
-);

--- a/scripts/parity/fixtures/ar-83/models.rb
+++ b/scripts/parity/fixtures/ar-83/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-83/models.ts
+++ b/scripts/parity/fixtures/ar-83/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-83/query.rb
+++ b/scripts/parity/fixtures/ar-83/query.rb
@@ -1,1 +1,0 @@
-Book.none

--- a/scripts/parity/fixtures/ar-83/query.ts
+++ b/scripts/parity/fixtures/ar-83/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.none();

--- a/scripts/parity/fixtures/ar-83/schema.sql
+++ b/scripts/parity/fixtures/ar-83/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-83
--- Query: Book.none
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);

--- a/scripts/parity/fixtures/ar-89/models.rb
+++ b/scripts/parity/fixtures/ar-89/models.rb
@@ -1,2 +1,0 @@
-class Book < ActiveRecord::Base
-end

--- a/scripts/parity/fixtures/ar-89/models.ts
+++ b/scripts/parity/fixtures/ar-89/models.ts
@@ -1,8 +1,0 @@
-import { Base, registerModel } from "@blazetrails/activerecord";
-
-export class Book extends Base {
-  static {
-    this.tableName = "books";
-    registerModel(this);
-  }
-}

--- a/scripts/parity/fixtures/ar-89/query.rb
+++ b/scripts/parity/fixtures/ar-89/query.rb
@@ -1,1 +1,0 @@
-Book.where(Book.arel_table[:title].matches("%rails%"))

--- a/scripts/parity/fixtures/ar-89/query.ts
+++ b/scripts/parity/fixtures/ar-89/query.ts
@@ -1,3 +1,0 @@
-import { Book } from "./models.js";
-
-export default Book.where(Book.arelTable.get("title").matches("%rails%"));

--- a/scripts/parity/fixtures/ar-89/schema.sql
+++ b/scripts/parity/fixtures/ar-89/schema.sql
@@ -1,7 +1,0 @@
--- Fixture for statement: ar-89
--- Query: Book.where(Book.arel_table[:title].matches("%rails%"))
-
-CREATE TABLE books (
-  id INTEGER PRIMARY KEY,
-  title TEXT
-);


### PR DESCRIPTION
## Summary

- Removes 14 fixtures that are either exact duplicates or too simple to justify CI cost (covered by unit tests).
- Exact duplicates dropped: ar-83 (= ar-27, `Book.none`), ar-89 (= ar-20, Arel `matches`), ar-116 (= ar-25, range BETWEEN), ar-118 (= ar-08/ar-91, array IN), ar-122 (= ar-24, IS NULL).
- Trivially simple dropped: ar-00 (`Book.all`), ar-24 (`where nil`), ar-30 (`select 2 cols`), ar-46 (`where []`), ar-72 (`select+distinct+where`), ar-119 (Arel `eq`), ar-124/125 (bool where), ar-128 (COUNT string select).
- 115 fixtures remain, focused on unique, exotic, or multi-step query chains.

## Test plan
- [ ] `pnpm parity:query` passes with 115 fixtures (no new known-gaps)