### PR TITLE
feat(activerecord): query_methods private helpers PR 2a/2 — column resolution and select/from/with (47% → 76%)

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1622,13 +1622,21 @@ function arelColumnWithTable(
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
   const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
+  const modelClass: any = (this as any)._modelClass;
+  // Schema-qualified table names (e.g. "schema.table") must not be passed to
+  // ArelTable — the visitor quotes the whole string as one identifier, producing
+  // "schema.table"."col" instead of "schema"."table"."col".
+  if (tableName.includes(".")) {
+    const quotedTable = safeQuoteTableName(modelClass, tableName);
+    const quotedCol = safeQuoteColumnName(modelClass, colStr);
+    return arelSql(`${quotedTable}.${quotedCol}`);
+  }
   if (typeof columnName === "symbol" || !/\W/.test(colStr)) {
     const builder = (this as any).predicateBuilder;
     return (
       builder?.resolveArelAttribute?.(tableName, colStr) ?? new ArelTable(tableName).get(colStr)
     );
   }
-  const modelClass: any = (this as any)._modelClass;
   const quotedTable = safeQuoteTableName(modelClass, tableName);
   return arelSql(`${quotedTable}.${colStr}`);
 }
@@ -1681,7 +1689,8 @@ function arelColumnAliasesFromHash(
     const columnsAliases = fields[key as any];
     const tableName = typeof key === "symbol" ? symbolToName(key) : key;
     const modelClass: any = (this as any)._modelClass;
-    const quoteAlias = (a: unknown): string => safeQuoteColumnName(modelClass, String(a));
+    const quoteAlias = (a: unknown): string =>
+      safeQuoteColumnName(modelClass, typeof a === "symbol" ? symbolToName(a) : String(a));
     if (isPlainObject(columnsAliases)) {
       return Reflect.ownKeys(columnsAliases as object).map((col) => {
         const alias = (columnsAliases as any)[col];
@@ -1690,7 +1699,7 @@ function arelColumnAliasesFromHash(
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as string[]).map((col) =>
+      return (columnsAliases as (string | symbol)[]).map((col) =>
         arelColumnWithTable.call(this, tableName, col),
       );
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1524,3 +1524,176 @@ export const QueryMethodBangs = {
   excludingBang,
   constructJoinDependency,
 } as const;
+
+// ---------------------------------------------------------------------------
+// PR 2a private helpers — column resolution, select/from/with building.
+// ---------------------------------------------------------------------------
+
+function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
+  const table: any = (this as any)._modelClass?.arelTable;
+  if (!table) return false;
+  const name = Regexp.escape ? Regexp.escape(table.name) : table.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const modelClass: any = (this as any)._modelClass;
+  const quotedName = (name: string) =>
+    modelClass?.adapter?.quoteTableName?.(name) ?? `"${name}"`;
+  const quoted = quotedName(table.name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${name}\\b|${quoted})(?!\\.)`, "i").test(String(from));
+}
+
+function arelColumn(this: QueryMethodsHost, field: string | symbol): unknown {
+  const modelClass: any = (this as any)._modelClass;
+  const table: any = modelClass?.arelTable;
+  let fieldStr = typeof field === "symbol" ? symbolToName(field) : field;
+  fieldStr = modelClass?.attributeAliases?.[fieldStr] ?? fieldStr;
+
+  const fromClause = (this as any)._fromClause;
+  const from = fromClause?.name || fromClause?.value;
+
+  if (modelClass?.columnsHash?.()[fieldStr] && (!from || isTableNameMatches.call(this, from))) {
+    return table?.get(fieldStr) ?? arelSql(fieldStr);
+  }
+  const dotMatch = fieldStr.match(/^(?<tbl>(?:\w+\.)?\w+)\.(?<col>\w+)$/);
+  if (dotMatch) {
+    return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
+  }
+  if (Nodes.isArelNode?.(field) || field instanceof Nodes.Node) return field;
+  const isSymbol = typeof field === "symbol";
+  return isSymbol
+    ? new ArelTable(fieldStr).get(fieldStr)
+    : arelSql(fieldStr);
+}
+
+function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
+  return columns.flatMap((field) => {
+    if (typeof field === "string" || typeof field === "symbol") return [arelColumn.call(this, field as any)];
+    if (typeof field === "function") return [field()];
+    if (isPlainObject(field)) return arelColumnsFromHash.call(this, field as Record<string, unknown>);
+    return [field];
+  });
+}
+
+function arelColumnWithTable(this: QueryMethodsHost, tableName: string, columnName: string | symbol): unknown {
+  const existing = (this as any)._referencesValues ?? [];
+  if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
+  const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
+  if (typeof columnName === "symbol" || !/\W/.test(colStr)) {
+    const builder = (this as any).predicateBuilder;
+    return (
+      builder?.resolveArelAttribute?.(tableName, colStr) ??
+      new ArelTable(tableName).get(colStr)
+    );
+  }
+  const modelClass: any = (this as any)._modelClass;
+  const quotedTable = modelClass?.adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`;
+  return arelSql(`${quotedTable}.${colStr}`);
+}
+
+function arelColumnsFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
+  return Object.entries(fields).flatMap(([tableName, columns]) => {
+    const tbl = typeof tableName === "symbol" ? symbolToName(tableName as unknown as symbol) : tableName;
+    if (typeof columns === "string" || typeof columns === "symbol") {
+      return [arelColumnWithTable.call(this, tbl, columns as any)];
+    }
+    if (Array.isArray(columns)) {
+      return columns.map((col) => arelColumnWithTable.call(this, tbl, col));
+    }
+    throw new TypeError(`Expected Symbol, String or Array, got: ${typeof columns}`);
+  });
+}
+
+function orderColumn(this: QueryMethodsHost, field: string): unknown {
+  // Mirrors Rails' order_column: resolves field via arel_column with a custom
+  // fallback that quotes the identifier as a table name (for "count" + group).
+  const result = arelColumn.call(this, field);
+  if (result) return result;
+  const modelClass: any = (this as any)._modelClass;
+  const table: any = modelClass?.arelTable;
+  if (field === "count" && ((this as any)._groupColumns ?? []).length > 0) {
+    return table?.get(field) ?? arelSql(field);
+  }
+  const quoted = modelClass?.adapter?.quoteTableName?.(field) ?? `"${field}"`;
+  return arelSql(quoted);
+}
+
+function processSelectArgs(this: QueryMethodsHost, fields: unknown[]): unknown[] {
+  return fields.flatMap((field) => {
+    if (isPlainObject(field)) return arelColumnAliasesFromHash.call(this, field as Record<string, unknown>);
+    return [field];
+  });
+}
+
+function arelColumnAliasesFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
+  return Object.entries(fields).flatMap(([key, columnsAliases]) => {
+    const tableName = typeof key === "symbol" ? symbolToName(key as unknown as symbol) : key;
+    const modelClass: any = (this as any)._modelClass;
+    if (isPlainObject(columnsAliases)) {
+      return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) => {
+        const attr = arelColumnWithTable.call(this, tableName, col);
+        const quotedAlias = modelClass?.adapter?.quoteColumnName?.(String(alias)) ?? `"${String(alias)}"`;
+        return (attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`);
+      });
+    }
+    if (Array.isArray(columnsAliases)) {
+      return (columnsAliases as string[]).map((col) => arelColumnWithTable.call(this, tableName, col));
+    }
+    if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {
+      const attr = arelColumn.call(this, key as any);
+      const quotedAlias = modelClass?.adapter?.quoteColumnName?.(String(columnsAliases)) ?? `"${String(columnsAliases)}"`;
+      return [(attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`)];
+    }
+    return [];
+  });
+}
+
+function buildFrom(this: QueryMethodsHost): unknown {
+  const fromClause = (this as any)._fromClause;
+  const opts = fromClause?.value;
+  let name = fromClause?.name;
+  if (opts && typeof (opts as any).toArel === "function") {
+    name ??= "subquery";
+    return (opts as any).toArel().as(String(name));
+  }
+  return opts;
+}
+
+function buildSelect(this: QueryMethodsHost, arel: any): void {
+  const selectCols = (this as any)._selectColumns;
+  if (selectCols && selectCols.length > 0) {
+    arel.project(...arelColumns.call(this, selectCols));
+    return;
+  }
+  const modelClass: any = (this as any)._modelClass;
+  const table: any = modelClass?.arelTable;
+  if ((modelClass?.ignoredColumns?.length ?? 0) > 0 || modelClass?.enumerateColumnsInSelectStatements) {
+    const cols: string[] = modelClass?.columnNames?.() ?? [];
+    if (cols.length > 0) {
+      arel.project(...cols.map((f: string) => table?.get(f) ?? arelSql(f)));
+      return;
+    }
+  }
+  arel.project(table ? table.star : arelSql("*"));
+}
+
+function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown, nested = false): unknown {
+  if (value instanceof Nodes.SqlLiteral) return new Nodes.Grouping(value);
+  if (value instanceof SelectManager) return value;
+  if (value !== null && typeof value === "object" && typeof (value as any).toArel === "function") {
+    return nested ? (value as any).toArel().ast : (value as any).toArel();
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0], false);
+    const parts = value.map((q) => buildWithExpressionFromValue.call(this, q, true));
+    return parts.reduce((result, part) => new (Nodes as any).UnionAll(result, part));
+  }
+  throw argumentError(`Unsupported argument type: \`${String(value)}\` ${typeof value}`);
+}
+
+function buildWithValueFromHash(this: QueryMethodsHost, hash: Record<string, unknown>): unknown[] {
+  return Object.entries(hash).map(([name, value]) => {
+    const expr = buildWithExpressionFromValue.call(this, value);
+    return new (Nodes as any).TableAlias(expr, name);
+  });
+}
+
+// lookupTableKlassFromJoinDependencies is implemented in PR 2b alongside
+// buildJoinDependencies and eachJoinDependencies which it depends on.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -12,6 +12,7 @@ import { WhereClause } from "./where-clause.js";
 import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
 import {
   quote,
+  quoteColumnName as quoteCol,
   columnNameWithOrderMatcher as abstractOrderMatcher,
 } from "../connection-adapters/abstract/quoting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
