### PR TITLE
feat(temporal): PR 3b — virtualizer emits Temporal types for date/time columns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist
 build
+**/type-virtualization/fixtures/**/expected.ts
 node_modules
 .svelte-kit
 *.svelte

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -177,6 +177,20 @@ class Article extends Base {
   }
 }
 
+// --- Temporal attribute typing ---
+import { Temporal } from "@blazetrails/activesupport/temporal";
+class Event extends Base {
+  declare starts_at: Temporal.Instant | Temporal.PlainDateTime;
+  declare starts_on: Temporal.PlainDate;
+  declare duration: Temporal.PlainTime;
+
+  static {
+    this.attribute("starts_at", "datetime");
+    this.attribute("starts_on", "date");
+    this.attribute("duration", "time");
+  }
+}
+
 // --- big_integer attribute typing ---
 class BigRecord extends Base {
   declare score: bigint;
@@ -287,5 +301,12 @@ describe("declare patterns — typing runtime-attached members", () => {
     // they don't exist on the class type. Assert that:
     type HasActive = "active" extends keyof typeof Plain ? true : false;
     expectTypeOf<HasActive>().toEqualTypeOf<false>();
+  });
+
+  it("Temporal attribute types: datetime → Instant | PlainDateTime, date → PlainDate, time → PlainTime", () => {
+    const e = new Event({});
+    expectTypeOf(e.starts_at).toEqualTypeOf<Temporal.Instant | Temporal.PlainDateTime>();
+    expectTypeOf(e.starts_on).toEqualTypeOf<Temporal.PlainDate>();
+    expectTypeOf(e.duration).toEqualTypeOf<Temporal.PlainTime>();
   });
 });

