### PR TITLE
feat(temporal): PR 3a — activemodel cast layer flip to Temporal

### DIFF
--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -1,8 +1,17 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { AttributeSet } from "./attribute-set.js";
 
 function cloneValue(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value;
-  if (value instanceof Date) return new Date(value.getTime());
+  // Temporal types are immutable — no clone needed
+  if (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime ||
+    value instanceof Temporal.ZonedDateTime
+  )
+    return value;
   if (Array.isArray(value)) return value.map(cloneValue);
   // Only deep-clone plain objects; preserve class instances as-is
   const proto = Object.getPrototypeOf(value);

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -109,3 +109,13 @@ export {
 } from "./secure-password.js";
 export { SerializeCastValue } from "./type/serialize-cast-value.js";
 export { Builder as AttributeSetBuilder } from "./attribute-set/builder.js";
+export {
+  DateInfinity,
+  DateNegativeInfinity,
+  isDateInfinity,
+  isDateNegativeInfinity,
+} from "./type/internal/sentinels.js";
+export type {
+  DateInfinity as DateInfinityType,
+  DateNegativeInfinity as DateNegativeInfinityType,
+} from "./type/internal/sentinels.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1,6 +1,7 @@
 import { Errors, StrictValidationFailed } from "./errors.js";
 import { ValidationError, ValidationContext } from "./validations.js";
 import { humanize, underscore, dasherize, htmlEscape } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { I18n } from "./i18n.js";
 import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
@@ -1767,7 +1768,15 @@ export class Model {
       const tag = dasherize(key);
       if (value === null || value === undefined) {
         xml += `${indent}<${tag} nil="true"/>\n`;
-      } else if (typeof value === "object" && !Array.isArray(value) && !(value instanceof Date)) {
+      } else if (
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        !(value instanceof Temporal.Instant) &&
+        !(value instanceof Temporal.PlainDateTime) &&
+        !(value instanceof Temporal.PlainDate) &&
+        !(value instanceof Temporal.PlainTime) &&
+        !(value instanceof Temporal.ZonedDateTime)
+      ) {
         xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ")}${indent}</${tag}>\n`;
       } else if (Array.isArray(value)) {
         xml += `${indent}<${tag} type="array">\n`;
@@ -1783,8 +1792,16 @@ export class Model {
         xml += `${indent}<${tag} type="integer">${value}</${tag}>\n`;
       } else if (typeof value === "boolean") {
         xml += `${indent}<${tag} type="boolean">${value}</${tag}>\n`;
-      } else if (value instanceof Date) {
-        xml += `${indent}<${tag} type="dateTime">${value.toISOString()}</${tag}>\n`;
+      } else if (
+        value instanceof Temporal.Instant ||
+        value instanceof Temporal.PlainDateTime ||
+        value instanceof Temporal.ZonedDateTime
+      ) {
+        xml += `${indent}<${tag} type="dateTime">${value.toJSON()}</${tag}>\n`;
+      } else if (value instanceof Temporal.PlainDate) {
+        xml += `${indent}<${tag} type="date">${value.toString()}</${tag}>\n`;
+      } else if (value instanceof Temporal.PlainTime) {
+        xml += `${indent}<${tag} type="time">${value.toString()}</${tag}>\n`;
       } else {
         xml += `${indent}<${tag}>${this._escapeXml(String(value))}</${tag}>\n`;
       }

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Model } from "./index.js";
 
 describe("SerializationTest", () => {
@@ -257,15 +258,22 @@ describe("SerializationTest", () => {
       expect(() => JSON.stringify(json)).not.toThrow();
     });
 
-    it("asJson coerces Date attributes to ISO 8601 strings", () => {
+    it("asJson coerces Temporal attributes to ISO 8601 strings", () => {
       class Event extends Model {
         static {
           this.attribute("startsAt", "datetime");
         }
       }
-      const e = new Event({ startsAt: new Date("2026-04-24T10:00:00Z") });
+      const e = new Event({ startsAt: "2026-04-24T10:00:00.123456Z" });
       const json = e.asJson();
-      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.000Z");
+      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.123456Z");
+    });
+
+    it("asJson preserves microsecond precision for Temporal.Instant", async () => {
+      const { coerceForJson } = await import("./serialization.js");
+      const i = instant("2026-04-24T10:00:00.123456Z");
+      const out = coerceForJson({ at: i }) as { at: unknown };
+      expect(out.at).toBe("2026-04-24T10:00:00.123456Z");
     });
 
     it("asJson recurses into include: arrays and nested objects", () => {
@@ -354,11 +362,9 @@ describe("SerializationTest", () => {
       expect(parsed.name).toBe("row-2");
     });
 
-    it("coerceForJson maps invalid Date to null (matches Date.prototype.toJSON)", async () => {
-      // Date.prototype.toJSON returns null for invalid dates; toISOString
-      // throws. asJson must stay JSON-safe even for garbage input.
+    it("coerceForJson maps null to null", async () => {
       const { coerceForJson } = await import("./serialization.js");
-      const out = coerceForJson({ at: new Date("not a date") }) as { at: unknown };
+      const out = coerceForJson({ at: null }) as { at: unknown };
       expect(out.at).toBe(null);
     });
 

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -1,3 +1,5 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRecord = any;
 
@@ -177,11 +179,15 @@ function _coerceForJson(
   // its description would misrepresent its role. Leave symbols alone;
   // `JSON.stringify` already drops them per spec, which correctly
   // signals "this doesn't serialize".
-  if (value instanceof Date) {
-    // Invalid Date (e.g. `new Date("bad")`) throws on `toISOString`.
-    // `Date.prototype.toJSON` returns null in that case — match it so
-    // `asJson` stays JSON-safe regardless of attribute hygiene.
-    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  if (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime ||
+    value instanceof Temporal.ZonedDateTime
+  ) {
+    // Temporal.prototype.toJSON() emits ISO 8601 with native precision.
+    return value.toJSON();
   }
   if (Array.isArray(value)) {
     // True cycle: short-circuit to null (Rails' JSON encoder raises, but

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -1,43 +1,66 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { instant, plainDateTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 
 describe("DateTimeTest", () => {
-  it("type cast datetime and timestamp", () => {
-    const type = new Types.DateTimeType();
-    const result = type.cast("2024-01-15T10:30:00Z");
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getUTCHours()).toBe(10);
-  });
-
-  it("string to time with timezone", () => {
-    const type = new Types.DateTimeType();
-    const result = type.cast("2024-01-15T10:30:00+05:00");
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getUTCHours()).toBe(5);
-  });
-
-  it("hash to time", () => {
-    const type = new Types.DateTimeType();
-    const date = new Date(2024, 5, 15, 12, 0, 0);
-    const result = type.cast(date);
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getMonth()).toBe(5);
-  });
-
-  it("hash with wrong keys", () => {
-    const type = new Types.DateTimeType();
-    expect(type.cast("not-a-date")).toBe(null);
-  });
-
-  it("serialize_cast_value is equivalent to serialize after cast", () => {
-    const type = new Types.DateTimeType();
-    const cast = type.cast("2024-01-15T10:30:00Z");
-    const serialized = type.serialize(cast);
-    expect(serialized).toEqual(cast);
-  });
-});
-describe("DateTimeType", () => {
   const type = new Types.DateTimeType();
+
+  it("type cast datetime and timestamp", () => {
+    const result = type.cast("2024-01-15T10:30:00Z");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect((result as Temporal.Instant).epochMilliseconds).toBe(
+      Temporal.Instant.from("2024-01-15T10:30:00Z").epochMilliseconds,
+    );
+  });
+
+  it("string with offset produces Instant", () => {
+    const result = type.cast("2024-01-15T10:30:00+05:00");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect((result as Temporal.Instant).epochMilliseconds).toBe(
+      Temporal.Instant.from("2024-01-15T05:30:00Z").epochMilliseconds,
+    );
+  });
+
+  it("string without offset produces PlainDateTime", () => {
+    const result = type.cast("2024-01-15T10:30:00");
+    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    const pdt = result as Temporal.PlainDateTime;
+    expect(pdt.hour).toBe(10);
+    expect(pdt.minute).toBe(30);
+  });
+
+  it("Postgres wire format (space separator, short offset) produces Instant", () => {
+    const result = type.cast("2026-04-26 14:23:55.123456+00");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const i = result as Temporal.Instant;
+    expect(i.toString({ smallestUnit: "microsecond" })).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("Postgres naive wire format produces PlainDateTime", () => {
+    const result = type.cast("2026-04-26 14:23:55.123456");
+    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    const pdt = result as Temporal.PlainDateTime;
+    expect(pdt.microsecond).toBe(456);
+  });
+
+  it("microsecond precision is preserved through cast", () => {
+    const result = type.cast("2026-04-26T14:23:55.123456Z");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(123);
+    expect(zdt.microsecond).toBe(456);
+  });
+
+  it("Temporal.Instant passthrough", () => {
+    const original = instant("2026-04-26T14:23:55.123456Z");
+    expect(type.cast(original)).toBe(original);
+  });
+
+  it("Temporal.PlainDateTime passthrough", () => {
+    const original = plainDateTime("2026-04-26T14:23:55.123456");
+    expect(type.cast(original)).toBe(original);
+  });
 
   it("has name 'datetime'", () => {
     expect(type.name).toBe("datetime");
@@ -47,8 +70,29 @@ describe("DateTimeType", () => {
     expect(type.cast(null)).toBe(null);
   });
 
-  it("casts Date to Date", () => {
-    const d = new Date("2024-01-15T10:30:00Z");
-    expect(type.cast(d)).toBe(d);
+  it("casts undefined to null", () => {
+    expect(type.cast(undefined)).toBe(null);
+  });
+
+  it("casts empty string to null", () => {
+    expect(type.cast("")).toBe(null);
+  });
+
+  it("hash with wrong keys", () => {
+    expect(type.cast("not-a-date")).toBe(null);
+  });
+
+  it("serialize returns microsecond ISO string for Instant", () => {
+    const i = instant("2026-04-26T14:23:55.123456Z");
+    expect(type.serialize(i)).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("serialize returns microsecond ISO string for PlainDateTime", () => {
+    const pdt = plainDateTime("2026-04-26T14:23:55.123456");
+    expect(type.serialize(pdt)).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
   });
 });

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -1,17 +1,45 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { ValueType } from "./value.js";
 
-export class DateTimeType extends ValueType<Date> {
+export type DateTimeCastResult = Temporal.Instant | Temporal.PlainDateTime;
+
+export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
 
-  cast(value: unknown): Date | null {
+  cast(value: unknown): DateTimeCastResult | null {
     if (value === null || value === undefined) return null;
-    if (value instanceof Date) return value;
-    const d = new Date(String(value));
-    return isNaN(d.getTime()) ? null : d;
+    if (value instanceof Temporal.Instant) return value;
+    if (value instanceof Temporal.PlainDateTime) return value;
+    const str = String(value).trim();
+    if (str === "") return null;
+    return this.parseString(str);
   }
 
-  serialize(value: unknown): Date | null {
-    return this.cast(value);
+  private parseString(str: string): DateTimeCastResult | null {
+    // Normalize wire-format quirks before parsing:
+    //   space separator → T; short offset ±HH → ±HH:MM
+    const normalized = str
+      .replace(" ", "T")
+      .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+    const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(normalized);
+    if (hasOffset) {
+      try {
+        return Temporal.Instant.from(normalized);
+      } catch {
+        return null;
+      }
+    }
+    try {
+      return Temporal.PlainDateTime.from(normalized);
+    } catch {
+      return null;
+    }
+  }
+
+  serialize(value: unknown): string | null {
+    const cast = this.cast(value);
+    if (cast === null) return null;
+    return cast.toString({ smallestUnit: "microsecond" });
   }
 
   type(): string {

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -1,82 +1,26 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 
-/**
- * Test-only subclass that promotes Rails' private helpers to callable
- * methods so behavior can be asserted directly (e.g. new_date returns
- * nil for year 0 in a way `cast` can't reliably surface).
- */
-class TestableDateType extends Types.DateType {
-  publicFastStringToDate(value: string) {
-    return this.fastStringToDate(value);
-  }
-  publicNewDate(year: number, month: number, day: number) {
-    return this.newDate(year, month, day);
-  }
-}
-
 describe("DateTest", () => {
-  it("type cast date", () => {
-    const type = new Types.DateType();
-    const result = type.cast("2024-01-15");
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getFullYear()).toBe(2024);
-  });
-
-  it("returns correct year", () => {
-    const type = new Types.DateType();
-    const result = type.cast("2024-01-15");
-    expect(result!.getUTCFullYear()).toBe(2024);
-  });
-
-  it("fast_string_to_date matches ISO YYYY-MM-DD only", () => {
-    // Rails type/date.rb — ISO_DATE regex, fast path; everything else
-    // falls through to fallback_string_to_date.
-    const type = new TestableDateType();
-    expect(type.publicFastStringToDate("2024-06-01")).not.toBeNull();
-    expect(type.publicFastStringToDate("2024/06/01")).toBeNull();
-    expect(type.publicFastStringToDate("2024-06-01T00:00:00")).toBeNull();
-  });
-
-  it("new_date preserves literal years 1–99 (not the JS Date.UTC 1900+ hack)", () => {
-    const type = new TestableDateType();
-    expect(type.publicNewDate(1, 1, 1)!.getUTCFullYear()).toBe(1);
-    expect(type.cast("0001-01-01")!.getUTCFullYear()).toBe(1);
-    expect(type.publicNewDate(99, 12, 31)!.getUTCFullYear()).toBe(99);
-  });
-
-  it("new_date rejects year 0 and day/month overflow", () => {
-    // Mirrors Rails new_date, which returns nil when year is 0 or when
-    // Date.new raises ArgumentError.
-    const type = new TestableDateType();
-    expect(type.publicNewDate(0, 1, 1)).toBeNull();
-    expect(type.publicNewDate(2024, 13, 1)).toBeNull();
-    expect(type.publicNewDate(2024, 2, 31)).toBeNull();
-    const d = type.publicNewDate(2024, 6, 15);
-    expect(d!.getUTCFullYear()).toBe(2024);
-    expect(d!.getUTCMonth()).toBe(5);
-    expect(d!.getUTCDate()).toBe(15);
-  });
-
-  it("cast falls through to fallback parser for non-ISO strings", () => {
-    // Use an ISO-datetime form — deterministic across JS runtimes but
-    // does not match the ISO_DATE fast path (which is YYYY-MM-DD only).
-    const type = new Types.DateType();
-    const d = type.cast("2024-06-01T00:00:00Z");
-    expect(d).toBeInstanceOf(Date);
-    expect(d!.getUTCFullYear()).toBe(2024);
-  });
-});
-describe("DateType", () => {
   const type = new Types.DateType();
+
+  it("type cast date", () => {
+    const result = type.cast("2024-01-15");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).year).toBe(2024);
+    expect((result as Temporal.PlainDate).month).toBe(1);
+    expect((result as Temporal.PlainDate).day).toBe(15);
+  });
+
+  it("Temporal.PlainDate passthrough", () => {
+    const original = plainDate("2024-01-15");
+    expect(type.cast(original)).toBe(original);
+  });
 
   it("has name 'date'", () => {
     expect(type.name).toBe("date");
-  });
-
-  it("casts Date to Date", () => {
-    const d = new Date("2024-01-15");
-    expect(type.cast(d)).toBe(d);
   });
 
   it("casts null to null", () => {
@@ -87,17 +31,29 @@ describe("DateType", () => {
     expect(type.cast(undefined)).toBe(null);
   });
 
+  it("casts empty string to null", () => {
+    expect(type.cast("")).toBe(null);
+  });
+
   it("casts invalid string to null", () => {
     expect(type.cast("not-a-date")).toBe(null);
   });
 
-  it("deserialize delegates to cast", () => {
-    const result = type.deserialize("2024-01-15");
-    expect(result).toBeInstanceOf(Date);
+  it("serialize returns ISO date string", () => {
+    const d = plainDate("2024-01-15");
+    expect(type.serialize(d)).toBe("2024-01-15");
   });
 
-  it("serialize delegates to cast", () => {
-    const result = type.serialize("2024-01-15");
-    expect(result).toBeInstanceOf(Date);
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
+  });
+
+  it("typeCastForSchema returns quoted string for PlainDate", () => {
+    const d = plainDate("2024-01-15");
+    expect(type.typeCastForSchema(d)).toBe('"2024-01-15"');
+  });
+
+  it("typeCastForSchema returns null for null", () => {
+    expect(type.typeCastForSchema(null)).toBe("null");
   });
 });

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,64 +1,24 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { ValueType } from "./value.js";
 
-/** `YYYY-MM-DD` — Rails `ISO_DATE` (type/date.rb). */
-const ISO_DATE = /^(\d{4})-(\d\d)-(\d\d)$/;
-
-export class DateType extends ValueType<Date> {
+export class DateType extends ValueType<Temporal.PlainDate> {
   readonly name: string = "date";
 
-  cast(value: unknown): Date | null {
+  cast(value: unknown): Temporal.PlainDate | null {
     if (value === null || value === undefined) return null;
-    if (value instanceof Date) return value;
-    if (typeof value === "string") {
-      if (value === "") return null;
-      return this.fastStringToDate(value) ?? this.fallbackStringToDate(value);
-    }
-    const d = new Date(String(value));
-    return isNaN(d.getTime()) ? null : d;
-  }
-
-  /**
-   * Skip `Date.parse` for the ISO-8601 date fast case, matching Rails'
-   * `type/date.rb#fast_string_to_date`.
-   */
-  protected fastStringToDate(value: string): Date | null {
-    const m = ISO_DATE.exec(value);
-    if (!m) return null;
-    return this.newDate(Number(m[1]), Number(m[2]), Number(m[3]));
-  }
-
-  /**
-   * Parse dates that don't match the ISO fast path; mirrors
-   * `type/date.rb#fallback_string_to_date` (which delegates to
-   * `Date._parse`). We fall back to the JS `Date` constructor since
-   * TS doesn't ship a locale-aware date parser.
-   */
-  protected fallbackStringToDate(value: string): Date | null {
-    const d = new Date(value);
-    return isNaN(d.getTime()) ? null : d;
-  }
-
-  /**
-   * Mirrors `type/date.rb#new_date`: rejects year 0 / missing year
-   * rather than returning a bogus Date.
-   */
-  protected newDate(year: number, month: number, day: number): Date | null {
-    if (!year || year === 0) return null;
-    // `Date.UTC(y, ...)` interprets 0–99 as 1900–1999; use setUTCFullYear
-    // so "0001-01-01" round-trips as literal year 1 instead of 1901.
-    const d = new Date(Date.UTC(2000, month - 1, day));
-    d.setUTCFullYear(year);
-    if (isNaN(d.getTime())) return null;
-    // Reject overflow — Date(UTC) silently normalizes month=13 into Jan
-    // of the next year; Rails raises and we want `null` instead.
-    if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    if (value instanceof Temporal.PlainDate) return value;
+    const str = String(value).trim();
+    if (str === "") return null;
+    try {
+      return Temporal.PlainDate.from(str);
+    } catch {
       return null;
     }
-    return d;
   }
 
-  serialize(value: unknown): Date | null {
-    return this.cast(value);
+  serialize(value: unknown): string | null {
+    const cast = this.cast(value);
+    return cast ? cast.toString() : null;
   }
 
   type(): string {
@@ -66,9 +26,7 @@ export class DateType extends ValueType<Date> {
   }
 
   typeCastForSchema(value: unknown): string {
-    if (value instanceof Date) {
-      return `"${value.toISOString().split("T")[0]}"`;
-    }
-    return JSON.stringify(value) ?? "null";
+    const cast = this.cast(value);
+    return cast ? JSON.stringify(cast.toString()) : "null";
   }
 }

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -2,43 +2,47 @@
  * TimeValue helper — shared behavior for time-based type casting.
  *
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
- *
- * Provides precision handling and serialization for Date/DateTime/Time types.
  */
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
 export interface TimeValue {
   serializeCastValue(value: unknown): string | null;
-  applySecondsPrecision(value: Date, precision?: number): Date;
   typeCastForSchema(value: unknown): string;
-  userInputInTimeZone(value: unknown): Date | null;
-}
-
-const DEFAULT_PRECISION = 0;
-
-export function applySecondsPrecision(value: Date, precision: number = DEFAULT_PRECISION): Date {
-  if (precision <= 0) {
-    const result = new Date(value);
-    result.setMilliseconds(0);
-    return result;
-  }
-  if (precision >= 3) return new Date(value);
-  const factor = Math.pow(10, 3 - precision);
-  const result = new Date(value);
-  result.setMilliseconds(Math.floor(result.getMilliseconds() / factor) * factor);
-  return result;
+  userInputInTimeZone(value: unknown, zone?: string): Temporal.ZonedDateTime | null;
 }
 
 export function serializeTimeValue(value: unknown): string | null {
   if (value === null || value === undefined) return null;
-  if (value instanceof Date) return value.toISOString();
+  if (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime ||
+    value instanceof Temporal.ZonedDateTime
+  ) {
+    return value.toJSON();
+  }
   return String(value);
 }
 
-export function userInputInTimeZone(value: unknown): Date | null {
+export function userInputInTimeZone(
+  value: unknown,
+  zone: string = "UTC",
+): Temporal.ZonedDateTime | null {
   if (value === null || value === undefined) return null;
-  if (value instanceof Date) return value;
-  if (typeof value === "string") {
-    const parsed = new Date(value);
-    return isNaN(parsed.getTime()) ? null : parsed;
+  if (value instanceof Temporal.ZonedDateTime) return value;
+  const str = String(value).trim();
+  if (str === "") return null;
+  if (str.includes("[")) {
+    try {
+      return Temporal.ZonedDateTime.from(str);
+    } catch {
+      return null;
+    }
   }
-  return null;
+  try {
+    return Temporal.PlainDateTime.from(str.replace(" ", "T")).toZonedDateTime(zone);
+  } catch {
+    return null;
+  }
 }

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -4,8 +4,8 @@
  * these have no Temporal equivalent.
  */
 
-export const DateInfinity: unique symbol = Symbol("DateInfinity");
-export const DateNegativeInfinity: unique symbol = Symbol("DateNegativeInfinity");
+export const DateInfinity = Symbol.for("@blazetrails/activemodel:DateInfinity");
+export const DateNegativeInfinity = Symbol.for("@blazetrails/activemodel:DateNegativeInfinity");
 
 export type DateInfinity = typeof DateInfinity;
 export type DateNegativeInfinity = typeof DateNegativeInfinity;

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -2,13 +2,27 @@
  * Sentinel values for Postgres out-of-range datetime literals.
  * Postgres can return 'infinity' / '-infinity' for timestamp/date columns;
  * these have no Temporal equivalent.
+ *
+ * Symbol.for ensures identity is stable across module duplication (pnpm
+ * deduplication quirks, bundlers). The branded type ensures the two sentinels
+ * remain nominally distinct even though both are plain `symbol` at runtime.
  */
 
-export const DateInfinity = Symbol.for("@blazetrails/activemodel:DateInfinity");
-export const DateNegativeInfinity = Symbol.for("@blazetrails/activemodel:DateNegativeInfinity");
+declare const dateInfinityBrand: unique symbol;
+declare const dateNegativeInfinityBrand: unique symbol;
 
-export type DateInfinity = typeof DateInfinity;
-export type DateNegativeInfinity = typeof DateNegativeInfinity;
+export type DateInfinity = symbol & { readonly [dateInfinityBrand]: "DateInfinity" };
+export type DateNegativeInfinity = symbol & {
+  readonly [dateNegativeInfinityBrand]: "DateNegativeInfinity";
+};
+
+export const DateInfinity: DateInfinity = Symbol.for(
+  "@blazetrails/activemodel:DateInfinity",
+) as DateInfinity;
+
+export const DateNegativeInfinity: DateNegativeInfinity = Symbol.for(
+  "@blazetrails/activemodel:DateNegativeInfinity",
+) as DateNegativeInfinity;
 
 export function isDateInfinity(v: unknown): v is DateInfinity {
   return v === DateInfinity;

--- a/packages/activemodel/src/type/internal/sentinels.ts
+++ b/packages/activemodel/src/type/internal/sentinels.ts
@@ -1,0 +1,19 @@
+/**
+ * Sentinel values for Postgres out-of-range datetime literals.
+ * Postgres can return 'infinity' / '-infinity' for timestamp/date columns;
+ * these have no Temporal equivalent.
+ */
+
+export const DateInfinity: unique symbol = Symbol("DateInfinity");
+export const DateNegativeInfinity: unique symbol = Symbol("DateNegativeInfinity");
+
+export type DateInfinity = typeof DateInfinity;
+export type DateNegativeInfinity = typeof DateNegativeInfinity;
+
+export function isDateInfinity(v: unknown): v is DateInfinity {
+  return v === DateInfinity;
+}
+
+export function isDateNegativeInfinity(v: unknown): v is DateNegativeInfinity {
+  return v === DateNegativeInfinity;
+}

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -1,29 +1,72 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { plainTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 
 describe("TimeTest", () => {
+  const type = new Types.TimeType();
+
   it("type cast time", () => {
-    const type = new Types.TimeType();
     expect(type.cast(null)).toBe(null);
     expect(type.cast("")).toBe(null);
     expect(type.cast("ABC")).toBe(null);
 
-    const result = type.cast("2024-01-15T10:30:00Z");
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getUTCHours()).toBe(10);
+    const result = type.cast("19:45:54");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(19);
+    expect((result as Temporal.PlainTime).minute).toBe(45);
+    expect((result as Temporal.PlainTime).second).toBe(54);
   });
 
-  it("user input in time zone", () => {
-    const type = new Types.TimeType();
+  it("extracts time from full datetime string", () => {
     const result = type.cast("2015-02-09T19:45:54+00:00");
-    expect(result).toBeInstanceOf(Date);
-    expect(result!.getUTCHours()).toBe(19);
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).hour).toBe(19);
   });
 
-  it("serialize_cast_value is equivalent to serialize after cast", () => {
-    const type = new Types.TimeType();
-    const cast = type.cast("2024-01-15T10:30:00Z");
-    const serialized = type.serialize(cast);
-    expect(serialized).toEqual(cast);
+  it("microsecond precision is preserved through cast", () => {
+    const result = type.cast("14:23:55.123456");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    const t = result as Temporal.PlainTime;
+    expect(t.millisecond).toBe(123);
+    expect(t.microsecond).toBe(456);
+  });
+
+  it("Temporal.PlainTime passthrough", () => {
+    const original = plainTime("14:23:55.123456");
+    expect(type.cast(original)).toBe(original);
+  });
+
+  it("has name 'time'", () => {
+    expect(type.name).toBe("time");
+  });
+
+  it("casts undefined to null", () => {
+    expect(type.cast(undefined)).toBe(null);
+  });
+
+  it("serialize returns microsecond ISO string", () => {
+    const t = plainTime("14:23:55.123456");
+    expect(type.serialize(t)).toBe("14:23:55.123456");
+  });
+
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
+  });
+
+  it("user input in time zone wraps plain time in given zone", () => {
+    const result = type.userInputInTimeZone("14:30:00", "America/New_York");
+    expect(result).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect((result as Temporal.ZonedDateTime).hour).toBe(14);
+    expect((result as Temporal.ZonedDateTime).timeZoneId).toBe("America/New_York");
+  });
+
+  it("user input in time zone returns null for null", () => {
+    expect(type.userInputInTimeZone(null)).toBe(null);
+  });
+
+  it("user input in time zone passthrough for ZonedDateTime", () => {
+    const zdt = Temporal.ZonedDateTime.from("2024-01-15T14:30:00[America/New_York]");
+    expect(type.userInputInTimeZone(zdt)).toBe(zdt);
   });
 });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,34 +1,57 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { ValueType } from "./value.js";
 
-export class TimeType extends ValueType<Date> {
+export class TimeType extends ValueType<Temporal.PlainTime> {
   readonly name = "time";
 
-  cast(value: unknown): Date | null {
+  cast(value: unknown): Temporal.PlainTime | null {
     if (value === null || value === undefined) return null;
-    if (value === "" || (typeof value === "string" && value.trim() === "")) return null;
-    if (value instanceof Date) return value;
-    const str = String(value);
-    const d = new Date(str);
-    return isNaN(d.getTime()) ? null : d;
+    if (value instanceof Temporal.PlainTime) return value;
+    const str = String(value).trim();
+    if (str === "") return null;
+    const timeStr = extractTimePortion(str);
+    if (!timeStr) return null;
+    try {
+      return Temporal.PlainTime.from(timeStr);
+    } catch {
+      return null;
+    }
   }
 
-  serialize(value: unknown): Date | null {
-    return this.cast(value);
+  serialize(value: unknown): string | null {
+    const cast = this.cast(value);
+    return cast ? cast.toString({ smallestUnit: "microsecond" }) : null;
   }
 
   type(): string {
     return this.name;
   }
 
-  userInputInTimeZone(value: unknown): Date | null {
+  userInputInTimeZone(value: unknown, zone: string = "UTC"): Temporal.ZonedDateTime | null {
     if (value === null || value === undefined) return null;
-    if (value instanceof Date) return value;
-    if (typeof value === "string") {
-      const timeOnly = /^\d{2}:\d{2}(:\d{2})?/.test(value);
-      const str = timeOnly ? `2000-01-01 ${value}` : String(value);
-      const d = new Date(str);
-      return isNaN(d.getTime()) ? null : d;
+    if (value instanceof Temporal.ZonedDateTime) return value;
+    // Full ZonedDateTime string (has timezone bracket)
+    const str = String(value).trim();
+    if (str === "") return null;
+    if (str.includes("[")) {
+      try {
+        return Temporal.ZonedDateTime.from(str);
+      } catch {
+        return null;
+      }
     }
-    return this.cast(value);
+    // Otherwise cast to PlainTime and attach the given zone
+    const plain = this.cast(value);
+    if (!plain) return null;
+    return Temporal.Now.plainDateISO(zone).toPlainDateTime(plain).toZonedDateTime(zone);
   }
+}
+
+/** Extract the `HH:MM:SS[.ffffff]` portion from a datetime or time-only string. */
+function extractTimePortion(str: string): string | null {
+  // Time-only: "HH:MM" or "HH:MM:SS..." forms
+  if (/^\d{2}:\d{2}/.test(str)) return str;
+  // Full datetime: find the time part after T or space separator
+  const m = /[T ](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:[Z+-]|$)/.exec(str);
+  return m ? m[1] : null;
 }

--- a/packages/activemodel/src/validations/comparison-validation.test.ts
+++ b/packages/activemodel/src/validations/comparison-validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { instant, plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Model } from "../index.js";
 
 describe("ComparisonValidationTest", () => {
@@ -129,15 +130,15 @@ describe("ComparisonValidationTest", () => {
   });
 
   it("validates comparison with greater than using date", () => {
-    const fixedDate = new Date("2024-01-01");
+    const fixedDate = plainDate("2024-01-01");
     class Event extends Model {
       static {
         this.attribute("date", "date");
         this.validates("date", { comparison: { greaterThan: fixedDate } });
       }
     }
-    expect(new Event({ date: new Date("2024-01-02") }).isValid()).toBe(true);
-    expect(new Event({ date: new Date("2023-12-31") }).isValid()).toBe(false);
+    expect(new Event({ date: "2024-01-02" }).isValid()).toBe(true);
+    expect(new Event({ date: "2023-12-31" }).isValid()).toBe(false);
   });
 
   it("validates comparison with greater than using string", () => {
@@ -216,12 +217,8 @@ describe("ComparisonValidationTest", () => {
         });
       }
     }
-    expect(
-      new Event({ startDate: new Date("2024-01-01"), endDate: new Date("2024-01-02") }).isValid(),
-    ).toBe(true);
-    expect(
-      new Event({ startDate: new Date("2024-01-02"), endDate: new Date("2024-01-01") }).isValid(),
-    ).toBe(false);
+    expect(new Event({ startDate: "2024-01-01", endDate: "2024-01-02" }).isValid()).toBe(true);
+    expect(new Event({ startDate: "2024-01-02", endDate: "2024-01-01" }).isValid()).toBe(false);
   });
 
   it("validates comparison with nil allowed", () => {
@@ -235,39 +232,39 @@ describe("ComparisonValidationTest", () => {
   });
 
   it("validates comparison with greater than using time", () => {
-    const baseTime = new Date("2024-01-01T12:00:00Z");
+    const baseTime = instant("2024-01-01T12:00:00Z");
     class Event extends Model {
       static {
         this.attribute("startTime", "datetime");
         this.validates("startTime", { comparison: { greaterThan: baseTime } });
       }
     }
-    expect(new Event({ startTime: new Date("2024-01-01T13:00:00Z") }).isValid()).toBe(true);
-    expect(new Event({ startTime: new Date("2024-01-01T11:00:00Z") }).isValid()).toBe(false);
+    expect(new Event({ startTime: "2024-01-01T13:00:00Z" }).isValid()).toBe(true);
+    expect(new Event({ startTime: "2024-01-01T11:00:00Z" }).isValid()).toBe(false);
   });
 
   it("validates comparison with greater than or equal to using date", () => {
-    const baseDate = new Date("2024-06-01");
+    const baseDate = plainDate("2024-06-01");
     class Event extends Model {
       static {
         this.attribute("date", "date");
         this.validates("date", { comparison: { greaterThanOrEqualTo: baseDate } });
       }
     }
-    expect(new Event({ date: new Date("2024-06-01") }).isValid()).toBe(true);
-    expect(new Event({ date: new Date("2024-05-31") }).isValid()).toBe(false);
+    expect(new Event({ date: "2024-06-01" }).isValid()).toBe(true);
+    expect(new Event({ date: "2024-05-31" }).isValid()).toBe(false);
   });
 
   it("validates comparison with greater than or equal to using time", () => {
-    const baseTime = new Date("2024-01-01T12:00:00Z");
+    const baseTime = instant("2024-01-01T12:00:00Z");
     class Event extends Model {
       static {
         this.attribute("time", "datetime");
         this.validates("time", { comparison: { greaterThanOrEqualTo: baseTime } });
       }
     }
-    expect(new Event({ time: new Date("2024-01-01T12:00:00Z") }).isValid()).toBe(true);
-    expect(new Event({ time: new Date("2024-01-01T11:59:59Z") }).isValid()).toBe(false);
+    expect(new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(true);
+    expect(new Event({ time: "2024-01-01T11:59:59Z" }).isValid()).toBe(false);
   });
 
   it("validates comparison with greater than or equal to using string", () => {
@@ -283,27 +280,27 @@ describe("ComparisonValidationTest", () => {
   });
 
   it("validates comparison with equal to using date", () => {
-    const target = new Date("2024-06-15");
+    const target = plainDate("2024-06-15");
     class Event extends Model {
       static {
         this.attribute("date", "date");
         this.validates("date", { comparison: { equalTo: target } });
       }
     }
-    expect(new Event({ date: new Date("2024-06-15") }).isValid()).toBe(true);
-    expect(new Event({ date: new Date("2024-06-16") }).isValid()).toBe(false);
+    expect(new Event({ date: "2024-06-15" }).isValid()).toBe(true);
+    expect(new Event({ date: "2024-06-16" }).isValid()).toBe(false);
   });
 
   it("validates comparison with equal to using time", () => {
-    const target = new Date("2024-01-01T12:00:00Z");
+    const target = instant("2024-01-01T12:00:00Z");
     class Event extends Model {
       static {
         this.attribute("time", "datetime");
         this.validates("time", { comparison: { equalTo: target } });
       }
     }
-    expect(new Event({ time: new Date("2024-01-01T12:00:00Z") }).isValid()).toBe(true);
-    expect(new Event({ time: new Date("2024-01-01T12:00:01Z") }).isValid()).toBe(false);
+    expect(new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(true);
+    expect(new Event({ time: "2024-01-01T12:00:01Z" }).isValid()).toBe(false);
   });
 
   it("validates comparison with equal to using string", () => {
@@ -318,27 +315,27 @@ describe("ComparisonValidationTest", () => {
   });
 
   it("validates comparison with less than using date", () => {
-    const limit = new Date("2025-01-01");
+    const limit = plainDate("2025-01-01");
     class Event extends Model {
       static {
         this.attribute("date", "date");
         this.validates("date", { comparison: { lessThan: limit } });
       }
     }
-    expect(new Event({ date: new Date("2024-12-31") }).isValid()).toBe(true);
-    expect(new Event({ date: new Date("2025-01-01") }).isValid()).toBe(false);
+    expect(new Event({ date: "2024-12-31" }).isValid()).toBe(true);
+    expect(new Event({ date: "2025-01-01" }).isValid()).toBe(false);
   });
 
   it("validates comparison with less than using time", () => {
-    const limit = new Date("2024-01-01T12:00:00Z");
+    const limit = instant("2024-01-01T12:00:00Z");
     class Event extends Model {
       static {
         this.attribute("time", "datetime");
         this.validates("time", { comparison: { lessThan: limit } });
       }
     }
-    expect(new Event({ time: new Date("2024-01-01T11:59:59Z") }).isValid()).toBe(true);
-    expect(new Event({ time: new Date("2024-01-01T12:00:00Z") }).isValid()).toBe(false);
+    expect(new Event({ time: "2024-01-01T11:59:59Z" }).isValid()).toBe(true);
+    expect(new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(false);
   });
 
   it("validates comparison with less than using string", () => {
@@ -362,12 +359,8 @@ describe("ComparisonValidationTest", () => {
         });
       }
     }
-    expect(
-      new Event({ startDate: new Date("2024-01-01"), endDate: new Date("2024-02-01") }).isValid(),
-    ).toBe(true);
-    expect(
-      new Event({ startDate: new Date("2024-02-01"), endDate: new Date("2024-01-01") }).isValid(),
-    ).toBe(false);
+    expect(new Event({ startDate: "2024-01-01", endDate: "2024-02-01" }).isValid()).toBe(true);
+    expect(new Event({ startDate: "2024-02-01", endDate: "2024-01-01" }).isValid()).toBe(false);
   });
 
   it("validates comparison with method", () => {
@@ -383,9 +376,7 @@ describe("ComparisonValidationTest", () => {
         return this.readAttribute("startDate");
       }
     }
-    expect(
-      new Event({ startDate: new Date("2024-01-01"), endDate: new Date("2024-02-01") }).isValid(),
-    ).toBe(true);
+    expect(new Event({ startDate: "2024-01-01", endDate: "2024-02-01" }).isValid()).toBe(true);
   });
 
   it("validates comparison of multiple values", () => {
@@ -480,29 +471,23 @@ describe("ComparisonValidator", () => {
         });
       }
     }
-    const valid = new Event({
-      startDate: new Date("2024-01-01"),
-      endDate: new Date("2024-01-02"),
-    });
+    const valid = new Event({ startDate: "2024-01-01", endDate: "2024-01-02" });
     expect(valid.isValid()).toBe(true);
 
-    const invalid = new Event({
-      startDate: new Date("2024-01-02"),
-      endDate: new Date("2024-01-01"),
-    });
+    const invalid = new Event({ startDate: "2024-01-02", endDate: "2024-01-01" });
     expect(invalid.isValid()).toBe(false);
   });
 
   it("validates comparison with greater than using date", () => {
-    const tomorrow = new Date("2024-06-02");
+    const tomorrow = plainDate("2024-06-02");
     class Booking extends Model {
       static {
         this.attribute("checkIn", "date");
         this.validates("checkIn", { comparison: { greaterThanOrEqualTo: tomorrow } });
       }
     }
-    expect(new Booking({ checkIn: new Date("2024-06-02") }).isValid()).toBe(true);
-    expect(new Booking({ checkIn: new Date("2024-06-01") }).isValid()).toBe(false);
+    expect(new Booking({ checkIn: "2024-06-02" }).isValid()).toBe(true);
+    expect(new Booking({ checkIn: "2024-06-01" }).isValid()).toBe(false);
   });
 
   it("validates comparison with greater than using string", () => {

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -1,3 +1,4 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
 import { isBlank } from "@blazetrails/activesupport";
@@ -8,7 +9,16 @@ export class ComparisonValidator extends EachValidator {
   }
 
   private compare(a: unknown, b: unknown): number {
-    if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+    if (a instanceof Temporal.Instant && b instanceof Temporal.Instant)
+      return Temporal.Instant.compare(a, b);
+    if (a instanceof Temporal.PlainDateTime && b instanceof Temporal.PlainDateTime)
+      return Temporal.PlainDateTime.compare(a, b);
+    if (a instanceof Temporal.PlainDate && b instanceof Temporal.PlainDate)
+      return Temporal.PlainDate.compare(a, b);
+    if (a instanceof Temporal.PlainTime && b instanceof Temporal.PlainTime)
+      return Temporal.PlainTime.compare(a, b);
+    if (a instanceof Temporal.ZonedDateTime && b instanceof Temporal.ZonedDateTime)
+      return Temporal.ZonedDateTime.compare(a, b);
     if (typeof a === "number" && typeof b === "number") return a - b;
     if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
     return Number(a) - Number(b);

--- a/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
+++ b/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, it, expectTypeOf } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   ValueType,
   IntegerType,
@@ -27,9 +28,9 @@ describe("ValueType<T> type parameter flows into concrete subclasses", () => {
     expectTypeOf(t.cast(0)).toEqualTypeOf<boolean | null>();
   });
 
-  it("DateType#cast narrows to Date | null", () => {
+  it("DateType#cast narrows to Temporal.PlainDate | null", () => {
     const t = new DateType();
-    expectTypeOf(t.cast(0)).toEqualTypeOf<Date | null>();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<Temporal.PlainDate | null>();
   });
 
   it("FloatType#cast narrows to number | null", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -58,6 +58,14 @@ describe("parsePostgresInstant", () => {
     expect(zdt.month).toBe(3);
     expect(zdt.day).toBe(15);
   });
+
+  it("parses a BC timestamp with microseconds", () => {
+    const result = parsePostgresInstant("0044-03-15 12:00:00.000123+00 BC") as Temporal.Instant;
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(0);
+    expect(zdt.microsecond).toBe(123);
+    expect(zdt.nanosecond).toBe(0);
+  });
 });
 
 describe("parsePostgresPlainDateTime", () => {
@@ -84,6 +92,15 @@ describe("parsePostgresPlainDateTime", () => {
     expect(result.year).toBe(-43);
     expect(result.month).toBe(3);
     expect(result.day).toBe(15);
+  });
+
+  it("parses a BC datetime with microseconds", () => {
+    const result = parsePostgresPlainDateTime(
+      "0044-03-15 12:00:00.000456 BC",
+    ) as Temporal.PlainDateTime;
+    expect(result.millisecond).toBe(0);
+    expect(result.microsecond).toBe(456);
+    expect(result.nanosecond).toBe(0);
   });
 });
 
@@ -181,11 +198,15 @@ describe("parseMysqlDate", () => {
 describe("parseMysqlTime", () => {
   it("parses a TIME string", () => {
     const result = parseMysqlTime("14:23:55.123456");
-    expect(result?.toString()).toBe("14:23:55.123456");
+    expect(result.toString()).toBe("14:23:55.123456");
   });
 
   it("parses midnight", () => {
     const result = parseMysqlTime("00:00:00");
-    expect(result?.toString()).toBe("00:00:00");
+    expect(result.toString()).toBe("00:00:00");
+  });
+
+  it("treats empty string as midnight", () => {
+    expect(parseMysqlTime("").toString()).toBe("00:00:00");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -192,6 +192,10 @@ describe("parseMysqlPlainDateTime", () => {
   it("returns null for zero-date", () => {
     expect(parseMysqlPlainDateTime("0000-00-00 00:00:00")).toBeNull();
   });
+
+  it("returns null for zero-date with fractional seconds (DATETIME(6))", () => {
+    expect(parseMysqlPlainDateTime("0000-00-00 00:00:00.000000")).toBeNull();
+  });
 });
 
 describe("parseMysqlDate", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -61,7 +61,7 @@ describe("parsePostgresInstant", () => {
   it("parses a BC timestamp", () => {
     // Postgres 0044-03-15 BC = ISO year -43
     const result = parsePostgresInstant("0044-03-15 12:00:00+00 BC") as Temporal.Instant;
-    expect(Number(result.epochNanoseconds)).toBeLessThan(0);
+    expect(result.epochNanoseconds).toBeLessThan(0n);
     // year -43 in proleptic Gregorian = 44 BC
     const zdt = result.toZonedDateTimeISO("UTC");
     expect(zdt.year).toBe(-43);

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  parsePostgresInstant,
+  parsePostgresPlainDateTime,
+  parsePostgresDate,
+  parsePostgresTime,
+  parsePostgresTimeTz,
+  parseMysqlInstant,
+  parseMysqlPlainDateTime,
+  parseMysqlDate,
+  parseMysqlTime,
+  DateInfinity,
+  DateNegativeInfinity,
+} from "./temporal-wire.js";
+
+describe("parsePostgresInstant", () => {
+  it("parses a timestamptz with space separator and two-digit offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55.123456+00");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parsePostgresInstant("2024-01-15 09:00:00.000001+00");
+    expect(result.toString()).toBe("2024-01-15T09:00:00.000001Z");
+  });
+
+  it("handles a positive offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55+02");
+    expect(result.toString()).toBe("2026-04-26T12:23:55Z");
+  });
+
+  it("handles ±HH:MM offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55.100000+05:30");
+    expect(result.toString()).toBe("2026-04-26T08:53:55.1Z");
+  });
+
+  it("handles negative offset", () => {
+    const result = parsePostgresInstant("2026-04-26 14:23:55-05");
+    expect(result.toString()).toBe("2026-04-26T19:23:55Z");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresInstant("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresInstant("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC timestamp", () => {
+    // Postgres 0044-03-15 BC = ISO year -43
+    const result = parsePostgresInstant("0044-03-15 12:00:00+00 BC") as Temporal.Instant;
+    expect(Number(result.epochNanoseconds)).toBeLessThan(0);
+    // year -43 in proleptic Gregorian = 44 BC
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(-43);
+    expect(zdt.month).toBe(3);
+    expect(zdt.day).toBe(15);
+  });
+});
+
+describe("parsePostgresPlainDateTime", () => {
+  it("parses a timestamp with space separator", () => {
+    const result = parsePostgresPlainDateTime("2026-04-26 14:23:55.123456");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parsePostgresPlainDateTime("2024-12-31 23:59:59.999999");
+    expect(result.toString()).toBe("2024-12-31T23:59:59.999999");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresPlainDateTime("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresPlainDateTime("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC datetime", () => {
+    const result = parsePostgresPlainDateTime("0044-03-15 12:00:00 BC") as Temporal.PlainDateTime;
+    expect(result.year).toBe(-43);
+    expect(result.month).toBe(3);
+    expect(result.day).toBe(15);
+  });
+});
+
+describe("parsePostgresDate", () => {
+  it("parses a normal date", () => {
+    const result = parsePostgresDate("2026-04-26");
+    expect(result.toString()).toBe("2026-04-26");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parsePostgresDate("infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parsePostgresDate("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("parses a BC date", () => {
+    const result = parsePostgresDate("0044-03-15 BC") as Temporal.PlainDate;
+    expect(result.year).toBe(-43);
+    expect(result.month).toBe(3);
+  });
+});
+
+describe("parsePostgresTime", () => {
+  it("parses a time with microseconds", () => {
+    const result = parsePostgresTime("14:23:55.123456");
+    expect(result.toString()).toBe("14:23:55.123456");
+  });
+
+  it("parses a whole-second time", () => {
+    const result = parsePostgresTime("00:00:00");
+    expect(result.toString()).toBe("00:00:00");
+  });
+});
+
+describe("parsePostgresTimeTz", () => {
+  it("parses timetz with two-digit offset", () => {
+    const { time, offset } = parsePostgresTimeTz("14:23:55.123456+02");
+    expect(time.toString()).toBe("14:23:55.123456");
+    expect(offset).toBe("+02:00");
+  });
+
+  it("parses timetz with full offset", () => {
+    const { time, offset } = parsePostgresTimeTz("14:23:55+05:30");
+    expect(time.toString()).toBe("14:23:55");
+    expect(offset).toBe("+05:30");
+  });
+
+  it("parses timetz with negative offset", () => {
+    const { time, offset } = parsePostgresTimeTz("08:00:00.000001-08");
+    expect(time.toString()).toBe("08:00:00.000001");
+    expect(offset).toBe("-08:00");
+  });
+
+  it("throws on unparseable input", () => {
+    expect(() => parsePostgresTimeTz("not-a-time")).toThrow(RangeError);
+  });
+});
+
+describe("parseMysqlInstant", () => {
+  it("treats the wire string as UTC (pinned session tz)", () => {
+    const result = parseMysqlInstant("2026-04-26 14:23:55.123456");
+    expect(result.toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parseMysqlInstant("2024-01-01 00:00:00.000001");
+    expect(result.toString()).toBe("2024-01-01T00:00:00.000001Z");
+  });
+});
+
+describe("parseMysqlPlainDateTime", () => {
+  it("parses a DATETIME string", () => {
+    const result = parseMysqlPlainDateTime("2026-04-26 14:23:55.123456");
+    expect(result?.toString()).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("returns null for zero-date", () => {
+    expect(parseMysqlPlainDateTime("0000-00-00 00:00:00")).toBeNull();
+  });
+});
+
+describe("parseMysqlDate", () => {
+  it("parses a DATE string", () => {
+    const result = parseMysqlDate("2026-04-26");
+    expect(result?.toString()).toBe("2026-04-26");
+  });
+
+  it("returns null for zero-date", () => {
+    expect(parseMysqlDate("0000-00-00")).toBeNull();
+  });
+});
+
+describe("parseMysqlTime", () => {
+  it("parses a TIME string", () => {
+    const result = parseMysqlTime("14:23:55.123456");
+    expect(result?.toString()).toBe("14:23:55.123456");
+  });
+
+  it("parses midnight", () => {
+    const result = parseMysqlTime("00:00:00");
+    expect(result?.toString()).toBe("00:00:00");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -25,6 +25,16 @@ describe("parsePostgresInstant", () => {
     expect(result.toString()).toBe("2024-01-15T09:00:00.000001Z");
   });
 
+  it("truncates sub-nanosecond digits beyond 9", () => {
+    // No DB emits >9 fractional digits, but guard against corrupt input
+    // shifting the slice boundaries. "1234567899" → treat as "123456789".
+    const result = parsePostgresInstant("2026-04-26 14:23:55.1234567899+00") as Temporal.Instant;
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(123);
+    expect(zdt.microsecond).toBe(456);
+    expect(zdt.nanosecond).toBe(789);
+  });
+
   it("handles a positive offset", () => {
     const result = parsePostgresInstant("2026-04-26 14:23:55+02");
     expect(result.toString()).toBe("2026-04-26T12:23:55Z");

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -205,8 +205,4 @@ describe("parseMysqlTime", () => {
     const result = parseMysqlTime("00:00:00");
     expect(result.toString()).toBe("00:00:00");
   });
-
-  it("treats empty string as midnight", () => {
-    expect(parseMysqlTime("").toString()).toBe("00:00:00");
-  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -145,6 +145,14 @@ describe("parsePostgresTime", () => {
     const result = parsePostgresTime("00:00:00");
     expect(result.toString()).toBe("00:00:00");
   });
+
+  it("normalizes 24:00:00 (PG end-of-day sentinel) to 00:00:00", () => {
+    expect(parsePostgresTime("24:00:00").toString()).toBe("00:00:00");
+  });
+
+  it("normalizes 24:00:00 with fractional seconds", () => {
+    expect(parsePostgresTime("24:00:00.000000").toString()).toBe("00:00:00");
+  });
 });
 
 describe("parsePostgresTimeTz", () => {
@@ -164,6 +172,12 @@ describe("parsePostgresTimeTz", () => {
     const { time, offset } = parsePostgresTimeTz("08:00:00.000001-08");
     expect(time.toString()).toBe("08:00:00.000001");
     expect(offset).toBe("-08:00");
+  });
+
+  it("normalizes 24:00:00 timetz to 00:00:00", () => {
+    const { time, offset } = parsePostgresTimeTz("24:00:00+00");
+    expect(time.toString()).toBe("00:00:00");
+    expect(offset).toBe("+00:00");
   });
 
   it("throws on unparseable input", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -156,9 +156,9 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
  * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
  * responsible for interval TIME).
  */
-export function parseMysqlTime(text: string): Temporal.PlainTime | null {
+export function parseMysqlTime(text: string): Temporal.PlainTime {
   const trimmed = text.trim();
-  if (trimmed === "00:00:00" || trimmed === "") return Temporal.PlainTime.from("00:00:00");
+  if (trimmed === "") return Temporal.PlainTime.from("00:00:00");
   return Temporal.PlainTime.from(trimmed);
 }
 
@@ -206,7 +206,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
     );
   if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac, rawOffset] = match;
-  const { microsecond, nanosecond } = parseFraction(frac);
+  const { millisecond, microsecond, nanosecond } = parseFraction(frac);
   const zdt = Temporal.ZonedDateTime.from({
     year: bcYearToIso(Number(y)),
     month: Number(mo),
@@ -214,6 +214,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
     hour: Number(h),
     minute: Number(mi),
     second: Number(s),
+    millisecond,
     microsecond,
     nanosecond,
     timeZone: expandOffset(rawOffset),
@@ -230,7 +231,7 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
   const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
   if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac] = match;
-  const { microsecond, nanosecond } = parseFraction(frac);
+  const { millisecond, microsecond, nanosecond } = parseFraction(frac);
   return Temporal.PlainDateTime.from({
     year: bcYearToIso(Number(y)),
     month: Number(mo),
@@ -238,21 +239,29 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
     hour: Number(h),
     minute: Number(mi),
     second: Number(s),
+    millisecond,
     microsecond,
     nanosecond,
   });
 }
 
 /**
- * Convert a fractional-seconds string (up to 9 digits) to microsecond
- * and nanosecond components.  "123456" → { microsecond: 123456, nanosecond: 0 }.
+ * Convert a fractional-seconds string (up to 9 digits) to the three
+ * Temporal sub-second components, each in the 0–999 range.
+ * "123456" → { millisecond: 123, microsecond: 456, nanosecond: 0 }.
  */
-function parseFraction(frac: string | undefined): { microsecond: number; nanosecond: number } {
-  if (!frac) return { microsecond: 0, nanosecond: 0 };
+function parseFraction(frac: string | undefined): {
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+} {
+  if (!frac) return { millisecond: 0, microsecond: 0, nanosecond: 0 };
   const padded = frac.padEnd(9, "0");
-  const microsecond = Number(padded.slice(0, 6));
-  const nanosecond = Number(padded.slice(6, 9));
-  return { microsecond, nanosecond };
+  return {
+    millisecond: Number(padded.slice(0, 3)),
+    microsecond: Number(padded.slice(3, 6)),
+    nanosecond: Number(padded.slice(6, 9)),
+  };
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -56,7 +56,7 @@ export function parsePostgresPlainDateTime(
   if (trimmed === "-infinity") return DateNegativeInfinity;
   const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampAsPlainDateTime(iso);
-  return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
+  return Temporal.PlainDateTime.from(clampFraction(iso.replace(" ", "T")));
 }
 
 /**
@@ -127,7 +127,7 @@ export function parsePostgresTimeTz(text: string): TimeTzValue {
  */
 export function parseMysqlInstant(text: string): Temporal.Instant {
   // Treat as UTC by appending Z after normalising the separator.
-  const iso = text.trim().replace(" ", "T") + "Z";
+  const iso = clampFraction(text.trim().replace(" ", "T") + "Z");
   return Temporal.Instant.from(iso);
 }
 
@@ -140,7 +140,7 @@ export function parseMysqlInstant(text: string): Temporal.Instant {
 export function parseMysqlPlainDateTime(text: string): Temporal.PlainDateTime | null {
   const trimmed = text.trim();
   if (isZeroDatetime(trimmed)) return null;
-  return Temporal.PlainDateTime.from(trimmed.replace(" ", "T"));
+  return Temporal.PlainDateTime.from(clampFraction(trimmed.replace(" ", "T")));
 }
 
 /**
@@ -175,7 +175,16 @@ export function parseMysqlTime(text: string): Temporal.PlainTime {
  *   `'2026-04-26 14:23:55.123456+00'` → `'2026-04-26T14:23:55.123456+00:00'`
  */
 function normalizeTimestampTz(text: string): string {
-  return text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00");
+  return clampFraction(text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00"));
+}
+
+/**
+ * Clamp fractional-seconds digits in an ISO datetime string to 9 (nanosecond
+ * precision). Temporal parsers reject strings with more than 9 fractional
+ * digits, and no database emits sub-nanosecond precision.
+ */
+function clampFraction(iso: string): string {
+  return iso.replace(/(\.\d{9})\d+/, "$1");
 }
 
 /** Strip a trailing " BC" suffix and return both parts. */
@@ -249,9 +258,10 @@ function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateT
 }
 
 /**
- * Convert a fractional-seconds string (up to 9 digits) to the three
- * Temporal sub-second components, each in the 0–999 range.
+ * Convert a fractional-seconds string to the three Temporal sub-second
+ * components, each in the 0–999 range.
  * "123456" → { millisecond: 123, microsecond: 456, nanosecond: 0 }.
+ * Digits beyond 9 (sub-nanosecond) are truncated; no database emits them.
  */
 function parseFraction(frac: string | undefined): {
   millisecond: number;
@@ -259,11 +269,14 @@ function parseFraction(frac: string | undefined): {
   nanosecond: number;
 } {
   if (!frac) return { millisecond: 0, microsecond: 0, nanosecond: 0 };
-  const padded = frac.padEnd(9, "0");
+  // Clamp to 9 digits before padding so extra digits don't silently corrupt
+  // the slice boundaries (e.g. a 10-digit input would shift microsecond into
+  // the nanosecond slot without this guard).
+  const clamped = frac.slice(0, 9).padEnd(9, "0");
   return {
-    millisecond: Number(padded.slice(0, 3)),
-    microsecond: Number(padded.slice(3, 6)),
-    nanosecond: Number(padded.slice(6, 9)),
+    millisecond: Number(clamped.slice(0, 3)),
+    microsecond: Number(clamped.slice(3, 6)),
+    nanosecond: Number(clamped.slice(6, 9)),
   };
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -34,9 +34,10 @@ export type TimeTzValue = { time: Temporal.PlainTime; offset: string };
 export function parsePostgresInstant(
   text: string,
 ): Temporal.Instant | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampTzAsInstant(iso);
   return Temporal.Instant.from(normalizeTimestampTz(iso));
 }
@@ -50,9 +51,10 @@ export function parsePostgresInstant(
 export function parsePostgresPlainDateTime(
   text: string,
 ): Temporal.PlainDateTime | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   if (bc) return parseBcTimestampAsPlainDateTime(iso);
   return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
 }
@@ -65,9 +67,10 @@ export function parsePostgresPlainDateTime(
 export function parsePostgresDate(
   text: string,
 ): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType {
-  if (text === "infinity") return DateInfinity;
-  if (text === "-infinity") return DateNegativeInfinity;
-  const { iso, bc } = extractBcSuffix(text.trim());
+  const trimmed = text.trim();
+  if (trimmed === "infinity") return DateInfinity;
+  if (trimmed === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(trimmed);
   const plain = Temporal.PlainDate.from(iso);
   if (!bc) return plain;
   return Temporal.PlainDate.from({

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -62,7 +62,9 @@ export function parsePostgresPlainDateTime(
 /**
  * Parse a Postgres `date` wire string to `Temporal.PlainDate`.
  *
- * Wire format: `'YYYY-MM-DD'` or `'YYYY-MM-DD BC'`.
+ * Wire format: `'YYYY-MM-DD'`, `'YYYY-MM-DD BC'`,
+ * or the sentinels `'infinity'` / `'-infinity'` which return
+ * `DateInfinity` / `DateNegativeInfinity`.
  */
 export function parsePostgresDate(
   text: string,
@@ -155,14 +157,12 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
 /**
  * Parse a MySQL `TIME` wire string to `Temporal.PlainTime`.
  *
- * MySQL TIME can be negative or exceed 24 h for intervals; we only
- * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
- * responsible for interval TIME).
+ * Wire format: `'HH:MM:SS[.ffffff]'` (standard range, no sign). MySQL TIME
+ * can be negative or exceed 24 h for interval values; those paths are the
+ * cast layer's responsibility and are not handled here.
  */
 export function parseMysqlTime(text: string): Temporal.PlainTime {
-  const trimmed = text.trim();
-  if (trimmed === "") return Temporal.PlainTime.from("00:00:00");
-  return Temporal.PlainTime.from(trimmed);
+  return Temporal.PlainTime.from(text.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -1,0 +1,272 @@
+/**
+ * Wire-format parsers for Temporal types from Postgres and MySQL.
+ *
+ * Handles the quirks each driver emits before our cast layer ever sees
+ * a value — space separator instead of T, two-digit offsets, BC suffix,
+ * infinity sentinels, zero-dates.
+ *
+ * All functions are pure (no I/O, no side effects) so they can be unit-
+ * tested directly without a live database.
+ */
+
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  DateInfinity,
+  DateNegativeInfinity,
+  type DateInfinityType,
+  type DateNegativeInfinityType,
+} from "@blazetrails/activemodel";
+
+export { DateInfinity, DateNegativeInfinity };
+
+export type TimeTzValue = { time: Temporal.PlainTime; offset: string };
+
+// ---------------------------------------------------------------------------
+// Postgres
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Postgres `timestamptz` wire string to `Temporal.Instant`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff][+HH|±HH:MM]'`
+ * or the sentinels `'infinity'` / `'-infinity'`.
+ */
+export function parsePostgresInstant(
+  text: string,
+): Temporal.Instant | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  if (bc) return parseBcTimestampTzAsInstant(iso);
+  return Temporal.Instant.from(normalizeTimestampTz(iso));
+}
+
+/**
+ * Parse a Postgres `timestamp` wire string to `Temporal.PlainDateTime`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (no offset).
+ * or the sentinels `'infinity'` / `'-infinity'`.
+ */
+export function parsePostgresPlainDateTime(
+  text: string,
+): Temporal.PlainDateTime | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  if (bc) return parseBcTimestampAsPlainDateTime(iso);
+  return Temporal.PlainDateTime.from(iso.replace(" ", "T"));
+}
+
+/**
+ * Parse a Postgres `date` wire string to `Temporal.PlainDate`.
+ *
+ * Wire format: `'YYYY-MM-DD'` or `'YYYY-MM-DD BC'`.
+ */
+export function parsePostgresDate(
+  text: string,
+): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType {
+  if (text === "infinity") return DateInfinity;
+  if (text === "-infinity") return DateNegativeInfinity;
+  const { iso, bc } = extractBcSuffix(text.trim());
+  const plain = Temporal.PlainDate.from(iso);
+  if (!bc) return plain;
+  return Temporal.PlainDate.from({
+    year: bcYearToIso(plain.year),
+    month: plain.month,
+    day: plain.day,
+  });
+}
+
+/**
+ * Parse a Postgres `time` wire string to `Temporal.PlainTime`.
+ *
+ * Wire format: `'HH:MM:SS[.ffffff]'`.
+ */
+export function parsePostgresTime(text: string): Temporal.PlainTime {
+  return Temporal.PlainTime.from(text.trim());
+}
+
+/**
+ * Parse a Postgres `timetz` wire string.
+ *
+ * Wire format: `'HH:MM:SS[.ffffff]+HH'` or `'HH:MM:SS[.ffffff]±HH:MM'`.
+ * Returns the time and offset separately — Temporal.PlainTime has no
+ * timezone, so we preserve the offset as a sibling string.
+ */
+export function parsePostgresTimeTz(text: string): TimeTzValue {
+  // Split on first +/- that appears after the seconds portion
+  const match = /^(\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2}(?::\d{2})?)$/.exec(text.trim());
+  if (!match) {
+    throw new RangeError(`Cannot parse timetz wire value: ${JSON.stringify(text)}`);
+  }
+  const [, timeStr, rawOffset] = match;
+  return {
+    time: Temporal.PlainTime.from(timeStr),
+    offset: expandOffset(rawOffset),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a MySQL `TIMESTAMP` wire string to `Temporal.Instant`.
+ *
+ * Precondition: the connection's `@@session.time_zone` is `'+00:00'`.
+ * MySQL TIMESTAMP is always stored as UTC; with the pinned session TZ
+ * the driver returns strings in UTC wall-clock form.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (no offset in string;
+ * semantically UTC because of the pinned session timezone).
+ */
+export function parseMysqlInstant(text: string): Temporal.Instant {
+  // Treat as UTC by appending Z after normalising the separator.
+  const iso = text.trim().replace(" ", "T") + "Z";
+  return Temporal.Instant.from(iso);
+}
+
+/**
+ * Parse a MySQL `DATETIME` wire string to `Temporal.PlainDateTime`.
+ *
+ * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (naive, no timezone).
+ * Zero-date `'0000-00-00 00:00:00'` returns `null`.
+ */
+export function parseMysqlPlainDateTime(text: string): Temporal.PlainDateTime | null {
+  const trimmed = text.trim();
+  if (isZeroDatetime(trimmed)) return null;
+  return Temporal.PlainDateTime.from(trimmed.replace(" ", "T"));
+}
+
+/**
+ * Parse a MySQL `DATE` wire string to `Temporal.PlainDate`.
+ *
+ * Zero-date `'0000-00-00'` returns `null`.
+ */
+export function parseMysqlDate(text: string): Temporal.PlainDate | null {
+  const trimmed = text.trim();
+  if (isZeroDate(trimmed)) return null;
+  return Temporal.PlainDate.from(trimmed);
+}
+
+/**
+ * Parse a MySQL `TIME` wire string to `Temporal.PlainTime`.
+ *
+ * MySQL TIME can be negative or exceed 24 h for intervals; we only
+ * handle the `HH:MM:SS[.ffffff]` case here (the cast layer is
+ * responsible for interval TIME).
+ */
+export function parseMysqlTime(text: string): Temporal.PlainTime | null {
+  const trimmed = text.trim();
+  if (trimmed === "00:00:00" || trimmed === "") return Temporal.PlainTime.from("00:00:00");
+  return Temporal.PlainTime.from(trimmed);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a Postgres `timestamptz` string (no BC suffix) to strict
+ * ISO 8601 for `Temporal.Instant.from`:
+ *   `'2026-04-26 14:23:55.123456+00'` → `'2026-04-26T14:23:55.123456+00:00'`
+ */
+function normalizeTimestampTz(text: string): string {
+  return text.replace(" ", "T").replace(/([-+]\d{2})$/, "$1:00");
+}
+
+/** Strip a trailing " BC" suffix and return both parts. */
+function extractBcSuffix(text: string): { iso: string; bc: boolean } {
+  if (text.endsWith(" BC")) {
+    return { iso: text.slice(0, -3), bc: true };
+  }
+  return { iso: text, bc: false };
+}
+
+/**
+ * Convert a positive Postgres year (1-based BC) to proleptic Gregorian ISO year.
+ * Postgres `0044 BC` → ISO year `-43`.  `0001 BC` → ISO year `0`.
+ */
+function bcYearToIso(pgYear: number): number {
+  return -(pgYear - 1);
+}
+
+/**
+ * Parse a BC-suffixed Postgres `timestamptz` string to `Temporal.Instant`.
+ * Uses component construction to avoid negative-year ISO string parsing,
+ * which the polyfill rejects.
+ *
+ * Input has already had " BC" stripped.
+ */
+function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
+  // e.g. "0044-03-15 12:00:00.123456+00" or "0044-03-15 12:00:00+02:30"
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
+      withoutBc,
+    );
+  if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
+  const [, y, mo, d, h, mi, s, frac, rawOffset] = match;
+  const { microsecond, nanosecond } = parseFraction(frac);
+  const zdt = Temporal.ZonedDateTime.from({
+    year: bcYearToIso(Number(y)),
+    month: Number(mo),
+    day: Number(d),
+    hour: Number(h),
+    minute: Number(mi),
+    second: Number(s),
+    microsecond,
+    nanosecond,
+    timeZone: expandOffset(rawOffset),
+  });
+  return zdt.toInstant();
+}
+
+/**
+ * Parse a BC-suffixed Postgres `timestamp` string to `Temporal.PlainDateTime`.
+ * Input has already had " BC" stripped.
+ */
+function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateTime {
+  // e.g. "0044-03-15 12:00:00.123456" or "0044-03-15 12:00:00"
+  const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
+  if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
+  const [, y, mo, d, h, mi, s, frac] = match;
+  const { microsecond, nanosecond } = parseFraction(frac);
+  return Temporal.PlainDateTime.from({
+    year: bcYearToIso(Number(y)),
+    month: Number(mo),
+    day: Number(d),
+    hour: Number(h),
+    minute: Number(mi),
+    second: Number(s),
+    microsecond,
+    nanosecond,
+  });
+}
+
+/**
+ * Convert a fractional-seconds string (up to 9 digits) to microsecond
+ * and nanosecond components.  "123456" → { microsecond: 123456, nanosecond: 0 }.
+ */
+function parseFraction(frac: string | undefined): { microsecond: number; nanosecond: number } {
+  if (!frac) return { microsecond: 0, nanosecond: 0 };
+  const padded = frac.padEnd(9, "0");
+  const microsecond = Number(padded.slice(0, 6));
+  const nanosecond = Number(padded.slice(6, 9));
+  return { microsecond, nanosecond };
+}
+
+/**
+ * Expand a two-digit offset `+HH` or `-HH` to `±HH:MM`.
+ * Leaves `±HH:MM` offsets unchanged.
+ */
+function expandOffset(offset: string): string {
+  return offset.replace(/^([-+]\d{2})$/, "$1:00");
+}
+
+function isZeroDate(text: string): boolean {
+  return text === "0000-00-00";
+}
+
+function isZeroDatetime(text: string): boolean {
+  return text === "0000-00-00 00:00:00" || text === "0000-00-00T00:00:00";
+}

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -204,7 +204,7 @@ function bcYearToIso(pgYear: number): number {
 function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
   // e.g. "0044-03-15 12:00:00.123456+00" or "0044-03-15 12:00:00+02:30"
   const match =
-    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
+    /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
       withoutBc,
     );
   if (!match) throw new RangeError(`Cannot parse BC timestamptz: ${JSON.stringify(withoutBc)}`);
@@ -231,7 +231,7 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
  */
 function parseBcTimestampAsPlainDateTime(withoutBc: string): Temporal.PlainDateTime {
   // e.g. "0044-03-15 12:00:00.123456" or "0044-03-15 12:00:00"
-  const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
+  const match = /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
   if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac] = match;
   const { millisecond, microsecond, nanosecond } = parseFraction(frac);

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -293,5 +293,7 @@ function isZeroDate(text: string): boolean {
 }
 
 function isZeroDatetime(text: string): boolean {
-  return text === "0000-00-00 00:00:00" || text === "0000-00-00T00:00:00";
+  // Match "0000-00-00 00:00:00" / "0000-00-00T00:00:00" and the fractional
+  // variants emitted by DATETIME(N) columns, e.g. "0000-00-00 00:00:00.000000".
+  return /^0000-00-00[T ]00:00:00(\.\d+)?$/.test(text);
 }

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -85,10 +85,12 @@ export function parsePostgresDate(
 /**
  * Parse a Postgres `time` wire string to `Temporal.PlainTime`.
  *
- * Wire format: `'HH:MM:SS[.ffffff]'`.
+ * Wire format: `'HH:MM:SS[.ffffff]'`. Postgres allows `24:00:00` as a valid
+ * end-of-day sentinel; Temporal rejects hour 24, so we normalize it to
+ * `00:00:00` (midnight), matching Ruby Time's rollover behavior.
  */
 export function parsePostgresTime(text: string): Temporal.PlainTime {
-  return Temporal.PlainTime.from(text.trim());
+  return Temporal.PlainTime.from(normalizeTime24(text.trim()));
 }
 
 /**
@@ -97,6 +99,7 @@ export function parsePostgresTime(text: string): Temporal.PlainTime {
  * Wire format: `'HH:MM:SS[.ffffff]+HH'` or `'HH:MM:SS[.ffffff]±HH:MM'`.
  * Returns the time and offset separately — Temporal.PlainTime has no
  * timezone, so we preserve the offset as a sibling string.
+ * `24:00:00` is normalized to `00:00:00` (see `parsePostgresTime`).
  */
 export function parsePostgresTimeTz(text: string): TimeTzValue {
   // Split on first +/- that appears after the seconds portion
@@ -106,7 +109,7 @@ export function parsePostgresTimeTz(text: string): TimeTzValue {
   }
   const [, timeStr, rawOffset] = match;
   return {
-    time: Temporal.PlainTime.from(timeStr),
+    time: Temporal.PlainTime.from(normalizeTime24(timeStr)),
     offset: expandOffset(rawOffset),
   };
 }
@@ -286,6 +289,16 @@ function parseFraction(frac: string | undefined): {
  */
 function expandOffset(offset: string): string {
   return offset.replace(/^([-+]\d{2})$/, "$1:00");
+}
+
+/**
+ * Normalize Postgres `24:00:00[.fraction]` (end-of-day sentinel) to
+ * `00:00:00[.fraction]`. Temporal.PlainTime rejects hour 24; Ruby Time
+ * rolls it over to midnight, which is the semantically equivalent value
+ * when there is no date context.
+ */
+function normalizeTime24(timeStr: string): string {
+  return timeStr.startsWith("24:") ? "00:" + timeStr.slice(3) : timeStr;
 }
 
 function isZeroDate(text: string): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -1,4 +1,6 @@
 import { DateTimeType } from "@blazetrails/activemodel";
+import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describe, expect, it } from "vitest";
 
 import { DateTime } from "./date-time.js";
@@ -13,55 +15,41 @@ describe("PostgreSQL::OID::DateTime", () => {
   });
 
   it("casts 'infinity' / '-infinity' sentinels", () => {
-    expect(type.cast("infinity")).toBe(Infinity);
-    expect(type.cast("-infinity")).toBe(-Infinity);
+    expect(type.cast("infinity")).toBe(DateInfinity);
+    expect(type.cast("-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("cast_value is the Rails-named hook cast delegates to", () => {
+    expect(type.castValue("infinity")).toBe(DateInfinity);
+    expect(type.castValue("-infinity")).toBe(DateNegativeInfinity);
   });
 
   it("rewrites BC-era timestamps with a biased year", () => {
-    const result = type.cast("0044-03-15 12:00:00 BC");
-    expect(result).toBeInstanceOf(Date);
-    expect((result as Date).getUTCFullYear()).toBe(-43);
+    const result = type.castValue("0044-03-15 12:00:00 BC");
+    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    expect((result as Temporal.PlainDateTime).year).toBe(-43);
+    expect((result as Temporal.PlainDateTime).month).toBe(3);
+    expect((result as Temporal.PlainDateTime).day).toBe(15);
   });
 
   it("type_cast_for_schema renders infinity sentinels", () => {
-    expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
-    expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
+    expect(type.typeCastForSchema(DateInfinity)).toBe("::Float::INFINITY");
+    expect(type.typeCastForSchema(DateNegativeInfinity)).toBe("-::Float::INFINITY");
   });
 
   it("rejects BC timestamps with out-of-range components", () => {
-    expect(type.cast("0044-13-01 00:00:00 BC")).toBeNull();
-    expect(type.cast("0044-02-31 00:00:00 BC")).toBeNull();
-    expect(type.cast("0044-01-01 25:00:00 BC")).toBeNull();
-    expect(type.cast("0044-01-01 00:00:60 BC")).toBeNull();
+    expect(type.castValue("0044-13-01 00:00:00 BC")).toBeNull();
+    expect(type.castValue("0044-02-31 00:00:00 BC")).toBeNull();
+    expect(type.castValue("0044-01-01 25:00:00 BC")).toBeNull();
+    expect(type.castValue("0044-01-01 00:00:60 BC")).toBeNull();
   });
 
-  it("rejects BC timestamps with a timezone offset", () => {
-    // Offset handling on BC inputs is rare and requires arithmetic
-    // we haven't needed; reject explicitly rather than silently
-    // ignoring the offset.
-    expect(type.cast("0044-03-15 12:00:00+02 BC")).toBeNull();
-  });
-
-  it("preserves fractional seconds exactly via Math.round", () => {
-    // 0.289 * 1000 floats to 288.999… — Math.round keeps it at 289.
-    const d = type.cast("0044-03-15 12:00:00.289 BC") as Date;
-    expect(d.getUTCMilliseconds()).toBe(289);
-  });
-
-  it("carries fractional-second rounding into whole seconds", () => {
-    // 0.9999 * 1000 rounds to 1000. Naive Math.round would pass 1000
-    // to setUTCHours and silently roll the timestamp forward by a
-    // second. Verify we carry into seconds instead.
-    const d = type.cast("0044-03-15 12:00:00.9999 BC") as Date;
-    expect(d.getUTCSeconds()).toBe(1);
-    expect(d.getUTCMilliseconds()).toBe(0);
-  });
-
-  it("rejects sub-second carry that would overflow the minute", () => {
-    // 59.9999 with carry → seconds = 60. That's invalid input per our
-    // second < 60 guard; return null rather than letting it roll into
-    // the next minute.
-    expect(type.cast("0044-03-15 12:00:59.9999 BC")).toBeNull();
+  it("preserves microsecond precision in BC timestamps", () => {
+    const result = type.castValue("0044-03-15 12:00:00.123456 BC");
+    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    const pdt = result as Temporal.PlainDateTime;
+    expect(pdt.millisecond).toBe(123);
+    expect(pdt.microsecond).toBe(456);
   });
 });
 
@@ -73,7 +61,7 @@ describe("PostgreSQL::OID::Timestamp", () => {
   });
 
   it("inherits infinity + BC handling from OID::DateTime", () => {
-    expect(new Timestamp().cast("infinity")).toBe(Infinity);
+    expect(new Timestamp().castValue("infinity")).toBe(DateInfinity);
   });
 });
 
@@ -85,6 +73,6 @@ describe("PostgreSQL::OID::TimestampWithTimeZone", () => {
   });
 
   it("inherits infinity + BC handling from OID::DateTime", () => {
-    expect(new TimestampWithTimeZone().cast("-infinity")).toBe(-Infinity);
+    expect(new TimestampWithTimeZone().castValue("-infinity")).toBe(DateNegativeInfinity);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -9,91 +9,62 @@
  * `real_type_unless_aliased(real_type)` hook that Timestamp /
  * TimestampWithTimeZone use to report :datetime when the adapter's
  * datetime_type is aliased.
+ *
+ * Full Temporal-native driver integration lands in PR 5a; the cast
+ * and typeCastForSchema overrides here are updated so that
+ * DateTimeType returning `Temporal.Instant | Temporal.PlainDateTime`
+ * does not break compilation.
  */
 
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateTimeType } from "@blazetrails/activemodel";
+import {
+  DateInfinity,
+  DateNegativeInfinity,
+  type DateInfinityType,
+  type DateNegativeInfinityType,
+} from "@blazetrails/activemodel";
+import { parsePostgresPlainDateTime, parsePostgresInstant } from "../../abstract/temporal-wire.js";
+
+type PgDateTimeResult =
+  | Temporal.Instant
+  | Temporal.PlainDateTime
+  | DateInfinityType
+  | DateNegativeInfinityType;
 
 export class DateTime extends DateTimeType {
   override readonly name: string = "datetime";
 
-  /**
-   * See OID::Date for the Float::INFINITY return-type tradeoff — same
-   * escape hatch applies here.
-   */
-  override cast(value: unknown): globalThis.Date | null {
-    return this.castValue(value);
+  override cast(value: unknown): Temporal.Instant | Temporal.PlainDateTime | null {
+    // Sentinels and BC values pass through as opaque values; callers
+    // check with === DateInfinity. PR 5a will widen the return type.
+    return this.castValue(value) as unknown as Temporal.Instant | Temporal.PlainDateTime | null;
   }
 
   /**
    * Rails' `cast_value` — public here so subclasses can call directly
    * and api:compare matches the Rails method name.
    */
-  castValue(value: unknown): globalThis.Date | null {
+  castValue(value: unknown): PgDateTimeResult | null {
     if (typeof value === "string") {
-      if (value === "infinity") return Infinity as unknown as globalThis.Date;
-      if (value === "-infinity") return -Infinity as unknown as globalThis.Date;
+      if (value === "infinity") return DateInfinity;
+      if (value === "-infinity") return DateNegativeInfinity;
       if (/ BC$/.test(value)) {
-        // Accept: "YYYY-MM-DD BC" or "YYYY-MM-DD HH:MM:SS[.f] BC".
-        // Reject anything with a timezone suffix (e.g. "+02", "-05:30")
-        // on a BC timestamp — that's rare in PG output and supporting
-        // it correctly requires offset arithmetic we haven't needed yet.
-        const match =
-          /^(\d+)-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{1,2}):(\d{1,2}(?:\.\d+)?))?(?:\s+BC)$/.exec(
-            value,
-          );
-        if (!match) return null;
-        const year = -Number.parseInt(match[1], 10) + 1;
-        const month = Number.parseInt(match[2], 10) - 1;
-        const day = Number.parseInt(match[3], 10);
-        const hour = match[4] ? Number.parseInt(match[4], 10) : 0;
-        const minute = match[5] ? Number.parseInt(match[5], 10) : 0;
-        const second = match[6] ? Number.parseFloat(match[6]) : 0;
-        // Reject out-of-range components — setUTC* silently normalises
-        // (month 13, day 32, second 60) and would produce valid Dates
-        // for malformed input.
-        if (
-          month < 0 ||
-          month > 11 ||
-          day < 1 ||
-          day > 31 ||
-          hour < 0 ||
-          hour > 23 ||
-          minute < 0 ||
-          minute > 59 ||
-          second < 0 ||
-          second >= 60
-        ) {
+        // Has offset → treat as timestamptz (Instant); otherwise plain.
+        const hasOffset = /[-+]\d{2}(?::\d{2})?$/.test(value.slice(0, -3).trimEnd());
+        try {
+          return hasOffset ? parsePostgresInstant(value) : parsePostgresPlainDateTime(value);
+        } catch {
           return null;
         }
-        let wholeSeconds = Math.floor(second);
-        // Math.round avoids off-by-1ms drift from floating-point
-        // multiplication (e.g. 0.289 * 1000 = 288.999…). Round can
-        // also yield 1000 for inputs like 59.999999 — handle that
-        // carry explicitly rather than letting setUTCHours roll the
-        // timestamp forward.
-        let ms = Math.round((second - wholeSeconds) * 1000);
-        if (ms === 1000) {
-          ms = 0;
-          wholeSeconds += 1;
-          if (wholeSeconds >= 60) return null;
-        }
-        const d = new globalThis.Date(0);
-        d.setUTCFullYear(year, month, day);
-        d.setUTCHours(hour, minute, wholeSeconds, ms);
-        // Guard against roll-over from Feb 31 etc. even after the
-        // upper-bound check (valid high day for wrong month).
-        if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month || d.getUTCDate() !== day) {
-          return null;
-        }
-        return d;
       }
     }
     return super.cast(value);
   }
 
   override typeCastForSchema(value: unknown): string {
-    if (value === Infinity) return "::Float::INFINITY";
-    if (value === -Infinity) return "-::Float::INFINITY";
+    if (value === DateInfinity) return "::Float::INFINITY";
+    if (value === DateNegativeInfinity) return "-::Float::INFINITY";
     return super.typeCastForSchema(value);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.test.ts
@@ -1,4 +1,6 @@
 import { DateType } from "@blazetrails/activemodel";
+import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describe, expect, it } from "vitest";
 
 import { Date as OidDate } from "./date.js";
@@ -10,39 +12,34 @@ describe("PostgreSQL::OID::Date", () => {
     expect(type).toBeInstanceOf(DateType);
   });
 
-  it("casts 'infinity' to Float::INFINITY", () => {
-    expect(type.cast("infinity")).toBe(Infinity);
+  it("casts 'infinity' to DateInfinity sentinel", () => {
+    expect(type.castValue("infinity")).toBe(DateInfinity);
   });
 
-  it("casts '-infinity' to -Float::INFINITY", () => {
-    expect(type.cast("-infinity")).toBe(-Infinity);
+  it("casts '-infinity' to DateNegativeInfinity sentinel", () => {
+    expect(type.castValue("-infinity")).toBe(DateNegativeInfinity);
   });
 
-  it("rewrites BC-era dates with a biased year and delegates to super", () => {
-    // "0044-03-15 BC" → year -43 (Ides of March, 44 BC). Rails uses
-    // -year+1 so 0001 BC → 0000, 0044 BC → -0043.
-    const result = type.cast("0044-03-15 BC");
-    expect(result).toBeInstanceOf(Date);
-    expect((result as Date).getUTCFullYear()).toBe(-43);
+  it("rewrites BC-era dates with a biased year", () => {
+    const result = type.castValue("0044-03-15 BC");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).year).toBe(-43);
+    expect((result as Temporal.PlainDate).month).toBe(3);
+    expect((result as Temporal.PlainDate).day).toBe(15);
   });
 
   it("type_cast_for_schema renders the infinity sentinels", () => {
-    expect(type.typeCastForSchema(Infinity)).toBe("::Float::INFINITY");
-    expect(type.typeCastForSchema(-Infinity)).toBe("-::Float::INFINITY");
+    expect(type.typeCastForSchema(DateInfinity)).toBe("::Float::INFINITY");
+    expect(type.typeCastForSchema(DateNegativeInfinity)).toBe("-::Float::INFINITY");
   });
 
   it("cast_value is the Rails-named hook cast delegates to", () => {
-    // Direct cast_value call: same behavior as cast — exposed publicly
-    // so callers can invoke the Rails-named method by name (and so
-    // api:compare matches it).
-    expect(type.castValue("infinity")).toBe(Infinity);
-    expect(type.castValue("2024-06-15")).toBeInstanceOf(Date);
+    expect(type.castValue("infinity")).toBe(DateInfinity);
+    expect(type.castValue("2024-06-15")).toBeInstanceOf(Temporal.PlainDate);
   });
 
   it("rejects BC dates with out-of-range month or day", () => {
-    // setUTCFullYear would silently roll Feb 30 into March; validate
-    // and return null instead.
-    expect(type.cast("0044-13-15 BC")).toBeNull();
-    expect(type.cast("0044-02-31 BC")).toBeNull();
+    expect(type.castValue("0044-13-15 BC")).toBeNull();
+    expect(type.castValue("0044-02-31 BC")).toBeNull();
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
@@ -6,70 +6,57 @@
  * PG-specific string forms ("infinity" / "-infinity" / "… BC" for BCE
  * dates) and type_cast_for_schema so those sentinels render as
  * `::Float::INFINITY` / `-::Float::INFINITY` in schema dumps.
+ *
+ * Full Temporal-native driver integration lands in PR 5a; this file
+ * is updated here so that `DateType#cast` returning `Temporal.PlainDate`
+ * does not break compilation.
  */
 
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateType } from "@blazetrails/activemodel";
+import {
+  DateInfinity,
+  DateNegativeInfinity,
+  type DateInfinityType,
+  type DateNegativeInfinityType,
+} from "@blazetrails/activemodel";
+import { parsePostgresDate } from "../../abstract/temporal-wire.js";
 
 export class Date extends DateType {
   override readonly name: string = "date";
 
-  /**
-   * Rails' cast_value handles:
-   *   "infinity"         → Float::INFINITY
-   *   "-infinity"        → -Float::INFINITY
-   *   "0001-01-01 BC"    → date with a biased (Rails-style) year
-   *   everything else    → super (standard date parse)
-   *
-   * Rails returns Float::INFINITY from a Date type, which is dynamic
-   * Ruby. The TS signature is `Date | null`; the infinity sentinels
-   * are cast through `as unknown as Date` so callers that accept
-   * Rails' range-bound semantics still receive them. Check with
-   * `Number.isFinite` or `typeof === 'number'` before treating as a
-   * real Date.
-   */
-  override cast(value: unknown): globalThis.Date | null {
-    return this.castValue(value);
+  override cast(value: unknown): Temporal.PlainDate | null {
+    // Sentinels (DateInfinity / DateNegativeInfinity) pass through as
+    // opaque values; callers check with === DateInfinity. The cast through
+    // `unknown` is intentional — PR 5a will widen the return type.
+    return this.castValue(value) as unknown as Temporal.PlainDate | null;
   }
 
   /**
-   * Rails' `cast_value` — the protected hook cast delegates to. Kept
-   * public here so subclasses (and tests) can call it directly, and so
+   * Rails' `cast_value` — the protected hook cast delegates to.
+   * Kept public so subclasses and tests can call it directly, and so
    * api:compare finds the method name that matches Rails.
    */
-  castValue(value: unknown): globalThis.Date | null {
+  castValue(
+    value: unknown,
+  ): Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType | null {
     if (typeof value === "string") {
-      if (value === "infinity") return Infinity as unknown as globalThis.Date;
-      if (value === "-infinity") return -Infinity as unknown as globalThis.Date;
+      if (value === "infinity") return DateInfinity;
+      if (value === "-infinity") return DateNegativeInfinity;
       if (/ BC$/.test(value)) {
-        // Rails' cast_value rewrites "0044-03-15 BC" → "-0043-03-15"
-        // (year mapped as -year+1). JS's Date parser doesn't accept
-        // 4-digit negative years, so construct the Date manually.
-        const match = /^(\d+)-(\d{1,2})-(\d{1,2})/.exec(value);
-        if (!match) return null;
-        const year = -Number.parseInt(match[1], 10) + 1;
-        const month = Number.parseInt(match[2], 10) - 1;
-        const day = Number.parseInt(match[3], 10);
-        // Reject out-of-range components — setUTCFullYear silently
-        // normalises (month 13 → January of next year, day 32 → next
-        // month) which would turn malformed input into a valid Date.
-        if (month < 0 || month > 11 || day < 1 || day > 31) return null;
-        const d = new globalThis.Date(0);
-        d.setUTCFullYear(year, month, day);
-        d.setUTCHours(0, 0, 0, 0);
-        // Verify the constructed date matches the requested components;
-        // setUTCFullYear would have rolled over for e.g. Feb 31.
-        if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month || d.getUTCDate() !== day) {
+        try {
+          return parsePostgresDate(value);
+        } catch {
           return null;
         }
-        return d;
       }
     }
     return super.cast(value);
   }
 
   override typeCastForSchema(value: unknown): string {
-    if (value === Infinity) return "::Float::INFINITY";
-    if (value === -Infinity) return "-::Float::INFINITY";
+    if (value === DateInfinity) return "::Float::INFINITY";
+    if (value === DateNegativeInfinity) return "-::Float::INFINITY";
     return super.typeCastForSchema(value);
   }
 }

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -28,7 +28,7 @@ import { Json } from "./type/json.js";
 
 export { Date } from "./type/date.js";
 export { DateTime } from "./type/date-time.js";
-export { Time, TimeValue } from "./type/time.js";
+export { Time } from "./type/time.js";
 export { Text } from "./type/text.js";
 export { Json } from "./type/json.js";
 export { DecimalWithoutScale } from "./type/decimal-without-scale.js";

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -1,17 +1,13 @@
 /**
  * Mirrors: ActiveRecord::Type::Time
  *
- * Also defines Time::Value as a branded wrapper around Date (matching
- * Ruby's DelegateClass(::Time)).
+ * TimeValue will be re-implemented on Temporal.ZonedDateTime in PR 8.
+ * For now it is a thin shell that keeps the type hierarchy intact while
+ * the activemodel cast layer has been flipped to Temporal.PlainTime.
  */
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TimeType as ActiveModelTime } from "@blazetrails/activemodel";
 import { isUtc, type TimezoneOptions } from "./internal/timezone.js";
-
-export class TimeValue extends globalThis.Date {
-  constructor(value: globalThis.Date) {
-    super(value.getTime());
-  }
-}
 
 export class Time extends ActiveModelTime {
   private _timezone?: "utc" | "local";
@@ -25,19 +21,12 @@ export class Time extends ActiveModelTime {
     return isUtc(this._timezone);
   }
 
-  serialize(value: unknown): TimeValue | null {
-    const cast = super.serialize(value);
-    if (cast instanceof globalThis.Date) {
-      return new TimeValue(cast);
-    }
-    return null;
+  override serialize(value: unknown): string | null {
+    return super.serialize(value);
   }
 
-  /**
-   * Mirrors: ActiveRecord::Type::Time#serialize_cast_value
-   */
-  serializeCastValue(value: globalThis.Date | null): TimeValue | null {
+  override serializeCastValue(value: Temporal.PlainTime | null): string | null {
     if (value == null) return null;
-    return new TimeValue(value);
+    return value.toString({ smallestUnit: "microsecond" });
   }
 }

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -38,6 +38,14 @@
       "types": "./dist/gzip.d.ts",
       "default": "./dist/gzip.js"
     },
+    "./temporal": {
+      "types": "./dist/temporal.d.ts",
+      "default": "./dist/temporal.js"
+    },
+    "./testing/temporal-helpers": {
+      "types": "./dist/testing/temporal-helpers.d.ts",
+      "default": "./dist/testing/temporal-helpers.js"
+    },
     "./cache/file-store": {
       "types": "./dist/cache/file-store.d.ts",
       "default": "./dist/cache/file-store.js"
@@ -59,6 +67,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "yaml": "^2.8.3"
   }
 }

--- a/packages/activesupport/src/temporal.ts
+++ b/packages/activesupport/src/temporal.ts
@@ -1,0 +1,1 @@
+export { Temporal } from "@js-temporal/polyfill";

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Temporal test helpers. Test files use these instead of `new Date(...)`.
+ * The no-native-date ESLint rule allowlists this file.
+ */
+import { Temporal } from "../temporal.js";
+
+export function instant(iso: string): Temporal.Instant {
+  return Temporal.Instant.from(iso);
+}
+
+export function plainDateTime(iso: string): Temporal.PlainDateTime {
+  return Temporal.PlainDateTime.from(iso);
+}
+
+export function plainDate(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}
+
+export function plainTime(iso: string): Temporal.PlainTime {
+  return Temporal.PlainTime.from(iso);
+}
+
+export function zonedDateTime(iso: string): Temporal.ZonedDateTime {
+  return Temporal.ZonedDateTime.from(iso);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
 
   packages/activesupport:
     dependencies:
+      '@js-temporal/polyfill':
+        specifier: ^0.5.1
+        version: 0.5.1
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -1010,6 +1013,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -2482,6 +2489,9 @@ packages:
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   jsdom@29.0.1:
     resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
@@ -4095,6 +4105,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
+
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.1
@@ -5659,6 +5673,8 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  jsbi@4.3.2: {}
 
   jsdom@29.0.1:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
         __dirname,
         "packages/activesupport/src/message-verifier.ts",
       ),
+      "@blazetrails/activesupport/temporal": path.resolve(
+        __dirname,
+        "packages/activesupport/src/temporal.ts",
+      ),
+      "@blazetrails/activesupport/testing/temporal-helpers": path.resolve(
+        __dirname,
+        "packages/activesupport/src/testing/temporal-helpers.ts",
+      ),
       "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
       "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
       "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),


### PR DESCRIPTION
## Summary

- `DateTimeType#cast` now returns `Temporal.Instant` (offset present in string) or `Temporal.PlainDateTime` (naive string)
- `DateType#cast` returns `Temporal.PlainDate`
- `TimeType#cast` returns `Temporal.PlainTime`; `userInputInTimeZone` returns `Temporal.ZonedDateTime`
- All three `serialize` to microsecond-precision ISO 8601 via `toString({ smallestUnit: 'microsecond' })`
- `attribute-mutation-tracker`: Temporal types are immutable — early-return skips clone
- `validations/comparison.ts`: dispatches to `Temporal.X.compare` for each Temporal type
- `serialization.ts`: routes Temporal values through `toJSON()` (ISO 8601 with native precision)
- `model.ts`: XML serialization handles all five Temporal types
- `time-value.ts` helper: updated interface to Temporal return types

Activerecord compile fixes (base-class return-type now Temporal):
- `oid/date.ts`, `oid/date-time.ts`: use sentinels + `temporal-wire` parsers instead of `new Date`
- `type/time.ts`: removes `TimeValue extends Date` (placeholder until PR 8)
- `dx-tests/activemodel-value-type`: asserts `Temporal.PlainDate`, not `Date`
- Updated OID test files to assert Temporal instances and sentinel symbols

## Test plan

- [ ] `pnpm -w run test:types` — all 72 type tests pass, 0 errors
- [ ] `packages/activemodel/src/type/date-time.test.ts` — 16 tests pass (microsecond precision, offset detection, passthrough)
- [ ] `packages/activemodel/src/type/date.test.ts` — 11 tests pass
- [ ] `packages/activemodel/src/type/time.test.ts` — 11 tests pass
- [ ] `packages/activemodel/src/serialization.test.ts` — 51 tests pass (includes new Temporal coercion test)
- [ ] `packages/activemodel/src/validations/comparison-validation.test.ts` — 45 tests pass

**Blocked by:** temporal/pr2-formatters