@@ -1567,7 +1568,7 @@ function arelColumn(
   if (field instanceof Nodes.Node) return field;
   if (fallback) return fallback(fieldStr);
   const quoted = isSymbol
-    ? (modelClass?.adapter?.quoteTableName?.(fieldStr) ?? `"${fieldStr}"`)
+    ? (modelClass?.adapter?.quoteColumnName?.(fieldStr) ?? quoteCol(fieldStr))
     : fieldStr;
   return arelSql(quoted);
 }
@@ -1603,9 +1604,9 @@ function arelColumnWithTable(
 }
 
 function arelColumnsFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
-  return Object.entries(fields).flatMap(([tableName, columns]) => {
-    const tbl =
-      typeof tableName === "symbol" ? symbolToName(tableName as unknown as symbol) : tableName;
+  return Reflect.ownKeys(fields).flatMap((key) => {
+    const columns = (fields as Record<string | symbol, unknown>)[key];
+    const tbl = typeof key === "symbol" ? symbolToName(key) : key;
     if (typeof columns === "string" || typeof columns === "symbol") {
       return [arelColumnWithTable.call(this, tbl, columns as any)];
     }
@@ -1623,7 +1624,7 @@ function orderColumn(this: QueryMethodsHost, field: string): unknown {
     if (attrName === "count" && ((this as any)._groupColumns ?? []).length > 0) {
       return table?.get(attrName) ?? arelSql(attrName);
     }
-    const quoted = modelClass?.adapter?.quoteTableName?.(attrName) ?? `"${attrName}"`;
+    const quoted = modelClass?.adapter?.quoteColumnName?.(attrName) ?? quoteCol(attrName);
     return arelSql(quoted);
   });
 }
@@ -1636,20 +1637,26 @@ function processSelectArgs(this: QueryMethodsHost, fields: unknown[]): unknown[]
   });
 }
 
