### PR TITLE
feat(temporal): PR 5b — MySQL per-connection Temporal type cast

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -192,12 +192,16 @@ describe("parsePostgresTimeTz", () => {
 describe("parseMysqlInstant", () => {
   it("treats the wire string as UTC (pinned session tz)", () => {
     const result = parseMysqlInstant("2026-04-26 14:23:55.123456");
-    expect(result.toString()).toBe("2026-04-26T14:23:55.123456Z");
+    expect(result?.toString()).toBe("2026-04-26T14:23:55.123456Z");
   });
 
   it("preserves microseconds", () => {
     const result = parseMysqlInstant("2024-01-01 00:00:00.000001");
-    expect(result.toString()).toBe("2024-01-01T00:00:00.000001Z");
+    expect(result?.toString()).toBe("2024-01-01T00:00:00.000001Z");
+  });
+
+  it("returns null for zero timestamp", () => {
+    expect(parseMysqlInstant("0000-00-00 00:00:00")).toBeNull();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -128,9 +128,11 @@ export function parsePostgresTimeTz(text: string): TimeTzValue {
  * Wire format: `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (no offset in string;
  * semantically UTC because of the pinned session timezone).
  */
-export function parseMysqlInstant(text: string): Temporal.Instant {
-  // Treat as UTC by appending Z after normalising the separator.
-  const iso = clampFraction(text.trim().replace(" ", "T") + "Z");
+export function parseMysqlInstant(text: string): Temporal.Instant | null {
+  const trimmed = text.trim();
+  // MySQL can emit zero timestamps from legacy schemas even on TIMESTAMP columns.
+  if (isZeroDatetime(trimmed)) return null;
+  const iso = clampFraction(trimmed.replace(" ", "T") + "Z");
   return Temporal.Instant.from(iso);
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -2,26 +2,16 @@ import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { temporalTypeCast } from "./temporal-type-cast.js";
 
-// mysql2 field type IDs (mirrors the values in temporal-type-cast.ts)
-const TYPE_TIMESTAMP = 7;
-const TYPE_DATE = 10;
-const TYPE_TIME = 11;
-const TYPE_DATETIME = 12;
-const TYPE_NEWDATE = 14;
-const TYPE_TIMESTAMP2 = 17; // binary protocol variant for TIMESTAMP(N)
-const TYPE_DATETIME2 = 18; // binary protocol variant for DATETIME(N)
-const TYPE_TIME2 = 19; // binary protocol variant for TIME(N)
-const TYPE_VARCHAR = 253;
-
-function field(type: number, value: string | null) {
+// mysql2's createTypecastField sets field.type to the string name, not a numeric OID.
+function field(type: string, value: string | null) {
   return { type, string: () => value };
 }
 const next = () => "next-called";
 
 describe("temporalTypeCast", () => {
-  describe("TIMESTAMP (type 7)", () => {
+  describe("TIMESTAMP", () => {
     it("parses a UTC timestamp to Temporal.Instant", () => {
-      const result = temporalTypeCast(field(TYPE_TIMESTAMP, "2026-04-27 14:23:55.123456"), next);
+      const result = temporalTypeCast(field("TIMESTAMP", "2026-04-27 14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.Instant);
       expect((result as Temporal.Instant).epochMilliseconds).toBe(
         Temporal.Instant.from("2026-04-27T14:23:55.123456Z").epochMilliseconds,
@@ -29,19 +19,24 @@ describe("temporalTypeCast", () => {
     });
 
     it("preserves microsecond precision", () => {
-      const result = temporalTypeCast(field(TYPE_TIMESTAMP, "2026-01-01 00:00:00.000001"), next);
+      const result = temporalTypeCast(field("TIMESTAMP", "2026-01-01 00:00:00.000001"), next);
       expect(result).toBeInstanceOf(Temporal.Instant);
       expect((result as Temporal.Instant).epochNanoseconds % 1000000000n).toBe(1000n);
     });
 
     it("returns null for NULL", () => {
-      expect(temporalTypeCast(field(TYPE_TIMESTAMP, null), next)).toBeNull();
+      expect(temporalTypeCast(field("TIMESTAMP", null), next)).toBeNull();
+    });
+
+    it("handles TIMESTAMP2 (binary protocol fractional variant)", () => {
+      const result = temporalTypeCast(field("TIMESTAMP2", "2026-04-27 14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.Instant);
     });
   });
 
-  describe("DATETIME (type 12) / NEWDATE (type 14)", () => {
+  describe("DATETIME", () => {
     it("parses DATETIME to Temporal.PlainDateTime", () => {
-      const result = temporalTypeCast(field(TYPE_DATETIME, "2026-04-27 14:23:55.123456"), next);
+      const result = temporalTypeCast(field("DATETIME", "2026-04-27 14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.PlainDateTime);
       // .123456 s → millisecond=123, microsecond=456 (sub-ms component)
       expect((result as Temporal.PlainDateTime).millisecond).toBe(123);
@@ -49,69 +44,62 @@ describe("temporalTypeCast", () => {
     });
 
     it("returns null for zero-date", () => {
-      expect(temporalTypeCast(field(TYPE_DATETIME, "0000-00-00 00:00:00"), next)).toBeNull();
+      expect(temporalTypeCast(field("DATETIME", "0000-00-00 00:00:00"), next)).toBeNull();
+    });
+
+    it("handles DATETIME2 (binary protocol fractional variant)", () => {
+      const result = temporalTypeCast(field("DATETIME2", "2026-04-27 00:00:00"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
     });
 
     it("handles NEWDATE type", () => {
-      const result = temporalTypeCast(field(TYPE_NEWDATE, "2026-04-27 00:00:00"), next);
+      const result = temporalTypeCast(field("NEWDATE", "2026-04-27 00:00:00"), next);
       expect(result).toBeInstanceOf(Temporal.PlainDateTime);
     });
 
     it("returns null for NULL", () => {
-      expect(temporalTypeCast(field(TYPE_DATETIME, null), next)).toBeNull();
+      expect(temporalTypeCast(field("DATETIME", null), next)).toBeNull();
     });
   });
 
-  describe("DATE (type 10)", () => {
+  describe("DATE", () => {
     it("parses DATE to Temporal.PlainDate", () => {
-      const result = temporalTypeCast(field(TYPE_DATE, "2026-04-27"), next);
+      const result = temporalTypeCast(field("DATE", "2026-04-27"), next);
       expect(result).toBeInstanceOf(Temporal.PlainDate);
       expect((result as Temporal.PlainDate).toString()).toBe("2026-04-27");
     });
 
     it("returns null for zero-date", () => {
-      expect(temporalTypeCast(field(TYPE_DATE, "0000-00-00"), next)).toBeNull();
+      expect(temporalTypeCast(field("DATE", "0000-00-00"), next)).toBeNull();
     });
 
     it("returns null for NULL", () => {
-      expect(temporalTypeCast(field(TYPE_DATE, null), next)).toBeNull();
+      expect(temporalTypeCast(field("DATE", null), next)).toBeNull();
     });
   });
 
-  describe("TIME (type 11)", () => {
+  describe("TIME", () => {
     it("parses TIME to Temporal.PlainTime", () => {
-      const result = temporalTypeCast(field(TYPE_TIME, "14:23:55.123456"), next);
+      const result = temporalTypeCast(field("TIME", "14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.PlainTime);
       const pt = result as Temporal.PlainTime;
-      expect(pt.millisecond).toBe(123);
-      expect(pt.microsecond).toBe(456);
+      expect(pt.hour).toBe(14);
+      expect(pt.minute).toBe(23);
+      expect(pt.second).toBe(55);
     });
 
     it("returns null for NULL", () => {
-      expect(temporalTypeCast(field(TYPE_TIME, null), next)).toBeNull();
-    });
-  });
-
-  describe("binary protocol variants (prepared statements)", () => {
-    it("TIMESTAMP2 (type 17) parses to Temporal.Instant", () => {
-      const result = temporalTypeCast(field(TYPE_TIMESTAMP2, "2026-04-27 14:23:55.123456"), next);
-      expect(result).toBeInstanceOf(Temporal.Instant);
-    });
-
-    it("DATETIME2 (type 18) parses to Temporal.PlainDateTime", () => {
-      const result = temporalTypeCast(field(TYPE_DATETIME2, "2026-04-27 14:23:55.123456"), next);
-      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
-    });
-
-    it("TIME2 (type 19) parses to Temporal.PlainTime", () => {
-      const result = temporalTypeCast(field(TYPE_TIME2, "14:23:55.123456"), next);
-      expect(result).toBeInstanceOf(Temporal.PlainTime);
+      expect(temporalTypeCast(field("TIME", null), next)).toBeNull();
     });
   });
 
   describe("non-temporal types", () => {
     it("delegates to next() for VARCHAR", () => {
-      expect(temporalTypeCast(field(TYPE_VARCHAR, "hello"), next)).toBe("next-called");
+      expect(temporalTypeCast(field("VARCHAR", "hello"), next)).toBe("next-called");
+    });
+
+    it("delegates to next() for LONG", () => {
+      expect(temporalTypeCast(field("LONG", "42"), next)).toBe("next-called");
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -52,11 +52,6 @@ describe("temporalTypeCast", () => {
       expect(result).toBeInstanceOf(Temporal.PlainDateTime);
     });
 
-    it("handles NEWDATE type", () => {
-      const result = temporalTypeCast(field("NEWDATE", "2026-04-27 00:00:00"), next);
-      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
-    });
-
     it("returns null for NULL", () => {
       expect(temporalTypeCast(field("DATETIME", null), next)).toBeNull();
     });
@@ -65,6 +60,12 @@ describe("temporalTypeCast", () => {
   describe("DATE", () => {
     it("parses DATE to Temporal.PlainDate", () => {
       const result = temporalTypeCast(field("DATE", "2026-04-27"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDate);
+      expect((result as Temporal.PlainDate).toString()).toBe("2026-04-27");
+    });
+
+    it("handles NEWDATE (DATE-only wire type) as Temporal.PlainDate", () => {
+      const result = temporalTypeCast(field("NEWDATE", "2026-04-27"), next);
       expect(result).toBeInstanceOf(Temporal.PlainDate);
       expect((result as Temporal.PlainDate).toString()).toBe("2026-04-27");
     });

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -8,6 +8,9 @@ const TYPE_DATE = 10;
 const TYPE_TIME = 11;
 const TYPE_DATETIME = 12;
 const TYPE_NEWDATE = 14;
+const TYPE_TIMESTAMP2 = 17; // binary protocol variant for TIMESTAMP(N)
+const TYPE_DATETIME2 = 18; // binary protocol variant for DATETIME(N)
+const TYPE_TIME2 = 19; // binary protocol variant for TIME(N)
 const TYPE_VARCHAR = 253;
 
 function field(type: number, value: string | null) {
@@ -86,6 +89,23 @@ describe("temporalTypeCast", () => {
 
     it("returns null for NULL", () => {
       expect(temporalTypeCast(field(TYPE_TIME, null), next)).toBeNull();
+    });
+  });
+
+  describe("binary protocol variants (prepared statements)", () => {
+    it("TIMESTAMP2 (type 17) parses to Temporal.Instant", () => {
+      const result = temporalTypeCast(field(TYPE_TIMESTAMP2, "2026-04-27 14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.Instant);
+    });
+
+    it("DATETIME2 (type 18) parses to Temporal.PlainDateTime", () => {
+      const result = temporalTypeCast(field(TYPE_DATETIME2, "2026-04-27 14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    });
+
+    it("TIME2 (type 19) parses to Temporal.PlainTime", () => {
+      const result = temporalTypeCast(field(TYPE_TIME2, "14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainTime);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -28,6 +28,10 @@ describe("temporalTypeCast", () => {
       expect(temporalTypeCast(field("TIMESTAMP", null), next)).toBeNull();
     });
 
+    it("returns null for zero timestamp '0000-00-00 00:00:00'", () => {
+      expect(temporalTypeCast(field("TIMESTAMP", "0000-00-00 00:00:00"), next)).toBeNull();
+    });
+
     it("handles TIMESTAMP2 (binary protocol fractional variant)", () => {
       const result = temporalTypeCast(field("TIMESTAMP2", "2026-04-27 14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.Instant);

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { temporalTypeCast } from "./temporal-type-cast.js";
+
+// mysql2 field type IDs (mirrors the values in temporal-type-cast.ts)
+const TYPE_TIMESTAMP = 7;
+const TYPE_DATE = 10;
+const TYPE_TIME = 11;
+const TYPE_DATETIME = 12;
+const TYPE_NEWDATE = 14;
+const TYPE_VARCHAR = 253;
+
+function field(type: number, value: string | null) {
+  return { type, string: () => value };
+}
+const next = () => "next-called";
+
+describe("temporalTypeCast", () => {
+  describe("TIMESTAMP (type 7)", () => {
+    it("parses a UTC timestamp to Temporal.Instant", () => {
+      const result = temporalTypeCast(field(TYPE_TIMESTAMP, "2026-04-27 14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.Instant);
+      expect((result as Temporal.Instant).epochMilliseconds).toBe(
+        Temporal.Instant.from("2026-04-27T14:23:55.123456Z").epochMilliseconds,
+      );
+    });
+
+    it("preserves microsecond precision", () => {
+      const result = temporalTypeCast(field(TYPE_TIMESTAMP, "2026-01-01 00:00:00.000001"), next);
+      expect(result).toBeInstanceOf(Temporal.Instant);
+      expect((result as Temporal.Instant).epochNanoseconds % 1000000000n).toBe(1000n);
+    });
+
+    it("returns null for NULL", () => {
+      expect(temporalTypeCast(field(TYPE_TIMESTAMP, null), next)).toBeNull();
+    });
+  });
+
+  describe("DATETIME (type 12) / NEWDATE (type 14)", () => {
+    it("parses DATETIME to Temporal.PlainDateTime", () => {
+      const result = temporalTypeCast(field(TYPE_DATETIME, "2026-04-27 14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+      expect((result as Temporal.PlainDateTime).microsecond).toBe(123);
+    });
+
+    it("returns null for zero-date", () => {
+      expect(temporalTypeCast(field(TYPE_DATETIME, "0000-00-00 00:00:00"), next)).toBeNull();
+    });
+
+    it("handles NEWDATE type", () => {
+      const result = temporalTypeCast(field(TYPE_NEWDATE, "2026-04-27 00:00:00"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDateTime);
+    });
+
+    it("returns null for NULL", () => {
+      expect(temporalTypeCast(field(TYPE_DATETIME, null), next)).toBeNull();
+    });
+  });
+
+  describe("DATE (type 10)", () => {
+    it("parses DATE to Temporal.PlainDate", () => {
+      const result = temporalTypeCast(field(TYPE_DATE, "2026-04-27"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainDate);
+      expect((result as Temporal.PlainDate).toString()).toBe("2026-04-27");
+    });
+
+    it("returns null for zero-date", () => {
+      expect(temporalTypeCast(field(TYPE_DATE, "0000-00-00"), next)).toBeNull();
+    });
+
+    it("returns null for NULL", () => {
+      expect(temporalTypeCast(field(TYPE_DATE, null), next)).toBeNull();
+    });
+  });
+
+  describe("TIME (type 11)", () => {
+    it("parses TIME to Temporal.PlainTime", () => {
+      const result = temporalTypeCast(field(TYPE_TIME, "14:23:55.123456"), next);
+      expect(result).toBeInstanceOf(Temporal.PlainTime);
+      expect((result as Temporal.PlainTime).toString()).toBe("14:23:55.12345600");
+    });
+
+    it("returns null for NULL", () => {
+      expect(temporalTypeCast(field(TYPE_TIME, null), next)).toBeNull();
+    });
+  });
+
+  describe("non-temporal types", () => {
+    it("delegates to next() for VARCHAR", () => {
+      expect(temporalTypeCast(field(TYPE_VARCHAR, "hello"), next)).toBe("next-called");
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -40,7 +40,9 @@ describe("temporalTypeCast", () => {
     it("parses DATETIME to Temporal.PlainDateTime", () => {
       const result = temporalTypeCast(field(TYPE_DATETIME, "2026-04-27 14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.PlainDateTime);
-      expect((result as Temporal.PlainDateTime).microsecond).toBe(123);
+      // .123456 s → millisecond=123, microsecond=456 (sub-ms component)
+      expect((result as Temporal.PlainDateTime).millisecond).toBe(123);
+      expect((result as Temporal.PlainDateTime).microsecond).toBe(456);
     });
 
     it("returns null for zero-date", () => {
@@ -77,7 +79,9 @@ describe("temporalTypeCast", () => {
     it("parses TIME to Temporal.PlainTime", () => {
       const result = temporalTypeCast(field(TYPE_TIME, "14:23:55.123456"), next);
       expect(result).toBeInstanceOf(Temporal.PlainTime);
-      expect((result as Temporal.PlainTime).toString()).toBe("14:23:55.12345600");
+      const pt = result as Temporal.PlainTime;
+      expect(pt.millisecond).toBe(123);
+      expect(pt.microsecond).toBe(456);
     });
 
     it("returns null for NULL", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -3,9 +3,12 @@
  *
  * mysql2's default field decoder converts DATETIME/TIMESTAMP/DATE/TIME
  * columns into JS Date objects, losing microsecond precision. Passing
- * `{ dateStrings: true, typeCast }` to `mysql.createPool` makes the
- * driver emit raw strings for those field types, and this callback
- * converts them to the appropriate Temporal type.
+ * `{ typeCast }` to `mysql.createPool` intercepts those fields and
+ * returns the appropriate Temporal type instead.
+ *
+ * mysql2 exposes `field.type` as a string name (e.g. "TIMESTAMP"), not
+ * a numeric OID. The callback reads the raw wire string via `field.string()`
+ * and dispatches to the matching parser from temporal-wire.ts.
  *
  * Precondition: the connection's `@@session.time_zone` must be `'+00:00'`
  * (enforced via a post-connect `SET time_zone = '+00:00'`). Without this,
@@ -24,54 +27,38 @@ import {
   parseMysqlTime,
 } from "../abstract/temporal-wire.js";
 
-// mysql2 field type IDs for temporal columns.
-// Text protocol (COM_QUERY): 7/10/11/12/14.
-// Binary protocol (COM_STMT_EXECUTE / prepared statements): MySQL 5.6+
-// uses _V2 variants (17/18/19) for fractional-second columns.  Both sets
-// are handled so the callback works regardless of which protocol executes.
-const TYPE_TIMESTAMP = 7;
-const TYPE_DATE = 10;
-const TYPE_TIME = 11;
-const TYPE_DATETIME = 12;
-const TYPE_NEWDATE = 14;
-const TYPE_TIMESTAMP2 = 17; // TIMESTAMP(N) in binary protocol
-const TYPE_DATETIME2 = 18; // DATETIME(N) in binary protocol
-const TYPE_TIME2 = 19; // TIME(N) in binary protocol
-
-type Field = { type: number };
+type Field = { type: string; string: () => string | null };
 type NextFn = () => unknown;
 
 /**
- * mysql2 `typeCast` callback. Pass as `{ typeCast }` in pool/connection
- * options alongside `{ dateStrings: true }`.
+ * mysql2 `typeCast` callback. Pass as `{ typeCast }` in pool/connection options.
  *
  * Returns Temporal types for temporal fields; delegates all other fields
  * to the driver default via `next()`.
  */
 export function temporalTypeCast(field: Field, next: NextFn): unknown {
-  const str = (field as unknown as { string: () => string | null }).string;
   switch (field.type) {
-    case TYPE_TIMESTAMP:
-    case TYPE_TIMESTAMP2: {
-      const raw = str();
+    case "TIMESTAMP":
+    case "TIMESTAMP2": {
+      const raw = field.string();
       if (raw === null) return null;
       return parseMysqlInstant(raw);
     }
-    case TYPE_DATETIME:
-    case TYPE_DATETIME2:
-    case TYPE_NEWDATE: {
-      const raw = str();
+    case "DATETIME":
+    case "DATETIME2":
+    case "NEWDATE": {
+      const raw = field.string();
       if (raw === null) return null;
       return parseMysqlPlainDateTime(raw);
     }
-    case TYPE_DATE: {
-      const raw = str();
+    case "DATE": {
+      const raw = field.string();
       if (raw === null) return null;
       return parseMysqlDate(raw);
     }
-    case TYPE_TIME:
-    case TYPE_TIME2: {
-      const raw = str();
+    case "TIME":
+    case "TIME2": {
+      const raw = field.string();
       if (raw === null) return null;
       return parseMysqlTime(raw);
     }
@@ -82,14 +69,7 @@ export function temporalTypeCast(field: Field, next: NextFn): unknown {
 
 /**
  * mysql2 pool options to wire up Temporal parsing.
- * Spread into the pool config AFTER user options so typeCast is never
- * overridden by a caller's config key.
- *
- * `dateStrings` is intentionally NOT set here. In mysql2, `dateStrings: true`
- * short-circuits the custom `typeCast` callback for temporal field types —
- * mysql2 returns the string directly without invoking `typeCast`. Our callback
- * reads the wire string via `field.string()` regardless, so `dateStrings` is
- * not needed and would break temporal parsing.
+ * Spread into the pool config alongside other options.
  */
 export const TEMPORAL_POOL_OPTIONS: Pick<mysql.PoolOptions, "typeCast"> = {
   typeCast: temporalTypeCast as unknown as mysql.PoolOptions["typeCast"],

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-connection Temporal typeCast callback for the mysql2 driver.
+ *
+ * mysql2's default field decoder converts DATETIME/TIMESTAMP/DATE/TIME
+ * columns into JS Date objects, losing microsecond precision. Passing
+ * `{ dateStrings: true, typeCast }` to `mysql.createPool` makes the
+ * driver emit raw strings for those field types, and this callback
+ * converts them to the appropriate Temporal type.
+ *
+ * Precondition: the connection's `@@session.time_zone` must be `'+00:00'`
+ * (enforced via a post-connect `SET time_zone = '+00:00'`). Without this,
+ * TIMESTAMP strings are emitted in the server's session timezone and
+ * parseMysqlInstant would silently produce wrong instants.
+ *
+ * We deliberately do NOT call any global mysql2 type registration — that
+ * would mutate a process-wide registry shared with other mysql2 users.
+ */
+
+import mysql from "mysql2/promise";
+import {
+  parseMysqlInstant,
+  parseMysqlPlainDateTime,
+  parseMysqlDate,
+  parseMysqlTime,
+} from "../abstract/temporal-wire.js";
+
+// mysql2 field type IDs for temporal columns.
+const TYPE_TIMESTAMP = 7;
+const TYPE_DATE = 10;
+const TYPE_TIME = 11;
+const TYPE_DATETIME = 12;
+const TYPE_NEWDATE = 14;
+
+type Field = { type: number };
+type NextFn = () => unknown;
+
+/**
+ * mysql2 `typeCast` callback. Pass as `{ typeCast }` in pool/connection
+ * options alongside `{ dateStrings: true }`.
+ *
+ * Returns Temporal types for temporal fields; delegates all other fields
+ * to the driver default via `next()`.
+ */
+export function temporalTypeCast(field: Field, next: NextFn): unknown {
+  switch (field.type) {
+    case TYPE_TIMESTAMP: {
+      const raw = (field as unknown as { string: () => string | null }).string();
+      if (raw === null) return null;
+      return parseMysqlInstant(raw);
+    }
+    case TYPE_DATETIME:
+    case TYPE_NEWDATE: {
+      const raw = (field as unknown as { string: () => string | null }).string();
+      if (raw === null) return null;
+      return parseMysqlPlainDateTime(raw);
+    }
+    case TYPE_DATE: {
+      const raw = (field as unknown as { string: () => string | null }).string();
+      if (raw === null) return null;
+      return parseMysqlDate(raw);
+    }
+    case TYPE_TIME: {
+      const raw = (field as unknown as { string: () => string | null }).string();
+      if (raw === null) return null;
+      return parseMysqlTime(raw);
+    }
+    default:
+      return next();
+  }
+}
+
+/**
+ * mysql2 pool options to wire up Temporal parsing.
+ * Spread into the pool config alongside user options.
+ */
+export const TEMPORAL_POOL_OPTIONS: Pick<mysql.PoolOptions, "dateStrings" | "typeCast"> = {
+  dateStrings: true,
+  typeCast: temporalTypeCast as unknown as mysql.PoolOptions["typeCast"],
+};

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -6,17 +6,17 @@
  * `{ typeCast }` to `mysql.createPool` intercepts those fields and
  * returns the appropriate Temporal type instead.
  *
- * mysql2 exposes `field.type` as a string name (e.g. "TIMESTAMP"), not
- * a numeric OID. The callback reads the raw wire string via `field.string()`
- * and dispatches to the matching parser from temporal-wire.ts.
+ * In mysql2's typeCast callback, `field.type` is a string name (e.g.
+ * "TIMESTAMP") not a numeric OID. The callback reads the raw wire string
+ * via `field.string()` and dispatches to the matching parser.
  *
  * Precondition: the connection's `@@session.time_zone` must be `'+00:00'`
- * (enforced via a post-connect `SET time_zone = '+00:00'`). Without this,
- * TIMESTAMP strings are emitted in the server's session timezone and
- * parseMysqlInstant would silently produce wrong instants.
+ * (enforced via pool.on('connection') in Mysql2Adapter.newClient). Without
+ * this, TIMESTAMP strings arrive in the server's session timezone and
+ * parseMysqlInstant would produce wrong instants.
  *
- * We deliberately do NOT call any global mysql2 type registration — that
- * would mutate a process-wide registry shared with other mysql2 users.
+ * We do NOT call any global mysql2 type registration — that would mutate
+ * a process-wide registry shared with other mysql2 users in the process.
  */
 
 import mysql from "mysql2/promise";

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -45,13 +45,14 @@ export function temporalTypeCast(field: Field, next: NextFn): unknown {
       return parseMysqlInstant(raw);
     }
     case "DATETIME":
-    case "DATETIME2":
-    case "NEWDATE": {
+    case "DATETIME2": {
       const raw = field.string();
       if (raw === null) return null;
       return parseMysqlPlainDateTime(raw);
     }
-    case "DATE": {
+    case "DATE":
+    case "NEWDATE": {
+      // NEWDATE is the MySQL protocol's internal DATE-only wire type.
       const raw = field.string();
       if (raw === null) return null;
       return parseMysqlDate(raw);

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -85,12 +85,12 @@ export function temporalTypeCast(field: Field, next: NextFn): unknown {
  * Spread into the pool config AFTER user options so typeCast is never
  * overridden by a caller's config key.
  *
- * `dateStrings: true` is redundant when a custom typeCast is provided
- * (typeCast intercepts every field before mysql2's own Date parser runs),
- * but acts as a safety net if typeCast somehow doesn't handle a temporal
- * field — ensuring mysql2 falls back to a string rather than a Date object.
+ * `dateStrings` is intentionally NOT set here. In mysql2, `dateStrings: true`
+ * short-circuits the custom `typeCast` callback for temporal field types —
+ * mysql2 returns the string directly without invoking `typeCast`. Our callback
+ * reads the wire string via `field.string()` regardless, so `dateStrings` is
+ * not needed and would break temporal parsing.
  */
-export const TEMPORAL_POOL_OPTIONS: Pick<mysql.PoolOptions, "dateStrings" | "typeCast"> = {
-  dateStrings: true,
+export const TEMPORAL_POOL_OPTIONS: Pick<mysql.PoolOptions, "typeCast"> = {
   typeCast: temporalTypeCast as unknown as mysql.PoolOptions["typeCast"],
 };

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -25,11 +25,18 @@ import {
 } from "../abstract/temporal-wire.js";
 
 // mysql2 field type IDs for temporal columns.
+// Text protocol (COM_QUERY): 7/10/11/12/14.
+// Binary protocol (COM_STMT_EXECUTE / prepared statements): MySQL 5.6+
+// uses _V2 variants (17/18/19) for fractional-second columns.  Both sets
+// are handled so the callback works regardless of which protocol executes.
 const TYPE_TIMESTAMP = 7;
 const TYPE_DATE = 10;
 const TYPE_TIME = 11;
 const TYPE_DATETIME = 12;
 const TYPE_NEWDATE = 14;
+const TYPE_TIMESTAMP2 = 17; // TIMESTAMP(N) in binary protocol
+const TYPE_DATETIME2 = 18; // DATETIME(N) in binary protocol
+const TYPE_TIME2 = 19; // TIME(N) in binary protocol
 
 type Field = { type: number };
 type NextFn = () => unknown;
@@ -42,25 +49,29 @@ type NextFn = () => unknown;
  * to the driver default via `next()`.
  */
 export function temporalTypeCast(field: Field, next: NextFn): unknown {
+  const str = (field as unknown as { string: () => string | null }).string;
   switch (field.type) {
-    case TYPE_TIMESTAMP: {
-      const raw = (field as unknown as { string: () => string | null }).string();
+    case TYPE_TIMESTAMP:
+    case TYPE_TIMESTAMP2: {
+      const raw = str();
       if (raw === null) return null;
       return parseMysqlInstant(raw);
     }
     case TYPE_DATETIME:
+    case TYPE_DATETIME2:
     case TYPE_NEWDATE: {
-      const raw = (field as unknown as { string: () => string | null }).string();
+      const raw = str();
       if (raw === null) return null;
       return parseMysqlPlainDateTime(raw);
     }
     case TYPE_DATE: {
-      const raw = (field as unknown as { string: () => string | null }).string();
+      const raw = str();
       if (raw === null) return null;
       return parseMysqlDate(raw);
     }
-    case TYPE_TIME: {
-      const raw = (field as unknown as { string: () => string | null }).string();
+    case TYPE_TIME:
+    case TYPE_TIME2: {
+      const raw = str();
       if (raw === null) return null;
       return parseMysqlTime(raw);
     }
@@ -71,7 +82,13 @@ export function temporalTypeCast(field: Field, next: NextFn): unknown {
 
 /**
  * mysql2 pool options to wire up Temporal parsing.
- * Spread into the pool config alongside user options.
+ * Spread into the pool config AFTER user options so typeCast is never
+ * overridden by a caller's config key.
+ *
+ * `dateStrings: true` is redundant when a custom typeCast is provided
+ * (typeCast intercepts every field before mysql2's own Date parser runs),
+ * but acts as a safety net if typeCast somehow doesn't handle a temporal
+ * field — ensuring mysql2 falls back to a string rather than a Date object.
  */
 export const TEMPORAL_POOL_OPTIONS: Pick<mysql.PoolOptions, "dateStrings" | "typeCast"> = {
   dateStrings: true,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import mysql from "mysql2/promise";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { Base, transaction, registerModel, loadBelongsTo, loadHasMany } from "../index.js";
 
@@ -685,6 +686,83 @@ describeIfMysql("Mysql2Adapter", () => {
       const cols = await cache.columns(adapter, "widgets");
       expect(cols?.map((c) => c.name)).toEqual(["id", "name", "owner"]);
       expect(await cache.primaryKeys(adapter, "widgets")).toBe("id");
+    });
+  });
+
+  describe("Temporal type parsers", () => {
+    beforeEach(async () => {
+      await adapter.exec("DROP TABLE IF EXISTS `temporal_test`");
+      await adapter.exec(`
+        CREATE TABLE \`temporal_test\` (
+          \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+          \`ts\` TIMESTAMP(6) NULL,
+          \`dt\` DATETIME(6) NULL,
+          \`d\` DATE NULL,
+          \`t\` TIME(6) NULL
+        )
+      `);
+    });
+
+    afterEach(async () => {
+      await adapter.exec("DROP TABLE IF EXISTS `temporal_test`");
+    });
+
+    it("round-trips TIMESTAMP(6) with microsecond precision as Temporal.Instant", async () => {
+      await adapter.exec(
+        "INSERT INTO `temporal_test` (`ts`) VALUES ('2026-04-27 14:23:55.123456')",
+      );
+      const rows = await adapter.execute("SELECT `ts` FROM `temporal_test`");
+      expect(rows[0].ts).toBeInstanceOf(Temporal.Instant);
+      expect((rows[0].ts as Temporal.Instant).epochNanoseconds % 1000000000n).toBe(123456000n);
+    });
+
+    it("round-trips DATETIME(6) with microsecond precision as Temporal.PlainDateTime", async () => {
+      await adapter.exec(
+        "INSERT INTO `temporal_test` (`dt`) VALUES ('2026-04-27 14:23:55.123456')",
+      );
+      const rows = await adapter.execute("SELECT `dt` FROM `temporal_test`");
+      expect(rows[0].dt).toBeInstanceOf(Temporal.PlainDateTime);
+      const pdt = rows[0].dt as Temporal.PlainDateTime;
+      expect(pdt.microsecond).toBe(123);
+      expect(pdt.millisecond).toBe(456);
+    });
+
+    it("returns null for zero DATETIME '0000-00-00 00:00:00'", async () => {
+      // Requires sql_mode without NO_ZERO_DATE; skip quietly if server rejects it.
+      try {
+        await adapter.exec("INSERT INTO `temporal_test` (`dt`) VALUES ('0000-00-00 00:00:00')");
+      } catch {
+        return;
+      }
+      const rows = await adapter.execute("SELECT `dt` FROM `temporal_test`");
+      expect(rows[0].dt).toBeNull();
+    });
+
+    it("round-trips DATE as Temporal.PlainDate", async () => {
+      await adapter.exec("INSERT INTO `temporal_test` (`d`) VALUES ('2026-04-27')");
+      const rows = await adapter.execute("SELECT `d` FROM `temporal_test`");
+      expect(rows[0].d).toBeInstanceOf(Temporal.PlainDate);
+      expect((rows[0].d as Temporal.PlainDate).toString()).toBe("2026-04-27");
+    });
+
+    it("round-trips TIME(6) as Temporal.PlainTime", async () => {
+      await adapter.exec("INSERT INTO `temporal_test` (`t`) VALUES ('14:23:55.123456')");
+      const rows = await adapter.execute("SELECT `t` FROM `temporal_test`");
+      expect(rows[0].t).toBeInstanceOf(Temporal.PlainTime);
+      const pt = rows[0].t as Temporal.PlainTime;
+      expect(pt.hour).toBe(14);
+      expect(pt.second).toBe(55);
+    });
+
+    it("does not affect a sibling mysql2 connection (no global registry mutation)", async () => {
+      const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
+      try {
+        const [rows] = await conn.query<mysql.RowDataPacket[]>("SELECT NOW() AS now");
+        // A raw mysql2 connection with no dateStrings option returns Date objects.
+        expect(rows[0].now).toBeInstanceOf(Date);
+      } finally {
+        await conn.end();
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -723,8 +723,9 @@ describeIfMysql("Mysql2Adapter", () => {
       const rows = await adapter.execute("SELECT `dt` FROM `temporal_test`");
       expect(rows[0].dt).toBeInstanceOf(Temporal.PlainDateTime);
       const pdt = rows[0].dt as Temporal.PlainDateTime;
-      expect(pdt.microsecond).toBe(123);
-      expect(pdt.millisecond).toBe(456);
+      // .123456 s → millisecond=123, microsecond=456 (sub-ms component)
+      expect(pdt.millisecond).toBe(123);
+      expect(pdt.microsecond).toBe(456);
     });
 
     it("returns null for zero DATETIME '0000-00-00 00:00:00'", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -729,12 +729,11 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("returns null for zero DATETIME '0000-00-00 00:00:00'", async () => {
-      // Requires sql_mode without NO_ZERO_DATE; skip quietly if server rejects it.
-      try {
-        await adapter.exec("INSERT INTO `temporal_test` (`dt`) VALUES ('0000-00-00 00:00:00')");
-      } catch {
-        return;
-      }
+      // NO_ZERO_DATE in sql_mode rejects the insert. Check first and skip if set.
+      const modeRows = await adapter.execute("SELECT @@SESSION.sql_mode AS m");
+      const sqlMode = String(modeRows[0].m ?? "");
+      if (sqlMode.includes("NO_ZERO_DATE") || sqlMode.includes("TRADITIONAL")) return;
+      await adapter.exec("INSERT INTO `temporal_test` (`dt`) VALUES ('0000-00-00 00:00:00')");
       const rows = await adapter.execute("SELECT `dt` FROM `temporal_test`");
       expect(rows[0].dt).toBeNull();
     });
@@ -746,13 +745,15 @@ describeIfMysql("Mysql2Adapter", () => {
       expect((rows[0].d as Temporal.PlainDate).toString()).toBe("2026-04-27");
     });
 
-    it("round-trips TIME(6) as Temporal.PlainTime", async () => {
+    it("round-trips TIME(6) with microsecond precision as Temporal.PlainTime", async () => {
       await adapter.exec("INSERT INTO `temporal_test` (`t`) VALUES ('14:23:55.123456')");
       const rows = await adapter.execute("SELECT `t` FROM `temporal_test`");
       expect(rows[0].t).toBeInstanceOf(Temporal.PlainTime);
       const pt = rows[0].t as Temporal.PlainTime;
       expect(pt.hour).toBe(14);
       expect(pt.second).toBe(55);
+      expect(pt.millisecond).toBe(123);
+      expect(pt.microsecond).toBe(456);
     });
 
     it("does not affect a sibling mysql2 connection (no global registry mutation)", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1016,20 +1016,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const pool = mysql.createPool({ supportBigNumbers: true, ...config, ...TEMPORAL_POOL_OPTIONS });
     // Pin session timezone to UTC so TIMESTAMP wire strings are always in UTC,
     // allowing parseMysqlInstant to treat them as Temporal.Instant correctly.
-    // The 'connection' event fires on the underlying (non-promise) pool for
-    // each new physical connection before it enters the pool.
-    pool.pool.on(
-      "connection",
-      (conn: { query: (sql: string, cb: (err: Error | null) => void) => void }) => {
-        conn.query("SET time_zone = '+00:00'", (err) => {
-          if (err) {
-            // Non-fatal — log but don't crash the pool. TIMESTAMP columns will
-            // fall back to server-default timezone behavior if this fails.
-            console.warn("[trails] Failed to pin MySQL session time_zone to UTC:", err.message);
-          }
-        });
-      },
-    );
+    // mysql.Pool (promise wrapper) re-emits 'connection' from the underlying pool
+    // via inheritEvents — this is the public typed API on mysql.Pool, no internal
+    // property access needed. The callback receives the raw PoolConnection (non-
+    // promise) so we use the callback-style query directly.
+    pool.on("connection", (conn) => {
+      (conn as unknown as { query: (sql: string) => void }).query("SET time_zone = '+00:00'");
+    });
     return pool;
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -13,7 +13,7 @@ import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
-import { TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
+import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 
 /**
  * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
@@ -1011,9 +1011,22 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Note: the threshold is mysql2's internal digit count (≥15), not
     // Number.MAX_SAFE_INTEGER (2^53-1 ≈ 9×10^15, 16 digits). Callers may
     // override via explicit false in config.
-    // TEMPORAL_POOL_OPTIONS is spread LAST so user config cannot accidentally
-    // override our typeCast callback and silently break Temporal parsing.
-    const pool = mysql.createPool({ supportBigNumbers: true, ...config, ...TEMPORAL_POOL_OPTIONS });
+    // Compose our Temporal typeCast with any user-supplied typeCast so callers
+    // can still intercept non-temporal fields (e.g. custom ENUM handling) without
+    // losing Temporal parsing on temporal columns.
+    const userTypeCast = config.typeCast;
+    const composedTypeCast =
+      typeof userTypeCast === "function"
+        ? (field: unknown, next: () => unknown) =>
+            temporalTypeCast(field as Parameters<typeof temporalTypeCast>[0], () =>
+              (userTypeCast as (f: unknown, n: () => unknown) => unknown)(field, next),
+            )
+        : TEMPORAL_POOL_OPTIONS.typeCast;
+    const pool = mysql.createPool({
+      supportBigNumbers: true,
+      ...config,
+      typeCast: composedTypeCast,
+    });
     // Pin session timezone to UTC so TIMESTAMP wire strings are always in UTC,
     // allowing parseMysqlInstant to treat them as Temporal.Instant correctly.
     // mysql.Pool (promise wrapper) re-emits 'connection' from the underlying pool
@@ -1021,7 +1034,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // property access needed. The callback receives the raw PoolConnection (non-
     // promise) so we use the callback-style query directly.
     pool.on("connection", (conn) => {
-      (conn as unknown as { query: (sql: string) => void }).query("SET time_zone = '+00:00'");
+      const rawConn = conn as unknown as {
+        query: (sql: string, cb: (err: Error | null) => void) => void;
+        destroy: () => void;
+      };
+      rawConn.query("SET time_zone = '+00:00'", (err) => {
+        if (err) rawConn.destroy();
+      });
     });
     return pool;
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1039,7 +1039,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         destroy: () => void;
       };
       rawConn.query("SET time_zone = '+00:00'", (err) => {
-        if (err) rawConn.destroy();
+        if (err) {
+          rawConn.destroy();
+          pool.emit("error", err);
+        }
       });
     });
     return pool;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1011,14 +1011,25 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Note: the threshold is mysql2's internal digit count (≥15), not
     // Number.MAX_SAFE_INTEGER (2^53-1 ≈ 9×10^15, 16 digits). Callers may
     // override via explicit false in config.
-    const pool = mysql.createPool({ supportBigNumbers: true, ...TEMPORAL_POOL_OPTIONS, ...config });
+    // TEMPORAL_POOL_OPTIONS is spread LAST so user config cannot accidentally
+    // override our typeCast callback and silently break Temporal parsing.
+    const pool = mysql.createPool({ supportBigNumbers: true, ...config, ...TEMPORAL_POOL_OPTIONS });
     // Pin session timezone to UTC so TIMESTAMP wire strings are always in UTC,
     // allowing parseMysqlInstant to treat them as Temporal.Instant correctly.
     // The 'connection' event fires on the underlying (non-promise) pool for
     // each new physical connection before it enters the pool.
-    pool.pool.on("connection", (conn: { query: (sql: string) => void }) => {
-      conn.query("SET time_zone = '+00:00'");
-    });
+    pool.pool.on(
+      "connection",
+      (conn: { query: (sql: string, cb: (err: Error | null) => void) => void }) => {
+        conn.query("SET time_zone = '+00:00'", (err) => {
+          if (err) {
+            // Non-fatal — log but don't crash the pool. TIMESTAMP columns will
+            // fall back to server-default timezone behavior if this fails.
+            console.warn("[trails] Failed to pin MySQL session time_zone to UTC:", err.message);
+          }
+        });
+      },
+    );
     return pool;
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -13,6 +13,7 @@ import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import { typeCastedBinds } from "./abstract/database-statements.js";
+import { TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 
 /**
  * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
@@ -1010,6 +1011,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Note: the threshold is mysql2's internal digit count (≥15), not
     // Number.MAX_SAFE_INTEGER (2^53-1 ≈ 9×10^15, 16 digits). Callers may
     // override via explicit false in config.
-    return mysql.createPool({ supportBigNumbers: true, ...config });
+    const pool = mysql.createPool({ supportBigNumbers: true, ...TEMPORAL_POOL_OPTIONS, ...config });
+    // Pin session timezone to UTC so TIMESTAMP wire strings are always in UTC,
+    // allowing parseMysqlInstant to treat them as Temporal.Instant correctly.
+    // The 'connection' event fires on the underlying (non-promise) pool for
+    // each new physical connection before it enters the pool.
+    pool.pool.on("connection", (conn: { query: (sql: string) => void }) => {
+      conn.query("SET time_zone = '+00:00'");
+    });
+    return pool;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `mysql/temporal-type-cast.ts` — a `typeCast` callback for mysql2 that converts TIMESTAMP/DATETIME/DATE/TIME field types into the appropriate `Temporal.*` types instead of JS `Date` objects. Non-temporal field types delegate to `next()` unchanged. `field.type` in mysql2's typeCast is a string name (e.g. `"TIMESTAMP"`), not a numeric OID.
- Wires `typeCast` into `Mysql2Adapter.newClient`, composing with any user-supplied `config.typeCast` so callers can still intercept non-temporal fields without losing Temporal parsing.
- Pins `@@session.time_zone = '+00:00'` on every new physical pool connection via `pool.on('connection')` — the public typed EventEmitter API on mysql2's promise Pool, which re-emits the underlying pool's `connection` event. Connection is destroyed if the `SET` fails to prevent silent wrong-timezone instants.
- Does **not** call any global mysql2 type registration — scope is per-connection only.

## Test plan

- [ ] Unit tests in `mysql/temporal-type-cast.test.ts`: all temporal field types (TIMESTAMP/TIMESTAMP2, DATETIME/DATETIME2, DATE/NEWDATE, TIME/TIME2), NULL passthrough, zero-date → null, non-temporal delegation, NEWDATE as PlainDate
- [ ] Integration tests in `mysql2-adapter.test.ts`: microsecond round-trip for TIMESTAMP(6), DATETIME(6) (millisecond+microsecond), DATE, TIME(6); zero-date → null (with sql_mode probe); sibling raw `mysql2.createConnection` still returns `Date` objects (no global mutation)
- [ ] MariaDB Tests CI green
- [ ] MySQL Tests CI green
- [ ] DX Type Tests CI green