### PR TITLE
test(parity): AR gap fixtures ar-161..ar-165 — order alias qualification + Arel aggregate nodes

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -70,5 +70,25 @@
   "ar-160": {
     "side": "trails-missing",
     "reason": "Arel aggregate nodes (Sum, Count, Avg, Max, Min) constructed directly via new Nodes.Sum([col]) crash: the Trails Arel visitor has no visitSum etc. handlers, throwing 'Unknown node type: Sum'. Rails' visitor handles these via visit_Arel_Nodes_Sum etc. Real fix: add visitor handlers for each aggregate node type in the Arel ToSql visitor."
+  },
+  "ar-161": {
+    "side": "diff",
+    "reason": "ORDER BY string alias from a SELECT expression is over-qualified: order('pub_year') on a query with EXTRACT(...) AS pub_year produces ORDER BY \"books\".\"pub_year\" ASC instead of ORDER BY pub_year. Trails' string-order path qualifies any bare identifier with the model's table name. Real fix: _applyOrderToManager must pass string ORDER BY values verbatim (as Rails does) instead of qualifying unrecognised bare identifiers."
+  },
+  "ar-162": {
+    "side": "diff",
+    "reason": "ORDER BY aggregate alias is over-qualified: order('cnt DESC') produces ORDER BY \"books\".\"cnt\" DESC instead of ORDER BY cnt DESC. Same root as ar-161 — Trails' order-qualification path treats any bare identifier as a table column. Real fix: same as ar-161."
+  },
+  "ar-163": {
+    "side": "trails-missing",
+    "reason": "Arel Nodes::Count not registered in Trails' Arel visitor: new Nodes.Count([col]) throws 'Unknown node type: Count'. Same root as ar-160 (Sum). Real fix: add visitCount to the Arel ToSql visitor."
+  },
+  "ar-164": {
+    "side": "trails-missing",
+    "reason": "Arel Nodes::Max and Nodes::Min not registered in Trails' Arel visitor: new Nodes.Max/Min([col]) throws 'Unknown node type: Max'. Same root as ar-160 (Sum). Real fix: add visitMax and visitMin to the Arel ToSql visitor."
+  },
+  "ar-165": {
+    "side": "trails-missing",
+    "reason": "Arel COUNT DISTINCT via Nodes.Count([col], true) not supported: throws 'Unknown node type: Count'. Pinning separately because the fix must also handle the distinct=true flag to emit COUNT(DISTINCT col). Real fix: visitCount must check the distinct flag and emit COUNT(DISTINCT ...) accordingly."
   }
 }

--- a/scripts/parity/fixtures/ar-155/schema.sql
+++ b/scripts/parity/fixtures/ar-155/schema.sql
@@ -1,1 +1,4 @@
 -- Fixture for statement: ar-155
+-- Query: Book.select(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then("yes").when("draft").then("maybe").else("no").as("is_visible"), Book.arel_table[:id]).order(:id).limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-157/schema.sql
+++ b/scripts/parity/fixtures/ar-157/schema.sql
@@ -1,1 +1,4 @@
 -- Fixture for statement: ar-157
+-- Query: query1 = Book.where(status: "active").arel; query2 = Book.where(status: "featured").arel; Book.from(query1.union(query2).as("all_books")).select("all_books.*").order("all_books.id")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-158/schema.sql
+++ b/scripts/parity/fixtures/ar-158/schema.sql
@@ -1,1 +1,5 @@
 -- Fixture for statement: ar-158
+-- Query: sub = Review.select(:book_id, Arel.sql("AVG(rating) AS avg_r")).group(:book_id).arel.as("sub"); Book.joins(Arel::Nodes::InnerJoin.new(sub, Arel::Nodes::On.new(sub[:book_id].eq(Book.arel_table[:id])))).select("books.*, sub.avg_r")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+CREATE TABLE reviews (id INTEGER PRIMARY KEY, book_id INTEGER REFERENCES books(id), rating INTEGER NOT NULL);

--- a/scripts/parity/fixtures/ar-159/schema.sql
+++ b/scripts/parity/fixtures/ar-159/schema.sql
@@ -1,1 +1,4 @@
 -- Fixture for statement: ar-159
+-- Query: Book.select(Arel::Nodes::Multiplication.new(Book.arel_table[:pages], 2).as("double_pages"), Book.arel_table[:id]).where(Book.arel_table[:pages].gt(0)).order(:id).limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-160/schema.sql
+++ b/scripts/parity/fixtures/ar-160/schema.sql
@@ -1,1 +1,4 @@
 -- Fixture for statement: ar-160
