### PR TITLE
test(parity): AR gap fixtures ar-134/137/138/139/143 — 5 identified implementation gaps

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -13,22 +13,22 @@
   },
   "ar-134": {
     "side": "diff",
-    "reason": "joins() does not support nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; trails falls through to a toString() on the hash object, producing 'FROM \"authors\" [object Object]'. Real fix: detect hash arguments in joinsBang and resolve them through the association chain."
+    "reason": "joins() does not support nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; trails falls through to a toString() on the hash object, producing 'FROM \"authors\" [object Object]'. Root cause: Relation#joins does not handle object arguments — they fall through to _rawJoins and are stringified during SQL generation. Real fix: handle object/hash arguments in Relation#joins by resolving them through the association chain (via _resolveAssociationJoin and _applyJoinsToManager) before they fall through to raw joins."
   },
   "ar-137": {
     "side": "diff",
-    "reason": "withRecursive union uses UNION instead of UNION ALL: Rails emits 'UNION ALL' between the anchor and recursive term of a recursive CTE; trails emits bare 'UNION'. Real fix: withRecursiveBang/resolveCteEntry should always use UNION ALL for the recursive term."
+    "reason": "withRecursive union uses UNION instead of UNION ALL: Rails emits 'UNION ALL' between the anchor and recursive term of a recursive CTE; trails emits bare 'UNION'. Real fix: only the recursive term assembled by withRecursive should use UNION ALL; keep non-recursive with({ cte: [rel1, rel2] }) array handling on plain UNION — do not change shared resolveCteEntry behavior globally."
   },
   "ar-138": {
     "side": "diff",
-    "reason": "HAVING clause is dropped when a relation is used as a WHERE IN subquery: Rails emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id HAVING COUNT(*) >= 3)'; trails drops the HAVING and emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id)'. Real fix: the WHERE IN subquery path must preserve the HAVING clause from the inner relation's toSql()."
+    "reason": "HAVING clause is dropped when a relation is used as a WHERE IN subquery: Rails emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id HAVING COUNT(*) >= 3)'; trails drops the HAVING and emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id)'. Root cause: the WHERE IN subquery path goes through PredicateBuilder::RelationHandler (relation-handler.ts:16) which calls relation.toArel(); Relation#toArel() does not apply the inner relation's HAVING clause. Real fix: Relation#toArel() must preserve GROUP BY and HAVING when building the subquery SelectManager."
   },
   "ar-139": {
     "side": "diff",
-    "reason": "joins(:assoc).where(assoc: {col: val}) does not alias the joined table: Rails aliases the joined table with the association name ('INNER JOIN \"authors\" \"author\" ON \"author\".\"id\" = ...') so WHERE \"author\".\"name\" resolves correctly; trails emits no alias ('INNER JOIN \"authors\" ON \"authors\".\"id\" = ...') leaving WHERE \"author\".\"name\" referencing an unknown table. Real fix: when joins(:assoc) is resolved symbolically, alias the table with the association name."
+    "reason": "joins(:assoc).where(assoc: {col: val}) uses inconsistent table naming between the JOIN and nested-hash predicate paths: trails resolves joins(:assoc) through _resolveAssociationJoin as an unaliased join on the base table name ('INNER JOIN \"authors\" ON \"authors\".\"id\" = ...'), but the nested-hash predicate path resolves the same association through TableMetadata.associatedTable and aliases it to the association key ('author'), producing WHERE \"author\".\"name\" against a query that only joined \"authors\". Real fix: make symbolic association joins and nested-hash predicate resolution share the same table name/alias strategy so both clauses reference the same table."
   },
   "ar-143": {
     "side": "trails-missing",
-    "reason": "leftOuterJoins() crashes on nested hash arguments: same root cause as ar-134 — trails does not resolve nested hashes through the association graph for leftOuterJoins, raising 'Unknown node type: Object'. Real fix: share the nested-hash resolution logic between joinsBang and leftOuterJoinsBang."
+    "reason": "leftOuterJoins() crashes on nested hash arguments: trails accepts an object into Relation#leftOuterJoins/leftJoins and later tries to build a LEFT OUTER JOIN with that plain object as the table operand (relation.ts:1230+), raising 'Unknown node type: Object'. Real fix: handle or reject nested-hash/object arguments in Relation#leftOuterJoins/leftJoins before _applyJoinsToManager builds Arel JOIN nodes — for example by reusing the nested-association resolution from joins() or adding early argument validation."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -10,5 +10,25 @@
   "ar-65": {
     "side": "diff",
     "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
+  },
+  "ar-134": {
+    "side": "diff",
+    "reason": "joins() does not support nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; trails falls through to a toString() on the hash object, producing 'FROM \"authors\" [object Object]'. Real fix: detect hash arguments in joinsBang and resolve them through the association chain."
+  },
+  "ar-137": {
+    "side": "diff",
+    "reason": "withRecursive union uses UNION instead of UNION ALL: Rails emits 'UNION ALL' between the anchor and recursive term of a recursive CTE; trails emits bare 'UNION'. Real fix: withRecursiveBang/resolveCteEntry should always use UNION ALL for the recursive term."
+  },
+  "ar-138": {
+    "side": "diff",
+    "reason": "HAVING clause is dropped when a relation is used as a WHERE IN subquery: Rails emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id HAVING COUNT(*) >= 3)'; trails drops the HAVING and emits 'WHERE id IN (SELECT author_id FROM books GROUP BY author_id)'. Real fix: the WHERE IN subquery path must preserve the HAVING clause from the inner relation's toSql()."
+  },
+  "ar-139": {
+    "side": "diff",
+    "reason": "joins(:assoc).where(assoc: {col: val}) does not alias the joined table: Rails aliases the joined table with the association name ('INNER JOIN \"authors\" \"author\" ON \"author\".\"id\" = ...') so WHERE \"author\".\"name\" resolves correctly; trails emits no alias ('INNER JOIN \"authors\" ON \"authors\".\"id\" = ...') leaving WHERE \"author\".\"name\" referencing an unknown table. Real fix: when joins(:assoc) is resolved symbolically, alias the table with the association name."
+  },
+  "ar-143": {
+    "side": "trails-missing",
+    "reason": "leftOuterJoins() crashes on nested hash arguments: same root cause as ar-134 — trails does not resolve nested hashes through the association graph for leftOuterJoins, raising 'Unknown node type: Object'. Real fix: share the nested-hash resolution logic between joinsBang and leftOuterJoinsBang."
   }
 }

