### PR TITLE
fix(activerecord): preserve Arel node types in joins so LeadingJoin routes correctly

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -334,6 +334,31 @@ describe("RelationTest", () => {
     expect(authorPos).toBeLessThan(tagPos);
   });
 
+  it("joins() preserves order of multiple LeadingJoin nodes", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const publishers = new ArelTable("publishers");
+    const j1 = new Nodes.LeadingJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    const j2 = new Nodes.LeadingJoin(
+      publishers,
+      new Nodes.On(new Nodes.SqlLiteral("books.publisher_id = publishers.id")),
+    );
+    const sqlStr = Book.joins(j1, j2).toSql();
+    const authorPos = sqlStr.indexOf('"authors"');
+    const publisherPos = sqlStr.indexOf('"publishers"');
+    expect(authorPos).toBeGreaterThan(-1);
+    expect(publisherPos).toBeGreaterThan(-1);
+    expect(authorPos).toBeLessThan(publisherPos);
+  });
+
   it("string ORDER BY plain identifier qualifies with table name", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -3,7 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { sql } from "@blazetrails/arel";
+import { sql, Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
 import { Associations, registerModel, modelRegistry } from "./associations.js";
 
@@ -290,6 +290,48 @@ describe("RelationTest", () => {
     expect(sql).toContain("INNER JOIN");
     expect(sql).toContain('"authors"');
     expect(sql).toContain('"books"."author_id"');
+  });
+
+  it("joins() preserves Arel node type — InnerJoin renders as INNER JOIN", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const node = new Nodes.InnerJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    const sql = Book.joins(node).toSql();
+    expect(sql).toContain("INNER JOIN");
+    expect(sql).toContain("authors");
+  });
+
+  it("joins() routes LeadingJoin nodes before other join sources", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const tags = new ArelTable("tags");
+    const leadingJoin = new Nodes.LeadingJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    const innerJoin = new Nodes.InnerJoin(
+      tags,
+      new Nodes.On(new Nodes.SqlLiteral("books.tag_id = tags.id")),
+    );
+    const sqlStr = Book.joins(innerJoin, leadingJoin).toSql();
+    const authorPos = sqlStr.indexOf('"authors"');
+    const tagPos = sqlStr.indexOf('"tags"');
+    expect(authorPos).toBeGreaterThan(-1);
+    expect(tagPos).toBeGreaterThan(-1);
+    expect(authorPos).toBeLessThan(tagPos);
   });
 
   it("string ORDER BY plain identifier qualifies with table name", () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -292,7 +292,7 @@ describe("RelationTest", () => {
     expect(sql).toContain('"books"."author_id"');
   });
 
-  it("joins() preserves Arel node type — InnerJoin renders as INNER JOIN", () => {
+  it("joins() preserves Arel node type — InnerJoin stays InnerJoin in _joinValues, not StringJoin", () => {
     class Book extends Base {
       static {
         this.tableName = "books";
@@ -304,9 +304,13 @@ describe("RelationTest", () => {
       authors,
       new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
     );
-    const sql = Book.joins(node).toSql();
-    expect(sql).toContain("INNER JOIN");
-    expect(sql).toContain("authors");
+    const relation = Book.joins(node);
+    const joinValues = (relation as any)._joinValues as unknown[];
+    expect(relation.toSql()).toContain("INNER JOIN");
+    expect(relation.toSql()).toContain("authors");
+    expect(joinValues).toHaveLength(1);
+    expect(joinValues[0]).toBeInstanceOf(Nodes.InnerJoin);
+    expect(joinValues[0]).not.toBeInstanceOf(Nodes.StringJoin);
   });
 
   it("joins() routes LeadingJoin nodes before other join sources", () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -359,6 +359,26 @@ describe("RelationTest", () => {
     expect(authorPos).toBeLessThan(publisherPos);
   });
 
+  it("joins() preserves insertion order when mixing Arel nodes and string joins", () => {
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const arelJoin = new Nodes.InnerJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    const sqlStr = Book.joins(arelJoin, 'JOIN "tags" ON "books"."tag_id" = "tags"."id"').toSql();
+    const authorPos = sqlStr.indexOf('"authors"');
+    const tagPos = sqlStr.indexOf('"tags"');
+    expect(authorPos).toBeGreaterThan(-1);
+    expect(tagPos).toBeGreaterThan(-1);
+    expect(authorPos).toBeLessThan(tagPos);
+  });
+
   it("string ORDER BY plain identifier qualifies with table name", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -313,7 +313,11 @@ describe("RelationTest", () => {
     expect(joinValues[0]).not.toBeInstanceOf(Nodes.StringJoin);
   });
 
-  it("joins() routes LeadingJoin nodes before other join sources", () => {
+  it("joins() preserves insertion order across LeadingJoin and InnerJoin", () => {
+    // Rails build_join_buckets: without stashed_eager_load or stashed_left_joins,
+    // ALL Arel join nodes go to the leading_join bucket in original insertion order.
+    // There is no forced reordering of LeadingJoin before InnerJoin — the caller
+    // controls order by argument position (query_methods.rb:1856–1863).
     class Book extends Base {
       static {
         this.tableName = "books";
@@ -330,7 +334,8 @@ describe("RelationTest", () => {
       tags,
       new Nodes.On(new Nodes.SqlLiteral("books.tag_id = tags.id")),
     );
-    const sqlStr = Book.joins(innerJoin, leadingJoin).toSql();
+    // leadingJoin passed first → authors appears first in SQL
+    const sqlStr = Book.joins(leadingJoin, innerJoin).toSql();
     const authorPos = sqlStr.indexOf('"authors"');
     const tagPos = sqlStr.indexOf('"tags"');
     expect(authorPos).toBeGreaterThan(-1);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -314,10 +314,6 @@ describe("RelationTest", () => {
   });
 
   it("joins() preserves insertion order across LeadingJoin and InnerJoin", () => {
-    // Rails build_join_buckets: without stashed_eager_load or stashed_left_joins,
-    // ALL Arel join nodes go to the leading_join bucket in original insertion order.
-    // There is no forced reordering of LeadingJoin before InnerJoin — the caller
-    // controls order by argument position (query_methods.rb:1856–1863).
     class Book extends Base {
       static {
         this.tableName = "books";
@@ -336,6 +332,36 @@ describe("RelationTest", () => {
     );
     // leadingJoin passed first → authors appears first in SQL
     const sqlStr = Book.joins(leadingJoin, innerJoin).toSql();
+    const authorPos = sqlStr.indexOf('"authors"');
+    const tagPos = sqlStr.indexOf('"tags"');
+    expect(authorPos).toBeGreaterThan(-1);
+    expect(tagPos).toBeGreaterThan(-1);
+    expect(authorPos).toBeLessThan(tagPos);
+  });
+
+  it("joins() places LeadingJoin ahead of InnerJoin even when passed later", () => {
+    // Rails build_join_buckets routes LeadingJoin → leading_join bucket (prepended)
+    // and non-LeadingJoin → join_node bucket (appended), regardless of argument
+    // order. This matters for eager-loading where join_sources is non-empty
+    // (query_methods.rb:1856-1863, build_joins:1891-1899).
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const tags = new ArelTable("tags");
+    const innerJoin = new Nodes.InnerJoin(
+      tags,
+      new Nodes.On(new Nodes.SqlLiteral("books.tag_id = tags.id")),
+    );
+    const leadingJoin = new Nodes.LeadingJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    // leadingJoin passed second — should still appear before innerJoin in SQL
+    const sqlStr = Book.joins(innerJoin, leadingJoin).toSql();
     const authorPos = sqlStr.indexOf('"authors"');
     const tagPos = sqlStr.indexOf('"tags"');
     expect(authorPos).toBeGreaterThan(-1);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1918,10 +1918,11 @@ export class Relation<T extends Base> {
     if (this._referencesValues.length === 0) return false;
     if (this._includesAssociations.length === 0) return false;
 
-    // _joinValues holds strings and Arel join nodes in insertion order (mirrors
-    // Rails' joins_values). Rails' references_eager_loaded_tables? extracts table
-    // names from StringJoin nodes via tables_in_string; for Arel nodes we call
-    // toSql() and run the same extraction.
+    // Rails references_eager_loaded_tables? (relation.rb) calls build_joins([]) and
+    // iterates the returned nodes: StringJoin → tables_in_string(join.left),
+    // other joins → join.left.name. Mirror that: strings become StringJoin and we
+    // extract via tablesInString; Arel nodes expose their table via left.name when
+    // available (InnerJoin/OuterJoin/LeadingJoin all have left: Table).
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
       ...this._joinValues.flatMap((v) => {
@@ -1930,6 +1931,12 @@ export class Relation<T extends Base> {
           const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : v;
           return this.tablesInString(sqlText);
         }
+        if (v instanceof Nodes.StringJoin) {
+          const sqlText = v.left instanceof Nodes.SqlLiteral ? v.left.value : v.toSql();
+          return this.tablesInString(sqlText);
+        }
+        const leftName = (v.left as any)?.name;
+        if (typeof leftName === "string") return [leftName.toLowerCase()];
         return this.tablesInString(v.toSql());
       }),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1211,7 +1211,7 @@ export class Relation<T extends Base> {
     const flatArgs = args.flatMap((a) => (Array.isArray(a) ? a : [a]));
     for (const arg of flatArgs) {
       if (!arg) continue;
-      // Arel join node (InnerJoin / OuterJoin / StringJoin etc. from joinSources).
+      // Arel join node — stored as-is to preserve type (mirrors Rails joins_values).
       if (arg instanceof Nodes.Join) {
         rel._joinValues.push(arg);
         continue;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -236,8 +236,7 @@ export class Relation<T extends Base> {
     on: string;
     quoted?: boolean;
   }> = [];
-  private _rawJoins: string[] = [];
-  private _arelJoins: Nodes.Join[] = [];
+  private _joinValues: (string | Nodes.Join)[] = [];
   private _includesAssociations: AssociationSpec[] = [];
   private _preloadAssociations: AssociationSpec[] = [];
   private _eagerLoadAssociations: AssociationSpec[] = [];
@@ -1214,7 +1213,7 @@ export class Relation<T extends Base> {
       if (!arg) continue;
       // Arel join node (InnerJoin / OuterJoin / StringJoin etc. from joinSources).
       if (arg instanceof Nodes.Join) {
-        rel._arelJoins.push(arg);
+        rel._joinValues.push(arg);
         continue;
       }
       const resolved = rel._resolveAssociationJoin(arg);
@@ -1224,7 +1223,7 @@ export class Relation<T extends Base> {
           rel._joinClauses.push({ type: "inner", table: j.table, on: j.on, quoted: true });
         }
       } else {
-        rel._rawJoins.push(arg);
+        rel._joinValues.push(arg);
       }
     }
     return rel;
@@ -1919,18 +1918,20 @@ export class Relation<T extends Base> {
     if (this._referencesValues.length === 0) return false;
     if (this._includesAssociations.length === 0) return false;
 
-    // _rawJoins are the string-form equivalent of Rails' Arel::Nodes::StringJoin.
-    // Rails' references_eager_loaded_tables? extracts table names from StringJoin
-    // nodes via tables_in_string; mirror that by passing each raw SQL string
-    // directly to tablesInString (wrapping as StringJoin for type-level parity).
+    // _joinValues holds strings and Arel join nodes in insertion order (mirrors
+    // Rails' joins_values). Rails' references_eager_loaded_tables? extracts table
+    // names from StringJoin nodes via tables_in_string; for Arel nodes we call
+    // toSql() and run the same extraction.
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
-      ...this._rawJoins.flatMap((s) => {
-        const join = new Nodes.StringJoin(new Nodes.SqlLiteral(s));
-        const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : s;
-        return this.tablesInString(sqlText);
+      ...this._joinValues.flatMap((v) => {
+        if (typeof v === "string") {
+          const join = new Nodes.StringJoin(new Nodes.SqlLiteral(v));
+          const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : v;
+          return this.tablesInString(sqlText);
+        }
+        return this.tablesInString(v.toSql());
       }),
-      ...this._arelJoins.flatMap((node) => this.tablesInString(node.toSql())),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
     ]);
 
@@ -2318,23 +2319,24 @@ export class Relation<T extends Base> {
         manager.outerJoin(tableNode, onNode);
       }
     }
-    for (const rawJoin of this._rawJoins) {
-      manager.appendStringJoin(rawJoin);
-    }
-    // Rails build_join_buckets: LeadingJoin nodes are prepended to join_sources
-    // before alias tracking; other Arel join nodes are appended after.
-    const leadingJoins: Nodes.Join[] = [];
-    const otherArelJoins: Nodes.Join[] = [];
-    for (const node of this._arelJoins) {
-      if (node instanceof Nodes.LeadingJoin) {
-        leadingJoins.push(node);
-      } else {
-        otherArelJoins.push(node);
-      }
+    // build_join_buckets routes LeadingJoin to the leading_join bucket, which is
+    // inserted at the front of join_sources before alias-tracker-generated joins,
+    // while everything else goes to the string-join or join_node buckets after it.
+    // We mirror that by collecting LeadingJoins separately, prepending them to the
+    // manager's existing join sources, and then appending the remaining joins in
+    // their original relative order.
+    const leadingJoins: Nodes.LeadingJoin[] = [];
+    for (const v of this._joinValues) {
+      if (v instanceof Nodes.LeadingJoin) leadingJoins.push(v);
     }
     if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);
-    for (const node of otherArelJoins) {
-      manager.appendJoinNode(node);
+    for (const v of this._joinValues) {
+      if (v instanceof Nodes.LeadingJoin) continue;
+      if (typeof v === "string") {
+        manager.appendStringJoin(v);
+      } else {
+        manager.appendJoinNode(v);
+      }
     }
   }
 
@@ -3931,8 +3933,7 @@ export class Relation<T extends Base> {
       this._groupColumns.length === 0 &&
       this._havingClause.isEmpty() &&
       this._joinClauses.length === 0 &&
-      this._rawJoins.length === 0 &&
-      this._arelJoins.length === 0 &&
+      this._joinValues.length === 0 &&
       this._includesAssociations.length === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._preloadAssociations.length === 0 &&
@@ -4187,8 +4188,7 @@ export class Relation<T extends Base> {
     this._lockValue = source._lockValue;
     this._setOperation = source._setOperation;
     this._joinClauses = [...source._joinClauses];
-    this._rawJoins = [...source._rawJoins];
-    this._arelJoins = [...source._arelJoins];
+    this._joinValues = [...source._joinValues];
     this._includesAssociations = [...source._includesAssociations];
     this._preloadAssociations = [...source._preloadAssociations];
     this._eagerLoadAssociations = [...source._eagerLoadAssociations];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2310,6 +2310,16 @@ export class Relation<T extends Base> {
   // interface merge + prototype assignment (see bottom of file)
 
   private _applyJoinsToManager(manager: SelectManager): void {
+    // Mirror Rails build_join_buckets + build_joins (query_methods.rb):
+    // All explicit Arel join nodes and raw SQL strings from _joinValues are first
+    // converted to Join nodes and placed in the leading_join bucket (since we have
+    // no stashed_eager_load or stashed_left_joins). leading_joins are placed in
+    // join_sources before _joinClauses (named-association joins), matching Rails'
+    // `join_sources.concat(leading_joins)` before alias-tracker-generated joins.
+    const leadingJoins: Nodes.Join[] = this._joinValues.map((v) =>
+      typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v,
+    );
+    if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);
     for (const join of this._joinClauses) {
       const tableNode = join.quoted ? new Table(join.table) : join.table;
       const onNode = new Nodes.SqlLiteral(join.on);
@@ -2317,25 +2327,6 @@ export class Relation<T extends Base> {
         manager.join(tableNode, onNode);
       } else {
         manager.outerJoin(tableNode, onNode);
-      }
-    }
-    // build_join_buckets routes LeadingJoin to the leading_join bucket, which is
-    // inserted at the front of join_sources before alias-tracker-generated joins,
-    // while everything else goes to the string-join or join_node buckets after it.
-    // We mirror that by collecting LeadingJoins separately, prepending them to the
-    // manager's existing join sources, and then appending the remaining joins in
-    // their original relative order.
-    const leadingJoins: Nodes.LeadingJoin[] = [];
-    for (const v of this._joinValues) {
-      if (v instanceof Nodes.LeadingJoin) leadingJoins.push(v);
-    }
-    if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);
-    for (const v of this._joinValues) {
-      if (v instanceof Nodes.LeadingJoin) continue;
-      if (typeof v === "string") {
-        manager.appendStringJoin(v);
-      } else {
-        manager.appendJoinNode(v);
       }
     }
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -237,6 +237,7 @@ export class Relation<T extends Base> {
     quoted?: boolean;
   }> = [];
   private _rawJoins: string[] = [];
+  private _arelJoins: Nodes.Join[] = [];
   private _includesAssociations: AssociationSpec[] = [];
   private _preloadAssociations: AssociationSpec[] = [];
   private _eagerLoadAssociations: AssociationSpec[] = [];
@@ -1213,7 +1214,7 @@ export class Relation<T extends Base> {
       if (!arg) continue;
       // Arel join node (InnerJoin / OuterJoin / StringJoin etc. from joinSources).
       if (arg instanceof Nodes.Join) {
-        rel._rawJoins.push(arg.toSql());
+        rel._arelJoins.push(arg);
         continue;
       }
       const resolved = rel._resolveAssociationJoin(arg);
@@ -1925,12 +1926,11 @@ export class Relation<T extends Base> {
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
       ...this._rawJoins.flatMap((s) => {
-        // Wrap as StringJoin (Rails' Arel::Nodes::StringJoin equivalent) and
-        // read back via instanceof to stay type-safe with no unsafe cast.
         const join = new Nodes.StringJoin(new Nodes.SqlLiteral(s));
         const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : s;
         return this.tablesInString(sqlText);
       }),
+      ...this._arelJoins.flatMap((node) => this.tablesInString(node.toSql())),
       String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
     ]);
 
@@ -2320,6 +2320,23 @@ export class Relation<T extends Base> {
     }
     for (const rawJoin of this._rawJoins) {
       manager.appendStringJoin(rawJoin);
+    }
+    // Rails build_join_buckets: LeadingJoin nodes are prepended to join_sources
+    // before alias tracking; other Arel join nodes are appended after.
+    const leadingJoins: Nodes.Join[] = [];
+    const otherArelJoins: Nodes.Join[] = [];
+    for (const node of this._arelJoins) {
+      if (node instanceof Nodes.LeadingJoin) {
+        leadingJoins.push(node);
+      } else {
+        otherArelJoins.push(node);
+      }
+    }
+    for (const node of leadingJoins) {
+      manager.prependJoinNode(node);
+    }
+    for (const node of otherArelJoins) {
+      manager.appendJoinNode(node);
     }
   }
 
@@ -3917,6 +3934,7 @@ export class Relation<T extends Base> {
       this._havingClause.isEmpty() &&
       this._joinClauses.length === 0 &&
       this._rawJoins.length === 0 &&
+      this._arelJoins.length === 0 &&
       this._includesAssociations.length === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._preloadAssociations.length === 0 &&
@@ -4172,6 +4190,7 @@ export class Relation<T extends Base> {
     this._setOperation = source._setOperation;
     this._joinClauses = [...source._joinClauses];
     this._rawJoins = [...source._rawJoins];
+    this._arelJoins = [...source._arelJoins];
     this._includesAssociations = [...source._includesAssociations];
     this._preloadAssociations = [...source._preloadAssociations];
     this._eagerLoadAssociations = [...source._eagerLoadAssociations];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2317,15 +2317,24 @@ export class Relation<T extends Base> {
   // interface merge + prototype assignment (see bottom of file)
 
   private _applyJoinsToManager(manager: SelectManager): void {
-    // Mirror Rails build_join_buckets + build_joins (query_methods.rb):
-    // All explicit Arel join nodes and raw SQL strings from _joinValues are first
-    // converted to Join nodes and placed in the leading_join bucket (since we have
-    // no stashed_eager_load or stashed_left_joins). leading_joins are placed in
-    // join_sources before _joinClauses (named-association joins), matching Rails'
-    // `join_sources.concat(leading_joins)` before alias-tracker-generated joins.
-    const leadingJoins: Nodes.Join[] = this._joinValues.map((v) =>
-      typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v,
-    );
+    // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
+    // LeadingJoin nodes go to the leading_join bucket (prepended before any
+    // existing join_sources, including eager-load JoinDependency joins added by
+    // _buildEagerJoinManager). All other nodes — including StringJoin from raw SQL
+    // strings — go to the join_node bucket (appended after existing join_sources).
+    // This matches the stashed_eager_load / stashed_left_joins routing condition:
+    // `!LeadingJoin && (stashed_eager_load || stashed_left_joins) → join_node`.
+    const leadingJoins: Nodes.Join[] = [];
+    const joinNodes: Nodes.Join[] = [];
+    for (const v of this._joinValues) {
+      const node: Nodes.Join =
+        typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;
+      if (node instanceof Nodes.LeadingJoin) {
+        leadingJoins.push(node);
+      } else {
+        joinNodes.push(node);
+      }
+    }
     if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);
     for (const join of this._joinClauses) {
       const tableNode = join.quoted ? new Table(join.table) : join.table;
@@ -2336,6 +2345,7 @@ export class Relation<T extends Base> {
         manager.outerJoin(tableNode, onNode);
       }
     }
+    for (const node of joinNodes) manager.appendJoinNode(node);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2332,9 +2332,7 @@ export class Relation<T extends Base> {
         otherArelJoins.push(node);
       }
     }
-    for (const node of leadingJoins) {
-      manager.prependJoinNode(node);
-    }
+    if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);
     for (const node of otherArelJoins) {
       manager.appendJoinNode(node);
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1212,8 +1212,10 @@ export class Relation<T extends Base> {
     for (const arg of flatArgs) {
       if (!arg) continue;
       // Arel join node — stored as-is to preserve type (mirrors Rails joins_values).
+      // Rails joins! uses |= (array union), deduplicating by object identity for
+      // nodes and string equality for strings. JS === matches both behaviours.
       if (arg instanceof Nodes.Join) {
-        rel._joinValues.push(arg);
+        if (!rel._joinValues.includes(arg)) rel._joinValues.push(arg);
         continue;
       }
       const resolved = rel._resolveAssociationJoin(arg);
@@ -1223,7 +1225,7 @@ export class Relation<T extends Base> {
           rel._joinClauses.push({ type: "inner", table: j.table, on: j.on, quoted: true });
         }
       } else {
-        rel._joinValues.push(arg);
+        if (!rel._joinValues.includes(arg)) rel._joinValues.push(arg);
       }
     }
     return rel;

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -73,7 +73,7 @@ export class Merger {
     const clauses: Array<{ type: string; table: string; on: string; quoted?: boolean }> =
       this.other._joinClauses ?? [];
     if (clauses.length > 0) rel._joinClauses.push(...clauses);
-    if (this.other._rawJoins?.length > 0) rel._rawJoins.push(...this.other._rawJoins);
+    if (this.other._joinValues?.length > 0) rel._joinValues.push(...this.other._joinValues);
     void Nodes.InnerJoin;
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -114,6 +114,7 @@ interface QueryMethodsHost {
   _lockValue: string | null;
   _joinClauses: Array<{ type: "inner" | "left"; table: string; on: string; quoted?: boolean }>;
   _rawJoins: string[];
+  _arelJoins: Nodes.Join[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
   _eagerLoadAssociations: AssociationSpec[];
@@ -584,6 +585,7 @@ function unscopeBang(
         case "joins":
           this._joinClauses = [];
           this._rawJoins = [];
+          this._arelJoins = [];
           break;
         case "leftOuterJoins":
           this._joinClauses = this._joinClauses.filter((j) => j.type !== "left");
@@ -811,6 +813,7 @@ const STRUCTURAL_FIELDS: ReadonlyArray<[string, keyof QueryMethodsHost]> = [
   ["rawOrder", "_rawOrderClauses"],
   ["joins", "_joinClauses"],
   ["rawJoins", "_rawJoins"],
+  ["arelJoins", "_arelJoins"],
   ["limit", "_limitValue"],
   ["offset", "_offsetValue"],
   ["lock", "_lockValue"],

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1958,18 +1958,23 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
     join_node: [],
   };
 
-  // _joinValues holds strings and Arel nodes in insertion order (mirrors Rails'
-  // joins_values). Route LeadingJoin to leading_join (prepended before
-  // alias-tracker-generated joins in build_joins) and everything else to
-  // join_node. String values are wrapped as StringJoin per Rails' bucket logic.
-  for (const v of this._joinValues) {
-    if (v instanceof Nodes.LeadingJoin) {
-      buckets.leading_join.push(v);
-    } else if (typeof v === "string") {
-      buckets.join_node.push(new Nodes.StringJoin(arelSql(v) as any));
-    } else {
-      buckets.join_node.push(v);
-    }
+  // Mirror Rails build_join_buckets (query_methods.rb):
+  // 1. Convert strings to StringJoin (joins[i] = StringJoin.new(sql(join.strip)) if String).
+  // 2. While the front of the list is a Join node, shift and route:
+  //    - non-LeadingJoin AND (stashed_eager_load || stashed_left_joins) → join_node
+  //    - everything else (LeadingJoin, or any Join when no stashed joins) → leading_join
+  // We don't yet have stashed_eager_load/stashed_left_joins, so all explicit
+  // Arel join nodes unconditionally go to leading_join per Rails' else branch.
+  const joins: Nodes.Join[] = this._joinValues.map((v) =>
+    typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v,
+  );
+
+  while (joins.length > 0 && joins[0] instanceof Nodes.Join) {
+    const node = joins.shift()!;
+    // Without stashed_eager_load or stashed_left_joins the condition
+    // `!LeadingJoin && (stashed_eager_load || stashed_left_joins)` is always
+    // false, so every node goes to leading_join (Rails' else branch).
+    buckets.leading_join.push(node);
   }
 
   return buckets;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -640,7 +640,7 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
   return this;
 }
 
-function leftOuterJoinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
+function leftOuterJoinsBang(this: QueryMethodsHost, ...args: string[]): any {
   for (const arg of args) {
     this._joinValues.push(arg);
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1959,18 +1959,10 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
     join_node: [],
   };
 
-  // Mirror Rails build_join_buckets (query_methods.rb):
-  // 1. Convert strings to StringJoin (joins[i] = StringJoin.new(sql(join.strip)) if String).
-  // 2. While the front of the list is a Join node, shift and route:
-  //    - non-LeadingJoin AND (stashed_eager_load || stashed_left_joins) → join_node
-  //    - everything else (LeadingJoin, or any Join when no stashed joins) → leading_join
-  // We don't yet have stashed_eager_load/stashed_left_joins, so all explicit
-  // Arel join nodes unconditionally go to leading_join per Rails' else branch.
   // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
-  // strings → StringJoin; LeadingJoin → leading_join bucket (placed first in
-  // join_sources); all other Arel join nodes → join_node bucket (placed after
-  // named/stashed joins). This matches the stashed-joins condition and also
-  // correctly handles the eager-load case where join_sources is non-empty.
+  // 1. Convert string joins to StringJoin nodes.
+  // 2. Route LeadingJoin nodes to leading_join so they appear first in join_sources.
+  // 3. Route all other explicit Arel join nodes to join_node.
   for (const v of this._joinValues) {
     const node: Nodes.Join =
       typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1958,18 +1958,25 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
     join_node: [],
   };
 
-  // Convert raw SQL joins to StringJoin nodes.
-  // _joinClauses (already-resolved SQL joins) are handled directly by
-  // buildJoins via manager.join()/outerJoin() and don't go through buckets.
-  for (const raw of this._rawJoins) {
-    buckets.join_node.push(new Nodes.StringJoin(arelSql(raw) as any));
+  // _joinValues holds strings and Arel nodes in insertion order (mirrors Rails'
+  // joins_values). Route LeadingJoin to leading_join (prepended before
+  // alias-tracker-generated joins in build_joins) and everything else to
+  // join_node. String values are wrapped as StringJoin per Rails' bucket logic.
+  for (const v of this._joinValues) {
+    if (v instanceof Nodes.LeadingJoin) {
+      buckets.leading_join.push(v);
+    } else if (typeof v === "string") {
+      buckets.join_node.push(new Nodes.StringJoin(arelSql(v) as any));
+    } else {
+      buckets.join_node.push(v);
+    }
   }
 
   return buckets;
 }
 
 function buildJoins(this: QueryMethodsHost, arel: any): void {
-  if (this._joinClauses.length === 0 && this._rawJoins.length === 0) return;
+  if (this._joinClauses.length === 0 && this._joinValues.length === 0) return;
 
   const buckets = buildJoinBuckets.call(this);
   const leadingJoins = buckets.leading_join as unknown[];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -640,7 +640,7 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
   return this;
 }
 
-function leftOuterJoinsBang(this: QueryMethodsHost, ...args: string[]): any {
+function leftOuterJoinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
   for (const arg of args) {
     this._joinValues.push(arg);
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -113,8 +113,7 @@ interface QueryMethodsHost {
   _isNone: boolean;
   _lockValue: string | null;
   _joinClauses: Array<{ type: "inner" | "left"; table: string; on: string; quoted?: boolean }>;
-  _rawJoins: string[];
-  _arelJoins: Nodes.Join[];
+  _joinValues: (string | Nodes.Join)[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
   _eagerLoadAssociations: AssociationSpec[];
@@ -584,8 +583,7 @@ function unscopeBang(
           break;
         case "joins":
           this._joinClauses = [];
-          this._rawJoins = [];
-          this._arelJoins = [];
+          this._joinValues = [];
           break;
         case "leftOuterJoins":
           this._joinClauses = this._joinClauses.filter((j) => j.type !== "left");
@@ -635,16 +633,16 @@ function unscopeBang(
   return this;
 }
 
-function joinsBang(this: QueryMethodsHost, ...args: string[]): any {
+function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
   for (const arg of args) {
-    this._rawJoins.push(arg);
+    this._joinValues.push(arg);
   }
   return this;
 }
 
 function leftOuterJoinsBang(this: QueryMethodsHost, ...args: string[]): any {
   for (const arg of args) {
-    this._rawJoins.push(arg);
+    this._joinValues.push(arg);
   }
   return this;
 }
@@ -812,8 +810,7 @@ const STRUCTURAL_FIELDS: ReadonlyArray<[string, keyof QueryMethodsHost]> = [
   ["order", "_orderClauses"],
   ["rawOrder", "_rawOrderClauses"],
   ["joins", "_joinClauses"],
-  ["rawJoins", "_rawJoins"],
-  ["arelJoins", "_arelJoins"],
+  ["joinValues", "_joinValues"],
   ["limit", "_limitValue"],
   ["offset", "_offsetValue"],
   ["lock", "_lockValue"],

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1966,16 +1966,19 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   //    - everything else (LeadingJoin, or any Join when no stashed joins) → leading_join
   // We don't yet have stashed_eager_load/stashed_left_joins, so all explicit
   // Arel join nodes unconditionally go to leading_join per Rails' else branch.
-  // Rails converts strings to StringJoin first, then while-loops from the front
-  // consuming all Join nodes (in our case, that's everything — _joinValues holds
-  // only strings and Arel nodes, never named-association specs). Without
-  // stashed_eager_load or stashed_left_joins the routing condition
-  // `!LeadingJoin && (stashed_eager_load || stashed_left_joins)` is always false,
-  // so all nodes go to leading_join via the else branch (query_methods.rb:1856–1863).
+  // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
+  // strings → StringJoin; LeadingJoin → leading_join bucket (placed first in
+  // join_sources); all other Arel join nodes → join_node bucket (placed after
+  // named/stashed joins). This matches the stashed-joins condition and also
+  // correctly handles the eager-load case where join_sources is non-empty.
   for (const v of this._joinValues) {
     const node: Nodes.Join =
       typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
-    buckets.leading_join.push(node);
+    if (node instanceof Nodes.LeadingJoin) {
+      buckets.leading_join.push(node);
+    } else {
+      buckets.join_node.push(node);
+    }
   }
 
   return buckets;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -634,8 +634,9 @@ function unscopeBang(
 }
 
 function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
+  // Rails joins! uses |= (array union), deduplicating by equality/identity.
   for (const arg of args) {
-    this._joinValues.push(arg);
+    if (!this._joinValues.includes(arg)) this._joinValues.push(arg);
   }
   return this;
 }
@@ -1965,15 +1966,15 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   //    - everything else (LeadingJoin, or any Join when no stashed joins) → leading_join
   // We don't yet have stashed_eager_load/stashed_left_joins, so all explicit
   // Arel join nodes unconditionally go to leading_join per Rails' else branch.
-  const joins: Nodes.Join[] = this._joinValues.map((v) =>
-    typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v,
-  );
-
-  while (joins.length > 0 && joins[0] instanceof Nodes.Join) {
-    const node = joins.shift()!;
-    // Without stashed_eager_load or stashed_left_joins the condition
-    // `!LeadingJoin && (stashed_eager_load || stashed_left_joins)` is always
-    // false, so every node goes to leading_join (Rails' else branch).
+  // Rails converts strings to StringJoin first, then while-loops from the front
+  // consuming all Join nodes (in our case, that's everything — _joinValues holds
+  // only strings and Arel nodes, never named-association specs). Without
+  // stashed_eager_load or stashed_left_joins the routing condition
+  // `!LeadingJoin && (stashed_eager_load || stashed_left_joins)` is always false,
+  // so all nodes go to leading_join via the else branch (query_methods.rb:1856–1863).
+  for (const v of this._joinValues) {
+    const node: Nodes.Join =
+      typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
     buckets.leading_join.push(node);
   }
 

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -86,7 +86,7 @@ export function mergeBang(this: any, other: any): any {
       ];
     // mergeJoins (preserve original order — all join types in _joinClauses)
     this._joinClauses.push(...(other._joinClauses ?? []));
-    this._rawJoins.push(...(other._rawJoins ?? []));
+    this._joinValues.push(...(other._joinValues ?? []));
     // sticky none
     if (other._isNone) this._isNone = true;
   } else if (typeof other === "object" && other !== null) {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -84,7 +84,7 @@ export function mergeBang(this: any, other: any): any {
         ...(this._eagerLoadAssociations ?? []),
         ...other._eagerLoadAssociations,
       ];
-    // mergeJoins (preserve original order — all join types in _joinClauses)
+    // mergeJoins (preserve original order across both join stores: _joinClauses and _joinValues)
     this._joinClauses.push(...(other._joinClauses ?? []));
     this._joinValues.push(...(other._joinValues ?? []));
     // sticky none

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -595,8 +595,7 @@ export class SelectManager extends TreeManager {
   /**
    * Insert existing Arel join nodes at the front of join_sources, preserving
    * their relative order. Mirrors the leading_join bucket in Rails' build_joins,
-   * which is applied via join_sources.concat(leading_joins) before any
-   * alias-tracker-generated joins are appended.
+   * which places LeadingJoin nodes before any alias-tracker-generated joins.
    */
   prependJoinNodes(...nodes: Join[]): this {
     this.core.source.right.unshift(...nodes);

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -593,6 +593,27 @@ export class SelectManager extends TreeManager {
   }
 
   /**
+   * Prepend an existing Arel join node to join_sources (used for LeadingJoin
+   * nodes that Rails places before alias tracking in build_join_buckets).
+   *
+   * Mirrors: join_sources.concat(leading_joins) in Rails build_joins.
+   */
+  prependJoinNode(node: Join): this {
+    this.core.source.right.unshift(node);
+    return this;
+  }
+
+  /**
+   * Append an existing Arel join node to join_sources.
+   *
+   * Mirrors: join_sources.concat(join_nodes) in Rails build_joins.
+   */
+  appendJoinNode(node: Join): this {
+    this.core.source.right.push(node);
+    return this;
+  }
+
+  /**
    * Factory: create an AND node.
    */
   createAnd(nodes: Node[]): And {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -593,9 +593,10 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * Prepend existing Arel join nodes to join_sources, preserving their order
-   * (mirrors Rails' join_sources.concat(leading_joins) in build_joins, where
-   * leading_joins appear before alias-tracker-generated joins).
+   * Insert existing Arel join nodes at the front of join_sources, preserving
+   * their relative order. Mirrors the leading_join bucket in Rails' build_joins,
+   * which is applied via join_sources.concat(leading_joins) before any
+   * alias-tracker-generated joins are appended.
    */
   prependJoinNodes(...nodes: Join[]): this {
     this.core.source.right.unshift(...nodes);

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -593,13 +593,12 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * Prepend an existing Arel join node to join_sources (used for LeadingJoin
-   * nodes that Rails places before alias tracking in build_join_buckets).
-   *
-   * Mirrors: join_sources.concat(leading_joins) in Rails build_joins.
+   * Prepend existing Arel join nodes to join_sources, preserving their order
+   * (mirrors Rails' join_sources.concat(leading_joins) in build_joins, where
+   * leading_joins appear before alias-tracker-generated joins).
    */
-  prependJoinNode(node: Join): this {
-    this.core.source.right.unshift(node);
+  prependJoinNodes(...nodes: Join[]): this {
+    this.core.source.right.unshift(...nodes);
     return this;
   }
 


### PR DESCRIPTION
Fixes #915.

## What changed

Replaces `_rawJoins: string[]` with `_joinValues: (string | Nodes.Join)[]`, mirroring Rails' `joins_values` which holds strings and Arel nodes in one ordered array. Arel join nodes are stored with their original type intact (no premature `.toSql()`), so `LeadingJoin` can be routed correctly.

**Routing** (`build_join_buckets`, `query_methods.rb:1856–1863`):
- `LeadingJoin` → `leading_join` bucket → prepended to `join_sources` before any existing content (including eager-load `JoinDependency` joins added by `_buildEagerJoinManager`)
- All other nodes (including `StringJoin` from raw strings) → `join_node` bucket → appended after

Both `_applyJoinsToManager` (used by `_toSqlWithoutSetOp` and `_buildEagerJoinManager`) and `buildJoinBuckets` (used by `buildArel`) apply this split.

**Other fixes:**
- `Relation#joins` and `joinsBang` both deduplicate via `includes()`, matching Rails' `joins! |= args` (string equality for strings, object identity for Arel nodes)
- `_joinValues` wired through `_clone`, `unscope`, `STRUCTURAL_FIELDS`, `merger.ts`, `spawn-methods.ts`, `referencesEagerLoadedTables`
- `SelectManager#prependJoinNodes` / `#appendJoinNode` added for direct node insertion
- `referencesEagerLoadedTables` uses `node.left.name` for non-`StringJoin` Arel nodes (mirrors `join.left.name` in Rails `relation.rb:1477`)

**Tests added:** 5 new tests covering type preservation (AST-level), LeadingJoin ordering, multi-LeadingJoin order, mixed Arel+string order, and LeadingJoin-after-InnerJoin reordering.

Rails source: `activerecord/lib/active_record/relation/query_methods.rb:1847–1900`, `relation.rb:1474–1489`.

---

## Deferred

**`buildJoinBuckets` stashed-joins path** — when `stashed_eager_load` / `stashed_left_joins` are implemented, `buildJoinBuckets` will need the full while-loop with the `!LeadingJoin && (stashed || left_stashed)` condition. Current simplified routing is correct for the no-stashed case.