### PR TITLE
chore(api-compare): ignore NotImplementedError stubs in private API match

### DIFF
--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -159,3 +159,4 @@ function readerMethod(): never {
 function writerMethod(): never {
   throw new NotImplementedError("ActiveRecord::Aggregations#writer_method is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -147,7 +147,6 @@ export const InstanceMethods = {
   reload,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError("ActiveRecord::Aggregations#init_internals is not implemented");
 }
@@ -159,4 +158,3 @@ function readerMethod(): never {
 function writerMethod(): never {
   throw new NotImplementedError("ActiveRecord::Aggregations#writer_method is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { reload as persistenceReload } from "./persistence.js";
 import { AggregateReflection } from "./reflection.js";
@@ -145,3 +146,16 @@ export const InstanceMethods = {
   initializeDup,
   reload,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError("ActiveRecord::Aggregations#init_internals is not implemented");
+}
+
+function readerMethod(): never {
+  throw new NotImplementedError("ActiveRecord::Aggregations#reader_method is not implemented");
+}
+
+function writerMethod(): never {
+  throw new NotImplementedError("ActiveRecord::Aggregations#writer_method is not implemented");
+}

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -49,7 +49,12 @@ export async function initializeAssociations(): Promise<void> {
     import("./association-relation.js"),
   ]);
 }
-import { StrictLoadingViolationError, ConfigurationError, Rollback } from "./errors.js";
+import {
+  StrictLoadingViolationError,
+  ConfigurationError,
+  Rollback,
+  NotImplementedError,
+} from "./errors.js";
 import {
   AssociationNotFoundError,
   DeleteRestrictionError,
@@ -2177,4 +2182,21 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
       await parent.touch(...(touchOpt as string[]));
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError("ActiveRecord::Associations#init_internals is not implemented");
+}
+
+function associationInstanceGet(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Associations#association_instance_get is not implemented",
+  );
+}
+
+function associationInstanceSet(name: any, association: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Associations#association_instance_set is not implemented",
+  );
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2184,7 +2184,6 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError("ActiveRecord::Associations#init_internals is not implemented");
 }
@@ -2200,4 +2199,3 @@ function associationInstanceSet(name: any, association: any): never {
     "ActiveRecord::Associations#association_instance_set is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2200,3 +2200,4 @@ function associationInstanceSet(name: any, association: any): never {
     "ActiveRecord::Associations#association_instance_set is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -284,7 +284,6 @@ export function _hasAttribute(this: AttributeMethodsHost, attrName: string): boo
   return this._attributeDefinitions.has(attrName);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function attributesWithValues(attributeNames: any): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods#attributes_with_values is not implemented",
@@ -312,4 +311,3 @@ function formatForInspect(name: any, value: any): never {
 function isPkAttribute(name: any): never {
   throw new NotImplementedError("ActiveRecord::AttributeMethods#pk_attribute? is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -3,6 +3,7 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods
  */
+import { NotImplementedError } from "./errors.js";
 import { isBlank } from "@blazetrails/activesupport";
 import { resolveAliasName } from "@blazetrails/activemodel";
 // ActiveModel provides aliasAttribute and undefineAttributeMethods on Model.
@@ -281,4 +282,33 @@ export function isAttributeMethod(this: AttributeMethodsHost, name: string): boo
 
 export function _hasAttribute(this: AttributeMethodsHost, attrName: string): boolean {
   return this._attributeDefinitions.has(attrName);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function attributesWithValues(attributeNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods#attributes_with_values is not implemented",
+  );
+}
+
+function attributesForUpdate(attributeNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods#attributes_for_update is not implemented",
+  );
+}
+
+function attributesForCreate(attributeNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods#attributes_for_create is not implemented",
+  );
+}
+
+function formatForInspect(name: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods#format_for_inspect is not implemented",
+  );
+}
+
+function isPkAttribute(name: any): never {
+  throw new NotImplementedError("ActiveRecord::AttributeMethods#pk_attribute? is not implemented");
 }

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -312,3 +312,4 @@ function formatForInspect(name: any, value: any): never {
 function isPkAttribute(name: any): never {
   throw new NotImplementedError("ActiveRecord::AttributeMethods#pk_attribute? is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -91,3 +91,4 @@ function isAttributeCameFromUser(attrName: any): never {
     "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_came_from_user? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -8,6 +8,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::BeforeTypeCast
  */
 
+import { NotImplementedError } from "../errors.js";
 interface BeforeTypeCastRecord {
   readAttributeBeforeTypeCast(name: string): unknown;
   readonly attributesBeforeTypeCast: Record<string, unknown>;
@@ -70,4 +71,23 @@ export function attributesForDatabase(record: DatabaseRecord): Record<string, un
     }
   }
   return result;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function attributeBeforeTypeCast(attrName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_before_type_cast is not implemented",
+  );
+}
+
+function attributeForDatabase(attrName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_for_database is not implemented",
+  );
+}
+
+function isAttributeCameFromUser(attrName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_came_from_user? is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -73,7 +73,6 @@ export function attributesForDatabase(record: DatabaseRecord): Record<string, un
   return result;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function attributeBeforeTypeCast(attrName: any): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_before_type_cast is not implemented",
@@ -91,4 +90,3 @@ function isAttributeCameFromUser(attrName: any): never {
     "ActiveRecord::AttributeMethods::BeforeTypeCast#attribute_came_from_user? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -135,7 +135,6 @@ export function attributesInDatabase(record: DirtyRecord): Record<string, unknow
   return result;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::Dirty#init_internals is not implemented",
@@ -171,4 +170,3 @@ function attributeNamesForPartialInserts(): never {
     "ActiveRecord::AttributeMethods::Dirty#attribute_names_for_partial_inserts is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -7,6 +7,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Dirty
  */
 
+import { NotImplementedError } from "../errors.js";
 interface DirtyRecord {
   changed: boolean;
   changedAttributes: string[];
@@ -132,4 +133,41 @@ export function attributesInDatabase(record: DirtyRecord): Record<string, unknow
     result[key] = newVal;
   }
   return result;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#init_internals is not implemented",
+  );
+}
+
+function _touchRow(attributeNames: any, time: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#_touch_row is not implemented",
+  );
+}
+
+function _updateRecord(attributeNames?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#_update_record is not implemented",
+  );
+}
+
+function _createRecord(attributeNames?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#_create_record is not implemented",
+  );
+}
+
+function attributeNamesForPartialUpdates(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#attribute_names_for_partial_updates is not implemented",
+  );
+}
+
+function attributeNamesForPartialInserts(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Dirty#attribute_names_for_partial_inserts is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -171,3 +171,4 @@ function attributeNamesForPartialInserts(): never {
     "ActiveRecord::AttributeMethods::Dirty#attribute_names_for_partial_inserts is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -155,3 +155,4 @@ function isAttributeMethod(attrName: any): never {
     "ActiveRecord::AttributeMethods::PrimaryKey#attribute_method? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -149,10 +149,8 @@ export function getPrimaryKey(
   return "id";
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isAttributeMethod(attrName: any): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::PrimaryKey#attribute_method? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -3,6 +3,7 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey
  */
+import { NotImplementedError } from "../errors.js";
 import { quoteIdentifier } from "../connection-adapters/abstract/quoting.js";
 import { detectAdapterName } from "../adapter-name.js";
 import { underscore } from "@blazetrails/activesupport";
@@ -146,4 +147,11 @@ export function getPrimaryKey(
     }
   }
   return "id";
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isAttributeMethod(attrName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::PrimaryKey#attribute_method? is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -76,3 +76,4 @@ function queryCastAttribute(attrName: any, value: any): never {
     "ActiveRecord::AttributeMethods::Query#query_cast_attribute is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -70,10 +70,8 @@ function castToBoolean(value: unknown): boolean {
   return !!value;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function queryCastAttribute(attrName: any, value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::Query#query_cast_attribute is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/query.ts
+++ b/packages/activerecord/src/attribute-methods/query.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Query
  */
 
+import { NotImplementedError } from "../errors.js";
 import { BooleanType } from "@blazetrails/activemodel";
 
 const booleanType = new BooleanType();
@@ -67,4 +68,11 @@ function castToBoolean(value: unknown): boolean {
   const cast = booleanType.cast(value);
   if (cast !== null) return cast;
   return !!value;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function queryCastAttribute(attrName: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Query#query_cast_attribute is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -40,10 +40,8 @@ export function _readAttribute(this: AttributeHolder, name: string): unknown {
   return this._attributes.fetchValue(name) ?? null;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function defineMethodAttribute(): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::Read#define_method_attribute is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -46,3 +46,4 @@ function defineMethodAttribute(): never {
     "ActiveRecord::AttributeMethods::Read#define_method_attribute is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -8,6 +8,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Read
  */
 
+import { NotImplementedError } from "../errors.js";
 import type { AttributeSet } from "@blazetrails/activemodel";
 
 /**
@@ -37,4 +38,11 @@ interface AttributeHolder {
  */
 export function _readAttribute(this: AttributeHolder, name: string): unknown {
   return this._attributes.fetchValue(name) ?? null;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function defineMethodAttribute(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Read#define_method_attribute is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/serialization.ts
+++ b/packages/activerecord/src/attribute-methods/serialization.ts
@@ -67,3 +67,4 @@ function isTypeIncompatibleWithSerialize(): never {
     "ActiveRecord::AttributeMethods::Serialization#type_incompatible_with_serialize? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/serialization.ts
+++ b/packages/activerecord/src/attribute-methods/serialization.ts
@@ -12,6 +12,7 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods::Serialization
  */
+import { NotImplementedError } from "../errors.js";
 export interface Serialization {
   serialize(attribute: string, options?: { coder?: unknown }): void;
 }
@@ -52,4 +53,17 @@ export class ColumnSerializer {
   load(raw: unknown): unknown {
     return this.coder.load(raw);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function buildColumnSerializer(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Serialization#build_column_serializer is not implemented",
+  );
+}
+
+function isTypeIncompatibleWithSerialize(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Serialization#type_incompatible_with_serialize? is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/serialization.ts
+++ b/packages/activerecord/src/attribute-methods/serialization.ts
@@ -55,7 +55,6 @@ export class ColumnSerializer {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function buildColumnSerializer(): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::Serialization#build_column_serializer is not implemented",
@@ -67,4 +66,3 @@ function isTypeIncompatibleWithSerialize(): never {
     "ActiveRecord::AttributeMethods::Serialization#type_incompatible_with_serialize? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -30,7 +30,6 @@ export class TimeZoneConverter {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function convertTimeToTimeZone(value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter#convert_time_to_time_zone is not implemented",
@@ -54,4 +53,3 @@ function isCreateTimeZoneConversionAttribute(): never {
     "ActiveRecord::AttributeMethods::TimeZoneConversion#create_time_zone_conversion_attribute? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -54,3 +54,4 @@ function isCreateTimeZoneConversionAttribute(): never {
     "ActiveRecord::AttributeMethods::TimeZoneConversion#create_time_zone_conversion_attribute? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -1,6 +1,7 @@
 /**
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
+import { NotImplementedError } from "../errors.js";
 export interface TimeZoneConversion {
   timeZoneAwareAttributes: string[];
   skipTimeZoneConversionForAttributes: string[];
@@ -27,4 +28,29 @@ export class TimeZoneConverter {
       ? (this.subtype as any).deserialize(value)
       : this.subtype.cast(value);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function convertTimeToTimeZone(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter#convert_time_to_time_zone is not implemented",
+  );
+}
+
+function setTimeZoneWithoutConversion(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter#set_time_zone_without_conversion is not implemented",
+  );
+}
+
+function hookAttributeType(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::TimeZoneConversion#hook_attribute_type is not implemented",
+  );
+}
+
+function isCreateTimeZoneConversionAttribute(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::TimeZoneConversion#create_time_zone_conversion_attribute? is not implemented",
+  );
 }

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -38,10 +38,8 @@ export function _writeAttribute(this: Model, name: string, value: unknown): void
   Model.prototype._writeAttribute.call(this, name, value);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function defineMethodAttribute(): never {
   throw new NotImplementedError(
     "ActiveRecord::AttributeMethods::Write#define_method_attribute= is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -44,3 +44,4 @@ function defineMethodAttribute(): never {
     "ActiveRecord::AttributeMethods::Write#define_method_attribute= is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -9,6 +9,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Model } from "@blazetrails/activemodel";
 
 /**
@@ -35,4 +36,11 @@ export interface Write {
  */
 export function _writeAttribute(this: Model, name: string, value: unknown): void {
   Model.prototype._writeAttribute.call(this, name, value);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function defineMethodAttribute(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AttributeMethods::Write#define_method_attribute= is not implemented",
+  );
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -8,6 +8,7 @@
  * Mirrors: ActiveRecord::Attributes
  */
 
+import { NotImplementedError } from "./errors.js";
 import {
   Attribute,
   AttributeSet,
@@ -175,4 +176,25 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     cacheHost._cachedDefaultAttributes = attributeSet;
   }
   return cacheHost._cachedDefaultAttributes;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function reloadSchemaFromCache(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Attributes#reload_schema_from_cache is not implemented",
+  );
+}
+
+function defineDefaultAttribute(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Attributes#define_default_attribute is not implemented",
+  );
+}
+
+function resolveTypeName(): never {
+  throw new NotImplementedError("ActiveRecord::Attributes#resolve_type_name is not implemented");
+}
+
+function typeForColumn(): never {
+  throw new NotImplementedError("ActiveRecord::Attributes#type_for_column is not implemented");
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -198,3 +198,4 @@ function resolveTypeName(): never {
 function typeForColumn(): never {
   throw new NotImplementedError("ActiveRecord::Attributes#type_for_column is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -178,7 +178,6 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
   return cacheHost._cachedDefaultAttributes;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function reloadSchemaFromCache(): never {
   throw new NotImplementedError(
     "ActiveRecord::Attributes#reload_schema_from_cache is not implemented",
@@ -198,4 +197,3 @@ function resolveTypeName(): never {
 function typeForColumn(): never {
   throw new NotImplementedError("ActiveRecord::Attributes#type_for_column is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -599,3 +599,4 @@ function defineAutosaveValidationCallbacks(): never {
     "ActiveRecord::AutosaveAssociation#define_autosave_validation_callbacks is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -485,7 +485,6 @@ function propagateErrors(parent: Base, child: Base, assocName: string): void {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError(
     "ActiveRecord::AutosaveAssociation#init_internals is not implemented",
@@ -599,4 +598,3 @@ function defineAutosaveValidationCallbacks(): never {
     "ActiveRecord::AutosaveAssociation#define_autosave_validation_callbacks is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -5,6 +5,7 @@
  * Instance methods are this-typed functions on the module object.
  * The [included] hook registers validateAssociations onto the class.
  */
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import type { ValidationContextArg } from "./validations.js";
 import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
@@ -482,4 +483,119 @@ function propagateErrors(parent: Base, child: Base, assocName: string): void {
   for (const msg of errorMessages) {
     parentErrors.add("base", "invalid", { message: msg });
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#init_internals is not implemented",
+  );
+}
+
+function associatedRecordsToValidateOrSave(association: any, newRecord: any, autosave: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#associated_records_to_validate_or_save is not implemented",
+  );
+}
+
+function isNestedRecordsChangedForAutosave(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#nested_records_changed_for_autosave? is not implemented",
+  );
+}
+
+function validateHasOneAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#validate_has_one_association is not implemented",
+  );
+}
+
+function validateBelongsToAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#validate_belongs_to_association is not implemented",
+  );
+}
+
+function validateCollectionAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#validate_collection_association is not implemented",
+  );
+}
+
+function isAssociationValid(association: any, record: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#association_valid? is not implemented",
+  );
+}
+
+function aroundSaveCollectionAssociation(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#around_save_collection_association is not implemented",
+  );
+}
+
+function saveCollectionAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#save_collection_association is not implemented",
+  );
+}
+
+function saveHasOneAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#save_has_one_association is not implemented",
+  );
+}
+
+function is_recordChanged(reflection: any, record: any, key: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#_record_changed? is not implemented",
+  );
+}
+
+function isAssociationForeignKeyChanged(reflection: any, record: any, key: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#association_foreign_key_changed? is not implemented",
+  );
+}
+
+function isInversePolymorphicAssociationChanged(reflection: any, record: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#inverse_polymorphic_association_changed? is not implemented",
+  );
+}
+
+function saveBelongsToAssociation(reflection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#save_belongs_to_association is not implemented",
+  );
+}
+
+function computePrimaryKey(reflection: any, record: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#compute_primary_key is not implemented",
+  );
+}
+
+function _ensureNoDuplicateErrors(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#_ensure_no_duplicate_errors is not implemented",
+  );
+}
+
+function defineNonCyclicMethod(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#define_non_cyclic_method is not implemented",
+  );
+}
+
+function addAutosaveAssociationCallbacks(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#add_autosave_association_callbacks is not implemented",
+  );
+}
+
+function defineAutosaveValidationCallbacks(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::AutosaveAssociation#define_autosave_validation_callbacks is not implemented",
+  );
 }

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -219,7 +219,6 @@ function registerCallback(
   klass._callbackChain!.register(timing, event, fn, conditions);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function createOrUpdate(opts?: any): never {
   throw new NotImplementedError("ActiveRecord::Callbacks#create_or_update is not implemented");
 }
@@ -231,4 +230,3 @@ function _createRecord(): never {
 function _updateRecord(): never {
   throw new NotImplementedError("ActiveRecord::Callbacks#_update_record is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -231,3 +231,4 @@ function _createRecord(): never {
 function _updateRecord(): never {
   throw new NotImplementedError("ActiveRecord::Callbacks#_update_record is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -8,6 +8,7 @@
  * Mirrors: ActiveRecord::Callbacks
  */
 
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 
 type ModelCtor = typeof Base;
@@ -216,4 +217,17 @@ function registerCallback(
     conditions.on = (options as ValidationCallbackOptions<never>).on;
   }
   klass._callbackChain!.register(timing, event, fn, conditions);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function createOrUpdate(opts?: any): never {
+  throw new NotImplementedError("ActiveRecord::Callbacks#create_or_update is not implemented");
+}
+
+function _createRecord(): never {
+  throw new NotImplementedError("ActiveRecord::Callbacks#_create_record is not implemented");
+}
+
+function _updateRecord(): never {
+  throw new NotImplementedError("ActiveRecord::Callbacks#_update_record is not implemented");
 }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -106,10 +106,8 @@ export class ColumnSerializer {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function checkArityOfConstructor(): never {
   throw new NotImplementedError(
     "ActiveRecord::Coders::ColumnSerializer#check_arity_of_constructor is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -1,4 +1,4 @@
-import { SerializationTypeMismatch } from "../errors.js";
+import { SerializationTypeMismatch, NotImplementedError } from "../errors.js";
 
 type CoderLike = { dump(obj: unknown): string | null; load(payload: unknown): unknown };
 type ClassLike = new (...args: unknown[]) => unknown;
@@ -104,4 +104,11 @@ export class ColumnSerializer {
       );
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function checkArityOfConstructor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Coders::ColumnSerializer#check_arity_of_constructor is not implemented",
+  );
 }

--- a/packages/activerecord/src/coders/column-serializer.ts
+++ b/packages/activerecord/src/coders/column-serializer.ts
@@ -112,3 +112,4 @@ function checkArityOfConstructor(): never {
     "ActiveRecord::Coders::ColumnSerializer#check_arity_of_constructor is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -127,3 +127,4 @@ function isExportNameOnSchemaDump(): never {
 function isDefinedFor(toTable?: any, validate?: any, options?: any): never {
   throw new NotImplementedError("ActiveRecord::ConnectionAdapters#defined_for? is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -103,7 +103,6 @@ export {
   TableDefinition,
 } from "./connection-adapters/abstract/schema-definitions.js";
 
-// --- api:compare private stubs (auto-generated) ---
 function defaultPrimaryKey(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters#default_primary_key is not implemented",
@@ -127,4 +126,3 @@ function isExportNameOnSchemaDump(): never {
 function isDefinedFor(toTable?: any, validate?: any, options?: any): never {
   throw new NotImplementedError("ActiveRecord::ConnectionAdapters#defined_for? is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::ConnectionAdapters
  */
-import { AdapterNotFound } from "./errors.js";
+import { AdapterNotFound, NotImplementedError } from "./errors.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 export interface ConnectionAdapters {
@@ -102,3 +102,28 @@ export {
   CheckConstraintDefinition,
   TableDefinition,
 } from "./connection-adapters/abstract/schema-definitions.js";
+
+// --- api:compare private stubs (auto-generated) ---
+function defaultPrimaryKey(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters#default_primary_key is not implemented",
+  );
+}
+
+function name(): never {
+  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#name is not implemented");
+}
+
+function isValidate(): never {
+  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#validate? is not implemented");
+}
+
+function isExportNameOnSchemaDump(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters#export_name_on_schema_dump? is not implemented",
+  );
+}
+
+function isDefinedFor(toTable?: any, validate?: any, options?: any): never {
+  throw new NotImplementedError("ActiveRecord::ConnectionAdapters#defined_for? is not implemented");
+}

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -7,7 +7,7 @@
 import { inspectExplainOption } from "../adapter.js";
 import type { DatabaseAdapter, ExplainOption } from "../adapter.js";
 import { type Nodes, Visitors } from "@blazetrails/arel";
-import { ReadOnlyError } from "../errors.js";
+import { ReadOnlyError, NotImplementedError } from "../errors.js";
 import { SchemaCache } from "./schema-cache.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
@@ -956,3 +956,203 @@ export class AbstractAdapter {
 
 // Rails: `include DatabaseStatements` inside the class body.
 include(AbstractAdapter, DatabaseStatements);
+
+// --- api:compare private stubs (auto-generated) ---
+function canPerformCaseInsensitiveComparisonFor(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#can_perform_case_insensitive_comparison_for? is not implemented",
+  );
+}
+
+function isReconnectCanRestoreState(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#reconnect_can_restore_state? is not implemented",
+  );
+}
+
+function withRawConnection(allowRetry?: any, materializeTransactions?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection is not implemented",
+  );
+}
+
+function verifiedBang(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#verified! is not implemented",
+  );
+}
+
+function isRetryableConnectionError(exception: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#retryable_connection_error? is not implemented",
+  );
+}
+
+function invalidateTransaction(exception: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#invalidate_transaction is not implemented",
+  );
+}
+
+function isRetryableQueryError(exception: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#retryable_query_error? is not implemented",
+  );
+}
+
+function backoff(counter: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#backoff is not implemented",
+  );
+}
+
+function reconnect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#reconnect is not implemented",
+  );
+}
+
+function anyRawConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#any_raw_connection is not implemented",
+  );
+}
+
+function validRawConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#valid_raw_connection is not implemented",
+  );
+}
+
+function extendedTypeMapKey(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extended_type_map_key is not implemented",
+  );
+}
+
+function typeMap(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#type_map is not implemented",
+  );
+}
+
+function translateExceptionClass(nativeError: any, sql: any, binds: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class is not implemented",
+  );
+}
+
+function log(
+  sql: any,
+  name?: any,
+  binds?: any,
+  typeCastedBinds?: any,
+  async?: any,
+  block?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#log is not implemented",
+  );
+}
+
+function instrumenter(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#instrumenter is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception is not implemented",
+  );
+}
+
+function columnFor(tableName: any, columnName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#column_for is not implemented",
+  );
+}
+
+function columnForAttribute(attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#column_for_attribute is not implemented",
+  );
+}
+
+function collector(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#collector is not implemented",
+  );
+}
+
+function arelVisitor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#arel_visitor is not implemented",
+  );
+}
+
+function buildStatementPool(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#build_statement_pool is not implemented",
+  );
+}
+
+function buildResult(columns?: any, rows?: any, columnTypes?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#build_result is not implemented",
+  );
+}
+
+function configureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#configure_connection is not implemented",
+  );
+}
+
+function attemptConfigureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#attempt_configure_connection is not implemented",
+  );
+}
+
+function defaultPreparedStatements(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#default_prepared_statements is not implemented",
+  );
+}
+
+function isWarningIgnored(warning: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#warning_ignored? is not implemented",
+  );
+}
+
+function initializeTypeMap(m: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#initialize_type_map is not implemented",
+  );
+}
+
+function registerClassWithLimit(mapping: any, key: any, klass: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#register_class_with_limit is not implemented",
+  );
+}
+
+function extractScale(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_scale is not implemented",
+  );
+}
+
+function extractPrecision(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_precision is not implemented",
+  );
+}
+
+function extractLimit(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_limit is not implemented",
+  );
+}

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -957,7 +957,6 @@ export class AbstractAdapter {
 // Rails: `include DatabaseStatements` inside the class body.
 include(AbstractAdapter, DatabaseStatements);
 
-// --- api:compare private stubs (auto-generated) ---
 function canPerformCaseInsensitiveComparisonFor(column: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::AbstractAdapter#can_perform_case_insensitive_comparison_for? is not implemented",
@@ -1156,4 +1155,3 @@ function extractLimit(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_limit is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1156,3 +1156,4 @@ function extractLimit(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::AbstractAdapter#extract_limit is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -937,7 +937,6 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function canPerformCaseInsensitiveComparisonFor(column: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#can_perform_case_insensitive_comparison_for? is not implemented",
@@ -1081,4 +1080,3 @@ function extractPrecision(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#extract_precision is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1081,3 +1081,4 @@ function extractPrecision(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#extract_precision is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -20,6 +20,7 @@ import {
   StatementInvalid,
   ValueTooLong,
   sqlTypeToMigrationKeyword,
+  NotImplementedError,
 } from "../errors.js";
 import { sql as arelSql, type Nodes } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
@@ -934,4 +935,149 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   nextKey(): string {
     return `a${++this._counter}`;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function canPerformCaseInsensitiveComparisonFor(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#can_perform_case_insensitive_comparison_for? is not implemented",
+  );
+}
+
+function stripWhitespaceCharacters(expression: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#strip_whitespace_characters is not implemented",
+  );
+}
+
+function extendedTypeMapKey(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#extended_type_map_key is not implemented",
+  );
+}
+
+function handleWarnings(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#handle_warnings is not implemented",
+  );
+}
+
+function isWarningIgnored(warning: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#warning_ignored? is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#translate_exception is not implemented",
+  );
+}
+
+function changeColumnForAlter(tableName: any, columnName: any, type: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#change_column_for_alter is not implemented",
+  );
+}
+
+function renameColumnForAlter(tableName: any, columnName: any, newColumnName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#rename_column_for_alter is not implemented",
+  );
+}
+
+function addIndexForAlter(tableName: any, columnName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#add_index_for_alter is not implemented",
+  );
+}
+
+function removeIndexForAlter(tableName: any, columnName?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#remove_index_for_alter is not implemented",
+  );
+}
+
+function supportsInsertRawAliasSyntax(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#supports_insert_raw_alias_syntax? is not implemented",
+  );
+}
+
+function supportsRenameIndex(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#supports_rename_index? is not implemented",
+  );
+}
+
+function supportsRenameColumn(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#supports_rename_column? is not implemented",
+  );
+}
+
+function configureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#configure_connection is not implemented",
+  );
+}
+
+function columnDefinitions(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#column_definitions is not implemented",
+  );
+}
+
+function createTableInfo(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#create_table_info is not implemented",
+  );
+}
+
+function arelVisitor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#arel_visitor is not implemented",
+  );
+}
+
+function buildStatementPool(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#build_statement_pool is not implemented",
+  );
+}
+
+function mismatchedForeignKeyDetails(message?: any, sql?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#mismatched_foreign_key_details is not implemented",
+  );
+}
+
+function mismatchedForeignKey(message: any, sql?: any, binds?: any, connectionPool?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#mismatched_foreign_key is not implemented",
+  );
+}
+
+function versionString(fullVersionString: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#version_string is not implemented",
+  );
+}
+
+function initializeTypeMap(m: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#initialize_type_map is not implemented",
+  );
+}
+
+function registerIntegerType(mapping: any, key: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#register_integer_type is not implemented",
+  );
+}
+
+function extractPrecision(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#extract_precision is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -265,7 +265,6 @@ export class ConnectionHandler {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connectionNameToPoolManager(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_name_to_pool_manager is not implemented",
@@ -307,4 +306,3 @@ function determineOwnerName(ownerName: any, config: any): never {
     "ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -307,3 +307,4 @@ function determineOwnerName(ownerName: any, config: any): never {
     "ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -12,7 +12,7 @@ import { DatabaseConfigurations } from "../../database-configurations.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
 import type { DatabaseAdapter } from "../../adapter.js";
-import { AdapterNotSpecified, ConnectionNotDefined } from "../../errors.js";
+import { AdapterNotSpecified, ConnectionNotDefined, NotImplementedError } from "../../errors.js";
 import type { QueryCachePool } from "./query-cache.js";
 import { Notifications } from "@blazetrails/activesupport";
 
@@ -263,4 +263,47 @@ export class ConnectionHandler {
       poolConfig.disconnect();
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connectionNameToPoolManager(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_name_to_pool_manager is not implemented",
+  );
+}
+
+function getPoolManager(connectionName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#get_pool_manager is not implemented",
+  );
+}
+
+function setPoolManager(connectionDescriptor: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#set_pool_manager is not implemented",
+  );
+}
+
+function poolManagers(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#pool_managers is not implemented",
+  );
+}
+
+function disconnectPoolFromPoolManager(poolManager: any, role: any, shard: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#disconnect_pool_from_pool_manager is not implemented",
+  );
+}
+
+function resolvePoolConfig(config: any, connectionName: any, role: any, shard: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#resolve_pool_config is not implemented",
+  );
+}
+
+function determineOwnerName(ownerName: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -993,3 +993,4 @@ function checkoutAndVerify(c: any): never {
     "ActiveRecord::ConnectionAdapters::ConnectionPool#checkout_and_verify is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -8,7 +8,11 @@ import type { DatabaseAdapter } from "../../adapter.js";
 import type { DatabaseConfig } from "../../database-configurations/database-config.js";
 import type { PoolConfig } from "../pool-config.js";
 import type { ConnectionDescriptor } from "./connection-descriptor.js";
-import { ConnectionNotEstablished, ConnectionTimeoutError } from "../../errors.js";
+import {
+  ConnectionNotEstablished,
+  ConnectionTimeoutError,
+  NotImplementedError,
+} from "../../errors.js";
 import { SchemaReflection, BoundSchemaReflection } from "../schema-cache.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { Reaper, type ReapablePool } from "./connection-pool/reaper.js";
@@ -902,5 +906,90 @@ function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConn
     typeof c.resetBang === "function" &&
     typeof c.transactionManager === "object" &&
     c.transactionManager !== null
+  );
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connectionLease(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#connection_lease is not implemented",
+  );
+}
+
+function buildAsyncExecutor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#build_async_executor is not implemented",
+  );
+}
+
+function bulkMakeNewConnections(numNewConnsNeeded: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#bulk_make_new_connections is not implemented",
+  );
+}
+
+function withExclusivelyAcquiredAllConnections(raiseOnAcquisitionTimeout?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#with_exclusively_acquired_all_connections is not implemented",
+  );
+}
+
+function attemptToCheckoutAllExistingConnections(raiseOnAcquisitionTimeout?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#attempt_to_checkout_all_existing_connections is not implemented",
+  );
+}
+
+function checkoutForExclusiveAccess(checkoutTimeout: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#checkout_for_exclusive_access is not implemented",
+  );
+}
+
+function withNewConnectionsBlocked(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#with_new_connections_blocked is not implemented",
+  );
+}
+
+function acquireConnection(checkoutTimeout: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#acquire_connection is not implemented",
+  );
+}
+
+function removeConnectionFromThreadCache(conn: any, ownerThread?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#remove_connection_from_thread_cache is not implemented",
+  );
+}
+
+function release(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#release is not implemented",
+  );
+}
+
+function tryToCheckoutNewConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#try_to_checkout_new_connection is not implemented",
+  );
+}
+
+function adoptConnection(conn: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#adopt_connection is not implemented",
+  );
+}
+
+function checkoutNewConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#checkout_new_connection is not implemented",
+  );
+}
+
+function checkoutAndVerify(c: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool#checkout_and_verify is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -909,7 +909,6 @@ function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConn
   );
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connectionLease(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::ConnectionPool#connection_lease is not implemented",
@@ -993,4 +992,3 @@ function checkoutAndVerify(c: any): never {
     "ActiveRecord::ConnectionAdapters::ConnectionPool#checkout_and_verify is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -343,7 +343,6 @@ export class ConnectionLeasingQueue extends Queue {
 // Rails: `include BiasableQueue` in ConnectionLeasingQueue
 include(ConnectionLeasingQueue, BiasableQueue);
 
-// --- api:compare private stubs (auto-generated) ---
 function synchronize(block?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#synchronize is not implemented",
@@ -361,4 +360,3 @@ function remove(): never {
     "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#remove is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -361,3 +361,4 @@ function remove(): never {
     "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#remove is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -11,7 +11,7 @@
  */
 
 import type { DatabaseAdapter } from "../../../adapter.js";
-import { ConnectionTimeoutError } from "../../../errors.js";
+import { ConnectionTimeoutError, NotImplementedError } from "../../../errors.js";
 import { include, type Included } from "@blazetrails/activesupport";
 
 /**
@@ -342,3 +342,22 @@ export class ConnectionLeasingQueue extends Queue {
 
 // Rails: `include BiasableQueue` in ConnectionLeasingQueue
 include(ConnectionLeasingQueue, BiasableQueue);
+
+// --- api:compare private stubs (auto-generated) ---
+function synchronize(block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#synchronize is not implemented",
+  );
+}
+
+function isAny(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#any? is not implemented",
+  );
+}
+
+function remove(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#remove is not implemented",
+  );
+}

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -115,10 +115,8 @@ export class Reaper {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function spawnThread(frequency: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper#spawn_thread is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -121,3 +121,4 @@ function spawnThread(frequency: any): never {
     "ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper#spawn_thread is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -12,6 +12,7 @@
  * static maps and `setInterval`, using WeakRef to avoid preventing pool GC.
  */
 
+import { NotImplementedError } from "../../../errors.js";
 export interface ReapablePool {
   reap?(): void;
   flush?(): void;
@@ -112,4 +113,11 @@ export class Reaper {
       Reaper._timers.delete(frequency);
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function spawnThread(frequency: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper#spawn_thread is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1461,3 +1461,4 @@ function extractTableRefFromInsertSql(sql: any): never {
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#extract_table_ref_from_insert_sql is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -8,7 +8,7 @@ import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Notifications } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { TransactionIsolationError } from "../../errors.js";
+import { TransactionIsolationError, NotImplementedError } from "../../errors.js";
 import {
   quote,
   quoteTableName,
@@ -1313,3 +1313,151 @@ export const DatabaseStatements = {
     return cacheableQuery.call(this as never, klass, arel);
   },
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function rawExecute(
+  sql: any,
+  name?: any,
+  binds?: any,
+  prepare?: any,
+  async?: any,
+  allowRetry?: any,
+  materializeTransactions?: any,
+  batch?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute is not implemented",
+  );
+}
+
+function performQuery(
+  rawConnection: any,
+  sql: any,
+  binds: any,
+  typeCastedBinds: any,
+  prepare?: any,
+  notificationPayload?: any,
+  batch?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#perform_query is not implemented",
+  );
+}
+
+function castResult(rawResult: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#cast_result is not implemented",
+  );
+}
+
+function affectedRows(rawResult: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#affected_rows is not implemented",
+  );
+}
+
+function preprocessQuery(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#preprocess_query is not implemented",
+  );
+}
+
+function internalExecute(
+  sql: any,
+  name?: any,
+  binds?: any,
+  prepare?: any,
+  async?: any,
+  allowRetry?: any,
+  materializeTransactions?: any,
+  block?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute is not implemented",
+  );
+}
+
+function executeBatch(statements: any, name?: any, kwargs?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch is not implemented",
+  );
+}
+
+function defaultInsertValue(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#default_insert_value is not implemented",
+  );
+}
+
+function buildFixtureSql(fixtures: any, tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#build_fixture_sql is not implemented",
+  );
+}
+
+function buildFixtureStatements(fixtureSet: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#build_fixture_statements is not implemented",
+  );
+}
+
+function buildTruncateStatement(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#build_truncate_statement is not implemented",
+  );
+}
+
+function buildTruncateStatements(tableNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#build_truncate_statements is not implemented",
+  );
+}
+
+function combineMultiStatements(totalSql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#combine_multi_statements is not implemented",
+  );
+}
+
+function select(
+  sql: any,
+  name?: any,
+  binds?: any,
+  prepare?: any,
+  async?: any,
+  allowRetry?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#select is not implemented",
+  );
+}
+
+function sqlForInsert(sql: any, pk: any, binds: any, returning: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#sql_for_insert is not implemented",
+  );
+}
+
+function lastInsertedId(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#last_inserted_id is not implemented",
+  );
+}
+
+function returningColumnValues(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#returning_column_values is not implemented",
+  );
+}
+
+function arelFromRelation(relation: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#arel_from_relation is not implemented",
+  );
+}
+
+function extractTableRefFromInsertSql(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::DatabaseStatements#extract_table_ref_from_insert_sql is not implemented",
+  );
+}

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1314,7 +1314,6 @@ export const DatabaseStatements = {
   },
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function rawExecute(
   sql: any,
   name?: any,
@@ -1461,4 +1460,3 @@ function extractTableRefFromInsertSql(sql: any): never {
     "ActiveRecord::ConnectionAdapters::DatabaseStatements#extract_table_ref_from_insert_sql is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -438,3 +438,4 @@ function cacheNotificationInfo(sql: any, name: any, binds: any): never {
     "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -402,7 +402,6 @@ export function dirtiesQueryCache(
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function checkVersion(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::QueryCache::Store#check_version is not implemented",
@@ -438,4 +437,3 @@ function cacheNotificationInfo(sql: any, name: any, binds: any): never {
     "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../../errors.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type { DatabaseStatementsHost } from "./database-statements.js";
 
@@ -399,4 +400,41 @@ export function dirtiesQueryCache(
       return original.apply(this, args);
     };
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function checkVersion(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache::Store#check_version is not implemented",
+  );
+}
+
+function unsetQueryCacheBang(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache#unset_query_cache! is not implemented",
+  );
+}
+
+function lookupSqlCache(sql: any, name: any, binds: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache#lookup_sql_cache is not implemented",
+  );
+}
+
+function cacheSql(sql: any, name: any, binds: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache#cache_sql is not implemented",
+  );
+}
+
+function cacheNotificationInfoResult(sql: any, name: any, binds: any, result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info_result is not implemented",
+  );
+}
+
+function cacheNotificationInfo(sql: any, name: any, binds: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::QueryCache#cache_notification_info is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -481,3 +481,4 @@ function lookupCastType(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -469,7 +469,6 @@ function isSqlLiteral(value: unknown): value is { value: string } {
   );
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function typeCastedBinds(binds: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Quoting#type_casted_binds is not implemented",
@@ -481,4 +480,3 @@ function lookupCastType(sqlType: any): never {
     "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getDefaultTimezone } from "../../type/internal/timezone.js";
 
@@ -465,5 +466,18 @@ function isSqlLiteral(value: unknown): value is { value: string } {
     typeof value === "object" &&
     value.constructor?.name === "SqlLiteral" &&
     typeof (value as any).value === "string"
+  );
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function typeCastedBinds(binds: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Quoting#type_casted_binds is not implemented",
+  );
+}
+
+function lookupCastType(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -392,3 +392,4 @@ function actionSql(action: any, dependency: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaCreation#action_sql is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -7,6 +7,7 @@
  * visit methods for dialect-specific SQL generation.
  */
 
+import { NotImplementedError } from "../../errors.js";
 import {
   type ColumnType,
   type ColumnOptions,
@@ -281,4 +282,113 @@ export class SchemaCreation {
         );
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function visit_AlterTable(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AlterTable is not implemented",
+  );
+}
+
+function visit_ColumnDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_ColumnDefinition is not implemented",
+  );
+}
+
+function visit_AddColumnDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddColumnDefinition is not implemented",
+  );
+}
+
+function visit_TableDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_TableDefinition is not implemented",
+  );
+}
+
+function visit_PrimaryKeyDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_PrimaryKeyDefinition is not implemented",
+  );
+}
+
+function visit_ForeignKeyDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_ForeignKeyDefinition is not implemented",
+  );
+}
+
+function visit_AddForeignKey(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddForeignKey is not implemented",
+  );
+}
+
+function visit_DropConstraint(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_DropConstraint is not implemented",
+  );
+}
+
+function visit_CreateIndexDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_CreateIndexDefinition is not implemented",
+  );
+}
+
+function visit_CheckConstraintDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_CheckConstraintDefinition is not implemented",
+  );
+}
+
+function visit_AddCheckConstraint(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AddCheckConstraint is not implemented",
+  );
+}
+
+function quotedColumns(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#quoted_columns is not implemented",
+  );
+}
+
+function addTableOptionsBang(createSql: any, o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#add_table_options! is not implemented",
+  );
+}
+
+function columnOptions(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#column_options is not implemented",
+  );
+}
+
+function addColumnOptionsBang(sql: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#add_column_options! is not implemented",
+  );
+}
+
+function toSql(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#to_sql is not implemented",
+  );
+}
+
+function tableModifierInCreate(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#table_modifier_in_create is not implemented",
+  );
+}
+
+function actionSql(action: any, dependency: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCreation#action_sql is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -284,7 +284,6 @@ export class SchemaCreation {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function visit_AlterTable(o: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SchemaCreation#visit_AlterTable is not implemented",
@@ -392,4 +391,3 @@ function actionSql(action: any, dependency: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaCreation#action_sql is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1300,3 +1300,4 @@ function defineColumnMethods(...columnTypes: any[]): never {
     "ActiveRecord::ConnectionAdapters::ColumnMethods#define_column_methods is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../../errors.js";
 import { quoteIdentifier, quoteTableName, quoteDefaultExpression } from "./quoting.js";
 import { singularize } from "@blazetrails/activesupport";
 
@@ -1159,4 +1160,143 @@ export interface SchemaStatementsLike {
   ): Promise<void>;
   isCheckConstraintExists?(tableName: string, options?: Record<string, unknown>): Promise<boolean>;
   primaryKey?(tableName: string): Promise<string | null>;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function conciseOptions(options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::IndexDefinition#concise_options is not implemented",
+  );
+}
+
+function polymorphic(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#polymorphic is not implemented",
+  );
+}
+
+function index(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#index is not implemented",
+  );
+}
+
+function foreignKey(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#foreign_key is not implemented",
+  );
+}
+
+function type(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#type is not implemented",
+  );
+}
+
+function options(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#options is not implemented",
+  );
+}
+
+function asOptions(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#as_options is not implemented",
+  );
+}
+
+function conditionalOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#conditional_options is not implemented",
+  );
+}
+
+function polymorphicOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#polymorphic_options is not implemented",
+  );
+}
+
+function polymorphicIndexName(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#polymorphic_index_name is not implemented",
+  );
+}
+
+function indexOptions(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#index_options is not implemented",
+  );
+}
+
+function foreignKeyOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#foreign_key_options is not implemented",
+  );
+}
+
+function columnName(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#column_name is not implemented",
+  );
+}
+
+function columnNames(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#column_names is not implemented",
+  );
+}
+
+function foreignTableName(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ReferenceDefinition#foreign_table_name is not implemented",
+  );
+}
+
+function validColumnDefinitionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#valid_column_definition_options is not implemented",
+  );
+}
+
+function createColumnDefinition(name: any, type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#create_column_definition is not implemented",
+  );
+}
+
+function aliasedTypes(name: any, fallback: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#aliased_types is not implemented",
+  );
+}
+
+function isIntegerLikePrimaryKey(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#integer_like_primary_key? is not implemented",
+  );
+}
+
+function integerLikePrimaryKeyType(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#integer_like_primary_key_type is not implemented",
+  );
+}
+
+function raiseOnDuplicateColumn(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TableDefinition#raise_on_duplicate_column is not implemented",
+  );
+}
+
+function raiseOnIfExistOptions(options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Table#raise_on_if_exist_options is not implemented",
+  );
+}
+
+function defineColumnMethods(...columnTypes: any[]): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::ColumnMethods#define_column_methods is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1162,7 +1162,6 @@ export interface SchemaStatementsLike {
   primaryKey?(tableName: string): Promise<string | null>;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function conciseOptions(options: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::IndexDefinition#concise_options is not implemented",
@@ -1300,4 +1299,3 @@ function defineColumnMethods(...columnTypes: any[]): never {
     "ActiveRecord::ConnectionAdapters::ColumnMethods#define_column_methods is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -26,7 +26,6 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function columnSpec(column: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SchemaDumper#column_spec is not implemented",
@@ -104,4 +103,3 @@ function schemaCollation(column: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_collation is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -12,6 +12,7 @@
  * column-spec hooks.
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
 
@@ -23,4 +24,83 @@ export class SchemaDumper extends BaseSchemaDumper {
   ): InstanceType<T> {
     return new this(source, options) as InstanceType<T>;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function columnSpec(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#column_spec is not implemented",
+  );
+}
+
+function columnSpecForPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#column_spec_for_primary_key is not implemented",
+  );
+}
+
+function prepareColumnOptions(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#prepare_column_options is not implemented",
+  );
+}
+
+function isDefaultPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#default_primary_key? is not implemented",
+  );
+}
+
+function isExplicitPrimaryKeyDefault(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#explicit_primary_key_default? is not implemented",
+  );
+}
+
+function schemaTypeWithVirtual(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_type_with_virtual is not implemented",
+  );
+}
+
+function schemaType(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_type is not implemented",
+  );
+}
+
+function schemaLimit(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_limit is not implemented",
+  );
+}
+
+function schemaPrecision(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_precision is not implemented",
+  );
+}
+
+function schemaScale(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_scale is not implemented",
+  );
+}
+
+function schemaDefault(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_default is not implemented",
+  );
+}
+
+function schemaExpression(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_expression is not implemented",
+  );
+}
+
+function schemaCollation(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_collation is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -104,3 +104,4 @@ function schemaCollation(column: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaDumper#schema_collation is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1416,7 +1416,6 @@ export class SchemaStatements {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function generateIndexName(tableName: any, column: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SchemaStatements#generate_index_name is not implemented",
@@ -1660,4 +1659,3 @@ function quotedScope(name?: any, type?: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaStatements#quoted_scope is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1660,3 +1660,4 @@ function quotedScope(name?: any, type?: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaStatements#quoted_scope is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -8,6 +8,7 @@
  * doesn't support ALTER TABLE ADD CONSTRAINT).
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { DatabaseAdapter } from "../../adapter.js";
 import {
   TableDefinition,
@@ -1413,4 +1414,249 @@ export class SchemaStatements {
       );
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function generateIndexName(tableName: any, column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#generate_index_name is not implemented",
+  );
+}
+
+function validateChangeColumnNullArgumentBang(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#validate_change_column_null_argument! is not implemented",
+  );
+}
+
+function columnOptionsKeys(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#column_options_keys is not implemented",
+  );
+}
+
+function addIndexSortOrder(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#add_index_sort_order is not implemented",
+  );
+}
+
+function optionsForIndexColumns(options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#options_for_index_columns is not implemented",
+  );
+}
+
+function addOptionsForIndexColumns(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#add_options_for_index_columns is not implemented",
+  );
+}
+
+function indexNameForRemove(tableName: any, columnName: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#index_name_for_remove is not implemented",
+  );
+}
+
+function renameTableIndexes(tableName: any, newName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#rename_table_indexes is not implemented",
+  );
+}
+
+function renameColumnIndexes(tableName: any, columnName: any, newColumnName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#rename_column_indexes is not implemented",
+  );
+}
+
+function createTableDefinition(name: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#create_table_definition is not implemented",
+  );
+}
+
+function createAlterTable(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#create_alter_table is not implemented",
+  );
+}
+
+function validateCreateTableOptionsBang(options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#validate_create_table_options! is not implemented",
+  );
+}
+
+function fetchTypeMetadata(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#fetch_type_metadata is not implemented",
+  );
+}
+
+function indexColumnNames(columnNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#index_column_names is not implemented",
+  );
+}
+
+function indexNameOptions(columnNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#index_name_options is not implemented",
+  );
+}
+
+function isExpressionColumnName(columnName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#expression_column_name? is not implemented",
+  );
+}
+
+function stripTableNamePrefixAndSuffix(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#strip_table_name_prefix_and_suffix is not implemented",
+  );
+}
+
+function foreignKeyName(tableName: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#foreign_key_name is not implemented",
+  );
+}
+
+function foreignKeyFor(fromTable: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#foreign_key_for is not implemented",
+  );
+}
+
+function foreignKeyForBang(fromTable: any, toTable?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#foreign_key_for! is not implemented",
+  );
+}
+
+function extractForeignKeyAction(specifier: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#extract_foreign_key_action is not implemented",
+  );
+}
+
+function isForeignKeysEnabled(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#foreign_keys_enabled? is not implemented",
+  );
+}
+
+function checkConstraintName(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#check_constraint_name is not implemented",
+  );
+}
+
+function checkConstraintFor(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#check_constraint_for is not implemented",
+  );
+}
+
+function checkConstraintForBang(tableName: any, expression?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#check_constraint_for! is not implemented",
+  );
+}
+
+function validateIndexLengthBang(tableName: any, newName: any, internal?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#validate_index_length! is not implemented",
+  );
+}
+
+function validateTableLengthBang(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#validate_table_length! is not implemented",
+  );
+}
+
+function extractNewDefaultValue(defaultOrChanges: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#extract_new_default_value is not implemented",
+  );
+}
+
+function canRemoveIndexByName(columnName: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#can_remove_index_by_name? is not implemented",
+  );
+}
+
+function referenceNameForTable(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#reference_name_for_table is not implemented",
+  );
+}
+
+function addColumnForAlter(tableName: any, columnName: any, type: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#add_column_for_alter is not implemented",
+  );
+}
+
+function changeColumnDefaultForAlter(
+  tableName: any,
+  columnName: any,
+  defaultOrChanges: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#change_column_default_for_alter is not implemented",
+  );
+}
+
+function renameColumnSql(tableName: any, columnName: any, newColumnName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#rename_column_sql is not implemented",
+  );
+}
+
+function removeColumnForAlter(tableName: any, columnName: any, type?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#remove_column_for_alter is not implemented",
+  );
+}
+
+function removeColumnsForAlter(tableName: any, columnNames?: any[], options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#remove_columns_for_alter is not implemented",
+  );
+}
+
+function addTimestampsForAlter(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#add_timestamps_for_alter is not implemented",
+  );
+}
+
+function removeTimestampsForAlter(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#remove_timestamps_for_alter is not implemented",
+  );
+}
+
+function insertVersionsSql(versions: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#insert_versions_sql is not implemented",
+  );
+}
+
+function dataSourceSql(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#data_source_sql is not implemented",
+  );
+}
+
+function quotedScope(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaStatements#quoted_scope is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1057,3 +1057,4 @@ function afterFailureActions(transaction: any, error: any): never {
     "ActiveRecord::ConnectionAdapters::TransactionManager#after_failure_actions is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1027,7 +1027,6 @@ export class TransactionManager {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function appendCallbacks(callbacks: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Transaction#append_callbacks is not implemented",
@@ -1057,4 +1056,3 @@ function afterFailureActions(transaction: any, error: any): never {
     "ActiveRecord::ConnectionAdapters::TransactionManager#after_failure_actions is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1,6 +1,10 @@
 import type { DatabaseAdapter } from "../../adapter.js";
 import { Transaction as UserTransaction } from "../../transaction.js";
-import { ActiveRecordError, PreparedStatementCacheExpired } from "../../errors.js";
+import {
+  ActiveRecordError,
+  PreparedStatementCacheExpired,
+  NotImplementedError,
+} from "../../errors.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 
 /**
@@ -1021,4 +1025,35 @@ export class TransactionManager {
     }
     return result;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function appendCallbacks(callbacks: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Transaction#append_callbacks is not implemented",
+  );
+}
+
+function uniqueRecords(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Transaction#unique_records is not implemented",
+  );
+}
+
+function runActionOnRecords(records: any, instancesToRunCallbacksOn: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Transaction#run_action_on_records is not implemented",
+  );
+}
+
+function prepareInstancesToRunCallbacksOn(records: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Transaction#prepare_instances_to_run_callbacks_on is not implemented",
+  );
+}
+
+function afterFailureActions(transaction: any, error: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TransactionManager#after_failure_actions is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Column
  */
 
+import { NotImplementedError } from "../errors.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import type { SqlTypeMetadataJSON } from "./sql-type-metadata.js";
 import { humanize } from "@blazetrails/activesupport";
@@ -168,4 +169,11 @@ export class NullColumn extends Column {
   constructor() {
     super("", null, null, true);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deduplicated(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Column#deduplicated is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -177,3 +177,4 @@ function deduplicated(): never {
     "ActiveRecord::ConnectionAdapters::Column#deduplicated is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -171,10 +171,8 @@ export class NullColumn extends Column {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deduplicated(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Column#deduplicated is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -36,3 +36,4 @@ function deduplicated(): never {
     "ActiveRecord::ConnectionAdapters::Deduplicable#deduplicated is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -8,6 +8,7 @@
  * string keys for deduplication.
  */
 
+import { NotImplementedError } from "../errors.js";
 export interface Deduplicable {
   deduplicateKey(): string;
 }
@@ -27,4 +28,11 @@ export function deduplicate<T extends Deduplicable>(obj: T): T {
   }
   registries.set(key, new WeakRef(obj));
   return obj;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deduplicated(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Deduplicable#deduplicated is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -30,10 +30,8 @@ export function deduplicate<T extends Deduplicable>(obj: T): T {
   return obj;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deduplicated(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Deduplicable#deduplicated is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements (module)
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { Nodes } from "@blazetrails/arel";
 import type { Result } from "../../result.js";
 
@@ -15,4 +16,41 @@ export interface DatabaseStatements {
   explain(sql: string, binds?: unknown[], options?: { extended?: boolean }): Promise<string>;
   lastInsertedId(result: unknown): number;
   highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isAnalyzeWithoutExplain(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain? is not implemented",
+  );
+}
+
+function defaultInsertValue(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#default_insert_value is not implemented",
+  );
+}
+
+function returningColumnValues(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#returning_column_values is not implemented",
+  );
+}
+
+function combineMultiStatements(totalSql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#combine_multi_statements is not implemented",
+  );
+}
+
+function isMaxAllowedPacketReached(currentPacket: any, previousPacket: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet_reached? is not implemented",
+  );
+}
+
+function maxAllowedPacket(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -18,7 +18,6 @@ export interface DatabaseStatements {
   highPrecisionCurrentTimestamp(): Nodes.SqlLiteral;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isAnalyzeWithoutExplain(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain? is not implemented",
@@ -54,4 +53,3 @@ function maxAllowedPacket(): never {
     "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -54,3 +54,4 @@ function maxAllowedPacket(): never {
     "ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
@@ -9,6 +9,7 @@
  * mysql CLI displays results.
  */
 
+import { NotImplementedError } from "../../errors.js";
 export class ExplainPrettyPrinter {
   pp(result: Array<Record<string, unknown>>, elapsed: number): string {
     if (result.length === 0) return "";
@@ -54,4 +55,29 @@ export class ExplainPrettyPrinter {
 
     return lines.join("\n");
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function computeColumnWidths(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#compute_column_widths is not implemented",
+  );
+}
+
+function buildSeparator(widths: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#build_separator is not implemented",
+  );
+}
+
+function buildCells(items: any, widths: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#build_cells is not implemented",
+  );
+}
+
+function buildFooter(nrows: any, elapsed: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#build_footer is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
@@ -57,7 +57,6 @@ export class ExplainPrettyPrinter {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function computeColumnWidths(result: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#compute_column_widths is not implemented",
@@ -81,4 +80,3 @@ function buildFooter(nrows: any, elapsed: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#build_footer is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.ts
@@ -81,3 +81,4 @@ function buildFooter(nrows: any, elapsed: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::ExplainPrettyPrinter#build_footer is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -102,3 +102,4 @@ function indexInCreate(tableName: any, columnName: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#index_in_create is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -36,7 +36,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function visit_DropForeignKey(name: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_DropForeignKey is not implemented",
@@ -102,4 +101,3 @@ function indexInCreate(tableName: any, columnName: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#index_in_create is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import type { ReferentialAction } from "../abstract/schema-definitions.js";
 import { singularize, underscore } from "@blazetrails/activesupport";
@@ -33,4 +34,71 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
     return sql;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function visit_DropForeignKey(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_DropForeignKey is not implemented",
+  );
+}
+
+function visit_DropCheckConstraint(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_DropCheckConstraint is not implemented",
+  );
+}
+
+function visit_AddColumnDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_AddColumnDefinition is not implemented",
+  );
+}
+
+function visit_ChangeColumnDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_ChangeColumnDefinition is not implemented",
+  );
+}
+
+function visit_ChangeColumnDefaultDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_ChangeColumnDefaultDefinition is not implemented",
+  );
+}
+
+function visit_CreateIndexDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_CreateIndexDefinition is not implemented",
+  );
+}
+
+function visit_IndexDefinition(o: any, create?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#visit_IndexDefinition is not implemented",
+  );
+}
+
+function addTableOptionsBang(createSql: any, o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#add_table_options! is not implemented",
+  );
+}
+
+function addColumnOptionsBang(sql: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#add_column_options! is not implemented",
+  );
+}
+
+function addColumnPositionBang(sql: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#add_column_position! is not implemented",
+  );
+}
+
+function indexInCreate(tableName: any, columnName: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation#index_in_create is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -6,6 +6,7 @@
  *          ActiveRecord::ConnectionAdapters::MySQL::ColumnMethods (module)
  */
 
+import { NotImplementedError } from "../../errors.js";
 import {
   TableDefinition as AbstractTableDefinition,
   ColumnDefinition,
@@ -142,4 +143,23 @@ export class Table extends AbstractTable {
   constructor(tableName: string, schema: SchemaStatementsLike) {
     super(tableName, schema);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function validColumnDefinitionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#valid_column_definition_options is not implemented",
+  );
+}
+
+function aliasedTypes(name: any, fallback: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#aliased_types is not implemented",
+  );
+}
+
+function integerLikePrimaryKeyType(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#integer_like_primary_key_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -163,3 +163,4 @@ function integerLikePrimaryKeyType(type: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -145,7 +145,6 @@ export class Table extends AbstractTable {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function validColumnDefinitionOptions(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#valid_column_definition_options is not implemented",
@@ -163,4 +162,3 @@ function integerLikePrimaryKeyType(type: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -67,3 +67,4 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -4,10 +4,66 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   defaultPrimaryKeyType(): string {
     return "bigint";
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function prepareColumnOptions(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#prepare_column_options is not implemented",
+  );
+}
+
+function columnSpecForPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#column_spec_for_primary_key is not implemented",
+  );
+}
+
+function isDefaultPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#default_primary_key? is not implemented",
+  );
+}
+
+function isExplicitPrimaryKeyDefault(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#explicit_primary_key_default? is not implemented",
+  );
+}
+
+function schemaType(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_type is not implemented",
+  );
+}
+
+function schemaLimit(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_limit is not implemented",
+  );
+}
+
+function schemaPrecision(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_precision is not implemented",
+  );
+}
+
+function schemaCollation(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#schema_collation is not implemented",
+  );
+}
+
+function extractExpressionForVirtualColumn(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -13,7 +13,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function prepareColumnOptions(column: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#prepare_column_options is not implemented",
@@ -67,4 +66,3 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -78,7 +78,6 @@ export interface SchemaStatements {
   schemaCreation(): unknown;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isRowFormatDynamicByDefault(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#row_format_dynamic_by_default? is not implemented",
@@ -174,4 +173,3 @@ function integerToSql(limit: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#integer_to_sql is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -174,3 +174,4 @@ function integerToSql(limit: any): never {
     "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#integer_to_sql is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (module)
  */
 
+import { NotImplementedError } from "../../errors.js";
 export interface SchemaStatements {
   createDatabase(name: string, options?: Record<string, unknown>): Promise<void>;
   dropDatabase(name: string): Promise<void>;
@@ -75,4 +76,101 @@ export interface SchemaStatements {
   typeToSql(type: string, options?: Record<string, unknown>): string;
   tableAliasLength(): number;
   schemaCreation(): unknown;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isRowFormatDynamicByDefault(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#row_format_dynamic_by_default? is not implemented",
+  );
+}
+
+function defaultRowFormat(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#default_row_format is not implemented",
+  );
+}
+
+function validPrimaryKeyOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#valid_primary_key_options is not implemented",
+  );
+}
+
+function createTableDefinition(name: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition is not implemented",
+  );
+}
+
+function defaultType(tableName: any, fieldName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#default_type is not implemented",
+  );
+}
+
+function newColumnFromField(tableName: any, field: any, Definitions: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#new_column_from_field is not implemented",
+  );
+}
+
+function fetchTypeMetadata(sqlType: any, extra?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#fetch_type_metadata is not implemented",
+  );
+}
+
+function extractForeignKeyAction(specifier: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#extract_foreign_key_action is not implemented",
+  );
+}
+
+function addIndexLength(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_index_length is not implemented",
+  );
+}
+
+function addOptionsForIndexColumns(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#add_options_for_index_columns is not implemented",
+  );
+}
+
+function dataSourceSql(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#data_source_sql is not implemented",
+  );
+}
+
+function quotedScope(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#quoted_scope is not implemented",
+  );
+}
+
+function extractSchemaQualifiedName(string: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#extract_schema_qualified_name is not implemented",
+  );
+}
+
+function typeWithSizeToSql(type: any, size: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#type_with_size_to_sql is not implemented",
+  );
+}
+
+function limitToSize(limit: any, type: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#limit_to_size is not implemented",
+  );
+}
+
+function integerToSql(limit: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#integer_to_sql is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -64,3 +64,4 @@ function deduplicated(): never {
     "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata#deduplicated is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -8,6 +8,7 @@
  * "VIRTUAL GENERATED", etc.
  */
 
+import { NotImplementedError } from "../../errors.js";
 export class TypeMetadata {
   readonly sqlType: string;
   readonly type: string;
@@ -55,4 +56,11 @@ export class TypeMetadata {
       this.extra,
     ]);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deduplicated(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata#deduplicated is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -58,10 +58,8 @@ export class TypeMetadata {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deduplicated(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata#deduplicated is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1014,7 +1014,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isTextType(type: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#text_type? is not implemented",
@@ -1068,4 +1067,3 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1068,3 +1068,4 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -6,7 +6,7 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
-import { MismatchedForeignKey } from "../errors.js";
+import { MismatchedForeignKey, NotImplementedError } from "../errors.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { quoteString as mysqlQuoteString } from "./mysql/quoting.js";
 import { Column } from "./column.js";
@@ -1012,4 +1012,59 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // override via explicit false in config.
     return mysql.createPool({ supportBigNumbers: true, ...config });
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isTextType(type: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#text_type? is not implemented",
+  );
+}
+
+function connect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#connect is not implemented",
+  );
+}
+
+function reconnect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#reconnect is not implemented",
+  );
+}
+
+function configureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#configure_connection is not implemented",
+  );
+}
+
+function fullVersion(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#full_version is not implemented",
+  );
+}
+
+function getFullVersion(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#get_full_version is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#translate_exception is not implemented",
+  );
+}
+
+function defaultPreparedStatements(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#default_prepared_statements is not implemented",
+  );
+}
+
+function initializeTypeMap(m: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -36,6 +36,7 @@ import {
   RecordNotUnique,
   StatementInvalid,
   ValueTooLong,
+  NotImplementedError,
 } from "../errors.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
@@ -3949,3 +3950,154 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
   "time with time zone": "timetz",
   boolean: "bool",
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function typeMap(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#type_map is not implemented",
+  );
+}
+
+function initializeTypeMap(m?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#initialize_type_map is not implemented",
+  );
+}
+
+function extractValueFromDefault(default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#extract_value_from_default is not implemented",
+  );
+}
+
+function extractDefaultFunction(defaultValue: any, default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#extract_default_function is not implemented",
+  );
+}
+
+function hasDefaultFunction(defaultValue: any, default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#has_default_function? is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#translate_exception is not implemented",
+  );
+}
+
+function isRetryableQueryError(exception: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#retryable_query_error? is not implemented",
+  );
+}
+
+function getOidType(oid: any, fmod: any, columnName: any, sqlType?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#get_oid_type is not implemented",
+  );
+}
+
+function loadAdditionalTypes(oids?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#load_additional_types is not implemented",
+  );
+}
+
+function isIsCachedPlanFailure(pgerror: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#is_cached_plan_failure? is not implemented",
+  );
+}
+
+function isInTransaction(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#in_transaction? is not implemented",
+  );
+}
+
+function sqlKey(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#sql_key is not implemented",
+  );
+}
+
+function prepareStatement(sql: any, binds: any, conn: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#prepare_statement is not implemented",
+  );
+}
+
+function connect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#connect is not implemented",
+  );
+}
+
+function reconnect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#reconnect is not implemented",
+  );
+}
+
+function configureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#configure_connection is not implemented",
+  );
+}
+
+function reconfigureConnectionTimezone(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#reconfigure_connection_timezone is not implemented",
+  );
+}
+
+function columnDefinitions(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#column_definitions is not implemented",
+  );
+}
+
+function arelVisitor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#arel_visitor is not implemented",
+  );
+}
+
+function buildStatementPool(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#build_statement_pool is not implemented",
+  );
+}
+
+function canPerformCaseInsensitiveComparisonFor(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#can_perform_case_insensitive_comparison_for? is not implemented",
+  );
+}
+
+function addPgEncoders(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#add_pg_encoders is not implemented",
+  );
+}
+
+function updateTypemapForDefaultTimezone(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#update_typemap_for_default_timezone is not implemented",
+  );
+}
+
+function addPgDecoders(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#add_pg_decoders is not implemented",
+  );
+}
+
+function constructCoder(row: any, coderClass: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#construct_coder is not implemented",
+  );
+}

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4101,3 +4101,4 @@ function constructCoder(row: any, coderClass: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#construct_coder is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3951,7 +3951,6 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
   boolean: "bool",
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function typeMap(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#type_map is not implemented",
@@ -4101,4 +4100,3 @@ function constructCoder(row: any, coderClass: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#construct_coder is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { Nodes } from "@blazetrails/arel";
 import type { ExplainOption } from "../../adapter.js";
 import type { Result } from "../../result.js";
@@ -67,4 +68,79 @@ export interface DatabaseStatements {
   buildExplainClause(options?: ExplainOption[]): string;
   // Mirrors: database_statements.rb:110
   setConstraints(deferred: "deferred" | "immediate", ...constraints: string[]): Promise<void>;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function cancelAnyRunningQuery(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query is not implemented",
+  );
+}
+
+function performQuery(
+  rawConnection: any,
+  sql: any,
+  binds: any,
+  typeCastedBinds: any,
+  prepare?: any,
+  notificationPayload?: any,
+  batch?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query is not implemented",
+  );
+}
+
+function castResult(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cast_result is not implemented",
+  );
+}
+
+function affectedRows(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows is not implemented",
+  );
+}
+
+function executeBatch(statements: any, name?: any, kwargs?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute_batch is not implemented",
+  );
+}
+
+function buildTruncateStatements(tableNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_truncate_statements is not implemented",
+  );
+}
+
+function lastInsertIdResult(sequenceName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#last_insert_id_result is not implemented",
+  );
+}
+
+function returningColumnValues(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#returning_column_values is not implemented",
+  );
+}
+
+function suppressCompositePrimaryKey(pk: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#suppress_composite_primary_key is not implemented",
+  );
+}
+
+function handleWarnings(sql: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings is not implemented",
+  );
+}
+
+function isWarningIgnored(warning: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored? is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -70,7 +70,6 @@ export interface DatabaseStatements {
   setConstraints(deferred: "deferred" | "immediate", ...constraints: string[]): Promise<void>;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function cancelAnyRunningQuery(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#cancel_any_running_query is not implemented",
@@ -144,4 +143,3 @@ function isWarningIgnored(warning: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -144,3 +144,4 @@ function isWarningIgnored(warning: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#warning_ignored? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -23,10 +23,8 @@ export class Enum extends ValueType<string> {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function castValue(value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum#cast_value is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -29,3 +29,4 @@ function castValue(value: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum#cast_value is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/enum.ts
@@ -6,6 +6,7 @@
  * def cast_value(value); value.to_s; end`.
  */
 
+import { NotImplementedError } from "../../../errors.js";
 import { ValueType } from "@blazetrails/activemodel";
 
 export class Enum extends ValueType<string> {
@@ -20,4 +21,11 @@ export class Enum extends ValueType<string> {
     if (value == null) return null;
     return String(value);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function castValue(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum#cast_value is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -56,3 +56,4 @@ function numberForPoint(number: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::LegacyPoint#number_for_point is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -50,10 +50,8 @@ export class LegacyPoint extends ValueType<[number, number]> {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function numberForPoint(number: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::LegacyPoint#number_for_point is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::LegacyPoint
  */
 
+import { NotImplementedError } from "../../../errors.js";
 import { ValueType } from "@blazetrails/activemodel";
 
 export class LegacyPoint extends ValueType<[number, number]> {
@@ -47,4 +48,11 @@ export class LegacyPoint extends ValueType<[number, number]> {
     if (isNaN(x) || isNaN(y)) return null;
     return [x, y];
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function numberForPoint(number: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::LegacyPoint#number_for_point is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -209,10 +209,8 @@ function inspect(value: unknown): string {
   return String(value);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function unquote(value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range#unquote is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -17,6 +17,7 @@
  *     the subtype and emits `Range` instances from `castValue`/`serialize`.
  */
 
+import { NotImplementedError } from "../../../errors.js";
 import { ValueType } from "@blazetrails/activemodel";
 
 export class Range {
@@ -206,4 +207,11 @@ function inspect(value: unknown): string {
   if (typeof value === "string") return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   if (value instanceof Date) return value.toISOString();
   return String(value);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function unquote(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range#unquote is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -215,3 +215,4 @@ function unquote(value: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range#unquote is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
@@ -373,5 +374,42 @@ function isSqlLiteral(value: unknown): value is { value: string } {
     typeof value === "object" &&
     value.constructor?.name === "SqlLiteral" &&
     typeof (value as any).value === "string"
+  );
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function lookupCastType(sqlType: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#lookup_cast_type is not implemented",
+  );
+}
+
+function encodeArray(arrayData: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#encode_array is not implemented",
+  );
+}
+
+function determineEncodingOfStringsInArray(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#determine_encoding_of_strings_in_array is not implemented",
+  );
+}
+
+function typeCastArray(values: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#type_cast_array is not implemented",
+  );
+}
+
+function typeCastRangeValue(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#type_cast_range_value is not implemented",
+  );
+}
+
+function isInfinity(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#infinity? is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -413,3 +413,4 @@ function isInfinity(value: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#infinity? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -377,7 +377,6 @@ function isSqlLiteral(value: unknown): value is { value: string } {
   );
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function lookupCastType(sqlType: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#lookup_cast_type is not implemented",
@@ -413,4 +412,3 @@ function isInfinity(value: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#infinity? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -134,3 +134,4 @@ function tableModifierInCreate(o: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#table_modifier_in_create is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import type { ForeignKeyDefinition, ReferentialAction } from "../abstract/schema-definitions.js";
 import { quoteIdentifier, quoteTableName } from "../abstract/quoting.js";
@@ -47,4 +48,89 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
     return sql;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function visit_AlterTable(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_AlterTable is not implemented",
+  );
+}
+
+function visit_AddForeignKey(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_AddForeignKey is not implemented",
+  );
+}
+
+function visit_ForeignKeyDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_ForeignKeyDefinition is not implemented",
+  );
+}
+
+function visit_CheckConstraintDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_CheckConstraintDefinition is not implemented",
+  );
+}
+
+function visit_ValidateConstraint(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_ValidateConstraint is not implemented",
+  );
+}
+
+function visit_ExclusionConstraintDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_ExclusionConstraintDefinition is not implemented",
+  );
+}
+
+function visit_UniqueConstraintDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_UniqueConstraintDefinition is not implemented",
+  );
+}
+
+function visit_AddExclusionConstraint(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_AddExclusionConstraint is not implemented",
+  );
+}
+
+function visit_AddUniqueConstraint(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_AddUniqueConstraint is not implemented",
+  );
+}
+
+function visit_ChangeColumnDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_ChangeColumnDefinition is not implemented",
+  );
+}
+
+function visit_ChangeColumnDefaultDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_ChangeColumnDefaultDefinition is not implemented",
+  );
+}
+
+function addColumnOptionsBang(sql: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#add_column_options! is not implemented",
+  );
+}
+
+function quotedIncludeColumns(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#quoted_include_columns is not implemented",
+  );
+}
+
+function tableModifierInCreate(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#table_modifier_in_create is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -50,7 +50,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function visit_AlterTable(o: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#visit_AlterTable is not implemented",
@@ -134,4 +133,3 @@ function tableModifierInCreate(o: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation#table_modifier_in_create is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -575,7 +575,6 @@ export class AlterTable extends AbstractAlterTable {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function validColumnDefinitionOptions(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#valid_column_definition_options is not implemented",
@@ -593,4 +592,3 @@ function integerLikePrimaryKeyType(type: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -593,3 +593,4 @@ function integerLikePrimaryKeyType(type: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -8,6 +8,7 @@
  *          ActiveRecord::ConnectionAdapters::PostgreSQL (top-level module)
  */
 
+import { NotImplementedError } from "../../errors.js";
 import {
   TableDefinition as AbstractTableDefinition,
   ColumnDefinition,
@@ -572,4 +573,23 @@ export class AlterTable extends AbstractAlterTable {
   addUniqueConstraint(columnName: string | string[], options: UniqueConstraintOptions = {}): void {
     this.uniqueConstraintAdds.push(this._td.newUniqueConstraintDefinition(columnName, options));
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function validColumnDefinitionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#valid_column_definition_options is not implemented",
+  );
+}
+
+function aliasedTypes(name: any, fallback: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#aliased_types is not implemented",
+  );
+}
+
+function integerLikePrimaryKeyType(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -13,7 +13,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function extensions(stream: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#extensions is not implemented",
@@ -79,4 +78,3 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -4,10 +4,78 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   defaultPrimaryKeyType(): string {
     return "bigserial";
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function extensions(stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#extensions is not implemented",
+  );
+}
+
+function types(stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#types is not implemented",
+  );
+}
+
+function schemas(stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#schemas is not implemented",
+  );
+}
+
+function exclusionConstraintsInCreate(table: any, stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#exclusion_constraints_in_create is not implemented",
+  );
+}
+
+function uniqueConstraintsInCreate(table: any, stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#unique_constraints_in_create is not implemented",
+  );
+}
+
+function prepareColumnOptions(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#prepare_column_options is not implemented",
+  );
+}
+
+function isDefaultPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#default_primary_key? is not implemented",
+  );
+}
+
+function isExplicitPrimaryKeyDefault(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#explicit_primary_key_default? is not implemented",
+  );
+}
+
+function schemaType(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#schema_type is not implemented",
+  );
+}
+
+function schemaExpression(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#schema_expression is not implemented",
+  );
+}
+
+function extractExpressionForVirtualColumn(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -79,3 +79,4 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -268,7 +268,6 @@ export interface SchemaStatements {
   schemaCreation(): unknown;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function createTableDefinition(name: any, options?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#create_table_definition is not implemented",
@@ -417,4 +416,3 @@ function columnNamesFromColumnNumbers(tableOid: any, columnNumbers: any): never 
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#column_names_from_column_numbers is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -417,3 +417,4 @@ function columnNamesFromColumnNumbers(tableOid: any, columnNumbers: any): never 
     "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#column_names_from_column_numbers is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
@@ -265,4 +266,154 @@ export interface SchemaStatements {
   foreignTableExists(tableName: string): Promise<boolean>;
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string;
   schemaCreation(): unknown;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function createTableDefinition(name: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#create_table_definition is not implemented",
+  );
+}
+
+function createAlterTable(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#create_alter_table is not implemented",
+  );
+}
+
+function newColumnFromField(tableName: any, field: any, Definitions: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#new_column_from_field is not implemented",
+  );
+}
+
+function fetchTypeMetadata(columnName: any, sqlType: any, oid: any, fmod: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#fetch_type_metadata is not implemented",
+  );
+}
+
+function sequenceNameFromParts(tableName: any, columnName: any, suffix: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#sequence_name_from_parts is not implemented",
+  );
+}
+
+function extractForeignKeyAction(specifier: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#extract_foreign_key_action is not implemented",
+  );
+}
+
+function assertValidDeferrable(deferrable: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#assert_valid_deferrable is not implemented",
+  );
+}
+
+function extractConstraintDeferrable(deferrable: any, deferred: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#extract_constraint_deferrable is not implemented",
+  );
+}
+
+function referenceNameForTable(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#reference_name_for_table is not implemented",
+  );
+}
+
+function addColumnForAlter(tableName: any, columnName: any, type: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#add_column_for_alter is not implemented",
+  );
+}
+
+function changeColumnForAlter(tableName: any, columnName: any, type: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#change_column_for_alter is not implemented",
+  );
+}
+
+function changeColumnNullForAlter(
+  tableName: any,
+  columnName: any,
+  null_: any,
+  default_?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#change_column_null_for_alter is not implemented",
+  );
+}
+
+function addIndexOpclass(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#add_index_opclass is not implemented",
+  );
+}
+
+function addOptionsForIndexColumns(quotedColumns: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#add_options_for_index_columns is not implemented",
+  );
+}
+
+function exclusionConstraintName(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#exclusion_constraint_name is not implemented",
+  );
+}
+
+function exclusionConstraintFor(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#exclusion_constraint_for is not implemented",
+  );
+}
+
+function exclusionConstraintForBang(tableName: any, expression?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#exclusion_constraint_for! is not implemented",
+  );
+}
+
+function uniqueConstraintName(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#unique_constraint_name is not implemented",
+  );
+}
+
+function uniqueConstraintFor(tableName: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#unique_constraint_for is not implemented",
+  );
+}
+
+function uniqueConstraintForBang(tableName: any, column?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#unique_constraint_for! is not implemented",
+  );
+}
+
+function dataSourceSql(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#data_source_sql is not implemented",
+  );
+}
+
+function quotedScope(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#quoted_scope is not implemented",
+  );
+}
+
+function extractSchemaQualifiedName(string: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#extract_schema_qualified_name is not implemented",
+  );
+}
+
+function columnNamesFromColumnNumbers(tableOid: any, columnNumbers: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#column_names_from_column_numbers is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -57,10 +57,8 @@ export class TypeMetadata {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deduplicated(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata#deduplicated is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -63,3 +63,4 @@ function deduplicated(): never {
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata#deduplicated is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata
  */
 
+import { NotImplementedError } from "../../errors.js";
 export class TypeMetadata {
   readonly sqlType: string;
   readonly type: string;
@@ -54,4 +55,11 @@ export class TypeMetadata {
       this.scale,
     ]);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deduplicated(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata#deduplicated is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -743,3 +743,4 @@ function open(filename: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaCache#open is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -713,7 +713,6 @@ export class FakePool {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function emptyCache(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SchemaReflection#empty_cache is not implemented",
@@ -743,4 +742,3 @@ function open(filename: any): never {
     "ActiveRecord::ConnectionAdapters::SchemaCache#open is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -5,6 +5,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SchemaCache
  */
 
+import { NotImplementedError } from "../errors.js";
 import { getFs, getPath } from "@blazetrails/activesupport";
 import { Column } from "./column.js";
 import type { ColumnJSON } from "./column.js";
@@ -710,4 +711,35 @@ export class FakePool {
   withConnection<T>(callback: (conn: unknown) => T): T {
     return callback(this._connection);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function emptyCache(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaReflection#empty_cache is not implemented",
+  );
+}
+
+function isIgnoredTable(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCache#ignored_table? is not implemented",
+  );
+}
+
+function deriveColumnsHashAndDeduplicateValues(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCache#derive_columns_hash_and_deduplicate_values is not implemented",
+  );
+}
+
+function deepDeduplicate(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate is not implemented",
+  );
+}
+
+function open(filename: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SchemaCache#open is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -67,10 +67,8 @@ export interface SqlTypeMetadataJSON {
   scale: number | null;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deduplicated(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SqlTypeMetadata#deduplicated is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SqlTypeMetadata
  */
 
+import { NotImplementedError } from "../errors.js";
 import type { Deduplicable } from "./deduplicable.js";
 
 export class SqlTypeMetadata implements Deduplicable {
@@ -64,4 +65,11 @@ export interface SqlTypeMetadataJSON {
   limit: number | null;
   precision: number | null;
   scale: number | null;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deduplicated(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SqlTypeMetadata#deduplicated is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -73,3 +73,4 @@ function deduplicated(): never {
     "ActiveRecord::ConnectionAdapters::SqlTypeMetadata#deduplicated is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1915,3 +1915,4 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize_type_map is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1801,7 +1801,6 @@ function normalizeReferentialAction(action: string): string {
   return REFERENTIAL_ACTION_MAP[action.toLowerCase()] ?? action.toUpperCase();
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function bindParamsLength(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#bind_params_length is not implemented",
@@ -1915,4 +1914,3 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize_type_map is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -13,6 +13,7 @@ import {
   NoDatabaseError,
   DatabaseConnectionError,
   TransactionIsolationError,
+  NotImplementedError,
 } from "../errors.js";
 import { TypeMap } from "../type/type-map.js";
 import { Date as DateType } from "../type/date.js";
@@ -1798,4 +1799,119 @@ const REFERENTIAL_ACTION_MAP: Record<string, string> = {
 
 function normalizeReferentialAction(action: string): string {
   return REFERENTIAL_ACTION_MAP[action.toLowerCase()] ?? action.toUpperCase();
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function bindParamsLength(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#bind_params_length is not implemented",
+  );
+}
+
+function tableStructure(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#table_structure is not implemented",
+  );
+}
+
+function extractValueFromDefault(default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#extract_value_from_default is not implemented",
+  );
+}
+
+function extractDefaultFunction(defaultValue: any, default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#extract_default_function is not implemented",
+  );
+}
+
+function hasDefaultFunction(defaultValue: any, default_: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#has_default_function? is not implemented",
+  );
+}
+
+function isInvalidAlterTableType(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#invalid_alter_table_type? is not implemented",
+  );
+}
+
+function moveTable(from: any, to: any, options?: any, block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#move_table is not implemented",
+  );
+}
+
+function copyTable(from: any, to: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#copy_table is not implemented",
+  );
+}
+
+function copyTableIndexes(from: any, to: any, rename?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#copy_table_indexes is not implemented",
+  );
+}
+
+function copyTableContents(from: any, to: any, columns: any, rename?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#copy_table_contents is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#translate_exception is not implemented",
+  );
+}
+
+function tableStructureWithCollation(tableName: any, basicStructure: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#table_structure_with_collation is not implemented",
+  );
+}
+
+function tableStructureSql(tableName: any, columnNames?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#table_structure_sql is not implemented",
+  );
+}
+
+function arelVisitor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#arel_visitor is not implemented",
+  );
+}
+
+function buildStatementPool(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#build_statement_pool is not implemented",
+  );
+}
+
+function connect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#connect is not implemented",
+  );
+}
+
+function reconnect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#reconnect is not implemented",
+  );
+}
+
+function configureConnection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#configure_connection is not implemented",
+  );
+}
+
+function initializeTypeMap(m: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize_type_map is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -142,3 +142,4 @@ function defaultInsertValue(column: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#default_insert_value is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -86,7 +86,6 @@ export async function resetIsolationLevel(
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function internalBeginTransaction(mode: any, isolation: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#internal_begin_transaction is not implemented",
@@ -142,4 +141,3 @@ function defaultInsertValue(column: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#default_insert_value is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -8,6 +8,7 @@
  * an adapter for execution, matching the codebase's mixin pattern.
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { Result } from "../../result.js";
 import { stripSqlComments } from "../sql-classification.js";
 
@@ -83,4 +84,61 @@ export async function resetIsolationLevel(
   if (previousReadUncommitted !== null) {
     await adapter.executeMutation(`PRAGMA read_uncommitted=${previousReadUncommitted}`);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function internalBeginTransaction(mode: any, isolation: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#internal_begin_transaction is not implemented",
+  );
+}
+
+function performQuery(
+  rawConnection: any,
+  sql: any,
+  binds: any,
+  typeCastedBinds: any,
+  prepare?: any,
+  notificationPayload?: any,
+  batch?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#perform_query is not implemented",
+  );
+}
+
+function castResult(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#cast_result is not implemented",
+  );
+}
+
+function affectedRows(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#affected_rows is not implemented",
+  );
+}
+
+function executeBatch(statements: any, name?: any, kwargs?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#execute_batch is not implemented",
+  );
+}
+
+function buildTruncateStatement(tableName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#build_truncate_statement is not implemented",
+  );
+}
+
+function returningColumnValues(result: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#returning_column_values is not implemented",
+  );
+}
+
+function defaultInsertValue(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#default_insert_value is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -38,3 +38,4 @@ function addColumnOptionsBang(sql: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#add_column_options! is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -20,7 +20,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function visit_ForeignKeyDefinition(o: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#visit_ForeignKeyDefinition is not implemented",
@@ -38,4 +37,3 @@ function addColumnOptionsBang(sql: any, options: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#add_column_options! is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 
 export class SchemaCreation extends AbstractSchemaCreation {
@@ -17,4 +18,23 @@ export class SchemaCreation extends AbstractSchemaCreation {
         "Use `foreignKey: true` on references when creating the table.",
     );
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function visit_ForeignKeyDefinition(o: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#visit_ForeignKeyDefinition is not implemented",
+  );
+}
+
+function supportsIndexUsing(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#supports_index_using? is not implemented",
+  );
+}
+
+function addColumnOptionsBang(sql: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#add_column_options! is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -50,7 +50,6 @@ export class TableDefinition extends AbstractTableDefinition {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function integerLikePrimaryKeyType(type: any, options: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition#integer_like_primary_key_type is not implemented",
@@ -62,4 +61,3 @@ function validColumnDefinitionOptions(): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition#valid_column_definition_options is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition
  */
 
+import { NotImplementedError } from "../../errors.js";
 import {
   TableDefinition as AbstractTableDefinition,
   ColumnDefinition,
@@ -47,4 +48,17 @@ export class TableDefinition extends AbstractTableDefinition {
     }
     return new ColumnDefinition(name, type, options);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function integerLikePrimaryKeyType(type: any, options: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition#integer_like_primary_key_type is not implemented",
+  );
+}
+
+function validColumnDefinitionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition#valid_column_definition_options is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -62,3 +62,4 @@ function validColumnDefinitionOptions(): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition#valid_column_definition_options is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
@@ -4,10 +4,42 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   defaultPrimaryKeyType(): string {
     return "integer";
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function virtualTables(stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#virtual_tables is not implemented",
+  );
+}
+
+function isDefaultPrimaryKey(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#default_primary_key? is not implemented",
+  );
+}
+
+function isExplicitPrimaryKeyDefault(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#explicit_primary_key_default? is not implemented",
+  );
+}
+
+function prepareColumnOptions(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#prepare_column_options is not implemented",
+  );
+}
+
+function extractExpressionForVirtualColumn(column: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#extract_expression_for_virtual_column is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
@@ -13,7 +13,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function virtualTables(stream: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#virtual_tables is not implemented",
@@ -43,4 +42,3 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
@@ -43,3 +43,4 @@ function extractExpressionForVirtualColumn(column: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#extract_expression_for_virtual_column is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -8,6 +8,7 @@
  * (via alterTable rebuild). The functions below delegate to the adapter.
  */
 
+import { NotImplementedError } from "../../errors.js";
 import type { DatabaseAdapter } from "../../adapter.js";
 import type { CheckConstraintDefinition } from "../abstract/schema-definitions.js";
 import { quoteColumnName } from "./quoting.js";
@@ -117,4 +118,59 @@ export function createSchemaDumper(
 
 export function schemaCreation(): SchemaCreation {
   return new SchemaCreation("sqlite");
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function validTableDefinitionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#valid_table_definition_options is not implemented",
+  );
+}
+
+function createTableDefinition(name: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#create_table_definition is not implemented",
+  );
+}
+
+function validateIndexLengthBang(tableName: any, newName: any, internal?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#validate_index_length! is not implemented",
+  );
+}
+
+function newColumnFromField(tableName: any, field: any, definitions: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#new_column_from_field is not implemented",
+  );
+}
+
+function isIsColumnTheRowid(field: any, columnDefinitions: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#is_column_the_rowid? is not implemented",
+  );
+}
+
+function dataSourceSql(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#data_source_sql is not implemented",
+  );
+}
+
+function quotedScope(name?: any, type?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#quoted_scope is not implemented",
+  );
+}
+
+function assertValidDeferrable(deferrable: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#assert_valid_deferrable is not implemented",
+  );
+}
+
+function extractGeneratedType(field: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#extract_generated_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -120,7 +120,6 @@ export function schemaCreation(): SchemaCreation {
   return new SchemaCreation("sqlite");
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function validTableDefinitionOptions(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#valid_table_definition_options is not implemented",
@@ -174,4 +173,3 @@ function extractGeneratedType(field: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#extract_generated_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -174,3 +174,4 @@ function extractGeneratedType(field: any): never {
     "ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#extract_generated_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -130,3 +130,4 @@ function cache(): never {
     "ActiveRecord::ConnectionAdapters::StatementPool#cache is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -124,10 +124,8 @@ export class StatementPool<T = unknown> {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function cache(): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::StatementPool#cache is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool
  */
 
+import { NotImplementedError } from "../errors.js";
 export class StatementPool<T = unknown> {
   private _statements = new Map<string, T>();
   private _maxSize: number;
@@ -121,4 +122,11 @@ export class StatementPool<T = unknown> {
   protected dealloc(_stmt: T): void {
     // Base implementation is a no-op; adapter-specific pools override.
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function cache(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::StatementPool#cache is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -78,7 +78,6 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isTextType(type: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::TrilogyAdapter#text_type? is not implemented",
@@ -132,4 +131,3 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::TrilogyAdapter#initialize_type_map is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -9,7 +9,12 @@
  */
 
 import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
-import { DatabaseConnectionError, NoDatabaseError, ConnectionNotEstablished } from "../errors.js";
+import {
+  DatabaseConnectionError,
+  NoDatabaseError,
+  ConnectionNotEstablished,
+  NotImplementedError,
+} from "../errors.js";
 
 const SSL_MODES: Record<string, number> = {
   SSL_MODE_DISABLED: 0,
@@ -71,4 +76,59 @@ export class TrilogyAdapter extends AbstractMysqlAdapter {
     }
     return new ConnectionNotEstablished(error.message);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isTextType(type: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#text_type? is not implemented",
+  );
+}
+
+function errorNumber(exception: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#error_number is not implemented",
+  );
+}
+
+function connect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#connect is not implemented",
+  );
+}
+
+function reconnect(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#reconnect is not implemented",
+  );
+}
+
+function fullVersion(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#full_version is not implemented",
+  );
+}
+
+function getFullVersion(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#get_full_version is not implemented",
+  );
+}
+
+function translateException(exception: any, message?: any, sql?: any, binds?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#translate_exception is not implemented",
+  );
+}
+
+function defaultPreparedStatements(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#default_prepared_statements is not implemented",
+  );
+}
+
+function initializeTypeMap(m: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionAdapters::TrilogyAdapter#initialize_type_map is not implemented",
+  );
 }

--- a/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/trilogy-adapter.ts
@@ -132,3 +132,4 @@ function initializeTypeMap(m: any): never {
     "ActiveRecord::ConnectionAdapters::TrilogyAdapter#initialize_type_map is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -750,10 +750,8 @@ export const ClassMethods = {
 // overrides like register("mysql2", ...) aren't shadowed by normalization.
 _setAdapterClassResolver(async (adapterName) => _loadAdapter(adapterName));
 
-// --- api:compare private stubs (auto-generated) ---
 function resolveConfigForConnection(configOrEnv: any): never {
   throw new NotImplementedError(
     "ActiveRecord::ConnectionHandling#resolve_config_for_connection is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -756,3 +756,4 @@ function resolveConfigForConnection(configOrEnv: any): never {
     "ActiveRecord::ConnectionHandling#resolve_config_for_connection is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -749,3 +749,10 @@ export const ClassMethods = {
 // unchanged — the registry handles canonical names and aliases, so caller
 // overrides like register("mysql2", ...) aren't shadowed by normalization.
 _setAdapterClassResolver(async (adapterName) => _loadAdapter(adapterName));
+
+// --- api:compare private stubs (auto-generated) ---
+function resolveConfigForConnection(configOrEnv: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ConnectionHandling#resolve_config_for_connection is not implemented",
+  );
+}

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Core
  */
 
+import { NotImplementedError } from "./errors.js";
 import { Notifications, ParameterFilter, getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
@@ -588,4 +589,41 @@ export function cachedFindByStatement(
     cache.set(key, block());
   }
   return cache.get(key);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError("ActiveRecord::Core#init_internals is not implemented");
+}
+
+function initializeInternalsCallback(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Core#initialize_internals_callback is not implemented",
+  );
+}
+
+function isCustomInspectMethodDefined(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Core#custom_inspect_method_defined? is not implemented",
+  );
+}
+
+function inspectWithAttributes(attributesToList: any): never {
+  throw new NotImplementedError("ActiveRecord::Core#inspect_with_attributes is not implemented");
+}
+
+function attributesForInspect(): never {
+  throw new NotImplementedError("ActiveRecord::Core#attributes_for_inspect is not implemented");
+}
+
+function allAttributesForInspect(): never {
+  throw new NotImplementedError("ActiveRecord::Core#all_attributes_for_inspect is not implemented");
+}
+
+function relation(): never {
+  throw new NotImplementedError("ActiveRecord::Core#relation is not implemented");
+}
+
+function cachedFindBy(): never {
+  throw new NotImplementedError("ActiveRecord::Core#cached_find_by is not implemented");
 }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -591,7 +591,6 @@ export function cachedFindByStatement(
   return cache.get(key);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError("ActiveRecord::Core#init_internals is not implemented");
 }
@@ -627,4 +626,3 @@ function relation(): never {
 function cachedFindBy(): never {
   throw new NotImplementedError("ActiveRecord::Core#cached_find_by is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -627,3 +627,4 @@ function relation(): never {
 function cachedFindBy(): never {
   throw new NotImplementedError("ActiveRecord::Core#cached_find_by is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -264,3 +264,4 @@ function is_foreignKeysEqual(fkey1: any, fkey2: any): never {
     "ActiveRecord::CounterCache#_foreign_keys_equal? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -250,7 +250,6 @@ export const ClassMethods = {
   isCounterCacheColumn,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function _createRecord(attributeNames?: any): never {
   throw new NotImplementedError("ActiveRecord::CounterCache#_create_record is not implemented");
 }
@@ -264,4 +263,3 @@ function is_foreignKeysEqual(fkey1: any, fkey2: any): never {
     "ActiveRecord::CounterCache#_foreign_keys_equal? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pendingCounterCacheColumns } from "./counter-cache-state.js";
@@ -248,3 +249,18 @@ export const ClassMethods = {
   resetCounters,
   isCounterCacheColumn,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function _createRecord(attributeNames?: any): never {
+  throw new NotImplementedError("ActiveRecord::CounterCache#_create_record is not implemented");
+}
+
+function destroyRow(): never {
+  throw new NotImplementedError("ActiveRecord::CounterCache#destroy_row is not implemented");
+}
+
+function is_foreignKeysEqual(fkey1: any, fkey2: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::CounterCache#_foreign_keys_equal? is not implemented",
+  );
+}

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -463,3 +463,4 @@ function environmentValueFor(name: any): never {
     "ActiveRecord::DatabaseConfigurations#environment_value_for is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -397,7 +397,6 @@ _setDefaultEnvGetter(() => DatabaseConfigurations.defaultEnv);
 // current DatabaseConfigurations instance (matching Rails' global Base.configurations).
 _setPrimaryChecker((name) => _currentConfigurations?.isPrimary(name) ?? false);
 
-// --- api:compare private stubs (auto-generated) ---
 function envWithConfigs(env?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::DatabaseConfigurations#env_with_configs is not implemented",
@@ -463,4 +462,3 @@ function environmentValueFor(name: any): never {
     "ActiveRecord::DatabaseConfigurations#environment_value_for is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import {
   DatabaseConfig,
   type DatabaseConfigOptions,
@@ -395,3 +396,70 @@ _setDefaultEnvGetter(() => DatabaseConfigurations.defaultEnv);
 // Register the primary checker so HashConfig.isPrimary can consult the
 // current DatabaseConfigurations instance (matching Rails' global Base.configurations).
 _setPrimaryChecker((name) => _currentConfigurations?.isPrimary(name) ?? false);
+
+// --- api:compare private stubs (auto-generated) ---
+function envWithConfigs(env?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#env_with_configs is not implemented",
+  );
+}
+
+function buildConfigs(configs: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#build_configs is not implemented",
+  );
+}
+
+function walkConfigs(envName: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#walk_configs is not implemented",
+  );
+}
+
+function resolveSymbolConnection(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#resolve_symbol_connection is not implemented",
+  );
+}
+
+function buildConfigurationSentence(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#build_configuration_sentence is not implemented",
+  );
+}
+
+function buildDbConfigFromRawConfig(envName: any, name: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#build_db_config_from_raw_config is not implemented",
+  );
+}
+
+function buildDbConfigFromString(envName: any, name: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#build_db_config_from_string is not implemented",
+  );
+}
+
+function buildDbConfigFromHash(envName: any, name: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#build_db_config_from_hash is not implemented",
+  );
+}
+
+function mergeDbEnvironmentVariables(currentEnv: any, configs: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#merge_db_environment_variables is not implemented",
+  );
+}
+
+function environmentUrlConfig(env: any, name: any, config: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#environment_url_config is not implemented",
+  );
+}
+
+function environmentValueFor(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations#environment_value_for is not implemented",
+  );
+}

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -9,6 +9,7 @@
  *   // => { adapter: "postgresql", host: "localhost", port: 9000,
  *   //      database: "foo_test", username: "foo", password: "bar", pool: "5" }
  */
+import { NotImplementedError } from "../errors.js";
 import type { DatabaseConfigOptions } from "./database-config.js";
 
 // Scheme-to-adapter mapping (Rails' ActiveRecord.protocol_adapters).
@@ -156,4 +157,41 @@ export class ConnectionUrlResolver {
 // logged without leaking credentials embedded in connection URLs.
 function redactUrl(url: string): string {
   return url.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function uri(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#uri is not implemented",
+  );
+}
+
+function uriParser(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#uri_parser is not implemented",
+  );
+}
+
+function queryHash(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#query_hash is not implemented",
+  );
+}
+
+function rawConfig(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#raw_config is not implemented",
+  );
+}
+
+function resolvedAdapter(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#resolved_adapter is not implemented",
+  );
+}
+
+function databaseFromPath(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#database_from_path is not implemented",
+  );
 }

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -195,3 +195,4 @@ function databaseFromPath(): never {
     "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#database_from_path is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -159,7 +159,6 @@ function redactUrl(url: string): string {
   return url.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/]+@/, "$1***@");
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function uri(): never {
   throw new NotImplementedError(
     "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#uri is not implemented",
@@ -195,4 +194,3 @@ function databaseFromPath(): never {
     "ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver#database_from_path is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -8,6 +8,7 @@
  * Creates a HashConfig with envName="development", name="primary",
  * and configuration={ database: "db_name" }.
  */
+import { NotImplementedError } from "../errors.js";
 import { DatabaseConfig, type DatabaseConfigOptions } from "./database-config.js";
 
 // Late-bound reference to the global configurations — set by
@@ -106,4 +107,11 @@ export class HashConfig extends DatabaseConfig {
         return null;
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function schemaFileType(format: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::HashConfig#schema_file_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -109,10 +109,8 @@ export class HashConfig extends DatabaseConfig {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function schemaFileType(format: any): never {
   throw new NotImplementedError(
     "ActiveRecord::DatabaseConfigurations::HashConfig#schema_file_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -115,3 +115,4 @@ function schemaFileType(format: any): never {
     "ActiveRecord::DatabaseConfigurations::HashConfig#schema_file_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -51,3 +51,4 @@ function toBooleanBang(configurationHash: any, key: any): never {
     "ActiveRecord::DatabaseConfigurations::UrlConfig#to_boolean! is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -45,10 +45,8 @@ function buildUrlHash(url: string): DatabaseConfigOptions {
   return new ConnectionUrlResolver(url).toHash();
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function toBooleanBang(configurationHash: any, key: any): never {
   throw new NotImplementedError(
     "ActiveRecord::DatabaseConfigurations::UrlConfig#to_boolean! is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -4,6 +4,7 @@
  * A configuration built from a connection URL. Parses the URL into a
  * config hash and merges with any provided configuration overrides.
  */
+import { NotImplementedError } from "../errors.js";
 import { HashConfig } from "./hash-config.js";
 import type { DatabaseConfigOptions } from "./database-config.js";
 import { ConnectionUrlResolver } from "./connection-url-resolver.js";
@@ -42,4 +43,11 @@ function buildUrlHash(url: string): DatabaseConfigOptions {
     return { url };
   }
   return new ConnectionUrlResolver(url).toHash();
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function toBooleanBang(configurationHash: any, key: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DatabaseConfigurations::UrlConfig#to_boolean! is not implemented",
+  );
 }

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -144,3 +144,4 @@ function defineDelegatedTypeMethods(role: any, types?: any, options?: any): neve
     "ActiveRecord::DelegatedType#define_delegated_type_methods is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { underscore } from "@blazetrails/activesupport";
 
@@ -135,4 +136,11 @@ export function getDelegatedTypeConfig(
   role: string,
 ): DelegatedTypeOptions | undefined {
   return (modelClass as any)._delegatedTypes?.get(role);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function defineDelegatedTypeMethods(role: any, types?: any, options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::DelegatedType#define_delegated_type_methods is not implemented",
+  );
 }

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -138,10 +138,8 @@ export function getDelegatedTypeConfig(
   return (modelClass as any)._delegatedTypes?.get(role);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function defineDelegatedTypeMethods(role: any, types?: any, options?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::DelegatedType#define_delegated_type_methods is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -482,3 +482,4 @@ function tryToDecryptWithEach(encryptedText: any, keys?: any): never {
 function cipherFor(secret: any, deterministic?: any): never {
   throw new NotImplementedError("ActiveRecord::Encryption::Cipher#cipher_for is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -18,6 +18,7 @@
  * two flows share a single wrapper implementation.
  */
 
+import { NotImplementedError } from "./errors.js";
 import { type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
@@ -469,4 +470,15 @@ export function ivLength(): number {
 /** Mirrors: ActiveRecord::Encryption.eager_load! */
 export function eagerLoadBang(): void {
   // No-op in TS — all encryption classes are statically imported.
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function tryToDecryptWithEach(encryptedText: any, keys?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Cipher#try_to_decrypt_with_each is not implemented",
+  );
+}
+
+function cipherFor(secret: any, deterministic?: any): never {
+  throw new NotImplementedError("ActiveRecord::Encryption::Cipher#cipher_for is not implemented");
 }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -472,7 +472,6 @@ export function eagerLoadBang(): void {
   // No-op in TS — all encryption classes are statically imported.
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function tryToDecryptWithEach(encryptedText: any, keys?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Cipher#try_to_decrypt_with_each is not implemented",
@@ -482,4 +481,3 @@ function tryToDecryptWithEach(encryptedText: any, keys?: any): never {
 function cipherFor(secret: any, deterministic?: any): never {
   throw new NotImplementedError("ActiveRecord::Encryption::Cipher#cipher_for is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Configurable } from "./configurable.js";
 
@@ -54,4 +55,35 @@ export class AutoFilteredParameters {
       this._filterParameters.push(filter);
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function app(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::AutoFilteredParameters#app is not implemented",
+  );
+}
+
+function installCollectingHook(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::AutoFilteredParameters#install_collecting_hook is not implemented",
+  );
+}
+
+function attributeWasDeclared(klass: any, attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::AutoFilteredParameters#attribute_was_declared is not implemented",
+  );
+}
+
+function isCollecting(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::AutoFilteredParameters#collecting? is not implemented",
+  );
+}
+
+function isExcludedFromFilterParameters(filterParameter: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::AutoFilteredParameters#excluded_from_filter_parameters? is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -57,7 +57,6 @@ export class AutoFilteredParameters {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function app(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::AutoFilteredParameters#app is not implemented",
@@ -87,4 +86,3 @@ function isExcludedFromFilterParameters(filterParameter: any): never {
     "ActiveRecord::Encryption::AutoFilteredParameters#excluded_from_filter_parameters? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -87,3 +87,4 @@ function isExcludedFromFilterParameters(filterParameter: any): never {
     "ActiveRecord::Encryption::AutoFilteredParameters#excluded_from_filter_parameters? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Cipher::Aes256Gcm
  */
 
+import { NotImplementedError } from "../../errors.js";
 import { getCrypto } from "@blazetrails/activesupport";
 import { ConfigError, DecryptionError } from "../errors.js";
 
@@ -123,4 +124,17 @@ export class Cipher {
       );
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function generateIv(cipher: any, clearText: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Cipher::Aes256Gcm#generate_iv is not implemented",
+  );
+}
+
+function generateDeterministicIv(clearText: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Cipher::Aes256Gcm#generate_deterministic_iv is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -126,7 +126,6 @@ export class Cipher {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function generateIv(cipher: any, clearText: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Cipher::Aes256Gcm#generate_iv is not implemented",
@@ -138,4 +137,3 @@ function generateDeterministicIv(clearText: any): never {
     "ActiveRecord::Encryption::Cipher::Aes256Gcm#generate_deterministic_iv is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -138,3 +138,4 @@ function generateDeterministicIv(clearText: any): never {
     "ActiveRecord::Encryption::Cipher::Aes256Gcm#generate_deterministic_iv is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Config
  */
 
+import { NotImplementedError } from "../errors.js";
 import { ConfigError } from "./errors.js";
 import type { SchemeOptions } from "./scheme.js";
 
@@ -69,3 +70,14 @@ export const defaultCompressor: Compressor = {
     return inflateSync(data).toString("utf-8");
   },
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function setDefaults(): never {
+  throw new NotImplementedError("ActiveRecord::Encryption::Config#set_defaults is not implemented");
+}
+
+function addPreviousScheme(properties?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Config#add_previous_scheme is not implemented",
+  );
+}

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -81,3 +81,4 @@ function addPreviousScheme(properties?: any): never {
     "ActiveRecord::Encryption::Config#add_previous_scheme is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -71,7 +71,6 @@ export const defaultCompressor: Compressor = {
   },
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function setDefaults(): never {
   throw new NotImplementedError("ActiveRecord::Encryption::Config#set_defaults is not implemented");
 }
@@ -81,4 +80,3 @@ function addPreviousScheme(properties?: any): never {
     "ActiveRecord::Encryption::Config#add_previous_scheme is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -11,6 +11,7 @@
  *
  * Mirrors: ActiveRecord::Encryption::Context
  */
+import { NotImplementedError } from "../errors.js";
 export class Context {
   private _keyProvider?: unknown;
   keyGenerator?: unknown;
@@ -102,4 +103,17 @@ export function isEncryptionDisabled(): boolean {
 
 export function isProtectedMode(): boolean {
   return currentContext().protectedMode === true;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function setDefaults(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Context#set_defaults is not implemented",
+  );
+}
+
+function buildDefaultKeyProvider(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Context#build_default_key_provider is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -105,7 +105,6 @@ export function isProtectedMode(): boolean {
   return currentContext().protectedMode === true;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function setDefaults(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Context#set_defaults is not implemented",
@@ -117,4 +116,3 @@ function buildDefaultKeyProvider(): never {
     "ActiveRecord::Encryption::Context#build_default_key_provider is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -117,3 +117,4 @@ function buildDefaultKeyProvider(): never {
     "ActiveRecord::Encryption::Context#build_default_key_provider is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/derived-secret-key-provider.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::DerivedSecretKeyProvider
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Key } from "./key.js";
 import { KeyProvider } from "./key-provider.js";
 import { KeyGenerator } from "./key-generator.js";
@@ -18,4 +19,11 @@ export class DerivedSecretKeyProvider extends KeyProvider {
     const keys = passwordList.map((p) => new Key(generator.deriveKeyFrom(p)));
     super(keys);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function deriveKeyFrom(password: any, using?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::DerivedSecretKeyProvider#derive_key_from is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/derived-secret-key-provider.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.ts
@@ -27,3 +27,4 @@ function deriveKeyFrom(password: any, using?: any): never {
     "ActiveRecord::Encryption::DerivedSecretKeyProvider#derive_key_from is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/derived-secret-key-provider.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.ts
@@ -21,10 +21,8 @@ export class DerivedSecretKeyProvider extends KeyProvider {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function deriveKeyFrom(password: any, using?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::DerivedSecretKeyProvider#derive_key_from is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { Scheme, type SchemeOptions } from "./scheme.js";
 import { LengthValidator } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
@@ -199,4 +200,125 @@ export class EncryptableRecord {
 export function getAttributeType(klass: any, name: string): unknown {
   const def = klass._attributeDefinitions?.get?.(name);
   return def?.type;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function encryptAttribute(
+  name: any,
+  keyProvider?: any,
+  key?: any,
+  deterministic?: any,
+  supportUnencryptedData?: any,
+  downcase?: any,
+  ignoreCase?: any,
+  previous?: any,
+  compress?: any,
+  compressor?: any,
+  contextProperties?: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attribute is not implemented",
+  );
+}
+
+function preserveOriginalEncrypted(name: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#preserve_original_encrypted is not implemented",
+  );
+}
+
+function overrideAccessorsToPreserveOriginal(name: any, originalAttributeName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#override_accessors_to_preserve_original is not implemented",
+  );
+}
+
+function loadSchemaBang(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#load_schema! is not implemented",
+  );
+}
+
+function addLengthValidationForEncryptedColumns(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#add_length_validation_for_encrypted_columns is not implemented",
+  );
+}
+
+function validateColumnSize(attributeName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#validate_column_size is not implemented",
+  );
+}
+
+function isEncryptedAttribute(attributeName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute? is not implemented",
+  );
+}
+
+function ciphertextFor(attributeName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#ciphertext_for is not implemented",
+  );
+}
+
+function encrypt(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#encrypt is not implemented",
+  );
+}
+
+function decrypt(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#decrypt is not implemented",
+  );
+}
+
+function _createRecord(attributeNames?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#_create_record is not implemented",
+  );
+}
+
+function encryptAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#encrypt_attributes is not implemented",
+  );
+}
+
+function decryptAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#decrypt_attributes is not implemented",
+  );
+}
+
+function validateEncryptionAllowed(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#validate_encryption_allowed is not implemented",
+  );
+}
+
+function hasEncryptedAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#has_encrypted_attributes? is not implemented",
+  );
+}
+
+function buildEncryptAttributeAssignments(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#build_encrypt_attribute_assignments is not implemented",
+  );
+}
+
+function buildDecryptAttributeAssignments(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#build_decrypt_attribute_assignments is not implemented",
+  );
+}
+
+function cantModifyEncryptedAttributesWhenFrozen(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptableRecord#cant_modify_encrypted_attributes_when_frozen is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -202,7 +202,6 @@ export function getAttributeType(klass: any, name: string): unknown {
   return def?.type;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function encryptAttribute(
   name: any,
   keyProvider?: any,
@@ -322,4 +321,3 @@ function cantModifyEncryptedAttributesWhenFrozen(): never {
     "ActiveRecord::Encryption::EncryptableRecord#cant_modify_encrypted_attributes_when_frozen is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -322,3 +322,4 @@ function cantModifyEncryptedAttributesWhenFrozen(): never {
     "ActiveRecord::Encryption::EncryptableRecord#cant_modify_encrypted_attributes_when_frozen is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -389,3 +389,4 @@ function databaseTypeToText(value: any): never {
     "ActiveRecord::Encryption::EncryptedAttributeType#database_type_to_text is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -293,7 +293,6 @@ function isAdditionalValue(value: unknown): boolean {
   );
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function previousSchemesIncludingCleanText(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::EncryptedAttributeType#previous_schemes_including_clean_text is not implemented",
@@ -389,4 +388,3 @@ function databaseTypeToText(value: any): never {
     "ActiveRecord::Encryption::EncryptedAttributeType#database_type_to_text is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { Type, ValueType, StringType } from "@blazetrails/activemodel";
 import { Scheme } from "./scheme.js";
 import type { EncryptorLike } from "./encryptor.js";
@@ -289,5 +290,102 @@ function isAdditionalValue(value: unknown): boolean {
     typeof value === "object" &&
     value !== null &&
     (value as Record<symbol, unknown>)[ADDITIONAL_VALUE_BRAND] === true
+  );
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function previousSchemesIncludingCleanText(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#previous_schemes_including_clean_text is not implemented",
+  );
+}
+
+function previousTypesWithoutCleanText(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#previous_types_without_clean_text is not implemented",
+  );
+}
+
+function buildPreviousTypesFor(schemes: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#build_previous_types_for is not implemented",
+  );
+}
+
+function isPreviousType(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#previous_type? is not implemented",
+  );
+}
+
+function decryptAsText(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#decrypt_as_text is not implemented",
+  );
+}
+
+function tryToDeserializeWithPreviousEncryptedTypes(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#try_to_deserialize_with_previous_encrypted_types is not implemented",
+  );
+}
+
+function handleDeserializeError(error: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#handle_deserialize_error is not implemented",
+  );
+}
+
+function isSerializeWithOldest(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_oldest? is not implemented",
+  );
+}
+
+function serializeWithOldest(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_oldest is not implemented",
+  );
+}
+
+function serializeWithCurrent(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#serialize_with_current is not implemented",
+  );
+}
+
+function encryptAsText(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#encrypt_as_text is not implemented",
+  );
+}
+
+function encryptor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#encryptor is not implemented",
+  );
+}
+
+function encryptionOptions(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#encryption_options is not implemented",
+  );
+}
+
+function cleanTextScheme(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#clean_text_scheme is not implemented",
+  );
+}
+
+function textToDatabaseType(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#text_to_database_type is not implemented",
+  );
+}
+
+function databaseTypeToText(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EncryptedAttributeType#database_type_to_text is not implemented",
   );
 }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -158,7 +158,6 @@ export class Encryptor {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function defaultKeyProvider(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Encryptor#default_key_provider is not implemented",
@@ -232,4 +231,3 @@ function forcedEncodingForDeterministicEncryption(): never {
     "ActiveRecord::Encryption::Encryptor#forced_encoding_for_deterministic_encryption is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Encryptor
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Cipher } from "./cipher/aes256-gcm.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
@@ -155,4 +156,79 @@ export class Encryptor {
   isCompress(): boolean {
     return this._compress;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function defaultKeyProvider(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#default_key_provider is not implemented",
+  );
+}
+
+function validatePayloadType(clearText: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#validate_payload_type is not implemented",
+  );
+}
+
+function cipher(): never {
+  throw new NotImplementedError("ActiveRecord::Encryption::Encryptor#cipher is not implemented");
+}
+
+function buildEncryptedMessage(clearText: any, keyProvider?: any, cipherOptions?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#build_encrypted_message is not implemented",
+  );
+}
+
+function serializeMessage(message: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#serialize_message is not implemented",
+  );
+}
+
+function deserializeMessage(message: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#deserialize_message is not implemented",
+  );
+}
+
+function serializer(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#serializer is not implemented",
+  );
+}
+
+function compressIfWorthIt(string: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#compress_if_worth_it is not implemented",
+  );
+}
+
+function compress(data: any): never {
+  throw new NotImplementedError("ActiveRecord::Encryption::Encryptor#compress is not implemented");
+}
+
+function uncompressIfNeeded(data: any, compressed: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#uncompress_if_needed is not implemented",
+  );
+}
+
+function uncompress(data: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#uncompress is not implemented",
+  );
+}
+
+function forceEncodingIfNeeded(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#force_encoding_if_needed is not implemented",
+  );
+}
+
+function forcedEncodingForDeterministicEncryption(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Encryptor#forced_encoding_for_deterministic_encryption is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -232,3 +232,4 @@ function forcedEncodingForDeterministicEncryption(): never {
     "ActiveRecord::Encryption::Encryptor#forced_encoding_for_deterministic_encryption is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -54,7 +54,6 @@ export class EnvelopeEncryptionKeyProvider {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function encryptDataKey(randomSecret: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#encrypt_data_key is not implemented",
@@ -78,4 +77,3 @@ function generateRandomSecret(): never {
     "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#generate_random_secret is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -5,6 +5,7 @@
  * Mirrors: ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider
  */
 
+import { NotImplementedError } from "../errors.js";
 import { getCrypto } from "@blazetrails/activesupport";
 import { Key } from "./key.js";
 import { Encryptor } from "./encryptor.js";
@@ -51,4 +52,29 @@ export class EnvelopeEncryptionKeyProvider {
   generateRandomEncryptionKey(): string {
     return getCrypto().randomBytes(32).toString("base64");
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function encryptDataKey(randomSecret: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#encrypt_data_key is not implemented",
+  );
+}
+
+function decryptDataKey(encryptedMessage: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#decrypt_data_key is not implemented",
+  );
+}
+
+function primaryKeyProvider(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#primary_key_provider is not implemented",
+  );
+}
+
+function generateRandomSecret(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#generate_random_secret is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -78,3 +78,4 @@ function generateRandomSecret(): never {
     "ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider#generate_random_secret is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -296,3 +296,4 @@ function additionalValuesFor(value: any, type: any): never {
     "ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery#additional_values_for is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -284,7 +284,6 @@ export class ExtendedEncryptableType {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function process(value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue#process is not implemented",
@@ -296,4 +295,3 @@ function additionalValuesFor(value: any, type: any): never {
     "ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery#additional_values_for is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { prepend } from "@blazetrails/activesupport";
 import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { getAttributeType } from "./encryptable-record.js";
@@ -281,4 +282,17 @@ export class ExtendedEncryptableType {
     }
     return originalSerialize(data);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function process(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue#process is not implemented",
+  );
+}
+
+function additionalValuesFor(value: any, type: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery#additional_values_for is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -55,3 +55,4 @@ function keyLength(): never {
     "ActiveRecord::Encryption::KeyGenerator#key_length is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -43,7 +43,6 @@ export class KeyGenerator {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function keyDerivationSalt(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::KeyGenerator#key_derivation_salt is not implemented",
@@ -55,4 +54,3 @@ function keyLength(): never {
     "ActiveRecord::Encryption::KeyGenerator#key_length is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::KeyGenerator
  */
 
+import { NotImplementedError } from "../errors.js";
 import { getCrypto } from "@blazetrails/activesupport";
 import { Configurable } from "./configurable.js";
 
@@ -40,4 +41,17 @@ export class KeyGenerator {
     const derived = crypto.pbkdf2Sync(password, effectiveSalt, 2 ** 16, length, digest);
     return derived.toString("base64");
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function keyDerivationSalt(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::KeyGenerator#key_derivation_salt is not implemented",
+  );
+}
+
+function keyLength(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::KeyGenerator#key_length is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -35,3 +35,4 @@ function keysGroupedById(): never {
     "ActiveRecord::Encryption::KeyProvider#keys_grouped_by_id is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -29,10 +29,8 @@ export class KeyProvider {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function keysGroupedById(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::KeyProvider#keys_grouped_by_id is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::KeyProvider
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Key } from "./key.js";
 import type { Message } from "./message.js";
 
@@ -26,4 +27,11 @@ export class KeyProvider {
     }
     return [...this._keys];
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function keysGroupedById(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::KeyProvider#keys_grouped_by_id is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -71,3 +71,4 @@ function parseProperties(headers: any, level: any): never {
     "ActiveRecord::Encryption::MessagePackMessageSerializer#parse_properties is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { Message } from "./message.js";
 import { MessageSerializer } from "./message-serializer.js";
 
@@ -38,4 +39,35 @@ export class MessagePackMessageSerializer {
   isBinary(): boolean {
     return this._fallback.isBinary();
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function messageToHash(message: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessagePackMessageSerializer#message_to_hash is not implemented",
+  );
+}
+
+function headersToHash(headers: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessagePackMessageSerializer#headers_to_hash is not implemented",
+  );
+}
+
+function hashToMessage(data: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessagePackMessageSerializer#hash_to_message is not implemented",
+  );
+}
+
+function validateMessageDataFormat(data: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessagePackMessageSerializer#validate_message_data_format is not implemented",
+  );
+}
+
+function parseProperties(headers: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessagePackMessageSerializer#parse_properties is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -41,7 +41,6 @@ export class MessagePackMessageSerializer {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function messageToHash(message: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::MessagePackMessageSerializer#message_to_hash is not implemented",
@@ -71,4 +70,3 @@ function parseProperties(headers: any, level: any): never {
     "ActiveRecord::Encryption::MessagePackMessageSerializer#parse_properties is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -142,3 +142,4 @@ function decodeIfNeeded(value: any): never {
     "ActiveRecord::Encryption::MessageSerializer#decode_if_needed is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -100,7 +100,6 @@ export class MessageSerializer {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function parseMessage(data: any, level: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::MessageSerializer#parse_message is not implemented",
@@ -142,4 +141,3 @@ function decodeIfNeeded(value: any): never {
     "ActiveRecord::Encryption::MessageSerializer#decode_if_needed is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::MessageSerializer
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Message } from "./message.js";
 import { DecryptionError, ForbiddenClass } from "./errors.js";
 
@@ -97,4 +98,47 @@ export class MessageSerializer {
   isBinary(): boolean {
     return false;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function parseMessage(data: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#parse_message is not implemented",
+  );
+}
+
+function validateMessageDataFormat(data: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#validate_message_data_format is not implemented",
+  );
+}
+
+function parseProperties(headers: any, level: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#parse_properties is not implemented",
+  );
+}
+
+function messageToJson(message: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#message_to_json is not implemented",
+  );
+}
+
+function headersToJson(headers: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#headers_to_json is not implemented",
+  );
+}
+
+function encodeIfNeeded(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#encode_if_needed is not implemented",
+  );
+}
+
+function decodeIfNeeded(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::MessageSerializer#decode_if_needed is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -35,3 +35,4 @@ function validatePayloadType(payload: any): never {
     "ActiveRecord::Encryption::Message#validate_payload_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -29,10 +29,8 @@ export class Message {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function validatePayloadType(payload: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Message#validate_payload_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Message
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Properties } from "./properties.js";
 import { ForbiddenClass } from "./errors.js";
 
@@ -26,4 +27,11 @@ export class Message {
   addHeaders(props: Record<string, unknown>): void {
     this.headers.add(props);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function validatePayloadType(payload: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Message#validate_payload_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -105,8 +105,6 @@ function _typeNameFor(value: unknown): string {
   return t;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function data(): never {
   throw new NotImplementedError("ActiveRecord::Encryption::Properties#data is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Properties
  */
 
+import { NotImplementedError } from "../errors.js";
 import { EncryptedContentIntegrity, ForbiddenClass } from "./errors.js";
 
 const ALLOWED_TYPES = new Set(["string", "number", "boolean"]);
@@ -102,4 +103,9 @@ function _typeNameFor(value: unknown): string {
     if (name) return name;
   }
   return t;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function data(): never {
+  throw new NotImplementedError("ActiveRecord::Encryption::Properties#data is not implemented");
 }

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -109,3 +109,4 @@ function _typeNameFor(value: unknown): string {
 function data(): never {
   throw new NotImplementedError("ActiveRecord::Encryption::Properties#data is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -224,7 +224,6 @@ export class Scheme {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function validateConfigBang(): never {
   throw new NotImplementedError(
     "ActiveRecord::Encryption::Scheme#validate_config! is not implemented",
@@ -248,4 +247,3 @@ function defaultKeyProvider(): never {
     "ActiveRecord::Encryption::Scheme#default_key_provider is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::Scheme
  */
 
+import { NotImplementedError } from "../errors.js";
 import { Encryptor, type EncryptorLike } from "./encryptor.js";
 import { ConfigError } from "./errors.js";
 import type { Compressor } from "./config.js";
@@ -221,4 +222,29 @@ export class Scheme {
       throw new ConfigError("compressor can't be used with encryptor");
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function validateConfigBang(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Scheme#validate_config! is not implemented",
+  );
+}
+
+function keyProviderFromKey(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Scheme#key_provider_from_key is not implemented",
+  );
+}
+
+function deterministicKeyProvider(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Scheme#deterministic_key_provider is not implemented",
+  );
+}
+
+function defaultKeyProvider(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Encryption::Scheme#default_key_provider is not implemented",
+  );
 }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -248,3 +248,4 @@ function defaultKeyProvider(): never {
     "ActiveRecord::Encryption::Scheme#default_key_provider is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -458,3 +458,4 @@ function detectNegativeEnumConditionsBang(methodNames: any): never {
     "ActiveRecord::Enum#detect_negative_enum_conditions! is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { camelize, pluralize } from "@blazetrails/activesupport";
 import { ValueType } from "@blazetrails/activemodel";
@@ -394,4 +395,66 @@ export function castEnumValue(
   if (!def) return null;
 
   return def.type.serialize(value) as number | null;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function name(): never {
+  throw new NotImplementedError("ActiveRecord::Enum::EnumType#name is not implemented");
+}
+
+function klass(): never {
+  throw new NotImplementedError("ActiveRecord::Enum::EnumMethods#klass is not implemented");
+}
+
+function defineEnumMethods(
+  name: any,
+  valueMethodName: any,
+  value: any,
+  scopes: any,
+  instanceMethods: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Enum::EnumMethods#define_enum_methods is not implemented",
+  );
+}
+
+function _enum(
+  name: any,
+  values: any,
+  prefix?: any,
+  suffix?: any,
+  scopes?: any,
+  instanceMethods?: any,
+  validate?: any,
+  options?: any,
+): never {
+  throw new NotImplementedError("ActiveRecord::Enum#_enum is not implemented");
+}
+
+function _enumMethodsModule(): never {
+  throw new NotImplementedError("ActiveRecord::Enum#_enum_methods_module is not implemented");
+}
+
+function assertValidEnumDefinitionValues(values: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Enum#assert_valid_enum_definition_values is not implemented",
+  );
+}
+
+function assertValidEnumOptions(options: any): never {
+  throw new NotImplementedError("ActiveRecord::Enum#assert_valid_enum_options is not implemented");
+}
+
+function detectEnumConflictBang(enumName: any, methodName: any, klassMethod?: any): never {
+  throw new NotImplementedError("ActiveRecord::Enum#detect_enum_conflict! is not implemented");
+}
+
+function raiseConflictError(enumName: any, methodName: any, type?: any, source?: any): never {
+  throw new NotImplementedError("ActiveRecord::Enum#raise_conflict_error is not implemented");
+}
+
+function detectNegativeEnumConditionsBang(methodNames: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Enum#detect_negative_enum_conditions! is not implemented",
+  );
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -397,7 +397,6 @@ export function castEnumValue(
   return def.type.serialize(value) as number | null;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function name(): never {
   throw new NotImplementedError("ActiveRecord::Enum::EnumType#name is not implemented");
 }
@@ -458,4 +457,3 @@ function detectNegativeEnumConditionsBang(methodNames: any): never {
     "ActiveRecord::Enum#detect_negative_enum_conditions! is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/explain-registry.ts
+++ b/packages/activerecord/src/explain-registry.ts
@@ -108,8 +108,6 @@ export class ExplainRegistry {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function instance(): never {
   throw new NotImplementedError("ActiveRecord::ExplainRegistry#instance is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/explain-registry.ts
+++ b/packages/activerecord/src/explain-registry.ts
@@ -112,3 +112,4 @@ export class ExplainRegistry {
 function instance(): never {
   throw new NotImplementedError("ActiveRecord::ExplainRegistry#instance is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/explain-registry.ts
+++ b/packages/activerecord/src/explain-registry.ts
@@ -16,6 +16,7 @@
  * scope has been opened so existing unit-level tests keep working.
  */
 
+import { NotImplementedError } from "./errors.js";
 import { getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 
@@ -105,4 +106,9 @@ export class ExplainRegistry {
       slot.queries = [];
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function instance(): never {
+  throw new NotImplementedError("ActiveRecord::ExplainRegistry#instance is not implemented");
 }

--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -41,7 +41,6 @@ export async function execExplain(
   return (modelClass as any).all()._execExplain(queries, options);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function renderBind(connection: any, attr: any): never {
   throw new NotImplementedError("ActiveRecord::Explain#render_bind is not implemented");
 }
@@ -49,4 +48,3 @@ function renderBind(connection: any, attr: any): never {
 function buildExplainClause(connection: any, options?: any): never {
   throw new NotImplementedError("ActiveRecord::Explain#build_explain_clause is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -49,3 +49,4 @@ function renderBind(connection: any, attr: any): never {
 function buildExplainClause(connection: any, options?: any): never {
   throw new NotImplementedError("ActiveRecord::Explain#build_explain_clause is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import { ExplainRegistry } from "./explain-registry.js";
 import type { Base } from "./base.js";
 import type { ExplainOption } from "./adapter.js";
@@ -38,4 +39,13 @@ export async function execExplain(
   // and adapter-specific buildExplainClause — reusing that logic avoids
   // duplicating the JSON.stringify / typeCast edge cases.
   return (modelClass as any).all()._execExplain(queries, options);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function renderBind(connection: any, attr: any): never {
+  throw new NotImplementedError("ActiveRecord::Explain#render_bind is not implemented");
+}
+
+function buildExplainClause(connection: any, options?: any): never {
+  throw new NotImplementedError("ActiveRecord::Explain#build_explain_clause is not implemented");
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -292,7 +292,6 @@ export function polymorphicClassFor(_modelClass: typeof Base, name: string): typ
   return klass;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function initializeInternalsCallback(): never {
   throw new NotImplementedError(
     "ActiveRecord::Inheritance#initialize_internals_callback is not implemented",
@@ -328,4 +327,3 @@ function subclassFromAttributes(): never {
     "ActiveRecord::Inheritance#subclass_from_attributes is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -6,7 +6,7 @@
 
 import type { Base } from "./base.js";
 import { modelRegistry } from "./associations.js";
-import { NameError, SubclassNotFound } from "./errors.js";
+import { NameError, SubclassNotFound, NotImplementedError } from "./errors.js";
 
 /**
  * Resolve a type name string to a model class.
@@ -290,4 +290,41 @@ export function polymorphicClassFor(_modelClass: typeof Base, name: string): typ
   const klass = modelRegistry.get(name);
   if (!klass) throw new NameError(`uninitialized constant ${name}`);
   return klass;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function initializeInternalsCallback(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Inheritance#initialize_internals_callback is not implemented",
+  );
+}
+
+function ensureProperType(): never {
+  throw new NotImplementedError("ActiveRecord::Inheritance#ensure_proper_type is not implemented");
+}
+
+function setBaseClass(): never {
+  throw new NotImplementedError("ActiveRecord::Inheritance#set_base_class is not implemented");
+}
+
+function discriminateClassForRecord(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Inheritance#discriminate_class_for_record is not implemented",
+  );
+}
+
+function isUsingSingleTableInheritance(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Inheritance#using_single_table_inheritance? is not implemented",
+  );
+}
+
+function typeCondition(): never {
+  throw new NotImplementedError("ActiveRecord::Inheritance#type_condition is not implemented");
+}
+
+function subclassFromAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Inheritance#subclass_from_attributes is not implemented",
+  );
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -328,3 +328,4 @@ function subclassFromAttributes(): never {
     "ActiveRecord::Inheritance#subclass_from_attributes is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -508,3 +508,4 @@ function disallowRawSqlBang(value: any): never {
 function timestampsForCreate(): never {
   throw new NotImplementedError("ActiveRecord::InsertAll#timestamps_for_create is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -436,7 +436,6 @@ export class Builder {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function hasAttributeAliases(attributes: any): never {
   throw new NotImplementedError(
     "ActiveRecord::InsertAll#has_attribute_aliases? is not implemented",
@@ -508,4 +507,3 @@ function disallowRawSqlBang(value: any): never {
 function timestampsForCreate(): never {
   throw new NotImplementedError("ActiveRecord::InsertAll#timestamps_for_create is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { SerializeCastValue } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
@@ -433,4 +434,77 @@ export class Builder {
       }),
     );
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function hasAttributeAliases(attributes: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#has_attribute_aliases? is not implemented",
+  );
+}
+
+function resolveSti(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#resolve_sti is not implemented");
+}
+
+function resolveAttributeAliases(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#resolve_attribute_aliases is not implemented",
+  );
+}
+
+function resolveAttributeAlias(attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#resolve_attribute_alias is not implemented",
+  );
+}
+
+function configureOnDuplicateUpdateLogic(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#configure_on_duplicate_update_logic is not implemented",
+  );
+}
+
+function isCustomUpdateSqlProvided(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#custom_update_sql_provided? is not implemented",
+  );
+}
+
+function findUniqueIndexFor(uniqueBy: any): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#find_unique_index_for is not implemented");
+}
+
+function uniqueIndexes(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#unique_indexes is not implemented");
+}
+
+function ensureValidOptionsForConnectionBang(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InsertAll#ensure_valid_options_for_connection! is not implemented",
+  );
+}
+
+function toSql(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#to_sql is not implemented");
+}
+
+function readonlyColumns(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#readonly_columns is not implemented");
+}
+
+function uniqueByColumns(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#unique_by_columns is not implemented");
+}
+
+function verifyAttributes(attributes: any): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#verify_attributes is not implemented");
+}
+
+function disallowRawSqlBang(value: any): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#disallow_raw_sql! is not implemented");
+}
+
+function timestampsForCreate(): never {
+  throw new NotImplementedError("ActiveRecord::InsertAll#timestamps_for_create is not implemented");
 }

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -222,7 +222,6 @@ export function collectionCacheKey(
   return Promise.resolve("");
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function canUseFastCacheVersion(timestamp: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Integration#can_use_fast_cache_version? is not implemented",
@@ -234,4 +233,3 @@ function rawTimestampToCacheVersion(timestamp: any): never {
     "ActiveRecord::Integration#raw_timestamp_to_cache_version is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -234,3 +234,4 @@ function rawTimestampToCacheVersion(timestamp: any): never {
     "ActiveRecord::Integration#raw_timestamp_to_cache_version is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Integration
  */
 
+import { NotImplementedError } from "./errors.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { squish, parameterize, truncate } from "@blazetrails/activesupport";
@@ -219,4 +220,17 @@ export function collectionCacheKey(
     return Promise.resolve(rel.cacheKey(timestampColumn));
   }
   return Promise.resolve("");
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function canUseFastCacheVersion(timestamp: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Integration#can_use_fast_cache_version? is not implemented",
+  );
+}
+
+function rawTimestampToCacheVersion(timestamp: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Integration#raw_timestamp_to_cache_version is not implemented",
+  );
 }

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -228,10 +228,8 @@ export class InternalMetadata {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function updateOrCreateEntry(connection: any, key: any, value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::InternalMetadata#update_or_create_entry is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -234,3 +234,4 @@ function updateOrCreateEntry(connection: any, key: any, value: any): never {
     "ActiveRecord::InternalMetadata#update_or_create_entry is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::InternalMetadata
  */
 
+import { NotImplementedError } from "./errors.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { detectAdapterName } from "./adapter-name.js";
 import { quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
@@ -225,4 +226,11 @@ export class InternalMetadata {
     um.where(this.arelTable.get(this.primaryKey).eq(key));
     await this._adapter.executeMutation(um.toSql());
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function updateOrCreateEntry(connection: any, key: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::InternalMetadata#update_or_create_entry is not implemented",
+  );
 }

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -131,7 +131,6 @@ export async function updateCounters(
   return 0;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function _createRecord(attributeNames?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Locking::Optimistic#_create_record is not implemented",
@@ -173,4 +172,3 @@ function hookAttributeType(): never {
     "ActiveRecord::Locking::Optimistic#hook_attribute_type is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -173,3 +173,4 @@ function hookAttributeType(): never {
     "ActiveRecord::Locking::Optimistic#hook_attribute_type is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import type { Base } from "../base.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 
@@ -128,4 +129,47 @@ export async function updateCounters(
     return scoped.updateCounters(counters);
   }
   return 0;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function _createRecord(attributeNames?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Locking::Optimistic#_create_record is not implemented",
+  );
+}
+
+function _touchRow(attributeNames: any, time: any): never {
+  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#_touch_row is not implemented");
+}
+
+function _updateRow(attributeNames: any, attemptedAction?: any): never {
+  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#_update_row is not implemented");
+}
+
+function destroyRow(): never {
+  throw new NotImplementedError("ActiveRecord::Locking::Optimistic#destroy_row is not implemented");
+}
+
+function _lockValueForDatabase(lockingColumn: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Locking::Optimistic#_lock_value_for_database is not implemented",
+  );
+}
+
+function _clearLockingColumn(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Locking::Optimistic#_clear_locking_column is not implemented",
+  );
+}
+
+function _queryConstraintsHash(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Locking::Optimistic#_query_constraints_hash is not implemented",
+  );
+}
+
+function hookAttributeType(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Locking::Optimistic#hook_attribute_type is not implemented",
+  );
 }

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import {
   LogSubscriber as BaseLogSubscriber,
   NotificationEvent as Event,
@@ -233,3 +234,40 @@ export class LogSubscriber extends BaseLogSubscriber {
 // Register log-level gates matching Rails' class-body `subscribe_log_level` calls.
 LogSubscriber.subscribeLogLevel("sql", "debug");
 LogSubscriber.subscribeLogLevel("strict_loading_violation", "debug");
+
+// --- api:compare private stubs (auto-generated) ---
+function typeCastedBinds(castedBinds: any): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#type_casted_binds is not implemented");
+}
+
+function renderBind(attr: any, value: any): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#render_bind is not implemented");
+}
+
+function colorizePayloadName(name: any, payloadName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::LogSubscriber#colorize_payload_name is not implemented",
+  );
+}
+
+function sqlColor(sql: any): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#sql_color is not implemented");
+}
+
+function logger(): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#logger is not implemented");
+}
+
+function debug(progname?: any, block?: any): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#debug is not implemented");
+}
+
+function logQuerySource(): never {
+  throw new NotImplementedError("ActiveRecord::LogSubscriber#log_query_source is not implemented");
+}
+
+function querySourceLocation(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::LogSubscriber#query_source_location is not implemented",
+  );
+}

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -271,3 +271,4 @@ function querySourceLocation(): never {
     "ActiveRecord::LogSubscriber#query_source_location is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -235,7 +235,6 @@ export class LogSubscriber extends BaseLogSubscriber {
 LogSubscriber.subscribeLogLevel("sql", "debug");
 LogSubscriber.subscribeLogLevel("strict_loading_violation", "debug");
 
-// --- api:compare private stubs (auto-generated) ---
 function typeCastedBinds(castedBinds: any): never {
   throw new NotImplementedError("ActiveRecord::LogSubscriber#type_casted_binds is not implemented");
 }
@@ -271,4 +270,3 @@ function querySourceLocation(): never {
     "ActiveRecord::LogSubscriber#query_source_location is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2151,7 +2151,6 @@ export class CheckPending {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function detailedMigrationMessage(pendingMigrations: any): never {
   throw new NotImplementedError(
     "ActiveRecord::PendingMigrationError#detailed_migration_message is not implemented",
@@ -2311,4 +2310,3 @@ function generateMigratorAdvisoryLockId(): never {
     "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -35,7 +35,7 @@ export {
   type Compatibility,
 } from "./migration/compatibility.js";
 
-import { ActiveRecordError } from "./errors.js";
+import { ActiveRecordError, NotImplementedError } from "./errors.js";
 
 // Migration error classes. Rails defines these in migration.rb, so
 // they live here. internal-metadata.ts imports EnvironmentStorageError
@@ -2149,4 +2149,165 @@ export class CheckPending {
       );
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function detailedMigrationMessage(pendingMigrations: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::PendingMigrationError#detailed_migration_message is not implemented",
+  );
+}
+
+function connectionPool(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::PendingMigrationError#connection_pool is not implemented",
+  );
+}
+
+function executeBlock(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#execute_block is not implemented");
+}
+
+function formatArguments(arguments_: any): never {
+  throw new NotImplementedError("ActiveRecord::Migration#format_arguments is not implemented");
+}
+
+function isInternalOption(optionName: any): never {
+  throw new NotImplementedError("ActiveRecord::Migration#internal_option? is not implemented");
+}
+
+function commandRecorder(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#command_recorder is not implemented");
+}
+
+function isAnySchemaNeedsUpdate(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration#any_schema_needs_update? is not implemented",
+  );
+}
+
+function dbConfigsInCurrentEnv(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration#db_configs_in_current_env is not implemented",
+  );
+}
+
+function pendingMigrations(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#pending_migrations is not implemented");
+}
+
+function env(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#env is not implemented");
+}
+
+function loadSchemaBang(): never {
+  throw new NotImplementedError("ActiveRecord::Migration#load_schema! is not implemented");
+}
+
+function buildWatcher(block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CheckPending#build_watcher is not implemented",
+  );
+}
+
+function connection(): never {
+  throw new NotImplementedError("ActiveRecord::MigrationContext#connection is not implemented");
+}
+
+function migrationFiles(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::MigrationContext#migration_files is not implemented",
+  );
+}
+
+function parseMigrationFilename(filename: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::MigrationContext#parse_migration_filename is not implemented",
+  );
+}
+
+function isValidateTimestamp(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::MigrationContext#validate_timestamp? is not implemented",
+  );
+}
+
+function isValidMigrationTimestamp(version: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::MigrationContext#valid_migration_timestamp? is not implemented",
+  );
+}
+
+function move(direction: any, steps: any): never {
+  throw new NotImplementedError("ActiveRecord::MigrationContext#move is not implemented");
+}
+
+function runWithoutLock(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#run_without_lock is not implemented");
+}
+
+function migrateWithoutLock(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#migrate_without_lock is not implemented");
+}
+
+function recordEnvironment(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#record_environment is not implemented");
+}
+
+function isRan(migration: any): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#ran? is not implemented");
+}
+
+function isInvalidTarget(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#invalid_target? is not implemented");
+}
+
+function executeMigrationInTransaction(migration: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migrator#execute_migration_in_transaction is not implemented",
+  );
+}
+
+function finish(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#finish is not implemented");
+}
+
+function validate(migrations: any): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#validate is not implemented");
+}
+
+function recordVersionStateAfterMigrating(version: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migrator#record_version_state_after_migrating is not implemented",
+  );
+}
+
+function isUp(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#up? is not implemented");
+}
+
+function isDown(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#down? is not implemented");
+}
+
+function ddlTransaction(migration: any, block?: any): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#ddl_transaction is not implemented");
+}
+
+function isUseTransaction(migration: any): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#use_transaction? is not implemented");
+}
+
+function isUseAdvisoryLock(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#use_advisory_lock? is not implemented");
+}
+
+function withAdvisoryLock(): never {
+  throw new NotImplementedError("ActiveRecord::Migrator#with_advisory_lock is not implemented");
+}
+
+function generateMigratorAdvisoryLockId(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
+  );
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2311,3 +2311,4 @@ function generateMigratorAdvisoryLockId(): never {
     "ActiveRecord::Migrator#generate_migrator_advisory_lock_id is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Migration::CommandRecorder
  */
 
+import { NotImplementedError } from "../errors.js";
 export interface StraightReversions {
   invertCreateTable(args: unknown[]): unknown[];
   invertDropTable(args: unknown[]): unknown[];
@@ -160,4 +161,149 @@ export class CommandRecorder {
     }
     return inverted;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function invertTransaction(args: any, block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_transaction is not implemented",
+  );
+}
+
+function invertCreateTable(args: any, block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_create_table is not implemented",
+  );
+}
+
+function invertDropTable(args: any, block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_drop_table is not implemented",
+  );
+}
+
+function invertRenameTable(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_rename_table is not implemented",
+  );
+}
+
+function invertRemoveColumn(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_column is not implemented",
+  );
+}
+
+function invertRemoveColumns(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_columns is not implemented",
+  );
+}
+
+function invertRenameIndex(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_rename_index is not implemented",
+  );
+}
+
+function invertRenameColumn(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_rename_column is not implemented",
+  );
+}
+
+function invertRemoveIndex(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_index is not implemented",
+  );
+}
+
+function invertChangeColumnDefault(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_change_column_default is not implemented",
+  );
+}
+
+function invertChangeColumnNull(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_change_column_null is not implemented",
+  );
+}
+
+function invertAddForeignKey(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_add_foreign_key is not implemented",
+  );
+}
+
+function invertRemoveForeignKey(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_foreign_key is not implemented",
+  );
+}
+
+function invertChangeColumnComment(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_change_column_comment is not implemented",
+  );
+}
+
+function invertChangeTableComment(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_change_table_comment is not implemented",
+  );
+}
+
+function invertAddCheckConstraint(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_add_check_constraint is not implemented",
+  );
+}
+
+function invertRemoveCheckConstraint(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_check_constraint is not implemented",
+  );
+}
+
+function invertRemoveExclusionConstraint(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_exclusion_constraint is not implemented",
+  );
+}
+
+function invertAddUniqueConstraint(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_add_unique_constraint is not implemented",
+  );
+}
+
+function invertRemoveUniqueConstraint(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_remove_unique_constraint is not implemented",
+  );
+}
+
+function invertDropEnum(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_drop_enum is not implemented",
+  );
+}
+
+function invertRenameEnum(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_rename_enum is not implemented",
+  );
+}
+
+function invertRenameEnumValue(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_rename_enum_value is not implemented",
+  );
+}
+
+function invertDropVirtualTable(args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::CommandRecorder#invert_drop_virtual_table is not implemented",
+  );
 }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -163,7 +163,6 @@ export class CommandRecorder {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function invertTransaction(args: any, block?: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Migration::CommandRecorder#invert_transaction is not implemented",
@@ -307,4 +306,3 @@ function invertDropVirtualTable(args: any): never {
     "ActiveRecord::Migration::CommandRecorder#invert_drop_virtual_table is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -307,3 +307,4 @@ function invertDropVirtualTable(args: any): never {
     "ActiveRecord::Migration::CommandRecorder#invert_drop_virtual_table is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -32,3 +32,4 @@ function connection(): never {
     "ActiveRecord::Migration::DefaultStrategy#connection is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -26,10 +26,8 @@ export class DefaultStrategy extends ExecutionStrategy {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Migration::DefaultStrategy#connection is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -7,6 +7,7 @@
  * wrap this with advisory locks to prevent concurrent migrations.
  */
 
+import { NotImplementedError } from "../errors.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { ExecutionStrategy } from "./execution-strategy.js";
 import type { MigrationLike } from "./execution-strategy.js";
@@ -23,4 +24,11 @@ export class DefaultStrategy extends ExecutionStrategy {
       await migration.down(adapter);
     }
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Migration::DefaultStrategy#connection is not implemented",
+  );
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
@@ -954,3 +955,38 @@ export const ClassMethods = {
   _returningColumnsForInsert,
   loadSchemaFromAdapter,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function initializeLoadSchemaMonitor(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ModelSchema#initialize_load_schema_monitor is not implemented",
+  );
+}
+
+function reloadSchemaFromCache(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ModelSchema#reload_schema_from_cache is not implemented",
+  );
+}
+
+function isSchemaLoaded(): never {
+  throw new NotImplementedError("ActiveRecord::ModelSchema#schema_loaded? is not implemented");
+}
+
+function loadSchemaBang(): never {
+  throw new NotImplementedError("ActiveRecord::ModelSchema#load_schema! is not implemented");
+}
+
+function undecoratedTableName(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::ModelSchema#undecorated_table_name is not implemented",
+  );
+}
+
+function computeTableName(): never {
+  throw new NotImplementedError("ActiveRecord::ModelSchema#compute_table_name is not implemented");
+}
+
+function typeForColumn(): never {
+  throw new NotImplementedError("ActiveRecord::ModelSchema#type_for_column is not implemented");
+}

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -990,3 +990,4 @@ function computeTableName(): never {
 function typeForColumn(): never {
   throw new NotImplementedError("ActiveRecord::ModelSchema#type_for_column is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -956,7 +956,6 @@ export const ClassMethods = {
   loadSchemaFromAdapter,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function initializeLoadSchemaMonitor(): never {
   throw new NotImplementedError(
     "ActiveRecord::ModelSchema#initialize_load_schema_monitor is not implemented",
@@ -990,4 +989,3 @@ function computeTableName(): never {
 function typeForColumn(): never {
   throw new NotImplementedError("ActiveRecord::ModelSchema#type_for_column is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -1,6 +1,6 @@
 import type { Base } from "./base.js";
 import { modelRegistry } from "./associations.js";
-import { ActiveRecordError, UnknownAttributeError } from "./errors.js";
+import { ActiveRecordError, UnknownAttributeError, NotImplementedError } from "./errors.js";
 import { singularize, camelize, underscore } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
 import { isMarkedForDestruction } from "./autosave-association.js";
@@ -254,4 +254,79 @@ async function processNestedAttributes(record: Base): Promise<void> {
   }
 
   (record as any)._pendingNestedAttributes = null;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function assignNestedAttributesForOneToOneAssociation(
+  associationName: any,
+  attributes: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#assign_nested_attributes_for_one_to_one_association is not implemented",
+  );
+}
+
+function assignNestedAttributesForCollectionAssociation(
+  associationName: any,
+  attributesCollection: any,
+): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#assign_nested_attributes_for_collection_association is not implemented",
+  );
+}
+
+function checkRecordLimitBang(limit: any, attributesCollection: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#check_record_limit! is not implemented",
+  );
+}
+
+function assignToOrMarkForDestruction(record: any, attributes: any, allowDestroy: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#assign_to_or_mark_for_destruction is not implemented",
+  );
+}
+
+function hasDestroyFlag(hash: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#has_destroy_flag? is not implemented",
+  );
+}
+
+function isRejectNewRecord(associationName: any, attributes: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#reject_new_record? is not implemented",
+  );
+}
+
+function callRejectIf(associationName: any, attributes: any): never {
+  throw new NotImplementedError("ActiveRecord::NestedAttributes#call_reject_if is not implemented");
+}
+
+function isWillBeDestroyed(associationName: any, attributes: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#will_be_destroyed? is not implemented",
+  );
+}
+
+function isAllowDestroy(associationName: any): never {
+  throw new NotImplementedError("ActiveRecord::NestedAttributes#allow_destroy? is not implemented");
+}
+
+function raiseNestedAttributesRecordNotFoundBang(associationName: any, recordId: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#raise_nested_attributes_record_not_found! is not implemented",
+  );
+}
+
+function findRecordById(klass: any, records: any, id: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#find_record_by_id is not implemented",
+  );
+}
+
+function generateAssociationWriter(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::NestedAttributes#generate_association_writer is not implemented",
+  );
 }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -330,3 +330,4 @@ function generateAssociationWriter(): never {
     "ActiveRecord::NestedAttributes#generate_association_writer is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -256,7 +256,6 @@ async function processNestedAttributes(record: Base): Promise<void> {
   (record as any)._pendingNestedAttributes = null;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function assignNestedAttributesForOneToOneAssociation(
   associationName: any,
   attributes: any,
@@ -330,4 +329,3 @@ function generateAssociationWriter(): never {
     "ActiveRecord::NestedAttributes#generate_association_writer is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -91,8 +91,6 @@ export function applyTo<R>(klass: any, fn: () => R | Promise<R>): R | Promise<R>
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function klasses(): never {
   throw new NotImplementedError("ActiveRecord::NoTouching#klasses is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -95,3 +95,4 @@ export function applyTo<R>(klass: any, fn: () => R | Promise<R>): R | Promise<R>
 function klasses(): never {
   throw new NotImplementedError("ActiveRecord::NoTouching#klasses is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::NoTouching
  */
 
+import { NotImplementedError } from "./errors.js";
 const _noTouchingDepth = new Map<Function, number>();
 
 /**
@@ -88,4 +89,9 @@ export function applyTo<R>(klass: any, fn: () => R | Promise<R>): R | Promise<R>
     cleanup();
     throw error;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function klasses(): never {
+  throw new NotImplementedError("ActiveRecord::NoTouching#klasses is not implemented");
 }

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -83,7 +83,6 @@ export function normalizeAttribute(record: InstanceType<typeof Model>, name: str
   return record.normalizeAttribute(name);
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function normalize(value: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Normalization::NormalizedValueType#normalize is not implemented",
@@ -95,4 +94,3 @@ function normalizeChangedInPlaceAttributes(): never {
     "ActiveRecord::Normalization#normalize_changed_in_place_attributes is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -10,6 +10,7 @@
  * Mirrors: ActiveRecord::Normalization
  */
 
+import { NotImplementedError } from "./errors.js";
 import { Model } from "@blazetrails/activemodel";
 
 /**
@@ -80,4 +81,17 @@ export function normalizeValueFor(
 
 export function normalizeAttribute(record: InstanceType<typeof Model>, name: string): void {
   return record.normalizeAttribute(name);
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function normalize(value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Normalization::NormalizedValueType#normalize is not implemented",
+  );
+}
+
+function normalizeChangedInPlaceAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Normalization#normalize_changed_in_place_attributes is not implemented",
+  );
 }

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -95,3 +95,4 @@ function normalizeChangedInPlaceAttributes(): never {
     "ActiveRecord::Normalization#normalize_changed_in_place_attributes is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -7,7 +7,7 @@
  * controller, action, etc.) to help trace queries back to application code.
  */
 
-import { ConfigurationError } from "./errors.js";
+import { ConfigurationError, NotImplementedError } from "./errors.js";
 import { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
 import type { TagValue, QueryLogsFormatter } from "./query-logs-formatter.js";
 
@@ -253,4 +253,21 @@ export function escapeComment(content: string): string {
   // Replace comment markers to prevent SQL comment injection
   s = s.replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
   return s;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function rebuildHandlers(): never {
+  throw new NotImplementedError("ActiveRecord::QueryLogs#rebuild_handlers is not implemented");
+}
+
+function buildHandler(name: any, handler?: any): never {
+  throw new NotImplementedError("ActiveRecord::QueryLogs#build_handler is not implemented");
+}
+
+function escapeSqlComment(content: any): never {
+  throw new NotImplementedError("ActiveRecord::QueryLogs#escape_sql_comment is not implemented");
+}
+
+function tagContent(connection: any): never {
+  throw new NotImplementedError("ActiveRecord::QueryLogs#tag_content is not implemented");
 }

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -255,7 +255,6 @@ export function escapeComment(content: string): string {
   return s;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function rebuildHandlers(): never {
   throw new NotImplementedError("ActiveRecord::QueryLogs#rebuild_handlers is not implemented");
 }
@@ -271,4 +270,3 @@ function escapeSqlComment(content: any): never {
 function tagContent(connection: any): never {
   throw new NotImplementedError("ActiveRecord::QueryLogs#tag_content is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -271,3 +271,4 @@ function escapeSqlComment(content: any): never {
 function tagContent(connection: any): never {
   throw new NotImplementedError("ActiveRecord::QueryLogs#tag_content is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import {
   underscore,
@@ -1840,3 +1841,46 @@ export const ClassMethods = {
   },
   _reflectOnAssociation: _reflectOnAssociationClassMethod,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function actualSourceReflection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::AbstractReflection#actual_source_reflection is not implemented",
+  );
+}
+
+function ensureOptionNotGivenAsClassBang(optionName: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::AbstractReflection#ensure_option_not_given_as_class! is not implemented",
+  );
+}
+
+function deriveClassName(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::MacroReflection#derive_class_name is not implemented",
+  );
+}
+
+function deriveJoinTable(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::AssociationReflection#derive_join_table is not implemented",
+  );
+}
+
+function delegateReflection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::ThroughReflection#delegate_reflection is not implemented",
+  );
+}
+
+function collectJoinReflections(seed: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::ThroughReflection#collect_join_reflections is not implemented",
+  );
+}
+
+function sourceTypeScope(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Reflection::PolymorphicReflection#source_type_scope is not implemented",
+  );
+}

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1842,7 +1842,6 @@ export const ClassMethods = {
   _reflectOnAssociation: _reflectOnAssociationClassMethod,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function actualSourceReflection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Reflection::AbstractReflection#actual_source_reflection is not implemented",
@@ -1884,4 +1883,3 @@ function sourceTypeScope(): never {
     "ActiveRecord::Reflection::PolymorphicReflection#source_type_scope is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1884,3 +1884,4 @@ function sourceTypeScope(): never {
     "ActiveRecord::Reflection::PolymorphicReflection#source_type_scope is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -250,3 +250,4 @@ function columnType(name: any, index: any, typeOverrides: any): never {
 function hashRows(): never {
   throw new NotImplementedError("ActiveRecord::Result#hash_rows is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -242,7 +242,6 @@ const EMPTY_COLUMNS = Object.freeze([]) as unknown as string[];
 const EMPTY_ROWS = Object.freeze([]) as unknown as unknown[][];
 const EMPTY = Object.freeze(new Result(EMPTY_COLUMNS, EMPTY_ROWS, EMPTY_COLUMN_TYPES)) as Result;
 
-// --- api:compare private stubs (auto-generated) ---
 function columnType(name: any, index: any, typeOverrides: any): never {
   throw new NotImplementedError("ActiveRecord::Result#column_type is not implemented");
 }
@@ -250,4 +249,3 @@ function columnType(name: any, index: any, typeOverrides: any): never {
 function hashRows(): never {
   throw new NotImplementedError("ActiveRecord::Result#hash_rows is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Result
  */
 
+import { NotImplementedError } from "./errors.js";
 export type ColumnType = { deserialize(value: unknown): unknown };
 export type ColumnTypes = Record<string | number, ColumnType>;
 
@@ -240,3 +241,12 @@ export class Result {
 const EMPTY_COLUMNS = Object.freeze([]) as unknown as string[];
 const EMPTY_ROWS = Object.freeze([]) as unknown as unknown[][];
 const EMPTY = Object.freeze(new Result(EMPTY_COLUMNS, EMPTY_ROWS, EMPTY_COLUMN_TYPES)) as Result;
+
+// --- api:compare private stubs (auto-generated) ---
+function columnType(name: any, index: any, typeOverrides: any): never {
+  throw new NotImplementedError("ActiveRecord::Result#column_type is not implemented");
+}
+
+function hashRows(): never {
+  throw new NotImplementedError("ActiveRecord::Result#hash_rows is not implemented");
+}

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -6,7 +6,11 @@
 
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { quote, quoteIdentifier, quoteTableName } from "./connection-adapters/abstract/quoting.js";
-import { PreparedStatementInvalid, UnknownAttributeReference } from "./errors.js";
+import {
+  PreparedStatementInvalid,
+  UnknownAttributeReference,
+  NotImplementedError,
+} from "./errors.js";
 
 /**
  * Sanitize a SQL template with bind parameters.
@@ -221,3 +225,32 @@ export const ClassMethods = {
   sanitizeSqlHashForAssignment,
   disallowRawSqlBang,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function replaceBindVariables(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Sanitization#replace_bind_variables is not implemented",
+  );
+}
+
+function replaceBindVariable(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Sanitization#replace_bind_variable is not implemented",
+  );
+}
+
+function replaceNamedBindVariables(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Sanitization#replace_named_bind_variables is not implemented",
+  );
+}
+
+function quoteBoundValue(): never {
+  throw new NotImplementedError("ActiveRecord::Sanitization#quote_bound_value is not implemented");
+}
+
+function raiseIfBindArityMismatch(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Sanitization#raise_if_bind_arity_mismatch is not implemented",
+  );
+}

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -254,3 +254,4 @@ function raiseIfBindArityMismatch(): never {
     "ActiveRecord::Sanitization#raise_if_bind_arity_mismatch is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -226,7 +226,6 @@ export const ClassMethods = {
   disallowRawSqlBang,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function replaceBindVariables(): never {
   throw new NotImplementedError(
     "ActiveRecord::Sanitization#replace_bind_variables is not implemented",
@@ -254,4 +253,3 @@ function raiseIfBindArityMismatch(): never {
     "ActiveRecord::Sanitization#raise_if_bind_arity_mismatch is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -643,7 +643,6 @@ function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
   );
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function tableName(): never {
   throw new NotImplementedError("ActiveRecord::SchemaDumper#table_name is not implemented");
 }
@@ -727,4 +726,3 @@ function isIgnored(tableName: any): never {
 function generateOptions(config: any): never {
   throw new NotImplementedError("ActiveRecord::SchemaDumper#generate_options is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -15,6 +15,7 @@
  * connection-adapters/abstract/schema-dumper.ts.
  */
 
+import { NotImplementedError } from "./errors.js";
 import type { DatabaseAdapter } from "./adapter.js";
 // Type-only import: SchemaStatements -> SchemaDumper (abstract inner
 // extends this file's base) -> schema-dumper.ts would be a runtime
@@ -640,4 +641,89 @@ function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
     typeof obj.executeMutation === "function" &&
     typeof obj.adapterName === "string"
   );
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function tableName(): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#table_name is not implemented");
+}
+
+function constructor(connection: any, options?: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#initialize is not implemented");
+}
+
+function formattedVersion(): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#formatted_version is not implemented");
+}
+
+function defineParams(): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#define_params is not implemented");
+}
+
+function extensions(stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#extensions is not implemented");
+}
+
+function types(stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#types is not implemented");
+}
+
+function schemas(stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#schemas is not implemented");
+}
+
+function virtualTables(stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#virtual_tables is not implemented");
+}
+
+function table(table: any, stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#table is not implemented");
+}
+
+function indexesInCreate(table: any, stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#indexes_in_create is not implemented");
+}
+
+function indexParts(index: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#index_parts is not implemented");
+}
+
+function checkConstraintsInCreate(table: any, stream: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::SchemaDumper#check_constraints_in_create is not implemented",
+  );
+}
+
+function checkParts(check: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#check_parts is not implemented");
+}
+
+function foreignKeys(table: any, stream: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#foreign_keys is not implemented");
+}
+
+function formatColspec(colspec: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#format_colspec is not implemented");
+}
+
+function formatOptions(options: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#format_options is not implemented");
+}
+
+function formatIndexParts(options: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#format_index_parts is not implemented");
+}
+
+function removePrefixAndSuffix(table: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::SchemaDumper#remove_prefix_and_suffix is not implemented",
+  );
+}
+
+function isIgnored(tableName: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#ignored? is not implemented");
+}
+
+function generateOptions(config: any): never {
+  throw new NotImplementedError("ActiveRecord::SchemaDumper#generate_options is not implemented");
 }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -727,3 +727,4 @@ function isIgnored(tableName: any): never {
 function generateOptions(config: any): never {
   throw new NotImplementedError("ActiveRecord::SchemaDumper#generate_options is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -95,7 +95,6 @@ export function isDefaultScopes(
   return scopes.length > 0;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function buildDefaultScope(): never {
   throw new NotImplementedError(
     "ActiveRecord::Scoping::Default#build_default_scope is not implemented",
@@ -123,4 +122,3 @@ function evaluateDefaultScope(): never {
     "ActiveRecord::Scoping::Default#evaluate_default_scope is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
 
@@ -92,4 +93,33 @@ export function isDefaultScopes(
     return scopes.some((s) => s.allQueries);
   }
   return scopes.length > 0;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function buildDefaultScope(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Scoping::Default#build_default_scope is not implemented",
+  );
+}
+
+function isExecuteScope(): never {
+  throw new NotImplementedError("ActiveRecord::Scoping::Default#execute_scope? is not implemented");
+}
+
+function isIgnoreDefaultScope(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Scoping::Default#ignore_default_scope? is not implemented",
+  );
+}
+
+function ignoreDefaultScope(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Scoping::Default#ignore_default_scope= is not implemented",
+  );
+}
+
+function evaluateDefaultScope(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Scoping::Default#evaluate_default_scope is not implemented",
+  );
 }

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -123,3 +123,4 @@ function evaluateDefaultScope(): never {
     "ActiveRecord::Scoping::Default#evaluate_default_scope is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -90,10 +90,8 @@ export const ClassMethods = {
   defaultExtensions,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function singletonMethodAdded(): never {
   throw new NotImplementedError(
     "ActiveRecord::Scoping::Named#singleton_method_added is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -96,3 +96,4 @@ function singletonMethodAdded(): never {
     "ActiveRecord::Scoping::Named#singleton_method_added is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
 
@@ -88,3 +89,10 @@ export const ClassMethods = {
   defaultScoped,
   defaultExtensions,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function singletonMethodAdded(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Scoping::Named#singleton_method_added is not implemented",
+  );
+}

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 
@@ -191,3 +192,22 @@ export function store(
  * Mirrors: ActiveRecord::Store.store_accessor
  */
 export const storeAccessor = store;
+
+// --- api:compare private stubs (auto-generated) ---
+function asRegularHash(obj: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Store::IndifferentCoder#as_regular_hash is not implemented",
+  );
+}
+
+function readStoreAttribute(storeAttribute: any, key: any): never {
+  throw new NotImplementedError("ActiveRecord::Store#read_store_attribute is not implemented");
+}
+
+function writeStoreAttribute(storeAttribute: any, key: any, value: any): never {
+  throw new NotImplementedError("ActiveRecord::Store#write_store_attribute is not implemented");
+}
+
+function storeAccessorFor(storeAttribute: any): never {
+  throw new NotImplementedError("ActiveRecord::Store#store_accessor_for is not implemented");
+}

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -211,3 +211,4 @@ function writeStoreAttribute(storeAttribute: any, key: any, value: any): never {
 function storeAccessorFor(storeAttribute: any): never {
   throw new NotImplementedError("ActiveRecord::Store#store_accessor_for is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -193,7 +193,6 @@ export function store(
  */
 export const storeAccessor = store;
 
-// --- api:compare private stubs (auto-generated) ---
 function asRegularHash(obj: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Store::IndifferentCoder#as_regular_hash is not implemented",
@@ -211,4 +210,3 @@ function writeStoreAttribute(storeAttribute: any, key: any, value: any): never {
 function storeAccessorFor(storeAttribute: any): never {
   throw new NotImplementedError("ActiveRecord::Store#store_accessor_for is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1101,7 +1101,6 @@ export interface DatabaseTaskHandler {
   ): Promise<void>;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function truncateTables(dbConfig: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::DatabaseTasks#truncate_tables is not implemented",
@@ -1195,4 +1194,3 @@ function initializeDatabase(dbConfig: any): never {
     "ActiveRecord::Tasks::DatabaseTasks#initialize_database is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1195,3 +1195,4 @@ function initializeDatabase(dbConfig: any): never {
     "ActiveRecord::Tasks::DatabaseTasks#initialize_database is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Tasks::DatabaseTasks
  */
 
+import { NotImplementedError } from "../errors.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
@@ -1098,4 +1099,99 @@ export interface DatabaseTaskHandler {
     filename: string,
     extraFlags?: string | string[] | null,
   ): Promise<void>;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function truncateTables(dbConfig: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#truncate_tables is not implemented",
+  );
+}
+
+function withTemporaryPool(dbConfig: any, clobber?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#with_temporary_pool is not implemented",
+  );
+}
+
+function configsFor(options?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#configs_for is not implemented",
+  );
+}
+
+function resolveConfiguration(configuration: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#resolve_configuration is not implemented",
+  );
+}
+
+function isVerbose(): never {
+  throw new NotImplementedError("ActiveRecord::Tasks::DatabaseTasks#verbose? is not implemented");
+}
+
+function databaseAdapterFor(dbConfig: any, ...arguments_: any[]): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#database_adapter_for is not implemented",
+  );
+}
+
+function classForAdapter(adapter: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#class_for_adapter is not implemented",
+  );
+}
+
+function eachCurrentConfiguration(environment: any, name?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#each_current_configuration is not implemented",
+  );
+}
+
+function eachCurrentEnvironment(environment: any, block?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#each_current_environment is not implemented",
+  );
+}
+
+function eachLocalConfiguration(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#each_local_configuration is not implemented",
+  );
+}
+
+function isLocalDatabase(dbConfig: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#local_database? is not implemented",
+  );
+}
+
+function schemaSha1(file: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#schema_sha1 is not implemented",
+  );
+}
+
+function structureDumpFlagsFor(adapter: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#structure_dump_flags_for is not implemented",
+  );
+}
+
+function structureLoadFlagsFor(adapter: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#structure_load_flags_for is not implemented",
+  );
+}
+
+function checkCurrentProtectedEnvironmentBang(dbConfig: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#check_current_protected_environment! is not implemented",
+  );
+}
+
+function initializeDatabase(dbConfig: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::DatabaseTasks#initialize_database is not implemented",
+  );
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -7,7 +7,7 @@
 import { getFs, getChildProcessAsync, type SpawnSyncResult } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
-import { DatabaseAlreadyExists } from "../errors.js";
+import { DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { coercePort } from "./task-utils.js";
 
@@ -334,4 +334,29 @@ export class MySQLDatabaseTasks {
   private escapeIdent(value: string): string {
     return value.replace(/`/g, "``");
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::MySQLDatabaseTasks#connection is not implemented",
+  );
+}
+
+function establishConnection(config?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::MySQLDatabaseTasks#establish_connection is not implemented",
+  );
+}
+
+function configurationHashWithoutDatabase(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::MySQLDatabaseTasks#configuration_hash_without_database is not implemented",
+  );
+}
+
+function runCmdError(cmd: any, args: any, action: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::MySQLDatabaseTasks#run_cmd_error is not implemented",
+  );
 }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -336,7 +336,6 @@ export class MySQLDatabaseTasks {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::MySQLDatabaseTasks#connection is not implemented",
@@ -360,4 +359,3 @@ function runCmdError(cmd: any, args: any, action: any): never {
     "ActiveRecord::Tasks::MySQLDatabaseTasks#run_cmd_error is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -360,3 +360,4 @@ function runCmdError(cmd: any, args: any, action: any): never {
     "ActiveRecord::Tasks::MySQLDatabaseTasks#run_cmd_error is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -414,7 +414,6 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
     .filter((s) => s.length > 0 && s !== "$user");
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#connection is not implemented",
@@ -438,4 +437,3 @@ function runCmdError(cmd: any, args: any, action: any): never {
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd_error is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -438,3 +438,4 @@ function runCmdError(cmd: any, args: any, action: any): never {
     "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd_error is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
-import { DatabaseAlreadyExists } from "../errors.js";
+import { DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { coercePort } from "./task-utils.js";
 
@@ -412,4 +412,29 @@ export function normalizeSchemaSearchPath(raw: string): string[] {
       return s;
     })
     .filter((s) => s.length > 0 && s !== "$user");
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#connection is not implemented",
+  );
+}
+
+function establishConnection(config?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#establish_connection is not implemented",
+  );
+}
+
+function publicSchemaConfig(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#public_schema_config is not implemented",
+  );
+}
+
+function runCmdError(cmd: any, args: any, action: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd_error is not implemented",
+  );
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -13,7 +13,7 @@ import { getFs, getPath } from "@blazetrails/activesupport";
 import type { DatabaseAdapter } from "../adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseTasks } from "./database-tasks.js";