--- a/scripts/parity/fixtures/ar-134/models.rb
+++ b/scripts/parity/fixtures/ar-134/models.rb
@@ -1,0 +1,12 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-134/models.ts
+++ b/scripts/parity/fixtures/ar-134/models.ts
@@ -1,0 +1,26 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-134/query.rb
+++ b/scripts/parity/fixtures/ar-134/query.rb
@@ -1,0 +1,1 @@
+Author.joins(books: :reviews).select("authors.id, authors.name, COUNT(reviews.id) AS total_reviews").group("authors.id, authors.name")

--- a/scripts/parity/fixtures/ar-134/query.ts
+++ b/scripts/parity/fixtures/ar-134/query.ts
@@ -1,0 +1,5 @@
+import { Author } from "./models.js";
+
+export default Author.joins({ books: "reviews" })
+  .select("authors.id, authors.name, COUNT(reviews.id) AS total_reviews")
+  .group("authors.id, authors.name");

--- a/scripts/parity/fixtures/ar-134/schema.sql
+++ b/scripts/parity/fixtures/ar-134/schema.sql
@@ -1,0 +1,19 @@
+-- Fixture for statement: ar-134
+-- Query: Author.joins(books: :reviews).select("authors.id, authors.name, COUNT(reviews.id) AS total_reviews").group("authors.id, authors.name")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER REFERENCES authors(id)
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  rating INTEGER NOT NULL
+);

--- a/scripts/parity/fixtures/ar-137/models.rb
+++ b/scripts/parity/fixtures/ar-137/models.rb
@@ -1,0 +1,4 @@
+class Employee < ActiveRecord::Base
+  belongs_to :manager, class_name: "Employee", optional: true
+  has_many :reports, class_name: "Employee", foreign_key: "manager_id"
+end

