### PR TITLE
test(parity): AR gap fixtures ar-172/173/174/176/178 — Arel node ordering + Float precision

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -110,5 +110,25 @@
   "ar-171": {
     "side": "trails-missing",
     "reason": "group(Arel.sql(...)) crashes: group(sql('DATE(created_at)')) throws 'col.trim is not a function' because groupBang stores Arel values in _groupColumns and groupColumnToArel later calls .trim() on each entry, assuming strings. Arel SqlLiteral (and NamedFunction, cf. ar-154) are not strings. Real fix: group/groupBang must handle Arel node arguments by passing them through to the Arel GROUP BY clause (or converting them appropriately) instead of letting non-strings reach string-only processing in groupColumnToArel."
+  },
+  "ar-172": {
+    "side": "trails-missing",
+    "reason": "Arel ordering methods (.asc()/.desc()) are missing from non-Attribute node types: NamedFunction.new('LENGTH', [col]).desc throws '(intermediate value).desc is not a function'. Rails' Arel nodes include OrderPredications which adds asc/desc to all nodes; Trails only implements these on Attribute. Real fix: add asc() and desc() to the Arel Node base class (or to non-Attribute ordering node types like NamedFunction, Extract, etc.)."
+  },
+  "ar-173": {
+    "side": "diff",
+    "reason": "Float values that are whole numbers lose their decimal in IN clauses: where({ rating: [3.5, 4.0, 4.5] }) produces IN (3.5, 4, 4.5) instead of IN (3.5, 4.0, 4.5). JavaScript's 4.0 === 4 causes the decimal to be dropped when serializing to SQL. Rails serializes Ruby Float 4.0 as '4.0'. Same root as ar-170/174/176. Real fix: the SQL value serializer must format whole-number floats with a decimal point."
+  },
+  "ar-174": {
+    "side": "diff",
+    "reason": "Float values that are whole numbers lose their decimal in exclusive-Range predicates: where({ rating: new Range(3.0, 5.0, true) }) produces >= 3 AND < 5 instead of >= 3.0 AND < 5.0. Same JavaScript serialization root as ar-170/173/176. Real fix: the SQL value serializer must format whole-number floats with a decimal point."
+  },
+  "ar-176": {
+    "side": "diff",
+    "reason": "Float equality predicate loses decimal for whole-number floats: where({ rating: 4.0 }) produces = 4 instead of = 4.0. JavaScript does not distinguish 4 from 4.0, so the SQL literal omits the decimal. Rails serializes Ruby Float 4.0 as '4.0'. Same root as ar-173/174/170. Real fix: the SQL value serializer must emit floats with at least one decimal digit."
+  },
+  "ar-178": {
+    "side": "trails-missing",
+    "reason": "Arel ordering methods (.desc()) are missing from Extract nodes: Nodes.Extract.new(col, 'year').desc() throws '(intermediate value).desc is not a function'. Same root as ar-172 — Rails adds asc/desc to all Arel nodes via OrderPredications but Trails only has them on Attribute. Real fix: add asc() and desc() to the Arel Node base class."
   }
 }

--- a/scripts/parity/fixtures/ar-172/models.rb
+++ b/scripts/parity/fixtures/ar-172/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-172/models.ts
+++ b/scripts/parity/fixtures/ar-172/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-172/query.rb
+++ b/scripts/parity/fixtures/ar-172/query.rb
@@ -1,0 +1,1 @@
+Book.order(Arel::Nodes::NamedFunction.new("LENGTH", [Book.arel_table[:title]]).desc).limit(5)

--- a/scripts/parity/fixtures/ar-172/query.ts
+++ b/scripts/parity/fixtures/ar-172/query.ts
@@ -1,0 +1,5 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.order(
+  new Nodes.NamedFunction("LENGTH", [Book.arelTable.get("title")]).desc(),
+).limit(5);

--- a/scripts/parity/fixtures/ar-172/schema.sql
+++ b/scripts/parity/fixtures/ar-172/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-172
+-- Query: Book.order(Arel::Nodes::NamedFunction.new("LENGTH", [Book.arel_table[:title]]).desc).limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-173/models.rb
+++ b/scripts/parity/fixtures/ar-173/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-173/models.ts
+++ b/scripts/parity/fixtures/ar-173/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-173/query.rb
+++ b/scripts/parity/fixtures/ar-173/query.rb
@@ -1,0 +1,1 @@
+Book.where(rating: [3.5, 4.0, 4.5]).order(:id)