-import { NoDatabaseError, DatabaseAlreadyExists } from "../errors.js";
+import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 
 export class SQLiteDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
@@ -352,4 +352,29 @@ function splitSqlStatements(sql: string): string[] {
   const tail = buf.trim();
   if (tail) result.push(tail);
   return result;
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function connection(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::SQLiteDatabaseTasks#connection is not implemented",
+  );
+}
+
+function establishConnection(config?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::SQLiteDatabaseTasks#establish_connection is not implemented",
+  );
+}
+
+function runCmd(cmd: any, args: any, out: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd is not implemented",
+  );
+}
+
+function runCmdError(cmd: any, args: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd_error is not implemented",
+  );
 }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -354,7 +354,6 @@ function splitSqlStatements(sql: string): string[] {
   return result;
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function connection(): never {
   throw new NotImplementedError(
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#connection is not implemented",
@@ -378,4 +377,3 @@ function runCmdError(cmd: any, args: any): never {
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd_error is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -378,3 +378,4 @@ function runCmdError(cmd: any, args: any): never {
     "ActiveRecord::Tasks::SQLiteDatabaseTasks#run_cmd_error is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { Base } from "./base.js";
-import { ReadOnlyRecord, StaleObjectError } from "./errors.js";
+import { ReadOnlyRecord, StaleObjectError, NotImplementedError } from "./errors.js";
 import { UpdateManager, Nodes } from "@blazetrails/arel";
 import { isAppliedTo as isNoTouchingApplied } from "./no-touching.js";
 
@@ -178,3 +178,62 @@ export const ClassMethods = {
 export const InstanceMethods = {
   touch,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError("ActiveRecord::Timestamp#init_internals is not implemented");
+}
+
+function _createRecord(): never {
+  throw new NotImplementedError("ActiveRecord::Timestamp#_create_record is not implemented");
+}
+
+function _updateRecord(): never {
+  throw new NotImplementedError("ActiveRecord::Timestamp#_update_record is not implemented");
+}
+
+function createOrUpdate(touch?: any, opts?: any): never {
+  throw new NotImplementedError("ActiveRecord::Timestamp#create_or_update is not implemented");
+}
+
+function recordUpdateTimestamps(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#record_update_timestamps is not implemented",
+  );
+}
+
+function shouldRecordTimestamps(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#should_record_timestamps? is not implemented",
+  );
+}
+
+function maxUpdatedColumnTimestamp(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#max_updated_column_timestamp is not implemented",
+  );
+}
+
+function clearTimestampAttributes(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#clear_timestamp_attributes is not implemented",
+  );
+}
+
+function reloadSchemaFromCache(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#reload_schema_from_cache is not implemented",
+  );
+}
+
+function timestampAttributesForCreate(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#timestamp_attributes_for_create is not implemented",
+  );
+}
+
+function timestampAttributesForUpdate(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Timestamp#timestamp_attributes_for_update is not implemented",
+  );
+}

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -237,3 +237,4 @@ function timestampAttributesForUpdate(): never {
     "ActiveRecord::Timestamp#timestamp_attributes_for_update is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -179,7 +179,6 @@ export const InstanceMethods = {
   touch,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError("ActiveRecord::Timestamp#init_internals is not implemented");
 }
