### PR TITLE
test(parity): AR gap fixtures ar-155/157/158/159/160 — 5 Arel visitor/node gaps

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -50,5 +50,25 @@
   "ar-154": {
     "side": "trails-missing",
     "reason": "group() does not accept Arel node arguments: group(new Nodes.NamedFunction(...)) throws TypeError: col.trim is not a function because the group implementation calls .trim() on each argument assuming strings. Rails accepts any Arel::Node in group() and passes it to the GROUP BY clause via the Arel visitor. Real fix: the groupBang implementation must handle Arel node arguments by calling .toSql() (or passing them directly to the Arel manager) instead of treating them as strings."
+  },
+  "ar-155": {
+    "side": "trails-missing",
+    "reason": "Arel::Nodes::Case fluent builder is incomplete: Rails supports case.when(val).then(result) chaining; Trails' Case node has when() and else() but no then() method, so building a CASE WHEN ... THEN ... expression throws '(intermediate value).when(...).then is not a function'. Real fix: add then() to the Case node builder mirroring Rails' Arel::Nodes::Case#then."
+  },
+  "ar-157": {
+    "side": "trails-missing",
+    "reason": "Arel::Nodes::Union (and Intersect) lack an as() method: Rails' Arel nodes all inherit Node#as() which wraps the node in Arel::Nodes::As; Trails' base Node class does not implement as(), so calling union.as('alias') throws 'union.as is not a function'. Real fix: add as() to the Arel Node base class to produce an As node, mirroring Rails' Arel::Nodes::Node#as."
+  },
+  "ar-158": {
+    "side": "diff",
+    "reason": "Table alias from SelectManager#as is over-quoted in Arel JOIN ON: Rails emits the alias unquoted in ON conditions (sub.\"book_id\"); Trails quotes the alias as a table name (\"sub\".\"book_id\"). Real fix: the Arel visitor's visitAs or table-alias resolution must emit the alias name without double-quoting in ON clause references."
+  },
+  "ar-159": {
+    "side": "trails-missing",
+    "reason": "Arel arithmetic nodes crash on bare number operands: Nodes.Multiplication.new(col, 2) throws 'Unknown node type: Number' because Trails' Arel visitor has no handler for plain Number values. Rails wraps bare values via Nodes.build_quoted automatically. Real fix: the Arel visitor must handle raw Number operands in arithmetic nodes as quoted literals, mirroring Rails' Arel::Visitors::ToSql arithmetic visit methods."
+  },
+  "ar-160": {
+    "side": "trails-missing",
+    "reason": "Arel aggregate nodes (Sum, Count, Avg, Max, Min) constructed directly via new Nodes.Sum([col]) crash: the Trails Arel visitor has no visitSum etc. handlers, throwing 'Unknown node type: Sum'. Rails' visitor handles these via visit_Arel_Nodes_Sum etc. Real fix: add visitor handlers for each aggregate node type in the Arel ToSql visitor."
   }
 }

--- a/scripts/parity/fixtures/ar-155/models.rb
+++ b/scripts/parity/fixtures/ar-155/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-155/models.ts
+++ b/scripts/parity/fixtures/ar-155/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-155/query.rb
+++ b/scripts/parity/fixtures/ar-155/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then("yes").when("draft").then("maybe").else("no").as("is_visible"), Book.arel_table[:id]).order(:id).limit(5)

--- a/scripts/parity/fixtures/ar-155/query.ts
+++ b/scripts/parity/fixtures/ar-155/query.ts
@@ -1,0 +1,14 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Case(Book.arelTable.get("status"))
+    .when("active")
+    .then("yes")
+    .when("draft")
+    .then("maybe")
+    .else("no")
+    .as("is_visible"),
+  Book.arelTable.get("id"),
+)
+  .order({ id: "asc" })
+  .limit(5);

--- a/scripts/parity/fixtures/ar-155/schema.sql
+++ b/scripts/parity/fixtures/ar-155/schema.sql
@@ -1,2 +1,1 @@
--- Query: Book.select(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then("yes").when("draft").then("maybe").else("no").as("is_visible"), Book.arel_table[:id]).order(:id).limit(5)
-CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);
+-- Fixture for statement: ar-155