+-- Query: Book.select(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).as("total_pages"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Sum.new([Book.arel_table[:pages]]).gt(1000))
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-161/models.rb
+++ b/scripts/parity/fixtures/ar-161/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-161/models.ts
+++ b/scripts/parity/fixtures/ar-161/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-161/query.rb
+++ b/scripts/parity/fixtures/ar-161/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").as("pub_year"), Book.arel_table[:author_id]).group("pub_year, author_id").order("pub_year")

--- a/scripts/parity/fixtures/ar-161/query.ts
+++ b/scripts/parity/fixtures/ar-161/query.ts
@@ -1,0 +1,8 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Extract(Book.arelTable.get("created_at"), "year").as("pub_year"),
+  Book.arelTable.get("author_id"),
+)
+  .group("pub_year, author_id")
+  .order("pub_year");

--- a/scripts/parity/fixtures/ar-161/schema.sql
+++ b/scripts/parity/fixtures/ar-161/schema.sql
@@ -1,0 +1,3 @@
+-- Fixture for statement: ar-161
+-- Query: Book.select(Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").as("pub_year"), Book.arel_table[:author_id]).group("pub_year, author_id").order("pub_year")
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, created_at DATETIME);

--- a/scripts/parity/fixtures/ar-161/schema.sql
+++ b/scripts/parity/fixtures/ar-161/schema.sql
@@ -1,3 +1,4 @@
 -- Fixture for statement: ar-161
 -- Query: Book.select(Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").as("pub_year"), Book.arel_table[:author_id]).group("pub_year, author_id").order("pub_year")
+
 CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, created_at DATETIME);

--- a/scripts/parity/fixtures/ar-162/models.rb
+++ b/scripts/parity/fixtures/ar-162/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-162/models.ts
+++ b/scripts/parity/fixtures/ar-162/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-162/query.rb
+++ b/scripts/parity/fixtures/ar-162/query.rb
@@ -1,0 +1,1 @@
+Book.select("author_id, COUNT(*) AS cnt").group("author_id").having("cnt > 2").order("cnt DESC")

--- a/scripts/parity/fixtures/ar-162/query.ts
+++ b/scripts/parity/fixtures/ar-162/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+export default Book.select("author_id, COUNT(*) AS cnt")
+  .group("author_id")
+  .having("cnt > 2")
+  .order("cnt DESC");

--- a/scripts/parity/fixtures/ar-162/schema.sql
+++ b/scripts/parity/fixtures/ar-162/schema.sql
@@ -1,3 +1,4 @@
 -- Fixture for statement: ar-162
 -- Query: Book.select("author_id, COUNT(*) AS cnt").group("author_id").having("cnt > 2").order("cnt DESC")
+
 CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);

--- a/scripts/parity/fixtures/ar-162/schema.sql
+++ b/scripts/parity/fixtures/ar-162/schema.sql
@@ -1,0 +1,3 @@
+-- Fixture for statement: ar-162
+-- Query: Book.select("author_id, COUNT(*) AS cnt").group("author_id").having("cnt > 2").order("cnt DESC")
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);

--- a/scripts/parity/fixtures/ar-163/models.rb
+++ b/scripts/parity/fixtures/ar-163/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-163/models.ts
+++ b/scripts/parity/fixtures/ar-163/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-163/query.rb
+++ b/scripts/parity/fixtures/ar-163/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Count.new([Book.arel_table[:id]]).as("book_count"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Count.new([Book.arel_table[:id]]).gt(2))

--- a/scripts/parity/fixtures/ar-163/query.ts
+++ b/scripts/parity/fixtures/ar-163/query.ts
@@ -1,0 +1,8 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Count([Book.arelTable.get("id")]).as("book_count"),
+  Book.arelTable.get("author_id"),
+)
+  .group("author_id")
+  .having(new Nodes.Count([Book.arelTable.get("id")]).gt(2));

--- a/scripts/parity/fixtures/ar-163/schema.sql
+++ b/scripts/parity/fixtures/ar-163/schema.sql
@@ -1,3 +1,4 @@
 -- Fixture for statement: ar-163
 -- Query: Book.select(Arel::Nodes::Count.new([Book.arel_table[:id]]).as("book_count"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Count.new([Book.arel_table[:id]]).gt(2))
+
 CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);

--- a/scripts/parity/fixtures/ar-163/schema.sql
+++ b/scripts/parity/fixtures/ar-163/schema.sql
@@ -1,0 +1,3 @@
+-- Fixture for statement: ar-163
+-- Query: Book.select(Arel::Nodes::Count.new([Book.arel_table[:id]]).as("book_count"), Book.arel_table[:author_id]).group(:author_id).having(Arel::Nodes::Count.new([Book.arel_table[:id]]).gt(2))
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);

