### PR TITLE
feat(temporal): PR 5a — Postgres per-connection Temporal type parsers

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -60,7 +60,9 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
-    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
+    if (cast === null) return null;
+    if (cast === DateInfinity) return "infinity";
+    if (cast === DateNegativeInfinity) return "-infinity";
     const temporal = cast as Temporal.Instant | Temporal.PlainDateTime;
     const p = this.precision ?? -1;
     const digits = (Number.isInteger(p) && p >= 0 && p <= 9 ? p : 6) as

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -60,9 +60,9 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
-    if (cast === null) return null;
-    if (cast === DateInfinity) return "infinity";
-    if (cast === DateNegativeInfinity) return "-infinity";
+    // Sentinels are Postgres-specific; base type returns null. The Postgres
+    // OID::DateTime subclass overrides serialize() to emit 'infinity'/'-infinity'.
+    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
     const temporal = cast as Temporal.Instant | Temporal.PlainDateTime;
     const p = this.precision ?? -1;
     const digits = (Number.isInteger(p) && p >= 0 && p <= 9 ? p : 6) as

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -18,6 +18,8 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   cast(value: unknown): DateTimeCastResult | null {
     if (value === null || value === undefined) return null;
+    if (value === DateInfinity) return DateInfinity;
+    if (value === DateNegativeInfinity) return DateNegativeInfinity;
     if (value instanceof Temporal.Instant) return value;
     if (value instanceof Temporal.PlainDateTime) return value;
     // Dual-typed window: pg driver still returns Date until PR 5a.

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -42,7 +42,9 @@ export class DateType extends ValueType<DateCastResult> {
 
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
-    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
+    if (cast === null) return null;
+    if (cast === DateInfinity) return "infinity";
+    if (cast === DateNegativeInfinity) return "-infinity";
     return cast.toString();
   }
 

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -42,9 +42,9 @@ export class DateType extends ValueType<DateCastResult> {
 
   serialize(value: unknown): string | null {
     const cast = this.cast(value);
-    if (cast === null) return null;
-    if (cast === DateInfinity) return "infinity";
-    if (cast === DateNegativeInfinity) return "-infinity";
+    // Sentinels are Postgres-specific; base type returns null. The Postgres
+    // OID::Date subclass overrides serialize() to emit 'infinity'/'-infinity'.
+    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return null;
     return cast.toString();
   }
 

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -17,6 +17,8 @@ export class DateType extends ValueType<DateCastResult> {
 
   cast(value: unknown): DateCastResult | null {
     if (value === null || value === undefined) return null;
+    if (value === DateInfinity) return DateInfinity;
+    if (value === DateNegativeInfinity) return DateNegativeInfinity;
     if (value instanceof Temporal.PlainDate) return value;
     // Accept PlainDateTime from multiparameter assignment — extract the date part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -21,6 +21,8 @@ export class ComparisonValidator extends EachValidator {
       return Temporal.ZonedDateTime.compare(a, b);
     if (typeof a === "number" && typeof b === "number") return a - b;
     if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
+    // Dual-typed window: Date values still in flight compare by epoch ms.
+    if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
     // Incomparable types (e.g. Temporal vs non-Temporal, mixed types).
     // Rails raises ArgumentError here; we throw so callers don't silently
     // skip validation due to NaN comparison semantics (NaN <= 0 is false).

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -21,12 +21,12 @@ export class ComparisonValidator extends EachValidator {
       return Temporal.ZonedDateTime.compare(a, b);
     if (typeof a === "number" && typeof b === "number") return a - b;
     if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
-    // Temporal objects throw on implicit numeric coercion — safe fallback.
-    try {
-      return Number(a) - Number(b);
-    } catch {
-      return NaN;
-    }
+    // Incomparable types (e.g. Temporal vs non-Temporal, mixed types).
+    // Rails raises ArgumentError here; we throw so callers don't silently
+    // skip validation due to NaN comparison semantics (NaN <= 0 is false).
+    throw new TypeError(
+      `Comparison of ${(a as object)?.constructor?.name ?? typeof a} with ${(b as object)?.constructor?.name ?? typeof b} failed`,
+    );
   }
 
   override checkValidity(): void {
@@ -52,9 +52,20 @@ export class ComparisonValidator extends EachValidator {
       return;
     }
 
+    const safeCompare = (a: unknown, b: unknown): number | null => {
+      try {
+        return this.compare(a, b);
+      } catch {
+        record.errors.add(attribute, "invalid", { value, message: this.options.message });
+        return null;
+      }
+    };
+
     if (this.options.greaterThan !== undefined) {
       const target = this.resolve(this.options.greaterThan, record);
-      if (this.compare(value, target) <= 0) {
+      const cmp = safeCompare(value, target);
+      if (cmp === null) return;
+      if (cmp <= 0) {
         record.errors.add(attribute, "greater_than", {
           count: target,
           value,
@@ -64,7 +75,9 @@ export class ComparisonValidator extends EachValidator {
     }
     if (this.options.greaterThanOrEqualTo !== undefined) {
       const target = this.resolve(this.options.greaterThanOrEqualTo, record);
-      if (this.compare(value, target) < 0) {
+      const cmpGte = safeCompare(value, target);
+      if (cmpGte === null) return;
+      if (cmpGte < 0) {
         record.errors.add(attribute, "greater_than_or_equal_to", {
           count: target,
           value,
@@ -74,7 +87,9 @@ export class ComparisonValidator extends EachValidator {
     }
     if (this.options.lessThan !== undefined) {
       const target = this.resolve(this.options.lessThan, record);
-      if (this.compare(value, target) >= 0) {
+      const cmpLt = safeCompare(value, target);
+      if (cmpLt === null) return;
+      if (cmpLt >= 0) {
         record.errors.add(attribute, "less_than", {
           count: target,
           value,
@@ -84,7 +99,9 @@ export class ComparisonValidator extends EachValidator {
     }
     if (this.options.lessThanOrEqualTo !== undefined) {
       const target = this.resolve(this.options.lessThanOrEqualTo, record);
-      if (this.compare(value, target) > 0) {
+      const cmpLte = safeCompare(value, target);
+      if (cmpLte === null) return;
+      if (cmpLte > 0) {
         record.errors.add(attribute, "less_than_or_equal_to", {
           count: target,
           value,
@@ -94,7 +111,9 @@ export class ComparisonValidator extends EachValidator {
     }
     if (this.options.equalTo !== undefined) {
       const target = this.resolve(this.options.equalTo, record);
-      if (this.compare(value, target) !== 0) {
+      const cmpEq = safeCompare(value, target);
+      if (cmpEq === null) return;
+      if (cmpEq !== 0) {
         record.errors.add(attribute, "equal_to", {
           count: target,
           value,
@@ -104,7 +123,9 @@ export class ComparisonValidator extends EachValidator {
     }
     if (this.options.otherThan !== undefined) {
       const target = this.resolve(this.options.otherThan, record);
-      if (this.compare(value, target) === 0) {
+      const cmpOther = safeCompare(value, target);
+      if (cmpOther === null) return;
+      if (cmpOther === 0) {
         record.errors.add(attribute, "other_than", {
           count: target,
           value,

--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -159,7 +159,9 @@ describe("ActiveRecordSchemaTest", () => {
     expect(rows.length).toBe(1);
     const createdAt = rows[0].created_at;
     expect(
-      createdAt instanceof Date ? createdAt.toISOString().slice(0, 10) : String(createdAt),
+      createdAt instanceof Date
+        ? createdAt.toISOString().slice(0, 10)
+        : String(createdAt).slice(0, 10),
     ).toBe("2023-01-01");
   });
 
@@ -213,7 +215,9 @@ describe("ActiveRecordSchemaTest", () => {
     expect(rows.length).toBe(1);
     const createdAt = rows[0].created_at;
     expect(
-      createdAt instanceof Date ? createdAt.toISOString().slice(0, 10) : String(createdAt),
+      createdAt instanceof Date
+        ? createdAt.toISOString().slice(0, 10)
+        : String(createdAt).slice(0, 10),
     ).toBe("2023-01-01");
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -3,6 +3,7 @@
  */
 import pg from "pg";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import * as Arel from "@blazetrails/arel";
 import {
@@ -415,12 +416,12 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("date time decoding", async () => {
       const rows = await adapter.execute(`SELECT TIMESTAMP '2023-06-15 10:30:00' AS val`);
-      expect(rows[0].val).toBeInstanceOf(Date);
+      expect(rows[0].val).toBeInstanceOf(Temporal.PlainDateTime);
     });
 
     it("date decoding", async () => {
       const rows = await adapter.execute(`SELECT DATE '2023-06-15' AS val`);
-      expect(rows[0].val).toBeInstanceOf(Date);
+      expect(rows[0].val).toBeInstanceOf(Temporal.PlainDate);
     });
 
     it("time decoding", async () => {
@@ -431,16 +432,16 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("timestamp decoding", async () => {
       const rows = await adapter.execute(`SELECT TIMESTAMP '2023-06-15 10:30:00' AS val`);
-      const d = rows[0].val as Date;
-      expect(d).toBeInstanceOf(Date);
-      expect(d.getFullYear()).toBe(2023);
+      const d = rows[0].val as Temporal.PlainDateTime;
+      expect(d).toBeInstanceOf(Temporal.PlainDateTime);
+      expect(d.year).toBe(2023);
     });
 
     it("timestamp with time zone decoding", async () => {
       const rows = await adapter.execute(`SELECT TIMESTAMPTZ '2023-06-15 10:30:00+00' AS val`);
-      const d = rows[0].val as Date;
-      expect(d).toBeInstanceOf(Date);
-      expect(d.getFullYear()).toBe(2023);
+      const d = rows[0].val as Temporal.Instant;
+      expect(d).toBeInstanceOf(Temporal.Instant);
+      expect(d.toZonedDateTimeISO("UTC").year).toBe(2023);
     });
 
     it("interval decoding", async () => {
@@ -675,11 +676,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`CREATE TABLE "ex_dates" ("id" SERIAL PRIMARY KEY, "d" DATE)`);
       await adapter.exec(`INSERT INTO "ex_dates" ("d") VALUES ('2023-06-15')`);
       const rows = await adapter.execute(`SELECT "d" FROM "ex_dates"`);
-      const d = rows[0].d as Date;
-      expect(d).toBeInstanceOf(Date);
-      expect(d.getFullYear()).toBe(2023);
-      expect(d.getMonth()).toBe(5);
-      expect(d.getDate()).toBe(15);
+      const d = rows[0].d as Temporal.PlainDate;
+      expect(d).toBeInstanceOf(Temporal.PlainDate);
+      expect(d.year).toBe(2023);
+      expect(d.month).toBe(6);
+      expect(d.day).toBe(15);
     });
 
     it.skip("date decoding disabled", async () => {

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/quoting_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { IntegerOutOf64BitRange } from "../../connection-adapters/postgresql/quoting.js";
 
@@ -73,23 +74,24 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("quote date", async () => {
       const rows = await adapter.execute("SELECT DATE '2023-01-15' AS val");
-      const val = rows[0].val;
-      expect(val).toBeInstanceOf(Date);
-      expect((val as Date).getFullYear()).toBe(2023);
+      const val = rows[0].val as Temporal.PlainDate;
+      expect(val).toBeInstanceOf(Temporal.PlainDate);
+      expect(val.year).toBe(2023);
     });
 
     it("quote time", async () => {
       const rows = await adapter.execute("SELECT TIME '14:30:00' AS val");
-      const val = rows[0].val;
-      expect(typeof val === "string" || val instanceof Date).toBe(true);
-      expect(String(val)).toContain("14:30");
+      const val = rows[0].val as Temporal.PlainTime;
+      expect(val).toBeInstanceOf(Temporal.PlainTime);
+      expect(val.hour).toBe(14);
+      expect(val.minute).toBe(30);
     });
 
     it("quote timestamp", async () => {
       const rows = await adapter.execute("SELECT TIMESTAMP '2023-01-15 14:30:00' AS val");
-      const val = rows[0].val;
-      expect(val).toBeInstanceOf(Date);
-      expect((val as Date).getFullYear()).toBe(2023);
+      const val = rows[0].val as Temporal.PlainDateTime;
+      expect(val).toBeInstanceOf(Temporal.PlainDateTime);
+      expect(val.year).toBe(2023);
     });
 
     it.skip("quote range", async () => {});

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/timestamp_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 
@@ -44,8 +45,8 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("timestamp type cast", async () => {
       const rows = await adapter.execute("SELECT TIMESTAMP '2023-06-15 14:30:00' AS val");
-      expect(rows[0].val).toBeInstanceOf(Date);
-      expect((rows[0].val as Date).getFullYear()).toBe(2023);
+      expect(rows[0].val).toBeInstanceOf(Temporal.PlainDateTime);
+      expect((rows[0].val as Temporal.PlainDateTime).year).toBe(2023);
     });
 
     it("timestamp with time zone", async () => {
@@ -56,7 +57,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         `SELECT "occurred_at" FROM "postgresql_timestamps" WHERE "id" = ?`,
         [id],
       );
-      expect(rows[0].occurred_at).toBeInstanceOf(Date);
+      expect(rows[0].occurred_at).toBeInstanceOf(Temporal.Instant);
     });
 
     it("timestamp precision", async () => {
@@ -73,8 +74,8 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("timestamp before epoch", async () => {
       const rows = await adapter.execute("SELECT TIMESTAMP '1969-12-31 23:59:59' AS val");
-      expect(rows[0].val).toBeInstanceOf(Date);
-      expect((rows[0].val as Date).getFullYear()).toBe(1969);
+      expect(rows[0].val).toBeInstanceOf(Temporal.PlainDateTime);
+      expect((rows[0].val as Temporal.PlainDateTime).year).toBe(1969);
     });
 
     it("timestamp schema dump", async () => {
@@ -101,7 +102,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("datetime type cast", async () => {
       const rows = await adapter.execute("SELECT TIMESTAMP '2023-01-15 10:00:00' AS val");
-      expect(rows[0].val).toBeInstanceOf(Date);
+      expect(rows[0].val).toBeInstanceOf(Temporal.PlainDateTime);
     });
 
     it("datetime precision", async () => {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -1,5 +1,12 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
+
+function epochMs(v: unknown): number {
+  if (v instanceof Temporal.Instant) return v.epochMilliseconds;
+  if (v instanceof Temporal.PlainDateTime)
+    return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
+  throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
+}
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_one_associations_test.rb
  */
@@ -1073,9 +1080,9 @@ describe("HasOneAssociationsTest", () => {
     const firm = await TouchFirm.create({ name: "Touch Corp", updated_at: originalTime });
     await TouchAccount.create({ touch_firm_id: firm.id, credit_limit: 100 });
     const reloaded = await TouchFirm.find(firm.id);
-    const updatedAt = reloaded.updated_at as Temporal.Instant;
-    expect(updatedAt).toBeInstanceOf(Temporal.Instant);
-    expect(updatedAt.epochMilliseconds).toBeGreaterThan(originalTime.epochMilliseconds);
+    const updatedAt = reloaded.updated_at;
+    expect(updatedAt).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(epochMs(updatedAt)).toBeGreaterThan(originalTime.epochMilliseconds);
   });
 
   it.skip("polymorphic has one with touch option on create wont cache association so fetching after transaction commit works", () => {
@@ -1115,10 +1122,7 @@ describe("HasOneAssociationsTest", () => {
     const acct = await TouchUpdAccount.create({ touch_upd_firm_id: firm.id, credit_limit: 100 });
     const afterCreate = await TouchUpdFirm.find(firm.id);
     const timeAfterCreate = afterCreate.updated_at;
-    const createTime =
-      timeAfterCreate instanceof Temporal.Instant
-        ? timeAfterCreate.epochMilliseconds
-        : Number(new Date(String(timeAfterCreate)));
+    const createTime = epochMs(timeAfterCreate);
 
     // Ensure time advances so we can detect the touch
     await new Promise((r) => setTimeout(r, 10));
@@ -1127,10 +1131,7 @@ describe("HasOneAssociationsTest", () => {
     await acct.save();
     const afterUpdate = await TouchUpdFirm.find(firm.id);
     const timeAfterUpdate = afterUpdate.updated_at;
-    const updateTime =
-      timeAfterUpdate instanceof Temporal.Instant
-        ? timeAfterUpdate.epochMilliseconds
-        : Number(new Date(String(timeAfterUpdate)));
+    const updateTime = epochMs(timeAfterUpdate);
     expect(updateTime).toBeGreaterThan(createTime);
   });
 
@@ -1165,20 +1166,14 @@ describe("HasOneAssociationsTest", () => {
     const acct = await TouchDesAccount.create({ touch_des_firm_id: firm.id, credit_limit: 100 });
     const afterCreate = await TouchDesFirm.find(firm.id);
     const afterCreateAt = afterCreate.updated_at;
-    const afterCreateTime =
-      afterCreateAt instanceof Temporal.Instant
-        ? afterCreateAt.epochMilliseconds
-        : Number(new Date(String(afterCreateAt)));
+    const afterCreateTime = epochMs(afterCreateAt);
 
     await new Promise((r) => setTimeout(r, 10));
 
     await acct.destroy();
     const afterDestroy = await TouchDesFirm.find(firm.id);
     const afterDestroyAt = afterDestroy.updated_at;
-    const afterDestroyTime =
-      afterDestroyAt instanceof Temporal.Instant
-        ? afterDestroyAt.epochMilliseconds
-        : Number(new Date(String(afterDestroyAt)));
+    const afterDestroyTime = epochMs(afterDestroyAt);
     expect(afterDestroyTime).toBeGreaterThan(afterCreateTime);
   });
 

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -7,6 +7,9 @@ function epochMs(v: unknown): number {
     return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
   throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
 }
+function isTemporalDatetime(v: unknown): boolean {
+  return v instanceof Temporal.Instant || v instanceof Temporal.PlainDateTime;
+}
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_one_associations_test.rb
  */
@@ -1081,7 +1084,7 @@ describe("HasOneAssociationsTest", () => {
     await TouchAccount.create({ touch_firm_id: firm.id, credit_limit: 100 });
     const reloaded = await TouchFirm.find(firm.id);
     const updatedAt = reloaded.updated_at;
-    expect(updatedAt).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(updatedAt).toSatisfy(isTemporalDatetime);
     expect(epochMs(updatedAt)).toBeGreaterThan(originalTime.epochMilliseconds);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -977,8 +977,11 @@ export function temporalToBindString(
   adapter?: "sqlite" | "postgres" | "mysql",
 ): unknown {
   // Postgres infinity sentinels must become the wire strings pg expects.
-  if (value === DateInfinity) return "infinity";
-  if (value === DateNegativeInfinity) return "-infinity";
+  // Gated to postgres adapter only — SQLite/MySQL have no infinity concept.
+  if (adapter === "postgres") {
+    if (value === DateInfinity) return "infinity";
+    if (value === DateNegativeInfinity) return "-infinity";
+  }
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -18,6 +18,7 @@ import {
   formatPlainDateForSql,
   formatPlainTimeForSql,
 } from "./quoting.js";
+import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
 import { TransactionManager } from "./transaction.js";
 import { Result } from "../../result.js";
 import { isWriteQuerySql } from "../sql-classification.js";
@@ -975,6 +976,9 @@ export function temporalToBindString(
   value: unknown,
   adapter?: "sqlite" | "postgres" | "mysql",
 ): unknown {
+  // Postgres infinity sentinels must become the wire strings pg expects.
+  if (value === DateInfinity) return "infinity";
+  if (value === DateNegativeInfinity) return "-infinity";
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -45,6 +45,8 @@ import {
   temporalToBindString,
 } from "./abstract/database-statements.js";
 import { getTypeParser as getTemporalTypeParser } from "./postgresql/temporal-type-parsers.js";
+
+const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
 import { READ_QUERY } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 import {
@@ -312,7 +314,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.
           // For all other OIDs, respect any user-supplied parser first, then
           // delegate to getTemporalTypeParser which falls back to pg built-ins.
-          if ([1082, 1083, 1114, 1184, 1266].includes(oid) && (format === "text" || !format)) {
+          if (TEMPORAL_OIDS.has(oid) && (format === "text" || !format)) {
             return getTemporalTypeParser(oid, format);
           }
           return userGetTypeParser?.(oid, format) ?? getTemporalTypeParser(oid, format);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -39,7 +39,12 @@ import {
 } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
-import { transactionIsolationLevels, typeCastedBinds } from "./abstract/database-statements.js";
+import {
+  transactionIsolationLevels,
+  typeCastedBinds,
+  temporalToBindString,
+} from "./abstract/database-statements.js";
+import { getTypeParser as getTemporalTypeParser } from "./postgresql/temporal-type-parsers.js";
 import { READ_QUERY } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./postgresql/schema-statements.js";
 import {
@@ -241,7 +246,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (typeof config === "string") {
       this._minMessages = "warning";
       this._sessionVariables = {};
-      this._driverPool = new pg.Pool({ connectionString: config });
+      this._driverPool = new pg.Pool({
+        connectionString: config,
+        types: { getTypeParser: getTemporalTypeParser },
+      });
       return;
     }
     // Rails' database.yml merges driver connection params + adapter
@@ -294,7 +302,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Freeze a shallow copy so post-construction mutation can't bypass the
     // key/value validation above and introduce un-sanitized SQL fragments.
     this._sessionVariables = Object.freeze({ ...(variables ?? {}) });
-    this._driverPool = new pg.Pool(pgConfig);
+    this._driverPool = new pg.Pool({
+      ...pgConfig,
+      types: { getTypeParser: getTemporalTypeParser },
+    });
   }
 
   /**
@@ -451,7 +462,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       fields: Array<{ name: string; dataTypeID: number }>;
       rows: unknown[][];
     }
-    const bindArray = binds ?? [];
+    // Convert any Temporal values to SQL strings before pg sees them.
+    // pg's extended/prepared protocol serializes parameters via its own
+    // writer which has no Temporal support.
+    const bindArray = (binds ?? []).map((v) => temporalToBindString(v, "postgres"));
     const rewritten = this.rewriteBinds(sql, bindArray);
     const payload: Record<string, unknown> = {
       sql: rewritten,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -302,9 +302,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Freeze a shallow copy so post-construction mutation can't bypass the
     // key/value validation above and introduce un-sanitized SQL fragments.
     this._sessionVariables = Object.freeze({ ...(variables ?? {}) });
+    const userGetTypeParser = (
+      pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined
+    )?.getTypeParser;
     this._driverPool = new pg.Pool({
       ...pgConfig,
-      types: { getTypeParser: getTemporalTypeParser },
+      types: {
+        getTypeParser(oid: number, format?: string): unknown {
+          // Our Temporal parsers handle text-format for the 5 datetime OIDs.
+          // For all other OIDs, respect any user-supplied parser first, then
+          // delegate to getTemporalTypeParser which falls back to pg built-ins.
+          if ([1082, 1083, 1114, 1184, 1266].includes(oid) && (format === "text" || !format)) {
+            return getTemporalTypeParser(oid, format);
+          }
+          return userGetTypeParser?.(oid, format) ?? getTemporalTypeParser(oid, format);
+        },
+      },
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -857,6 +857,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<Record<string, unknown>[]> {
     this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
+    binds = binds.map((v) => temporalToBindString(v, "postgres"));
     const rewritten = this.rewriteBinds(sql, binds);
     // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber
     // stores something that can be re-EXPLAIN'd on the same adapter
@@ -895,6 +896,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
+    binds = binds.map((v) => temporalToBindString(v, "postgres"));
     const pgSql = this.rewriteBinds(sql, binds);
     // payload.sql records the rewritten SQL — ExplainSubscriber captures
     // something that can be re-EXPLAIN'd without re-running rewriteBinds
@@ -1227,8 +1229,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // re-EXPLAIN'd. Bind values pass through to pg as the values
       // array so `EXPLAIN` with parameters doesn't error with
       // "there is no parameter $1".
-      const rewritten = this.rewriteBinds(sql, binds);
-      const result = await client.query(`${clause} ${rewritten}`, binds);
+      const pgBinds = binds.map((v) => temporalToBindString(v, "postgres"));
+      const rewritten = this.rewriteBinds(sql, pgBinds);
+      const result = await client.query(`${clause} ${rewritten}`, pgBinds);
       const printer = new ExplainPrettyPrinter();
       return printer.pp(result.rows);
     });

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the per-connection Temporal type parsers.
+ *
+ * These tests exercise `getTypeParser` in isolation (no live DB needed)
+ * and verify that the global pg type registry is unaffected.
+ */
+
+import { describe, expect, it } from "vitest";
+import pg from "pg";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
+import { getTypeParser } from "./temporal-type-parsers.js";
+
+const OID_DATE = 1082;
+const OID_TIME = 1083;
+const OID_TIMESTAMP = 1114;
+const OID_TIMESTAMPTZ = 1184;
+const OID_TIMETZ = 1266;
+
+function parse(oid: number, value: string): unknown {
+  const parser = getTypeParser(oid, "text");
+  if (!parser) throw new Error(`No parser for OID ${oid}`);
+  return parser(value);
+}
+
+describe("getTypeParser — timestamptz (OID 1184)", () => {
+  it("returns a Temporal.Instant", () => {
+    const result = parse(OID_TIMESTAMPTZ, "2026-04-26 14:23:55.123456+00");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect((result as Temporal.Instant).toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("preserves microseconds", () => {
+    const result = parse(OID_TIMESTAMPTZ, "2024-01-01 00:00:00.000001+00") as Temporal.Instant;
+    expect(result.toString()).toBe("2024-01-01T00:00:00.000001Z");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parse(OID_TIMESTAMPTZ, "infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parse(OID_TIMESTAMPTZ, "-infinity")).toBe(DateNegativeInfinity);
+  });
+
+  it("handles BC timestamps", () => {
+    const result = parse(OID_TIMESTAMPTZ, "0044-03-15 12:00:00+00 BC") as Temporal.Instant;
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(-43);
+  });
+});
+
+describe("getTypeParser — timestamp (OID 1114)", () => {
+  it("returns a Temporal.PlainDateTime", () => {
+    const result = parse(OID_TIMESTAMP, "2026-04-26 14:23:55.123456");
+    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    expect((result as Temporal.PlainDateTime).toString()).toBe("2026-04-26T14:23:55.123456");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parse(OID_TIMESTAMP, "infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parse(OID_TIMESTAMP, "-infinity")).toBe(DateNegativeInfinity);
+  });
+});
+
+describe("getTypeParser — date (OID 1082)", () => {
+  it("returns a Temporal.PlainDate", () => {
+    const result = parse(OID_DATE, "2026-04-26");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2026-04-26");
+  });
+
+  it("returns DateInfinity for 'infinity'", () => {
+    expect(parse(OID_DATE, "infinity")).toBe(DateInfinity);
+  });
+
+  it("returns DateNegativeInfinity for '-infinity'", () => {
+    expect(parse(OID_DATE, "-infinity")).toBe(DateNegativeInfinity);
+  });
+});
+
+describe("getTypeParser — time (OID 1083)", () => {
+  it("returns a Temporal.PlainTime", () => {
+    const result = parse(OID_TIME, "14:23:55.123456");
+    expect(result).toBeInstanceOf(Temporal.PlainTime);
+    expect((result as Temporal.PlainTime).toString()).toBe("14:23:55.123456");
+  });
+
+  it("normalizes 24:00:00 to midnight", () => {
+    const result = parse(OID_TIME, "24:00:00") as Temporal.PlainTime;
+    expect(result.toString()).toBe("00:00:00");
+  });
+});
+
+describe("getTypeParser — timetz (OID 1266)", () => {
+  it("returns a TimeTzValue with time and offset", () => {
+    const result = parse(OID_TIMETZ, "14:23:55.123456+02") as {
+      time: Temporal.PlainTime;
+      offset: string;
+    };
+    expect(result.time).toBeInstanceOf(Temporal.PlainTime);
+    expect(result.time.toString()).toBe("14:23:55.123456");
+    expect(result.offset).toBe("+02:00");
+  });
+});
+
+describe("getTypeParser — binary format", () => {
+  it("returns null for binary format (not intercepted)", () => {
+    expect(getTypeParser(OID_TIMESTAMPTZ, "binary")).toBeNull();
+    expect(getTypeParser(OID_DATE, "binary")).toBeNull();
+  });
+});
+
+describe("getTypeParser — unknown OIDs", () => {
+  it("returns null for non-temporal OIDs", () => {
+    expect(getTypeParser(23, "text")).toBeNull(); // int4
+    expect(getTypeParser(25, "text")).toBeNull(); // text
+  });
+});
+
+describe("global pg type registry is unaffected", () => {
+  it("pg.types still returns its default Date parser for timestamptz", () => {
+    // Calling getTypeParser from our module must NOT mutate pg.types.
+    // The global parser for OID 1184 should still be pg's built-in one.
+    const globalParser = pg.types.getTypeParser(OID_TIMESTAMPTZ, "text");
+    // pg's built-in parser returns a Date or string, not a Temporal.Instant.
+    const result = (globalParser as (v: string) => unknown)("2026-04-26 14:23:55+00");
+    expect(result).not.toBeInstanceOf(Temporal.Instant);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
@@ -108,16 +108,16 @@ describe("getTypeParser — timetz (OID 1266)", () => {
 });
 
 describe("getTypeParser — binary format", () => {
-  it("returns null for binary format (not intercepted)", () => {
-    expect(getTypeParser(OID_TIMESTAMPTZ, "binary")).toBeNull();
-    expect(getTypeParser(OID_DATE, "binary")).toBeNull();
+  it("delegates binary format to pg built-ins (always returns a function)", () => {
+    expect(typeof getTypeParser(OID_TIMESTAMPTZ, "binary")).toBe("function");
+    expect(typeof getTypeParser(OID_DATE, "binary")).toBe("function");
   });
 });
 
 describe("getTypeParser — unknown OIDs", () => {
-  it("returns null for non-temporal OIDs", () => {
-    expect(getTypeParser(23, "text")).toBeNull(); // int4
-    expect(getTypeParser(25, "text")).toBeNull(); // text
+  it("delegates non-temporal OIDs to pg built-ins (always returns a function)", () => {
+    expect(typeof getTypeParser(23, "text")).toBe("function"); // int4
+    expect(typeof getTypeParser(25, "text")).toBe("function"); // text
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -45,7 +45,7 @@ const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser
  * which pg interprets as "use the built-in default for this OID".
  */
 export function getTypeParser(oid: number, format?: string): PgParser | null {
-  if (format === "text" || format === undefined) {
+  if (format === "text" || !format) {
     const parser = TEMPORAL_PARSERS.get(oid);
     if (parser) return parser;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -27,14 +27,15 @@ const OID_TIMESTAMP = 1114;
 const OID_TIMESTAMPTZ = 1184;
 const OID_TIMETZ = 1266;
 
-type PgParser = (value: string) => unknown;
+// Text-format parsers receive strings; binary-format parsers receive Buffer.
+type PgParser = (value: string | Buffer) => unknown;
 
 const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser>([
-  [OID_TIMESTAMPTZ, (v) => parsePostgresInstant(v)],
-  [OID_TIMESTAMP, (v) => parsePostgresPlainDateTime(v)],
-  [OID_DATE, (v) => parsePostgresDate(v)],
-  [OID_TIME, (v) => parsePostgresTime(v)],
-  [OID_TIMETZ, (v) => parsePostgresTimeTz(v)],
+  [OID_TIMESTAMPTZ, (v) => parsePostgresInstant(v as string)],
+  [OID_TIMESTAMP, (v) => parsePostgresPlainDateTime(v as string)],
+  [OID_DATE, (v) => parsePostgresDate(v as string)],
+  [OID_TIME, (v) => parsePostgresTime(v as string)],
+  [OID_TIMETZ, (v) => parsePostgresTimeTz(v as string)],
 ]);
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-connection Temporal type parsers for the pg driver.
+ *
+ * pg's default OID parsers decode timestamp/date columns into JS Date
+ * objects, losing microsecond precision. By passing `{ types: { getTypeParser } }`
+ * to `new pg.Pool(...)` we redirect those OIDs to our wire parsers, which
+ * return Temporal types with full precision.
+ *
+ * We deliberately do NOT call `pg.types.setTypeParser` — that mutates a
+ * process-global registry shared with drizzle, pg-boss, raw pg.Client users,
+ * etc. Per-connection tables, not global mutation.
+ */
+
+import {
+  parsePostgresInstant,
+  parsePostgresPlainDateTime,
+  parsePostgresDate,
+  parsePostgresTime,
+  parsePostgresTimeTz,
+} from "../abstract/temporal-wire.js";
+
+// PostgreSQL OIDs for the temporal types we intercept.
+const OID_DATE = 1082;
+const OID_TIME = 1083;
+const OID_TIMESTAMP = 1114;
+const OID_TIMESTAMPTZ = 1184;
+const OID_TIMETZ = 1266;
+
+type PgParser = (value: string) => unknown;
+
+const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser>([
+  [OID_TIMESTAMPTZ, (v) => parsePostgresInstant(v)],
+  [OID_TIMESTAMP, (v) => parsePostgresPlainDateTime(v)],
+  [OID_DATE, (v) => parsePostgresDate(v)],
+  [OID_TIME, (v) => parsePostgresTime(v)],
+  [OID_TIMETZ, (v) => parsePostgresTimeTz(v)],
+]);
+
+/**
+ * Drop-in replacement for `pg.types.getTypeParser`.
+ * Pass as `{ types: { getTypeParser } }` in the pg.Pool / pg.Client config.
+ *
+ * Only intercepts text-format (`format === 'text'`) for the five temporal
+ * OIDs. Everything else falls through to the default pg parser via `null`,
+ * which pg interprets as "use the built-in default for this OID".
+ */
+export function getTypeParser(oid: number, format?: string): PgParser | null {
+  if (format === "text" || format === undefined) {
+    const parser = TEMPORAL_PARSERS.get(oid);
+    if (parser) return parser;
+  }
+  return null;
+}

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -11,6 +11,7 @@
  * etc. Per-connection tables, not global mutation.
  */
 
+import pg from "pg";
 import {
   parsePostgresInstant,
   parsePostgresPlainDateTime,
@@ -40,14 +41,17 @@ const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser
  * Drop-in replacement for `pg.types.getTypeParser`.
  * Pass as `{ types: { getTypeParser } }` in the pg.Pool / pg.Client config.
  *
- * Only intercepts text-format (`format === 'text'`) for the five temporal
- * OIDs. Everything else falls through to the default pg parser via `null`,
- * which pg interprets as "use the built-in default for this OID".
+ * Intercepts text-format for the five temporal OIDs and returns our Temporal
+ * wire parsers. All other OIDs delegate to `pg.types.getTypeParser` so the
+ * built-in parsers (int, bool, numeric, etc.) remain active. Returning `null`
+ * is NOT correct — pg stores the return value directly in its `_parsers` array
+ * and calls it; a non-function crashes query processing.
  */
-export function getTypeParser(oid: number, format?: string): PgParser | null {
-  if (format === "text" || !format) {
+export function getTypeParser(oid: number, format?: string): PgParser {
+  const fmt = format || "text";
+  if (fmt === "text") {
     const parser = TEMPORAL_PARSERS.get(oid);
     if (parser) return parser;
   }
-  return null;
+  return pg.types.getTypeParser(oid, fmt as "text" | "binary") as PgParser;
 }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1721,9 +1721,12 @@ describe("MigrationTest", () => {
       const rows = await bulkAdapter.execute(`SELECT * FROM "bk4"`);
       expect(rows.length).toBe(1);
       const createdAt = rows[0].created_at;
-      expect(
-        createdAt instanceof Date ? createdAt.toISOString().slice(0, 10) : String(createdAt),
-      ).toBe("2023-01-01");
+      // PlainDateTime.toString() gives 'YYYY-MM-DDTHH:MM:SS'; take the date portion.
+      const dateStr =
+        createdAt instanceof Date
+          ? createdAt.toISOString().slice(0, 10)
+          : String(createdAt).slice(0, 10);
+      expect(dateStr).toBe("2023-01-01");
     });
 
     it("removing timestamps", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1139,7 +1139,7 @@ describe("PersistenceTest", () => {
     const p = await Post.create({ title: "auto", created_at: now });
     expect(p.created_at).toBeInstanceOf(Temporal.PlainDateTime);
     // timestamp (no tz) round-trip: compare via UTC epoch ms
-    expect(epochMs(p.created_at)).toBe(now);
+    expect(epochMs(p.created_at)).toBe(now.epochMilliseconds);
     expect(p.isPersisted()).toBe(true);
   });
 

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -9,6 +9,10 @@ function epochMs(v: unknown): number {
     return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
   throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
 }
+// SQLite datetime → Temporal.Instant; Postgres timestamp (no tz) → Temporal.PlainDateTime
+function isTemporalDatetime(v: unknown): boolean {
+  return v instanceof Temporal.Instant || v instanceof Temporal.PlainDateTime;
+}
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -1137,7 +1141,7 @@ describe("PersistenceTest", () => {
     }
     const now = Temporal.Now.instant();
     const p = await Post.create({ title: "auto", created_at: now });
-    expect(p.created_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(p.created_at).toSatisfy(isTemporalDatetime);
     // timestamp (no tz) round-trip: compare via UTC epoch ms
     expect(epochMs(p.created_at)).toBe(now.epochMilliseconds);
     expect(p.isPersisted()).toBe(true);
@@ -1393,7 +1397,7 @@ describe("PersistenceTest", () => {
     const t = await Topic.create({ title: "old" });
     t.title = "new";
     await t.save();
-    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(t.updated_at).toSatisfy(isTemporalDatetime);
   });
 
   it("save without N+1", async () => {
@@ -1478,8 +1482,8 @@ describe("PersistenceTest", () => {
       }
     }
     const t = await Topic.create({ title: "test" });
-    expect(t.created_at).toBeInstanceOf(Temporal.PlainDateTime);
-    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(t.created_at).toSatisfy(isTemporalDatetime);
+    expect(t.updated_at).toSatisfy(isTemporalDatetime);
   });
 
   it("update_attribute_vs_update_column", async () => {
@@ -2129,7 +2133,7 @@ describe("PersistenceTest", () => {
     }
     const t = await Topic.create({ title: "test" });
     await t.updateAttributeBang("title", "new");
-    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(t.updated_at).toSatisfy(isTemporalDatetime);
   });
 
   it("update column for readonly attribute", async () => {
@@ -3509,8 +3513,8 @@ describe("PersistenceTest", () => {
 
     await topic.touch("replied_at");
 
-    expect(topic.replied_at).toBeInstanceOf(Temporal.PlainDateTime);
-    expect(topic.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(topic.replied_at).toSatisfy(isTemporalDatetime);
+    expect(topic.updated_at).toSatisfy(isTemporalDatetime);
   });
 
   it("touch does not run callbacks", async () => {
@@ -3634,7 +3638,7 @@ describe("PersistenceTest", () => {
     await user.save();
     // updated_at should be set (may or may not differ due to timing,
     // but at minimum it should be a Date)
-    expect(user.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(user.updated_at).toSatisfy(isTemporalDatetime);
   });
 });
 
@@ -3821,8 +3825,8 @@ describe("PersistenceTest", () => {
     const user = await User.create({ name: "Alice" });
     expect(user.last_login_at).toBeNull();
     await user.touch("last_login_at");
-    expect(user.last_login_at).toBeInstanceOf(Temporal.PlainDateTime);
-    expect(user.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(user.last_login_at).toSatisfy(isTemporalDatetime);
+    expect(user.updated_at).toSatisfy(isTemporalDatetime);
   });
 
   // Rails: test_touch_persists_to_database
@@ -3838,7 +3842,7 @@ describe("PersistenceTest", () => {
     const user = await User.create({ name: "Alice" });
     await user.touch();
     const reloaded = await User.find(user.id!);
-    expect(reloaded.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(reloaded.updated_at).toSatisfy(isTemporalDatetime);
   });
 });
 

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1,5 +1,14 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
+
+// timestamp (no tz) columns return PlainDateTime. With default_timezone=:utc
+// the stored value is UTC, so treat it as UTC to get epoch milliseconds.
+function epochMs(v: unknown): number {
+  if (v instanceof Temporal.Instant) return v.epochMilliseconds;
+  if (v instanceof Temporal.PlainDateTime)
+    return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
+  throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
+}
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -1128,8 +1137,9 @@ describe("PersistenceTest", () => {
     }
     const now = Temporal.Now.instant();
     const p = await Post.create({ title: "auto", created_at: now });
-    expect(p.created_at).toBeInstanceOf(Temporal.Instant);
-    expect(Temporal.Instant.compare(p.created_at as Temporal.Instant, now)).toBe(0);
+    expect(p.created_at).toBeInstanceOf(Temporal.PlainDateTime);
+    // timestamp (no tz) round-trip: compare via UTC epoch ms
+    expect(epochMs(p.created_at)).toBe(now);
     expect(p.isPersisted()).toBe(true);
   });
 
@@ -1383,7 +1393,7 @@ describe("PersistenceTest", () => {
     const t = await Topic.create({ title: "old" });
     t.title = "new";
     await t.save();
-    expect(t.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   it("save without N+1", async () => {
@@ -1468,8 +1478,8 @@ describe("PersistenceTest", () => {
       }
     }
     const t = await Topic.create({ title: "test" });
-    expect(t.created_at).toBeInstanceOf(Temporal.Instant);
-    expect(t.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(t.created_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   it("update_attribute_vs_update_column", async () => {
@@ -1713,7 +1723,7 @@ describe("PersistenceTest", () => {
     await t.incrementBang("count", 1, { touch: "updated_at" });
     const reloaded = await Topic.find(t.id);
     expect(reloaded.count).toBe(2);
-    expect((reloaded.updated_at as Temporal.Instant).epochMilliseconds).toBeGreaterThan(
+    expect(epochMs(reloaded.updated_at)).toBeGreaterThan(
       instant("2020-01-01T00:00:00Z").epochMilliseconds,
     );
   });
@@ -2089,10 +2099,10 @@ describe("PersistenceTest", () => {
       }
     }
     const t = await Topic.create({ title: "test" });
-    const before = t.updated_at as Temporal.Instant;
+    const before = t.updated_at;
     await t.updateAttribute("title", "new");
-    const after = t.updated_at as Temporal.Instant;
-    expect(after.epochMilliseconds).toBeGreaterThanOrEqual(before.epochMilliseconds);
+    const after = t.updated_at;
+    expect(epochMs(after)).toBeGreaterThanOrEqual(epochMs(before));
   });
 
   it("update attribute!", async () => {
@@ -2119,7 +2129,7 @@ describe("PersistenceTest", () => {
     }
     const t = await Topic.create({ title: "test" });
     await t.updateAttributeBang("title", "new");
-    expect(t.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(t.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   it("update column for readonly attribute", async () => {
@@ -2492,7 +2502,7 @@ describe("PersistenceTest", () => {
     }
 
     const post = await Post.create({ title: "Hello" });
-    const originalCreatedAt = (post.created_at as Temporal.Instant).epochMilliseconds;
+    const originalCreatedAt = epochMs(post.created_at);
 
     post.title = "Updated";
     await post.save();
@@ -2500,7 +2510,7 @@ describe("PersistenceTest", () => {
     post.title = "Updated again";
     await post.save();
 
-    expect((post.created_at as Temporal.Instant).epochMilliseconds).toBe(originalCreatedAt);
+    expect(epochMs(post.created_at)).toBe(originalCreatedAt);
   });
 
   it("updateColumn does not auto-update updated_at", async () => {
@@ -2515,12 +2525,12 @@ describe("PersistenceTest", () => {
     }
 
     const post = await Post.create({ title: "Hello" });
-    const originalUpdatedAt = (post.updated_at as Temporal.Instant).epochMilliseconds;
+    const originalUpdatedAt = epochMs(post.updated_at);
 
     await post.updateColumn("title", "Changed");
 
     // updateColumn should NOT auto-bump updated_at
-    expect((post.updated_at as Temporal.Instant).epochMilliseconds).toBe(originalUpdatedAt);
+    expect(epochMs(post.updated_at)).toBe(originalUpdatedAt);
   });
 });
 
@@ -3486,12 +3496,12 @@ describe("PersistenceTest", () => {
 
   it("touching a record updates its timestamp", async () => {
     const topic = await Topic.create({ title: "Test" });
-    const before = topic.updated_at as Temporal.Instant;
+    const before = topic.updated_at;
 
     await topic.touch();
 
-    const after = topic.updated_at as Temporal.Instant;
-    expect(after.epochMilliseconds).toBeGreaterThanOrEqual(before.epochMilliseconds);
+    const after = topic.updated_at;
+    expect(epochMs(after)).toBeGreaterThanOrEqual(epochMs(before));
   });
 
   it("touching an attribute updates it", async () => {
@@ -3499,8 +3509,8 @@ describe("PersistenceTest", () => {
 
     await topic.touch("replied_at");
 
-    expect(topic.replied_at).toBeInstanceOf(Temporal.Instant);
-    expect(topic.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(topic.replied_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(topic.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   it("touch does not run callbacks", async () => {
@@ -3624,7 +3634,7 @@ describe("PersistenceTest", () => {
     await user.save();
     // updated_at should be set (may or may not differ due to timing,
     // but at minimum it should be a Date)
-    expect(user.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(user.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 });
 
@@ -3791,10 +3801,10 @@ describe("PersistenceTest", () => {
     }
 
     const user = await User.create({ name: "Alice" });
-    const before = user.updated_at as Temporal.Instant;
+    const before = user.updated_at;
     await user.touch();
-    const after = user.updated_at as Temporal.Instant;
-    expect(after.epochMilliseconds).toBeGreaterThanOrEqual(before.epochMilliseconds);
+    const after = user.updated_at;
+    expect(epochMs(after)).toBeGreaterThanOrEqual(epochMs(before));
   });
 
   // Rails: test_touch_with_specific_columns
@@ -3811,8 +3821,8 @@ describe("PersistenceTest", () => {
     const user = await User.create({ name: "Alice" });
     expect(user.last_login_at).toBeNull();
     await user.touch("last_login_at");
-    expect(user.last_login_at).toBeInstanceOf(Temporal.Instant);
-    expect(user.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(user.last_login_at).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(user.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   // Rails: test_touch_persists_to_database
@@ -3828,7 +3838,7 @@ describe("PersistenceTest", () => {
     const user = await User.create({ name: "Alice" });
     await user.touch();
     const reloaded = await User.find(user.id!);
-    expect(reloaded.updated_at).toBeInstanceOf(Temporal.Instant);
+    expect(reloaded.updated_at).toBeInstanceOf(Temporal.PlainDateTime);
   });
 });
 

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -4,6 +4,13 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+
+function epochMs(v: unknown): number {
+  if (v instanceof Temporal.Instant) return v.epochMilliseconds;
+  if (v instanceof Temporal.PlainDateTime)
+    return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
+  throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
+}
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany, processDependentAssociations } from "../associations.js";
 
@@ -205,15 +212,13 @@ describe("DeleteAllTest", () => {
     }
 
     const post = await Post.create({ title: "Hello" });
-    const originalUpdatedAt = post.updated_at as Temporal.Instant;
+    const originalUpdatedAt = post.updated_at;
 
     await Post.all().updateAll({ title: "Changed" });
 
     const reloaded = await Post.find(post.id);
     // updateAll should NOT auto-bump updated_at
-    expect((reloaded.updated_at as Temporal.Instant).epochMilliseconds).toBe(
-      originalUpdatedAt.epochMilliseconds,
-    );
+    expect(epochMs(reloaded.updated_at)).toBe(epochMs(originalUpdatedAt));
   });
 
   it("deleteAll does not run callbacks", async () => {

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -1,5 +1,12 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
+
+function epochMs(v: unknown): number {
+  if (v instanceof Temporal.Instant) return v.epochMilliseconds;
+  if (v instanceof Temporal.PlainDateTime)
+    return v.toZonedDateTime("UTC").toInstant().epochMilliseconds;
+  throw new TypeError(`epochMs: unsupported type ${(v as object)?.constructor?.name}`);
+}
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -269,9 +276,7 @@ describe("UpdateAllTest", () => {
     await Post.all().touchAll();
     const p = (await Post.first()) as any;
     const updatedAt = p.updated_at;
-    expect((updatedAt as Temporal.Instant).epochMilliseconds).toBeGreaterThan(
-      past.epochMilliseconds,
-    );
+    expect(epochMs(updatedAt)).toBeGreaterThan(past.epochMilliseconds);
   });
 
   it.skip("touch all with custom timestamp", () => {


### PR DESCRIPTION
## Summary

Fifth PR in the Temporal migration ([plan](docs/temporal-migration-plan.md)), Postgres adapter path. Blocked by PR 3a (cast layer).

- **`postgresql/temporal-type-parsers.ts`** — `getTypeParser(oid, format?)` factory keyed on OIDs 1082/1083/1114/1184/1266. Reuses wire parsers from PR 1 (`parsePostgresInstant`, `parsePostgresPlainDateTime`, etc.). For text-format temporal OIDs, returns our Temporal parsers. For all other OIDs and binary format, delegates to `pg.types.getTypeParser` (the built-in fallback) — returning `null` would store `null` in pg's `_parsers` array and crash on every row.

- **`postgresql-adapter.ts`** — Both `pg.Pool` constructors pass `{ types: { getTypeParser } }`. `pg.types.setTypeParser` is never called — per-connection table only. `execute`, `execQuery`, `executeMutation`, and `explain` all map bind values through `temporalToBindString('postgres')` before passing to pg's extended-protocol writer.

- **Sentinel passthrough** — `DateType.cast()` and `DateTimeType.cast()` now pass through `DateInfinity`/`DateNegativeInfinity` symbols early so infinity values from Postgres survive the cast/hydration cycle.

- **Comparison validation** — `ComparisonValidator.compare()` throws `TypeError` for incomparable types (Temporal vs non-Temporal, mixed); `validateEach` wraps in `safeCompare()` and adds an `'invalid'` error on throw, preventing silent pass-through from `NaN` comparison semantics.

- **Test updates** — `timestamp without time zone` columns now return `Temporal.PlainDateTime` (not `Date` or `Instant`). Tests updated with `epochMs()` helper and correct `toBeInstanceOf` types.

## Test plan

- [x] 17 unit tests in `temporal-type-parsers.test.ts` — each OID, precision, infinity, BC, 24:00:00, unknown OIDs and binary format delegate to pg built-ins, global registry unaffected
- [x] `pnpm build` clean, `pnpm test:types` 72/72