### PR TITLE
test(parity): AR gap fixtures ar-166/167/169/170/171 — ORDER BY overqualification, Range gaps, group(sql) crash

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -109,6 +109,6 @@
   },
   "ar-171": {
     "side": "trails-missing",
-    "reason": "group(Arel.sql(...)) crashes: group(sql('DATE(created_at)')) throws 'col.trim is not a function' because groupBang calls .trim() on every argument, assuming strings. Arel SqlLiteral (and NamedFunction, cf. ar-154) are not strings. Real fix: groupBang must handle Arel node arguments by calling .toSql() (or passing them to the Arel GROUP BY clause directly) instead of treating every argument as a string."
+    "reason": "group(Arel.sql(...)) crashes: group(sql('DATE(created_at)')) throws 'col.trim is not a function' because groupBang stores Arel values in _groupColumns and groupColumnToArel later calls .trim() on each entry, assuming strings. Arel SqlLiteral (and NamedFunction, cf. ar-154) are not strings. Real fix: group/groupBang must handle Arel node arguments by passing them through to the Arel GROUP BY clause (or converting them appropriately) instead of letting non-strings reach string-only processing in groupColumnToArel."
   }
 }

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -13,7 +13,7 @@
   },
   "ar-134": {
     "side": "trails-missing",
-    "reason": "joins() does not support nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; trails falls through to a toString() on the hash object, producing 'FROM \"authors\" [object Object]'. Root cause: Relation#joins does not handle object arguments — they fall through to _rawJoins and are stringified during SQL generation. Real fix: handle object/hash arguments in Relation#joins by resolving them through the association chain (via _resolveAssociationJoin and _applyJoinsToManager) before they fall through to raw joins."
+    "reason": "joins() crashes on nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; Trails accepts the object argument into _rawJoins and later attempts to use it as a join node during SQL generation, causing a runtime failure instead of producing a valid query. Root cause: Relation#joins does not handle object/hash arguments — they fall through to _rawJoins and fail when the SQL builder encounters a non-string join entry. Real fix: handle nested object/hash arguments in Relation#joins by resolving them through _resolveAssociationJoin and applying the resulting joins via _applyJoinsToManager."
   },
   "ar-137": {
     "side": "diff",

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -12,7 +12,7 @@
     "reason": "Same datetime-precision gap as ar-01/ar-52 (equality form): Order.where(created_at: Time.now) — rails truncates to whole seconds for the unprecisioned DATETIME column, trails keeps subsecond precision in both the bind and the inlined SQL. Flakes whenever the frozen-at is not on a whole second."
   },
   "ar-134": {
-    "side": "diff",
+    "side": "trails-missing",
     "reason": "joins() does not support nested hash arguments: Rails resolves joins({books: :reviews}) to two INNER JOINs via the association graph; trails falls through to a toString() on the hash object, producing 'FROM \"authors\" [object Object]'. Root cause: Relation#joins does not handle object arguments — they fall through to _rawJoins and are stringified during SQL generation. Real fix: handle object/hash arguments in Relation#joins by resolving them through the association chain (via _resolveAssociationJoin and _applyJoinsToManager) before they fall through to raw joins."
   },
   "ar-137": {
@@ -90,5 +90,25 @@
   "ar-165": {
     "side": "trails-missing",
     "reason": "Arel COUNT DISTINCT via Nodes.Count([col], true) not supported: throws 'Unknown node type: Count'. Pinning separately because the fix must also handle the distinct=true flag to emit COUNT(DISTINCT col). Real fix: visitCount must check the distinct flag and emit COUNT(DISTINCT ...) accordingly."
+  },
+  "ar-166": {
+    "side": "diff",
+    "reason": "ORDER BY SUM/aggregate alias over-qualified in group+having context: order('total DESC') produces ORDER BY \"books\".\"total\" DESC instead of ORDER BY total DESC. A SUM alias from a SELECT is not a real table column; same root cause as ar-161/162. Real fix: _applyOrderToManager must not qualify bare ORDER BY identifiers that are not resolvable as table columns."
+  },
+  "ar-167": {
+    "side": "diff",
+    "reason": "ORDER BY select alias over-qualified even when the alias is correctly listed in GROUP BY: order('avg_pages DESC') produces ORDER BY \"books\".\"avg_pages\" DESC instead of ORDER BY avg_pages DESC. GROUP BY correctly passes the comma-separated string through, but ORDER BY still qualifies the single-word alias. Same fix as ar-161/162/166."
+  },
+  "ar-169": {
+    "side": "diff",
+    "reason": "Arel Attribute#between with an exclusive-end Range emits BETWEEN instead of >= AND <: between(Range(100, 300, excludeEnd: true)) produces WHERE pages BETWEEN 100 AND 300 instead of WHERE pages >= 100 AND pages < 300. Rails' between uses the Range's exclude_end? flag to choose between BETWEEN (inclusive) and >= AND < (exclusive). Real fix: the between() predicate implementation must check the Range's exclude_end flag and emit >= AND < for exclusive ranges."
+  },
+  "ar-170": {
+    "side": "diff",
+    "reason": "Float values in Range lose decimal precision: where({ rating: new Range(3.5, 5.0) }) produces BETWEEN 3.5 AND 5 instead of BETWEEN 3.5 AND 5.0. JavaScript numbers don't distinguish 5 from 5.0, so the SQL literal omits the decimal. Rails serializes Ruby Float 5.0 as '5.0'. Real fix: the SQL value serializer must emit floats with at least one decimal digit (e.g. 5 → 5.0) to match Rails' Float#to_s behavior."
+  },
+  "ar-171": {
+    "side": "trails-missing",
+    "reason": "group(Arel.sql(...)) crashes: group(sql('DATE(created_at)')) throws 'col.trim is not a function' because groupBang calls .trim() on every argument, assuming strings. Arel SqlLiteral (and NamedFunction, cf. ar-154) are not strings. Real fix: groupBang must handle Arel node arguments by calling .toSql() (or passing them to the Arel GROUP BY clause directly) instead of treating every argument as a string."
   }
 }