+function nodeAs(attr: unknown, quotedAlias: string): unknown {
+  if (typeof (attr as any)?.as === "function") return (attr as any).as(quotedAlias);
+  const attrSql = typeof (attr as any)?.toSql === "function" ? (attr as any).toSql() : String(attr);
+  return arelSql(`${attrSql} AS ${quotedAlias}`);
+}
+
 function arelColumnAliasesFromHash(
   this: QueryMethodsHost,
-  fields: Record<string, unknown>,
+  fields: Record<string | symbol, unknown>,
 ): unknown[] {
-  return Object.entries(fields).flatMap(([key, columnsAliases]) => {
-    const tableName = typeof key === "symbol" ? symbolToName(key as unknown as symbol) : key;
+  return Reflect.ownKeys(fields).flatMap((key) => {
+    const columnsAliases = fields[key as string];
+    const tableName = typeof key === "symbol" ? symbolToName(key) : key;
     const modelClass: any = (this as any)._modelClass;
+    const quoteAlias = (a: unknown): string =>
+      modelClass?.adapter?.quoteColumnName?.(String(a)) ?? quoteCol(String(a));
     if (isPlainObject(columnsAliases)) {
-      return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) => {
-        const attr = arelColumnWithTable.call(this, tableName, col);
-        const quotedAlias =
-          modelClass?.adapter?.quoteColumnName?.(String(alias)) ?? `"${String(alias)}"`;
-        return (attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`);
-      });
+      return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) =>
+        nodeAs(arelColumnWithTable.call(this, tableName, col), quoteAlias(alias)),
+      );
     }
     if (Array.isArray(columnsAliases)) {
       return (columnsAliases as string[]).map((col) =>
@@ -1657,11 +1664,7 @@ function arelColumnAliasesFromHash(
       );
     }
     if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {
-      const attr = arelColumn.call(this, key as any);
-      const quotedAlias =
-        modelClass?.adapter?.quoteColumnName?.(String(columnsAliases)) ??
-        `"${String(columnsAliases)}"`;
-      return [(attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`)];
+      return [nodeAs(arelColumn.call(this, key as any), quoteAlias(columnsAliases))];
     }
     return [];
   });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1534,12 +1534,28 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function safeQuoteTableName(modelClass: any, name: string): string {
+  try {
+    return modelClass?.adapter?.quoteTableName?.(name) ?? `"${name}"`;
+  } catch {
+    return `"${name}"`;
+  }
+}
+
+function safeQuoteColumnName(modelClass: any, name: string): string {
+  try {
+    return modelClass?.adapter?.quoteColumnName?.(name) ?? quoteCol(name);
+  } catch {
+    return quoteCol(name);
+  }
+}
+
 function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const table: any = (this as any)._modelClass?.arelTable;
   if (!table) return false;
   const modelClass: any = (this as any)._modelClass;
   const name = escapeRegex(table.name);
-  const quotedTableName = modelClass?.adapter?.quoteTableName?.(table.name) ?? `"${table.name}"`;
+  const quotedTableName = safeQuoteTableName(modelClass, table.name);
   const quoted = escapeRegex(quotedTableName);
   return new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${name}\\b|${quoted})(?!\\.)`, "i").test(String(from));
 }
@@ -1566,9 +1582,7 @@ function arelColumn(
     return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
   }
   if (fallback) return fallback(fieldStr);
-  const quoted = isSymbol
-    ? (modelClass?.adapter?.quoteColumnName?.(fieldStr) ?? quoteCol(fieldStr))
-    : fieldStr;
+  const quoted = isSymbol ? safeQuoteColumnName(modelClass, fieldStr) : fieldStr;
   return arelSql(quoted);
 }
 
@@ -1598,7 +1612,7 @@ function arelColumnWithTable(
     );
   }
   const modelClass: any = (this as any)._modelClass;
-  const quotedTable = modelClass?.adapter?.quoteTableName?.(tableName) ?? `"${tableName}"`;
+  const quotedTable = safeQuoteTableName(modelClass, tableName);
   return arelSql(`${quotedTable}.${colStr}`);
 }
 
@@ -1623,7 +1637,7 @@ function orderColumn(this: QueryMethodsHost, field: string): unknown {
     if (attrName === "count" && ((this as any)._groupColumns ?? []).length > 0) {
       return table?.get(attrName) ?? arelSql(attrName);
     }
-    const quoted = modelClass?.adapter?.quoteColumnName?.(attrName) ?? quoteCol(attrName);
+    const quoted = safeQuoteColumnName(modelClass, attrName);
     return arelSql(quoted);
   });
 }
@@ -1647,11 +1661,10 @@ function arelColumnAliasesFromHash(
   fields: Record<string | symbol, unknown>,
 ): unknown[] {
   return Reflect.ownKeys(fields).flatMap((key) => {
-    const columnsAliases = fields[key as string];
+    const columnsAliases = fields[key as any];
     const tableName = typeof key === "symbol" ? symbolToName(key) : key;
     const modelClass: any = (this as any)._modelClass;
-    const quoteAlias = (a: unknown): string =>
-      modelClass?.adapter?.quoteColumnName?.(String(a)) ?? quoteCol(String(a));
+    const quoteAlias = (a: unknown): string => safeQuoteColumnName(modelClass, String(a));
     if (isPlainObject(columnsAliases)) {
       return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) =>
         nodeAs(arelColumnWithTable.call(this, tableName, col), quoteAlias(alias)),

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1666,9 +1666,10 @@ function arelColumnAliasesFromHash(
     const modelClass: any = (this as any)._modelClass;
     const quoteAlias = (a: unknown): string => safeQuoteColumnName(modelClass, String(a));
     if (isPlainObject(columnsAliases)) {
-      return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) =>
-        nodeAs(arelColumnWithTable.call(this, tableName, col), quoteAlias(alias)),
-      );
+      return Reflect.ownKeys(columnsAliases as object).map((col) => {
+        const alias = (columnsAliases as any)[col];
+        return nodeAs(arelColumnWithTable.call(this, tableName, col as any), quoteAlias(alias));
+      });
     }
     if (Array.isArray(columnsAliases)) {
       return (columnsAliases as string[]).map((col) =>

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -13,8 +13,10 @@ import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
 import {
   quote,
   quoteColumnName as quoteCol,
+  quoteTableName as quoteTable,
   columnNameWithOrderMatcher as abstractOrderMatcher,
 } from "../connection-adapters/abstract/quoting.js";
+import { detectAdapterName } from "../adapter-name.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 
 /**
@@ -1536,17 +1538,23 @@ function escapeRegex(s: string): string {
 
 function safeQuoteTableName(modelClass: any, name: string): string {
   try {
-    return modelClass?.adapter?.quoteTableName?.(name) ?? `"${name.replace(/"/g, '""')}"`;
+    return (
+      modelClass?.adapter?.quoteTableName?.(name) ??
+      quoteTable(name, detectAdapterName(modelClass?.adapter))
+    );
   } catch {
-    return `"${name.replace(/"/g, '""')}"`;
+    return quoteTable(name, detectAdapterName(modelClass?.adapter));
   }
 }
 
 function safeQuoteColumnName(modelClass: any, name: string): string {
   try {
-    return modelClass?.adapter?.quoteColumnName?.(name) ?? quoteCol(name);
+    return (
+      modelClass?.adapter?.quoteColumnName?.(name) ??
+      quoteCol(name, detectAdapterName(modelClass?.adapter))
+    );
   } catch {
-    return quoteCol(name);
+    return quoteCol(name, detectAdapterName(modelClass?.adapter));
   }
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1588,6 +1588,7 @@ function arelColumn(
 
 function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
+    if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
     if (typeof field === "string" || typeof field === "symbol")
       return [arelColumn.call(this, field as any)];
     if (typeof field === "function") return [field()];
@@ -1668,7 +1669,12 @@ function arelColumnAliasesFromHash(
     if (isPlainObject(columnsAliases)) {
       return Reflect.ownKeys(columnsAliases as object).map((col) => {
         const alias = (columnsAliases as any)[col];
-        return nodeAs(arelColumnWithTable.call(this, tableName, col as any), quoteAlias(alias));
+        // col may be a Nodes.SqlLiteral (pre-quoted identifier) or plain string/symbol
+        const attr =
+          col instanceof Nodes.SqlLiteral
+            ? col
+            : arelColumnWithTable.call(this, tableName, col as any);
+        return nodeAs(attr, quoteAlias(alias));
       });
     }
     if (Array.isArray(columnsAliases)) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1537,24 +1537,32 @@ function escapeRegex(s: string): string {
 }
 
 function safeQuoteTableName(modelClass: any, name: string): string {
+  let adapter: any;
   try {
-    return (
-      modelClass?.adapter?.quoteTableName?.(name) ??
-      quoteTable(name, detectAdapterName(modelClass?.adapter))
-    );
+    adapter = modelClass?.adapter;
   } catch {
-    return quoteTable(name, detectAdapterName(modelClass?.adapter));
+    /* adapter getter threw — no connection */
+  }
+  const dialect = detectAdapterName(adapter);
+  try {
+    return adapter?.quoteTableName?.(name) ?? quoteTable(name, dialect);
+  } catch {
+    return quoteTable(name, dialect);
   }
 }
 
 function safeQuoteColumnName(modelClass: any, name: string): string {
+  let adapter: any;
   try {
-    return (
-      modelClass?.adapter?.quoteColumnName?.(name) ??
-      quoteCol(name, detectAdapterName(modelClass?.adapter))
-    );
+    adapter = modelClass?.adapter;
   } catch {
-    return quoteCol(name, detectAdapterName(modelClass?.adapter));
+    /* adapter getter threw — no connection */
+  }
+  const dialect = detectAdapterName(adapter);
+  try {
+    return adapter?.quoteColumnName?.(name) ?? quoteCol(name, dialect);
+  } catch {
+    return quoteCol(name, dialect);
   }
 }
 
@@ -1737,6 +1745,7 @@ function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown): u
     return (value as any).toArel().ast;
   }
   if (Array.isArray(value)) {
+    if (value.length === 0) throw argumentError("Empty array passed to buildWithExpressionFromValue");
     if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0]);
     const parts = value.map((q) => buildWithExpressionFromValue.call(this, q));
     return parts.reduce(
@@ -1747,13 +1756,14 @@ function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown): u
 }
 
 function buildWithValueFromHash(this: QueryMethodsHost, hash: Record<string, unknown>): unknown[] {
-  return Object.entries(hash).map(([name, value]) => {
+  return Reflect.ownKeys(hash).map((key) => {
+    const name = typeof key === "symbol" ? symbolToName(key) : key;
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
       throw argumentError(
         `Invalid CTE name "${name}": must be a valid SQL identifier (letters, digits, underscores, not starting with a digit).`,
       );
     }
-    const expr = buildWithExpressionFromValue.call(this, value);
+    const expr = buildWithExpressionFromValue.call(this, (hash as any)[key]);
     return new Nodes.Cte(name, expr as any);
   });
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1573,7 +1573,9 @@ function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const name = escapeRegex(table.name);
   const quotedTableName = safeQuoteTableName(modelClass, table.name);
   const quoted = escapeRegex(quotedTableName);
-  return new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${name}\\b|${quoted})(?!\\.)`, "i").test(String(from));
+  // Mirror Rails: from.to_sql if from.respond_to?(:to_sql)
+  const fromStr = typeof (from as any)?.toSql === "function" ? (from as any).toSql() : String(from);
+  return new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${name}\\b|${quoted})(?!\\.)`, "i").test(fromStr);
 }
 
 function arelColumn(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1745,7 +1745,8 @@ function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown): u
     return (value as any).toArel().ast;
   }
   if (Array.isArray(value)) {
-    if (value.length === 0) throw argumentError("Empty array passed to buildWithExpressionFromValue");
+    if (value.length === 0)
+      throw argumentError("Empty array passed to buildWithExpressionFromValue");
     if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0]);
     const parts = value.map((q) => buildWithExpressionFromValue.call(this, q));
     return parts.reduce(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1669,12 +1669,8 @@ function arelColumnAliasesFromHash(
     if (isPlainObject(columnsAliases)) {
       return Reflect.ownKeys(columnsAliases as object).map((col) => {
         const alias = (columnsAliases as any)[col];
-        // col may be a Nodes.SqlLiteral (pre-quoted identifier) or plain string/symbol
-        const attr =
-          col instanceof Nodes.SqlLiteral
-            ? col
-            : arelColumnWithTable.call(this, tableName, col as any);
-        return nodeAs(attr, quoteAlias(alias));
+        const attr = arelColumnWithTable.call(this, tableName, col as any);
+        return nodeAs(attr instanceof Nodes.Node ? attr : arelSql(String(col)), quoteAlias(alias));
       });
     }
     if (Array.isArray(columnsAliases)) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1536,9 +1536,9 @@ function escapeRegex(s: string): string {
 
 function safeQuoteTableName(modelClass: any, name: string): string {
   try {
-    return modelClass?.adapter?.quoteTableName?.(name) ?? `"${name}"`;
+    return modelClass?.adapter?.quoteTableName?.(name) ?? `"${name.replace(/"/g, '""')}"`;
   } catch {
-    return `"${name}"`;
+    return `"${name.replace(/"/g, '""')}"`;
   }
 }
 
@@ -1691,7 +1691,11 @@ function buildFrom(this: QueryMethodsHost): unknown {
   let name = fromClause?.name;
   if (opts && typeof (opts as any).toArel === "function") {
     name ??= "subquery";
-    return (opts as any).toArel().as(String(name));
+    const alias = String(name);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
+      throw argumentError(`Invalid subquery alias "${alias}": must be a safe SQL identifier`);
+    }
+    return (opts as any).toArel().as(alias);
   }
   return opts;
 }
@@ -1717,11 +1721,7 @@ function buildSelect(this: QueryMethodsHost, arel: any): void {
   arel.project(table ? table.star : arelSql("*"));
 }
 
-function buildWithExpressionFromValue(
-  this: QueryMethodsHost,
-  value: unknown,
-  nested = false,
-): unknown {
+function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown): unknown {
   if (value instanceof Nodes.SqlLiteral) return new Nodes.Grouping(value as any);
   // Always return the AST node so Cte.relation receives a Node, not a SelectManager.
   if (value instanceof SelectManager) return value.ast;
@@ -1729,8 +1729,8 @@ function buildWithExpressionFromValue(
     return (value as any).toArel().ast;
   }
   if (Array.isArray(value)) {
-    if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0], false);
-    const parts = value.map((q) => buildWithExpressionFromValue.call(this, q, true));
+    if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0]);
+    const parts = value.map((q) => buildWithExpressionFromValue.call(this, q));
     return parts.reduce(
       (result: unknown, part: unknown) => new Nodes.UnionAll(result as any, part as any),
     );
