### PR TITLE
test(parity): add 5 exotic AR query fixtures ar-129..ar-133

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -145,7 +145,7 @@ export function order<T extends typeof Base>(
     | [import("@blazetrails/arel").Nodes.Node, ...unknown[]]
   >
 ): Relation<InstanceType<T>> {
-  return this.all().order(...(args as any));
+  return this.all().order(...args);
 }
 
 /** Mirrors: ActiveRecord::Querying#group */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -137,13 +137,7 @@ export function select<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#order */
 export function order<T extends typeof Base>(
   this: T,
-  ...args: Array<
-    | string
-    | Record<string, "asc" | "desc" | "ASC" | "DESC">
-    | import("@blazetrails/arel").Nodes.Node
-    | string[]
-    | [import("@blazetrails/arel").Nodes.Node, ...unknown[]]
-  >
+  ...args: Parameters<Relation<InstanceType<T>>["order"]>
 ): Relation<InstanceType<T>> {
   return this.all().order(...args);
 }

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -145,7 +145,7 @@ export function order<T extends typeof Base>(
     | [import("@blazetrails/arel").Nodes.Node, ...unknown[]]
   >
 ): Relation<InstanceType<T>> {
-  return this.all().order(...args);
+  return this.all().order(...(args as any));
 }
 
 /** Mirrors: ActiveRecord::Querying#group */

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
+import { sql } from "@blazetrails/arel";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
 import { Associations, registerModel, modelRegistry } from "./associations.js";
 