@@ -237,4 +236,3 @@ function timestampAttributesForUpdate(): never {
     "ActiveRecord::Timestamp#timestamp_attributes_for_update is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -183,7 +183,6 @@ export const InstanceMethods = {
   beforeCommittedBang,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function initInternals(): never {
   throw new NotImplementedError("ActiveRecord::TouchLater#init_internals is not implemented");
 }
@@ -193,4 +192,3 @@ function hasDeferTouchAttrs(): never {
     "ActiveRecord::TouchLater#has_defer_touch_attrs? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { ActiveRecordError, ReadOnlyRecord } from "./errors.js";
+import { ActiveRecordError, ReadOnlyRecord, NotImplementedError } from "./errors.js";
 import {
   touch as timestampTouch,
   timestampAttributesForUpdateInModel,
@@ -182,3 +182,14 @@ export const InstanceMethods = {
   touch,
   beforeCommittedBang,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function initInternals(): never {
+  throw new NotImplementedError("ActiveRecord::TouchLater#init_internals is not implemented");
+}
+
+function hasDeferTouchAttrs(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::TouchLater#has_defer_touch_attrs? is not implemented",
+  );
+}

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -193,3 +193,4 @@ function hasDeferTouchAttrs(): never {
     "ActiveRecord::TouchLater#has_defer_touch_attrs? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 
 /**
@@ -62,4 +63,11 @@ export class Connection {
 
     return undefined;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function tableName(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::TypeCaster::Connection#table_name is not implemented",
+  );
 }

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -65,10 +65,8 @@ export class Connection {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function tableName(): never {
   throw new NotImplementedError(
     "ActiveRecord::TypeCaster::Connection#table_name is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -71,3 +71,4 @@ function tableName(): never {
     "ActiveRecord::TypeCaster::Connection#table_name is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/adapter-specific-registry.ts
+++ b/packages/activerecord/src/type/adapter-specific-registry.ts
@@ -3,6 +3,7 @@
  *
  * Also defines Registration, DecorationRegistration, and TypeConflictError.
  */
+import { NotImplementedError } from "../errors.js";
 import { Type } from "@blazetrails/activemodel";
 
 export class TypeConflictError extends Error {
@@ -153,4 +154,85 @@ export class AdapterSpecificRegistry {
       return cmp < 0 ? current : best;
     });
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function registrations(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::AdapterSpecificRegistry#registrations is not implemented",
+  );
+}
+
+function findRegistration(symbol: any, args?: any[], kwargs?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::AdapterSpecificRegistry#find_registration is not implemented",
+  );
+}
+
+function name(): never {
+  throw new NotImplementedError("ActiveRecord::Type::Registration#name is not implemented");
+}
+
+function block(): never {
+  throw new NotImplementedError("ActiveRecord::Type::Registration#block is not implemented");
+}
+
+function adapter(): never {
+  throw new NotImplementedError("ActiveRecord::Type::Registration#adapter is not implemented");
+}
+
+function override(): never {
+  throw new NotImplementedError("ActiveRecord::Type::Registration#override is not implemented");
+}
+
+function priority(): never {
+  throw new NotImplementedError("ActiveRecord::Type::Registration#priority is not implemented");
+}
+
+function priorityExceptAdapter(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::Registration#priority_except_adapter is not implemented",
+  );
+}
+
+function isMatchesAdapter(adapter?: any, opts?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::Registration#matches_adapter? is not implemented",
+  );
+}
+
+function isConflictsWith(other: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::Registration#conflicts_with? is not implemented",
+  );
+}
+
+function isSamePriorityExceptAdapter(other: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::Registration#same_priority_except_adapter? is not implemented",
+  );
+}
+
+function hasAdapterConflict(other: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::Registration#has_adapter_conflict? is not implemented",
+  );
+}
+
+function options(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::DecorationRegistration#options is not implemented",
+  );
+}
+
+function klass(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::DecorationRegistration#klass is not implemented",
+  );
+}
+
+function isMatchesOptions(kwargs?: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Type::DecorationRegistration#matches_options? is not implemented",
+  );
 }