--- a/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
@@ -2,9 +2,7 @@ export class Post extends Base {
   declare title: string;
   declare view_count: number;
   declare published: boolean;
-  declare published_at:
-    | import("@blazetrails/activesupport/temporal").Temporal.Instant
-    | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
+  declare published_at: import("@blazetrails/activesupport/temporal").Temporal.Instant | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
 
   static {
     this.attribute("title", "string");

--- a/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/01-attribute/expected.ts
@@ -2,7 +2,9 @@ export class Post extends Base {
   declare title: string;
   declare view_count: number;
   declare published: boolean;
-  declare published_at: Date;
+  declare published_at:
+    | import("@blazetrails/activesupport/temporal").Temporal.Instant
+    | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
 
   static {
     this.attribute("title", "string");

--- a/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/expected.ts
@@ -1,0 +1,13 @@
+export class Event extends Base {
+  declare starts_at:
+    | import("@blazetrails/activesupport/temporal").Temporal.Instant
+    | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
+  declare starts_on: import("@blazetrails/activesupport/temporal").Temporal.PlainDate;
+  declare duration: import("@blazetrails/activesupport/temporal").Temporal.PlainTime;
+
+  static {
+    this.attribute("starts_at", "datetime");
+    this.attribute("starts_on", "date");
+    this.attribute("duration", "time");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/expected.ts
@@ -1,7 +1,5 @@
 export class Event extends Base {
-  declare starts_at:
-    | import("@blazetrails/activesupport/temporal").Temporal.Instant
-    | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
+  declare starts_at: import("@blazetrails/activesupport/temporal").Temporal.Instant | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime;
   declare starts_on: import("@blazetrails/activesupport/temporal").Temporal.PlainDate;
   declare duration: import("@blazetrails/activesupport/temporal").Temporal.PlainTime;
 

--- a/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/21-temporal-types/input.ts
@@ -1,0 +1,7 @@
+export class Event extends Base {
+  static {
+    this.attribute("starts_at", "datetime");
+    this.attribute("starts_on", "date");
+    this.attribute("duration", "time");
+  }
+}

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -114,14 +114,17 @@ function renderSchemaColumnDeclares(
  */
 function renderSchemaValueType(value: SchemaColumnValue): string {
   if (typeof value === "string") return tsTypeFor(value);
-  let ts = tsTypeFor(value.type);
+  let tsT = tsTypeFor(value.type);
   // For array columns with a known element type, render
   // `ElementTsType[]` instead of the default `unknown[]`.
+  // Wrap the element type in parens when it is a union so we emit
+  // `(A | B)[]` rather than the invalid `A | B[]`.
   if (value.type === "array" && value.arrayElementType) {
-    ts = `${tsTypeFor(value.arrayElementType)}[]`;
+    const elType = tsTypeFor(value.arrayElementType);
+    tsT = elType.includes("|") ? `(${elType})[]` : `${elType}[]`;
   }
-  if (value.null !== false) ts = `${ts} | null`;
-  return ts;
+  if (value.null !== false) tsT = tsT.includes("|") ? `(${tsT}) | null` : `${tsT} | null`;
+  return tsT;
 }
 
 function renderDeclaredMemberName(name: string): string {

--- a/packages/activerecord/src/type-virtualization/type-registry.ts
+++ b/packages/activerecord/src/type-virtualization/type-registry.ts
@@ -19,6 +19,13 @@
 // passing them to `this.attribute(...)` would throw. The virtualizer
 // maps both kinds to TS types so the compile-time declare is correct
 // for user-declared attributes AND schema-reflected columns.
+//
+// Temporal types are emitted as inline `import(...)` expressions so
+// the user's model file does not need to import from activesupport.
+// This mirrors the pattern used for ActiveRecord types (AR_IMPORT in
+// synthesize.ts).
+
+const T = `import("@blazetrails/activesupport/temporal").Temporal`;
 
 export const ATTRIBUTE_TYPE_MAP: Record<string, string> = {
   string: "string",
@@ -33,10 +40,18 @@ export const ATTRIBUTE_TYPE_MAP: Record<string, string> = {
   float: "number",
   decimal: "number",
   boolean: "boolean",
-  date: "Date",
-  datetime: "Date",
-  timestamp: "Date",
-  time: "Date",
+  // date → PlainDate (no time component, no timezone).
+  date: `${T}.PlainDate`,
+  // datetime is the generic AR type; cast returns Instant when the stored
+  // value has a UTC offset (timestamptz columns) or PlainDateTime when it
+  // doesn't (naive timestamp columns). The union covers both cases.
+  datetime: `${T}.Instant | ${T}.PlainDateTime`,
+  // timestamp is the schema-dump key for naive (no-TZ) timestamp columns.
+  timestamp: `${T}.PlainDateTime`,
+  // timestamptz is the schema-dump key for timezone-aware columns.
+  timestamptz: `${T}.Instant`,
+  // time → PlainTime (no date, no timezone).
+  time: `${T}.PlainTime`,
   json: "unknown",
   jsonb: "unknown",
   // hstore values are nullable at runtime (see

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -188,6 +188,29 @@ describe("virtualize — deltas", () => {
     expect(text).toMatch(/declare strict_tags: string\[\];/);
   });
 
+  test("schemaColumnsByTable emits Temporal types for timestamp/timestamptz/date/time columns", () => {
+    const src = "export class Event extends Base {}\n";
+    const { text } = virtualize(src, "event.ts", {
+      schemaColumnsByTable: {
+        events: {
+          created_at: { type: "timestamptz", null: false },
+          updated_at: { type: "timestamp", null: false },
+          starts_on: { type: "date", null: true },
+          duration: { type: "time", null: false },
+          scheduled_at: { type: "datetime", null: true },
+        },
+      },
+    });
+    expect(text).toMatch(/declare created_at:.*Temporal\.Instant[^|]/);
+    expect(text).toMatch(/declare updated_at:.*Temporal\.PlainDateTime[^|]/);
+    expect(text).toMatch(/declare starts_on:.*Temporal\.PlainDate.*\| null/);
+    expect(text).toMatch(/declare duration:.*Temporal\.PlainTime[^|]/);
+    // nullable datetime union must be parenthesised: (Instant | PlainDateTime) | null
+    expect(text).toMatch(
+      /declare scheduled_at: \(.*Temporal\.Instant.*Temporal\.PlainDateTime\) \| null/,
+    );
+  });
+
   test("schemaColumnsByTable emits bigint for big_integer schema columns", () => {
     const src = "export class Post extends Base {}\n";
     const { text } = virtualize(src, "post.ts", {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -201,10 +201,10 @@ describe("virtualize — deltas", () => {
         },
       },
     });
-    expect(text).toMatch(/declare created_at:.*Temporal\.Instant[^|]/);
-    expect(text).toMatch(/declare updated_at:.*Temporal\.PlainDateTime[^|]/);
+    expect(text).toMatch(/declare created_at:.*Temporal\.Instant;/);
+    expect(text).toMatch(/declare updated_at:.*Temporal\.PlainDateTime;/);
     expect(text).toMatch(/declare starts_on:.*Temporal\.PlainDate.*\| null/);
-    expect(text).toMatch(/declare duration:.*Temporal\.PlainTime[^|]/);
+    expect(text).toMatch(/declare duration:.*Temporal\.PlainTime;/);
     // nullable datetime union must be parenthesised: (Instant | PlainDateTime) | null
     expect(text).toMatch(
       /declare scheduled_at: \(.*Temporal\.Instant.*Temporal\.PlainDateTime\) \| null/,

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -67,7 +67,7 @@ describe("virtualize — deltas", () => {
     expect(text.match(/declare title: string;/g)?.length).toBe(1);
     // Schema-only columns ARE emitted.
     expect(text).toMatch(/declare body: string;/);
-    expect(text).toMatch(/declare published_at: Date;/);
+    expect(text).toMatch(/declare published_at:.*Temporal\.Instant.*Temporal\.PlainDateTime/);
     expect(text).toMatch(/declare views: number;/);
   });
 

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -93,6 +93,14 @@ class BigRecord extends Base {
   }
 }
 
+class Event extends Base {
+  static {
+    this.attribute("starts_at", "datetime");
+    this.attribute("starts_on", "date");
+    this.attribute("duration", "time");
+  }
+}
+
 describe("virtualized patterns — trails-tsc injects declares + auto-imports", () => {
   it("attributes resolve to their declared type", () => {
     const u = new User({ name: "dean", email: "d@example.com", admin: false });
@@ -163,5 +171,19 @@ describe("virtualized patterns — trails-tsc injects declares + auto-imports", 
     expectTypeOf(await profile.loadBelongsTo("author")).toEqualTypeOf<Author | null>();
     const author = new Author({ name: "dean" });
     expectTypeOf(await author.loadHasOne("profile")).toEqualTypeOf<Profile | null>();
+  });
+
+  it("Temporal attribute types: datetime → Instant | PlainDateTime, date → PlainDate, time → PlainTime", () => {
+    const e = new Event({});
+    expectTypeOf(e.starts_at).toEqualTypeOf<
+      | import("@blazetrails/activesupport/temporal").Temporal.Instant
+      | import("@blazetrails/activesupport/temporal").Temporal.PlainDateTime
+    >();
+    expectTypeOf(e.starts_on).toEqualTypeOf<
+      import("@blazetrails/activesupport/temporal").Temporal.PlainDate
+    >();
+    expectTypeOf(e.duration).toEqualTypeOf<
+      import("@blazetrails/activesupport/temporal").Temporal.PlainTime
+    >();
   });
 });


### PR DESCRIPTION
## Summary

Second half of the temporal cast-layer train. PR 3a flipped the runtime cast to return Temporal objects; this PR makes the `trails-tsc` virtualizer emit matching `declare` types so user models typecheck correctly.

**Type mapping (matches runtime cast from PR 3a):**

| Rails type | Emitted TS type |
|---|---|
| `date` | `Temporal.PlainDate` |
| `datetime` | `Temporal.Instant \| Temporal.PlainDateTime` |
| `timestamp` | `Temporal.PlainDateTime` |
| `timestamptz` | `Temporal.Instant` |
| `time` | `Temporal.PlainTime` |

All types use inline `import("@blazetrails/activesupport/temporal").Temporal.*` expressions — no import required in user model files.

## Changes

- `type-registry.ts`: replace `"Date"` with Temporal inline-import strings
- Fixture 01-attribute: update expected output for `datetime`
- Fixture 21-temporal-types: new fixture covering `datetime`/`date`/`time`
- `virtualize.test.ts`: update schema-columns inline assertion