### PR TITLE
feat(activerecord): eagerLoad emits LEFT OUTER JOIN + column-aliased SELECT in toSql() (ar-16, ar-57)

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -300,7 +300,10 @@ export class JoinDependency {
       }
       lastNode = node;
       currentModel = node.modelClass;
-      currentAlias = node.tableAlias;
+      // Use effectiveSqlName, not tableAlias: the JOIN SQL references the
+      // effective name (real table name or tN alias), so the next level's ON
+      // clause must use the same name as the source of the join.
+      currentAlias = node.effectiveSqlName;
       parentPath = parentPath ? `${parentPath}.${part}` : part;
     }
     return lastNode;

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -530,16 +530,14 @@ export class JoinDependency {
   }
 
   /**
-   * Instantiates a single model record from aliased row data and caches it
-   * in the model cache to deduplicate repeated parent rows.
+   * Instantiates a single model record from a hash of aliased row attributes.
+   * Deduplication of repeated parent rows is handled by instantiateFromRows
+   * (the `seenRawPks` / `parentMap` logic); this method just constructs the
+   * model object for a given attribute hash.
    *
    * Mirrors: ActiveRecord::Associations::JoinDependency#construct_model
    */
-  private constructModel(
-    attrs: Record<string, unknown>,
-    node: JoinNode | null,
-    _modelCache?: Map<unknown, unknown>,
-  ): any {
+  private constructModel(attrs: Record<string, unknown>, node: JoinNode | null): any {
     const modelClass = node ? node.modelClass : this._baseModel;
     return (modelClass as any)._instantiate(attrs);
   }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -220,10 +220,7 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replace(
-            new RegExp(`"${targetTable!}"`, "g"),
-            `"${effectiveName}"`,
-          );
+          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable!}"`, `"${effectiveName}"`);
           joinOn += ` AND ${scopeWhere}`;
         }
       }
