### PR TITLE
test(parity): AR gap fixtures ar-150..ar-154 — 5 more identified gaps

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -30,5 +30,25 @@
   "ar-143": {
     "side": "trails-missing",
     "reason": "leftOuterJoins() crashes on nested hash arguments: trails accepts an object into Relation#leftOuterJoins/leftJoins and later tries to build a LEFT OUTER JOIN with that plain object as the table operand (relation.ts:1230+), raising 'Unknown node type: Object'. Real fix: handle or reject nested-hash/object arguments in Relation#leftOuterJoins/leftJoins before _applyJoinsToManager builds Arel JOIN nodes — for example by reusing the nested-association resolution from joins() or adding early argument validation."
+  },
+  "ar-150": {
+    "side": "diff",
+    "reason": "where(assoc_name: relation) uses the literal key as the column name instead of resolving the FK: where({ author: relation }) produces WHERE \"books\".\"author\" IN (...) instead of WHERE \"books\".\"author_id\" IN (...). Rails resolves the association name to its foreign_key via the belongs_to definition; Trails uses the key directly as a column name. Real fix: the WHERE-condition path must check if the key matches an association name and substitute its foreign_key."
+  },
+  "ar-151": {
+    "side": "diff",
+    "reason": "annotate() comment is appended after ORDER BY instead of before it: Rails emits the /* comment */ between the WHERE clause and ORDER BY (e.g. WHERE ... /* comment */ ORDER BY ...); Trails appends it at the very end after ORDER BY (WHERE ... ORDER BY ... /* comment */). Real fix: the SQL-generation path in Relation#toSql must insert annotate comments before ORDER BY, matching Rails' Arel visitor output order."
+  },
+  "ar-152": {
+    "side": "diff",
+    "reason": "has_many with a default scope does not embed the scope condition in the JOIN ON clause: Rails resolves joins(:published_books) to INNER JOIN \"books\" ON \"books\".\"status\" = 'published' AND \"books\".\"author_id\" = ...; Trails emits only INNER JOIN \"books\" ON \"books\".\"author_id\" = ... (scope condition dropped). Real fix: _resolveAssociationJoin must apply the association's :scope condition to the JOIN ON predicate when building the join for a scoped has_many."
+  },
+  "ar-153": {
+    "side": "trails-missing",
+    "reason": "Table#join(...).on(...).joinSources() crashes: Arel's Table#join returns a SelectManager whose ast.cores is undefined (the join builder path does not populate cores), so calling joinSources() throws TypeError: Cannot read properties of undefined (reading 'cores'). Rails returns a fully-formed join-sources array from the same call. Real fix: Table#join must build a SelectManager with a populated SelectCore so joinSources() can read the join list."
+  },
+  "ar-154": {
+    "side": "trails-missing",
+    "reason": "group() does not accept Arel node arguments: group(new Nodes.NamedFunction(...)) throws TypeError: col.trim is not a function because the group implementation calls .trim() on each argument assuming strings. Rails accepts any Arel::Node in group() and passes it to the GROUP BY clause via the Arel visitor. Real fix: the groupBang implementation must handle Arel node arguments by calling .toSql() (or passing them directly to the Arel manager) instead of treating them as strings."
   }
 }

--- a/scripts/parity/fixtures/ar-150/models.rb
+++ b/scripts/parity/fixtures/ar-150/models.rb
@@ -1,0 +1,4 @@
+class Author < ActiveRecord::Base; end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-150/models.ts
+++ b/scripts/parity/fixtures/ar-150/models.ts
@@ -1,0 +1,14 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-150/query.rb
+++ b/scripts/parity/fixtures/ar-150/query.rb
@@ -1,0 +1,1 @@
+Book.where(author: Author.where("authors.active = 1")).order(:id)