--- a/scripts/parity/fixtures/ar-155/schema.sql
+++ b/scripts/parity/fixtures/ar-155/schema.sql
@@ -1,0 +1,2 @@
+-- Query: Book.select(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then("yes").when("draft").then("maybe").else("no").as("is_visible"), Book.arel_table[:id]).order(:id).limit(5)
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-157/models.rb
+++ b/scripts/parity/fixtures/ar-157/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-157/models.ts
+++ b/scripts/parity/fixtures/ar-157/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-157/query.rb
+++ b/scripts/parity/fixtures/ar-157/query.rb
@@ -1,0 +1,3 @@
+query1 = Book.where(status: "active").arel
+query2 = Book.where(status: "featured").arel
+Book.from(query1.union(query2).as("all_books")).select("all_books.*").order("all_books.id")

--- a/scripts/parity/fixtures/ar-157/query.ts
+++ b/scripts/parity/fixtures/ar-157/query.ts
@@ -1,0 +1,4 @@
+import { Book } from "./models.js";
+const q1 = Book.where({ status: "active" }).toArel();
+const q2 = Book.where({ status: "featured" }).toArel();
+export default Book.from(q1.union(q2).as("all_books")).select("all_books.*").order("all_books.id");

--- a/scripts/parity/fixtures/ar-157/schema.sql
+++ b/scripts/parity/fixtures/ar-157/schema.sql
@@ -1,0 +1,2 @@
+-- Query: union = Book.where(status: "active").union(Book.where(status: "featured")); Book.from(union.as("all_books")).select("all_books.*").order("all_books.id")
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-157/schema.sql
+++ b/scripts/parity/fixtures/ar-157/schema.sql
@@ -1,2 +1,1 @@
--- Query: union = Book.where(status: "active").union(Book.where(status: "featured")); Book.from(union.as("all_books")).select("all_books.*").order("all_books.id")
-CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);
+-- Fixture for statement: ar-157

--- a/scripts/parity/fixtures/ar-158/models.rb
+++ b/scripts/parity/fixtures/ar-158/models.rb
@@ -1,0 +1,2 @@
+class Book < ActiveRecord::Base; end
+class Review < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-158/models.ts
+++ b/scripts/parity/fixtures/ar-158/models.ts
@@ -1,0 +1,13 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}
+export class Review extends Base {
+  static {
+    this.tableName = "reviews";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-158/query.rb
+++ b/scripts/parity/fixtures/ar-158/query.rb
@@ -1,0 +1,2 @@
+sub = Review.select(:book_id, Arel.sql("AVG(rating) AS avg_r")).group(:book_id).arel.as("sub")
+Book.joins(Arel::Nodes::InnerJoin.new(sub, Arel::Nodes::On.new(sub[:book_id].eq(Book.arel_table[:id])))).select("books.*, sub.avg_r")

--- a/scripts/parity/fixtures/ar-158/query.ts
+++ b/scripts/parity/fixtures/ar-158/query.ts
@@ -1,0 +1,11 @@
+import { Nodes, sql } from "@blazetrails/arel";
+import { Book, Review } from "./models.js";
+const sub = Review.select("book_id", sql("AVG(rating) AS avg_r"))
+  .group("book_id")
+  .toArel()
+  .as("sub");
+const join = new Nodes.InnerJoin(
+  sub,
+  new Nodes.On(sub.get("book_id").eq(Book.arelTable.get("id"))),
+);
+export default Book.joins(join).select("books.*, sub.avg_r");

--- a/scripts/parity/fixtures/ar-158/schema.sql
+++ b/scripts/parity/fixtures/ar-158/schema.sql
@@ -1,0 +1,3 @@
+-- Query: sub = Review.select(:book_id, Arel.sql("AVG(rating) AS avg_r")).group(:book_id).arel.as("sub"); Book.joins(Arel::Nodes::InnerJoin.new(sub, Arel::Nodes::On.new(sub[:book_id].eq(Book.arel_table[:id])))).select("books.*, sub.avg_r")
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+CREATE TABLE reviews (id INTEGER PRIMARY KEY, book_id INTEGER REFERENCES books(id), rating INTEGER NOT NULL);

--- a/scripts/parity/fixtures/ar-158/schema.sql
+++ b/scripts/parity/fixtures/ar-158/schema.sql
@@ -1,3 +1,1 @@
--- Query: sub = Review.select(:book_id, Arel.sql("AVG(rating) AS avg_r")).group(:book_id).arel.as("sub"); Book.joins(Arel::Nodes::InnerJoin.new(sub, Arel::Nodes::On.new(sub[:book_id].eq(Book.arel_table[:id])))).select("books.*, sub.avg_r")
-CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL);
-CREATE TABLE reviews (id INTEGER PRIMARY KEY, book_id INTEGER REFERENCES books(id), rating INTEGER NOT NULL);
+-- Fixture for statement: ar-158

--- a/scripts/parity/fixtures/ar-159/models.rb
+++ b/scripts/parity/fixtures/ar-159/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-159/models.ts
+++ b/scripts/parity/fixtures/ar-159/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-159/query.rb
+++ b/scripts/parity/fixtures/ar-159/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Multiplication.new(Book.arel_table[:pages], 2).as("double_pages"), Book.arel_table[:id]).where(Book.arel_table[:pages].gt(0)).order(:id).limit(5)

