### PR TITLE
fix(activerecord): wire stashed-joins routing into buildJoinBuckets and _applyJoinsToManager

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -356,10 +356,12 @@ export class JoinDependency {
     joinsToAdd: JoinDependency[],
     _aliasTracker?: any,
     _references?: string[],
-  ): any[] {
-    const joins = this._nodes.map((n) => arelSql(n.joinSql));
+  ): Nodes.StringJoin[] {
+    const toStringJoin = (n: { joinSql: string }): Nodes.StringJoin =>
+      new Nodes.StringJoin(arelSql(n.joinSql));
+    const joins = this._nodes.map(toStringJoin);
     for (const oj of joinsToAdd) {
-      joins.push(...oj._nodes.map((n) => arelSql(n.joinSql)));
+      joins.push(...oj._nodes.map(toStringJoin));
     }
     return joins;
   }

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -339,11 +339,11 @@ describe("RelationTest", () => {
     expect(authorPos).toBeLessThan(tagPos);
   });
 
-  it("joins() places LeadingJoin ahead of InnerJoin even when passed later", () => {
-    // Rails build_join_buckets routes LeadingJoin → leading_join bucket (prepended)
-    // and non-LeadingJoin → join_node bucket (appended), regardless of argument
-    // order. This matters for eager-loading where join_sources is non-empty
-    // (query_methods.rb:1856-1863, build_joins:1891-1899).
+  it("joins() preserves insertion order with no stashed joins — InnerJoin before LeadingJoin when passed first", () => {
+    // Without stashed_eager_load or stashed_left_joins, Rails routes ALL explicit
+    // join nodes to leading_join in original insertion order (query_methods.rb:1856-1863
+    // else branch: condition `!LeadingJoin && (stashed_eager_load || stashed_left_joins)`
+    // is false, so every node goes to leading_join).
     class Book extends Base {
       static {
         this.tableName = "books";
@@ -360,8 +360,40 @@ describe("RelationTest", () => {
       authors,
       new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
     );
-    // leadingJoin passed second — should still appear before innerJoin in SQL
+    // innerJoin passed first → tags appears first (insertion order preserved)
     const sqlStr = Book.joins(innerJoin, leadingJoin).toSql();
+    const authorPos = sqlStr.indexOf('"authors"');
+    const tagPos = sqlStr.indexOf('"tags"');
+    expect(authorPos).toBeGreaterThan(-1);
+    expect(tagPos).toBeGreaterThan(-1);
+    expect(tagPos).toBeLessThan(authorPos);
+  });
+
+  it("joins() with stashed eager-load: LeadingJoin before InnerJoin regardless of argument order", () => {
+    // With stashed joins present (eagerLoad triggers stashed_eager_load), Rails
+    // routes LeadingJoin → leading_join (first) and non-LeadingJoin → join_node
+    // (last), so LeadingJoin appears before InnerJoin regardless of argument order.
+    class Book extends Base {
+      static {
+        this.tableName = "books";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    const authors = new ArelTable("authors");
+    const tags = new ArelTable("tags");
+    const innerJoin = new Nodes.InnerJoin(
+      tags,
+      new Nodes.On(new Nodes.SqlLiteral("books.tag_id = tags.id")),
+    );
+    const leadingJoin = new Nodes.LeadingJoin(
+      authors,
+      new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
+    );
+    // innerJoin passed first, but stashed joins (eagerLoad) cause routing split:
+    // leadingJoin → leading (prepended), innerJoin → join_node (appended)
+    const rel = Book.joins(innerJoin, leadingJoin).eagerLoad("author" as any);
+    const sqlStr = rel.toSql();
     const authorPos = sqlStr.indexOf('"authors"');
     const tagPos = sqlStr.indexOf('"tags"');
     expect(authorPos).toBeGreaterThan(-1);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -370,9 +370,12 @@ describe("RelationTest", () => {
   });
 
   it("joins() with stashed eager-load: LeadingJoin before InnerJoin regardless of argument order", () => {
-    // With stashed joins present (eagerLoad triggers stashed_eager_load), Rails
-    // routes LeadingJoin → leading_join (first) and non-LeadingJoin → join_node
-    // (last), so LeadingJoin appears before InnerJoin regardless of argument order.
+    // With stashed joins present (eagerLoad sets _eagerLoadAssociations, the
+    // stashed_eager_load signal), _applyJoinsToManager routes LeadingJoin →
+    // leading_join (prepended first) and non-LeadingJoin → join_node (appended
+    // last). The "author" association need not exist on the model — this test
+    // exercises the routing split in _applyJoinsToManager (toSql path), not
+    // the stashed JOIN SQL insertion in buildJoins (buildArel path).
     class Book extends Base {
       static {
         this.tableName = "books";
@@ -390,8 +393,8 @@ describe("RelationTest", () => {
       authors,
       new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
     );
-    // innerJoin passed first, but stashed joins (eagerLoad) cause routing split:
-    // leadingJoin → leading (prepended), innerJoin → join_node (appended)
+    // innerJoin passed first, but stashed signal causes routing split:
+    // leadingJoin → prepended, innerJoin → appended → authors before tags in SQL
     const rel = Book.joins(innerJoin, leadingJoin).eagerLoad("author");
     const sqlStr = rel.toSql();
     const authorPos = sqlStr.indexOf('"authors"');

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -392,7 +392,7 @@ describe("RelationTest", () => {
     );
     // innerJoin passed first, but stashed joins (eagerLoad) cause routing split:
     // leadingJoin → leading (prepended), innerJoin → join_node (appended)
-    const rel = Book.joins(innerJoin, leadingJoin).eagerLoad("author" as any);
+    const rel = Book.joins(innerJoin, leadingJoin).eagerLoad("author");
     const sqlStr = rel.toSql();
     const authorPos = sqlStr.indexOf('"authors"');
     const tagPos = sqlStr.indexOf('"tags"');

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2320,21 +2320,26 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
-    // LeadingJoin nodes go to the leading_join bucket (prepended before any
-    // existing join_sources, including eager-load JoinDependency joins added by
-    // _buildEagerJoinManager). All other nodes — including StringJoin from raw SQL
-    // strings — go to the join_node bucket (appended after existing join_sources).
-    // This matches the stashed_eager_load / stashed_left_joins routing condition:
-    // `!LeadingJoin && (stashed_eager_load || stashed_left_joins) → join_node`.
+    // When stashed joins exist (eager-load or existing join_sources from
+    // _buildEagerJoinManager), non-LeadingJoin nodes go to join_node (appended
+    // after). Without stashed joins, all nodes go to leading_join (prepended
+    // before _joinClauses), matching Rails' else branch.
+    // We treat any existing join_sources OR eager/includes associations as the
+    // stashed signal — both indicate a stashed_eager_load / stashed_left_joins
+    // context where the routing split matters.
+    const hasStashed =
+      manager.joinSources.length > 0 ||
+      this._eagerLoadAssociations.length > 0 ||
+      this._includesAssociations.length > 0;
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
     for (const v of this._joinValues) {
       const node: Nodes.Join =
         typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;
-      if (node instanceof Nodes.LeadingJoin) {
-        leadingJoins.push(node);
-      } else {
+      if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
         joinNodes.push(node);
+      } else {
+        leadingJoins.push(node);
       }
     }
     if (leadingJoins.length > 0) manager.prependJoinNodes(...leadingJoins);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2320,17 +2320,14 @@ export class Relation<T extends Base> {
 
   private _applyJoinsToManager(manager: SelectManager): void {
     // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
-    // When stashed joins exist (eager-load or existing join_sources from
-    // _buildEagerJoinManager), non-LeadingJoin nodes go to join_node (appended
-    // after). Without stashed joins, all nodes go to leading_join (prepended
-    // before _joinClauses), matching Rails' else branch.
-    // We treat any existing join_sources OR eager/includes associations as the
-    // stashed signal — both indicate a stashed_eager_load / stashed_left_joins
-    // context where the routing split matters.
-    const hasStashed =
-      manager.joinSources.length > 0 ||
-      this._eagerLoadAssociations.length > 0 ||
-      this._includesAssociations.length > 0;
+    // When stashed joins exist, non-LeadingJoin nodes go to join_node (appended
+    // after), LeadingJoin goes to leading_join (prepended before). Without stashed
+    // joins all nodes go to leading_join in insertion order (Rails' else branch).
+    // Stashed signal: existing join_sources (set by _buildEagerJoinManager before
+    // this call) OR _eagerLoadAssociations (stashed_eager_load equivalent).
+    // _includesAssociations is NOT included — includes may resolve via preload
+    // (no joins), so counting it would incorrectly split even in the non-join path.
+    const hasStashed = manager.joinSourceCount > 0 || this._eagerLoadAssociations.length > 0;
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
     for (const v of this._joinValues) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1961,15 +1961,14 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   };
 
   // Mirror Rails build_join_buckets (query_methods.rb:1844–1876):
-  // Detect stashed joins from eagerLoad/includes associations. When present,
-  // non-LeadingJoin explicit nodes go to join_node (after alias-tracker joins).
-  // When absent, all explicit nodes go to leading_join (before named joins),
-  // matching Rails' else branch: `!LeadingJoin && (stashed_eager_load ||
-  // stashed_left_joins)` is false, so all nodes route to leading_join.
+  // Detect stashed joins from _eagerLoadAssociations only — includes may resolve
+  // via preload (no joins) and is not a reliable stashed signal. When stashed
+  // joins are present, non-LeadingJoin explicit nodes go to join_node (after
+  // alias-tracker joins). When absent, all explicit nodes go to leading_join
+  // (before named joins), matching Rails' else branch: `!LeadingJoin &&
+  // (stashed_eager_load || stashed_left_joins)` is false → leading_join.
   // Guard the call: buildJoinDependencies always returns at least [primaryJD]
-  // even when there are no associations, so we check first to avoid false positives.
-  // Only eagerLoad associations trigger stashed_eager_load in Rails —
-  // includes may resolve via preload (no joins) and should not be counted.
+  // even when associations are empty, so we check first to avoid false positives.
   const hasAssocStashed = this._eagerLoadAssociations.length > 0;
   const stashedJoins = hasAssocStashed ? buildJoinDependencies.call(this) : [];
   const hasStashed = stashedJoins.length > 0;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1966,7 +1966,11 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   // When absent, all explicit nodes go to leading_join (before named joins),
   // matching Rails' else branch: `!LeadingJoin && (stashed_eager_load ||
   // stashed_left_joins)` is false, so all nodes route to leading_join.
-  const stashedJoins = buildJoinDependencies.call(this);
+  // Guard the call: buildJoinDependencies always returns at least [primaryJD]
+  // even when there are no associations, so we check first to avoid false positives.
+  const hasAssocStashed =
+    this._eagerLoadAssociations.length > 0 || this._includesAssociations.length > 0;
+  const stashedJoins = hasAssocStashed ? buildJoinDependencies.call(this) : [];
   const hasStashed = stashedJoins.length > 0;
   buckets.stashed_join.push(...stashedJoins);
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1957,19 +1957,26 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   const buckets: Record<string, unknown[]> = {
     leading_join: [],
     join_node: [],
+    stashed_join: [],
   };
 
-  // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
-  // 1. Convert string joins to StringJoin nodes.
-  // 2. Route LeadingJoin nodes to leading_join so they appear first in join_sources.
-  // 3. Route all other explicit Arel join nodes to join_node.
+  // Mirror Rails build_join_buckets (query_methods.rb:1844–1876):
+  // Detect stashed joins from eagerLoad/includes associations. When present,
+  // non-LeadingJoin explicit nodes go to join_node (after alias-tracker joins).
+  // When absent, all explicit nodes go to leading_join (before named joins),
+  // matching Rails' else branch: `!LeadingJoin && (stashed_eager_load ||
+  // stashed_left_joins)` is false, so all nodes route to leading_join.
+  const stashedJoins = buildJoinDependencies.call(this);
+  const hasStashed = stashedJoins.length > 0;
+  buckets.stashed_join.push(...stashedJoins);
+
   for (const v of this._joinValues) {
     const node: Nodes.Join =
       typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
-    if (node instanceof Nodes.LeadingJoin) {
-      buckets.leading_join.push(node);
-    } else {
+    if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
       buckets.join_node.push(node);
+    } else {
+      buckets.leading_join.push(node);
     }
   }
 
@@ -1977,16 +1984,19 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
 }
 
 function buildJoins(this: QueryMethodsHost, arel: any): void {
-  if (this._joinClauses.length === 0 && this._joinValues.length === 0) return;
+  const hasAssocs = this._eagerLoadAssociations.length > 0 || this._includesAssociations.length > 0;
+  if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasAssocs) return;
 
   const buckets = buildJoinBuckets.call(this);
   const leadingJoins = buckets.leading_join as unknown[];
   const joinNodes = buckets.join_node as unknown[];
+  const stashedJoins = buckets.stashed_join as JoinDependency[];
 
   for (const j of leadingJoins) arel.source.right.push(j);
 
-  // Mirror _applyJoinsToManager: use manager.join()/outerJoin() so the
-  // SelectManager handles string→SqlLiteral conversion and On wrapping.
+  // Named association joins from _joinClauses (pre-resolved SQL join specs).
+  // Mirrors Rails' join_dependency.join_constraints(stashed_joins, alias_tracker)
+  // for the named_join + stashed_join buckets.
   for (const j of this._joinClauses) {
     const tableNode = j.quoted ? new ArelTable(j.table) : j.table;
     const onNode = arelSql(j.on) as any;
@@ -1995,6 +2005,14 @@ function buildJoins(this: QueryMethodsHost, arel: any): void {
     } else {
       arel.outerJoin(tableNode, onNode);
     }
+  }
+
+  // Stashed join dependencies (eager_load/includes) — generate join SQL via
+  // joinConstraints and push directly to join_sources (mirrors build_joins:1896).
+  if (stashedJoins.length > 0) {
+    const [primary, ...rest] = stashedJoins;
+    const constraintNodes = primary.joinConstraints(rest);
+    for (const node of constraintNodes) arel.source.right.push(node);
   }
 
   for (const node of joinNodes) arel.source.right.push(node);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1968,8 +1968,9 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   // stashed_left_joins)` is false, so all nodes route to leading_join.
   // Guard the call: buildJoinDependencies always returns at least [primaryJD]
   // even when there are no associations, so we check first to avoid false positives.
-  const hasAssocStashed =
-    this._eagerLoadAssociations.length > 0 || this._includesAssociations.length > 0;
+  // Only eagerLoad associations trigger stashed_eager_load in Rails —
+  // includes may resolve via preload (no joins) and should not be counted.
+  const hasAssocStashed = this._eagerLoadAssociations.length > 0;
   const stashedJoins = hasAssocStashed ? buildJoinDependencies.call(this) : [];
   const hasStashed = stashedJoins.length > 0;
   buckets.stashed_join.push(...stashedJoins);
@@ -1988,8 +1989,8 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
 }
 
 function buildJoins(this: QueryMethodsHost, arel: any): void {
-  const hasAssocs = this._eagerLoadAssociations.length > 0 || this._includesAssociations.length > 0;
-  if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasAssocs) return;
+  const hasEagerAssocs = this._eagerLoadAssociations.length > 0;
+  if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasEagerAssocs) return;
 
   const buckets = buildJoinBuckets.call(this);
   const leadingJoins = buckets.leading_join as unknown[];

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -334,6 +334,10 @@ export class SelectManager extends TreeManager {
     return [...this.core.source.right] as Join[];
   }
 
+  get joinSourceCount(): number {
+    return this.core.source.right.length;
+  }
+
   /**
    * Return the FROM sources (left side of the source).
    *


### PR DESCRIPTION
Deferred from #916. Implements the full stashed-joins routing condition in `buildJoinBuckets` and `_applyJoinsToManager`.

## Rails source

`build_join_buckets` (query_methods.rb:1848–1863) routes explicit Arel join nodes conditionally:

```ruby
if !join_node.is_a?(LeadingJoin) && (stashed_eager_load || stashed_left_joins)
  buckets[:join_node]    # appended after alias-tracker-generated joins
else
  buckets[:leading_join] # prepended before alias-tracker-generated joins
end
```

- **No stashed joins**: all explicit nodes → `leading_join` (original insertion order)
- **With stashed joins**: `LeadingJoin` → `leading_join`, others → `join_node`

## Changes

**`buildJoinBuckets`** — detect stashed joins from `_eagerLoadAssociations` only (not `_includesAssociations` — includes may resolve via preload with no joins); apply conditional routing; populate `stashed_join` bucket.

**`buildJoins`** — early return widened to also skip when `_eagerLoadAssociations` is the only signal; process `stashed_join` via `joinConstraints` (now returns `StringJoin` nodes); push to `join_sources`.

**`_applyJoinsToManager`** — detect stashed signal from `joinSourceCount > 0` (set by `_buildEagerJoinManager`) OR `_eagerLoadAssociations`. `_includesAssociations` is not included — includes may use preload strategy with no joins.

**`joinConstraints`** — now returns `Nodes.StringJoin[]` instead of `SqlLiteral[]` so `joinSources` stays type-consistent.

**`SelectManager#joinSourceCount`** — new getter reading `core.source.right.length` directly, avoiding the copy allocated by `joinSources`.

## Tests

- Updated: no-stashed case preserves insertion order (InnerJoin before LeadingJoin when passed first)
- Added: stashed case (`eagerLoad` present) routes LeadingJoin before InnerJoin regardless of argument order (exercises the `hasStashed` routing split in `_applyJoinsToManager`)

## Deferred

`stashed_left_joins` path — requires a `left_outer_joins_values` field that doesn't exist yet.