--- a/scripts/parity/fixtures/ar-150/query.ts
+++ b/scripts/parity/fixtures/ar-150/query.ts
@@ -1,0 +1,2 @@
+import { Author, Book } from "./models.js";
+export default Book.where({ author: Author.where("authors.active = 1") }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-150/schema.sql
+++ b/scripts/parity/fixtures/ar-150/schema.sql
@@ -1,0 +1,5 @@
+-- Fixture for statement: ar-150
+-- Query: Book.where(author: Author.where("authors.active = 1")).order(:id)
+
+CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1);
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES authors(id));

--- a/scripts/parity/fixtures/ar-151/models.rb
+++ b/scripts/parity/fixtures/ar-151/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-151/models.ts
+++ b/scripts/parity/fixtures/ar-151/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-151/query.rb
+++ b/scripts/parity/fixtures/ar-151/query.rb
@@ -1,0 +1,1 @@
+Book.annotate("finding active books").optimizer_hints("SeqScan(books)").where(active: true).order(:id)

--- a/scripts/parity/fixtures/ar-151/query.ts
+++ b/scripts/parity/fixtures/ar-151/query.ts
@@ -1,0 +1,6 @@
+import { Book } from "./models.js";
+export default Book.all()
+  .annotate("finding active books")
+  .optimizerHints("SeqScan(books)")
+  .where({ active: true })
+  .order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-151/schema.sql
+++ b/scripts/parity/fixtures/ar-151/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-151
+-- Query: Book.annotate("finding active books").optimizer_hints("SeqScan(books)").where(active: true).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1);

--- a/scripts/parity/fixtures/ar-152/models.rb
+++ b/scripts/parity/fixtures/ar-152/models.rb
@@ -1,0 +1,7 @@
+class Author < ActiveRecord::Base
+  has_many :books
+  has_many :published_books, -> { where(status: "published") }, class_name: "Book"
+end
+class Book < ActiveRecord::Base
+  belongs_to :author
+end

--- a/scripts/parity/fixtures/ar-152/models.ts
+++ b/scripts/parity/fixtures/ar-152/models.ts
@@ -1,0 +1,21 @@
+import { Base, Relation, registerModel } from "@blazetrails/activerecord";
+
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    this.hasMany("books");
+    this.hasMany("publishedBooks", {
+      className: "Book",
+      scope: (rel: Relation<any>) => rel.where({ status: "published" }),
+    });
+    registerModel(this);
+  }
+}
+
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    this.belongsTo("author");
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-152/query.rb
+++ b/scripts/parity/fixtures/ar-152/query.rb
@@ -1,0 +1,1 @@
+Author.joins(:published_books).where("published_books.title LIKE ?", "%Rails%").select("authors.*, COUNT(published_books.id) AS book_count").group("authors.id")

--- a/scripts/parity/fixtures/ar-152/query.ts
+++ b/scripts/parity/fixtures/ar-152/query.ts
@@ -1,0 +1,5 @@
+import { Author } from "./models.js";
+export default Author.joins("publishedBooks")
+  .where("published_books.title LIKE ?", "%Rails%")
+  .select("authors.*, COUNT(published_books.id) AS book_count")
+  .group("authors.id");

--- a/scripts/parity/fixtures/ar-152/schema.sql
+++ b/scripts/parity/fixtures/ar-152/schema.sql
@@ -1,0 +1,5 @@
+-- Fixture for statement: ar-152
+-- Query: Author.joins(:published_books).where("published_books.title LIKE ?", "%Rails%").select("authors.*, COUNT(published_books.id) AS book_count").group("authors.id")
+
+CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES authors(id), status TEXT NOT NULL DEFAULT 'draft');

