### PR TITLE
feat(temporal): PR 4 — SQLite microsecond round-trip via Temporal

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -250,14 +250,22 @@ export function quotedTime(value: Date): string {
 }
 
 /**
+ * Return the IANA timezone string for SQL datetime serialization/deserialization,
+ * based on `ActiveRecord.default_timezone`. Shared by all instant formatters and
+ * by `SQLiteDateTimeType#cast` so both directions always agree on the timezone.
+ */
+export function defaultSqlTimezone(): string {
+  return getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
+}
+
+/**
  * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]`.
  * Respects `ActiveRecord.default_timezone` exactly as `quotedDate()` does:
  * UTC when the setting is `"utc"`, otherwise the host system's local timezone.
  * Preserves up to nanosecond precision; trailing zero groups are trimmed.
  */
 export function formatInstantForSql(value: Temporal.Instant): string {
-  const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
-  return formatZonedComponents(value.toZonedDateTimeISO(tz));
+  return formatZonedComponents(value.toZonedDateTimeISO(defaultSqlTimezone()));
 }
 
 /**
@@ -300,8 +308,7 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
  * in strict SQL mode causes an error rather than silent truncation.
  */
 export function formatInstantForSqlMysql(value: Temporal.Instant): string {
-  const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
-  const zdt = value.toZonedDateTimeISO(tz);
+  const zdt = value.toZonedDateTimeISO(defaultSqlTimezone());
   return (
     formatDatePrefix(zdt) +
     formatTimeComponents(zdt.hour, zdt.minute, zdt.second, zdt.millisecond, zdt.microsecond, 0, 6)

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -54,13 +54,14 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
 /**
  * SQLite-specific DateTime type.
  *
- * better-sqlite3 returns datetime columns as TEXT (SQLite stores them as
- * offset-less UTC strings).  The base DateTimeType#cast returns
- * Temporal.PlainDateTime for such strings.  This subclass converts any
- * PlainDateTime result to Temporal.Instant (UTC) so callers get a
- * timezone-aware value that matches the UTC-convention SQLite uses.
+ * better-sqlite3 returns datetime columns as TEXT. The base
+ * DateTimeType#cast returns Temporal.PlainDateTime for offset-less datetime
+ * strings. This subclass converts any PlainDateTime result to
+ * Temporal.Instant so callers get a timezone-aware value.
  *
- * Mirrors the Rails convention that SQLite datetime values are always UTC.
+ * Stored datetime strings are interpreted according to
+ * ActiveRecord.default_timezone (defaulting to UTC), matching the timezone
+ * selection used when formatting instants for SQLite.
  */
 export class SQLiteDateTimeType extends ARDateTimeType {
   override cast(value: unknown): DateTimeCastResult | null {
@@ -552,11 +553,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     });
     map.registerType("decimal", new DecimalType());
     map.registerType("boolean", new BooleanType());
-    // Date/time types — no driver-level work needed for Temporal (PR 4).
-    // better-sqlite3 returns datetime columns as TEXT strings (SQLite has
-    // no native datetime type).  SQLiteDateTimeType converts the offset-less
-    // UTC strings back to Temporal.Instant (UTC convention).  Writes go
-    // through sqlite3/quoting.ts which formats all Temporal types as :db strings.
+    // Date/time types: no driver-level type-parser work needed for Temporal.
+    // better-sqlite3 returns datetime columns as TEXT strings (SQLite has no
+    // native datetime type).  SQLiteDateTimeType converts offset-less strings
+    // to Temporal.Instant using the same timezone as formatInstantForSql
+    // (default_timezone: UTC → UTC, local → host tz).  Writes go through
+    // sqlite3/quoting.ts which formats all Temporal types as :db strings.
     map.registerType("date", new DateType());
     map.registerType("datetime", new SQLiteDateTimeType());
     map.registerType("timestamp", new SQLiteDateTimeType());

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -20,7 +20,7 @@ import { DateTime as ARDateTimeType } from "../type/date-time.js";
 import { Time as TimeType } from "../type/time.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { DateTimeCastResult } from "@blazetrails/activemodel";
-import { getDefaultTimezone } from "../type/internal/timezone.js";
+import { defaultSqlTimezone } from "./abstract/quoting.js";
 import { Text as TextType } from "../type/text.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
@@ -67,10 +67,7 @@ export class SQLiteDateTimeType extends ARDateTimeType {
   override cast(value: unknown): DateTimeCastResult | null {
     const result = super.cast(value);
     if (result instanceof Temporal.PlainDateTime) {
-      // Mirror formatInstantForSql's timezone selection so reads match writes:
-      // UTC default → interpret stored string as UTC; local → host timezone.
-      const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
-      return result.toZonedDateTime(tz).toInstant();
+      return result.toZonedDateTime(defaultSqlTimezone()).toInstant();
     }
     return result;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -16,8 +16,10 @@ import {
 } from "../errors.js";
 import { TypeMap } from "../type/type-map.js";
 import { Date as DateType } from "../type/date.js";
-import { DateTime as DateTimeType } from "../type/date-time.js";
+import { DateTime as ARDateTimeType } from "../type/date-time.js";
 import { Time as TimeType } from "../type/time.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import type { DateTimeCastResult } from "@blazetrails/activemodel";
 import { Text as TextType } from "../type/text.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
@@ -47,6 +49,27 @@ import {
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
+
+/**
+ * SQLite-specific DateTime type.
+ *
+ * better-sqlite3 returns datetime columns as TEXT (SQLite stores them as
+ * offset-less UTC strings).  The base DateTimeType#cast returns
+ * Temporal.PlainDateTime for such strings.  This subclass converts any
+ * PlainDateTime result to Temporal.Instant (UTC) so callers get a
+ * timezone-aware value that matches the UTC-convention SQLite uses.
+ *
+ * Mirrors the Rails convention that SQLite datetime values are always UTC.
+ */
+export class SQLiteDateTimeType extends ARDateTimeType {
+  override cast(value: unknown): DateTimeCastResult | null {
+    const result = super.cast(value);
+    if (result instanceof Temporal.PlainDateTime) {
+      return result.toZonedDateTime("UTC").toInstant();
+    }
+    return result;
+  }
+}
 
 /**
  * SQLite adapter — connects ActiveRecord to a real SQLite database.
@@ -527,12 +550,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     map.registerType("boolean", new BooleanType());
     // Date/time types — no driver-level work needed for Temporal (PR 4).
     // better-sqlite3 returns datetime columns as TEXT strings (SQLite has
-    // no native datetime type), so DateTimeType#cast receives a string and
-    // returns Temporal.PlainDateTime.  Writes go through sqlite3/quoting.ts
-    // which already formats all Temporal types as :db strings.
+    // no native datetime type).  SQLiteDateTimeType converts the offset-less
+    // UTC strings back to Temporal.Instant (UTC convention).  Writes go
+    // through sqlite3/quoting.ts which formats all Temporal types as :db strings.
     map.registerType("date", new DateType());
-    map.registerType("datetime", new DateTimeType());
-    map.registerType("timestamp", new DateTimeType());
+    map.registerType("datetime", new SQLiteDateTimeType());
+    map.registerType("timestamp", new SQLiteDateTimeType());
     map.registerType("time", new TimeType());
     map.registerType("blob", new BinaryType());
     map.registerType("binary", new BinaryType());

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -20,6 +20,7 @@ import { DateTime as ARDateTimeType } from "../type/date-time.js";
 import { Time as TimeType } from "../type/time.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { DateTimeCastResult } from "@blazetrails/activemodel";
+import { getDefaultTimezone } from "../type/internal/timezone.js";
 import { Text as TextType } from "../type/text.js";
 import { Json as JsonType } from "../type/json.js";
 import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
@@ -65,7 +66,10 @@ export class SQLiteDateTimeType extends ARDateTimeType {
   override cast(value: unknown): DateTimeCastResult | null {
     const result = super.cast(value);
     if (result instanceof Temporal.PlainDateTime) {
-      return result.toZonedDateTime("UTC").toInstant();
+      // Mirror formatInstantForSql's timezone selection so reads match writes:
+      // UTC default → interpret stored string as UTC; local → host timezone.
+      const tz = getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
+      return result.toZonedDateTime(tz).toInstant();
     }
     return result;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -525,6 +525,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     });
     map.registerType("decimal", new DecimalType());
     map.registerType("boolean", new BooleanType());
+    // Date/time types — no driver-level work needed for Temporal (PR 4).
+    // better-sqlite3 returns datetime columns as TEXT strings (SQLite has
+    // no native datetime type), so DateTimeType#cast receives a string and
+    // returns Temporal.PlainDateTime.  Writes go through sqlite3/quoting.ts
+    // which already formats all Temporal types as :db strings.
     map.registerType("date", new DateType());
     map.registerType("datetime", new DateTimeType());
     map.registerType("timestamp", new DateTimeType());

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { SQLite3Adapter } from "../sqlite3-adapter.js";
-import { DateTime as DateTimeType } from "../../type/date-time.js";
+import { SQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
 import {
@@ -354,34 +353,28 @@ describe("SQLite3::Quoting", () => {
       adapter.close();
     });
 
-    it("Temporal.Instant with microsecond precision survives INSERT → SELECT", async () => {
+    it("Temporal.Instant with microsecond precision survives INSERT → SELECT as Instant", async () => {
       const instant = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
       await adapter.executeMutation(`INSERT INTO "events" ("ts") VALUES (${quote(instant)})`);
       const rows = await adapter.execute(`SELECT "ts" FROM "events" LIMIT 1`);
       const raw = (rows as any[])[0].ts as string;
-      // SQLite stores as offset-less UTC string; read back via DateTimeType#cast.
-      const cast = new DateTimeType().cast(raw);
-      expect(cast).toBeInstanceOf(Temporal.PlainDateTime);
-      const pdt = cast as Temporal.PlainDateTime;
-      expect(pdt.year).toBe(2026);
-      expect(pdt.month).toBe(4);
-      expect(pdt.day).toBe(18);
-      expect(pdt.hour).toBe(12);
-      expect(pdt.minute).toBe(34);
-      expect(pdt.second).toBe(56);
-      expect(pdt.microsecond).toBe(123456 % 1000); // 456
-      expect(pdt.millisecond).toBe(Math.floor(123456 / 1000)); // 123
+      // SQLiteDateTimeType converts the offset-less UTC string → Temporal.Instant.
+      const cast = new SQLiteDateTimeType().cast(raw);
+      expect(cast).toBeInstanceOf(Temporal.Instant);
+      // Microsecond precision is preserved end-to-end.
+      expect((cast as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
     });
 
-    it("Temporal.PlainDateTime with microseconds survives INSERT → SELECT", async () => {
+    it("Temporal.PlainDateTime with microseconds survives INSERT → SELECT as Instant", async () => {
       const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.654321");
       await adapter.executeMutation(`INSERT INTO "events" ("dt") VALUES (${quote(dt)})`);
       const rows = await adapter.execute(`SELECT "dt" FROM "events" LIMIT 1`);
       const raw = (rows as any[])[0].dt as string;
-      const cast = new DateTimeType().cast(raw) as Temporal.PlainDateTime;
-      expect(cast).toBeInstanceOf(Temporal.PlainDateTime);
-      expect(cast.microsecond).toBe(654321 % 1000); // 321
-      expect(cast.millisecond).toBe(Math.floor(654321 / 1000)); // 654
+      const cast = new SQLiteDateTimeType().cast(raw) as Temporal.Instant;
+      expect(cast).toBeInstanceOf(Temporal.Instant);
+      const zdt = cast.toZonedDateTimeISO("UTC");
+      expect(zdt.microsecond).toBe(654321 % 1000); // 321 µs
+      expect(zdt.millisecond).toBe(Math.floor(654321 / 1000)); // 654 ms
     });
 
     it("Temporal.PlainDate survives INSERT → SELECT", async () => {
@@ -398,20 +391,20 @@ describe("SQLite3::Quoting", () => {
     });
 
     it("Temporal.PlainTime with microseconds survives INSERT → SELECT", async () => {
-      // SQLite stores time as the '2000-01-01 HH:MM:SS.ffffff' sentinel form.
+      // SQLite stores time with the '2000-01-01' sentinel date prefix.
+      // TimeType#cast handles the full '2000-01-01 HH:MM:SS.ffffff' string via
+      // extractTimePortion(), so no manual stripping is needed.
       const time = Temporal.PlainTime.from("14:23:55.654321");
       await adapter.executeMutation(`INSERT INTO "events" ("t") VALUES (${quote(time)})`);
       const rows = await adapter.execute(`SELECT "t" FROM "events" LIMIT 1`);
       const raw = (rows as any[])[0].t as string;
-      // Strip the sentinel date prefix before casting.
-      const timePart = raw.includes(" ") ? raw.slice(raw.indexOf(" ") + 1) : raw;
-      const cast = new TimeType().cast(timePart) as Temporal.PlainTime;
+      const cast = new TimeType().cast(raw) as Temporal.PlainTime;
       expect(cast).toBeInstanceOf(Temporal.PlainTime);
       expect(cast.hour).toBe(14);
       expect(cast.minute).toBe(23);
       expect(cast.second).toBe(55);
-      expect(cast.microsecond).toBe(654321 % 1000); // 321
-      expect(cast.millisecond).toBe(Math.floor(654321 / 1000)); // 654
+      expect(cast.microsecond).toBe(654321 % 1000); // 321 µs
+      expect(cast.millisecond).toBe(Math.floor(654321 / 1000)); // 654 ms
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -357,7 +357,7 @@ describe("SQLite3::Quoting", () => {
       const instant = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
       await adapter.executeMutation(`INSERT INTO "events" ("ts") VALUES (${quote(instant)})`);
       const rows = await adapter.execute(`SELECT "ts" FROM "events" LIMIT 1`);
-      const raw = (rows as any[])[0].ts as string;
+      const raw = (rows as Record<string, unknown>[])[0].ts as string;
       // SQLiteDateTimeType converts the offset-less UTC string → Temporal.Instant.
       const cast = new SQLiteDateTimeType().cast(raw);
       expect(cast).toBeInstanceOf(Temporal.Instant);
@@ -369,7 +369,7 @@ describe("SQLite3::Quoting", () => {
       const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.654321");
       await adapter.executeMutation(`INSERT INTO "events" ("dt") VALUES (${quote(dt)})`);
       const rows = await adapter.execute(`SELECT "dt" FROM "events" LIMIT 1`);
-      const raw = (rows as any[])[0].dt as string;
+      const raw = (rows as Record<string, unknown>[])[0].dt as string;
       const cast = new SQLiteDateTimeType().cast(raw) as Temporal.Instant;
       expect(cast).toBeInstanceOf(Temporal.Instant);
       const zdt = cast.toZonedDateTimeISO("UTC");
@@ -381,7 +381,7 @@ describe("SQLite3::Quoting", () => {
       const date = Temporal.PlainDate.from("2026-04-18");
       await adapter.executeMutation(`INSERT INTO "events" ("d") VALUES (${quote(date)})`);
       const rows = await adapter.execute(`SELECT "d" FROM "events" LIMIT 1`);
-      const raw = (rows as any[])[0].d as string;
+      const raw = (rows as Record<string, unknown>[])[0].d as string;
       const cast = new DateType().cast(raw);
       expect(cast).toBeInstanceOf(Temporal.PlainDate);
       const pd = cast as Temporal.PlainDate;
@@ -397,7 +397,7 @@ describe("SQLite3::Quoting", () => {
       const time = Temporal.PlainTime.from("14:23:55.654321");
       await adapter.executeMutation(`INSERT INTO "events" ("t") VALUES (${quote(time)})`);
       const rows = await adapter.execute(`SELECT "t" FROM "events" LIMIT 1`);
-      const raw = (rows as any[])[0].t as string;
+      const raw = (rows as Record<string, unknown>[])[0].t as string;
       const cast = new TimeType().cast(raw) as Temporal.PlainTime;
       expect(cast).toBeInstanceOf(Temporal.PlainTime);
       expect(cast.hour).toBe(14);

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { SQLite3Adapter } from "../sqlite3-adapter.js";
+import { DateTime as DateTimeType } from "../../type/date-time.js";
+import { Date as DateType } from "../../type/date.js";
+import { Time as TimeType } from "../../type/time.js";
 import {
   columnNameMatcher,
   columnNameWithOrderMatcher,
@@ -279,6 +284,134 @@ describe("SQLite3::Quoting", () => {
     it("quotedTimeUtc carries the microseconds suffix too", () => {
       const d = new Date(Date.UTC(2026, 3, 18, 12, 34, 56, 123));
       expect(quotedTimeUtc(d)).toMatch(/^12:34:56\.\d{6}$/);
+    });
+  });
+
+  describe("quote(Temporal.*) — unit", () => {
+    it("quotes Temporal.Instant as offset-less :db format with microseconds", () => {
+      const ts = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
+      expect(quote(ts)).toBe("'2026-04-18 12:34:56.123456'");
+    });
+
+    it("quotes Temporal.Instant with whole seconds (no trailing fraction)", () => {
+      const ts = Temporal.Instant.from("2026-04-18T12:34:56Z");
+      expect(quote(ts)).toBe("'2026-04-18 12:34:56'");
+    });
+
+    it("quotes Temporal.PlainDateTime with microseconds", () => {
+      const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.123456");
+      expect(quote(dt)).toBe("'2026-04-18 12:34:56.123456'");
+    });
+
+    it("quotes Temporal.PlainDate as YYYY-MM-DD", () => {
+      const d = Temporal.PlainDate.from("2026-04-18");
+      expect(quote(d)).toBe("'2026-04-18'");
+    });
+
+    it("quotes Temporal.PlainTime prefixed with 2000-01-01 sentinel date", () => {
+      const t = Temporal.PlainTime.from("14:23:55.654321");
+      expect(quote(t)).toBe("'2000-01-01 14:23:55.654321'");
+    });
+  });
+
+  describe("typeCast(Temporal.*) — unit", () => {
+    it("typeCast Temporal.Instant returns unquoted :db string", () => {
+      const ts = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
+      expect(typeCast(ts)).toBe("2026-04-18 12:34:56.123456");
+    });
+
+    it("typeCast Temporal.PlainDateTime returns unquoted string", () => {
+      const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.123456");
+      expect(typeCast(dt)).toBe("2026-04-18 12:34:56.123456");
+    });
+
+    it("typeCast Temporal.PlainDate returns YYYY-MM-DD string", () => {
+      const d = Temporal.PlainDate.from("2026-04-18");
+      expect(typeCast(d)).toBe("2026-04-18");
+    });
+
+    it("typeCast Temporal.PlainTime returns prefixed time string", () => {
+      const t = Temporal.PlainTime.from("14:23:55.654321");
+      expect(typeCast(t)).toBe("2000-01-01 14:23:55.654321");
+    });
+  });
+
+  describe("SQLite microsecond round-trip — integration", () => {
+    let adapter: SQLite3Adapter;
+
+    beforeEach(() => {
+      adapter = new SQLite3Adapter(":memory:");
+      adapter.exec(`CREATE TABLE "events" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "ts"  DATETIME,
+        "dt"  DATETIME,
+        "d"   DATE,
+        "t"   TIME
+      )`);
+    });
+
+    afterEach(() => {
+      adapter.close();
+    });
+
+    it("Temporal.Instant with microsecond precision survives INSERT → SELECT", async () => {
+      const instant = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
+      await adapter.executeMutation(`INSERT INTO "events" ("ts") VALUES (${quote(instant)})`);
+      const rows = await adapter.execute(`SELECT "ts" FROM "events" LIMIT 1`);
+      const raw = (rows as any[])[0].ts as string;
+      // SQLite stores as offset-less UTC string; read back via DateTimeType#cast.
+      const cast = new DateTimeType().cast(raw);
+      expect(cast).toBeInstanceOf(Temporal.PlainDateTime);
+      const pdt = cast as Temporal.PlainDateTime;
+      expect(pdt.year).toBe(2026);
+      expect(pdt.month).toBe(4);
+      expect(pdt.day).toBe(18);
+      expect(pdt.hour).toBe(12);
+      expect(pdt.minute).toBe(34);
+      expect(pdt.second).toBe(56);
+      expect(pdt.microsecond).toBe(123456 % 1000); // 456
+      expect(pdt.millisecond).toBe(Math.floor(123456 / 1000)); // 123
+    });
+
+    it("Temporal.PlainDateTime with microseconds survives INSERT → SELECT", async () => {
+      const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.654321");
+      await adapter.executeMutation(`INSERT INTO "events" ("dt") VALUES (${quote(dt)})`);
+      const rows = await adapter.execute(`SELECT "dt" FROM "events" LIMIT 1`);
+      const raw = (rows as any[])[0].dt as string;
+      const cast = new DateTimeType().cast(raw) as Temporal.PlainDateTime;
+      expect(cast).toBeInstanceOf(Temporal.PlainDateTime);
+      expect(cast.microsecond).toBe(654321 % 1000); // 321
+      expect(cast.millisecond).toBe(Math.floor(654321 / 1000)); // 654
+    });
+
+    it("Temporal.PlainDate survives INSERT → SELECT", async () => {
+      const date = Temporal.PlainDate.from("2026-04-18");
+      await adapter.executeMutation(`INSERT INTO "events" ("d") VALUES (${quote(date)})`);
+      const rows = await adapter.execute(`SELECT "d" FROM "events" LIMIT 1`);
+      const raw = (rows as any[])[0].d as string;
+      const cast = new DateType().cast(raw);
+      expect(cast).toBeInstanceOf(Temporal.PlainDate);
+      const pd = cast as Temporal.PlainDate;
+      expect(pd.year).toBe(2026);
+      expect(pd.month).toBe(4);
+      expect(pd.day).toBe(18);
+    });
+
+    it("Temporal.PlainTime with microseconds survives INSERT → SELECT", async () => {
+      // SQLite stores time as the '2000-01-01 HH:MM:SS.ffffff' sentinel form.
+      const time = Temporal.PlainTime.from("14:23:55.654321");
+      await adapter.executeMutation(`INSERT INTO "events" ("t") VALUES (${quote(time)})`);
+      const rows = await adapter.execute(`SELECT "t" FROM "events" LIMIT 1`);
+      const raw = (rows as any[])[0].t as string;
+      // Strip the sentinel date prefix before casting.
+      const timePart = raw.includes(" ") ? raw.slice(raw.indexOf(" ") + 1) : raw;
+      const cast = new TimeType().cast(timePart) as Temporal.PlainTime;
+      expect(cast).toBeInstanceOf(Temporal.PlainTime);
+      expect(cast.hour).toBe(14);
+      expect(cast.minute).toBe(23);
+      expect(cast.second).toBe(55);
+      expect(cast.microsecond).toBe(654321 % 1000); // 321
+      expect(cast.millisecond).toBe(Math.floor(654321 / 1000)); // 654
     });
   });
 });


### PR DESCRIPTION
## Summary

PR 4 of the temporal migration plan. SQLite requires no driver-level type-parser work (no `getTypeParser`/`setTypeParser` as in PR 5a for PG) — `better-sqlite3` returns datetime columns as TEXT strings which the cast layer handles.

**Runtime change — `SQLiteDateTimeType`:**
- New subclass of `DateTime` registered for `datetime`/`timestamp` columns
- Converts `Temporal.PlainDateTime` (from offset-less TEXT strings) → `Temporal.Instant` using the same timezone selection as `formatInstantForSql` (`default_timezone: utc` → UTC, `local` → host tz), so write and read are always consistent
- Matches the migration plan type table: "SQLite datetime/timestamp → Temporal.Instant"

**What was already in place (PRs 2 & 3a):**
- `sqlite3/quoting.ts` formats all Temporal types as `:db` strings on write
- `DateType#cast` parses strings → `Temporal.PlainDate`
- `TimeType#cast` parses strings → `Temporal.PlainTime` (handles sentinel date prefix)

**Tests added (`sqlite3/quoting.test.ts`):**
- Unit tests for `quote(Temporal.*)` and `typeCast(Temporal.*)` for all four Temporal types
- Integration round-trip tests via real in-memory SQLite asserting microsecond precision (`epochNanoseconds`) survives exactly for `Instant`, `PlainDateTime`, `PlainDate`, and `PlainTime`

**DoD:** SQLite `INSERT` then `SELECT` of a microsecond timestamp preserves all six digits. ✓