--- a/scripts/parity/fixtures/ar-159/query.ts
+++ b/scripts/parity/fixtures/ar-159/query.ts
@@ -1,0 +1,9 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Multiplication(Book.arelTable.get("pages"), 2).as("double_pages"),
+  Book.arelTable.get("id"),
+)
+  .where(Book.arelTable.get("pages").gt(0))
+  .order({ id: "asc" })
+  .limit(5);

--- a/scripts/parity/fixtures/ar-159/schema.sql
+++ b/scripts/parity/fixtures/ar-159/schema.sql
@@ -1,0 +1,2 @@
+-- Query: Book.select(Arel::Nodes::Multiplication.new(Book.arel_table[:pages], 2).as("double_pages"), Book.arel_table[:id]).where(Book.arel_table[:pages].gt(0)).order(:id).limit(5)
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-159/schema.sql
+++ b/scripts/parity/fixtures/ar-159/schema.sql
@@ -1,2 +1,1 @@
--- Query: Book.select(Arel::Nodes::Multiplication.new(Book.arel_table[:pages], 2).as("double_pages"), Book.arel_table[:id]).where(Book.arel_table[:pages].gt(0)).order(:id).limit(5)
-CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, pages INTEGER NOT NULL DEFAULT 0);
+-- Fixture for statement: ar-159

--- a/scripts/parity/fixtures/ar-160/models.rb
+++ b/scripts/parity/fixtures/ar-160/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-160/models.ts
+++ b/scripts/parity/fixtures/ar-160/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-160/query.rb
+++ b/scripts/parity/fixtures/ar-160/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).as("total_pages"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).gt(1000))

--- a/scripts/parity/fixtures/ar-160/query.ts
+++ b/scripts/parity/fixtures/ar-160/query.ts
@@ -1,0 +1,8 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Sum([Book.arelTable.get("pages")]).as("total_pages"),
+  Book.arelTable.get("author_id"),
+)
+  .group("author_id")
+  .having(new Nodes.Sum([Book.arelTable.get("pages")]).gt(1000));

--- a/scripts/parity/fixtures/ar-160/schema.sql
+++ b/scripts/parity/fixtures/ar-160/schema.sql
@@ -1,0 +1,2 @@
+-- Query: Book.select(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).as("total_pages"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).gt(1000))
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-160/schema.sql
+++ b/scripts/parity/fixtures/ar-160/schema.sql
@@ -1,2 +1,1 @@
--- Query: Book.select(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).as("total_pages"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).gt(1000))
-CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);
+-- Fixture for statement: ar-160


### PR DESCRIPTION
## Summary

Adds 5 fixtures documenting Arel visitor and node-level gaps in Trails.

| Fixture | Gap | Fix location |
|---------|-----|-------------|
| **ar-155** | `Case` node fluent builder: `when().then()` — `then` not defined | Add `then()` to `Arel::Nodes::Case` builder |
| **ar-157** | `Union`/`Intersect` nodes lack `as()` — `union.as("alias")` throws | Add `as()` to Arel `Node` base class |
| **ar-158** | Subquery alias over-quoted in JOIN ON: `"sub"."col"` vs `sub."col"` | Arel visitor `visitAs` quoting strategy |
| **ar-159** | Arithmetic nodes crash on bare number operands — `Multiplication(col, 2)` → `Unknown node type: Number` | Arel visitor number handling in arithmetic |
| **ar-160** | Aggregate node constructors not in visitor — `new Nodes.Sum([col])` → `Unknown node type: Sum` | Add `visitSum`/`visitCount`/etc. to Arel ToSql |

## Test plan
- [ ] `pnpm parity:query` — all 5 show as KNOWN-GAP, no FAIL