### PR TITLE
feat(temporal): PR 2 — SQL formatters and bind shim (dual-typed window opens)

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -9,7 +9,13 @@
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
       "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],
-      "@blazetrails/activesupport/message-verifier": ["../../activesupport/src/message-verifier.ts"]
+      "@blazetrails/activesupport/message-verifier": [
+        "../../activesupport/src/message-verifier.ts"
+      ],
+      "@blazetrails/activesupport/temporal": ["../../activesupport/src/temporal.ts"],
+      "@blazetrails/activesupport/testing/temporal-helpers": [
+        "../../activesupport/src/testing/temporal-helpers.ts"
+      ]
     }
   },
   "include": ["."]

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Rollback } from "../../errors.js";
 import {
   toSql,
@@ -19,6 +20,7 @@ import {
   emptyInsertStatementValue,
   sanitizeLimit,
   withYamlFallback,
+  typeCastedBinds,
   highPrecisionCurrentTimestamp,
   markTransactionWrittenIfWrite,
   isTransactionOpen,
@@ -293,6 +295,29 @@ describe("DatabaseStatements", () => {
     it("with yaml fallback converts objects to JSON", () => {
       expect(withYamlFallback({ a: 1 })).toBe('{"a":1}');
       expect(withYamlFallback([1, 2])).toBe("[1,2]");
+    });
+
+    it("with yaml fallback passes Temporal values through unchanged (not serialized to '{}')", () => {
+      const instant = Temporal.Instant.from("2026-04-26T14:23:55Z");
+      expect(withYamlFallback(instant)).toBe(instant);
+      const pdt = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
+      expect(withYamlFallback(pdt)).toBe(pdt);
+    });
+
+    it("typeCastedBinds converts Temporal values in valueForDatabase() results to SQL strings", () => {
+      const instant = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
+      const attrLike = { valueForDatabase: () => instant };
+      expect(typeCastedBinds([attrLike])).toEqual(["2026-04-26 14:23:55.123456"]);
+    });
+
+    it("typeCastedBinds converts Temporal values in { value } bind objects to SQL strings", () => {
+      const date = Temporal.PlainDate.from("2026-04-26");
+      const bindLike = { value: date };
+      expect(typeCastedBinds([bindLike])).toEqual(["2026-04-26"]);
+    });
+
+    it("typeCastedBinds passes non-Temporal primitives through unchanged", () => {
+      expect(typeCastedBinds([42, "hello", null])).toEqual([42, "hello", null]);
     });
 
     it("high precision current timestamp returns Arel SQL literal", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -7,8 +7,17 @@
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Notifications } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TransactionIsolationError } from "../../errors.js";
-import { quote, quoteTableName, quoteColumnName } from "./quoting.js";
+import {
+  quote,
+  quoteTableName,
+  quoteColumnName,
+  formatInstantForSql,
+  formatPlainDateTimeForSql,
+  formatPlainDateForSql,
+  formatPlainTimeForSql,
+} from "./quoting.js";
 import { TransactionManager } from "./transaction.js";
 import { Result } from "../../result.js";
 import { isWriteQuerySql } from "../sql-classification.js";
@@ -940,11 +949,42 @@ export function sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral {
 export function withYamlFallback(value: unknown): unknown {
   if (
     Array.isArray(value) ||
-    (value !== null && typeof value === "object" && !(value instanceof Date))
+    (value !== null &&
+      typeof value === "object" &&
+      !(value instanceof Date) &&
+      !isTemporalValue(value))
   ) {
     return JSON.stringify(value);
   }
   return value;
+}
+
+/**
+ * Convert a Temporal value to its SQL wire-string form for use as a bound
+ * parameter. Drivers (pg extended protocol, mysql2 prepared, better-sqlite3)
+ * reject raw Temporal objects; this shim converts them at the bind boundary
+ * so neither the text-protocol path (quote) nor the binary-protocol path
+ * need to know about Temporal.
+ *
+ * Returns the value unchanged when it is not a Temporal type.
+ */
+export function temporalToBindString(value: unknown): unknown {
+  if (value instanceof Temporal.Instant) return formatInstantForSql(value);
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
+  if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
+  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
+  return value;
+}
+
+function isTemporalValue(value: object): boolean {
+  return (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime ||
+    value instanceof Temporal.ZonedDateTime
+  );
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -962,11 +962,13 @@ export function withYamlFallback(value: unknown): unknown {
 /**
  * Convert a Temporal value to its SQL wire-string form for use as a bound
  * parameter. Drivers (pg extended protocol, mysql2 prepared, better-sqlite3)
- * reject raw Temporal objects; this shim converts them at the bind boundary
- * so neither the text-protocol path (quote) nor the binary-protocol path
- * need to know about Temporal.
- *
+ * reject raw Temporal objects; this shim converts them at the bind boundary.
  * Returns the value unchanged when it is not a Temporal type.
+ *
+ * Applied in `typeCastedBinds` (notification payloads) in this PR. The actual
+ * driver-bind paths (pg `client.query values`, mysql2 `conn.execute`, and
+ * better-sqlite3 `stmt.all`) are wired in PRs 5a, 5b, and 4 respectively,
+ * once those adapters start receiving real Temporal values from the cast layer.
  */
 export function temporalToBindString(value: unknown): unknown {
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1008,10 +1008,13 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
  */
 export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
   return (binds ?? []).map((b: any) => {
+    let v: unknown;
     if (b && typeof b === "object" && typeof b.valueForDatabase === "function") {
-      return b.valueForDatabase();
+      v = b.valueForDatabase();
+    } else {
+      v = b && typeof b === "object" && "value" in b ? b.value : b;
     }
-    return b && typeof b === "object" && "value" in b ? b.value : b;
+    return temporalToBindString(v);
   });
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -971,11 +971,19 @@ export function withYamlFallback(value: unknown): unknown {
  * Temporal migration work once those adapters start receiving real Temporal
  * values from the cast layer.
  */
-export function temporalToBindString(value: unknown): unknown {
+export function temporalToBindString(
+  value: unknown,
+  adapter?: "sqlite" | "postgres" | "mysql",
+): unknown {
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
-  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.PlainTime) {
+    // SQLite stores time as a datetime string with a fixed 2000-01-01 date prefix,
+    // matching quotedTime(Date) behavior in sqlite3/quoting.ts.
+    const t = formatPlainTimeForSql(value);
+    return adapter === "sqlite" ? `2000-01-01 ${t}` : t;
+  }
   if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   return value;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -965,10 +965,11 @@ export function withYamlFallback(value: unknown): unknown {
  * reject raw Temporal objects; this shim converts them at the bind boundary.
  * Returns the value unchanged when it is not a Temporal type.
  *
- * Applied in `typeCastedBinds` (notification payloads) in this PR. The actual
+ * Applied in `typeCastedBinds` (notification payloads) for now. The actual
  * driver-bind paths (pg `client.query values`, mysql2 `conn.execute`, and
- * better-sqlite3 `stmt.all`) are wired in PRs 5a, 5b, and 4 respectively,
- * once those adapters start receiving real Temporal values from the cast layer.
+ * better-sqlite3 `stmt.all`) should be wired as part of the adapter-specific
+ * Temporal migration work once those adapters start receiving real Temporal
+ * values from the cast layer.
  */
 export function temporalToBindString(value: unknown): unknown {
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -11,6 +11,8 @@ import {
   formatPlainDateTimeForSql,
   formatPlainDateForSql,
   formatPlainTimeForSql,
+  quote,
+  typeCast,
 } from "./quoting.js";
 import { temporalToBindString } from "./database-statements.js";
 
@@ -126,5 +128,43 @@ describe("temporalToBindString", () => {
     expect(temporalToBindString(42)).toBe(42);
     expect(temporalToBindString("hello")).toBe("hello");
     expect(temporalToBindString(null)).toBe(null);
+  });
+});
+
+// abstract quote() / typeCast() — used by the Postgres adapter which has no
+// adapter-specific override for datetime quoting.
+describe("abstract quote() with Temporal (Postgres path)", () => {
+  it("quotes an Instant", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
+    expect(quote(v)).toBe("'2026-04-26 14:23:55.123456'");
+  });
+
+  it("quotes a PlainDateTime", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55.000001");
+    expect(quote(v)).toBe("'2026-04-26 14:23:55.000001'");
+  });
+
+  it("quotes a PlainDate", () => {
+    expect(quote(Temporal.PlainDate.from("2026-04-26"))).toBe("'2026-04-26'");
+  });
+
+  it("quotes a PlainTime", () => {
+    expect(quote(Temporal.PlainTime.from("14:23:55.123456"))).toBe("'14:23:55.123456'");
+  });
+
+  it("quotes a ZonedDateTime as its UTC instant", () => {
+    const v = Temporal.ZonedDateTime.from("2026-04-26T16:23:55+02:00[Europe/Paris]");
+    expect(quote(v)).toBe("'2026-04-26 14:23:55'");
+  });
+});
+
+describe("abstract typeCast() with Temporal (Postgres path)", () => {
+  it("casts an Instant to its UTC string", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
+    expect(typeCast(v)).toBe("2026-04-26 14:23:55.123456");
+  });
+
+  it("casts a PlainDate to string", () => {
+    expect(typeCast(Temporal.PlainDate.from("2026-04-26"))).toBe("2026-04-26");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Precision round-trip tests for the Temporal SQL formatters introduced in PR 2.
+ * Precision round-trip tests for the Temporal SQL formatters.
  * Verifies that sub-millisecond precision is preserved end-to-end through the
  * format functions that feed both the text-protocol (quote) and bind paths.
  */

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Precision round-trip tests for the Temporal SQL formatters introduced in PR 2.
+ * Verifies that sub-millisecond precision is preserved end-to-end through the
+ * format functions that feed both the text-protocol (quote) and bind paths.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  formatInstantForSql,
+  formatPlainDateTimeForSql,
+  formatPlainDateForSql,
+  formatPlainTimeForSql,
+} from "./quoting.js";
+import { temporalToBindString } from "./database-statements.js";
+
+describe("formatInstantForSql", () => {
+  it("formats a whole-second instant", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("preserves millisecond precision", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123");
+  });
+
+  it("preserves microsecond precision", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123456");
+  });
+
+  it("preserves nanosecond precision", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456789Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123456789");
+  });
+
+  it("preserves the smallest possible non-zero value (1 µs)", () => {
+    const v = Temporal.Instant.from("2024-01-01T00:00:00.000001Z");
+    expect(formatInstantForSql(v)).toBe("2024-01-01 00:00:00.000001");
+  });
+
+  it("converts a non-UTC instant to UTC", () => {
+    const v = Temporal.Instant.from("2026-04-26T16:23:55+02:00");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
+  });
+});
+
+describe("formatPlainDateTimeForSql", () => {
+  it("formats a whole-second datetime", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
+    expect(formatPlainDateTimeForSql(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("preserves microsecond precision", () => {
+    const v = Temporal.PlainDateTime.from("2024-12-31T23:59:59.999999");
+    expect(formatPlainDateTimeForSql(v)).toBe("2024-12-31 23:59:59.999999");
+  });
+
+  it("preserves nanosecond precision", () => {
+    const v = Temporal.PlainDateTime.from("2024-01-01T00:00:00.000000001");
+    expect(formatPlainDateTimeForSql(v)).toBe("2024-01-01 00:00:00.000000001");
+  });
+});
+
+describe("formatPlainDateForSql", () => {
+  it("formats a date", () => {
+    expect(formatPlainDateForSql(Temporal.PlainDate.from("2026-04-26"))).toBe("2026-04-26");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(formatPlainDateForSql(Temporal.PlainDate.from("2026-01-05"))).toBe("2026-01-05");
+  });
+});
+
+describe("formatPlainTimeForSql", () => {
+  it("formats a whole-second time", () => {
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("14:23:55"))).toBe("14:23:55");
+  });
+
+  it("preserves microseconds", () => {
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("14:23:55.123456"))).toBe(
+      "14:23:55.123456",
+    );
+  });
+
+  it("preserves nanoseconds", () => {
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("00:00:00.000000001"))).toBe(
+      "00:00:00.000000001",
+    );
+  });
+
+  it("omits trailing zeros beyond the precision present", () => {
+    // millisecond only — 3 fractional digits
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("12:00:00.100"))).toBe("12:00:00.100");
+  });
+});
+
+describe("temporalToBindString", () => {
+  it("converts Instant to UTC string", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
+    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55.123456");
+  });
+
+  it("converts PlainDateTime to string", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55.000001");
+    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55.000001");
+  });
+
+  it("converts PlainDate to string", () => {
+    expect(temporalToBindString(Temporal.PlainDate.from("2026-04-26"))).toBe("2026-04-26");
+  });
+
+  it("converts PlainTime to string", () => {
+    expect(temporalToBindString(Temporal.PlainTime.from("14:23:55.123456"))).toBe(
+      "14:23:55.123456",
+    );
+  });
+
+  it("converts ZonedDateTime to UTC instant string", () => {
+    const v = Temporal.ZonedDateTime.from("2026-04-26T16:23:55+02:00[Europe/Paris]");
+    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("passes non-Temporal values through unchanged", () => {
+    expect(temporalToBindString(42)).toBe(42);
+    expect(temporalToBindString("hello")).toBe("hello");
+    expect(temporalToBindString(null)).toBe(null);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -11,6 +11,9 @@ import {
   formatPlainDateTimeForSql,
   formatPlainDateForSql,
   formatPlainTimeForSql,
+  formatInstantForSqlMysql,
+  formatPlainDateTimeForSqlMysql,
+  formatPlainTimeForSqlMysql,
   quote,
   typeCast,
 } from "./quoting.js";
@@ -138,6 +141,40 @@ describe("temporalToBindString", () => {
     expect(temporalToBindString(42)).toBe(42);
     expect(temporalToBindString("hello")).toBe("hello");
     expect(temporalToBindString(null)).toBe(null);
+  });
+});
+
+describe("MySQL-safe formatters (clamped to 6 fractional digits)", () => {
+  it("formatInstantForSqlMysql drops nanoseconds", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.123456789Z");
+    expect(formatInstantForSqlMysql(v)).toBe("2026-04-26 14:23:55.123456");
+  });
+
+  it("formatPlainDateTimeForSqlMysql drops nanoseconds", () => {
+    const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55.123456789");
+    expect(formatPlainDateTimeForSqlMysql(v)).toBe("2026-04-26 14:23:55.123456");
+  });
+
+  it("formatPlainTimeForSqlMysql drops nanoseconds", () => {
+    const v = Temporal.PlainTime.from("14:23:55.000000001");
+    expect(formatPlainTimeForSqlMysql(v)).toBe("14:23:55");
+  });
+
+  it("formatPlainTimeForSqlMysql preserves microseconds", () => {
+    const v = Temporal.PlainTime.from("14:23:55.000001");
+    expect(formatPlainTimeForSqlMysql(v)).toBe("14:23:55.000001");
+  });
+});
+
+describe("temporalToBindString adapter=sqlite uses 2000-01-01 prefix for PlainTime", () => {
+  it("wraps PlainTime in 2000-01-01 for sqlite", () => {
+    const v = Temporal.PlainTime.from("14:23:55.123456");
+    expect(temporalToBindString(v, "sqlite")).toBe("2000-01-01 14:23:55.123456");
+  });
+
+  it("returns bare time string for postgres", () => {
+    const v = Temporal.PlainTime.from("14:23:55.123456");
+    expect(temporalToBindString(v, "postgres")).toBe("14:23:55.123456");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -73,6 +73,13 @@ describe("formatPlainDateForSql", () => {
   it("zero-pads month and day", () => {
     expect(formatPlainDateForSql(Temporal.PlainDate.from("2026-01-05"))).toBe("2026-01-05");
   });
+
+  it("formats a negative (BCE) year with leading minus", () => {
+    // year -43 = 44 BC in proleptic Gregorian
+    expect(formatPlainDateForSql(Temporal.PlainDate.from({ year: -43, month: 3, day: 15 }))).toBe(
+      "-0043-03-15",
+    );
+  });
 });
 
 describe("formatPlainTimeForSql", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -76,10 +76,11 @@ describe("formatPlainDateForSql", () => {
     expect(formatPlainDateForSql(Temporal.PlainDate.from("2026-01-05"))).toBe("2026-01-05");
   });
 
-  it("formats a negative (BCE) year with leading minus", () => {
-    // year -43 = 44 BC in proleptic Gregorian
+  it("formats a negative (BCE) year matching quotedDate(Date) convention (no zero-padding)", () => {
+    // year -43 = 44 BC in proleptic Gregorian; String(-43) → "-43", matching
+    // how quotedDate(Date) formats years (String(getUTCFullYear()) — no padding).
     expect(formatPlainDateForSql(Temporal.PlainDate.from({ year: -43, month: 3, day: 15 }))).toBe(
-      "-0043-03-15",
+      "-43-03-15",
     );
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -42,7 +42,9 @@ describe("formatInstantForSql", () => {
     expect(formatInstantForSql(v)).toBe("2024-01-01 00:00:00.000001");
   });
 
-  it("converts a non-UTC instant to UTC", () => {
+  it("converts a non-UTC instant to UTC when default_timezone is utc (the default)", () => {
+    // getDefaultTimezone() returns "utc" in tests; local-tz path is
+    // integration-tested in PR 7 (timestamp.test.ts with time-travel).
     const v = Temporal.Instant.from("2026-04-26T16:23:55+02:00");
     expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
   });

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting
  */
 
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getDefaultTimezone } from "../../type/internal/timezone.js";
 
 /**
@@ -236,6 +237,109 @@ export function quotedTime(value: Date): string {
     : new Date(2000, 0, 1, h, m, s, ms);
   const full = quotedDate(adjusted);
   return full.replace(/^\d{4}-\d{2}-\d{2} /, "");
+}
+
+/**
+ * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]` in
+ * UTC. Preserves up to microsecond precision (6 fractional digits); nanosecond
+ * digits are included when non-zero.
+ *
+ * Used by the abstract quote/bind path during the dual-typed window (PRs 2–6).
+ * After PR 6 this becomes the sole path and quotedDate is Date-only.
+ */
+export function formatInstantForSql(value: Temporal.Instant): string {
+  const zdt = value.toZonedDateTimeISO("UTC");
+  return formatZonedComponents(zdt);
+}
+
+/**
+ * Format a `Temporal.PlainDateTime` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]`.
+ * No timezone conversion — the value is naive by definition.
+ */
+export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string {
+  return formatPlainComponents(value);
+}
+
+/**
+ * Format a `Temporal.PlainDate` for SQL as `YYYY-MM-DD`.
+ */
+export function formatPlainDateForSql(value: Temporal.PlainDate): string {
+  const y = String(value.year).padStart(4, "0");
+  const m = String(value.month).padStart(2, "0");
+  const d = String(value.day).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.ffffff]`.
+ */
+export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
+  return formatTimeComponents(
+    value.hour,
+    value.minute,
+    value.second,
+    value.millisecond,
+    value.microsecond,
+    value.nanosecond,
+  );
+}
+
+function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
+  const y = String(zdt.year).padStart(4, "0");
+  const mo = String(zdt.month).padStart(2, "0");
+  const d = String(zdt.day).padStart(2, "0");
+  const base = `${y}-${mo}-${d} `;
+  return (
+    base +
+    formatTimeComponents(
+      zdt.hour,
+      zdt.minute,
+      zdt.second,
+      zdt.millisecond,
+      zdt.microsecond,
+      zdt.nanosecond,
+    )
+  );
+}
+
+function formatPlainComponents(pdt: Temporal.PlainDateTime): string {
+  const y = String(pdt.year).padStart(4, "0");
+  const mo = String(pdt.month).padStart(2, "0");
+  const d = String(pdt.day).padStart(2, "0");
+  const base = `${y}-${mo}-${d} `;
+  return (
+    base +
+    formatTimeComponents(
+      pdt.hour,
+      pdt.minute,
+      pdt.second,
+      pdt.millisecond,
+      pdt.microsecond,
+      pdt.nanosecond,
+    )
+  );
+}
+
+function formatTimeComponents(
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  us: number,
+  ns: number,
+): string {
+  const hh = String(h).padStart(2, "0");
+  const mm = String(min).padStart(2, "0");
+  const ss = String(s).padStart(2, "0");
+  const base = `${hh}:${mm}:${ss}`;
+  if (ms === 0 && us === 0 && ns === 0) return base;
+  // Build up to 9 fractional digits, trimming trailing zeros to the nearest
+  // 3-digit group (preserves full precision without unnecessary padding).
+  const frac9 =
+    String(ms).padStart(3, "0") + String(us).padStart(3, "0") + String(ns).padStart(3, "0");
+  // Trim to smallest non-zero 3-digit group (ms, us, or ns).
+  const frac = ns !== 0 ? frac9 : us !== 0 ? frac9.slice(0, 6) : frac9.slice(0, 3);
+  return `${base}.${frac}`;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -53,6 +53,11 @@ export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value instanceof Temporal.Instant) return `'${formatInstantForSql(value)}'`;
+  if (value instanceof Temporal.PlainDateTime) return `'${formatPlainDateTimeForSql(value)}'`;
+  if (value instanceof Temporal.PlainDate) return `'${formatPlainDateForSql(value)}'`;
+  if (value instanceof Temporal.PlainTime) return `'${formatPlainTimeForSql(value)}'`;
+  if (value instanceof Temporal.ZonedDateTime) return `'${formatInstantForSql(value.toInstant())}'`;
   if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (typeof value === "symbol") {
     const desc = value.description;
@@ -81,6 +86,11 @@ export function typeCast(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
+  if (value instanceof Temporal.Instant) return formatInstantForSql(value);
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
+  if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
+  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Date) return quotedDate(value);
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
 }
@@ -240,12 +250,11 @@ export function quotedTime(value: Date): string {
 }
 
 /**
- * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]` in
- * UTC. Preserves up to microsecond precision (6 fractional digits); nanosecond
- * digits are included when non-zero.
- *
- * Used by the abstract quote/bind path during the dual-typed window (PRs 2–6).
- * After PR 6 this becomes the sole path and quotedDate is Date-only.
+ * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]` in
+ * UTC. Preserves up to nanosecond precision (9 fractional digits); trailing
+ * zero groups are trimmed so whole-second and millisecond-only values stay
+ * compact. Used by the abstract quote/bind path during the dual-typed window
+ * (PRs 2–6); after PR 6 this becomes the sole datetime-write path.
  */
 export function formatInstantForSql(value: Temporal.Instant): string {
   const zdt = value.toZonedDateTimeISO("UTC");

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -295,7 +295,7 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
 }
 
 function padYear(year: number): string {
-  return year < 0 ? `-${String(-year).padStart(4, "0")}` : String(year).padStart(4, "0");
+  return String(year);
 }
 
 function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -262,8 +262,9 @@ export function formatInstantForSql(value: Temporal.Instant): string {
 }
 
 /**
- * Format a `Temporal.PlainDateTime` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]`.
- * No timezone conversion — the value is naive by definition.
+ * Format a `Temporal.PlainDateTime` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]`.
+ * No timezone conversion — the value is naive by definition. Fractional digits
+ * are trimmed to the smallest non-zero 3-digit group (ms/µs/ns).
  */
 export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string {
   return formatPlainComponents(value);
@@ -273,14 +274,15 @@ export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string
  * Format a `Temporal.PlainDate` for SQL as `YYYY-MM-DD`.
  */
 export function formatPlainDateForSql(value: Temporal.PlainDate): string {
-  const y = String(value.year).padStart(4, "0");
+  const y = padYear(value.year);
   const m = String(value.month).padStart(2, "0");
   const d = String(value.day).padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
 
 /**
- * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.ffffff]`.
+ * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.fffffffff]`.
+ * Fractional digits are trimmed to the smallest non-zero 3-digit group.
  */
 export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
   return formatTimeComponents(
@@ -293,8 +295,12 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
   );
 }
 
+function padYear(year: number): string {
+  return year < 0 ? `-${String(-year).padStart(4, "0")}` : String(year).padStart(4, "0");
+}
+
 function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
-  const y = String(zdt.year).padStart(4, "0");
+  const y = padYear(zdt.year);
   const mo = String(zdt.month).padStart(2, "0");
   const d = String(zdt.day).padStart(2, "0");
   const base = `${y}-${mo}-${d} `;
@@ -312,7 +318,7 @@ function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
 }
 
 function formatPlainComponents(pdt: Temporal.PlainDateTime): string {
-  const y = String(pdt.year).padStart(4, "0");
+  const y = padYear(pdt.year);
   const mo = String(pdt.month).padStart(2, "0");
   const d = String(pdt.day).padStart(2, "0");
   const base = `${y}-${mo}-${d} `;

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -294,17 +294,58 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
   );
 }
 
+/**
+ * MySQL-safe variants of the formatters. MySQL TIME/DATETIME/TIMESTAMP support
+ * at most 6 fractional digits (microseconds); emitting 7–9 nanosecond digits
+ * in strict SQL mode causes an error rather than silent truncation.
+ */
+export function formatInstantForSqlMysql(value: Temporal.Instant): string {
+  const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
+  const zdt = value.toZonedDateTimeISO(tz);
+  return (
+    formatDatePrefix(zdt) +
+    formatTimeComponents(zdt.hour, zdt.minute, zdt.second, zdt.millisecond, zdt.microsecond, 0, 6)
+  );
+}
+
+export function formatPlainDateTimeForSqlMysql(value: Temporal.PlainDateTime): string {
+  return (
+    formatDatePrefix(value) +
+    formatTimeComponents(
+      value.hour,
+      value.minute,
+      value.second,
+      value.millisecond,
+      value.microsecond,
+      0,
+      6,
+    )
+  );
+}
+
+export function formatPlainTimeForSqlMysql(value: Temporal.PlainTime): string {
+  return formatTimeComponents(
+    value.hour,
+    value.minute,
+    value.second,
+    value.millisecond,
+    value.microsecond,
+    0,
+    6,
+  );
+}
+
+function formatDatePrefix(v: { year: number; month: number; day: number }): string {
+  return `${padYear(v.year)}-${String(v.month).padStart(2, "0")}-${String(v.day).padStart(2, "0")} `;
+}
+
 function padYear(year: number): string {
   return String(year);
 }
 
 function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
-  const y = padYear(zdt.year);
-  const mo = String(zdt.month).padStart(2, "0");
-  const d = String(zdt.day).padStart(2, "0");
-  const base = `${y}-${mo}-${d} `;
   return (
-    base +
+    formatDatePrefix(zdt) +
     formatTimeComponents(
       zdt.hour,
       zdt.minute,
@@ -317,10 +358,7 @@ function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
 }
 
 function formatPlainComponents(pdt: Temporal.PlainDateTime): string {
-  const y = padYear(pdt.year);
-  const mo = String(pdt.month).padStart(2, "0");
-  const d = String(pdt.day).padStart(2, "0");
-  const base = `${y}-${mo}-${d} `;
+  const base = formatDatePrefix(pdt);
   return (
     base +
     formatTimeComponents(
@@ -341,19 +379,23 @@ function formatTimeComponents(
   ms: number,
   us: number,
   ns: number,
+  maxFracDigits = 9,
 ): string {
   const hh = String(h).padStart(2, "0");
   const mm = String(min).padStart(2, "0");
   const ss = String(s).padStart(2, "0");
   const base = `${hh}:${mm}:${ss}`;
-  if (ms === 0 && us === 0 && ns === 0) return base;
-  // Build up to 9 fractional digits, trimming trailing zeros to the nearest
-  // 3-digit group (preserves full precision without unnecessary padding).
+  // Clamp sub-second components to maxFracDigits before building the string.
+  const effectiveUs = maxFracDigits >= 6 ? us : 0;
+  const effectiveNs = maxFracDigits >= 9 ? ns : 0;
+  if (ms === 0 && effectiveUs === 0 && effectiveNs === 0) return base;
   const frac9 =
-    String(ms).padStart(3, "0") + String(us).padStart(3, "0") + String(ns).padStart(3, "0");
-  // Trim to smallest non-zero 3-digit group (ms, us, or ns).
-  const frac = ns !== 0 ? frac9 : us !== 0 ? frac9.slice(0, 6) : frac9.slice(0, 3);
-  return `${base}.${frac}`;
+    String(ms).padStart(3, "0") +
+    String(effectiveUs).padStart(3, "0") +
+    String(effectiveNs).padStart(3, "0");
+  const frac =
+    effectiveNs !== 0 ? frac9 : effectiveUs !== 0 ? frac9.slice(0, 6) : frac9.slice(0, 3);
+  return `${base}.${frac.slice(0, maxFracDigits)}`;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -250,15 +250,14 @@ export function quotedTime(value: Date): string {
 }
 
 /**
- * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]` in
- * UTC. Preserves up to nanosecond precision (9 fractional digits); trailing
- * zero groups are trimmed so whole-second and millisecond-only values stay
- * compact. Used by the abstract quote/bind path during the dual-typed window
- * (PRs 2–6); after PR 6 this becomes the sole datetime-write path.
+ * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]`.
+ * Respects `ActiveRecord.default_timezone` exactly as `quotedDate()` does:
+ * UTC when the setting is `"utc"`, otherwise the host system's local timezone.
+ * Preserves up to nanosecond precision; trailing zero groups are trimmed.
  */
 export function formatInstantForSql(value: Temporal.Instant): string {
-  const zdt = value.toZonedDateTimeISO("UTC");
-  return formatZonedComponents(zdt);
+  const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
+  return formatZonedComponents(value.toZonedDateTimeISO(tz));
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -153,6 +153,10 @@ describe("parsePostgresTime", () => {
   it("normalizes 24:00:00 with fractional seconds", () => {
     expect(parsePostgresTime("24:00:00.000000").toString()).toBe("00:00:00");
   });
+
+  it("does not normalize 24:01:00 — only 24:00:00 is a valid PG sentinel", () => {
+    expect(() => parsePostgresTime("24:01:00")).toThrow();
+  });
 });
 
 describe("parsePostgresTimeTz", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -293,12 +293,13 @@ function expandOffset(offset: string): string {
 
 /**
  * Normalize Postgres `24:00:00[.fraction]` (end-of-day sentinel) to
- * `00:00:00[.fraction]`. Temporal.PlainTime rejects hour 24; Ruby Time
- * rolls it over to midnight, which is the semantically equivalent value
- * when there is no date context.
+ * `00:00:00[.fraction]`. Only the exact sentinel is normalized; any other
+ * `24:xx:xx` value is left unchanged so `Temporal.PlainTime.from` throws —
+ * Postgres never emits those and they should not be silently corrupted.
  */
 function normalizeTime24(timeStr: string): string {
-  return timeStr.startsWith("24:") ? "00:" + timeStr.slice(3) : timeStr;
+  const match = /^24:00:00(\.\d+)?$/.exec(timeStr);
+  return match ? `00:00:00${match[1] ?? ""}` : timeStr;
 }
 
 function isZeroDate(text: string): boolean {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -8,7 +8,14 @@
  * the pattern used by the PostgreSQL and SQLite3 adapters.
  */
 
-import { quotedDate as abstractQuotedDate } from "../abstract/quoting.js";
+import {
+  quotedDate as abstractQuotedDate,
+  formatInstantForSql,
+  formatPlainDateTimeForSql,
+  formatPlainDateForSql,
+  formatPlainTimeForSql,
+} from "../abstract/quoting.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -179,6 +186,11 @@ export function quote(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value instanceof Temporal.Instant) return `'${formatInstantForSql(value)}'`;
+  if (value instanceof Temporal.PlainDateTime) return `'${formatPlainDateTimeForSql(value)}'`;
+  if (value instanceof Temporal.PlainDate) return `'${formatPlainDateForSql(value)}'`;
+  if (value instanceof Temporal.PlainTime) return `'${formatPlainTimeForSql(value)}'`;
+  if (value instanceof Temporal.ZonedDateTime) return `'${formatInstantForSql(value.toInstant())}'`;
   if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (value instanceof Buffer) return quotedBinary(value);
   if (typeof value === "symbol") {
@@ -221,6 +233,11 @@ export function typeCast(value: unknown): unknown {
   // Rails' `type_cast` returns `quoted_date(value)` — an unquoted
   // formatted string. EXPLAIN / log-subscriber renderers want the
   // primitive, not the Date instance.
+  if (value instanceof Temporal.Instant) return formatInstantForSql(value);
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
+  if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
+  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Date) return quotedDate(value);
   throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
 }

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -10,10 +10,10 @@
 
 import {
   quotedDate as abstractQuotedDate,
-  formatInstantForSql,
-  formatPlainDateTimeForSql,
+  formatInstantForSqlMysql as formatInstantForSql,
+  formatPlainDateTimeForSqlMysql as formatPlainDateTimeForSql,
   formatPlainDateForSql,
-  formatPlainTimeForSql,
+  formatPlainTimeForSqlMysql as formatPlainTimeForSql,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -100,7 +100,7 @@ export function quote(value: unknown): string {
   if (value instanceof Temporal.Instant) return `'${formatInstantForSql(value)}'`;
   if (value instanceof Temporal.PlainDateTime) return `'${formatPlainDateTimeForSql(value)}'`;
   if (value instanceof Temporal.PlainDate) return `'${formatPlainDateForSql(value)}'`;
-  if (value instanceof Temporal.PlainTime) return `'${formatPlainTimeForSql(value)}'`;
+  if (value instanceof Temporal.PlainTime) return `'2000-01-01 ${formatPlainTimeForSql(value)}'`;
   if (value instanceof Temporal.ZonedDateTime) return `'${formatInstantForSql(value.toInstant())}'`;
   if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
@@ -157,7 +157,7 @@ export function typeCast(value: unknown): unknown {
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
-  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.PlainTime) return `2000-01-01 ${formatPlainTimeForSql(value)}`;
   if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Date) return quotedDate(value);
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -4,7 +4,14 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting
  */
 
-import { quotedDate as abstractQuotedDate } from "../abstract/quoting.js";
+import {
+  quotedDate as abstractQuotedDate,
+  formatInstantForSql,
+  formatPlainDateTimeForSql,
+  formatPlainDateForSql,
+  formatPlainTimeForSql,
+} from "../abstract/quoting.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -90,6 +97,11 @@ export function quote(value: unknown): string {
     }
     return quoteString(value.description);
   }
+  if (value instanceof Temporal.Instant) return `'${formatInstantForSql(value)}'`;
+  if (value instanceof Temporal.PlainDateTime) return `'${formatPlainDateTimeForSql(value)}'`;
+  if (value instanceof Temporal.PlainDate) return `'${formatPlainDateForSql(value)}'`;
+  if (value instanceof Temporal.PlainTime) return `'${formatPlainTimeForSql(value)}'`;
+  if (value instanceof Temporal.ZonedDateTime) return `'${formatInstantForSql(value.toInstant())}'`;
   if (value instanceof Date) return `'${quotedDate(value)}'`;
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
     return quotedBinary(value);
@@ -142,6 +154,11 @@ export function typeCast(value: unknown): unknown {
   // Rails' `type_cast` returns `quoted_date(value)` — a formatted
   // string, not the Date object itself. Callers (EXPLAIN rendering,
   // bind-value logs) want the primitive, not the Date instance.
+  if (value instanceof Temporal.Instant) return formatInstantForSql(value);
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
+  if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
+  if (value instanceof Temporal.PlainTime) return formatPlainTimeForSql(value);
+  if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Date) return quotedDate(value);
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;
   throw new TypeError(`can't cast ${Object.prototype.toString.call(value)} to a SQLite3 type`);

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -1,6 +1,5 @@
 /**
  * Temporal test helpers. Test files use these instead of `new Date(...)`.
- * The no-native-date ESLint rule allowlists this file.
  */
 import { Temporal } from "../temporal.js";
 


### PR DESCRIPTION
## Summary

Second PR in the Temporal migration ([plan](docs/temporal-migration-plan.md)). Adds Temporal-aware formatters alongside the existing \`Date\` ones — **no call site is forced to pass Temporal yet**. This is the only PR that deliberately accepts both \`Date | Temporal.*\`; the \`Date\` overloads are removed in PR 6 once all adapters have switched.

- **\`abstract/quoting.ts\`** — four new formatters: \`formatInstantForSql\`, \`formatPlainDateTimeForSql\`, \`formatPlainDateForSql\`, \`formatPlainTimeForSql\`. All preserve up to nanosecond precision with trailing zero groups trimmed. \`formatInstantForSql\` respects \`ActiveRecord.default_timezone\` exactly as \`quotedDate()\` does: UTC when the setting is \`"utc"\`, otherwise the host system's local timezone via \`Temporal.Now.timeZoneId()\`. Temporal branches added to abstract \`quote()\` and \`typeCast()\` (used by the Postgres adapter).
- **\`abstract/database-statements.ts\`** — \`temporalToBindString(value)\` converts any Temporal value to its SQL wire string at the bind boundary. Applied in \`typeCastedBinds\` (notification payloads) now; driver exec paths (pg/mysql2/sqlite3) wired in adapter-specific Temporal work once the cast layer starts emitting Temporal values. \`withYamlFallback\` widened to skip Temporal objects.
- **\`sqlite3/quoting.ts\`** and **\`mysql/quoting.ts\`** — Temporal branches added before the \`instanceof Date\` branches in \`quote()\` and \`typeCast()\`.
- **\`dx-tests/tsconfig.json\`** — added \`@blazetrails/activesupport/temporal\` and \`testing/temporal-helpers\` path entries so \`pnpm test:types\` resolves them via \`tsc\`.

## Test plan

- [x] 29 tests in \`precision-roundtrip.test.ts\` — all four formatters, \`temporalToBindString\`, abstract \`quote()\`/\`typeCast()\` (Postgres path), BCE year formatting
- [x] \`sqlite3/quoting.test.ts\` (46 tests) and \`mysql/quoting.test.ts\` (31 tests) — existing \`Date\` behavior unaffected
- [x] \`pnpm test:types\` — 72/72, no type errors
- [x] \`pnpm build\` clean