### PR TITLE
docs(claude): 300 LOC PR size ceiling + splitting heuristic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,19 @@ When NOT to use this:
   Code" lines to PR descriptions.
 - Tests live next to source files as `*.test.ts`.
 - Prefer small, focused modules.
+- **PR size ceiling: 300 LOC** (additions + deletions, excluding lockfiles,
+  snapshots, and generated parity fixtures). Check before opening with
+  `git diff --shortstat origin/main...HEAD -- ':!**/pnpm-lock.yaml' ':!**/__snapshots__/**'`.
+  Tests and fixtures count. The historical 20-method rule is a soft guide;
+  300 LOC is the hard one — review-cycle data shows PRs ≥400 LOC need 4–6
+  rounds minimum and ≥700 LOC need 13+. If a feature is larger, split via the
+  `<base>` / `<base>b` / `<base>c` pattern before opening. Splitting
+  heuristic, in order:
+  (1) impl + smoke test in `<base>`, full Rails-mirrored tests in `<base>b`;
+  (2) public surface first, privates follow; (3) one Rails source file per
+  PR when multiple are touched; (4) happy path vs edges only as a last
+  resort. The only exception is a single mechanical rename — note it in the
+  PR body.
 - Do NOT use subagents unless explicitly requested.
 - Do use worktrees for any changes; leave the default worktree for the user.
 - Open new PRs in **draft** status.


### PR DESCRIPTION
## Summary
- Adds a hard 300 LOC ceiling for PRs to `CLAUDE.md` Conventions, with the exact `git diff` command to verify before opening.
- Encodes the `<base>` / `<base>b` / `<base>c` splitting heuristic in priority order so it stops being tribal knowledge.
- Keeps the existing 20-method rule as a soft guide; 300 LOC is the hard one.

## Why
Review-cycle data across recent merged PRs:

| Cycles | PRs | avg LOC | avg comments |
|---|---|---|---|
| 0–1 | 31 | 211 | 0.3 |
| 2–3 | 48 | 256 | 3.6 |
| 4–6 | 43 | 395 | 10.5 |
| 7–12 | 32 | 441 | 18.1 |
| 13+ | 10 | 687 | 40.4 |

LOC is the dominant predictor of review thrash. The 20-method rule lets PRs balloon via fixtures/tests; capping LOC directly closes the loop.

## Test plan
- [ ] No code change — docs only.