### PR TITLE
feat(temporal): PR 1 — polyfill, sentinels, wire-format parsers, test helpers

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -109,3 +109,13 @@ export {
 } from "./secure-password.js";
 export { SerializeCastValue } from "./type/serialize-cast-value.js";
 export { Builder as AttributeSetBuilder } from "./attribute-set/builder.js";
+export {
+  DateInfinity,
+  DateNegativeInfinity,
+  isDateInfinity,
+  isDateNegativeInfinity,
+} from "./type/internal/sentinels.js";
+export type {
+  DateInfinity as DateInfinityType,
+  DateNegativeInfinity as DateNegativeInfinityType,
+} from "./type/internal/sentinels.js";

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -4,8 +4,8 @@
  * these have no Temporal equivalent.
  */
 
-export const DateInfinity: unique symbol = Symbol("DateInfinity");
-export const DateNegativeInfinity: unique symbol = Symbol("DateNegativeInfinity");
+export const DateInfinity = Symbol.for("@blazetrails/activemodel:DateInfinity");
+export const DateNegativeInfinity = Symbol.for("@blazetrails/activemodel:DateNegativeInfinity");
 
 export type DateInfinity = typeof DateInfinity;
 export type DateNegativeInfinity = typeof DateNegativeInfinity;

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -2,13 +2,27 @@
  * Sentinel values for Postgres out-of-range datetime literals.
  * Postgres can return 'infinity' / '-infinity' for timestamp/date columns;
  * these have no Temporal equivalent.
+ *
+ * Symbol.for ensures identity is stable across module duplication (pnpm
+ * deduplication quirks, bundlers). The branded type ensures the two sentinels
+ * remain nominally distinct even though both are plain `symbol` at runtime.
  */
 
-export const DateInfinity = Symbol.for("@blazetrails/activemodel:DateInfinity");
-export const DateNegativeInfinity = Symbol.for("@blazetrails/activemodel:DateNegativeInfinity");
+declare const dateInfinityBrand: unique symbol;
+declare const dateNegativeInfinityBrand: unique symbol;
 
-export type DateInfinity = typeof DateInfinity;
-export type DateNegativeInfinity = typeof DateNegativeInfinity;
+export type DateInfinity = symbol & { readonly [dateInfinityBrand]: "DateInfinity" };
+export type DateNegativeInfinity = symbol & {
+  readonly [dateNegativeInfinityBrand]: "DateNegativeInfinity";
+};
+
+export const DateInfinity: DateInfinity = Symbol.for(
+  "@blazetrails/activemodel:DateInfinity",
+) as DateInfinity;
+
+export const DateNegativeInfinity: DateNegativeInfinity = Symbol.for(
+  "@blazetrails/activemodel:DateNegativeInfinity",
+) as DateNegativeInfinity;
 
 export function isDateInfinity(v: unknown): v is DateInfinity {
   return v === DateInfinity;

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -1,0 +1,19 @@
+/**
+ * Sentinel values for Postgres out-of-range datetime literals.
+ * Postgres can return 'infinity' / '-infinity' for timestamp/date columns;
+ * these have no Temporal equivalent.
+ */
+
+export const DateInfinity: unique symbol = Symbol("DateInfinity");
+export const DateNegativeInfinity: unique symbol = Symbol("DateNegativeInfinity");
+
+export type DateInfinity = typeof DateInfinity;
+export type DateNegativeInfinity = typeof DateNegativeInfinity;
+
+export function isDateInfinity(v: unknown): v is DateInfinity {
+  return v === DateInfinity;
+}
+
+export function isDateNegativeInfinity(v: unknown): v is DateNegativeInfinity {
+  return v === DateNegativeInfinity;
+}

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -58,6 +58,14 @@ describe("parsePostgresInstant", () => {
     expect(zdt.month).toBe(3);
     expect(zdt.day).toBe(15);
   });
+
+  it("parses a BC timestamp with microseconds", () => {
+    const result = parsePostgresInstant("0044-03-15 12:00:00.000123+00 BC") as Temporal.Instant;
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(0);
+    expect(zdt.microsecond).toBe(123);
+    expect(zdt.nanosecond).toBe(0);
+  });
 });
 
 describe("parsePostgresPlainDateTime", () => {
@@ -84,6 +92,15 @@ describe("parsePostgresPlainDateTime", () => {
     expect(result.year).toBe(-43);
     expect(result.month).toBe(3);
     expect(result.day).toBe(15);
+  });
+
+  it("parses a BC datetime with microseconds", () => {
+    const result = parsePostgresPlainDateTime(
+      "0044-03-15 12:00:00.000456 BC",
+    ) as Temporal.PlainDateTime;
+    expect(result.millisecond).toBe(0);
+    expect(result.microsecond).toBe(456);
+    expect(result.nanosecond).toBe(0);
   });
 });
 