--- a/scripts/parity/fixtures/ar-153/models.rb
+++ b/scripts/parity/fixtures/ar-153/models.rb
@@ -1,0 +1,2 @@
+class Author < ActiveRecord::Base; end
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-153/models.ts
+++ b/scripts/parity/fixtures/ar-153/models.ts
@@ -1,0 +1,13 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Author extends Base {
+  static {
+    this.tableName = "authors";
+    registerModel(this);
+  }
+}
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-153/query.rb
+++ b/scripts/parity/fixtures/ar-153/query.rb
@@ -1,0 +1,1 @@
+Book.joins(Book.arel_table.join(Author.arel_table).on(Book.arel_table[:author_id].eq(Author.arel_table[:id]).and(Author.arel_table[:active].eq(1))).join_sources).select("books.*, authors.name AS author_name")

--- a/scripts/parity/fixtures/ar-153/query.ts
+++ b/scripts/parity/fixtures/ar-153/query.ts
@@ -1,0 +1,11 @@
+import { Author, Book } from "./models.js";
+const joinSrc = Book.arelTable
+  .join(Author.arelTable)
+  .on(
+    Book.arelTable
+      .get("author_id")
+      .eq(Author.arelTable.get("id"))
+      .and(Author.arelTable.get("active").eq(1)),
+  )
+  .joinSources();
+export default Book.joins(...joinSrc).select("books.*, authors.name AS author_name");

--- a/scripts/parity/fixtures/ar-153/schema.sql
+++ b/scripts/parity/fixtures/ar-153/schema.sql
@@ -1,0 +1,5 @@
+-- Fixture for statement: ar-153
+-- Query: Book.joins(Book.arel_table.join(Author.arel_table).on(Book.arel_table[:author_id].eq(Author.arel_table[:id]).and(Author.arel_table[:active].eq(1))).join_sources).select("books.*, authors.name AS author_name")
+
+CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1);
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES authors(id));

--- a/scripts/parity/fixtures/ar-154/models.rb
+++ b/scripts/parity/fixtures/ar-154/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-154/models.ts
+++ b/scripts/parity/fixtures/ar-154/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-154/query.rb
+++ b/scripts/parity/fixtures/ar-154/query.rb
@@ -1,0 +1,1 @@
+Book.group(Arel::Nodes::NamedFunction.new("LENGTH", [Book.arel_table[:title]])).select("LENGTH(title) AS title_length, COUNT(*) AS cnt").order("title_length")

--- a/scripts/parity/fixtures/ar-154/query.ts
+++ b/scripts/parity/fixtures/ar-154/query.ts
@@ -1,0 +1,5 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.group(new Nodes.NamedFunction("LENGTH", [Book.arelTable.get("title")]))
+  .select("LENGTH(title) AS title_length, COUNT(*) AS cnt")
+  .order("title_length");

--- a/scripts/parity/fixtures/ar-154/schema.sql
+++ b/scripts/parity/fixtures/ar-154/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-154
+-- Query: Book.group(Arel::Nodes::NamedFunction.new("LENGTH", [Book.arel_table[:title]])).select("LENGTH(title) AS title_length, COUNT(*) AS cnt").order("title_length")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL);


### PR DESCRIPTION
## Summary

Adds 5 fixtures surfacing concrete Trails implementation gaps, each with a precise fix location.

| Fixture | Gap | Fix location |
|---------|-----|-------------|
| **ar-150** | `where(author: relation)` uses raw key `author` as column instead of FK `author_id` | WHERE-condition path needs to check belongs_to FK |
| **ar-151** | `annotate()` comment appended after ORDER BY; Rails emits it before ORDER BY | `Relation#toSql` comment-insertion order |
| **ar-152** | Scoped `has_many` scope condition dropped from JOIN ON | `_resolveAssociationJoin` must apply `:scope` to ON predicate |
| **ar-153** | `Table#join().on().joinSources()` crashes — `ast.cores` undefined | `Table#join` must populate `SelectCore` |
| **ar-154** | `group(ArelNode)` crashes — `col.trim is not a function` | `groupBang` must handle Arel node arguments |

## Test plan
- [ ] `pnpm parity:query` — all 5 show as KNOWN-GAP, no FAIL