### PR TITLE
fix(activerecord): from() accepts Arel nodes for subquery FROM (ar-133)

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -120,7 +120,7 @@ export function _loadFromSql<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#from */
 export function from<T extends typeof Base>(
   this: T,
-  source: string | Relation<any>,
+  source: string | Relation<any> | import("@blazetrails/arel").Nodes.Node,
   subqueryName?: string,
 ): Relation<InstanceType<T>> {
   return this.all().from(source, subqueryName);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -315,6 +315,25 @@ describe("RelationTest", () => {
     expect(sql).not.toContain('"developers"."hotness"');
   });
 
+  it("from() with an Arel TableAlias node emits (SELECT …) alias subquery form", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    // SelectManager#as produces a Nodes.TableAlias — mirrors Rails'
+    // `relation.arel.as("ranked")` as the from() argument.
+    const ranked = Book.select("title").toArel().as("ranked");
+    const result = Book.from(ranked).where("ranked.title IS NOT NULL").toSql();
+    expect(result).toContain("FROM (SELECT");
+    expect(result).toContain(") ranked");
+    expect(result).toContain("ranked.title IS NOT NULL");
+    // Must not produce [object Object]
+    expect(result).not.toContain("[object");
+  });
+
   it("Model.optimizerHints() delegates to all().optimizerHints()", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1083,7 +1083,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#from
    */
-  from(source: string | Relation<any>, subqueryName?: string): Relation<T> {
+  from(source: string | Relation<any> | Nodes.Node, subqueryName?: string): Relation<T> {
     return this._clone().fromBang(source, subqueryName);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3300,6 +3300,11 @@ export class Relation<T extends Base> {
         // Only emit bare when the alias is a safe identifier; fall back to quoted
         // for names that would produce invalid SQL or risk injection.
         fromExpr = `(${subSql}) ${_safeAlias(name)}`;
+      } else if (raw instanceof Nodes.Node) {
+        // Arel node (e.g. SelectManager#as → Nodes.TableAlias) — call toSql()
+        // so the visitor emits correct SQL (e.g. "(SELECT ...) ranked").
+        // Rails accepts Arel::Nodes::As from relation.arel.as("alias") here.
+        fromExpr = raw.toSql();
       } else if (alias) {
         fromExpr = `${raw} ${_safeAlias(alias)}`;
       } else {

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -10,9 +10,5 @@
   "ar-65": {
     "side": "diff",
     "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
-  },
-  "ar-133": {
-    "side": "diff",
-    "reason": "from() does not handle Arel::Nodes::As arguments: Rails accepts an Arel As node (SelectManager#as result) as the from() value and inlines it as a parenthesised subquery — 'FROM (SELECT ...) ranked'. Trails' from() handler checks for Relation, string, or string+alias, but falls through to a bare toString() for Arel nodes, producing 'FROM [object Object]'. Real fix: detect Arel As / SelectManager in the from() handler and call toSql() on them."
   }
 }

--- a/scripts/parity/fixtures/ar-133/query.ts
+++ b/scripts/parity/fixtures/ar-133/query.ts
@@ -2,7 +2,7 @@ import { sql } from "@blazetrails/arel";
 import { Book } from "./models.js";
 
 const ranked = Book.select(
-  sql("books.*"),
+  sql('"books".*'),
   sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn"),
 )
   .toArel()


### PR DESCRIPTION
## Summary

Closes parity gap ar-133.

`Relation#from()` now handles Arel node arguments (e.g. `SelectManager#as("alias")` → `Nodes.TableAlias`) by calling `.toSql()` on them instead of falling through to `toString()` which produced `FROM [object Object]`.

Rails accepts `relation.arel.as("alias")` directly as a `from()` argument and emits `FROM (SELECT ...) alias`. Trails now matches.

Also fixes the ar-133 fixture to quote the table name in `sql('"books".*')` matching Rails' `arel_table[Arel.star]` output.

## Test plan

- [x] `pnpm parity:query` — 166/169 passed, 0 known gaps (ar-02/03/04/05 are empty placeholder dirs)
- [ ] CI