--- a/scripts/parity/fixtures/ar-166/models.rb
+++ b/scripts/parity/fixtures/ar-166/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-166/models.ts
+++ b/scripts/parity/fixtures/ar-166/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-166/query.rb
+++ b/scripts/parity/fixtures/ar-166/query.rb
@@ -1,0 +1,1 @@
+Book.select("author_id, COUNT(*) AS cnt, SUM(pages) AS total").group("author_id").having("total > 500").order("total DESC")

--- a/scripts/parity/fixtures/ar-166/query.ts
+++ b/scripts/parity/fixtures/ar-166/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+export default Book.select("author_id, COUNT(*) AS cnt, SUM(pages) AS total")
+  .group("author_id")
+  .having("total > 500")
+  .order("total DESC");

--- a/scripts/parity/fixtures/ar-166/schema.sql
+++ b/scripts/parity/fixtures/ar-166/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-166
+-- Query: Book.select("author_id, COUNT(*) AS cnt, SUM(pages) AS total").group("author_id").having("total > 500").order("total DESC")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-167/models.rb
+++ b/scripts/parity/fixtures/ar-167/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-167/models.ts
+++ b/scripts/parity/fixtures/ar-167/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-167/query.rb
+++ b/scripts/parity/fixtures/ar-167/query.rb
@@ -1,0 +1,1 @@
+Book.select(Arel.sql("author_id, ROUND(AVG(pages), 0) AS avg_pages")).group("author_id, avg_pages").order("avg_pages DESC")

--- a/scripts/parity/fixtures/ar-167/query.ts
+++ b/scripts/parity/fixtures/ar-167/query.ts
@@ -1,0 +1,5 @@
+import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(sql("author_id, ROUND(AVG(pages), 0) AS avg_pages"))
+  .group("author_id, avg_pages")
+  .order("avg_pages DESC");