@@ -1740,9 +1740,12 @@ function buildWithExpressionFromValue(
 
 function buildWithValueFromHash(this: QueryMethodsHost, hash: Record<string, unknown>): unknown[] {
   return Object.entries(hash).map(([name, value]) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw argumentError(
+        `Invalid CTE name "${name}": must be a valid SQL identifier (letters, digits, underscores, not starting with a digit).`,
+      );
+    }
     const expr = buildWithExpressionFromValue.call(this, value);
-    // Cte renders "name" AS (expr) — correct CTE SQL.
-    // TableAlias renders (expr) name — wrong for CTEs.
     return new Nodes.Cte(name, expr as any);
   });
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1707,9 +1707,10 @@ function buildWithExpressionFromValue(
   nested = false,
 ): unknown {
   if (value instanceof Nodes.SqlLiteral) return new Nodes.Grouping(value as any);
-  if (value instanceof SelectManager) return value;
+  // Always return the AST node so Cte.relation receives a Node, not a SelectManager.
+  if (value instanceof SelectManager) return value.ast;
   if (value !== null && typeof value === "object" && typeof (value as any).toArel === "function") {
-    return nested ? (value as any).toArel().ast : (value as any).toArel();
+    return (value as any).toArel().ast;
   }
   if (Array.isArray(value)) {
     if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0], false);
