### PR TITLE
test(parity): AR gap fixtures ar-179/180/182/183/184 — float zero, ORDER BY aliases, union in IN, Case then()

### DIFF
--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -130,5 +130,25 @@
   "ar-178": {
     "side": "trails-missing",
     "reason": "Arel ordering methods (.desc()) are missing from Extract nodes: Nodes.Extract.new(col, 'year').desc() throws '(intermediate value).desc is not a function'. Same root as ar-172 — Rails adds asc/desc to all Arel nodes via OrderPredications but Trails only has them on Attribute. Real fix: add asc() and desc() to the Arel Node base class."
+  },
+  "ar-179": {
+    "side": "diff",
+    "reason": "Float 0.0 loses its decimal point: where({ rating: 0.0 }) produces = 0 instead of = 0.0. JavaScript 0.0 === 0 so the decimal is dropped during SQL serialization. Rails serializes Ruby Float 0.0 as '0.0'. Same root as ar-173/174/176 — Real fix: SQL value serializer must emit floats with at least one decimal digit."
+  },
+  "ar-180": {
+    "side": "diff",
+    "reason": "ORDER BY Arel attribute alias over-qualified: select(col.as('p')).order('p DESC') produces ORDER BY \"books\".\"p\" DESC instead of ORDER BY p DESC. Single-char alias 'p' matches the bare-identifier regex and gets table-qualified. Same root as ar-161/162/166/167. Real fix: _applyOrderToManager must not qualify identifiers that are SELECT aliases rather than real table columns."
+  },
+  "ar-182": {
+    "side": "trails-missing",
+    "reason": "Arel Attribute#in() does not accept a Union node: where(col.in(union_node)) throws 'values.map is not a function' because the in() predicate method calls .map() on its argument, assuming an array or SelectManager, not an Arel Union node. Rails accepts any Arel::Node in not_in/in and passes it to the Arel visitor. Real fix: the in()/notIn() predicate implementation must handle Arel node arguments (Union, Intersect, etc.) by passing them through to the visitor instead of calling .map()."
+  },
+  "ar-183": {
+    "side": "trails-missing",
+    "reason": "Arel Case node fluent builder with integer .then() args: Case.new(col).when('active').then(1) throws '(intermediate value).when(...).then is not a function'. Same root as ar-155 — Case builder lacks then(). This fixture pins that the gap also manifests when .then() receives integer literals rather than string values. Real fix: same as ar-155 — add then() to the Case node builder."
+  },
+  "ar-184": {
+    "side": "diff",
+    "reason": "ORDER BY single-char aggregate alias over-qualified: order('n DESC') produces ORDER BY \"books\".\"n\" DESC instead of ORDER BY n DESC. Short alias 'n' is a bare identifier that _applyOrderToManager qualifies with the model's table name. Same root as ar-161/162/166/167/180. Confirms the fix must apply to all bare identifiers in ORDER BY string clauses, not just multi-character ones."
   }
 }

--- a/scripts/parity/fixtures/ar-179/models.rb
+++ b/scripts/parity/fixtures/ar-179/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-179/models.ts
+++ b/scripts/parity/fixtures/ar-179/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-179/query.rb
+++ b/scripts/parity/fixtures/ar-179/query.rb
@@ -1,0 +1,1 @@
+Book.where(rating: 0.0).order(:id)

--- a/scripts/parity/fixtures/ar-179/query.ts
+++ b/scripts/parity/fixtures/ar-179/query.ts
@@ -1,0 +1,2 @@
+import { Book } from "./models.js";
+export default Book.where({ rating: 0.0 }).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-179/schema.sql
+++ b/scripts/parity/fixtures/ar-179/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-179
+-- Query: Book.where(rating: 0.0).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, rating REAL NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-180/models.rb
+++ b/scripts/parity/fixtures/ar-180/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-180/models.ts
+++ b/scripts/parity/fixtures/ar-180/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-180/query.rb
+++ b/scripts/parity/fixtures/ar-180/query.rb
@@ -1,0 +1,1 @@
+Book.select(Book.arel_table[:pages].as("p"), Book.arel_table[:author_id]).where(Book.arel_table[:pages].gt(0)).order("p DESC").limit(5)

--- a/scripts/parity/fixtures/ar-180/query.ts
+++ b/scripts/parity/fixtures/ar-180/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+export default Book.select(Book.arelTable.get("pages").as("p"), Book.arelTable.get("author_id"))
+  .where(Book.arelTable.get("pages").gt(0))
+  .order("p DESC")
+  .limit(5);

--- a/scripts/parity/fixtures/ar-180/schema.sql
+++ b/scripts/parity/fixtures/ar-180/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-180
+-- Query: Book.select(Book.arel_table[:pages].as("p"), Book.arel_table[:author_id]).where(Book.arel_table[:pages].gt(0)).order("p DESC").limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER, pages INTEGER NOT NULL DEFAULT 0);

