### PR TITLE
fix(activerecord): collection= and has_one= replace in-memory only; flush on owner.save()

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -707,8 +707,9 @@ async function replaceRecords(
   if (toDelete.length > 0) await assoc.delete(...toDelete);
   const toAdd = newTarget.filter((r) => !(assoc.target as Base[]).includes(r));
   if (toAdd.length > 0) {
-    const result = await assoc.concat(...toAdd);
-    if (!result) {
+    try {
+      await assoc.concat(...toAdd);
+    } catch {
       (assoc as any).target = originalTarget;
       throw new RecordNotSaved(
         `Failed to replace ${assoc.reflection.name} because one or more records could not be saved.`,
@@ -738,7 +739,7 @@ function replaceOnTarget(
 ): Base | null {
   const replaced = assoc as any;
   let index = -1;
-  if (replace && replaced._replacedOrAddedTargets?.has(record)) {
+  if (replace) {
     index = (assoc.target as Base[]).indexOf(record);
   }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -297,11 +297,12 @@ export class CollectionAssociation extends Association {
   async persistReplace(): Promise<void> {
     const pending = this._pendingReplace;
     if (!pending || this.owner.isNewRecord()) return;
-    // If the association wasn't loaded at assignment time, load now to get the
-    // real DB baseline before diffing (mirrors Rails' load_target in replace).
+    // If the association wasn't loaded at assignment time, fetch the persisted
+    // baseline directly via doAsyncFindTarget to avoid the loadedBang short-circuit
+    // and without mutating this.target (mirrors Rails' load_target in replace).
     if (!pending.wasLoaded) {
-      await this.loadTarget();
-      pending.originalTarget = [...this.target];
+      const dbRecords = await this.doAsyncFindTarget();
+      pending.originalTarget = Array.isArray(dbRecords) ? [...dbRecords] : [];
     }
     const currentTarget = this.target;
     await transaction(this, async () => {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -18,6 +18,7 @@ export class CollectionAssociation extends Association {
   nestedAttributesTarget: Base[] | null = null;
   private _replacedOrAddedTargets: Set<Base> = new Set();
   private _associationIds: unknown[] | null = null;
+  _pendingReplace: { newTarget: Base[]; originalTarget: Base[] } | null = null;
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
@@ -62,27 +63,28 @@ export class CollectionAssociation extends Association {
     const filteredIds = (ids ?? []).filter((id) => id != null && id !== "");
     if (filteredIds.length === 0) {
       this.replace([]);
-      return;
-    }
-    const Klass = this.klass as any;
-    const pk = Klass.primaryKey ?? "id";
+    } else {
+      const Klass = this.klass as any;
+      const pk = Klass.primaryKey ?? "id";
 
-    if (Array.isArray(pk)) {
-      const found = await Promise.all(
-        filteredIds.map(async (id) => {
-          const conditions: Record<string, unknown> = {};
-          const idParts = Array.isArray(id) ? id : [id];
-          pk.forEach((col: string, i: number) => {
-            conditions[col] = idParts[i];
-          });
-          return Klass.findBy(conditions);
-        }),
-      );
-      this.replace(found.filter((r): r is Base => r != null));
-    } else if (typeof Klass.where === "function") {
-      const records: Base[] = await Klass.where({ [pk]: filteredIds }).toArray();
-      this.replace(records);
+      if (Array.isArray(pk)) {
+        const found = await Promise.all(
+          filteredIds.map(async (id) => {
+            const conditions: Record<string, unknown> = {};
+            const idParts = Array.isArray(id) ? id : [id];
+            pk.forEach((col: string, i: number) => {
+              conditions[col] = idParts[i];
+            });
+            return Klass.findBy(conditions);
+          }),
+        );
+        this.replace(found.filter((r): r is Base => r != null));
+      } else if (typeof Klass.where === "function") {
+        const records: Base[] = await Klass.where({ [pk]: filteredIds }).toArray();
+        this.replace(records);
+      }
     }
+    await this.persistReplace();
   }
 
   override reset(): void {
@@ -255,16 +257,11 @@ export class CollectionAssociation extends Association {
   replace(otherArray: Base[]): void {
     for (const val of otherArray) (this as any).raiseOnTypeMismatchBang(val);
     const originalTarget = [...this.target];
-    // Update in-memory target immediately (synchronous) then persist async.
-    // Rails does the same: replace_common_records_in_memory runs first,
-    // then transaction { replace_records } (async) handles DB.
     replaceCommonRecordsInMemory(this, otherArray, originalTarget);
     if (this.owner.isNewRecord()) {
-      // For new owners: just set the in-memory target directly
       this.target = [...otherArray];
       this.loadedBang();
     } else if (!arraysEqual(otherArray, originalTarget)) {
-      // Sync in-memory: remove records not in new target, add new ones
       for (const r of originalTarget) {
         if (!otherArray.includes(r)) {
           const idx = this.target.indexOf(r);
@@ -278,11 +275,17 @@ export class CollectionAssociation extends Association {
         }
       }
       this.loadedBang();
-      // Persist changes async (matches Rails: transaction { replace_records })
-      void transaction(this, async () => {
-        await replaceRecords(this, otherArray, originalTarget);
-      });
+      this._pendingReplace = { newTarget: [...otherArray], originalTarget };
     }
+  }
+
+  async persistReplace(): Promise<void> {
+    const pending = this._pendingReplace;
+    if (!pending || this.owner.isNewRecord()) return;
+    this._pendingReplace = null;
+    await transaction(this, async () => {
+      await replaceRecords(this, pending.newTarget, pending.originalTarget);
+    });
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { fireAssocCallbacks } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
-import { RecordNotSaved, Rollback } from "../errors.js";
+import { RecordNotSaved, Rollback, AssociationNotLoadedError } from "../errors.js";
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -256,6 +256,11 @@ export class CollectionAssociation extends Association {
    */
   replace(otherArray: Base[]): void {
     for (const val of otherArray) (this as any).raiseOnTypeMismatchBang(val);
+    // Rails calls load_target synchronously before replacing. Since loadTarget()
+    // is async here, require callers to load first on persisted owners.
+    if (!this.owner.isNewRecord() && !this.isLoaded()) {
+      throw new AssociationNotLoadedError(this.owner.constructor.name, this.reflection.name);
+    }
     const originalTarget = [...this.target];
     replaceCommonRecordsInMemory(this, otherArray, originalTarget);
     if (this.owner.isNewRecord()) {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,6 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { fireAssocCallbacks } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
+import { RecordNotSaved } from "../errors.js";
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -688,8 +689,9 @@ async function replaceRecords(
     const result = await assoc.concat(...toAdd);
     if (!result) {
       (assoc as any).target = originalTarget;
-      throw new Error(
+      throw new RecordNotSaved(
         `Failed to replace ${assoc.reflection.name} because one or more records could not be saved.`,
+        assoc.owner,
       );
     }
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -276,7 +276,18 @@ export class CollectionAssociation extends Association {
         }
       }
       this.loadedBang();
-      this._pendingReplace = { newTarget: [...otherArray], originalTarget };
+      // Preserve the first originalTarget (what's in the DB) across multiple
+      // replace() calls before save(). Only update newTarget so the final flush
+      // diffs against the real persisted state, not an intermediate in-memory one.
+      if (this._pendingReplace) {
+        if (arraysEqual(otherArray, this._pendingReplace.originalTarget)) {
+          this._pendingReplace = null; // reverted to DB state — nothing to flush
+        } else {
+          this._pendingReplace.newTarget = [...otherArray];
+        }
+      } else {
+        this._pendingReplace = { newTarget: [...otherArray], originalTarget };
+      }
     }
   }
 
@@ -284,8 +295,16 @@ export class CollectionAssociation extends Association {
     const pending = this._pendingReplace;
     if (!pending || this.owner.isNewRecord()) return;
     this._pendingReplace = null;
+    const currentTarget = this.target;
     await transaction(this, async () => {
-      await replaceRecords(this, pending.newTarget, pending.originalTarget);
+      // replaceRecords diffs against assoc.target; restore originalTarget so
+      // it sees the real DB state rather than the already-updated in-memory target
+      this.target = [...pending.originalTarget];
+      try {
+        await replaceRecords(this, pending.newTarget, pending.originalTarget);
+      } finally {
+        this.target = currentTarget;
+      }
     });
   }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { fireAssocCallbacks } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
-import { RecordNotSaved, Rollback, ActiveRecordError } from "../errors.js";
+import { RecordNotSaved, Rollback } from "../errors.js";
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -151,7 +151,7 @@ export class CollectionAssociation extends Association {
         if (!saved) result = false;
       }
     }
-    if (!result) throw new Error("ActiveRecord::Rollback");
+    if (!result) throw new Rollback();
   }
 
   /**
@@ -709,7 +709,7 @@ async function replaceRecords(
       await assoc.concat(...toAdd);
     } catch (e) {
       // Only translate validation/rollback failures; re-throw adapter/query errors as-is
-      if (e instanceof Rollback || e instanceof ActiveRecordError) {
+      if (e instanceof Rollback) {
         (assoc as any).target = originalTarget;
         throw new RecordNotSaved(
           `Failed to replace ${assoc.reflection.name} because one or more records could not be saved.`,

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { fireAssocCallbacks } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
-import { RecordNotSaved } from "../errors.js";
+import { RecordNotSaved, Rollback, ActiveRecordError } from "../errors.js";
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -17,7 +17,6 @@ import { RecordNotSaved } from "../errors.js";
 export class CollectionAssociation extends Association {
   declare target: Base[];
   nestedAttributesTarget: Base[] | null = null;
-  private _replacedOrAddedTargets: Set<Base> = new Set();
   private _associationIds: unknown[] | null = null;
   _pendingReplace: { newTarget: Base[]; originalTarget: Base[] } | null = null;
 
@@ -91,7 +90,6 @@ export class CollectionAssociation extends Association {
   override reset(): void {
     super.reset();
     this.target = [];
-    this._replacedOrAddedTargets = new Set();
     this._associationIds = null;
     this._pendingReplace = null;
   }
@@ -709,12 +707,16 @@ async function replaceRecords(
   if (toAdd.length > 0) {
     try {
       await assoc.concat(...toAdd);
-    } catch {
-      (assoc as any).target = originalTarget;
-      throw new RecordNotSaved(
-        `Failed to replace ${assoc.reflection.name} because one or more records could not be saved.`,
-        assoc.owner,
-      );
+    } catch (e) {
+      // Only translate validation/rollback failures; re-throw adapter/query errors as-is
+      if (e instanceof Rollback || e instanceof ActiveRecordError) {
+        (assoc as any).target = originalTarget;
+        throw new RecordNotSaved(
+          `Failed to replace ${assoc.reflection.name} because one or more records could not be saved.`,
+          assoc.owner,
+        );
+      }
+      throw e;
     }
   }
   return assoc.target as Base[];
@@ -749,7 +751,6 @@ function replaceOnTarget(
   }
 
   assoc.setInverseInstance(record);
-  replaced._replacedOrAddedTargets?.add(record);
   replaced._associationIds = null;
 
   const target = assoc.target as Base[];

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { fireAssocCallbacks } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
-import { RecordNotSaved, Rollback, AssociationNotLoadedError } from "../errors.js";
+import { RecordNotSaved, Rollback } from "../errors.js";
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -18,7 +18,7 @@ export class CollectionAssociation extends Association {
   declare target: Base[];
   nestedAttributesTarget: Base[] | null = null;
   private _associationIds: unknown[] | null = null;
-  _pendingReplace: { newTarget: Base[]; originalTarget: Base[] } | null = null;
+  _pendingReplace: { newTarget: Base[]; originalTarget: Base[]; wasLoaded: boolean } | null = null;
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
@@ -60,6 +60,9 @@ export class CollectionAssociation extends Association {
    * Loads records by the given IDs and replaces the collection.
    */
   async idsWriter(ids: unknown[]): Promise<void> {
+    if (!this.owner.isNewRecord() && !this.isLoaded()) {
+      await this.loadTarget();
+    }
     const filteredIds = (ids ?? []).filter((id) => id != null && id !== "");
     if (filteredIds.length === 0) {
       this.replace([]);
@@ -256,11 +259,7 @@ export class CollectionAssociation extends Association {
    */
   replace(otherArray: Base[]): void {
     for (const val of otherArray) (this as any).raiseOnTypeMismatchBang(val);
-    // Rails calls load_target synchronously before replacing. Since loadTarget()
-    // is async here, require callers to load first on persisted owners.
-    if (!this.owner.isNewRecord() && !this.isLoaded()) {
-      throw new AssociationNotLoadedError(this.owner.constructor.name, this.reflection.name);
-    }
+    const wasLoaded = this.isLoaded();
     const originalTarget = [...this.target];
     replaceCommonRecordsInMemory(this, otherArray, originalTarget);
     if (this.owner.isNewRecord()) {
@@ -290,7 +289,7 @@ export class CollectionAssociation extends Association {
           this._pendingReplace.newTarget = [...otherArray];
         }
       } else {
-        this._pendingReplace = { newTarget: [...otherArray], originalTarget };
+        this._pendingReplace = { newTarget: [...otherArray], originalTarget, wasLoaded };
       }
     }
   }
@@ -298,6 +297,12 @@ export class CollectionAssociation extends Association {
   async persistReplace(): Promise<void> {
     const pending = this._pendingReplace;
     if (!pending || this.owner.isNewRecord()) return;
+    // If the association wasn't loaded at assignment time, load now to get the
+    // real DB baseline before diffing (mirrors Rails' load_target in replace).
+    if (!pending.wasLoaded) {
+      await this.loadTarget();
+      pending.originalTarget = [...this.target];
+    }
     const currentTarget = this.target;
     await transaction(this, async () => {
       // replaceRecords diffs against assoc.target; restore originalTarget so

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -265,7 +265,7 @@ export class CollectionAssociation extends Association {
     if (this.owner.isNewRecord()) {
       this.target = [...otherArray];
       this.loadedBang();
-    } else if (!arraysEqual(otherArray, originalTarget)) {
+    } else if (!wasLoaded || !arraysEqual(otherArray, originalTarget)) {
       for (const r of originalTarget) {
         if (!otherArray.includes(r)) {
           const idx = this.target.indexOf(r);
@@ -283,7 +283,7 @@ export class CollectionAssociation extends Association {
       // replace() calls before save(). Only update newTarget so the final flush
       // diffs against the real persisted state, not an intermediate in-memory one.
       if (this._pendingReplace) {
-        if (arraysEqual(otherArray, this._pendingReplace.originalTarget)) {
+        if (wasLoaded && arraysEqual(otherArray, this._pendingReplace.originalTarget)) {
           this._pendingReplace = null; // reverted to DB state — nothing to flush
         } else {
           this._pendingReplace.newTarget = [...otherArray];

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -93,6 +93,7 @@ export class CollectionAssociation extends Association {
     this.target = [];
     this._replacedOrAddedTargets = new Set();
     this._associationIds = null;
+    this._pendingReplace = null;
   }
 
   /**
@@ -294,7 +295,6 @@ export class CollectionAssociation extends Association {
   async persistReplace(): Promise<void> {
     const pending = this._pendingReplace;
     if (!pending || this.owner.isNewRecord()) return;
-    this._pendingReplace = null;
     const currentTarget = this.target;
     await transaction(this, async () => {
       // replaceRecords diffs against assoc.target; restore originalTarget so
@@ -306,6 +306,8 @@ export class CollectionAssociation extends Association {
         this.target = currentTarget;
       }
     });
+    // Clear only after success — leave intact on error so save() retry can re-attempt
+    this._pendingReplace = null;
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -117,7 +117,15 @@ export class HasOneAssociation extends SingularAssociation {
         !(pending.previousTarget as any).isDestroyed?.() &&
         pending.previousTarget !== pending.record
       ) {
-        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+        // removeTargetBang reads assoc.target; temporarily restore previousTarget
+        // so it operates on the old record, not the new one already set in replace()
+        const currentTarget = this.target;
+        this.target = pending.previousTarget;
+        try {
+          await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+        } finally {
+          this.target = currentTarget;
+        }
       }
       if (pending.record && typeof (pending.record as any).save === "function") {
         const saved = await (pending.record as any).save();

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -20,6 +20,11 @@ export class HasOneAssociation extends SingularAssociation {
     super(owner, definition);
   }
 
+  override reset(): void {
+    super.reset();
+    this._pendingReplace = null;
+  }
+
   /**
    * Handle the :dependent option when the owner is being destroyed.
    */
@@ -118,7 +123,6 @@ export class HasOneAssociation extends SingularAssociation {
   async persistReplace(): Promise<void> {
     const pending = this._pendingReplace;
     if (!pending) return;
-    this._pendingReplace = null;
     await transactionIf(this, true, async () => {
       if (
         pending.previousTarget &&
@@ -147,6 +151,8 @@ export class HasOneAssociation extends SingularAssociation {
         }
       }
     });
+    // Clear only after success — leave intact on error so save() retry can re-attempt
+    this._pendingReplace = null;
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -2,6 +2,7 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { loadHasOne } from "../associations.js";
 import { DeleteRestrictionError } from "./errors.js";
+import { RecordNotSaved } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { SingularAssociation } from "./singular-association.js";
 
@@ -122,7 +123,11 @@ export class HasOneAssociation extends SingularAssociation {
         const saved = await (pending.record as any).save();
         if (!saved) {
           this.nullifyOwnerAttributes(pending.record);
-          throw new Error(`Failed to save the new associated ${this.reflection.name}.`);
+          if (pending.previousTarget) this.setOwnerAttributes(pending.previousTarget);
+          throw new RecordNotSaved(
+            `Failed to save the new associated ${this.reflection.name}.`,
+            pending.record,
+          );
         }
       }
     });

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -13,6 +13,8 @@ import { SingularAssociation } from "./singular-association.js";
  * Mirrors: ActiveRecord::Associations::HasOneAssociation
  */
 export class HasOneAssociation extends SingularAssociation {
+  _pendingReplace: { record: Base | null; previousTarget: Base | null } | null = null;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
   }
@@ -92,26 +94,38 @@ export class HasOneAssociation extends SingularAssociation {
     if (record) (this as any).raiseOnTypeMismatchBang(record);
     const assigningAnother = this.target !== record;
     if (assigningAnother || (record as any)?.hasChangesToSave?.()) {
-      const shouldSave = save && (this.owner as any).isPersisted?.();
-      void transactionIf(this, !!shouldSave, async () => {
-        if (this.target && !(this.target as any).isDestroyed?.() && assigningAnother) {
-          await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-        }
-        if (record) {
-          this.setOwnerAttributes(record);
-          this.setInverseInstance(record);
-          if (shouldSave && typeof (record as any).save === "function") {
-            const saved = await (record as any).save();
-            if (!saved) {
-              this.nullifyOwnerAttributes(record);
-              throw new Error(`Failed to save the new associated ${this.reflection.name}.`);
-            }
-          }
-        }
-      });
+      if (record) {
+        this.setOwnerAttributes(record);
+        this.setInverseInstance(record);
+      }
+      if (save && (this.owner as any).isPersisted?.()) {
+        this._pendingReplace = { record, previousTarget: this.target };
+      }
     }
     this.target = record;
     this.loadedBang();
+  }
+
+  async persistReplace(): Promise<void> {
+    const pending = this._pendingReplace;
+    if (!pending) return;
+    this._pendingReplace = null;
+    await transactionIf(this, true, async () => {
+      if (
+        pending.previousTarget &&
+        !(pending.previousTarget as any).isDestroyed?.() &&
+        pending.previousTarget !== pending.record
+      ) {
+        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+      }
+      if (pending.record && typeof (pending.record as any).save === "function") {
+        const saved = await (pending.record as any).save();
+        if (!saved) {
+          this.nullifyOwnerAttributes(pending.record);
+          throw new Error(`Failed to save the new associated ${this.reflection.name}.`);
+        }
+      }
+    });
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -243,6 +243,13 @@ function removeTargetBang(assoc: HasOneAssociation, method: string): Promise<voi
   if (!target) return Promise.resolve();
   if (method === "delete") return (target as any).delete?.() ?? Promise.resolve();
   if (method === "destroy") return (target as any).destroy?.() ?? Promise.resolve();
+  if (method === "nullify") {
+    if (target.isPersisted()) {
+      (assoc as any).nullifyOwnerAttributes(target);
+      return (target as any).save?.() ?? Promise.resolve();
+    }
+    return Promise.resolve();
+  }
   return Promise.resolve();
 }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -106,10 +106,14 @@ export class HasOneAssociation extends SingularAssociation {
       }
       if (save && (this.owner as any).isPersisted?.()) {
         if (this._pendingReplace) {
-          if (record === this._pendingReplace.previousTarget) {
-            this._pendingReplace = null; // reverted to DB state — nothing to flush
+          // Only clear on a true revert: a different-record assignment being set back.
+          // Same-record (dirty) assignments must not clear even if record === previousTarget.
+          const wasAssignedAnother =
+            this._pendingReplace.previousTarget !== this._pendingReplace.record;
+          if (wasAssignedAnother && record === this._pendingReplace.previousTarget) {
+            this._pendingReplace = null;
           } else {
-            this._pendingReplace.record = record; // update destination, keep original previousTarget
+            this._pendingReplace.record = record;
           }
         } else {
           this._pendingReplace = { record, previousTarget: this.target };

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -14,7 +14,7 @@ import { SingularAssociation } from "./singular-association.js";
  * Mirrors: ActiveRecord::Associations::HasOneAssociation
  */
 export class HasOneAssociation extends SingularAssociation {
-  _pendingReplace: { record: Base | null; previousTarget: Base | null } | null = null;
+  _pendingReplace: { record: Base | null; readonly previousTarget: Base | null } | null = null;
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
@@ -100,7 +100,15 @@ export class HasOneAssociation extends SingularAssociation {
         this.setInverseInstance(record);
       }
       if (save && (this.owner as any).isPersisted?.()) {
-        this._pendingReplace = { record, previousTarget: this.target };
+        if (this._pendingReplace) {
+          if (record === this._pendingReplace.previousTarget) {
+            this._pendingReplace = null; // reverted to DB state — nothing to flush
+          } else {
+            this._pendingReplace.record = record; // update destination, keep original previousTarget
+          }
+        } else {
+          this._pendingReplace = { record, previousTarget: this.target };
+        }
       }
     }
     this.target = record;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -159,6 +159,20 @@ export function validOptions(): string[] {
   return ["autosave"];
 }
 
+export async function flushPendingReplaces(record: Base): Promise<void> {
+  const ctor = record.constructor as any;
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
+  for (const assoc of associations) {
+    const cached =
+      (record as any)._cachedAssociations?.get(assoc.name) ??
+      (record as any)._preloadedAssociations?.get(assoc.name);
+    if (!cached) continue;
+    if (typeof (cached as any).persistReplace === "function" && (cached as any)._pendingReplace) {
+      await (cached as any).persistReplace();
+    }
+  }
+}
+
 export function clearAutosaveState(record: Base): void {
   const r = record as any;
   r[MARKED_FOR_DESTRUCTION] = false;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -160,15 +160,11 @@ export function validOptions(): string[] {
 }
 
 export async function flushPendingReplaces(record: Base): Promise<void> {
-  const ctor = record.constructor as any;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  for (const assoc of associations) {
-    const cached =
-      (record as any)._cachedAssociations?.get(assoc.name) ??
-      (record as any)._preloadedAssociations?.get(assoc.name);
-    if (!cached) continue;
-    if (typeof (cached as any).persistReplace === "function" && (cached as any)._pendingReplace) {
-      await (cached as any).persistReplace();
+  const instances: Map<string, unknown> = (record as any)._associationInstances;
+  if (!instances?.values) return;
+  for (const assoc of instances.values()) {
+    if (typeof (assoc as any).persistReplace === "function" && (assoc as any)._pendingReplace) {
+      await (assoc as any).persistReplace();
     }
   }
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -36,6 +36,7 @@ import {
   AutosaveAssociation,
   autosaveBelongsTo,
   autosaveChildren,
+  flushPendingReplaces,
 } from "./autosave-association.js";
 import {
   isValid as validationsIsValid,
@@ -2302,6 +2303,8 @@ export class Base extends Model {
       if (wasNewRecord) {
         await updateCounterCaches(this, "increment");
       }
+
+      await flushPendingReplaces(this);
 
       const autosaveOk = await autosaveChildren(this);
       if (!autosaveOk) return false;

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -552,6 +552,16 @@ export class UnknownAttributeReference extends ActiveRecordError {
   }
 }
 
+export class AssociationNotLoadedError extends ActiveRecordError {
+  constructor(ownerName: string, associationName: string) {
+    super(
+      `Association '${associationName}' on '${ownerName}' must be loaded before replacing. ` +
+        `Await the reader (e.g. \`await record.${associationName}\`) before assigning.`,
+    );
+    this.name = "AssociationNotLoadedError";
+  }
+}
+
 export class MultiparameterAssignmentErrors extends ActiveRecordError {
   readonly errors: Error[];
 

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -552,16 +552,6 @@ export class UnknownAttributeReference extends ActiveRecordError {
   }
 }
 
-export class AssociationNotLoadedError extends ActiveRecordError {
-  constructor(ownerName: string, associationName: string) {
-    super(
-      `Association '${associationName}' on '${ownerName}' must be loaded before replacing. ` +
-        `Await the reader (e.g. \`await record.${associationName}\`) before assigning.`,
-    );
-    this.name = "AssociationNotLoadedError";
-  }
-}
-
 export class MultiparameterAssignmentErrors extends ActiveRecordError {
   readonly errors: Error[];
 


### PR DESCRIPTION
## Summary

- \`collection=\` and \`has_one=\` writers are JS property setters — they cannot be \`async\`. The previous implementation used \`void transaction(...)\` (fire-and-forget), causing unhandled promise rejections on save failure and no way for callers to await completion.
- This PR separates the concern: the setter updates in-memory state immediately; persistence is deferred to \`owner.save()\`.

## What changed

**\`CollectionAssociation#replace\`** — in-memory only. Records \`wasLoaded\` in the \`_pendingReplace\` token. Schedules a flush when \`!wasLoaded || !arraysEqual(newTarget, inMemoryTarget)\` so unloaded empty-array assignments always reach the DB.

**\`CollectionAssociation#persistReplace\`** — if \`wasLoaded\` was false, calls \`doAsyncFindTarget()\` to fetch the real DB baseline before diffing. Avoids the \`loadedBang\` short-circuit and doesn't mutate \`this.target\`.

**\`idsWriter\`** — loads before replacing when persisted and unloaded.

**\`HasOneAssociation#replace\`** — same deferred treatment. Stores \`_pendingReplace\` with previous target, multi-call and dirty-record edge cases handled.

**\`HasOneAssociation#removeTargetBang\`** — adds \`nullify\` case matching \`#delete("nullify")\`.

**\`flushPendingReplaces(record)\`** — new in \`autosave-association.ts\`. Iterates \`_associationInstances\`, calls \`persistReplace()\` on pending ones. Called from \`_createOrUpdate\` after INSERT/UPDATE, before \`autosaveChildren\`.

**\`CollectionProxy#replace\`** — unchanged; remains the explicit immediate-persist API.

## Semantics

| Call | DB write |
|------|----------|
| \`blog.posts = [p1]\` | on next \`blog.save()\` |
| \`blog.postIds = [1, 2]\` | immediately (already async) |
| \`await blog.posts.replace([p1])\` | immediately |
| \`await blog.save()\` | flushes any pending replace + autosave |

## Test plan

- [x] All 36 association test files pass (1299 tests)
- [x] \`persistence.test.ts\` + \`base.test.ts\` pass (661 tests)
- [x] \`pnpm build\` — clean
- [x] \`pnpm api:compare\` — all affected files stay at 100%