--- a/scripts/parity/fixtures/ar-164/models.rb
+++ b/scripts/parity/fixtures/ar-164/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-164/models.ts
+++ b/scripts/parity/fixtures/ar-164/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-164/query.rb
+++ b/scripts/parity/fixtures/ar-164/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Max.new([Book.arel_table[:pages]]).as("max_pages"), Arel::Nodes::Min.new([Book.arel_table[:pages]]).as("min_pages"), Book.arel_table[:author_id]).group(:author_id)

--- a/scripts/parity/fixtures/ar-164/query.ts
+++ b/scripts/parity/fixtures/ar-164/query.ts
@@ -1,0 +1,7 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Max([Book.arelTable.get("pages")]).as("max_pages"),
+  new Nodes.Min([Book.arelTable.get("pages")]).as("min_pages"),
+  Book.arelTable.get("author_id"),
+).group("author_id");

--- a/scripts/parity/fixtures/ar-164/schema.sql
+++ b/scripts/parity/fixtures/ar-164/schema.sql
@@ -1,3 +1,4 @@
 -- Fixture for statement: ar-164
 -- Query: Book.select(Arel::Nodes::Max.new([Book.arel_table[:pages]]).as("max_pages"), Arel::Nodes::Min.new([Book.arel_table[:pages]]).as("min_pages"), Book.arel_table[:author_id]).group(:author_id)
+
 CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-164/schema.sql
+++ b/scripts/parity/fixtures/ar-164/schema.sql
@@ -1,0 +1,3 @@
+-- Fixture for statement: ar-164
+-- Query: Book.select(Arel::Nodes::Max.new([Book.arel_table[:pages]]).as("max_pages"), Arel::Nodes::Min.new([Book.arel_table[:pages]]).as("min_pages"), Book.arel_table[:author_id]).group(:author_id)
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-165/models.rb
+++ b/scripts/parity/fixtures/ar-165/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-165/models.ts
+++ b/scripts/parity/fixtures/ar-165/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-165/query.rb
+++ b/scripts/parity/fixtures/ar-165/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel::Nodes::Count.new([Book.arel_table[:author_id]], true).as("distinct_authors"))

--- a/scripts/parity/fixtures/ar-165/query.ts
+++ b/scripts/parity/fixtures/ar-165/query.ts
@@ -1,0 +1,5 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  new Nodes.Count([Book.arelTable.get("author_id")], true).as("distinct_authors"),
+);

--- a/scripts/parity/fixtures/ar-165/schema.sql
+++ b/scripts/parity/fixtures/ar-165/schema.sql
@@ -1,0 +1,3 @@
+-- Fixture for statement: ar-165
+-- Query: Book.select(Arel::Nodes::Count.new([Book.arel_table[:author_id]], true).as("distinct_authors"))
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);

--- a/scripts/parity/fixtures/ar-165/schema.sql
+++ b/scripts/parity/fixtures/ar-165/schema.sql
@@ -1,3 +1,4 @@
 -- Fixture for statement: ar-165
 -- Query: Book.select(Arel::Nodes::Count.new([Book.arel_table[:author_id]], true).as("distinct_authors"))
+
 CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);


### PR DESCRIPTION
## Summary

Fixes a regression from PR #920 (schema.sql files stripped of their CREATE TABLE content), then adds 5 new gap fixtures.

### Regression fix
Restores the `CREATE TABLE` content in ar-155/157/158/159/160 schema.sql files, which were inadvertently emptied by the header-prepend commit in PR #920.

### New gap fixtures

| Fixture | Gap | Fix location |
|---------|-----|-------------|
| **ar-161** | `order("computed_alias")` over-qualified: `ORDER BY pub_year` → `ORDER BY "books"."pub_year" ASC` | `_applyOrderToManager` string-order path |
| **ar-162** | Same over-qualification for aggregate alias: `order("cnt DESC")` → `ORDER BY "books"."cnt" DESC` | Same fix as ar-161 |
| **ar-163** | `new Nodes.Count([col])` → `Unknown node type: Count` | Add `visitCount` to Arel ToSql visitor |
| **ar-164** | `new Nodes.Max/Min([col])` → `Unknown node type: Max` | Add `visitMax`/`visitMin` to Arel ToSql visitor |
| **ar-165** | `new Nodes.Count([col], true)` (COUNT DISTINCT) → `Unknown node type: Count` | `visitCount` must handle the `distinct` flag |

## Test plan
- [ ] `pnpm parity:query` — 5 new KNOWN-GAP, no FAIL, existing ar-155..ar-160 now KNOWN-GAP (not both-missing)