--- a/scripts/parity/fixtures/ar-182/models.rb
+++ b/scripts/parity/fixtures/ar-182/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-182/models.ts
+++ b/scripts/parity/fixtures/ar-182/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-182/query.rb
+++ b/scripts/parity/fixtures/ar-182/query.rb
@@ -1,0 +1,2 @@
+ids = Book.where(status: "active").select(:id).arel.union(Book.where(status: "featured").select(:id).arel)
+Book.where(Book.arel_table[:id].in(ids)).order(:id)

--- a/scripts/parity/fixtures/ar-182/query.ts
+++ b/scripts/parity/fixtures/ar-182/query.ts
@@ -1,0 +1,6 @@
+import { Book } from "./models.js";
+const ids = Book.where({ status: "active" })
+  .select("id")
+  .toArel()
+  .union(Book.where({ status: "featured" }).select("id").toArel());
+export default Book.where(Book.arelTable.get("id").in(ids)).order({ id: "asc" });

--- a/scripts/parity/fixtures/ar-182/schema.sql
+++ b/scripts/parity/fixtures/ar-182/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-182
+-- Query: ids = Book.where(status: "active").select(:id).arel.union(Book.where(status: "featured").select(:id).arel); Book.where(Book.arel_table[:id].in(ids)).order(:id)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-183/models.rb
+++ b/scripts/parity/fixtures/ar-183/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-183/models.ts
+++ b/scripts/parity/fixtures/ar-183/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-183/query.rb
+++ b/scripts/parity/fixtures/ar-183/query.rb
@@ -1,0 +1,1 @@
+Book.order(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then(1).when("featured").then(2).else(3), Book.arel_table[:id]).limit(5)

--- a/scripts/parity/fixtures/ar-183/query.ts
+++ b/scripts/parity/fixtures/ar-183/query.ts
@@ -1,0 +1,11 @@
+import { Nodes } from "@blazetrails/arel";
+import { Book } from "./models.js";
+export default Book.order(
+  new Nodes.Case(Book.arelTable.get("status"))
+    .when("active")
+    .then(1)
+    .when("featured")
+    .then(2)
+    .else(3),
+  Book.arelTable.get("id"),
+).limit(5);

--- a/scripts/parity/fixtures/ar-183/schema.sql
+++ b/scripts/parity/fixtures/ar-183/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-183
+-- Query: Book.order(Arel::Nodes::Case.new(Book.arel_table[:status]).when("active").then(1).when("featured").then(2).else(3), Book.arel_table[:id]).limit(5)
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, status TEXT NOT NULL);

--- a/scripts/parity/fixtures/ar-184/models.rb
+++ b/scripts/parity/fixtures/ar-184/models.rb
@@ -1,0 +1,1 @@
+class Book < ActiveRecord::Base; end

--- a/scripts/parity/fixtures/ar-184/models.ts
+++ b/scripts/parity/fixtures/ar-184/models.ts
@@ -1,0 +1,7 @@
+import { Base, registerModel } from "@blazetrails/activerecord";
+export class Book extends Base {
+  static {
+    this.tableName = "books";
+    registerModel(this);
+  }
+}

--- a/scripts/parity/fixtures/ar-184/query.rb
+++ b/scripts/parity/fixtures/ar-184/query.rb
@@ -1,0 +1,1 @@
+Book.select("author_id, COUNT(*) AS n").group("author_id").having("n > 2").order("n DESC")

--- a/scripts/parity/fixtures/ar-184/query.ts
+++ b/scripts/parity/fixtures/ar-184/query.ts
@@ -1,0 +1,5 @@
+import { Book } from "./models.js";
+export default Book.select("author_id, COUNT(*) AS n")
+  .group("author_id")
+  .having("n > 2")
+  .order("n DESC");

--- a/scripts/parity/fixtures/ar-184/schema.sql
+++ b/scripts/parity/fixtures/ar-184/schema.sql
@@ -1,0 +1,4 @@
+-- Fixture for statement: ar-184
+-- Query: Book.select("author_id, COUNT(*) AS n").group("author_id").having("n > 2").order("n DESC")
+
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);


### PR DESCRIPTION
## Summary

Five more gap fixtures across four gap families:

| Fixture | Gap | New? |
|---------|-----|------|
| **ar-179** | Float `0.0` → `0` (zero edge case) | Same family as ar-173/174/176 |
| **ar-180** | `ORDER BY` Arel attribute alias over-qualified: `col.as('p')` then `order('p DESC')` → `"books"."p" DESC` | Same family as ar-161/162/166/167/184 |
| **ar-182** | `Attribute#in(union_node)` crashes — `values.map is not a function` | **New**: `in()`/`notIn()` can't accept Union/Intersect nodes |
| **ar-183** | `Case.when().then(integer)` crashes — same as ar-155 but pins integer `.then()` args | Same root as ar-155 |
| **ar-184** | `ORDER BY 'n DESC'` → `"books"."n" DESC` — single-char alias still over-qualified | Same family as ar-161 family |

## Test plan
- [ ] `pnpm parity:query` — all 5 KNOWN-GAP, no FAIL