@@ -1724,7 +1725,9 @@ function buildWithExpressionFromValue(
 function buildWithValueFromHash(this: QueryMethodsHost, hash: Record<string, unknown>): unknown[] {
   return Object.entries(hash).map(([name, value]) => {
     const expr = buildWithExpressionFromValue.call(this, value);
-    return new Nodes.TableAlias(expr as any, name);
+    // Cte renders "name" AS (expr) — correct CTE SQL.
+    // TableAlias renders (expr) name — wrong for CTEs.
+    return new Nodes.Cte(name, expr as any);
   });
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1565,7 +1565,6 @@ function arelColumn(
   if (dotMatch) {
     return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
   }
-  if (field instanceof Nodes.Node) return field;
   if (fallback) return fallback(fieldStr);
   const quoted = isSymbol
     ? (modelClass?.adapter?.quoteColumnName?.(fieldStr) ?? quoteCol(fieldStr))

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1529,22 +1529,30 @@ export const QueryMethodBangs = {
 // PR 2a private helpers — column resolution, select/from/with building.
 // ---------------------------------------------------------------------------
 
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const table: any = (this as any)._modelClass?.arelTable;
   if (!table) return false;
-  const name = Regexp.escape ? Regexp.escape(table.name) : table.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const modelClass: any = (this as any)._modelClass;
-  const quotedName = (name: string) =>
-    modelClass?.adapter?.quoteTableName?.(name) ?? `"${name}"`;
-  const quoted = quotedName(table.name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const name = escapeRegex(table.name);
+  const quotedTableName = modelClass?.adapter?.quoteTableName?.(table.name) ?? `"${table.name}"`;
+  const quoted = escapeRegex(quotedTableName);
   return new RegExp(`(?:^|(?<!FROM)\\s)(?:\\b${name}\\b|${quoted})(?!\\.)`, "i").test(String(from));
 }
 
-function arelColumn(this: QueryMethodsHost, field: string | symbol): unknown {
+function arelColumn(
+  this: QueryMethodsHost,
+  field: string | symbol,
+  fallback?: (attr: string) => unknown,
+): unknown {
   const modelClass: any = (this as any)._modelClass;
   const table: any = modelClass?.arelTable;
-  let fieldStr = typeof field === "symbol" ? symbolToName(field) : field;
-  fieldStr = modelClass?.attributeAliases?.[fieldStr] ?? fieldStr;
+  const isSymbol = typeof field === "symbol";
+  let fieldStr = isSymbol ? symbolToName(field) : field;
+  fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;
 
   const fromClause = (this as any)._fromClause;
   const from = fromClause?.name || fromClause?.value;
@@ -1556,31 +1564,37 @@ function arelColumn(this: QueryMethodsHost, field: string | symbol): unknown {
   if (dotMatch) {
     return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
   }
-  if (Nodes.isArelNode?.(field) || field instanceof Nodes.Node) return field;
-  const isSymbol = typeof field === "symbol";
-  return isSymbol
-    ? new ArelTable(fieldStr).get(fieldStr)
-    : arelSql(fieldStr);
+  if (field instanceof Nodes.Node) return field;
+  if (fallback) return fallback(fieldStr);
+  const quoted = isSymbol
+    ? (modelClass?.adapter?.quoteTableName?.(fieldStr) ?? `"${fieldStr}"`)
+    : fieldStr;
+  return arelSql(quoted);
 }
 
 function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
-    if (typeof field === "string" || typeof field === "symbol") return [arelColumn.call(this, field as any)];
+    if (typeof field === "string" || typeof field === "symbol")
+      return [arelColumn.call(this, field as any)];
     if (typeof field === "function") return [field()];
-    if (isPlainObject(field)) return arelColumnsFromHash.call(this, field as Record<string, unknown>);
+    if (isPlainObject(field))
+      return arelColumnsFromHash.call(this, field as Record<string, unknown>);
     return [field];
   });
 }
 
-function arelColumnWithTable(this: QueryMethodsHost, tableName: string, columnName: string | symbol): unknown {
+function arelColumnWithTable(
+  this: QueryMethodsHost,
+  tableName: string,
+  columnName: string | symbol,
+): unknown {
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
   const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
   if (typeof columnName === "symbol" || !/\W/.test(colStr)) {
     const builder = (this as any).predicateBuilder;
     return (
-      builder?.resolveArelAttribute?.(tableName, colStr) ??
-      new ArelTable(tableName).get(colStr)
+      builder?.resolveArelAttribute?.(tableName, colStr) ?? new ArelTable(tableName).get(colStr)
     );
   }
   const modelClass: any = (this as any)._modelClass;
@@ -1590,7 +1604,8 @@ function arelColumnWithTable(this: QueryMethodsHost, tableName: string, columnNa
 
 function arelColumnsFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
   return Object.entries(fields).flatMap(([tableName, columns]) => {
-    const tbl = typeof tableName === "symbol" ? symbolToName(tableName as unknown as symbol) : tableName;
+    const tbl =
+      typeof tableName === "symbol" ? symbolToName(tableName as unknown as symbol) : tableName;
     if (typeof columns === "string" || typeof columns === "symbol") {
       return [arelColumnWithTable.call(this, tbl, columns as any)];
     }
@@ -1602,43 +1617,50 @@ function arelColumnsFromHash(this: QueryMethodsHost, fields: Record<string, unkn
 }
 
 function orderColumn(this: QueryMethodsHost, field: string): unknown {
-  // Mirrors Rails' order_column: resolves field via arel_column with a custom
-  // fallback that quotes the identifier as a table name (for "count" + group).
-  const result = arelColumn.call(this, field);
-  if (result) return result;
   const modelClass: any = (this as any)._modelClass;
   const table: any = modelClass?.arelTable;
-  if (field === "count" && ((this as any)._groupColumns ?? []).length > 0) {
-    return table?.get(field) ?? arelSql(field);
-  }
-  const quoted = modelClass?.adapter?.quoteTableName?.(field) ?? `"${field}"`;
-  return arelSql(quoted);
+  return arelColumn.call(this, field, (attrName: string) => {
+    if (attrName === "count" && ((this as any)._groupColumns ?? []).length > 0) {
+      return table?.get(attrName) ?? arelSql(attrName);
+    }
+    const quoted = modelClass?.adapter?.quoteTableName?.(attrName) ?? `"${attrName}"`;
+    return arelSql(quoted);
+  });
 }
 
 function processSelectArgs(this: QueryMethodsHost, fields: unknown[]): unknown[] {
   return fields.flatMap((field) => {
-    if (isPlainObject(field)) return arelColumnAliasesFromHash.call(this, field as Record<string, unknown>);
+    if (isPlainObject(field))
+      return arelColumnAliasesFromHash.call(this, field as Record<string, unknown>);
     return [field];
   });
 }
 
-function arelColumnAliasesFromHash(this: QueryMethodsHost, fields: Record<string, unknown>): unknown[] {
+function arelColumnAliasesFromHash(
+  this: QueryMethodsHost,
+  fields: Record<string, unknown>,
+): unknown[] {
   return Object.entries(fields).flatMap(([key, columnsAliases]) => {
     const tableName = typeof key === "symbol" ? symbolToName(key as unknown as symbol) : key;
     const modelClass: any = (this as any)._modelClass;
     if (isPlainObject(columnsAliases)) {
       return Object.entries(columnsAliases as Record<string, unknown>).map(([col, alias]) => {
         const attr = arelColumnWithTable.call(this, tableName, col);
-        const quotedAlias = modelClass?.adapter?.quoteColumnName?.(String(alias)) ?? `"${String(alias)}"`;
+        const quotedAlias =
+          modelClass?.adapter?.quoteColumnName?.(String(alias)) ?? `"${String(alias)}"`;
         return (attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`);
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as string[]).map((col) => arelColumnWithTable.call(this, tableName, col));
+      return (columnsAliases as string[]).map((col) =>
+        arelColumnWithTable.call(this, tableName, col),
+      );
     }
     if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {
       const attr = arelColumn.call(this, key as any);
-      const quotedAlias = modelClass?.adapter?.quoteColumnName?.(String(columnsAliases)) ?? `"${String(columnsAliases)}"`;
+      const quotedAlias =
+        modelClass?.adapter?.quoteColumnName?.(String(columnsAliases)) ??
+        `"${String(columnsAliases)}"`;
       return [(attr as any)?.as?.(quotedAlias) ?? arelSql(`${attr} AS ${quotedAlias}`)];
     }
     return [];
@@ -1664,7 +1686,10 @@ function buildSelect(this: QueryMethodsHost, arel: any): void {
   }
   const modelClass: any = (this as any)._modelClass;
   const table: any = modelClass?.arelTable;
-  if ((modelClass?.ignoredColumns?.length ?? 0) > 0 || modelClass?.enumerateColumnsInSelectStatements) {
+  if (
+    (modelClass?.ignoredColumns?.length ?? 0) > 0 ||
+    modelClass?.enumerateColumnsInSelectStatements
+  ) {
     const cols: string[] = modelClass?.columnNames?.() ?? [];
     if (cols.length > 0) {
       arel.project(...cols.map((f: string) => table?.get(f) ?? arelSql(f)));
@@ -1674,8 +1699,12 @@ function buildSelect(this: QueryMethodsHost, arel: any): void {
   arel.project(table ? table.star : arelSql("*"));
 }
 
-function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown, nested = false): unknown {
-  if (value instanceof Nodes.SqlLiteral) return new Nodes.Grouping(value);
+function buildWithExpressionFromValue(
+  this: QueryMethodsHost,
+  value: unknown,
+  nested = false,
+): unknown {
+  if (value instanceof Nodes.SqlLiteral) return new Nodes.Grouping(value as any);
   if (value instanceof SelectManager) return value;
   if (value !== null && typeof value === "object" && typeof (value as any).toArel === "function") {
     return nested ? (value as any).toArel().ast : (value as any).toArel();
@@ -1683,7 +1712,9 @@ function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown, ne
   if (Array.isArray(value)) {
     if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0], false);
     const parts = value.map((q) => buildWithExpressionFromValue.call(this, q, true));
-    return parts.reduce((result, part) => new (Nodes as any).UnionAll(result, part));
+    return parts.reduce(
+      (result: unknown, part: unknown) => new Nodes.UnionAll(result as any, part as any),
+    );
   }
   throw argumentError(`Unsupported argument type: \`${String(value)}\` ${typeof value}`);
 }
@@ -1691,7 +1722,7 @@ function buildWithExpressionFromValue(this: QueryMethodsHost, value: unknown, ne
 function buildWithValueFromHash(this: QueryMethodsHost, hash: Record<string, unknown>): unknown[] {
   return Object.entries(hash).map(([name, value]) => {
     const expr = buildWithExpressionFromValue.call(this, value);
-    return new (Nodes as any).TableAlias(expr, name);
+    return new Nodes.TableAlias(expr as any, name);
   });
 }
 


### PR DESCRIPTION
## Summary

Adds 12 file-local private functions mirroring `ActiveRecord::QueryMethods` private block (column resolution + clause builders). Advances \`relation/query_methods.rb\` from **47% → 76%** (21/45 → 34/45). Overall: **13% → 13.9%** (186 → 199/1429).

**Column resolution:**
\`arelColumn\`, \`arelColumns\`, \`arelColumnWithTable\`, \`arelColumnsFromHash\`, \`isTableNameMatches\`, \`orderColumn\`

**Select helpers:**
\`processSelectArgs\`, \`arelColumnAliasesFromHash\`

**Clause builders:**
\`buildFrom\`, \`buildSelect\`, \`buildWithExpressionFromValue\`, \`buildWithValueFromHash\`

PR 2b will add the remaining 11: \`lookupTableKlassFromJoinDependencies\`, \`eachJoinDependencies\`, \`buildJoinDependencies\`, \`selectNamedJoins\`, \`selectAssociationList\`, \`buildJoinBuckets\`, \`buildJoins\`, \`buildWith\`, \`buildWithJoinNode\`, \`buildArel\`, \`scopeAssociationReflection\`.

## Test plan
- [x] \`pnpm api:compare --package activerecord --privates-only\` → \`relation/query_methods.rb  34/45  76%\`
- [x] Build + typecheck clean