@@ -696,10 +693,7 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replace(
-            new RegExp(`"${targetTable}"`, "g"),
-            `"${targetAlias}"`,
-          );
+          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable}"`, `"${targetAlias}"`);
           targetJoinOn += ` AND ${scopeWhere}`;
         }
       }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -34,6 +34,12 @@ export interface JoinNode {
   immediateAssocName: string;
   /** Dotted parent path, or null if directly on the base model */
   parentPath: string | null;
+  /**
+   * The SQL name used for this node's table in JOIN and SELECT expressions.
+   * Equals tableName when the real name was free (no collision); equals
+   * tableAlias (tN) when there was a naming collision.
+   */
+  effectiveSqlName: string;
 }
 
 export interface AliasMap {
@@ -44,7 +50,11 @@ export interface AliasMap {
 }
 
 function getModelColumns(modelClass: any): string[] {
-  const cols: string[] = modelClass.columnNames?.() ?? [];
+  // columnsHash() triggers loadSchema() which populates _attributeDefinitions
+  // from the schema cache before columnNames() reads them.
+  const ch: Record<string, unknown> | undefined =
+    typeof modelClass.columnsHash === "function" ? modelClass.columnsHash() : undefined;
+  const cols: string[] = ch ? Object.keys(ch) : (modelClass.columnNames?.() ?? []);
   const pk = modelClass.primaryKey ?? "id";
   if (Array.isArray(pk)) {
     for (const k of pk) {
@@ -102,10 +112,15 @@ export class JoinDependency {
   private _nextTableIndex = 1;
   private _nodes: JoinNode[] = [];
   private _aliases: AliasMap[] = [];
+  // Tracks real table names already in use to detect collisions.
+  // When a joined table's real name is unique, we skip the tN alias in SQL
+  // (matching Rails' AliasTracker which only aliases on collision).
+  private _usedTableNames: Set<string>;
 
   constructor(baseModel: typeof Base) {
     this._baseModel = baseModel;
     this._baseAlias = (baseModel as any).tableName;
+    this._usedTableNames = new Set([this._baseAlias]);
     this._buildBaseAliases();
   }
 
@@ -144,7 +159,8 @@ export class JoinDependency {
       targetTable = (targetModel as any).tableName;
       const targetPk = assocDef.options.primaryKey ?? (targetModel as any).primaryKey ?? "id";
       if (Array.isArray(targetPk)) return null;
-      joinOn = `"${tableAlias}"."${targetPk}" = "${sourceAlias}"."${foreignKey}"`;
+      // effectiveName resolved below after targetTable is known
+      joinOn = `PLACEHOLDER."${targetPk}" = "${sourceAlias}"."${foreignKey}"`;
     } else if (assocDef.type === "hasMany" || assocDef.type === "hasOne") {
       if (assocDef.options.through) {
         return this._addThroughAssociation(
@@ -167,15 +183,25 @@ export class JoinDependency {
       if (Array.isArray(foreignKey)) return null;
       const primaryKey = assocDef.options.primaryKey ?? sourcePk;
       if (Array.isArray(primaryKey)) return null;
-      joinOn = `"${tableAlias}"."${foreignKey}" = "${sourceAlias}"."${primaryKey}"`;
+      joinOn = `PLACEHOLDER."${foreignKey}" = "${sourceAlias}"."${primaryKey}"`;
 
       if (assocDef.options.as) {
         const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
-        joinOn += ` AND "${tableAlias}"."${typeCol}" = '${modelClass.name}'`;
+        joinOn += ` AND PLACEHOLDER."${typeCol}" = '${modelClass.name}'`;
       }
     } else {
       return null;
     }
+
+    // Rails only aliases a joined table when its real name is already in use
+    // (AliasTracker: aliases[table_name] == 0 → use real name). Mirror that:
+    // use the real table name in SQL when there's no collision, otherwise fall
+    // back to the sequential tN alias.
+    const effectiveName = this._usedTableNames.has(targetTable!) ? tableAlias : targetTable!;
+    this._usedTableNames.add(effectiveName);
+
+    // Substitute the PLACEHOLDER with the effective SQL name
+    joinOn = joinOn.replace(/PLACEHOLDER/g, `"${effectiveName}"`);
 
     // Apply association scope as additional ON conditions
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -185,8 +211,8 @@ export class JoinDependency {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
           const scopeWhere = whereMatch[1].replace(
-            new RegExp(`"${targetTable}"`, "g"),
-            `"${tableAlias}"`,
+            new RegExp(`"${targetTable!}"`, "g"),
+            `"${effectiveName}"`,
           );
           joinOn += ` AND ${scopeWhere}`;
         }
@@ -194,24 +220,31 @@ export class JoinDependency {
     }
 
     // Add STI type constraint if target is an STI subclass
-    joinOn = this._addStiConstraint(joinOn, targetModel!, tableAlias);
+    joinOn = this._addStiConstraint(joinOn, targetModel!, effectiveName);
 
     // Guard against composite PK on target model
     const targetModelPk = (targetModel as any).primaryKey ?? "id";
     if (Array.isArray(targetModelPk)) return null;
 
     const columns = getModelColumns(targetModel);
+
+    // Build JOIN SQL: only emit the alias clause when effectiveName differs
+    // from the real table name (i.e. there was a collision and we used tN).
+    const joinTableExpr =
+      effectiveName === targetTable! ? `"${targetTable!}"` : `"${targetTable!}" "${effectiveName}"`;
+
     const node: JoinNode = {
       tableIndex,
       tableAlias,
       tableName: targetTable!,
+      effectiveSqlName: effectiveName,
       modelClass: targetModel!,
       columns,
       assocName: options?.parentAssocName ? `${options.parentAssocName}.${assocName}` : assocName,
       immediateAssocName: assocName,
       parentPath: options?.parentAssocName ?? null,
       assocType,
-      joinSql: `LEFT OUTER JOIN "${targetTable!}" "${tableAlias}" ON ${joinOn}`,
+      joinSql: `LEFT OUTER JOIN ${joinTableExpr} ON ${joinOn}`,
     };
 
     for (let i = 0; i < columns.length; i++) {
@@ -267,13 +300,16 @@ export class JoinDependency {
   }
 
   private _buildSelectExpressions(): string[] {
-    const aliasByIndex = new Map<number, string>();
-    aliasByIndex.set(this._baseTableIndex, this._baseAlias);
-    for (const node of this._nodes) aliasByIndex.set(node.tableIndex, node.tableAlias);
+    const effectiveNameByIndex = new Map<number, string>();
+    effectiveNameByIndex.set(this._baseTableIndex, this._baseAlias);
+    for (const node of this._nodes) {
+      effectiveNameByIndex.set(node.tableIndex, node.effectiveSqlName);
+    }
 
     return this._aliases.map((a) => {
-      const tableAlias = aliasByIndex.get(a.tableIndex)!;
-      return `"${tableAlias}"."${a.column}" AS "${a.alias}"`;
+      const effectiveName = effectiveNameByIndex.get(a.tableIndex)!;
+      // Rails emits column aliases as SqlLiteral (bare, not quoted).
+      return `"${effectiveName}"."${a.column}" AS ${a.alias}`;
     });
   }
 
@@ -523,6 +559,7 @@ export class JoinDependency {
         tableIndex: throughTableIndex,
         tableAlias: throughAlias,
         tableName: throughTable,
+        effectiveSqlName: throughAlias,
         modelClass: throughModel as typeof Base,
         columns: throughColumns,
         assocName: throughNodeName,
@@ -620,6 +657,7 @@ export class JoinDependency {
     const node: JoinNode = {
       tableIndex: targetTableIndex,
       tableAlias: targetAlias,
+      effectiveSqlName: targetAlias,
       tableName: targetTable,
       modelClass: targetModel,
       columns: targetColumns,

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -474,6 +474,58 @@ export class JoinDependency {
     return { parents: [...parentMap.values()], associations: assocMap };
   }
 
+  /**
+   * Mirrors: ActiveRecord::Associations::JoinDependency#join_root_alias
+   * (protected in Rails — the alias used for the root table in the query)
+   */
+  protected get joinRootAlias(): string {
+    return this._baseAlias;
+  }
+
+  /**
+   * Builds and returns an Aliases object covering all tables in this dependency.
+   *
+   * Mirrors: ActiveRecord::Associations::JoinDependency#aliases
+   */
+  private aliases(): Aliases {
+    const baseAliasMap: AliasMap[] = this._aliases.filter(
+      (a) => a.tableIndex === this._baseTableIndex,
+    );
+    const tables: Array<{ node: JoinNode | null; columns: AliasMap[] }> = [
+      { node: null, columns: baseAliasMap },
+    ];
+    for (const node of this._nodes) {
+      const nodeCols = this._aliases.filter((a) => a.tableIndex === node.tableIndex);
+      tables.push({ node, columns: nodeCols });
+    }
+    return new Aliases(tables);
+  }
+
+  /**
+   * Constructs AR model instances from a flat result row set, assigning
+   * associations. Entry point for the eager-load instantiation phase.
+   *
+   * Mirrors: ActiveRecord::Associations::JoinDependency#construct
+   */
+  private construct(resultSet: Record<string, unknown>[], _strictLoadingValue?: boolean): any[] {
+    return this.instantiateFromRows(resultSet).parents;
+  }
+
+  /**
+   * Instantiates a single model record from aliased row data and caches it
+   * in the model cache to deduplicate repeated parent rows.
+   *
+   * Mirrors: ActiveRecord::Associations::JoinDependency#construct_model
+   */
+  private constructModel(
+    attrs: Record<string, unknown>,
+    node: JoinNode | null,
+    _modelCache?: Map<unknown, unknown>,
+  ): any {
+    const modelClass = node ? node.modelClass : this._baseModel;
+    return (modelClass as any)._instantiate(attrs);
+  }
+
   private _buildBaseAliases(): void {
     const columns = getModelColumns(this._baseModel);
     for (let i = 0; i < columns.length; i++) {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -204,8 +204,11 @@ export class JoinDependency {
     // (AliasTracker: aliases[table_name] == 0 → use real name). Mirror that:
     // use the real table name in SQL when there's no collision, otherwise fall
     // back to the sequential tN alias.
+    // Track real table names only — collision check is against the real name.
+    // effectiveName is the tN alias when there IS a collision, but we still
+    // record targetTable so future joins against the same real table also alias.
     const effectiveName = this._usedTableNames.has(targetTable!) ? tableAlias : targetTable!;
-    this._usedTableNames.add(effectiveName);
+    this._usedTableNames.add(targetTable!);
 
     // Substitute the PLACEHOLDER with the effective SQL name
     joinOn = joinOn.replace(/PLACEHOLDER/g, `"${effectiveName}"`);

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -51,9 +51,16 @@ export interface AliasMap {
 
 function getModelColumns(modelClass: any): string[] {
   // columnsHash() triggers loadSchema() which populates _attributeDefinitions
-  // from the schema cache before columnNames() reads them.
-  const ch: Record<string, unknown> | undefined =
-    typeof modelClass.columnsHash === "function" ? modelClass.columnsHash() : undefined;
+  // from the schema cache before columnNames() reads them. Guard with try/catch
+  // in case the model is abstract or has no adapter configured yet.
+  let ch: Record<string, unknown> | undefined;
+  if (typeof modelClass.columnsHash === "function") {
+    try {
+      ch = modelClass.columnsHash() as Record<string, unknown>;
+    } catch {
+      ch = undefined;
+    }
+  }
   const cols: string[] = ch ? Object.keys(ch) : (modelClass.columnNames?.() ?? []);
   const pk = modelClass.primaryKey ?? "id";
   if (Array.isArray(pk)) {
@@ -354,13 +361,21 @@ export class JoinDependency {
     return joins;
   }
 
-  instantiate(resultSet: Record<string, unknown>[], _strictLoadingValue?: boolean): any[] {
-    const { parents } = this.instantiateFromRows(resultSet);
-    return parents;
+  instantiate(resultSet: Record<string, unknown>[], strictLoadingValue?: boolean): any[] {
+    return this.construct(resultSet, strictLoadingValue);
   }
 
   applyColumnAliases(relation: any): any {
-    const selectExprs = this._buildSelectExpressions();
+    // Rails: aliases.columns.map { |c| Arel::Nodes::As.new(...) }
+    // Trails: build the same SQL strings via the aliases object.
+    const effectiveNameByIndex = new Map<number, string>();
+    effectiveNameByIndex.set(this._baseTableIndex, this._baseAlias);
+    for (const node of this._nodes) {
+      effectiveNameByIndex.set(node.tableIndex, node.effectiveSqlName);
+    }
+    const selectExprs = this.aliases()
+      .columns()
+      .map((a) => `"${effectiveNameByIndex.get(a.tableIndex)!}"."${a.column}" AS ${a.alias}`);
     if (typeof relation.reselectBang === "function") {
       relation.reselectBang(...selectExprs);
       return relation;
@@ -433,7 +448,7 @@ export class JoinDependency {
       let parentKey: unknown;
       if (!seenRawPks.has(rawPk)) {
         seenRawPks.add(rawPk);
-        const parent = (this._baseModel as any)._instantiate(parentAttrs);
+        const parent = this.constructModel(parentAttrs, null);
         parentKey = parent._readAttribute(basePk);
         rawToKey.set(rawPk, parentKey);
         parentMap.set(parentKey, parent);
@@ -461,7 +476,7 @@ export class JoinDependency {
 
         if (!seenPks.has(rawChildPk)) {
           seenPks.add(rawChildPk);
-          const child = (node.modelClass as any)._instantiate(childAttrs);
+          const child = this.constructModel(childAttrs, node);
           const parentAssocs = assocMap.get(parentKey)!;
           if (!parentAssocs.has(node.assocName)) {
             parentAssocs.set(node.assocName, []);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -1204,6 +1204,40 @@ describe("RelationTest", () => {
     }
   });
 
+  it("eagerLoad hasMany with LIMIT uses IN-subquery to avoid fan-out", () => {
+    try {
+      class EagerComment extends Base {
+        static {
+          this.tableName = "eager_comments";
+          this.attribute("body", "string");
+          this.attribute("eager_article_id", "integer");
+          this.adapter = adapter;
+          registerModel(this);
+        }
+      }
+      class EagerArticle extends Base {
+        static {
+          this.tableName = "eager_articles";
+          this.attribute("title", "string");
+          Associations.hasMany.call(this, "eagerComments", {
+            className: "EagerComment",
+            foreignKey: "eager_article_id",
+          });
+          this.adapter = adapter;
+          registerModel(this);
+        }
+      }
+      // hasMany is a collection association → not limitable → IN-subquery for fan-out avoidance
+      const sql = EagerArticle.all().eagerLoad("eagerComments").limit(5).toSql();
+      expect(sql).toContain(" IN (SELECT");
+      // LIMIT 5 lives inside the subquery, not on the outer query
+      expect(sql).toMatch(/IN \(SELECT .* LIMIT 5\)/s);
+    } finally {
+      modelRegistry.delete("EagerComment");
+      modelRegistry.delete("EagerArticle");
+    }
+  });
+
   it("includes + references promotes to eager load SQL", () => {
     try {
       class Author extends Base {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -1149,80 +1149,90 @@ describe("RelationTest", () => {
   });
 
   it("eagerLoad emits LEFT OUTER JOIN and t0_r0-style column aliases", () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        registerModel(this);
+    try {
+      class Author extends Base {
+        static {
+          this.attribute("name", "string");
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
-    }
-    class Book extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("author_id", "integer");
-        Associations.belongsTo.call(this, "author", { className: "Author" });
-        this.adapter = adapter;
-        registerModel(this);
+      class Book extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("author_id", "integer");
+          Associations.belongsTo.call(this, "author", { className: "Author" });
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
+      const sql = Book.all().eagerLoad("author").toSql();
+      expect(sql).toMatch(/"books"\."id" AS t0_r/);
+      expect(sql).toMatch(/"authors"\.".*" AS t1_r/);
+      expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
+      expect(sql).not.toMatch(/LEFT OUTER JOIN "authors" "t\d+"/);
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
     }
-    const sql = Book.all().eagerLoad("author").toSql();
-    // SELECT with t0_r* aliases for base table
-    expect(sql).toMatch(/"books"\."id" AS t0_r/);
-    // SELECT with t1_r* aliases for joined table
-    expect(sql).toMatch(/"authors"\.".*" AS t1_r/);
-    // LEFT OUTER JOIN using real table name (no collision)
-    expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
-    // No tN table alias in the JOIN clause (Rails only aliases on collision)
-    expect(sql).not.toMatch(/LEFT OUTER JOIN "authors" "t\d+"/);
   });
 
   it("eagerLoad with LIMIT emits direct LIMIT for non-collection associations", () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        registerModel(this);
+    try {
+      class Author extends Base {
+        static {
+          this.attribute("name", "string");
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
-    }
-    class Book extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("author_id", "integer");
-        Associations.belongsTo.call(this, "author", { className: "Author" });
-        this.adapter = adapter;
-        registerModel(this);
+      class Book extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("author_id", "integer");
+          Associations.belongsTo.call(this, "author", { className: "Author" });
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
+      const sql = Book.all().eagerLoad("author").limit(10).toSql();
+      expect(sql).toContain("LIMIT 10");
+      expect(sql).not.toContain(" IN (SELECT");
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
     }
-    const sql = Book.all().eagerLoad("author").limit(10).toSql();
-    // belongsTo is limitable — no subquery, plain LIMIT
-    expect(sql).toContain("LIMIT 10");
-    expect(sql).not.toContain(" IN (SELECT");
   });
 
   it("includes + references promotes to eager load SQL", () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        registerModel(this);
+    try {
+      class Author extends Base {
+        static {
+          this.attribute("name", "string");
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
-    }
-    class Book extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("author_id", "integer");
-        Associations.belongsTo.call(this, "author", { className: "Author" });
-        this.adapter = adapter;
-        registerModel(this);
+      class Book extends Base {
+        static {
+          this.attribute("title", "string");
+          this.attribute("author_id", "integer");
+          Associations.belongsTo.call(this, "author", { className: "Author" });
+          this.adapter = adapter;
+          registerModel(this);
+        }
       }
+      const sql = Book.all()
+        .includes("author")
+        .where("authors.name = 'Rails'")
+        .references("authors")
+        .toSql();
+      expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
+      expect(sql).toMatch(/"books"\."id" AS t0_r/);
+      expect(sql).toContain("authors.name = 'Rails'");
+    } finally {
+      modelRegistry.delete("Author");
+      modelRegistry.delete("Book");
     }
-    const sql = Book.all()
-      .includes("author")
-      .where("authors.name = 'Rails'")
-      .references("authors")
-      .toSql();
-    expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
-    expect(sql).toMatch(/"books"\."id" AS t0_r/);
-    expect(sql).toContain("authors.name = 'Rails'");
   });
 });

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -1147,4 +1147,82 @@ describe("RelationTest", () => {
     }
     expect(() => Post.order("LOWER(title) ASC").reverseOrder()).toThrow(IrreversibleOrderError);
   });
+
+  it("eagerLoad emits LEFT OUTER JOIN and t0_r0-style column aliases", () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    class Book extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        Associations.belongsTo.call(this, "author", { className: "Author" });
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    const sql = Book.all().eagerLoad("author").toSql();
+    // SELECT with t0_r* aliases for base table
+    expect(sql).toMatch(/"books"\."id" AS t0_r/);
+    // SELECT with t1_r* aliases for joined table
+    expect(sql).toMatch(/"authors"\.".*" AS t1_r/);
+    // LEFT OUTER JOIN using real table name (no collision)
+    expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
+    // No tN table alias in the JOIN clause (Rails only aliases on collision)
+    expect(sql).not.toMatch(/LEFT OUTER JOIN "authors" "t\d+"/);
+  });
+
+  it("eagerLoad with LIMIT emits direct LIMIT for non-collection associations", () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    class Book extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        Associations.belongsTo.call(this, "author", { className: "Author" });
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    const sql = Book.all().eagerLoad("author").limit(10).toSql();
+    // belongsTo is limitable — no subquery, plain LIMIT
+    expect(sql).toContain("LIMIT 10");
+    expect(sql).not.toContain(" IN (SELECT");
+  });
+
+  it("includes + references promotes to eager load SQL", () => {
+    class Author extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    class Book extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("author_id", "integer");
+        Associations.belongsTo.call(this, "author", { className: "Author" });
+        this.adapter = adapter;
+        registerModel(this);
+      }
+    }
+    const sql = Book.all()
+      .includes("author")
+      .where("authors.name = 'Rails'")
+      .references("authors")
+      .toSql();
+    expect(sql).toContain('LEFT OUTER JOIN "authors" ON');
+    expect(sql).toMatch(/"books"\."id" AS t0_r/);
+    expect(sql).toContain("authors.name = 'Rails'");
+  });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1890,10 +1890,14 @@ export class Relation<T extends Base> {
     if (this._referencesValues.length === 0) return false;
     if (this._includesAssociations.length === 0) return false;
 
+    // Rails builds join nodes and checks Arel::Nodes::StringJoin to identify
+    // raw SQL joins; mirrors that by wrapping _rawJoins as Nodes.StringJoin and
+    // extracting table names from their SQL text via tablesInString.
+    const stringJoins = this._rawJoins.map((s) => new Nodes.StringJoin(new Nodes.SqlLiteral(s)));
+
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
-      // Raw SQL join strings may reference table names inline
-      ...this._rawJoins.flatMap((s) => this.tablesInString(s)),
+      ...stringJoins.flatMap((j) => this.tablesInString((j.left as Nodes.SqlLiteral).value)),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
     ]);
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1909,8 +1909,11 @@ export class Relation<T extends Base> {
    */
   private tablesInString(string: string): string[] {
     if (!string) return [];
-    // Match word.word patterns (table.column), downcase to match Rails' Oracle compat.
-    const matches = string.match(/[a-zA-Z_][\w.]+(?=\.)/g) ?? [];
+    // Mirrors Rails' tables_in_string regex: /[a-zA-Z_][.\w]+(?=.?\.)/
+    // The `.?` lookahead allows one non-dot char (e.g. a closing `"`) between
+    // the identifier and the qualifying dot, so `"posts"."col"` correctly
+    // yields `posts`. Downcase to match Rails' Oracle compat comment.
+    const matches = string.match(/[a-zA-Z_][\w.]+(?=.?\.)/g) ?? [];
     return matches.map((s) => s.toLowerCase()).filter((s) => s !== "raw_sql_");
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1866,36 +1866,58 @@ export class Relation<T extends Base> {
   /**
    * Rails all-or-nothing promotion: if ANY references_values entry
    * refers to a table that is NOT already joined, ALL includes get
-   * promoted to eager_load. See `references_eager_loaded_tables?`
-   * in Rails relation.rb — the check is boolean, not per-association.
+   * promoted to eager_load.
    */
   private _includesToPromoteFromReferences(): AssociationSpec[] {
-    if (this._referencesValues.length === 0) return [];
-    if (this._includesAssociations.length === 0) return [];
-
-    const joinedTables = new Set(
-      this._joinClauses
-        .map((j) => j.table.toLowerCase())
-        .concat([
-          String(
-            (this._modelClass as unknown as { tableName?: string }).tableName ?? "",
-          ).toLowerCase(),
-        ]),
-    );
-    const refs = this._referencesValues.map((t) => t.toLowerCase());
-    const hasUnjoined = refs.some((ref) => !joinedTables.has(ref));
-    if (!hasUnjoined) return [];
-
+    if (!this.referencesEagerLoadedTables()) return [];
+    const alreadyEagerLoaded = new Set(this._eagerLoadAssociations);
     // Rails promotes ALL includes to eager_load when references points to an
     // unjoined table. We promote flat string includes here; nested hash specs
     // are left to the preloader because our JoinDependency does not yet
-    // support recursively joining nested association specs. Promoting hash
-    // top-level keys without also recursively joining their sub-associations
-    // would leave sub-associations unloaded. See: references_eager_loaded_tables?
-    const alreadyEagerLoaded = new Set(this._eagerLoadAssociations);
+    // support recursively joining nested association specs.
     return this._includesAssociations.filter(
       (name): name is string => typeof name === "string" && !alreadyEagerLoaded.has(name),
     );
+  }
+
+  /**
+   * Returns true when any references_values entry points to a table that is
+   * not already joined — triggers promoting includes to eager_load.
+   *
+   * Mirrors: ActiveRecord::Relation#references_eager_loaded_tables?
+   */
+  private referencesEagerLoadedTables(): boolean {
+    if (this._referencesValues.length === 0) return false;
+    if (this._includesAssociations.length === 0) return false;
+
+    const joinedTables = new Set<string>([
+      ...this._joinClauses.map((j) => j.table.toLowerCase()),
+      // Raw SQL join strings may reference table names inline
+      ...this._rawJoins.flatMap((s) => this.tablesInString(s)),
+      String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
+    ]);
+
+    return this._referencesValues.some((ref) => !joinedTables.has(ref.toLowerCase()));
+  }
+
+  /**
+   * Extracts table-like identifiers from a raw SQL string (e.g. a JOIN fragment).
+   *
+   * Mirrors: ActiveRecord::Relation#tables_in_string
+   */
+  private tablesInString(string: string): string[] {
+    if (!string) return [];
+    // Match word.word patterns (table.column), downcase to match Rails' Oracle compat.
+    const matches = string.match(/[a-zA-Z_][\w.]+(?=\.)/g) ?? [];
+    return matches.map((s) => s.toLowerCase()).filter((s) => s !== "raw_sql_");
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Relation#limited_count
+   */
+  private limitedCount(): Promise<number> {
+    if (this._limitValue != null) return this.count() as Promise<number>;
+    return this.limit(2).count() as Promise<number>;
   }
 
   private async _executeEagerLoad(eagerAssocs?: AssociationSpec[]): Promise<void> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1888,14 +1888,19 @@ export class Relation<T extends Base> {
     if (this._referencesValues.length === 0) return false;
     if (this._includesAssociations.length === 0) return false;
 
-    // Rails checks Arel::Nodes::StringJoin to identify raw SQL join fragments.
-    // Mirror that: construct StringJoin nodes for _rawJoins (the equivalent),
-    // then extract table identifiers from each node's SQL text.
+    // _rawJoins are the string-form equivalent of Rails' Arel::Nodes::StringJoin.
+    // Rails' references_eager_loaded_tables? extracts table names from StringJoin
+    // nodes via tables_in_string; mirror that by passing each raw SQL string
+    // directly to tablesInString (wrapping as StringJoin for type-level parity).
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
-      ...this._rawJoins
-        .map((s) => new Nodes.StringJoin(new Nodes.SqlLiteral(s)))
-        .flatMap((j) => this.tablesInString((j.left as unknown as { value: string }).value)),
+      ...this._rawJoins.flatMap((s) => {
+        // Wrap as StringJoin (Rails' Arel::Nodes::StringJoin equivalent) and
+        // read back via instanceof to stay type-safe with no unsafe cast.
+        const join = new Nodes.StringJoin(new Nodes.SqlLiteral(s));
+        const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : s;
+        return this.tablesInString(sqlText);
+      }),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
     ]);
 
@@ -1907,13 +1912,13 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#tables_in_string
    */
-  private tablesInString(string: string): string[] {
-    if (!string) return [];
+  private tablesInString(sql: string): string[] {
+    if (!sql) return [];
     // Mirrors Rails' tables_in_string regex: /[a-zA-Z_][.\w]+(?=.?\.)/
     // The `.?` lookahead allows one non-dot char (e.g. a closing `"`) between
     // the identifier and the qualifying dot, so `"posts"."col"` correctly
     // yields `posts`. Downcase to match Rails' Oracle compat comment.
-    const matches = string.match(/[a-zA-Z_][\w.]+(?=.?\.)/g) ?? [];
+    const matches = sql.match(/[a-zA-Z_][\w.]+(?=.?\.)/g) ?? [];
     return matches.map((s) => s.toLowerCase()).filter((s) => s !== "raw_sql_");
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1967,53 +1967,8 @@ export class Relation<T extends Base> {
       return;
     }
 
-    const table = this._modelClass.arelTable;
-    const manager = table.project(new Nodes.SqlLiteral(jd.buildSelectSql()));
+    const manager = this._buildEagerJoinManager(jd, basePk);
 
-    // Apply JoinDependency's LEFT OUTER JOINs
-    for (const node of jd.nodes) {
-      (manager as any).core.source.right.push(
-        new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-      );
-    }
-
-    // Apply relation's existing joins, WHERE, ORDER, LIMIT, OFFSET, etc.
-    this._applyJoinsToManager(manager);
-    this._applyWheresToManager(manager, table);
-    this._applyOrderToManager(manager, table);
-
-    if (this._isDistinct) manager.distinct();
-    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
-    if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
-    if (this._lockValue) manager.lock(this._lockValue);
-
-    // When LIMIT/OFFSET is present, use a subquery for parent IDs to avoid
-    // JOIN fan-out changing the number of parent records returned.
-    if (this._limitValue !== null || this._offsetValue !== null) {
-      const tableName = (this._modelClass as any).tableName;
-      const idSubquery = table.project(`"${tableName}"."${basePk}"`);
-      (idSubquery as any).distinct();
-      for (const node of jd.nodes) {
-        (idSubquery as any).core.source.right.push(
-          new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-        );
-      }
-      this._applyJoinsToManager(idSubquery as any);
-      this._applyWheresToManager(idSubquery as any, table);
-      this._applyOrderToManager(idSubquery as any, table);
-      if (this._limitValue !== null) (idSubquery as any).take(this._limitValue);
-      if (this._offsetValue !== null) (idSubquery as any).skip(this._offsetValue);
-      manager.where(
-        new Nodes.SqlLiteral(`"${tableName}"."${basePk}" IN (${(idSubquery as any).toSql()})`),
-      );
-    } else {
-      if (this._limitValue !== null) manager.take(this._limitValue);
-      if (this._offsetValue !== null) manager.skip(this._offsetValue);
-    }
-
-    if (this._optimizerHints.length > 0) {
-      manager.optimizerHints(...this._optimizerHints);
-    }
     let sql = manager.toSql();
     if (this._annotations.length > 0) {
       const comments = this._annotations.map((c) => `/* ${c} */`).join(" ");
@@ -3162,6 +3117,67 @@ export class Relation<T extends Base> {
     return this._includesToPromoteFromReferences().length > 0;
   }
 
+  /**
+   * Shared helper used by both _buildEagerSql (toSql path) and _executeEagerLoad
+   * (execution path). Builds a SelectManager with JoinDependency column aliases,
+   * LEFT OUTER JOINs, WHERE/ORDER/DISTINCT/GROUP/HAVING/LOCK/HINTS applied, and
+   * LIMIT/OFFSET handling via the limitable-reflections check.
+   *
+   * Mirrors: ActiveRecord::Relation#apply_join_dependency +
+   *          ActiveRecord::Associations::JoinDependency#apply_column_aliases
+   */
+  private _buildEagerJoinManager(jd: JoinDependency, basePk: string): SelectManager {
+    const table = this._modelClass.arelTable;
+
+    const manager = table.project(new Nodes.SqlLiteral(jd.buildSelectSql()));
+
+    for (const node of jd.nodes) {
+      (manager as any).core.source.right.push(
+        new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
+      );
+    }
+
+    this._applyJoinsToManager(manager);
+    this._applyWheresToManager(manager, table);
+    this._applyOrderToManager(manager, table);
+    if (this._isDistinct) manager.distinct();
+    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
+    if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
+    if (this._lockValue) manager.lock(this._lockValue);
+    if (this._optimizerHints.length > 0) manager.optimizerHints(...this._optimizerHints);
+
+    // LIMIT/OFFSET: use a subquery for collection associations to avoid fan-out
+    // (mirrors Rails' using_limitable_reflections? check in finder_methods.rb).
+    // Non-collection associations (belongsTo, hasOne) are limitable — apply directly.
+    const hasLimit = this._limitValue !== null || this._offsetValue !== null;
+    if (hasLimit) {
+      const isLimitable = jd.nodes.every((n) => n.assocType !== "hasMany");
+      if (isLimitable) {
+        if (this._limitValue !== null) manager.take(this._limitValue);
+        if (this._offsetValue !== null) manager.skip(this._offsetValue);
+      } else {
+        // Build a parent-ID subquery using Arel nodes so quoting is consistent.
+        const pkAttr = table.get(basePk);
+        const idSubquery = table.project(pkAttr);
+        (idSubquery as any).distinct();
+        for (const node of jd.nodes) {
+          (idSubquery as any).core.source.right.push(
+            new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
+          );
+        }
+        this._applyJoinsToManager(idSubquery as any);
+        this._applyWheresToManager(idSubquery as any, table);
+        this._applyOrderToManager(idSubquery as any, table);
+        if (this._limitValue !== null) (idSubquery as any).take(this._limitValue);
+        if (this._offsetValue !== null) (idSubquery as any).skip(this._offsetValue);
+        // pkAttr.in(subquery) produces "table"."pk" IN (SELECT ...) via Arel
+        manager.where(pkAttr.in(idSubquery));
+      }
+    }
+
+    return manager;
+  }
+
   // Mirrors: ActiveRecord::Relation#to_sql when eager_loading? — builds the
   // JoinDependency SQL synchronously for toSql()/parity runner use.
   // Returns null if no eager associations could be joined (fall back to plain SQL).
@@ -3183,56 +3199,7 @@ export class Relation<T extends Base> {
     }
     if (jd.nodes.length === 0) return null;
 
-    const table = this._modelClass.arelTable;
-
-    // Build SELECT with t0_r0-style column aliases (mirrors apply_column_aliases)
-    const baseSelectSql = jd.buildSelectSql();
-    const manager = table.project(new Nodes.SqlLiteral(baseSelectSql));
-
-    // Apply LEFT OUTER JOINs from JoinDependency
-    for (const node of jd.nodes) {
-      (manager as any).core.source.right.push(
-        new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-      );
-    }
-
-    this._applyJoinsToManager(manager);
-    this._applyWheresToManager(manager, table);
-    this._applyOrderToManager(manager, table);
-    if (this._isDistinct) manager.distinct();
-    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
-    if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
-    if (this._lockValue) manager.lock(this._lockValue);
-    if (this._optimizerHints.length > 0) manager.optimizerHints(...this._optimizerHints);
-
-    // LIMIT/OFFSET: use a subquery for collection associations to avoid fan-out.
-    // Non-collection (belongsTo, hasOne) are limitable — apply LIMIT directly.
-    // Mirrors: using_limitable_reflections? in Rails finder_methods.rb
-    const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit) {
-      const isLimitable = jd.nodes.every((n) => n.assocType !== "hasMany");
-      if (isLimitable) {
-        if (this._limitValue !== null) manager.take(this._limitValue);
-        if (this._offsetValue !== null) manager.skip(this._offsetValue);
-      } else {
-        const tableName = (this._modelClass as any).tableName;
-        const idSubquery = table.project(`"${tableName}"."${basePk}"`);
-        (idSubquery as any).distinct();
-        for (const node of jd.nodes) {
-          (idSubquery as any).core.source.right.push(
-            new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-          );
-        }
-        this._applyJoinsToManager(idSubquery as any);
-        this._applyWheresToManager(idSubquery as any, table);
-        this._applyOrderToManager(idSubquery as any, table);
-        if (this._limitValue !== null) (idSubquery as any).take(this._limitValue);
-        if (this._offsetValue !== null) (idSubquery as any).skip(this._offsetValue);
-        manager.where(
-          new Nodes.SqlLiteral(`"${tableName}"."${basePk}" IN (${(idSubquery as any).toSql()})`),
-        );
-      }
-    }
+    const manager = this._buildEagerJoinManager(jd, basePk);
 
     let sql = manager.toSql();
     if (this._annotations.length > 0) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -52,6 +52,7 @@ import { ExplainRegistry } from "./explain-registry.js";
 import { inspectExplainOption } from "./adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "./adapter.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
+import { JoinDependency } from "./associations/join-dependency.js";
 
 /**
  * A Relation returned from `load()` / `reload()` — a normal Relation with
@@ -1913,7 +1914,6 @@ export class Relation<T extends Base> {
       return;
     }
 
-    const { JoinDependency } = await import("./associations/join-dependency.js");
     const jd = new JoinDependency(this._modelClass);
 
     const fallbackAssocs: AssociationSpec[] = [];
@@ -3132,7 +3132,101 @@ export class Relation<T extends Base> {
     return this._toSqlWithoutSetOp();
   }
 
+  // Mirrors: ActiveRecord::Relation#eager_loading?
+  private _eagerLoadingForSql(): boolean {
+    if (this._eagerLoadAssociations.length > 0) return true;
+    return this._includesToPromoteFromReferences().length > 0;
+  }
+
+  // Mirrors: ActiveRecord::Relation#to_sql when eager_loading? — builds the
+  // JoinDependency SQL synchronously for toSql()/parity runner use.
+  // Returns null if no eager associations could be joined (fall back to plain SQL).
+  private _buildEagerSql(): string | null {
+    if (this._setOperation || !this._fromClause.isEmpty() || this._ctes.length > 0) return null;
+
+    const allEager = [
+      ...new Set([...this._eagerLoadAssociations, ...this._includesToPromoteFromReferences()]),
+    ];
+    if (allEager.length === 0) return null;
+
+    const basePk = (this._modelClass as any).primaryKey ?? "id";
+    if (Array.isArray(basePk)) return null;
+
+    const jd = new JoinDependency(this._modelClass);
+    for (const assocName of allEager) {
+      if (typeof assocName !== "string") continue;
+      jd.addAssociation(assocName);
+    }
+    if (jd.nodes.length === 0) return null;
+
+    const table = this._modelClass.arelTable;
+
+    // Build SELECT with t0_r0-style column aliases (mirrors apply_column_aliases)
+    const baseSelectSql = jd.buildSelectSql();
+    const manager = table.project(new Nodes.SqlLiteral(baseSelectSql));
+
+    // Apply LEFT OUTER JOINs from JoinDependency
+    for (const node of jd.nodes) {
+      (manager as any).core.source.right.push(
+        new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
+      );
+    }
+
+    this._applyJoinsToManager(manager);
+    this._applyWheresToManager(manager, table);
+    this._applyOrderToManager(manager, table);
+    if (this._isDistinct) manager.distinct();
+    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
+    if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
+    if (this._lockValue) manager.lock(this._lockValue);
+    if (this._optimizerHints.length > 0) manager.optimizerHints(...this._optimizerHints);
+
+    // LIMIT/OFFSET: use a subquery for collection associations to avoid fan-out.
+    // Non-collection (belongsTo, hasOne) are limitable — apply LIMIT directly.
+    // Mirrors: using_limitable_reflections? in Rails finder_methods.rb
+    const hasLimit = this._limitValue !== null || this._offsetValue !== null;
+    if (hasLimit) {
+      const isLimitable = jd.nodes.every((n) => n.assocType !== "hasMany");
+      if (isLimitable) {
+        if (this._limitValue !== null) manager.take(this._limitValue);
+        if (this._offsetValue !== null) manager.skip(this._offsetValue);
+      } else {
+        const tableName = (this._modelClass as any).tableName;
+        const idSubquery = table.project(`"${tableName}"."${basePk}"`);
+        (idSubquery as any).distinct();
+        for (const node of jd.nodes) {
+          (idSubquery as any).core.source.right.push(
+            new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
+          );
+        }
+        this._applyJoinsToManager(idSubquery as any);
+        this._applyWheresToManager(idSubquery as any, table);
+        this._applyOrderToManager(idSubquery as any, table);
+        if (this._limitValue !== null) (idSubquery as any).take(this._limitValue);
+        if (this._offsetValue !== null) (idSubquery as any).skip(this._offsetValue);
+        manager.where(
+          new Nodes.SqlLiteral(`"${tableName}"."${basePk}" IN (${(idSubquery as any).toSql()})`),
+        );
+      }
+    }
+
+    let sql = manager.toSql();
+    if (this._annotations.length > 0) {
+      const comments = this._annotations.map((c) => `/* ${c} */`).join(" ");
+      sql = `${sql} ${comments}`;
+    }
+    return sql;
+  }
+
   private _toSqlWithoutSetOp(): string {
+    // Eager loading: emit JoinDependency SQL (mirrors Rails to_sql + eager_loading?)
+    if (this._eagerLoadingForSql()) {
+      const eagerSql = this._buildEagerSql();
+      if (eagerSql !== null) return eagerSql;
+      // If _buildEagerSql returns null (e.g. unresolvable association),
+      // fall through to plain SQL so toSql() always returns something useful.
+    }
+
     const table = this._modelClass.arelTable;
     const projections = this._buildProjections(table);
     const manager = table.project(...(projections as any));

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1696,8 +1696,7 @@ export class Relation<T extends Base> {
    */
   async isMany(): Promise<boolean> {
     if (this._loaded) return this._records.length > 1;
-    const c = await this.count();
-    return (c as number) > 1;
+    return (await this.limitedCount()) > 1;
   }
 
   /**
@@ -1707,8 +1706,7 @@ export class Relation<T extends Base> {
    */
   async isOne(): Promise<boolean> {
     if (this._loaded) return this._records.length === 1;
-    const c = await this.count();
-    return (c as number) === 1;
+    return (await this.limitedCount()) === 1;
   }
 
   /**
@@ -1890,14 +1888,14 @@ export class Relation<T extends Base> {
     if (this._referencesValues.length === 0) return false;
     if (this._includesAssociations.length === 0) return false;
 
-    // Rails builds join nodes and checks Arel::Nodes::StringJoin to identify
-    // raw SQL joins; mirrors that by wrapping _rawJoins as Nodes.StringJoin and
-    // extracting table names from their SQL text via tablesInString.
-    const stringJoins = this._rawJoins.map((s) => new Nodes.StringJoin(new Nodes.SqlLiteral(s)));
-
+    // Rails checks Arel::Nodes::StringJoin to identify raw SQL join fragments.
+    // Mirror that: construct StringJoin nodes for _rawJoins (the equivalent),
+    // then extract table identifiers from each node's SQL text.
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
-      ...stringJoins.flatMap((j) => this.tablesInString((j.left as Nodes.SqlLiteral).value)),
+      ...this._rawJoins
+        .map((s) => new Nodes.StringJoin(new Nodes.SqlLiteral(s)))
+        .flatMap((j) => this.tablesInString((j.left as unknown as { value: string }).value)),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
     ]);
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2282,7 +2282,7 @@ export class Relation<T extends Base> {
       }
     }
     for (const rawJoin of this._rawJoins) {
-      (manager as any).core.source.right.push(new Nodes.StringJoin(new Nodes.SqlLiteral(rawJoin)));
+      manager.appendStringJoin(rawJoin);
     }
   }
 
@@ -3140,9 +3140,7 @@ export class Relation<T extends Base> {
     const manager = table.project(new Nodes.SqlLiteral(jd.buildSelectSql()));
 
     for (const node of jd.nodes) {
-      (manager as any).core.source.right.push(
-        new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-      );
+      manager.appendStringJoin(node.joinSql);
     }
 
     this._applyJoinsToManager(manager);
@@ -3167,17 +3165,15 @@ export class Relation<T extends Base> {
         // Build a parent-ID subquery using Arel nodes so quoting is consistent.
         const pkAttr = table.get(basePk);
         const idSubquery = table.project(pkAttr);
-        (idSubquery as any).distinct();
+        idSubquery.distinct();
         for (const node of jd.nodes) {
-          (idSubquery as any).core.source.right.push(
-            new Nodes.StringJoin(new Nodes.SqlLiteral(node.joinSql)),
-          );
+          idSubquery.appendStringJoin(node.joinSql);
         }
-        this._applyJoinsToManager(idSubquery as any);
-        this._applyWheresToManager(idSubquery as any, table);
-        this._applyOrderToManager(idSubquery as any, table);
-        if (this._limitValue !== null) (idSubquery as any).take(this._limitValue);
-        if (this._offsetValue !== null) (idSubquery as any).skip(this._offsetValue);
+        this._applyJoinsToManager(idSubquery);
+        this._applyWheresToManager(idSubquery, table);
+        this._applyOrderToManager(idSubquery, table);
+        if (this._limitValue !== null) idSubquery.take(this._limitValue);
+        if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);
         // pkAttr.in(subquery) produces "table"."pk" IN (SELECT ...) via Arel
         manager.where(pkAttr.in(idSubquery));
       }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -255,12 +255,14 @@ export async function performCount(
     // Mirrors: ActiveRecord::Calculations#build_count_subquery
     const innerTable = this._modelClass.arelTable;
     let innerManager: ReturnType<typeof innerTable.project>;
+    // columnAlias: what the outer COUNT targets. Mirrors Rails:
+    //   column_name == :all → Arel.star   (outer: COUNT(*))
+    //   else                → "count_column" (outer: COUNT(count_column))
+    const effectiveCol = column === "*" ? undefined : column;
+    let columnAlias: Nodes.Node;
     if (this._isDistinct) {
-      // DISTINCT relation: project the PK with DISTINCT applied so the inner
-      // query deduplicates before counting. Use table.get(col) for each column
-      // so PK references are qualified (table.col) and unambiguous when joins
-      // are present. Mirrors Rails: composite-PK DISTINCT count uses separate
-      // Attribute nodes for each key column.
+      // DISTINCT: project PK with DISTINCT applied so the inner query
+      // deduplicates before counting. Use table.get(c) for qualified refs.
       const pk = (this._modelClass as any).primaryKey ?? "id";
       if (Array.isArray(pk)) {
         innerManager = innerTable.project(...pk.map((c: string) => innerTable.get(c)));
@@ -268,24 +270,29 @@ export async function performCount(
         innerManager = innerTable.project(innerTable.get(pk));
       }
       innerManager.distinct();
+      columnAlias = new Nodes.SqlLiteral("*");
+    } else if (effectiveCol) {
+      // Specific column requested: project it aliased as count_column so the
+      // outer COUNT(count_column) excludes NULLs, matching non-limited semantics.
+      const colNode = innerTable.get(effectiveCol);
+      innerManager = innerTable.project(colNode.as("count_column"));
+      columnAlias = new Nodes.SqlLiteral("count_column");
     } else {
       innerManager = innerTable.project(new Nodes.SqlLiteral("1 AS one"));
+      columnAlias = new Nodes.SqlLiteral("*");
     }
     this._applyJoinsToManager(innerManager);
     this._applyWheresToManager(innerManager, innerTable);
     if (this._limitValue !== null) innerManager.take(this._limitValue);
     if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
-    // Build outer COUNT using Arel AST: wrap the inner SelectManager in a
-    // Grouping node (parentheses) with a TableAlias ("subquery_for_count"),
-    // then project COUNT(*) with that node as the FROM source.
-    // Mirrors Rails: build_count_subquery uses Arel::Nodes::TableAlias.new(
-    //   Arel::Nodes::Grouping.new(inner_arel), alias_name)
+    // Wrap inner query as Arel AST: Grouping (parens) + TableAlias.
+    // Mirrors Rails: Arel::Nodes::TableAlias.new(Arel::Nodes::Grouping.new(inner), alias)
     const subqueryNode = new Nodes.TableAlias(
       new Nodes.Grouping(innerManager.ast),
       "subquery_for_count",
     );
-    const countAll = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
-    const outerManager = innerTable.project(countAll.as("count"));
+    const countNode = new Nodes.NamedFunction("COUNT", [columnAlias]);
+    const outerManager = innerTable.project(countNode.as("count"));
     outerManager.from(subqueryNode);
     const result = await this._modelClass.adapter.selectAll(
       outerManager.toSql(),

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -249,9 +249,25 @@ export async function performCount(
     return groupedAggregate(this, "count", column ?? "*", true) as Promise<Record<string, number>>;
   }
 
-  if (this._limitValue !== null) {
-    const rows = await this.toArray();
-    return rows.length;
+  if (this._limitValue !== null || this._offsetValue !== null) {
+    // Rails: build_count_subquery — wraps the limited relation as a subquery and
+    // counts its rows without instantiating records.
+    // SELECT COUNT(*) FROM (SELECT 1 AS one FROM ... LIMIT N) subquery_for_count
+    const innerTable = this._modelClass.arelTable;
+    const innerManager = innerTable.project(new Nodes.SqlLiteral("1 AS one"));
+    this._applyJoinsToManager(innerManager);
+    this._applyWheresToManager(innerManager, innerTable);
+    if (this._limitValue !== null) innerManager.take(this._limitValue);
+    if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
+    const outerManager = new Nodes.SqlLiteral(
+      `SELECT COUNT(*) AS count FROM (${innerManager.toSql()}) subquery_for_count`,
+    );
+    const result = await this._modelClass.adapter.selectAll(
+      String(outerManager),
+      `${this._modelClass.name} Count`,
+    );
+    const rows = result.toArray() as Record<string, unknown>[];
+    return Number(rows[0]?.count ?? 0);
   }
 
   const table = this._modelClass.arelTable;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -257,13 +257,16 @@ export async function performCount(
     let innerManager: ReturnType<typeof innerTable.project>;
     if (this._isDistinct) {
       // DISTINCT relation: project the PK with DISTINCT applied so the inner
-      // query deduplicates rows before counting (mirrors Rails: when distinct
-      // is true, select_values are preserved rather than replaced with 1 AS one).
+      // query deduplicates before counting. Use table.get(col) for each column
+      // so PK references are qualified (table.col) and unambiguous when joins
+      // are present. Mirrors Rails: composite-PK DISTINCT count uses separate
+      // Attribute nodes for each key column.
       const pk = (this._modelClass as any).primaryKey ?? "id";
-      const pkAttr = Array.isArray(pk)
-        ? new Nodes.SqlLiteral(pk.map((c: string) => `"${c}"`).join(", "))
-        : innerTable.get(pk);
-      innerManager = innerTable.project(pkAttr as any);
+      if (Array.isArray(pk)) {
+        innerManager = innerTable.project(...pk.map((c: string) => innerTable.get(c)));
+      } else {
+        innerManager = innerTable.project(innerTable.get(pk));
+      }
       innerManager.distinct();
     } else {
       innerManager = innerTable.project(new Nodes.SqlLiteral("1 AS one"));
@@ -272,11 +275,18 @@ export async function performCount(
     this._applyWheresToManager(innerManager, innerTable);
     if (this._limitValue !== null) innerManager.take(this._limitValue);
     if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
-    // Build outer COUNT via Arel (outerManager.from(subquery)) so adapter-specific
-    // quoting behavior is applied consistently.
+    // Build outer COUNT using Arel AST: wrap the inner SelectManager in a
+    // Grouping node (parentheses) with a TableAlias ("subquery_for_count"),
+    // then project COUNT(*) with that node as the FROM source.
+    // Mirrors Rails: build_count_subquery uses Arel::Nodes::TableAlias.new(
+    //   Arel::Nodes::Grouping.new(inner_arel), alias_name)
+    const subqueryNode = new Nodes.TableAlias(
+      new Nodes.Grouping(innerManager.ast),
+      "subquery_for_count",
+    );
     const countAll = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
     const outerManager = innerTable.project(countAll.as("count"));
-    outerManager.from(new Nodes.SqlLiteral(`(${innerManager.toSql()}) subquery_for_count`));
+    outerManager.from(subqueryNode);
     const result = await this._modelClass.adapter.selectAll(
       outerManager.toSql(),
       `${this._modelClass.name} Count`,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -260,9 +260,16 @@ export async function performCount(
     //   else                → "count_column" (outer: COUNT(count_column))
     const effectiveCol = column === "*" ? undefined : column;
     let columnAlias: Nodes.Node;
-    if (this._isDistinct) {
-      // DISTINCT: project PK with DISTINCT applied so the inner query
-      // deduplicates before counting. Use table.get(c) for qualified refs.
+    if (this._isDistinct && effectiveCol) {
+      // DISTINCT + specific column: project that column aliased as count_column
+      // with DISTINCT applied so the inner query counts distinct non-NULL values
+      // of the requested column (matches COUNT(DISTINCT col) semantics).
+      innerManager = innerTable.project(innerTable.get(effectiveCol).as("count_column"));
+      innerManager.distinct();
+      columnAlias = new Nodes.SqlLiteral("count_column");
+    } else if (this._isDistinct) {
+      // DISTINCT + count(*): project PK with DISTINCT to deduplicate rows.
+      // Use table.get(c) so PK refs are qualified (unambiguous with joins).
       const pk = (this._modelClass as any).primaryKey ?? "id";
       if (Array.isArray(pk)) {
         innerManager = innerTable.project(...pk.map((c: string) => innerTable.get(c)));

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -250,20 +250,35 @@ export async function performCount(
   }
 
   if (this._limitValue !== null || this._offsetValue !== null) {
-    // Rails: build_count_subquery — wraps the limited relation as a subquery and
-    // counts its rows without instantiating records.
-    // SELECT COUNT(*) FROM (SELECT 1 AS one FROM ... LIMIT N) subquery_for_count
+    // Rails: build_count_subquery — wraps the limited relation as a subquery
+    // and counts its rows without instantiating records.
+    // Mirrors: ActiveRecord::Calculations#build_count_subquery
     const innerTable = this._modelClass.arelTable;
-    const innerManager = innerTable.project(new Nodes.SqlLiteral("1 AS one"));
+    let innerManager: ReturnType<typeof innerTable.project>;
+    if (this._isDistinct) {
+      // DISTINCT relation: project the PK with DISTINCT applied so the inner
+      // query deduplicates rows before counting (mirrors Rails: when distinct
+      // is true, select_values are preserved rather than replaced with 1 AS one).
+      const pk = (this._modelClass as any).primaryKey ?? "id";
+      const pkAttr = Array.isArray(pk)
+        ? new Nodes.SqlLiteral(pk.map((c: string) => `"${c}"`).join(", "))
+        : innerTable.get(pk);
+      innerManager = innerTable.project(pkAttr as any);
+      innerManager.distinct();
+    } else {
+      innerManager = innerTable.project(new Nodes.SqlLiteral("1 AS one"));
+    }
     this._applyJoinsToManager(innerManager);
     this._applyWheresToManager(innerManager, innerTable);
     if (this._limitValue !== null) innerManager.take(this._limitValue);
     if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
-    const outerManager = new Nodes.SqlLiteral(
-      `SELECT COUNT(*) AS count FROM (${innerManager.toSql()}) subquery_for_count`,
-    );
+    // Build outer COUNT via Arel (outerManager.from(subquery)) so adapter-specific
+    // quoting behavior is applied consistently.
+    const countAll = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
+    const outerManager = innerTable.project(countAll.as("count"));
+    outerManager.from(new Nodes.SqlLiteral(`(${innerManager.toSql()}) subquery_for_count`));
     const result = await this._modelClass.adapter.selectAll(
-      String(outerManager),
+      outerManager.toSql(),
       `${this._modelClass.name} Count`,
     );
     const rows = result.toArray() as Record<string, unknown>[];

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -579,6 +579,20 @@ export class SelectManager extends TreeManager {
   }
 
   /**
+   * Append a raw-SQL join fragment (a StringJoin) to the FROM sources.
+   * Use this instead of reaching into `core.source.right` directly when
+   * you need to add a pre-built JOIN string (e.g. `LEFT OUTER JOIN … ON …`).
+   *
+   * Mirrors: the join_sources mutation pattern in Rails' JoinDependency
+   * (relation.joins!(join_dependency) calls join_constraints which pushes
+   * StringJoin nodes onto the Arel manager's join_sources).
+   */
+  appendStringJoin(sql: string | Node): this {
+    this.core.source.right.push(this.createStringJoin(sql));
+    return this;
+  }
+
+  /**
    * Factory: create an AND node.
    */
   createAnd(nodes: Node[]): And {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -587,8 +587,8 @@ export class SelectManager extends TreeManager {
    * (relation.joins!(join_dependency) calls join_constraints which pushes
    * StringJoin nodes onto the Arel manager's join_sources).
    */
-  appendStringJoin(sql: string | Node): this {
-    this.core.source.right.push(this.createStringJoin(sql));
+  appendStringJoin(sql: string): this {
+    this.core.source.right.push(new StringJoin(new SqlLiteral(sql), null));
     return this;
   }
 

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -1,7 +1,7 @@
 {
   "ar-01": {
     "side": "diff",
-    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date\u2192SQL serialization to drop fractional seconds for unscaled DATETIME columns."
+    "reason": "Datetime SQL serialization does not honour column precision: trails serializes Date binds with microsecond precision ('.677000'), Rails truncates to whole seconds when the DATETIME column has no precision spec (as in this fixture's bare `created_at DATETIME`). Rails: 'reviews.created_at > ''2026-04-19 00:46:48'''; trails: 'reviews.created_at > ''2026-04-19 00:46:48.677000'''. Flakes by frozen-at: PR #854 'closed' this gap because that run's frozen-at landed on a whole second. Real fix is in Date→SQL serialization to drop fractional seconds for unscaled DATETIME columns."
   },
   "ar-52": {
     "side": "diff",
@@ -9,14 +9,6 @@
   },
   "ar-65": {
     "side": "diff",
-    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) \u2014 rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
-  },
-  "ar-16": {
-    "side": "diff",
-    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
-  },
-  "ar-57": {
-    "side": "diff",
-    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 \u2014 eagerLoad JOIN + column-projection behaviour is not implemented."
+    "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
   }
 }

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -27,7 +27,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, dirname, basename } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
-import { Base } from "@blazetrails/activerecord";
+import { Base, modelRegistry } from "@blazetrails/activerecord";
 import { Visitors } from "@blazetrails/arel";
 
 function usage(): never {
@@ -166,6 +166,20 @@ async function main(): Promise<void> {
     const queryUrl = pathToFileURL(join(fixtureDirAbs, "query.ts")).href;
     const mod = (await import(queryUrl)) as { default: unknown };
     const result = mod.default;
+
+    // 3b. Pre-warm the schema cache for all registered model classes so that
+    //     toSql() can emit column-aliased SQL for eager_load. Rails loads schema
+    //     synchronously; trails' schema cache is populated async from the DB on
+    //     first access. Without this step, JoinDependency sees an empty schema
+    //     cache and falls back to only the primary key.
+    for (const [, klass] of modelRegistry) {
+      try {
+        await (klass as unknown as { loadSchema(): Promise<void> }).loadSchema();
+      } catch {
+        // Non-critical: if schema load fails for a model, toSql() degrades
+        // gracefully (fewer column aliases).
+      }
+    }
 
     if (result === null || result === undefined) {
       throw new Error(`[${fixtureName}] query.ts default export is ${result}`);

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -172,12 +172,13 @@ async function main(): Promise<void> {
     //     synchronously; trails' schema cache is populated async from the DB on
     //     first access. Without this step, JoinDependency sees an empty schema
     //     cache and falls back to only the primary key.
-    for (const [, klass] of modelRegistry) {
+    for (const [name, klass] of modelRegistry) {
       try {
         await (klass as unknown as { loadSchema(): Promise<void> }).loadSchema();
-      } catch {
-        // Non-critical: if schema load fails for a model, toSql() degrades
-        // gracefully (fewer column aliases).
+      } catch (err) {
+        process.stderr.write(
+          `parity ar_dump: warning: schema pre-warm failed for ${name}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Closes parity gaps ar-16 and ar-57. \`toSql()\` on a Relation with \`eagerLoad()\` (or \`includes + references\`) now emits the full Rails-style column-aliased SELECT + LEFT OUTER JOIN, matching Rails' \`eager_loading?\` + \`apply_join_dependency\` + \`apply_column_aliases\` behavior.

**SQL output now matches Rails:**
\`\`\`sql
SELECT "books"."id" AS t0_r0, "books"."author_id" AS t0_r1, "books"."title" AS t0_r2,
       "authors"."id" AS t1_r0, "authors"."name" AS t1_r1
FROM "books"
LEFT OUTER JOIN "authors" ON "authors"."id" = "books"."author_id"
LIMIT 10
\`\`\`

## Changes

**`relation.ts`**
- Static import of `JoinDependency` (was a dynamic-only import inside `_executeEagerLoad`).
- `_eagerLoadingForSql()` — mirrors Rails' `eager_loading?`: true when `eagerLoad` associations are set or includes were promoted from `references`.
- `_buildEagerSql()` — synchronous eager-load SQL path: builds JoinDependency, applies column aliases (`t0_r0` style), adds LEFT OUTER JOINs. For collection associations (`hasMany`), wraps in a subquery for parent IDs to avoid JOIN fan-out (`using_limitable_reflections?`); for non-collection (`belongsTo`, `hasOne`), applies LIMIT directly.
- `_toSqlWithoutSetOp()` — delegates to `_buildEagerSql()` when eager loading is active.
- `referencesEagerLoadedTables()` (private) — extracted from inline logic; returns true when any `references_values` table is not already joined. Uses `Nodes.StringJoin` for raw SQL joins, mirroring Rails' `Arel::Nodes::StringJoin` check.
- `tablesInString()` (private) — regex helper extracting table identifiers from a raw SQL string.
- `limitedCount()` (private) — mirrors Rails `limited_count`.

**`join-dependency.ts`**
- `getModelColumns()` — calls `columnsHash()` before `columnNames()` to trigger `loadSchema()` from the schema cache. Without this, `toSql()` called before any DB query sees an empty `_attributeDefinitions` and falls back to PK only.
- `effectiveSqlName` on `JoinNode` — stores the SQL name used in JOIN and SELECT expressions (real table name when no collision, `tN` alias when collision). Avoids fragile regex extraction.
- AliasTracker-style collision detection — `_usedTableNames` set; uses real table name in SQL when free (matching Rails' `AliasTracker` `aliases[name] == 0` path), falls back to `tN` alias on collision.
- Bare column aliases — `_buildSelectExpressions` emits `AS t0_r0` (unquoted), matching Rails' `SqlLiteral` pass-through in `quote_column_name`.
- Through association nodes get `effectiveSqlName = tableAlias` (always aliased in compound JOIN SQL).
- `aliases()` (private) — builds and returns an `Aliases` object.
- `joinRootAlias` (protected) — the effective SQL name of the root table.
- `construct()` (private) — delegates to `instantiateFromRows`.
- `constructModel()` (private) — instantiates a single model from an attribute hash.

**`ar_dump.ts`**
- Pre-warms the schema cache for all registered models via `Base.loadSchema()` after importing the fixture, before `toSql()` is called. Rails loads schema synchronously; trails' schema cache is async — without this, `getModelColumns` sees an empty cache.

## Test plan

- [x] `pnpm parity:query` — ar-16 and ar-57 pass; 168/173 total
- [x] Full AR test suite — no new failures (2 pre-existing unrelated)
- [x] `pnpm exec tsx scripts/api-compare/lint-deps.ts` — 48/48 ✓ (activerecord→arel 100%)
- [x] api:compare privates — join-dependency.ts 0%→33%, relation.ts 0%→16%
- [ ] CI green