@@ -181,11 +198,15 @@ describe("parseMysqlDate", () => {
 describe("parseMysqlTime", () => {
   it("parses a TIME string", () => {
     const result = parseMysqlTime("14:23:55.123456");
-    expect(result?.toString()).toBe("14:23:55.123456");
+    expect(result.toString()).toBe("14:23:55.123456");
   });
 
   it("parses midnight", () => {
     const result = parseMysqlTime("00:00:00");
-    expect(result?.toString()).toBe("00:00:00");
+    expect(result.toString()).toBe("00:00:00");
+  });
+
+  it("treats empty string as midnight", () => {
+    expect(parseMysqlTime("").toString()).toBe("00:00:00");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -192,6 +192,10 @@ describe("parseMysqlPlainDateTime", () => {
   it("returns null for zero-date", () => {
     expect(parseMysqlPlainDateTime("0000-00-00 00:00:00")).toBeNull();
   });
+
+  it("returns null for zero-date with fractional seconds (DATETIME(6))", () => {
+    expect(parseMysqlPlainDateTime("0000-00-00 00:00:00.000000")).toBeNull();
+  });
 });
 
 describe("parseMysqlDate", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -61,7 +61,7 @@ describe("parsePostgresInstant", () => {
   it("parses a BC timestamp", () => {
     // Postgres 0044-03-15 BC = ISO year -43
     const result = parsePostgresInstant("0044-03-15 12:00:00+00 BC") as Temporal.Instant;
-    expect(Number(result.epochNanoseconds)).toBeLessThan(0);
+    expect(result.epochNanoseconds).toBeLessThan(0n);
     // year -43 in proleptic Gregorian = 44 BC
     const zdt = result.toZonedDateTimeISO("UTC");
     expect(zdt.year).toBe(-43);

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  parsePostgresInstant,
+  parsePostgresPlainDateTime,
+  parsePostgresDate,
+  parsePostgresTime,
+  parsePostgresTimeTz,
+  parseMysqlInstant,
+  parseMysqlPlainDateTime,
+  parseMysqlDate,
+  parseMysqlTime,
+  DateInfinity,
+  DateNegativeInfinity,
+} from "./temporal-wire.js";
+
+describe("parsePostgresInstant", () => {
+  it("parses a timestamptz with space separator and two-digit offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55.123456+00");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parsePostgresInstant("2024-01-15 09:00:00.000001+00");
+    expect(result.toString()).toBe("2024-01-15T09:00:00.000001Z");
+  });
+
+  it("handles a positive offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55+02");
+    expect(result.toString()).toBe("2026-04-26T12:23:55Z");
+  });
+
+  it("handles ±HH:MM offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55.100000+05:30");
+    expect(result.toString()).toBe("2026-04-26T08:53:55.1Z");
+  });
+
+  it("handles negative offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55-05");
+    expect(result.toString()).toBe("2026-04-26T19:23:55Z");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresInstant("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresInstant("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC timestamp", () => {
+    // Postgres 0044-03-15 BC = ISO year -43
+    const result = parsePostgresInstant("0044-03-15 12:00:00+00 BC") as Temporal.Instant;
+    expect(Number(result.epochNanoseconds)).toBeLessThan(0);
+    // year -43 in proleptic Gregorian = 44 BC
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(-43);
+    expect(zdt.month).toBe(3);
+    expect(zdt.day).toBe(15);
+  });
+});
+
+describe("parsePostgresPlainDateTime", () => {
+  it("parses a timestamp with space separator", () => {
+    const result = parsePostgresPlainDateTime("2026-04-26 14:23:55.123456");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parsePostgresPlainDateTime("2024-12-31 23:59:59.999999");
+    expect(result.toString()).toBe("2024-12-31T23:59:59.999999");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresPlainDateTime("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresPlainDateTime("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC datetime", () => {
+    const result = parsePostgresPlainDateTime("0044-03-15 12:00:00 BC") as Temporal.PlainDateTime;
+    expect(result.year).toBe(-43);
+    expect(result.month).toBe(3);
+    expect(result.day).toBe(15);
+  });
+});
+
+describe("parsePostgresDate", () => {
+  it("parses a normal date", () => {
+    const result = parsePostgresDate("2026-04-26");
+    expect(result.toString()).toBe("2026-04-26");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresDate("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresDate("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC date", () => {
+    const result = parsePostgresDate("0044-03-15 BC") as Temporal.PlainDate;
+    expect(result.year).toBe(-43);
+    expect(result.month).toBe(3);
+  });
+});
+
+describe("parsePostgresTime", () => {
+  it("parses a time with microseconds", () => {
+    const result = parsePostgresTime("14:23:55.123456");
+    expect(result.toString()).toBe("14:23:55.123456");
+  });
+
+  it("parses a whole-second time", () => {
+    const result = parsePostgresTime("00:00:00");
+    expect(result.toString()).toBe("00:00:00");
+  });
+});
+
+describe("parsePostgresTimeTz", () => {
+  it("parses timetz with two-digit offset", () => {
+    const { time, offset } = parsePostgresTimeTz("14:23:55.123456+02");
+    expect(time.toString()).toBe("14:23:55.123456");
+    expect(offset).toBe("+02:00");
+  });
+
+  it("parses timetz with full offset", () => {
+    const { time, offset } = parsePostgresTimeTz("14:23:55+05:30");
+    expect(time.toString()).toBe("14:23:55");
+    expect(offset).toBe("+05:30");
+  });
+
+  it("parses timetz with negative offset", () => {
+    const { time, offset } = parsePostgresTimeTz("08:00:00.000001-08");
+    expect(time.toString()).toBe("08:00:00.000001");
+    expect(offset).toBe("-08:00");
+  });
+
+  it("throws on unparseable input", () => {
+    expect(() => parsePostgresTimeTz("not-a-time")).toThrow(RangeError);
+  });
+});
+
+describe("parseMysqlInstant", () => {
+  it("treats the wire string as UTC (pinned session tz)", () => {
+    const result = parseMysqlInstant("2026-04-26 14:23:55.123456");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parseMysqlInstant("2024-01-01 00:00:00.000001");
+    expect(result.toString()).toBe("2024-01-01T00:00:00.000001Z");
+  });
+});
+
+describe("parseMysqlPlainDateTime", () => {
+  it("parses a DATETIME string", () => {
+    const result = parseMysqlPlainDateTime("2026-04-26 14:23:55.123456");
+    expect(result?.toString()).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("returns null for zero-date", () => {
+    expect(parseMysqlPlainDateTime("0000-00-00 00:00:00")).toBeNull();
+  });
+});
+
+describe("parseMysqlDate", () => {
+  it("parses a DATE string", () => {
+    const result = parseMysqlDate("2026-04-26");
+    expect(result?.toString()).toBe("2026-04-26");
+  });
+
+  it("returns null for zero-date", () => {
+    expect(parseMysqlDate("0000-00-00")).toBeNull();
+  });
+});
+
+describe("parseMysqlTime", () => {
+  it("parses a TIME string", () => {
+    const result = parseMysqlTime("14:23:55.123456");
+    expect(result?.toString()).toBe("14:23:55.123456");
+  });
+
+  it("parses midnight", () => {
+    const result = parseMysqlTime("00:00:00");
+    expect(result?.toString()).toBe("00:00:00");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -25,6 +25,16 @@ describe("parsePostgresInstant", () => {
     expect(result.toString()).toBe("2024-01-15T09:00:00.000001Z");
   });
 
+  it("truncates sub-nanosecond digits beyond 9", () => {
+    // No DB emits >9 fractional digits, but guard against corrupt input
+    // shifting the slice boundaries. "1234567899" → treat as "123456789".
+    const result = parsePostgresInstant("2026-04-26 14:23:55.1234567899+00") as Temporal.Instant;
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(123);
+    expect(zdt.microsecond).toBe(456);
+    expect(zdt.nanosecond).toBe(789);
+  });
+
   it("handles a positive offset", () => {
     const result = parsePostgresInstant("2026-04-26 14:23:55+02");
     expect(result.toString()).toBe("2026-04-26T12:23:55Z");

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -205,8 +205,4 @@ describe("parseMysqlTime", () => {
     const result = parseMysqlTime("00:00:00");
     expect(result.toString()).toBe("00:00:00");
   });
-
-  it("treats empty string as midnight", () => {
-    expect(parseMysqlTime("").toString()).toBe("00:00:00");
-  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -145,6 +145,14 @@ describe("parsePostgresTime", () => {
     const result = parsePostgresTime("00:00:00");
     expect(result.toString()).toBe("00:00:00");
   });
+
+  it("normalizes 24:00:00 (PG end-of-day sentinel) to 00:00:00", () => {
+    expect(parsePostgresTime("24:00:00").toString()).toBe("00:00:00");
+  });
+
+  it("normalizes 24:00:00 with fractional seconds", () => {
+    expect(parsePostgresTime("24:00:00.000000").toString()).toBe("00:00:00");
+  });
 });
 
 describe("parsePostgresTimeTz", () => {
@@ -164,6 +172,12 @@ describe("parsePostgresTimeTz", () => {
     const { time, offset } = parsePostgresTimeTz("08:00:00.000001-08");
     expect(time.toString()).toBe("08:00:00.000001");
     expect(offset).toBe("-08:00");
+  });
+
+  it("normalizes 24:00:00 timetz to 00:00:00", () => {
+    const { time, offset } = parsePostgresTimeTz("24:00:00+00");
+    expect(time.toString()).toBe("00:00:00");
+    expect(offset).toBe("+00:00");
   });
 
   it("throws on unparseable input", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -156,9 +156,9 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
  * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
  * responsible for interval TIME).
  */
-export function parseMysqlTime(text: string): Temporal.PlainTime | null {
+export function parseMysqlTime(text: string): Temporal.PlainTime {
   const trimmed = text.trim();
-  if (trimmed === "00:00:00" || trimmed === "") return Temporal.PlainTime.from("00:00:00");
+  if (trimmed === "") return Temporal.PlainTime.from("00:00:00");
   return Temporal.PlainTime.from(trimmed);
 }
 
@@ -206,7 +206,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
     );
   if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac, rawOffset] = match;
-  const { microsecond, nanosecond } = parseFraction(frac);
+  const { millisecond, microsecond, nanosecond } = parseFraction(frac);
   const zdt = Temporal.ZonedDateTime.from({
     year: bcYearToIso(Number(y)),
     month: Number(mo),
@@ -214,6 +214,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
     hour: Number(h),
     minute: Number(mi),
     second: Number(s),
+    millisecond,
     microsecond,
     nanosecond,
     timeZone: expandOffset(rawOffset),
@@ -230,7 +231,7 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
   const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
   if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac] = match;
-  const { microsecond, nanosecond } = parseFraction(frac);
+  const { millisecond, microsecond, nanosecond } = parseFraction(frac);
   return Temporal.PlainDateTime.from({
     year: bcYearToIso(Number(y)),
     month: Number(mo),
@@ -238,21 +239,29 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
     hour: Number(h),
     minute: Number(mi),
     second: Number(s),
+    millisecond,
     microsecond,
     nanosecond,
   });
 }
 
 /**
- * Convert a fractional-seconds string (up to 9 digits) to microsecond
- * and nanosecond components.  "123456" → { microsecond: 123456, nanosecond: 0 }.
+ * Convert a fractional-seconds string (up to 9 digits) to the three
+ * Temporal sub-second components, each in the 0–999 range.
+ * "123456" → { millisecond: 123, microsecond: 456, nanosecond: 0 }.
  */
-function parseFraction(frac: string | undefined): { microsecond: number; nanosecond: number } {
-  if (!frac) return { microsecond: 0, nanosecond: 0 };
+function parseFraction(frac: string | undefined): {
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+} {
+  if (!frac) return { millisecond: 0, microsecond: 0, nanosecond: 0 };
   const padded = frac.padEnd(9, "0");
-  const microsecond = Number(padded.slice(0, 6));
-  const nanosecond = Number(padded.slice(6, 9));
-  return { microsecond, nanosecond };
+  return {
+    millisecond: Number(padded.slice(0, 3)),
+    microsecond: Number(padded.slice(3, 6)),
+    nanosecond: Number(padded.slice(6, 9)),
+  };
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -56,7 +56,7 @@ export function parsePostgresPlainDateTime(
   if (trimmed === "-infinity") return DateNegativeInfinity;
   const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampAsPlainDateTime(iso);
-  return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
+  return Temporal.PlainDateTime.from(clampFraction(iso.replace(" ", "T")));
 }
 
 /**
@@ -127,7 +127,7 @@ export function parsePostgresTimeTz(text: string): TimeTzValue {
  */
 export function parseMysqlInstant(text: string): Temporal.Instant {
   // Treat as UTC by appending Z after normalising the separator.
-  const iso = text.trim().replace(" ", "T") + "Z";
+  const iso = clampFraction(text.trim().replace(" ", "T") + "Z");
   return Temporal.Instant.from(iso);
 }
 
@@ -140,7 +140,7 @@ export function parseMysqlInstant(text: string): Temporal.Instant {
 export function parseMysqlPlainDateTime(text: string): Temporal.PlainDateTime | null {
   const trimmed = text.trim();
   if (isZeroDatetime(trimmed)) return null;
-  return Temporal.PlainDateTime.from(trimmed.replace(" ", "T"));
+  return Temporal.PlainDateTime.from(clampFraction(trimmed.replace(" ", "T")));
 }
 
 /**
@@ -175,7 +175,16 @@ export function parseMysqlTime(text: string): Temporal.PlainTime {
  *   `'2026-04-26 14:23:55.123456+00'` → `'2026-04-26T14:23:55.123456+00:00'`
  */
 function normalizeTimestampTz(text: string): string {
-  return text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00");
+  return clampFraction(text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00"));
+}
+
+/**
+ * Clamp fractional-seconds digits in an ISO datetime string to 9 (nanosecond
+ * precision). Temporal parsers reject strings with more than 9 fractional
+ * digits, and no database emits sub-nanosecond precision.
+ */
+function clampFraction(iso: string): string {
+  return iso.replace(/(\.\d{9})\d+/, "$1");
 }
 
 /** Strip a trailing " BC" suffix and return both parts. */
@@ -249,9 +258,10 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
 }
 
 /**
- * Convert a fractional-seconds string (up to 9 digits) to the three
- * Temporal sub-second components, each in the 0–999 range.
+ * Convert a fractional-seconds string to the three Temporal sub-second
+ * components, each in the 0–999 range.
  * "123456" → { millisecond: 123, microsecond: 456, nanosecond: 0 }.
+ * Digits beyond 9 (sub-nanosecond) are truncated; no database emits them.
  */
 function parseFraction(frac: string | undefined): {
   millisecond: number;
@@ -259,11 +269,14 @@ function parseFraction(frac: string | undefined): {
   nanosecond: number;
 } {
   if (!frac) return { millisecond: 0, microsecond: 0, nanosecond: 0 };
-  const padded = frac.padEnd(9, "0");
+  // Clamp to 9 digits before padding so extra digits don't silently corrupt
+  // the slice boundaries (e.g. a 10-digit input would shift microsecond into
+  // the nanosecond slot without this guard).
+  const clamped = frac.slice(0, 9).padEnd(9, "0");
   return {
-    millisecond: Number(padded.slice(0, 3)),
-    microsecond: Number(padded.slice(3, 6)),
-    nanosecond: Number(padded.slice(6, 9)),
+    millisecond: Number(clamped.slice(0, 3)),
+    microsecond: Number(clamped.slice(3, 6)),
+    nanosecond: Number(clamped.slice(6, 9)),
   };
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -34,9 +34,10 @@ export type TimeTzValue = { time: Temporal.PlainTime; offset: string };
 export function parsePostgresInstant(
   text: string,
 ): Temporal.Instant | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampTzAsInstant(iso);
   return Temporal.Instant.from(normalizeTimestampTz(iso));
 }
@@ -50,9 +51,10 @@ export function parsePostgresInstant(
 export function parsePostgresPlainDateTime(
   text: string,
 ): Temporal.PlainDateTime | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampAsPlainDateTime(iso);
   return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
 }
@@ -65,9 +67,10 @@ export function parsePostgresPlainDateTime(
 export function parsePostgresDate(
   text: string,
 ): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   const plain = Temporal.PlainDate.from(iso);
   if (!bc) return plain;
   return Temporal.PlainDate.from({

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -62,7 +62,9 @@ export function parsePostgresPlainDateTime(
 /**
  * Parse a Postgres `date` wire string to `Temporal.PlainDate`.
  *
- * Wire format: `'YYYY-MM-DD'` or `'YYYY-MM-DD BC'`.
+ * Wire format: `'YYYY-MM-DD'`, `'YYYY-MM-DD BC'`,
+ * or the sentinels `'infinity'` / `'-infinity'` which return
+ * `DateInfinity` / `DateNegativeInfinity`.
  */
 export function parsePostgresDate(
   text: string,
@@ -155,14 +157,12 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
 /**
  * Parse a MySQL `TIME` wire string to `Temporal.PlainTime`.
  *
- * MySQL TIME can be negative or exceed 24 h for intervals; we only
- * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
- * responsible for interval TIME).
+ * Wire format: `'HH:MM:SS[.ffffff]'` (standard range, no sign). MySQL TIME
+ * can be negative or exceed 24 h for interval values; those paths are the
+ * cast layer's responsibility and are not handled here.
  */
 export function parseMysqlTime(text: string): Temporal.PlainTime {
-  const trimmed = text.trim();
-  if (trimmed === "") return Temporal.PlainTime.from("00:00:00");
-  return Temporal.PlainTime.from(trimmed);
+  return Temporal.PlainTime.from(text.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -1,0 +1,272 @@
+/**
+ * Wire-format parsers for Temporal types from Postgres and MySQL.
+ *
+ * Handles the quirks each driver emits before our cast layer ever sees
+ * a value — space separator instead of T, two-digit offsets, BC suffix,
+ * infinity sentinels, zero-dates.
+ *
+ * All functions are pure (no I/O, no side effects) so they can be unit-
+ * tested directly without a live database.
+ */
+
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  DateInfinity,
+  DateNegativeInfinity,
+  type DateInfinityType,
+  type DateNegativeInfinityType,
+} from "@blazetrails/activemodel";
+
+export { DateInfinity, DateNegativeInfinity };
+
+export type TimeTzValue = { time: Temporal.PlainTime; offset: string };
+
+// ---------------------------------------------------------------------------
+// Postgres
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Postgres `timestamptz` wire string to `Temporal.Instant`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff][+HH|±HH:MM]'`
+ * or the sentinels `'infinity'` / `'-infinity'`.
+ */
+export function parsePostgresInstant(
+  text: string,
+): Temporal.Instant | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  if (bc) return parseBcTimestampTzAsInstant(iso);
+  return Temporal.Instant.from(normalizeTimestampTz(iso));
+}
+
+/**
+ * Parse a Postgres `timestamp` wire string to `Temporal.PlainDateTime`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (no offset).
+ * or the sentinels `'infinity'` / `'-infinity'`.
+ */
+export function parsePostgresPlainDateTime(
+  text: string,
+): Temporal.PlainDateTime | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  if (bc) return parseBcTimestampAsPlainDateTime(iso);
+  return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
+}
+
+/**
+ * Parse a Postgres `date` wire string to `Temporal.PlainDate`.
+ *
+ * Wire format: `'YYYY-MM-DD'` or `'YYYY-MM-DD BC'`.
+ */
+export function parsePostgresDate(
+  text: string,
+): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  const plain = Temporal.PlainDate.from(iso);
+  if (!bc) return plain;
+  return Temporal.PlainDate.from({
+    year: bcYearToIso(plain.year),
+    month: plain.month,
+    day: plain.day,
+  });
+}
+
+/**
+ * Parse a Postgres `time` wire string to `Temporal.PlainTime`.
+ *
+ * Wire format: `'HH:MM:SS[.ffffff]'`.
+ */
+export function parsePostgresTime(text: string): Temporal.PlainTime {
+  return Temporal.PlainTime.from(text.trim());
+}
+
+/**
+ * Parse a Postgres `timetz` wire string.
+ *
+ * Wire format: `'HH:MM:SS[.ffffff]+HH'` or `'HH:MM:SS[.ffffff]±HH:MM'`.
+ * Returns the time and offset separately — Temporal.PlainTime has no
+ * timezone, so we preserve the offset as a sibling string.
+ */
+export function parsePostgresTimeTz(text: string): TimeTzValue {
+  // Split on first +/- that appears after the seconds portion
+  const match = /^(\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2}(?::\d{2})?)$/.exec(text.trim());
+  if (!match) {
+    throw new RangeError(`Cannot parse timetz wire value: ${JSON.stringify(text)}`);
+  }
+  const [, timeStr, rawOffset] = match;
+  return {
+    time: Temporal.PlainTime.from(timeStr),
+    offset: expandOffset(rawOffset),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a MySQL `TIMESTAMP` wire string to `Temporal.Instant`.
+ *
+ * Precondition: the connection's `@@session.time_zone` is `'+00:00'`.
+ * MySQL TIMESTAMP is always stored as UTC; with the pinned session TZ
+ * the driver returns strings in UTC wall-clock form.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (no offset in string;
+ * semantically UTC because of the pinned session timezone).
+ */
+export function parseMysqlInstant(text: string): Temporal.Instant {
+  // Treat as UTC by appending Z after normalising the separator.
+  const iso = text.trim().replace(" ", "T") + "Z";
+  return Temporal.Instant.from(iso);
+}
+
+/**
+ * Parse a MySQL `DATETIME` wire string to `Temporal.PlainDateTime`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (naive, no timezone).
+ * Zero-date `'0000-00-00 00:00:00'` returns `null`.
+ */
+export function parseMysqlPlainDateTime(text: string): Temporal.PlainDateTime | null {
+  const trimmed = text.trim();
+  if (isZeroDatetime(trimmed)) return null;
+  return Temporal.PlainDateTime.from(trimmed.replace(" ", "T"));
+}
+
+/**
+ * Parse a MySQL `DATE` wire string to `Temporal.PlainDate`.
+ *
+ * Zero-date `'0000-00-00'` returns `null`.
+ */
+export function parseMysqlDate(text: string): Temporal.PlainDate | null {
+  const trimmed = text.trim();
+  if (isZeroDate(trimmed)) return null;
+  return Temporal.PlainDate.from(trimmed);
+}
+
+/**
+ * Parse a MySQL `TIME` wire string to `Temporal.PlainTime`.
+ *
+ * MySQL TIME can be negative or exceed 24 h for intervals; we only
+ * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
+ * responsible for interval TIME).
+ */
+export function parseMysqlTime(text: string): Temporal.PlainTime | null {
+  const trimmed = text.trim();
+  if (trimmed === "00:00:00" || trimmed === "") return Temporal.PlainTime.from("00:00:00");
+  return Temporal.PlainTime.from(trimmed);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a Postgres `timestamptz` string (no BC suffix) to strict
+ * ISO 8601 for `Temporal.Instant.from`:
+ *   `'2026-04-26 14:23:55.123456+00'` → `'2026-04-26T14:23:55.123456+00:00'`
+ */
+function normalizeTimestampTz(text: string): string {
+  return text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00");
+}
+
+/** Strip a trailing " BC" suffix and return both parts. */
+function extractBcSuffix(text: string): { iso: string; bc: boolean } {
+  if (text.endsWith(" BC")) {
+    return { iso: text.slice(0, -3), bc: true };
+  }
+  return { iso: text, bc: false };
+}
+
+/**
+ * Convert a positive Postgres year (1-based BC) to proleptic Gregorian ISO year.
+ * Postgres `0044 BC` → ISO year `-43`.  `0001 BC` → ISO year `0`.
+ */
+function bcYearToIso(pgYear: number): number {
+  return -(pgYear - 1);
+}
+
+/**
+ * Parse a BC-suffixed Postgres `timestamptz` string to `Temporal.Instant`.
+ * Uses component construction to avoid negative-year ISO string parsing,
+ * which the polyfill rejects.
+ *
+ * Input has already had " BC" stripped.
+ */
+function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
+  // e.g. "0044-03-15 12:00:00.123456+00" or "0044-03-15 12:00:00+02:30"
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
+      withoutBc,
+    );
+  if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
+  const [, y, mo, d, h, mi, s, frac, rawOffset] = match;
+  const { microsecond, nanosecond } = parseFraction(frac);
+  const zdt = Temporal.ZonedDateTime.from({
+    year: bcYearToIso(Number(y)),
+    month: Number(mo),
+    day: Number(d),
+    hour: Number(h),
+    minute: Number(mi),
+    second: Number(s),
+    microsecond,
+    nanosecond,
+    timeZone: expandOffset(rawOffset),
+  });
+  return zdt.toInstant();
+}
+
+/**
+ * Parse a BC-suffixed Postgres `timestamp` string to `Temporal.PlainDateTime`.
+ * Input has already had " BC" stripped.
+ */
+function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateTime {
+  // e.g. "0044-03-15 12:00:00.123456" or "0044-03-15 12:00:00"
+  const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
+  if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
+  const [, y, mo, d, h, mi, s, frac] = match;
+  const { microsecond, nanosecond } = parseFraction(frac);
+  return Temporal.PlainDateTime.from({
+    year: bcYearToIso(Number(y)),
+    month: Number(mo),
+    day: Number(d),
+    hour: Number(h),
+    minute: Number(mi),
+    second: Number(s),
+    microsecond,
+    nanosecond,
+  });
+}
+
+/**
+ * Convert a fractional-seconds string (up to 9 digits) to microsecond
+ * and nanosecond components.  "123456" → { microsecond: 123456, nanosecond: 0 }.
+ */
+function parseFraction(frac: string | undefined): { microsecond: number; nanosecond: number } {
+  if (!frac) return { microsecond: 0, nanosecond: 0 };
+  const padded = frac.padEnd(9, "0");
+  const microsecond = Number(padded.slice(0, 6));
+  const nanosecond = Number(padded.slice(6, 9));
+  return { microsecond, nanosecond };
+}
+
+/**
+ * Expand a two-digit offset `+HH` or `-HH` to `±HH:MM`.
+ * Leaves `±HH:MM` offsets unchanged.
+ */
+function expandOffset(offset: string): string {
+  return offset.replace(/^([-+]\d{2})$/, "$1:00");
+}
+
+function isZeroDate(text: string): boolean {
+  return text === "0000-00-00";
+}
+
+function isZeroDatetime(text: string): boolean {
+  return text === "0000-00-00 00:00:00" || text === "0000-00-00T00:00:00";
+}

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -204,7 +204,7 @@ function bcYearToIso(pgYear: number): number {
 function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
   // e.g. "0044-03-15 12:00:00.123456+00" or "0044-03-15 12:00:00+02:30"
   const match =
-    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
+    /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
       withoutBc,
     );
   if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
@@ -231,7 +231,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
  */
 function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateTime {
   // e.g. "0044-03-15 12:00:00.123456" or "0044-03-15 12:00:00"
-  const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
+  const match = /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
   if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac] = match;
   const { millisecond, microsecond, nanosecond } = parseFraction(frac);

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -293,5 +293,7 @@ function isZeroDate(text: string): boolean {
 }
 
 function isZeroDatetime(text: string): boolean {
-  return text === "0000-00-00 00:00:00" || text === "0000-00-00T00:00:00";
+  // Match "0000-00-00 00:00:00" / "0000-00-00T00:00:00" and the fractional
+  // variants emitted by DATETIME(N) columns, e.g. "0000-00-00 00:00:00.000000".
+  return /^0000-00-00[T ]00:00:00(\.\d+)?$/.test(text);
 }

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -85,10 +85,12 @@ export function parsePostgresDate(
 /**
  * Parse a Postgres `time` wire string to `Temporal.PlainTime`.
  *
- * Wire format: `'HH:MM:SS[.ffffff]'`.
+ * Wire format: `'HH:MM:SS[.ffffff]'`. Postgres allows `24:00:00` as a valid
+ * end-of-day sentinel; Temporal rejects hour 24, so we normalize it to
+ * `00:00:00` (midnight), matching Ruby Time's rollover behavior.
  */
 export function parsePostgresTime(text: string): Temporal.PlainTime {
-  return Temporal.PlainTime.from(text.trim());
+  return Temporal.PlainTime.from(normalizeTime24(text.trim()));
 }
 
 /**
@@ -97,6 +99,7 @@ export function parsePostgresTime(text: string): Temporal.PlainTime {
  * Wire format: `'HH:MM:SS[.ffffff]+HH'` or `'HH:MM:SS[.ffffff]±HH:MM'`.
  * Returns the time and offset separately — Temporal.PlainTime has no
  * timezone, so we preserve the offset as a sibling string.
+ * `24:00:00` is normalized to `00:00:00` (see `parsePostgresTime`).
  */
 export function parsePostgresTimeTz(text: string): TimeTzValue {
   // Split on first +/- that appears after the seconds portion
@@ -106,7 +109,7 @@ export function parsePostgresTimeTz(text: string): TimeTzValue {
   }
   const [, timeStr, rawOffset] = match;
   return {
-    time: Temporal.PlainTime.from(timeStr),
+    time: Temporal.PlainTime.from(normalizeTime24(timeStr)),
     offset: expandOffset(rawOffset),
   };
 }
@@ -286,6 +289,16 @@ function parseFraction(frac: string | undefined): {
  */
 function expandOffset(offset: string): string {
   return offset.replace(/^([-+]\d{2})$/, "$1:00");
+}
+
+/**
+ * Normalize Postgres `24:00:00[.fraction]` (end-of-day sentinel) to
+ * `00:00:00[.fraction]`. Temporal.PlainTime rejects hour 24; Ruby Time
+ * rolls it over to midnight, which is the semantically equivalent value
+ * when there is no date context.
+ */
+function normalizeTime24(timeStr: string): string {
+  return timeStr.startsWith("24:") ? "00:" + timeStr.slice(3) : timeStr;
 }
 
 function isZeroDate(text: string): boolean {

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -38,6 +38,14 @@
       "types": "./dist/gzip.d.ts",
       "default": "./dist/gzip.js"
     },
+    "./temporal": {
+      "types": "./dist/temporal.d.ts",
+      "default": "./dist/temporal.js"
+    },
+    "./testing/temporal-helpers": {
+      "types": "./dist/testing/temporal-helpers.d.ts",
+      "default": "./dist/testing/temporal-helpers.js"
+    },
     "./cache/file-store": {
       "types": "./dist/cache/file-store.d.ts",
       "default": "./dist/cache/file-store.js"
@@ -59,6 +67,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "yaml": "^2.8.3"
   }
 }

--- a/packages/activesupport/src/temporal.ts
+++ b/packages/activesupport/src/temporal.ts
@@ -1,0 +1,1 @@
+export { Temporal } from "@js-temporal/polyfill";

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Temporal test helpers. Test files use these instead of `new Date(...)`.
+ * The no-native-date ESLint rule allowlists this file.
+ */
+import { Temporal } from "../temporal.js";
+
+export function instant(iso: string): Temporal.Instant {
+  return Temporal.Instant.from(iso);
+}
+
+export function plainDateTime(iso: string): Temporal.PlainDateTime {
+  return Temporal.PlainDateTime.from(iso);
+}
+
+export function plainDate(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}
+
+export function plainTime(iso: string): Temporal.PlainTime {
+  return Temporal.PlainTime.from(iso);
+}
+
+export function zonedDateTime(iso: string): Temporal.ZonedDateTime {
+  return Temporal.ZonedDateTime.from(iso);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
 
   packages/activesupport:
     dependencies:
+      '@js-temporal/polyfill':
+        specifier: ^0.5.1
+        version: 0.5.1
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -1010,6 +1013,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -2482,6 +2489,9 @@ packages:
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   jsdom@29.0.1:
     resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
@@ -4095,6 +4105,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
+
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.1
@@ -5659,6 +5673,8 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  jsbi@4.3.2: {}
 
   jsdom@29.0.1:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
         __dirname,
         "packages/activesupport/src/message-verifier.ts",
       ),
+      "@blazetrails/activesupport/temporal": path.resolve(
+        __dirname,
+        "packages/activesupport/src/temporal.ts",
+      ),
+      "@blazetrails/activesupport/testing/temporal-helpers": path.resolve(
+        __dirname,
+        "packages/activesupport/src/testing/temporal-helpers.ts",
+      ),
       "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
       "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
       "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),


### PR DESCRIPTION
## Summary

Foundation for the Temporal migration ([plan](docs/temporal-migration-plan.md)). No behavior change to existing code — all new files.

- `@js-temporal/polyfill` added to `@blazetrails/activesupport`; re-exported as `@blazetrails/activesupport/temporal`
- `DateInfinity` / `DateNegativeInfinity` symbols in `activemodel/src/type/internal/sentinels.ts` for Postgres out-of-range datetime literals (`'infinity'` / `'-infinity'`); re-exported from activemodel index
- `activesupport/src/testing/temporal-helpers.ts` — `instant()`, `plainDateTime()`, `plainDate()`, `plainTime()`, `zonedDateTime()` helpers for tests (the `no-native-date` ESLint rule from PR 12 will allowlist this file)
- `activerecord/.../abstract/temporal-wire.ts` — pure wire-format parsers for Postgres (`timestamptz`, `timestamp`, `date`, `time`, `timetz`) and MySQL (`TIMESTAMP`, `DATETIME`, `DATE`, `TIME`), handling: space separator, two-digit offset (`+00` → `+00:00`), BC suffix, infinity sentinels, zero-dates, microsecond/nanosecond fractions
- 34 unit tests covering every wire-format quirk

**Notable:** the polyfill (v0.5.1) rejects negative-year ISO strings like `-0043-03-15T12:00:00Z`; BC timestamps use component construction via `Temporal.ZonedDateTime.from({year: -43, ...})`. Temporal's sub-second component fields are each 0–999, so `parseFraction("123456")` decomposes to `{millisecond: 123, microsecond: 456, nanosecond: 0}` — not a single `microsecond: 123456` which the polyfill would silently clamp.

## Test plan

- [x] 34/34 tests pass (`temporal-wire.test.ts`)
- [x] BC + microsecond round-trip tested explicitly (catches the `parseFraction` component decomposition)
- [x] `pnpm build` clean across activesupport, activemodel, activerecord
- [x] `packages/activemodel/src/type/` tests unaffected