--- a/scripts/parity/fixtures/ar-167/schema.sql
+++ b/scripts/parity/fixtures/ar-167/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-167
+-- Query: Book.select(Arel.sql("author_id, ROUND(AVG(pages), 0) AS avg_pages")).group("author_id, avg_pages").order("avg_pages DESC")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-169/models.rb
+++ b/scripts/parity/fixtures/ar-169/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-169/models.ts
+++ b/scripts/parity/fixtures/ar-169/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-169/query.rb
+++ b/scripts/parity/fixtures/ar-169/query.rb
@@ -1,0 +1,1 @@
+Book.where(Book.arel_table[:pages].between(100...300)).order(:id)

--- a/scripts/parity/fixtures/ar-169/query.ts
+++ b/scripts/parity/fixtures/ar-169/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+import { Range } from "@blazetrails/activerecord";
+export default Book.where(Book.arelTable.get("pages").between(new Range(100, 300, true))).order({
+  id: "asc",
+});

--- a/scripts/parity/fixtures/ar-169/schema.sql
+++ b/scripts/parity/fixtures/ar-169/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-169
+-- Query: Book.where(Book.arel_table[:pages].between(100...300)).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-170/models.rb
+++ b/scripts/parity/fixtures/ar-170/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-170/models.ts
+++ b/scripts/parity/fixtures/ar-170/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-170/query.rb
+++ b/scripts/parity/fixtures/ar-170/query.rb
@@ -1,0 +1,1 @@
+Book.where(rating: 3.5..5.0).order(:id)

--- a/scripts/parity/fixtures/ar-170/query.ts
+++ b/scripts/parity/fixtures/ar-170/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+import { Range } from "@blazetrails/activerecord";
+export default Book.where({ rating: new Range(3.5, 5.0) }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-170/schema.sql
+++ b/scripts/parity/fixtures/ar-170/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-170
+-- Query: Book.where(rating: 3.5..5.0).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, rating REAL NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-171/models.rb
+++ b/scripts/parity/fixtures/ar-171/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-171/models.ts
+++ b/scripts/parity/fixtures/ar-171/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-171/query.rb
+++ b/scripts/parity/fixtures/ar-171/query.rb
@@ -1,0 +1,1 @@
+Book.group(Arel.sql("DATE(created_at)")).select(Arel.sql("DATE(created_at) AS pub_date"), Arel.sql("COUNT(*) AS cnt")).order(Arel.sql("pub_date"))

--- a/scripts/parity/fixtures/ar-171/query.ts
+++ b/scripts/parity/fixtures/ar-171/query.ts
@@ -1,0 +1,5 @@
+import { sql } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.group(sql("DATE(created_at)"))
+  .select(sql("DATE(created_at) AS pub_date"), sql("COUNT(*) AS cnt"))
+  .order(sql("pub_date"));

--- a/scripts/parity/fixtures/ar-171/schema.sql
+++ b/scripts/parity/fixtures/ar-171/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-171
+-- Query: Book.group(Arel.sql("DATE(created_at)")).select(Arel.sql("DATE(created_at) AS pub_date"), Arel.sql("COUNT(*) AS cnt")).order(Arel.sql("pub_date"))
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, created_at DATETIME);


### PR DESCRIPTION
## Summary

Adds 5 new gap fixtures and corrects ar-134's side classification.

| Fixture | Gap | Fix location |
|---------|-----|-------------|
| **ar-166** | `ORDER BY` SUM alias over-qualified in group+having context | `_applyOrderToManager` string-order path |
| **ar-167** | `ORDER BY` select alias over-qualified even when it's in `GROUP BY` | Same fix |
| **ar-169** | `between()` with exclusive-end Range emits `BETWEEN` instead of `>= AND <` | `between()` predicate must check `excludeEnd` flag |
| **ar-170** | Float in Range loses decimal: `5.0` → `5` | SQL value serializer needs `Float#to_s`-style formatting |
| **ar-171** | `group(sql(...))` crashes — `col.trim is not a function` | `groupBang` must handle Arel node arguments |

Also updates ar-134 `side` from `diff` → `trails-missing` (the query now crashes rather than producing wrong SQL).