--- a/packages/activerecord/src/type/adapter-specific-registry.ts
+++ b/packages/activerecord/src/type/adapter-specific-registry.ts
@@ -156,7 +156,6 @@ export class AdapterSpecificRegistry {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function registrations(): never {
   throw new NotImplementedError(
     "ActiveRecord::Type::AdapterSpecificRegistry#registrations is not implemented",
@@ -236,4 +235,3 @@ function isMatchesOptions(kwargs?: any): never {
     "ActiveRecord::Type::DecorationRegistration#matches_options? is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/adapter-specific-registry.ts
+++ b/packages/activerecord/src/type/adapter-specific-registry.ts
@@ -236,3 +236,4 @@ function isMatchesOptions(kwargs?: any): never {
     "ActiveRecord::Type::DecorationRegistration#matches_options? is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -100,3 +100,4 @@ export class Serialized extends ValueType {
 function encoded(value: any): never {
   throw new NotImplementedError("ActiveRecord::Type::Serialized#encoded is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -96,8 +96,6 @@ export class Serialized extends ValueType {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function encoded(value: any): never {
   throw new NotImplementedError("ActiveRecord::Type::Serialized#encoded is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 
 export interface Coder {
@@ -93,4 +94,9 @@ export class Serialized extends ValueType {
     }
     return false;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function encoded(value: any): never {
+  throw new NotImplementedError("ActiveRecord::Type::Serialized#encoded is not implemented");
 }

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -26,3 +26,4 @@ export class Time extends ActiveModelTime {
 function castValue(value: any): never {
   throw new NotImplementedError("ActiveRecord::Type::Time#cast_value is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -5,6 +5,7 @@
  * Values are cast by ActiveModel; this type adds timezone-aware behavior
  * through the `timezone` option and `isUtc` accessor.
  */
+import { NotImplementedError } from "../errors.js";
 import { TimeType as ActiveModelTime } from "@blazetrails/activemodel";
 import { isUtc, type TimezoneOptions } from "./internal/timezone.js";
 
@@ -19,4 +20,9 @@ export class Time extends ActiveModelTime {
   get isUtc(): boolean {
     return isUtc(this._timezone);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function castValue(value: any): never {
+  throw new NotImplementedError("ActiveRecord::Type::Time#cast_value is not implemented");
 }

--- a/packages/activerecord/src/type/time.ts
+++ b/packages/activerecord/src/type/time.ts
@@ -22,8 +22,6 @@ export class Time extends ActiveModelTime {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function castValue(value: any): never {
   throw new NotImplementedError("ActiveRecord::Type::Time#cast_value is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/type-map.ts
+++ b/packages/activerecord/src/type/type-map.ts
@@ -1,6 +1,7 @@
 /**
  * Mirrors: ActiveRecord::Type::TypeMap
  */
+import { NotImplementedError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
 
 export class TypeMap {
@@ -54,4 +55,9 @@ export class TypeMap {
     if (fallback) return fallback(lookupKey);
     return new ValueType();
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function performFetch(lookupKey: any, block?: any): never {
+  throw new NotImplementedError("ActiveRecord::Type::TypeMap#perform_fetch is not implemented");
 }

--- a/packages/activerecord/src/type/type-map.ts
+++ b/packages/activerecord/src/type/type-map.ts
@@ -61,3 +61,4 @@ export class TypeMap {
 function performFetch(lookupKey: any, block?: any): never {
   throw new NotImplementedError("ActiveRecord::Type::TypeMap#perform_fetch is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/type-map.ts
+++ b/packages/activerecord/src/type/type-map.ts
@@ -57,8 +57,6 @@ export class TypeMap {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function performFetch(lookupKey: any, block?: any): never {
   throw new NotImplementedError("ActiveRecord::Type::TypeMap#perform_fetch is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -27,7 +27,6 @@ export class UnsignedInteger extends IntegerType {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function maxValue(): never {
   throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#max_value is not implemented");
 }
@@ -35,4 +34,3 @@ function maxValue(): never {
 function minValue(): never {
   throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#min_value is not implemented");
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -35,3 +35,4 @@ function maxValue(): never {
 function minValue(): never {
   throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#min_value is not implemented");
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/type/unsigned-integer.ts
+++ b/packages/activerecord/src/type/unsigned-integer.ts
@@ -1,3 +1,4 @@
+import { NotImplementedError } from "../errors.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
 /**
@@ -24,4 +25,13 @@ export class UnsignedInteger extends IntegerType {
   override isSerializable(value: unknown): boolean {
     return value == null || this.cast(value) !== null;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function maxValue(): never {
+  throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#max_value is not implemented");
+}
+
+function minValue(): never {
+  throw new NotImplementedError("ActiveRecord::Type::UnsignedInteger#min_value is not implemented");
 }

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -6,7 +6,7 @@
  * and overrides save/valid? to run validations with context awareness.
  */
 import type { ValidationContext } from "@blazetrails/activemodel";
-import { ActiveRecordError } from "./errors.js";
+import { ActiveRecordError, NotImplementedError } from "./errors.js";
 
 /**
  * Anything Rails' `valid?(context = nil)` accepts — shared between
@@ -293,3 +293,10 @@ export const ClassMethods = {
   validatesAssociated,
   validatesUniqueness,
 };
+
+// --- api:compare private stubs (auto-generated) ---
+function raiseValidationError(): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations#raise_validation_error is not implemented",
+  );
+}

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -294,10 +294,8 @@ export const ClassMethods = {
   validatesUniqueness,
 };
 
-// --- api:compare private stubs (auto-generated) ---
 function raiseValidationError(): never {
   throw new NotImplementedError(
     "ActiveRecord::Validations#raise_validation_error is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -300,3 +300,4 @@ function raiseValidationError(): never {
     "ActiveRecord::Validations#raise_validation_error is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -67,3 +67,4 @@ function recordValidationContextForAssociation(record: any): never {
     "ActiveRecord::Validations::AssociatedValidator#record_validation_context_for_association is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -8,6 +8,7 @@
  *     static { this.hasMany("pages"); this.validatesAssociated("pages"); }
  *   }
  */
+import { NotImplementedError } from "../errors.js";
 import { EachValidator } from "@blazetrails/activemodel";
 
 /**
@@ -52,4 +53,17 @@ export class AssociatedValidator extends EachValidator {
     }
     return undefined;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function isValidObject(record: any, context: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::AssociatedValidator#valid_object? is not implemented",
+  );
+}
+
+function recordValidationContextForAssociation(record: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::AssociatedValidator#record_validation_context_for_association is not implemented",
+  );
 }

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -55,7 +55,6 @@ export class AssociatedValidator extends EachValidator {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function isValidObject(record: any, context: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Validations::AssociatedValidator#valid_object? is not implemented",
@@ -67,4 +66,3 @@ function recordValidationContextForAssociation(record: any): never {
     "ActiveRecord::Validations::AssociatedValidator#record_validation_context_for_association is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/numericality.ts
+++ b/packages/activerecord/src/validations/numericality.ts
@@ -4,6 +4,7 @@
  * Extracts column precision and scale from the database schema
  * and passes them to the ActiveModel validator.
  */
+import { NotImplementedError } from "../errors.js";
 import { NumericalityValidator as BaseNumericalityValidator } from "@blazetrails/activemodel";
 
 // JS Number.MAX_SAFE_INTEGER has 15–16 significant digits. Rails uses
@@ -28,4 +29,17 @@ export class NumericalityValidator extends BaseNumericalityValidator {
     if (typeof klass.typeForAttribute !== "function") return undefined;
     return klass.typeForAttribute(attribute)?.scale ?? undefined;
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function columnPrecisionFor(record: any, attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::NumericalityValidator#column_precision_for is not implemented",
+  );
+}
+
+function columnScaleFor(record: any, attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::NumericalityValidator#column_scale_for is not implemented",
+  );
 }

--- a/packages/activerecord/src/validations/numericality.ts
+++ b/packages/activerecord/src/validations/numericality.ts
@@ -31,7 +31,6 @@ export class NumericalityValidator extends BaseNumericalityValidator {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function columnPrecisionFor(record: any, attribute: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Validations::NumericalityValidator#column_precision_for is not implemented",
@@ -43,4 +42,3 @@ function columnScaleFor(record: any, attribute: any): never {
     "ActiveRecord::Validations::NumericalityValidator#column_scale_for is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/numericality.ts
+++ b/packages/activerecord/src/validations/numericality.ts
@@ -43,3 +43,4 @@ function columnScaleFor(record: any, attribute: any): never {
     "ActiveRecord::Validations::NumericalityValidator#column_scale_for is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -160,3 +160,4 @@ function mapEnumAttribute(klass: any, attribute: any, value: any): never {
     "ActiveRecord::Validations::UniquenessValidator#map_enum_attribute is not implemented",
   );
 }
+// --- end api:compare private stubs ---

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -5,6 +5,7 @@
  * Builds a query against the model's table to check for existing records
  * with the same value, optionally scoped to other columns.
  */
+import { NotImplementedError } from "../errors.js";
 import { EachValidator } from "@blazetrails/activemodel";
 
 /**
@@ -115,4 +116,47 @@ export class UniquenessValidator extends EachValidator {
     });
     asyncValidations.push(validationPromise);
   }
+}
+
+// --- api:compare private stubs (auto-generated) ---
+function findFinderClassFor(record: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#find_finder_class_for is not implemented",
+  );
+}
+
+function isValidationNeeded(klass: any, record: any, attribute: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#validation_needed? is not implemented",
+  );
+}
+
+function isCoveredByUniqueIndex(klass: any, record: any, attribute: any, scope: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#covered_by_unique_index? is not implemented",
+  );
+}
+
+function resolveAttributes(record: any, attributes: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#resolve_attributes is not implemented",
+  );
+}
+
+function buildRelation(klass: any, attribute: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#build_relation is not implemented",
+  );
+}
+
+function scopeRelation(record: any, relation: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#scope_relation is not implemented",
+  );
+}
+
+function mapEnumAttribute(klass: any, attribute: any, value: any): never {
+  throw new NotImplementedError(
+    "ActiveRecord::Validations::UniquenessValidator#map_enum_attribute is not implemented",
+  );
 }

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -118,7 +118,6 @@ export class UniquenessValidator extends EachValidator {
   }
 }
 
-// --- api:compare private stubs (auto-generated) ---
 function findFinderClassFor(record: any): never {
   throw new NotImplementedError(
     "ActiveRecord::Validations::UniquenessValidator#find_finder_class_for is not implemented",
@@ -160,4 +159,3 @@ function mapEnumAttribute(klass: any, attribute: any, value: any): never {
     "ActiveRecord::Validations::UniquenessValidator#map_enum_attribute is not implemented",
   );
 }
-// --- end api:compare private stubs ---

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -134,6 +134,18 @@ describe("extractFileLocalHelpers", () => {
     expect(helpers).toEqual([]);
   });
 
+  it("skips NotImplementedError stubs (function decls and arrow consts)", () => {
+    const helpers = helpersFromSource(`
+      function realHelper(x) { return x; }
+      function stubFn(a, b) {
+        throw new NotImplementedError("not implemented");
+      }
+      const stubArrow = (x) => { throw new NotImplementedError("nope"); };
+      const realArrow = (x) => x + 1;
+    `);
+    expect(helpers.map((h) => h.name)).toEqual(["realHelper", "realArrow"]);
+  });
+
   it("records line numbers for traceback", () => {
     const helpers = helpersFromSource(`function first() {}\nfunction second() {}\n`);
     expect(helpers[0].line).toBe(1);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -429,6 +429,11 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
  *   - `function helper(...) {}`
  *   - `const helper = (...) => {}` / `const helper = function (...) {}`
  *
+ * Helpers whose body is just `throw new NotImplementedError(...)` are
+ * skipped: they satisfy api:compare's name match but contribute no
+ * behavior, and Rails reserves NotImplementedError for abstract methods
+ * subclasses must override — they should not inflate the privates score.
+ *
  * Caller must already have ensured `node` is not exported.
  */
 export function extractFileLocalHelpers(
@@ -439,6 +444,7 @@ export function extractFileLocalHelpers(
 
   if (ts.isFunctionDeclaration(node)) {
     if (!node.name) return out;
+    if (isNotImplementedStub(node.body)) return out;
     const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
     out.push({
       name: node.name.text,
@@ -457,6 +463,7 @@ export function extractFileLocalHelpers(
     const init = decl.initializer;
     if (!init) continue;
     if (!ts.isArrowFunction(init) && !ts.isFunctionExpression(init)) continue;
+    if (isNotImplementedStub(init.body)) continue;
     const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
     out.push({
       name: decl.name.text,
@@ -469,6 +476,17 @@ export function extractFileLocalHelpers(
     });
   }
   return out;
+}
+
+export function isNotImplementedStub(body: ts.Node | undefined): boolean {
+  if (!body || !ts.isBlock(body)) return false;
+  if (body.statements.length !== 1) return false;
+  const stmt = body.statements[0];
+  if (!ts.isThrowStatement(stmt)) return false;
+  const expr = stmt.expression;
+  if (!ts.isNewExpression(expr)) return false;
+  const callee = expr.expression;
+  return ts.isIdentifier(callee) && callee.text === "NotImplementedError";
 }
 
 export function resolveRelModule(fromRel: string, spec: string): string | null {

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -16,6 +16,7 @@ import * as ts from "typescript";
 import type { ApiManifest, ClassInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import { isNotImplementedStub } from "./extract-ts-api.js";
 
 // ---------------------------------------------------------------------------
 // Dependency rules — add new entries to extend to other packages
@@ -205,14 +206,16 @@ function visitMethodDeclarations(
       return;
     }
     if (ts.isFunctionDeclaration(node) && node.name) {
-      callback(node.name.text, node);
+      if (!isNotImplementedStub(node.body)) callback(node.name.text, node);
       return;
     }
     if (ts.isVariableStatement(node)) {
       for (const decl of node.declarationList.declarations) {
         if (ts.isIdentifier(decl.name) && decl.initializer) {
           if (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer)) {
-            callback(decl.name.text, decl.initializer);
+            if (!isNotImplementedStub(decl.initializer.body)) {
+              callback(decl.name.text, decl.initializer);
+            }
           }
         }
       }

--- a/scripts/stub-private-methods.ts
+++ b/scripts/stub-private-methods.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Stubs out missing private methods in existing activerecord TS files.
+ * For each method reported by `api:compare` as missing, appends a non-exported
+ * function with the same parameter names as the Rails source. Body throws
+ * NotImplementedError. Extracted as "private" by extract-ts-api's file-local
+ * helper logic.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "..");
+const PKG_SRC = path.join(ROOT, "packages/activerecord/src");
+
+type RubyParam = { name: string; kind: string };
+type RubyMethod = { name: string; params: RubyParam[]; visibility?: string };
+type RubyClass = {
+  fqn: string;
+  file: string;
+  instanceMethods?: RubyMethod[];
+  classMethods?: RubyMethod[];
+};
+
+const privates = JSON.parse(
+  fs.readFileSync(
+    path.join(ROOT, "scripts/api-compare/output/api-comparison-privates-only.json"),
+    "utf8",
+  ),
+);
+const railsApi = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "scripts/api-compare/output/rails-api.json"), "utf8"),
+);
+
+const ar = privates.results.find((r: any) => r.package === "activerecord");
+if (!ar) throw new Error("no activerecord results");
+
+// Build lookup: fqn -> name -> params
+const arRails = railsApi.packages.activerecord;
+const methodsByFqn = new Map<string, Map<string, RubyParam[]>>();
+for (const c of [
+  ...Object.values(arRails.classes || {}),
+  ...Object.values(arRails.modules || {}),
+] as RubyClass[]) {
+  const m = new Map<string, RubyParam[]>();
+  for (const meth of [...(c.instanceMethods || []), ...(c.classMethods || [])]) {
+    if (!m.has(meth.name)) m.set(meth.name, meth.params || []);
+  }
+  methodsByFqn.set(c.fqn, m);
+}
+
+const RESERVED = new Set([
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+  "let",
+  "static",
+  "implements",
+  "interface",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "arguments",
+  "eval",
+]);
+
+function snakeToCamel(name: string): string {
+  return name.replace(/_([a-zA-Z0-9])/g, (_m, c) => c.toUpperCase());
+}
+
+function safeIdent(raw: string, fallback: string): string {
+  if (!raw || raw === "*" || raw === "**" || raw === "&") return fallback;
+  let id = snakeToCamel(raw.replace(/^[*&]+/, ""));
+  if (!/^[A-Za-z_$][\w$]*$/.test(id)) id = fallback;
+  if (RESERVED.has(id)) id = id + "_";
+  return id;
+}
+
+function paramList(params: RubyParam[]): string {
+  const out: string[] = [];
+  // Only emit a real `...rest` if the rest param is the last in the list;
+  // otherwise demote to `name?: any[]` so TS rules (rest must be last) hold.
+  const trailingRestIdx =
+    params.length > 0 && params[params.length - 1].kind === "rest" ? params.length - 1 : -1;
+  let restSeen = false;
+  let i = 0;
+  for (const p of params) {
+    i++;
+    const fb = `arg${i}`;
+    switch (p.kind) {
+      case "required": {
+        const id = safeIdent(p.name, fb);
+        out.push(`${id}: any`);
+        break;
+      }
+      case "optional": {
+        const id = safeIdent(p.name, fb);
+        out.push(`${id}?: any`);
+        break;
+      }
+      case "rest": {
+        const id = safeIdent(p.name, "args");
+        const idx = i - 1;
+        if (idx === trailingRestIdx && !restSeen) {
+          out.push(`...${id}: any[]`);
+          restSeen = true;
+        } else {
+          out.push(`${id}?: any[]`);
+        }
+        break;
+      }
+      case "keyword": {
+        const id = safeIdent(p.name, `opt${i}`);
+        out.push(`${id}?: any`);
+        break;
+      }
+      case "keyword_rest": {
+        const id = safeIdent(p.name, "opts");
+        out.push(`${id}?: any`);
+        break;
+      }
+      case "block": {
+        const id = safeIdent(p.name, "block");
+        out.push(`${id}?: any`);
+        break;
+      }
+    }
+  }
+  return out.join(", ");
+}
+
+let totalAppended = 0;
+let filesTouched = 0;
+
+for (const fileEntry of ar.files) {
+  if (!fileEntry.tsFileExists) continue;
+  if (!fileEntry.missingMethods?.length) continue;
+
+  const tsRel = fileEntry.expectedTsFile as string;
+  const tsAbs = path.join(PKG_SRC, tsRel);
+  if (!fs.existsSync(tsAbs)) continue;
+
+  let src = fs.readFileSync(tsAbs, "utf8");
+
+  // Determine import for NotImplementedError. The errors module lives at
+  // packages/activerecord/src/errors.ts. Compute relative import.
+  const fromDir = path.dirname(tsAbs);
+  let relImport = path.relative(fromDir, path.join(PKG_SRC, "errors")).replaceAll("\\", "/");
+  if (!relImport.startsWith(".")) relImport = "./" + relImport;
+  const importSpec = relImport + ".js";
+
+  // Match an existing import from the *same module specifier* so we can merge
+  // NotImplementedError into it instead of adding a duplicate `import` line.
+  const escapedSpec = importSpec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const sameModuleImportRe = new RegExp(
+    `^([ \\t]*import\\s+(?:type\\s+)?\\{)([^}]*)(\\}\\s+from\\s+["']${escapedSpec}["'][^\\n]*)$`,
+    "m",
+  );
+  const sameModuleMatch = sameModuleImportRe.exec(src);
+  const alreadyImported =
+    sameModuleMatch !== null && /\bNotImplementedError\b/.test(sameModuleMatch[2]);
+
+  const stubs: string[] = [];
+  const usedNames = new Set<string>();
+  // Avoid clashing with anything already in the file. Simple regex check.
+  const existingTopLevel = new Set<string>();
+  for (const m of src.matchAll(/^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/gm)) {
+    existingTopLevel.add(m[1]);
+  }
+  for (const m of src.matchAll(/^\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm)) {
+    existingTopLevel.add(m[1]);
+  }
+  for (const m of src.matchAll(/^\s*(?:export\s+)?class\s+([A-Za-z_$][\w$]*)/gm)) {
+    existingTopLevel.add(m[1]);
+  }
+  // Imports — capture all named bindings and default/namespace.
+  for (const im of src.matchAll(
+    /^\s*import\s+(?:type\s+)?(?:([A-Za-z_$][\w$]*)\s*,?\s*)?(?:\{([^}]+)\})?\s*(?:from)?/gm,
+  )) {
+    if (im[1]) existingTopLevel.add(im[1]);
+    if (im[2]) {
+      for (const part of im[2].split(",")) {
+        const t = part.trim().split(/\s+as\s+/);
+        const name = (t[1] || t[0]).trim();
+        if (name) existingTopLevel.add(name);
+      }
+    }
+  }
+
+  for (const mm of fileEntry.missingMethods) {
+    const tsName = mm.tsName as string;
+    if (existingTopLevel.has(tsName)) continue;
+    if (usedNames.has(tsName)) continue;
+    usedNames.add(tsName);
+    const params = methodsByFqn.get(mm.rubyModule)?.get(mm.rubyName) || [];
+    const sig = paramList(params);
+    stubs.push(
+      `function ${tsName}(${sig}): never {\n` +
+        `  throw new NotImplementedError("${mm.rubyModule}#${mm.rubyName} is not implemented");\n` +
+        `}`,
+    );
+  }
+
+  if (stubs.length === 0) continue;
+
+  if (!alreadyImported) {
+    if (sameModuleMatch) {
+      // Merge into the existing import-from-errors line.
+      const [whole, head, names, tail] = sameModuleMatch;
+      const merged = `${head}${names.replace(/[\s,]*$/, "")}, NotImplementedError ${tail}`;
+      src = src.replace(whole, merged);
+    } else {
+      // Insert after any leading block-comment / line-comment header so we
+      // don't push module-level JSDoc off the first line.
+      // Consume any trailing whitespace/newlines after `*/` so the inserted
+      // import lands on its own line, not adjacent to the closing comment.
+      const headerRe = /^(\s*(?:\/\*[\s\S]*?\*\/\s*|\/\/[^\n]*\n\s*)+)/;
+      const headerMatch = headerRe.exec(src);
+      const importLine = `import { NotImplementedError } from "${importSpec}";\n`;
+      if (headerMatch) {
+        const idx = headerMatch[0].length;
+        src = src.slice(0, idx) + importLine + src.slice(idx);
+      } else {
+        src = importLine + src;
+      }
+    }
+  }
+
+  if (!src.endsWith("\n")) src += "\n";
+  src += "\n// --- api:compare private stubs (auto-generated) ---\n";
+  src += stubs.join("\n\n") + "\n";
+
+  fs.writeFileSync(tsAbs, src);
+  totalAppended += stubs.length;
+  filesTouched++;
+}
+
+console.log(`Appended ${totalAppended} stubs across ${filesTouched} files.`);

--- a/scripts/stub-private-methods.ts
+++ b/scripts/stub-private-methods.ts
@@ -3,8 +3,16 @@
  * Stubs out missing private methods in existing activerecord TS files.
  * For each method reported by `api:compare` as missing, appends a non-exported
  * function with the same parameter names as the Rails source. Body throws
- * NotImplementedError. Extracted as "private" by extract-ts-api's file-local
- * helper logic.
+ * NotImplementedError.
+ *
+ * These stubs are intentionally *not* counted by `extract-ts-api` (which
+ * skips file-local helpers whose body is just `throw new NotImplementedError`)
+ * — they are a navigational aid, not API coverage, and should not inflate
+ * the privates score.
+ *
+ * Idempotent: each file's generated block lives between marker comments. On
+ * re-run the existing block is removed before a fresh one is appended, so a
+ * file never accumulates multiple generated sections.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -176,6 +184,12 @@ for (const fileEntry of ar.files) {
 
   let src = fs.readFileSync(tsAbs, "utf8");
 
+  // Strip any existing generated block so re-runs replace it instead of
+  // accumulating a new section each time.
+  const blockRe =
+    /\n*\/\/ --- api:compare private stubs \(auto-generated\) ---[\s\S]*?\/\/ --- end api:compare private stubs ---\n?/;
+  src = src.replace(blockRe, "\n");
+
   // Determine import for NotImplementedError. The errors module lives at
   // packages/activerecord/src/errors.ts. Compute relative import.
   const fromDir = path.dirname(tsAbs);
@@ -263,6 +277,7 @@ for (const fileEntry of ar.files) {
   if (!src.endsWith("\n")) src += "\n";
   src += "\n// --- api:compare private stubs (auto-generated) ---\n";
   src += stubs.join("\n\n") + "\n";
+  src += "// --- end api:compare private stubs ---\n";
 
   fs.writeFileSync(tsAbs, src);
   totalAppended += stubs.length;

--- a/scripts/stub-private-methods.ts
+++ b/scripts/stub-private-methods.ts
@@ -184,11 +184,13 @@ for (const fileEntry of ar.files) {
 
   let src = fs.readFileSync(tsAbs, "utf8");
 
-  // Strip any existing generated block so re-runs replace it instead of
-  // accumulating a new section each time.
-  const blockRe =
-    /\n*\/\/ --- api:compare private stubs \(auto-generated\) ---[\s\S]*?\/\/ --- end api:compare private stubs ---\n?/;
-  src = src.replace(blockRe, "\n");
+  // Strip any trailing run of previously-generated stubs so re-runs replace
+  // them instead of stacking new ones. A stub is identified structurally:
+  // a non-exported `function NAME(...): never { throw new NotImplementedError("..."); }`
+  // (matching what this script emits below).
+  const trailingStubRe =
+    /(?:\s*function\s+[A-Za-z_$][\w$]*\s*\([^)]*\)\s*:\s*never\s*\{\s*throw\s+new\s+NotImplementedError\("[^"]*"\);\s*\})+\s*$/;
+  src = src.replace(trailingStubRe, "\n");
 
   // Determine import for NotImplementedError. The errors module lives at
   // packages/activerecord/src/errors.ts. Compute relative import.
@@ -275,9 +277,7 @@ for (const fileEntry of ar.files) {
   }
 
   if (!src.endsWith("\n")) src += "\n";
-  src += "\n// --- api:compare private stubs (auto-generated) ---\n";
-  src += stubs.join("\n\n") + "\n";
-  src += "// --- end api:compare private stubs ---\n";
+  src += "\n" + stubs.join("\n\n") + "\n";
 
   fs.writeFileSync(tsAbs, src);
   totalAppended += stubs.length;


### PR DESCRIPTION
## Summary
- `extract-ts-api` and `lint-deps` skip non-exported helpers whose body is just `throw new NotImplementedError(...)`. Stubs satisfy api:compare's name-match step but contribute no behavior, and Rails reserves `NotImplementedError` for abstract methods that subclasses must override — they should not inflate the privates score.
- Adds `scripts/stub-private-methods.ts`: reads `api-compare`'s missing-private report and appends stub functions (with Rails parameter names) to existing TS files, as a navigational aid for finding gaps. Idempotent — re-runs strip the previous trailing run of stubs before regenerating.
- Commits the generated stubs (867 across 127 files) so they're discoverable via grep / IDE go-to-definition. The extractor + lint-deps filters ensure they don't inflate the score or trip dependency-cross-check lint.
- Adds a unit test covering both function declarations and arrow consts.

## Status: max Copilot review cycles reached (7) — requesting human review

The bot has cycled 7 times. Latest two outstanding suggestions are noted here for the human reviewer rather than auto-applied:

### Outstanding Copilot suggestions (review #7)
1. **Runtime cost of stubs in `dist/`.** Stubs are real top-level functions, so they are emitted into `packages/activerecord/dist/` and add to shipped JS size / parse time. Suggested mitigation: emit `.d.ts`-only stubs, or move them under a directory excluded from the package build. **Decision deferred to human reviewer** — this changes the shape of the PR (currently the stubs *are* real callable code that throws, which is what makes them visible to grep and runtime debugging when something accidentally calls one). The right answer depends on whether shipping the stubs in JS is acceptable as a navigation aid or whether they should be type-only.
2. **Stub-removal regex is non-global.** `String.replace` with a non-global RegExp removes only the first match. If a file ever ends up with multiple generated runs (e.g., from a future merge conflict that duplicates the trailing block), re-running the generator would leave the extras behind. Currently a non-issue because we strip a *trailing* run anchored with `$`, but worth a small follow-up to loop until stable. **Low priority follow-up.**

### Earlier suggestions already addressed (reviews #1–#6)
- Shebang `-S` flag, unused vars, JSDoc placement, fragmented JSDoc folded into the helper's main doc.
- Stubs filtered by extractor *and* by `lint-deps` (caught CI failure on activesupport/arel cross-check).
- Imports merged into existing `errors.js` import line; trailing-comma stripping when merging into multi-line named imports; module-specifier-anchored regex to avoid false-positive "already imported".
- Header docstring corrected; insertion lands on its own line (not glued to closing `*/`).
- Idempotent regeneration without sentinel marker comments — trailing stub run is identified structurally.

## Test plan
- [x] `pnpm vitest run scripts/api-compare/extract-ts-api.test.ts` — 15 passed
- [x] `pnpm --filter @blazetrails/activerecord build` — clean (no errors from this PR's diff)
- [x] `pnpm tsx scripts/api-compare/extract-ts-api.ts && pnpm tsx scripts/api-compare/compare.ts --privates-only --package activerecord` — privates score unaffected by stubs
- [x] `pnpm tsx scripts/api-compare/lint-deps.ts` — exit 0, output matches main
- [x] Two back-to-back runs of `scripts/stub-private-methods.ts` produce identical output (idempotent)