--- a/scripts/parity/fixtures/ar-173/query.ts
+++ b/scripts/parity/fixtures/ar-173/query.ts
@@ -1,0 +1,2 @@
+import { Book } from "./models.js";
+export default Book.where({ rating: [3.5, 4.0, 4.5] }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-173/schema.sql
+++ b/scripts/parity/fixtures/ar-173/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-173
+-- Query: Book.where(rating: [3.5, 4.0, 4.5]).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, rating REAL NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-174/models.rb
+++ b/scripts/parity/fixtures/ar-174/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-174/models.ts
+++ b/scripts/parity/fixtures/ar-174/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-174/query.rb
+++ b/scripts/parity/fixtures/ar-174/query.rb
@@ -1,0 +1,1 @@
+Book.where(rating: 3.0...5.0).order(:id)

--- a/scripts/parity/fixtures/ar-174/query.ts
+++ b/scripts/parity/fixtures/ar-174/query.ts
@@ -1,0 +1,3 @@
+import { Book } from "./models.js";
+import { Range } from "@blazetrails/activerecord";
+export default Book.where({ rating: new Range(3.0, 5.0, true) }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-174/schema.sql
+++ b/scripts/parity/fixtures/ar-174/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-174
+-- Query: Book.where(rating: 3.0...5.0).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, rating REAL NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-176/models.rb
+++ b/scripts/parity/fixtures/ar-176/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-176/models.ts
+++ b/scripts/parity/fixtures/ar-176/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-176/query.rb
+++ b/scripts/parity/fixtures/ar-176/query.rb
@@ -1,0 +1,1 @@
+Book.where(rating: 4.0).order(:id)

--- a/scripts/parity/fixtures/ar-176/query.ts
+++ b/scripts/parity/fixtures/ar-176/query.ts
@@ -1,0 +1,2 @@
+import { Book } from "./models.js";
+export default Book.where({ rating: 4.0 }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-176/schema.sql
+++ b/scripts/parity/fixtures/ar-176/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-176
+-- Query: Book.where(rating: 4.0).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, rating REAL NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-178/models.rb
+++ b/scripts/parity/fixtures/ar-178/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-178/models.ts
+++ b/scripts/parity/fixtures/ar-178/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-178/query.rb
+++ b/scripts/parity/fixtures/ar-178/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:id], Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").as("yr")).order(Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").desc).limit(5)

--- a/scripts/parity/fixtures/ar-178/query.ts
+++ b/scripts/parity/fixtures/ar-178/query.ts
@@ -1,0 +1,8 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.select(
+  Book.arelTable.get("id"),
+  new Nodes.Extract(Book.arelTable.get("created_at"), "year").as("yr"),
+)
+  .order(new Nodes.Extract(Book.arelTable.get("created_at"), "year").desc())
+  .limit(5);

--- a/scripts/parity/fixtures/ar-178/schema.sql
+++ b/scripts/parity/fixtures/ar-178/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-178
+-- Query: Book.select(Book.arel_table[:id], Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").as("yr")).order(Arel::Nodes::Extract.new(Book.arel_table[:created_at], "year").desc).limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, created_at DATETIME);


### PR DESCRIPTION
## Summary

Two gap families, 5 fixtures total:

**Arel node ordering methods missing (.asc()/.desc() not on non-Attribute nodes)**
| Fixture | Node type | Error |
|---------|-----------|-------|
| **ar-172** | `NamedFunction` | `.desc()` is not a function |
| **ar-178** | `Extract` | `.desc()` is not a function |

Root cause: Rails adds `asc`/`desc` to all nodes via `OrderPredications`; Trails only implements these on `Attribute`. Fix: add `asc()`/`desc()` to the Arel `Node` base class.

**Float whole-number values serialized without decimal point**
| Fixture | Context | Rails | Trails |
|---------|---------|-------|--------|
| **ar-176** | Equality | `= 4.0` | `= 4` |
| **ar-173** | Array IN | `IN (3.5, 4.0, 4.5)` | `IN (3.5, 4, 4.5)` |
| **ar-174** | Exclusive range | `>= 3.0 AND < 5.0` | `>= 3 AND < 5` |

Root cause: JavaScript's `4.0 === 4` — the decimal is dropped during SQL value serialization.

## Test plan
- [ ] `pnpm parity:query` — all 5 KNOWN-GAP, no FAIL