@@ -117,6 +118,25 @@ describe("RelationTest", () => {
     // Rails never strips or re-qualifies cross-table references in string form.
     expect(Post.order("comments.body ASC").toSql()).toContain("ORDER BY comments.body ASC");
     expect(Post.order("posts.id DESC").toSql()).toContain("ORDER BY posts.id DESC");
+  });
+
+  it("order(sql(...)) passes computed aliases and raw expressions through verbatim without table qualification", () => {
+    class Post extends Base {
+      static _tableName = "posts";
+      static {
+        this.attribute("id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    // Computed select alias — must not be qualified as "posts"."avg_rating"
+    expect(Post.order(sql("avg_rating DESC")).toSql()).toContain("ORDER BY avg_rating DESC");
+    expect(Post.order(sql("avg_rating DESC")).toSql()).not.toContain('"posts"."avg_rating"');
+    // Chained: plain col comes before raw literal, both in call order
+    expect(Post.order({ id: "asc" }).order(sql("score DESC")).toSql()).toContain(
+      'ORDER BY "posts"."id" ASC, score DESC',
+    );
+    // Raw SQL expressions pass through verbatim
+    expect(Post.order(sql("RANDOM()")).toSql()).toContain("ORDER BY RANDOM()");
   });
 
   it("order by primary key stays table-qualified even before schema reflection", () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2858,8 +2858,12 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#order_values
    */
-  get orderValues(): Array<string | [string, "asc" | "desc"] | { raw: string }> {
-    return [...this._orderClauses];
+  get orderValues(): Array<string | [string, "asc" | "desc"] | Nodes.Node> {
+    return this._orderClauses.map((clause) =>
+      typeof clause === "object" && !Array.isArray(clause) && "raw" in clause
+        ? new Nodes.SqlLiteral((clause as { raw: string }).raw)
+        : clause,
+    );
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -206,8 +206,7 @@ export class Relation<T extends Base> {
   private _modelClass: typeof Base;
   /** @internal */
   _whereClause: WhereClause = WhereClause.empty();
-  private _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string } | Nodes.Node> =
-    [];
+  private _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }> = [];
   private _rawOrderClauses: string[] = [];
   private _limitValue: number | null = null;
   private _offsetValue: number | null = null;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -206,7 +206,8 @@ export class Relation<T extends Base> {
   private _modelClass: typeof Base;
   /** @internal */
   _whereClause: WhereClause = WhereClause.empty();
-  private _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }> = [];
+  private _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string } | Nodes.Node> =
+    [];
   private _rawOrderClauses: string[] = [];
   private _limitValue: number | null = null;
   private _offsetValue: number | null = null;
@@ -2859,11 +2860,12 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#order_values
    */
   get orderValues(): Array<string | [string, "asc" | "desc"] | Nodes.Node> {
-    return this._orderClauses.map((clause) =>
-      typeof clause === "object" && !Array.isArray(clause) && "raw" in clause
-        ? new Nodes.SqlLiteral((clause as { raw: string }).raw)
-        : clause,
-    );
+    return this._orderClauses.map((clause) => {
+      if (clause instanceof Nodes.Node) return clause;
+      if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause)
+        return new Nodes.SqlLiteral((clause as { raw: string }).raw);
+      return clause;
+    });
   }
 
   /**
@@ -3362,6 +3364,10 @@ export class Relation<T extends Base> {
       manager.order(new Nodes.SqlLiteral(rawClause));
     }
     for (const clause of this._orderClauses) {
+      if (clause instanceof Nodes.Node) {
+        manager.order(clause);
+        continue;
+      }
       if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
         manager.order(new Nodes.SqlLiteral((clause as { raw: string }).raw));
         continue;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -206,7 +206,7 @@ export class Relation<T extends Base> {
   private _modelClass: typeof Base;
   /** @internal */
   _whereClause: WhereClause = WhereClause.empty();
-  private _orderClauses: Array<string | [string, "asc" | "desc"]> = [];
+  private _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }> = [];
   private _rawOrderClauses: string[] = [];
   private _limitValue: number | null = null;
   private _offsetValue: number | null = null;
@@ -2858,7 +2858,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#order_values
    */
-  get orderValues(): Array<string | [string, "asc" | "desc"]> {
+  get orderValues(): Array<string | [string, "asc" | "desc"] | { raw: string }> {
     return [...this._orderClauses];
   }
 
@@ -3358,6 +3358,10 @@ export class Relation<T extends Base> {
       manager.order(new Nodes.SqlLiteral(rawClause));
     }
     for (const clause of this._orderClauses) {
+      if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
+        manager.order(new Nodes.SqlLiteral((clause as { raw: string }).raw));
+        continue;
+      }
       if (typeof clause === "string") {
         const trimmed = clause.trim();
         // Detect SQL expressions (functions, parens, operators) and pass as raw SQL

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2860,12 +2860,11 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#order_values
    */
   get orderValues(): Array<string | [string, "asc" | "desc"] | Nodes.Node> {
-    return this._orderClauses.map((clause) => {
-      if (clause instanceof Nodes.Node) return clause;
-      if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause)
-        return new Nodes.SqlLiteral((clause as { raw: string }).raw);
-      return clause;
-    });
+    return this._orderClauses.map((clause) =>
+      typeof clause === "object" && !Array.isArray(clause) && "raw" in clause
+        ? new Nodes.SqlLiteral((clause as { raw: string }).raw)
+        : clause,
+    );
   }
 
   /**
@@ -3364,10 +3363,6 @@ export class Relation<T extends Base> {
       manager.order(new Nodes.SqlLiteral(rawClause));
     }
     for (const clause of this._orderClauses) {
-      if (clause instanceof Nodes.Node) {
-        manager.order(clause);
-        continue;
-      }
       if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
         manager.order(new Nodes.SqlLiteral((clause as { raw: string }).raw));
         continue;
@@ -3409,7 +3404,7 @@ export class Relation<T extends Base> {
             }
           }
         }
-      } else {
+      } else if (Array.isArray(clause)) {
         const [col, dir] = clause;
         // Function expressions, quoted identifiers, and dotted names must be
         // emitted as raw SQL — table.get() would double-quote them incorrectly.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -84,7 +84,7 @@ export type AssociationSpec = string | { [assoc: string]: AssociationSpec | Asso
 // ---------------------------------------------------------------------------
 interface QueryMethodsHost {
   _whereClause: WhereClause;
-  _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string } | Nodes.Node>;
+  _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }>;
   _rawOrderClauses: string[];
   _limitValue: number | null;
   _offsetValue: number | null;
@@ -347,10 +347,11 @@ function orderBang(
     if (Array.isArray(arg)) {
       const [first, ...rest] = arg as unknown[];
       if (first instanceof Nodes.Node) {
-        // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check
+        // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check.
+        // Store as { raw } so _applyOrderToManager emits it verbatim.
         const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "") this._orderClauses.push(interpolated);
+        if (interpolated.trim() !== "") this._orderClauses.push({ raw: String(interpolated) });
       } else {
         // Plain string array: all elements must be strings; validate each immediately.
         if (!(arg as unknown[]).every((e) => typeof e === "string")) {
@@ -362,9 +363,12 @@ function orderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      // Store Arel nodes directly — mirrors Rails, which keeps live Arel::Node
-      // objects in order_values without pre-rendering.
-      this._orderClauses.push(arg);
+      // Pre-render to raw SQL string tagged as { raw } so _applyOrderToManager
+      // emits it verbatim (bypasses column qualification). Using { raw } rather
+      // than a live Nodes.Node keeps _orderClauses serializable (inspect(), merge
+      // dedup, etc. use JSON.stringify on the array).
+      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: String(rawSql) });
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -425,9 +429,12 @@ function reorderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      // Store Arel nodes directly — mirrors Rails, which keeps live Arel::Node
-      // objects in order_values without pre-rendering.
-      this._orderClauses.push(arg);
+      // Pre-render to raw SQL string tagged as { raw } so _applyOrderToManager
+      // emits it verbatim (bypasses column qualification). Using { raw } rather
+      // than a live Nodes.Node keeps _orderClauses serializable (inspect(), merge
+      // dedup, etc. use JSON.stringify on the array).
+      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: String(rawSql) });
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -1014,22 +1021,19 @@ function optimizerHintsBang(this: QueryMethodsHost, ...hints: string[]): any {
 
 function reverseOrderBang(this: QueryMethodsHost): any {
   this._orderClauses = this._orderClauses.map((clause) => {
-    if (clause instanceof Nodes.Node) {
-      throw new IrreversibleOrderError(
-        `Relation has a non-reversible order and cannot be reversed: ${(clause as any).toSql?.() ?? clause}`,
-      );
-    }
     if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
+      // Mirrors Rails reverse_sql_order string case: flip trailing ASC↔DESC,
+      // or append DESC if no direction present.
       const raw = (clause as { raw: string }).raw.trim();
-      const match = raw.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
-      if (match) {
-        const reversed = match[2].toUpperCase() === "ASC" ? "DESC" : "ASC";
-        return { raw: `${match[1]} ${reversed}` };
+      const flipped = raw.replace(/\s+ASC$/i, " DESC").replace(/\s+DESC$/i, " ASC");
+      if (flipped !== raw) return { raw: flipped };
+      // No direction suffix — append DESC (matches Rails `s << " DESC"` fallback)
+      if (/[(),]/.test(raw) || /CASE/i.test(raw)) {
+        throw new IrreversibleOrderError(
+          `Relation has a non-reversible order and cannot be reversed: ${raw}`,
+        );
       }
-      if (/^[A-Za-z_$][\w$]*$/.test(raw)) return { raw: `${raw} DESC` };
-      throw new IrreversibleOrderError(
-        `Relation has a non-reversible order and cannot be reversed: ${raw}`,
-      );
+      return { raw: `${raw} DESC` };
     }
     if (typeof clause === "string") {
       const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1023,12 +1023,10 @@ function reverseOrderBang(this: QueryMethodsHost): any {
       const raw = (clause as { raw: string }).raw.trim();
       const match = raw.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
       if (match) {
-        return [match[1], match[2].toUpperCase() === "ASC" ? "desc" : "asc"] as [
-          string,
-          "asc" | "desc",
-        ];
+        const reversed = match[2].toUpperCase() === "ASC" ? "DESC" : "ASC";
+        return { raw: `${match[1]} ${reversed}` };
       }
-      if (/^[A-Za-z_$][\w$]*$/.test(raw)) return [raw, "desc" as const];
+      if (/^[A-Za-z_$][\w$]*$/.test(raw)) return { raw: `${raw} DESC` };
       throw new IrreversibleOrderError(
         `Relation has a non-reversible order and cannot be reversed: ${raw}`,
       );

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -418,7 +418,7 @@ function reorderBang(
       if (first instanceof Nodes.Node) {
         const rawSql = (first as any).value ?? (first as Nodes.Node).toSql();
         const interpolated = rest.length > 0 ? sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "") this._orderClauses.push(interpolated);
+        if (interpolated.trim() !== "") this._orderClauses.push({ raw: String(interpolated) });
       } else {
         if (!(arg as unknown[]).every((e) => typeof e === "string")) {
           throw argumentError("Order arguments passed as an array must contain only strings");

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -84,7 +84,7 @@ export type AssociationSpec = string | { [assoc: string]: AssociationSpec | Asso
 // ---------------------------------------------------------------------------
 interface QueryMethodsHost {
   _whereClause: WhereClause;
-  _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }>;
+  _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string } | Nodes.Node>;
   _rawOrderClauses: string[];
   _limitValue: number | null;
   _offsetValue: number | null;
@@ -362,12 +362,9 @@ function orderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") {
-        // All Arel nodes (SqlLiteral, Ascending, Descending, …) have fully-formed
-        // SQL — store as { raw } to bypass column qualification in _applyOrderToManager.
-        this._orderClauses.push({ raw: rawSql });
-      }
+      // Store Arel nodes directly — mirrors Rails, which keeps live Arel::Node
+      // objects in order_values without pre-rendering.
+      this._orderClauses.push(arg);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -428,10 +425,9 @@ function reorderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") {
-        this._orderClauses.push({ raw: rawSql });
-      }
+      // Store Arel nodes directly — mirrors Rails, which keeps live Arel::Node
+      // objects in order_values without pre-rendering.
+      this._orderClauses.push(arg);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -1018,6 +1014,11 @@ function optimizerHintsBang(this: QueryMethodsHost, ...hints: string[]): any {
 
 function reverseOrderBang(this: QueryMethodsHost): any {
   this._orderClauses = this._orderClauses.map((clause) => {
+    if (clause instanceof Nodes.Node) {
+      throw new IrreversibleOrderError(
+        `Relation has a non-reversible order and cannot be reversed: ${(clause as any).toSql?.() ?? clause}`,
+      );
+    }
     if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
       const raw = (clause as { raw: string }).raw.trim();
       const match = raw.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -84,7 +84,7 @@ export type AssociationSpec = string | { [assoc: string]: AssociationSpec | Asso
 // ---------------------------------------------------------------------------
 interface QueryMethodsHost {
   _whereClause: WhereClause;
-  _orderClauses: Array<string | [string, "asc" | "desc"]>;
+  _orderClauses: Array<string | [string, "asc" | "desc"] | { raw: string }>;
   _rawOrderClauses: string[];
   _limitValue: number | null;
   _offsetValue: number | null;
@@ -362,9 +362,10 @@ function orderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      // Arel node (e.g. Arel.sql("title")) — store raw SQL directly.
+      // Arel node — preserve raw SQL without table qualification.
+      // SqlLiteral must pass through verbatim (no column-qualification).
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._orderClauses.push(rawSql);
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: rawSql });
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -426,7 +427,7 @@ function reorderBang(
       }
     } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._orderClauses.push(rawSql);
+      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: rawSql });
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -1013,6 +1014,11 @@ function optimizerHintsBang(this: QueryMethodsHost, ...hints: string[]): any {
 
 function reverseOrderBang(this: QueryMethodsHost): any {
   this._orderClauses = this._orderClauses.map((clause) => {
+    if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
+      throw new IrreversibleOrderError(
+        `Relation has a non-reversible order and cannot be reversed: ${(clause as { raw: string }).raw}`,
+      );
+    }
     if (typeof clause === "string") {
       const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);
       if (match) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -362,10 +362,13 @@ function orderBang(
         }
       }
     } else if (arg instanceof Nodes.Node) {
-      // Arel node — preserve raw SQL without table qualification.
-      // SqlLiteral must pass through verbatim (no column-qualification).
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: rawSql });
+      if (rawSql && rawSql.trim() !== "") {
+        // SqlLiteral must pass through verbatim — store as { raw } to bypass column qualification.
+        // Structured nodes (Ascending, Descending) already have fully-formed SQL from .toSql(),
+        // so they can use the same raw passthrough path.
+        this._orderClauses.push(arg instanceof Nodes.SqlLiteral ? { raw: rawSql } : rawSql);
+      }
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -427,7 +430,9 @@ function reorderBang(
       }
     } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
-      if (rawSql && rawSql.trim() !== "") this._orderClauses.push({ raw: rawSql });
+      if (rawSql && rawSql.trim() !== "") {
+        this._orderClauses.push(arg instanceof Nodes.SqlLiteral ? { raw: rawSql } : rawSql);
+      }
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -1015,8 +1020,17 @@ function optimizerHintsBang(this: QueryMethodsHost, ...hints: string[]): any {
 function reverseOrderBang(this: QueryMethodsHost): any {
   this._orderClauses = this._orderClauses.map((clause) => {
     if (typeof clause === "object" && !Array.isArray(clause) && "raw" in clause) {
+      const raw = (clause as { raw: string }).raw.trim();
+      const match = raw.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
+      if (match) {
+        return [match[1], match[2].toUpperCase() === "ASC" ? "desc" : "asc"] as [
+          string,
+          "asc" | "desc",
+        ];
+      }
+      if (/^[A-Za-z_$][\w$]*$/.test(raw)) return [raw, "desc" as const];
       throw new IrreversibleOrderError(
-        `Relation has a non-reversible order and cannot be reversed: ${(clause as { raw: string }).raw}`,
+        `Relation has a non-reversible order and cannot be reversed: ${raw}`,
       );
     }
     if (typeof clause === "string") {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -364,10 +364,9 @@ function orderBang(
     } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
       if (rawSql && rawSql.trim() !== "") {
-        // SqlLiteral must pass through verbatim — store as { raw } to bypass column qualification.
-        // Structured nodes (Ascending, Descending) already have fully-formed SQL from .toSql(),
-        // so they can use the same raw passthrough path.
-        this._orderClauses.push(arg instanceof Nodes.SqlLiteral ? { raw: rawSql } : rawSql);
+        // All Arel nodes (SqlLiteral, Ascending, Descending, …) have fully-formed
+        // SQL — store as { raw } to bypass column qualification in _applyOrderToManager.
+        this._orderClauses.push({ raw: rawSql });
       }
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
@@ -431,7 +430,7 @@ function reorderBang(
     } else if (arg instanceof Nodes.Node) {
       const rawSql = (arg as any).value ?? (arg as Nodes.Node).toSql();
       if (rawSql && rawSql.trim() !== "") {
-        this._orderClauses.push(arg instanceof Nodes.SqlLiteral ? { raw: rawSql } : rawSql);
+        this._orderClauses.push({ raw: rawSql });
       }
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1025,14 +1025,14 @@ function reverseOrderBang(this: QueryMethodsHost): any {
       // Mirrors Rails reverse_sql_order string case: flip trailing ASC↔DESC,
       // or append DESC if no direction present.
       const raw = (clause as { raw: string }).raw.trim();
-      const flipped = raw.replace(/\s+ASC$/i, " DESC").replace(/\s+DESC$/i, " ASC");
-      if (flipped !== raw) return { raw: flipped };
-      // No direction suffix — append DESC (matches Rails `s << " DESC"` fallback)
-      if (/[(),]/.test(raw) || /CASE/i.test(raw)) {
+      if (isDoesNotSupportReverse(raw)) {
         throw new IrreversibleOrderError(
           `Relation has a non-reversible order and cannot be reversed: ${raw}`,
         );
       }
+      const flipped = raw.replace(/\s+ASC$/i, " DESC").replace(/\s+DESC$/i, " ASC");
+      if (flipped !== raw) return { raw: flipped };
+      // No direction suffix — append DESC (matches Rails `s << " DESC"` fallback)
       return { raw: `${raw} DESC` };
     }
     if (typeof clause === "string") {

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -10,5 +10,17 @@
   "ar-65": {
     "side": "diff",
     "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
+  },
+  "ar-16": {
+    "side": "diff",
+    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
+  },
+  "ar-57": {
+    "side": "diff",
+    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
+  },
+  "ar-133": {
+    "side": "diff",
+    "reason": "from() does not handle Arel::Nodes::As arguments: Rails accepts an Arel As node (SelectManager#as result) as the from() value and inlines it as a parenthesised subquery — 'FROM (SELECT ...) ranked'. Trails' from() handler checks for Relation, string, or string+alias, but falls through to a bare toString() for Arel nodes, producing 'FROM [object Object]'. Real fix: detect Arel As / SelectManager in the from() handler and call toSql() on them."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -11,14 +11,6 @@
     "side": "diff",
     "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
   },
-  "ar-16": {
-    "side": "diff",
-    "reason": "Book.all().eagerLoad(\"author\").limit(10): trails eagerLoad pushes the association into _eagerLoadAssociations but doesn't emit the LEFT OUTER JOIN + column-aliased SELECT that Rails produces. Rails emits 'SELECT \"books\".\"id\" AS t0_r0, ... FROM \"books\" LEFT OUTER JOIN \"authors\" ON ... LIMIT 10'; trails emits the bare 'SELECT \"books\".* FROM \"books\" LIMIT 10'. Real trails-missing feature: eagerLoad's JOIN + column-projection behaviour."
-  },
-  "ar-57": {
-    "side": "diff",
-    "reason": "includes + references + string where: Rails promotes includes(:author) to a LEFT OUTER JOIN + column-aliased SELECT when references(:author) is combined with a string WHERE touching that table (same mechanism as eagerLoad). trails emits a plain SELECT with the WHERE clause but no JOIN. Same root cause as ar-16 — eagerLoad JOIN + column-projection behaviour is not implemented."
-  },
   "ar-133": {
     "side": "diff",
     "reason": "from() does not handle Arel::Nodes::As arguments: Rails accepts an Arel As node (SelectManager#as result) as the from() value and inlines it as a parenthesised subquery — 'FROM (SELECT ...) ranked'. Trails' from() handler checks for Relation, string, or string+alias, but falls through to a bare toString() for Arel nodes, producing 'FROM [object Object]'. Real fix: detect Arel As / SelectManager in the from() handler and call toSql() on them."

--- a/scripts/parity/fixtures/ar-129/models.rb
+++ b/scripts/parity/fixtures/ar-129/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-129/models.ts
+++ b/scripts/parity/fixtures/ar-129/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-129/query.rb
+++ b/scripts/parity/fixtures/ar-129/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::NamedFunction.new("COALESCE", [Book.arel_table[:subtitle], Book.arel_table[:title]]).as("display_title"), Book.arel_table[:id]).order(:id).limit(5)

--- a/scripts/parity/fixtures/ar-129/query.ts
+++ b/scripts/parity/fixtures/ar-129/query.ts
@@ -1,0 +1,12 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+
+export default Book.select(
+  new Nodes.NamedFunction("COALESCE", [
+    Book.arelTable.get("subtitle"),
+    Book.arelTable.get("title"),
+  ]).as("display_title"),
+  Book.arelTable.get("id"),
+)
+  .order({ id: "asc" })
+  .limit(5);

--- a/scripts/parity/fixtures/ar-129/schema.sql
+++ b/scripts/parity/fixtures/ar-129/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-129
+-- Query: Book.select(Arel::Nodes::NamedFunction.new("COALESCE", [Book.arel_table[:subtitle], Book.arel_table[:title]]).as("display_title"), Book.arel_table[:id]).order(:id).limit(5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  subtitle TEXT
+);

--- a/scripts/parity/fixtures/ar-130/models.rb
+++ b/scripts/parity/fixtures/ar-130/models.rb
@@ -1,0 +1,12 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-130/models.ts
+++ b/scripts/parity/fixtures/ar-130/models.ts
@@ -1,0 +1,26 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-130/query.rb
+++ b/scripts/parity/fixtures/ar-130/query.rb
@@ -1,0 +1,1 @@
+Author.joins(:books).joins("INNER JOIN reviews ON reviews.book_id = books.id").where("reviews.rating >= 4").group("authors.id, authors.name").select("authors.id, authors.name, COUNT(DISTINCT books.id) AS book_count, AVG(reviews.rating) AS avg_rating").having("COUNT(DISTINCT books.id) >= 2").order(Arel.sql("avg_rating DESC")).limit(5)

--- a/scripts/parity/fixtures/ar-130/query.ts
+++ b/scripts/parity/fixtures/ar-130/query.ts
@@ -1,0 +1,13 @@
+import { sql } from "@blazetrails/arel";
+import { Author } from "./models.js";
+
+export default Author.joins("books")
+  .joins("INNER JOIN reviews ON reviews.book_id = books.id")
+  .where("reviews.rating >= 4")
+  .group("authors.id, authors.name")
+  .select(
+    "authors.id, authors.name, COUNT(DISTINCT books.id) AS book_count, AVG(reviews.rating) AS avg_rating",
+  )
+  .having("COUNT(DISTINCT books.id) >= 2")
+  .order(sql("avg_rating DESC"))
+  .limit(5);

--- a/scripts/parity/fixtures/ar-130/schema.sql
+++ b/scripts/parity/fixtures/ar-130/schema.sql
@@ -1,0 +1,19 @@
+-- Fixture for statement: ar-130
+-- Query: Author.joins(:books).joins("INNER JOIN reviews ON reviews.book_id = books.id").where("reviews.rating >= 4").group("authors.id, authors.name").select("authors.id, authors.name, COUNT(DISTINCT books.id) AS book_count, AVG(reviews.rating) AS avg_rating").having("COUNT(DISTINCT books.id) >= 2").order(Arel.sql("avg_rating DESC")).limit(5)
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER REFERENCES authors(id)
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  rating INTEGER NOT NULL
+);

--- a/scripts/parity/fixtures/ar-131/models.rb
+++ b/scripts/parity/fixtures/ar-131/models.rb
@@ -1,0 +1,7 @@
+class Book < ActiveRecord::Base
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-131/models.ts
+++ b/scripts/parity/fixtures/ar-131/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-131/query.rb
+++ b/scripts/parity/fixtures/ar-131/query.rb
@@ -1,0 +1,1 @@
+Book.with(avg_ratings: Review.select(:book_id, Arel.sql("ROUND(AVG(rating), 1) AS avg_score")).group(:book_id)).joins("INNER JOIN avg_ratings ON avg_ratings.book_id = books.id").where("avg_ratings.avg_score >= 4").select("books.id, books.title, avg_ratings.avg_score").order("avg_ratings.avg_score DESC")

--- a/scripts/parity/fixtures/ar-131/query.ts
+++ b/scripts/parity/fixtures/ar-131/query.ts
@@ -1,0 +1,13 @@
+import { sql } from "@blazetrails/arel";
+import { Book, Review } from "./models.js";
+
+export default Book.all()
+  .with({
+    avg_ratings: Review.select("book_id", sql("ROUND(AVG(rating), 1) AS avg_score")).group(
+      "book_id",
+    ),
+  })
+  .joins("INNER JOIN avg_ratings ON avg_ratings.book_id = books.id")
+  .where("avg_ratings.avg_score >= 4")
+  .select("books.id, books.title, avg_ratings.avg_score")
+  .order("avg_ratings.avg_score DESC");

--- a/scripts/parity/fixtures/ar-131/schema.sql
+++ b/scripts/parity/fixtures/ar-131/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-131
+-- Query: Book.with(avg_ratings: Review.select(:book_id, Arel.sql("ROUND(AVG(rating), 1) AS avg_score")).group(:book_id)).joins("INNER JOIN avg_ratings ON avg_ratings.book_id = books.id").where("avg_ratings.avg_score >= 4").select("books.id, books.title, avg_ratings.avg_score").order("avg_ratings.avg_score DESC")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  rating INTEGER NOT NULL
+);

--- a/scripts/parity/fixtures/ar-132/models.rb
+++ b/scripts/parity/fixtures/ar-132/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-132/models.ts
+++ b/scripts/parity/fixtures/ar-132/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-132/query.rb
+++ b/scripts/parity/fixtures/ar-132/query.rb
@@ -1,0 +1,1 @@
+Book.where(status: "draft").where(active: false).order(:title).limit(100).unscope(:limit, :order).rewhere(status: "published").order(id: :desc).limit(5)

--- a/scripts/parity/fixtures/ar-132/query.ts
+++ b/scripts/parity/fixtures/ar-132/query.ts
@@ -1,0 +1,10 @@
+import { Book } from "./models.js";
+
+export default Book.where({ status: "draft" })
+  .where({ active: false })
+  .order({ title: "asc" })
+  .limit(100)
+  .unscope("limit", "order")
+  .rewhere({ status: "published" })
+  .order({ id: "desc" })
+  .limit(5);

--- a/scripts/parity/fixtures/ar-132/schema.sql
+++ b/scripts/parity/fixtures/ar-132/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-132
+-- Query: Book.where(status: "draft").where(active: false).order(:title).limit(100).unscope(:limit, :order).rewhere(status: "published").order(id: :desc).limit(5)
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1
+);

--- a/scripts/parity/fixtures/ar-133/models.rb
+++ b/scripts/parity/fixtures/ar-133/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base
+end

--- a/scripts/parity/fixtures/ar-133/models.ts
+++ b/scripts/parity/fixtures/ar-133/models.ts
@@ -1,0 +1,8 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-133/query.rb
+++ b/scripts/parity/fixtures/ar-133/query.rb
@@ -1,0 +1,2 @@
+ranked = Book.select(Book.arel_table[Arel.star], Arel.sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn")).arel.as("ranked")
+Book.from(ranked).where("ranked.rn = 1").order("ranked.id")

--- a/scripts/parity/fixtures/ar-133/query.ts
+++ b/scripts/parity/fixtures/ar-133/query.ts
@@ -1,0 +1,10 @@
+import { sql, star } from "@blazetrails/arel";
+import { Book } from "./models.js";
+
+const ranked = Book.select(
+  star,
+  sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn"),
+)
+  .toArel()
+  .as("ranked");
+export default Book.from(ranked).where("ranked.rn = 1").order("ranked.id");

--- a/scripts/parity/fixtures/ar-133/query.ts
+++ b/scripts/parity/fixtures/ar-133/query.ts
@@ -1,8 +1,8 @@
-import { sql, star } from "@blazetrails/arel";
+import { sql } from "@blazetrails/arel";
 import { Book } from "./models.js";
 
 const ranked = Book.select(
-  star,
+  sql("books.*"),
   sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn"),
 )
   .toArel()

--- a/scripts/parity/fixtures/ar-133/schema.sql
+++ b/scripts/parity/fixtures/ar-133/schema.sql
@@ -1,0 +1,9 @@
+-- Fixture for statement: ar-133
+-- Query: ranked = Book.select(Book.arel_table[Arel.star], Arel.sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn")).arel.as("ranked"); Book.from(ranked).where("ranked.rn = 1").order("ranked.id")
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER,
+  pages INTEGER NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary

Adds 5 exotic/complex query fixtures and fixes a real Trails bug uncovered by ar-130:

### Bug fix
- **`order(Arel.sql(...))`** now passes through verbatim without column qualification. Previously, `sql("avg_rating DESC")` would produce `ORDER BY "authors"."avg_rating" DESC`; it now correctly produces `ORDER BY avg_rating DESC`. All Arel node inputs to `order()`/`reorder()` (including bind-array form) are pre-rendered via `.toSql()` and stored as `{ raw: string }` so `_applyOrderToManager` emits them verbatim, bypassing column-qualification. `reverseOrder` uses suffix-flip matching Rails' `reverse_sql_order` string case.

### New fixtures
- **ar-129**: `Arel::Nodes::NamedFunction` (COALESCE) in SELECT — **PASS**
- **ar-130**: 7-method author→books→reviews chain (joins+group+select+having+order+limit) — **PASS**
- **ar-131**: CTE joined via INNER JOIN with computed `avg_score` column — **PASS**
- **ar-132**: `unscope(:limit, :order)` + `rewhere` + new `order` + `limit` chain — **PASS**
- **ar-133**: Arel `SelectManager#as` as `from()` argument (windowed row-number subquery) — **KNOWN-GAP**: `from()` does not handle `Arel::Nodes::As` (documented)

ar-01/ar-52/ar-65 remain in known-gaps (datetime-precision flakiness, pending temporal conversion work).

## Test plan
- [ ] `pnpm parity:query` — 4 PASS, 1 KNOWN-GAP (ar-133), no unexpected failures (ar-01/52/65 flaky by frozen-at)
- [ ] `pnpm test` in `packages/activerecord` — 101 tests pass, no regressions on order tests