--- a/scripts/parity/fixtures/ar-137/models.ts
+++ b/scripts/parity/fixtures/ar-137/models.ts
@@ -1,0 +1,10 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Employee extends Base {
+  static {
+    this.tableName = "employees";
+    this.belongsTo("manager", { className: "Employee" });
+    this.hasMany("reports", { className: "Employee", foreignKey: "manager_id" });
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-137/query.rb
+++ b/scripts/parity/fixtures/ar-137/query.rb
@@ -1,0 +1,1 @@
+Employee.with_recursive(hierarchy: [Employee.where(manager_id: nil), Employee.joins("INNER JOIN hierarchy ON employees.manager_id = hierarchy.id")]).from("hierarchy")

--- a/scripts/parity/fixtures/ar-137/query.ts
+++ b/scripts/parity/fixtures/ar-137/query.ts
@@ -1,0 +1,10 @@
+import { Employee } from "./models.js";
+
+export default Employee.all()
+  .withRecursive({
+    hierarchy: [
+      Employee.where({ manager_id: null }),
+      Employee.joins("INNER JOIN hierarchy ON employees.manager_id = hierarchy.id"),
+    ],
+  })
+  .from("hierarchy");

--- a/scripts/parity/fixtures/ar-137/schema.sql
+++ b/scripts/parity/fixtures/ar-137/schema.sql
@@ -1,0 +1,8 @@
+-- Fixture for statement: ar-137
+-- Query: Employee.with_recursive(hierarchy: [Employee.where(manager_id: nil), Employee.joins("INNER JOIN hierarchy ON employees.manager_id = hierarchy.id")]).from("hierarchy")
+
+CREATE TABLE employees (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  manager_id INTEGER REFERENCES employees(id)
+);

--- a/scripts/parity/fixtures/ar-138/models.rb
+++ b/scripts/parity/fixtures/ar-138/models.rb
@@ -1,0 +1,7 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-138/models.ts
+++ b/scripts/parity/fixtures/ar-138/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-138/query.rb
+++ b/scripts/parity/fixtures/ar-138/query.rb
@@ -1,0 +1,1 @@
+Author.where(id: Book.select(:author_id).group(:author_id).having("COUNT(*) >= 3"))

--- a/scripts/parity/fixtures/ar-138/query.ts
+++ b/scripts/parity/fixtures/ar-138/query.ts
@@ -1,0 +1,5 @@
+import { Author, Book } from "./models.js";
+
+export default Author.where({
+  id: Book.select("author_id").group("author_id").having("COUNT(*) >= 3"),
+});

--- a/scripts/parity/fixtures/ar-138/schema.sql
+++ b/scripts/parity/fixtures/ar-138/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-138
+-- Query: Author.where(id: Book.select(:author_id).group(:author_id).having("COUNT(*) >= 3"))
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-139/models.rb
+++ b/scripts/parity/fixtures/ar-139/models.rb
@@ -1,0 +1,7 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-139/models.ts
+++ b/scripts/parity/fixtures/ar-139/models.ts
@@ -1,0 +1,17 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-139/query.rb
+++ b/scripts/parity/fixtures/ar-139/query.rb
@@ -1,0 +1,1 @@
+Book.joins(:author).where(author: { name: "Alice" }).order("authors.id")

--- a/scripts/parity/fixtures/ar-139/query.ts
+++ b/scripts/parity/fixtures/ar-139/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+
+export default Book.joins("author")
+  .where({ author: { name: "Alice" } })
+  .order("authors.id");

--- a/scripts/parity/fixtures/ar-139/schema.sql
+++ b/scripts/parity/fixtures/ar-139/schema.sql
@@ -1,0 +1,13 @@
+-- Fixture for statement: ar-139
+-- Query: Book.joins(:author).where(author: { name: "Alice" }).order("authors.id")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER REFERENCES authors(id)
+);

--- a/scripts/parity/fixtures/ar-143/models.rb
+++ b/scripts/parity/fixtures/ar-143/models.rb
@@ -1,0 +1,12 @@
+class Author < ActiveRecord::Base
+  has_many :books
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+  has_many :reviews
+end
+
+class Review < ActiveRecord::Base
+  belongs_to :book
+end

--- a/scripts/parity/fixtures/ar-143/models.ts
+++ b/scripts/parity/fixtures/ar-143/models.ts
@@ -1,0 +1,26 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    this.hasMany("reviews");
+    registerModel(this);
+  }
+}
+
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    this.belongsTo("book");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-143/query.rb
+++ b/scripts/parity/fixtures/ar-143/query.rb
@@ -1,0 +1,1 @@
+Author.left_outer_joins(books: :reviews).select("authors.id, authors.name, COUNT(reviews.id) AS review_count").group("authors.id, authors.name")

--- a/scripts/parity/fixtures/ar-143/query.ts
+++ b/scripts/parity/fixtures/ar-143/query.ts
@@ -1,0 +1,5 @@
+import { Author } from "./models.js";
+
+export default Author.leftOuterJoins({ books: "reviews" })
+  .select("authors.id, authors.name, COUNT(reviews.id) AS review_count")
+  .group("authors.id, authors.name");

--- a/scripts/parity/fixtures/ar-143/schema.sql
+++ b/scripts/parity/fixtures/ar-143/schema.sql
@@ -1,0 +1,19 @@
+-- Fixture for statement: ar-143
+-- Query: Author.left_outer_joins(books: :reviews).select("authors.id, authors.name, COUNT(reviews.id) AS review_count").group("authors.id, authors.name")
+
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER REFERENCES authors(id)
+);
+
+CREATE TABLE reviews (
+  id INTEGER PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id),
+  rating INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary

Adds 5 fixtures that each surface a concrete Trails implementation gap by running both the Rails and Trails runners and diffing the output. All 5 are classified as KNOWN-GAP with actionable fix descriptions.

| Fixture | Gap |
|---------|-----|
| **ar-134** | `joins({books: :reviews})` — nested hash not resolved through association graph; produces `FROM "authors" [object Object]` |
| **ar-137** | `withRecursive` emits `UNION` instead of Rails' `UNION ALL` for the recursive CTE term |
| **ar-138** | `HAVING` clause is stripped when a relation is used as a `WHERE IN` subquery value |
| **ar-139** | `joins(:assoc).where(assoc: {col: val})` — Rails aliases the joined table with the association name; Trails doesn't, leaving `WHERE "author"."name"` referencing an unknown table |
| **ar-143** | `leftOuterJoins({books: :reviews})` — same nested-hash gap as ar-134 for `leftOuterJoins`; crashes with `Unknown node type: Object` |

## Test plan
- [ ] `pnpm parity:query` — all 5 show as KNOWN-GAP, no FAIL