### PR TITLE
feat(activerecord): implement left_outer_joins_values

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -321,6 +321,37 @@ describe("RelationTest", () => {
     expect(rel.toSql()).toMatch(/LEFT OUTER JOIN/i);
   });
 
+  it("eagerLoad + leftJoins: buildJoinBuckets short-circuit does not drop eager stash", () => {
+    // Regression: when _joinValues and _joinClauses are empty, buildJoinBuckets
+    // short-circuits for the left-outer-only path. If _eagerLoadAssociations is
+    // also present, the short-circuit must not fire — eager stash would be skipped.
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("EagerLeftAuthor", Author);
+    registerModel("EagerLeftPost", Post);
+    Associations.hasMany.call(Author, "posts", {
+      className: "EagerLeftPost",
+      foreignKey: "author_id",
+    });
+    // Both eagerLoad and leftJoins present, no explicit _joinValues/_joinClauses
+    const rel = Author.leftJoins("posts").eagerLoad("posts");
+    expect((rel as any)._eagerLoadAssociations).toContain("posts");
+    expect((rel as any)._leftOuterJoinsValues).toContain("posts");
+    // buildJoinBuckets must not short-circuit; SQL must be non-empty (no throw)
+    expect(() => rel.toSql()).not.toThrow();
+  });
+
   it("joins() preserves Arel node type — InnerJoin stays InnerJoin in _joinValues, not StringJoin", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -292,6 +292,35 @@ describe("RelationTest", () => {
     expect(sql).toContain('"books"."author_id"');
   });
 
+  it("leftJoins(:assoc) stores in _leftOuterJoinsValues and generates LEFT OUTER JOIN", () => {
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("LeftJoinAuthor2", Author);
+    registerModel("LeftJoinPost2", Post);
+    Associations.hasMany.call(Author, "posts", {
+      className: "LeftJoinPost2",
+      foreignKey: "author_id",
+    });
+
+    const rel = Author.leftJoins("posts");
+    // Association name stored in _leftOuterJoinsValues, not pre-resolved to _joinClauses
+    expect((rel as any)._leftOuterJoinsValues).toContain("posts");
+    expect((rel as any)._joinClauses.some((j: any) => j.table === "posts")).toBe(false);
+    // SQL still contains LEFT OUTER JOIN
+    expect(rel.toSql()).toMatch(/LEFT OUTER JOIN/i);
+  });
+
   it("joins() preserves Arel node type — InnerJoin stays InnerJoin in _joinValues, not StringJoin", () => {
     class Book extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -321,6 +321,38 @@ describe("RelationTest", () => {
     expect(rel.toSql()).toMatch(/LEFT OUTER JOIN/i);
   });
 
+  it("includes().references() + leftJoins(): no duplicate LEFT OUTER JOIN in SQL", () => {
+    // Regression: includes promoted to eager load via references() causes
+    // _buildEagerJoinManager to emit the LEFT OUTER JOIN. The pendingLeftOuter
+    // filter must exclude promoted includes so leftJoins(:assoc) doesn't emit
+    // a second JOIN for the same association.
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("RefLeftAuthor", Author);
+    registerModel("RefLeftPost", Post);
+    Associations.hasMany.call(Author, "posts", {
+      className: "RefLeftPost",
+      foreignKey: "author_id",
+    });
+
+    const rel = Author.all().includes("posts").references("posts").leftJoins("posts");
+    const sqlStr = rel.toSql();
+    // "posts" table should appear only once in LEFT OUTER JOIN clauses
+    const leftJoinMatches = sqlStr.match(/LEFT OUTER JOIN/gi) ?? [];
+    expect(leftJoinMatches.length).toBe(1);
+  });
+
   it("eagerLoad + leftJoins: buildJoinBuckets short-circuit does not drop eager stash", () => {
     // Regression: when _joinValues and _joinClauses are empty, buildJoinBuckets
     // short-circuits for the left-outer-only path. If _eagerLoadAssociations is

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1934,8 +1934,16 @@ export class Relation<T extends Base> {
     // other joins → join.left.name. Mirror that: strings become StringJoin and we
     // extract via tablesInString; Arel nodes expose their table via left.name when
     // available (InnerJoin/OuterJoin/LeadingJoin all have left: Table).
+    // _leftOuterJoinsValues holds association names (not table names). Rails
+    // build_joins([]) processes left_outer_joins_values and includes their tables
+    // in references_eager_loaded_tables?. We approximate by using the association
+    // name as the table name (matches standard Rails pluralized naming).
+    const leftOuterTables = this._leftOuterJoinsValues
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.toLowerCase());
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
+      ...leftOuterTables,
       ...this._joinValues.flatMap((v) => {
         if (typeof v === "string") {
           const join = new Nodes.StringJoin(new Nodes.SqlLiteral(v));
@@ -2363,9 +2371,12 @@ export class Relation<T extends Base> {
     // Process left_outer_joins_values: resolve via JoinDependency and emit as
     // StringJoin nodes (mirrors Rails build_join_buckets stashed_left_joins path).
     if (this._leftOuterJoinsValues.length > 0) {
-      const jd = (this as any).constructJoinDependency(this._leftOuterJoinsValues, Nodes.OuterJoin);
-      const constraints = (jd as any).joinConstraints([]);
-      for (const node of constraints) manager.appendJoinNode(node);
+      const jd = QueryMethodBangs.constructJoinDependency.call(
+        this as any,
+        this._leftOuterJoinsValues,
+        Nodes.OuterJoin,
+      );
+      for (const node of jd.joinConstraints([])) manager.appendJoinNode(node);
     }
     for (const node of joinNodes) manager.appendJoinNode(node);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -110,12 +110,12 @@ function _addAssocJoin(
   join: { table: string; on: string },
   assocName: string,
   modelClass: any,
-  leftOuterJoinsValues?: string[],
+  leftOuterJoinsValues?: ReadonlyArray<unknown>,
 ): void {
   // If the association is already covered by _leftOuterJoinsValues (deferred
   // LEFT OUTER JOIN path), skip — the join will be emitted when the manager
   // is built, so adding a second join here would cause ambiguous column names.
-  if (leftOuterJoinsValues?.includes(assocName)) return;
+  if (leftOuterJoinsValues?.some((v) => typeof v === "string" && v === assocName)) return;
   const sameTableJoins = clauses.filter((j) => j.table === join.table);
   if (sameTableJoins.length > 0) {
     if (sameTableJoins.every((j) => j.on === join.on)) return; // all compatible — skip
@@ -391,7 +391,7 @@ export class Relation<T extends Base> {
           join,
           assocName,
           rel._modelClass as any,
-          cloned._leftOuterJoinsValues as string[],
+          cloned._leftOuterJoinsValues,
         );
       }
       const tgtTable = new Table(target.table);
@@ -429,7 +429,7 @@ export class Relation<T extends Base> {
           join,
           assocName,
           rel._modelClass as any,
-          cloned._leftOuterJoinsValues as string[],
+          cloned._leftOuterJoinsValues,
         );
       }
       const tgtTable = new Table(target.table);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1935,12 +1935,17 @@ export class Relation<T extends Base> {
     // extract via tablesInString; Arel nodes expose their table via left.name when
     // available (InnerJoin/OuterJoin/LeadingJoin all have left: Table).
     // _leftOuterJoinsValues holds association names (not table names). Rails
-    // build_joins([]) processes left_outer_joins_values and includes their tables
-    // in references_eager_loaded_tables?. We approximate by using the association
-    // name as the table name (matches standard Rails pluralized naming).
+    // build_joins([]) processes left_outer_joins_values and extracts table names
+    // from the resulting join nodes. We resolve via _resolveAssociationJoin to
+    // get the actual table name (handles camelCase → snake_case mappings).
     const leftOuterTables = this._leftOuterJoinsValues
       .filter((v): v is string => typeof v === "string")
-      .map((v) => v.toLowerCase());
+      .flatMap((v) => {
+        const resolved = this._resolveAssociationJoin(v);
+        if (!resolved) return [v.toLowerCase()]; // fallback
+        const entries = Array.isArray(resolved) ? resolved : [resolved];
+        return entries.map((e) => e.table.toLowerCase());
+      });
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
       ...leftOuterTables,
@@ -2370,10 +2375,15 @@ export class Relation<T extends Base> {
     }
     // Process left_outer_joins_values: resolve via JoinDependency and emit as
     // StringJoin nodes (mirrors Rails build_join_buckets stashed_left_joins path).
-    if (this._leftOuterJoinsValues.length > 0) {
+    // Exclude associations already covered by _eagerLoadAssociations to avoid
+    // duplicate JOINs when e.g. eagerLoad("posts").leftJoins("posts") is used.
+    const pendingLeftOuter = this._leftOuterJoinsValues.filter(
+      (v) => !this._eagerLoadAssociations.includes(v),
+    );
+    if (pendingLeftOuter.length > 0) {
       const jd = QueryMethodBangs.constructJoinDependency.call(
         this as any,
-        this._leftOuterJoinsValues,
+        pendingLeftOuter,
         Nodes.OuterJoin,
       );
       for (const node of jd.joinConstraints([])) manager.appendJoinNode(node);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2375,11 +2375,13 @@ export class Relation<T extends Base> {
     }
     // Process left_outer_joins_values: resolve via JoinDependency and emit as
     // StringJoin nodes (mirrors Rails build_join_buckets stashed_left_joins path).
-    // Exclude associations already covered by _eagerLoadAssociations to avoid
-    // duplicate JOINs when e.g. eagerLoad("posts").leftJoins("posts") is used.
-    const pendingLeftOuter = this._leftOuterJoinsValues.filter(
-      (v) => !this._eagerLoadAssociations.includes(v),
-    );
+    // Exclude associations already covered by _eagerLoadAssociations OR by
+    // includes promoted to eager load (includes().references()) — both cause
+    // _buildEagerJoinManager to emit LEFT OUTER JOINs, so emitting again here
+    // would produce duplicate JOINs / ambiguous column errors.
+    const promotedIncludes = this._includesToPromoteFromReferences();
+    const eagerCovered = new Set([...this._eagerLoadAssociations, ...promotedIncludes]);
+    const pendingLeftOuter = this._leftOuterJoinsValues.filter((v) => !eagerCovered.has(v));
     if (pendingLeftOuter.length > 0) {
       const jd = QueryMethodBangs.constructJoinDependency.call(
         this as any,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -110,7 +110,12 @@ function _addAssocJoin(
   join: { table: string; on: string },
   assocName: string,
   modelClass: any,
+  leftOuterJoinsValues?: string[],
 ): void {
+  // If the association is already covered by _leftOuterJoinsValues (deferred
+  // LEFT OUTER JOIN path), skip — the join will be emitted when the manager
+  // is built, so adding a second join here would cause ambiguous column names.
+  if (leftOuterJoinsValues?.includes(assocName)) return;
   const sameTableJoins = clauses.filter((j) => j.table === join.table);
   if (sameTableJoins.length > 0) {
     if (sameTableJoins.every((j) => j.on === join.on)) return; // all compatible — skip
@@ -237,6 +242,7 @@ export class Relation<T extends Base> {
     quoted?: boolean;
   }> = [];
   private _joinValues: (string | Nodes.Join)[] = [];
+  private _leftOuterJoinsValues: AssociationSpec[] = [];
   private _includesAssociations: AssociationSpec[] = [];
   private _preloadAssociations: AssociationSpec[] = [];
   private _eagerLoadAssociations: AssociationSpec[] = [];
@@ -379,7 +385,14 @@ export class Relation<T extends Base> {
       }
       const cloned = rel._clone();
       for (const join of target.joins) {
-        _addAssocJoin(cloned._joinClauses, "inner", join, assocName, rel._modelClass as any);
+        _addAssocJoin(
+          cloned._joinClauses,
+          "inner",
+          join,
+          assocName,
+          rel._modelClass as any,
+          cloned._leftOuterJoinsValues as string[],
+        );
       }
       const tgtTable = new Table(target.table);
       for (const pk of target.pks) {
@@ -410,7 +423,14 @@ export class Relation<T extends Base> {
       }
       const cloned = rel._clone();
       for (const join of target.joins) {
-        _addAssocJoin(cloned._joinClauses, "left", join, assocName, rel._modelClass as any);
+        _addAssocJoin(
+          cloned._joinClauses,
+          "left",
+          join,
+          assocName,
+          rel._modelClass as any,
+          cloned._leftOuterJoinsValues as string[],
+        );
       }
       const tgtTable = new Table(target.table);
       for (const pk of target.pks) {
@@ -1240,24 +1260,13 @@ export class Relation<T extends Base> {
   leftJoins(table: string, on?: string): Relation<T> {
     const rel = this._clone();
     if (on) {
+      // Explicit SQL form: LEFT OUTER JOIN table ON condition — store directly.
       rel._joinClauses.push({ type: "left", table, on });
     } else {
-      const resolved = rel._resolveAssociationJoin(table);
-      if (resolved) {
-        if (Array.isArray(resolved)) {
-          for (const join of resolved) {
-            rel._joinClauses.push({ type: "left", table: join.table, on: join.on, quoted: true });
-          }
-        } else {
-          rel._joinClauses.push({
-            type: "left",
-            table: resolved.table,
-            on: resolved.on,
-            quoted: true,
-          });
-        }
-      } else {
-        rel._joinClauses.push({ type: "left", table, on: "1=1" });
+      // Association name form — mirrors Rails left_outer_joins! storing in
+      // left_outer_joins_values for deferred resolution via JoinDependency.
+      if (!rel._leftOuterJoinsValues.includes(table as AssociationSpec)) {
+        rel._leftOuterJoinsValues.push(table as AssociationSpec);
       }
     }
     return rel;
@@ -2324,10 +2333,12 @@ export class Relation<T extends Base> {
     // after), LeadingJoin goes to leading_join (prepended before). Without stashed
     // joins all nodes go to leading_join in insertion order (Rails' else branch).
     // Stashed signal: existing join_sources (set by _buildEagerJoinManager before
-    // this call) OR _eagerLoadAssociations (stashed_eager_load equivalent).
-    // _includesAssociations is NOT included — includes may resolve via preload
-    // (no joins), so counting it would incorrectly split even in the non-join path.
-    const hasStashed = manager.joinSourceCount > 0 || this._eagerLoadAssociations.length > 0;
+    // this call) OR eagerLoad (stashed_eager_load) OR leftOuterJoins associations
+    // (stashed_left_joins).
+    const hasStashed =
+      manager.joinSourceCount > 0 ||
+      this._eagerLoadAssociations.length > 0 ||
+      this._leftOuterJoinsValues.length > 0;
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
     for (const v of this._joinValues) {
@@ -2348,6 +2359,13 @@ export class Relation<T extends Base> {
       } else {
         manager.outerJoin(tableNode, onNode);
       }
+    }
+    // Process left_outer_joins_values: resolve via JoinDependency and emit as
+    // StringJoin nodes (mirrors Rails build_join_buckets stashed_left_joins path).
+    if (this._leftOuterJoinsValues.length > 0) {
+      const jd = (this as any).constructJoinDependency(this._leftOuterJoinsValues, Nodes.OuterJoin);
+      const constraints = (jd as any).joinConstraints([]);
+      for (const node of constraints) manager.appendJoinNode(node);
     }
     for (const node of joinNodes) manager.appendJoinNode(node);
   }
@@ -3946,6 +3964,7 @@ export class Relation<T extends Base> {
       this._havingClause.isEmpty() &&
       this._joinClauses.length === 0 &&
       this._joinValues.length === 0 &&
+      this._leftOuterJoinsValues.length === 0 &&
       this._includesAssociations.length === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._preloadAssociations.length === 0 &&
@@ -4201,6 +4220,7 @@ export class Relation<T extends Base> {
     this._setOperation = source._setOperation;
     this._joinClauses = [...source._joinClauses];
     this._joinValues = [...source._joinValues];
+    this._leftOuterJoinsValues = [...source._leftOuterJoinsValues];
     this._includesAssociations = [...source._includesAssociations];
     this._preloadAssociations = [...source._preloadAssociations];
     this._eagerLoadAssociations = [...source._eagerLoadAssociations];

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -83,10 +83,11 @@ export class Merger {
   }
 
   private mergeOuterJoins(_rel: any): void {
-    // Our _joinClauses already contains both inner and outer joins (merged above
-    // in order). Rails' merge_outer_joins handles left_outer_joins_values, a
-    // separate array not present in our data model — Arel::Nodes::OuterJoin is
-    // the type used in Rails' cross-model outer-join path.
+    // Same-model left outer join associations are merged in mergeJoins above via
+    // _leftOuterJoinsValues. Rails' merge_outer_joins also handles a cross-model
+    // path (partitions associations, calls left_outer_joins! on a new JoinDependency)
+    // which is not yet implemented here — Arel::Nodes::OuterJoin is the join type
+    // used in that cross-model path.
     void Nodes.OuterJoin;
   }
 

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -74,8 +74,9 @@ export class Merger {
       this.other._joinClauses ?? [];
     if (clauses.length > 0) rel._joinClauses.push(...clauses);
     if (this.other._joinValues?.length > 0) rel._joinValues.push(...this.other._joinValues);
-    if (this.other._leftOuterJoinsValues?.length > 0)
-      rel._leftOuterJoinsValues.push(...this.other._leftOuterJoinsValues);
+    for (const v of this.other._leftOuterJoinsValues ?? []) {
+      if (!rel._leftOuterJoinsValues.includes(v)) rel._leftOuterJoinsValues.push(v);
+    }
     void Nodes.InnerJoin;
   }
 

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -67,9 +67,11 @@ export class Merger {
   private mergeJoins(rel: any): void {
     // Rails: joins_values and left_outer_joins_values are separate arrays, so each
     // merge helper unions its own array independently (no interleaving in Rails).
-    // In our codebase both types share _joinClauses in insertion order. Push the
-    // entire array here so the original sequence is preserved — Arel::Nodes::InnerJoin
-    // is the type used for same-model inner joins in Rails' cross-model merge path.
+    // Our codebase mirrors that split: explicit SQL joins go into _joinClauses,
+    // Arel/string join nodes into _joinValues, and named left-outer-join associations
+    // into _leftOuterJoinsValues. Each is merged independently below.
+    // Arel::Nodes::InnerJoin is the type used for same-model inner joins in Rails'
+    // cross-model merge path.
     const clauses: Array<{ type: string; table: string; on: string; quoted?: boolean }> =
       this.other._joinClauses ?? [];
     if (clauses.length > 0) rel._joinClauses.push(...clauses);

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -74,6 +74,8 @@ export class Merger {
       this.other._joinClauses ?? [];
     if (clauses.length > 0) rel._joinClauses.push(...clauses);
     if (this.other._joinValues?.length > 0) rel._joinValues.push(...this.other._joinValues);
+    if (this.other._leftOuterJoinsValues?.length > 0)
+      rel._leftOuterJoinsValues.push(...this.other._leftOuterJoinsValues);
     void Nodes.InnerJoin;
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1981,8 +1981,15 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
     const stashedLeft: JoinDependency[] = [];
     const namedLeft = selectNamedJoins.call(this, this._leftOuterJoinsValues, stashedLeft);
 
-    if (this._joinValues.length === 0 && this._joinClauses.length === 0) {
-      // Only left outer joins — short-circuit (query_methods.rb:1838-1842).
+    if (
+      this._joinValues.length === 0 &&
+      this._joinClauses.length === 0 &&
+      this._eagerLoadAssociations.length === 0
+    ) {
+      // Only left outer joins, no explicit joins or eager stash — short-circuit
+      // (query_methods.rb:1838-1842: `if joins_values.empty?`). In Rails, eager
+      // stash lives inside joins_values; here it's a separate field so we must
+      // also exclude it from the short-circuit to avoid dropping eager-load JOINs.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
       return buckets;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -643,12 +643,11 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
   return this;
 }
 
-function leftOuterJoinsBang(this: QueryMethodsHost, ...args: string[]): any {
+function leftOuterJoinsBang(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   // Mirrors Rails left_outer_joins! which stores into left_outer_joins_values
   // (separate from joins_values / _joinValues which is the inner-join path).
   for (const arg of args) {
-    if (!this._leftOuterJoinsValues.includes(arg as AssociationSpec))
-      this._leftOuterJoinsValues.push(arg as AssociationSpec);
+    if (!this._leftOuterJoinsValues.includes(arg)) this._leftOuterJoinsValues.push(arg);
   }
   return this;
 }
@@ -1980,11 +1979,7 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   // JoinDependency is prepended to stashed_left_joins.
   if (this._leftOuterJoinsValues.length > 0) {
     const stashedLeft: JoinDependency[] = [];
-    const namedLeft = selectNamedJoins.call(
-      this,
-      this._leftOuterJoinsValues as string[],
-      stashedLeft,
-    );
+    const namedLeft = selectNamedJoins.call(this, this._leftOuterJoinsValues, stashedLeft);
 
     if (this._joinValues.length === 0 && this._joinClauses.length === 0) {
       // Only left outer joins — short-circuit (query_methods.rb:1838-1842).

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -114,6 +114,7 @@ interface QueryMethodsHost {
   _lockValue: string | null;
   _joinClauses: Array<{ type: "inner" | "left"; table: string; on: string; quoted?: boolean }>;
   _joinValues: (string | Nodes.Join)[];
+  _leftOuterJoinsValues: AssociationSpec[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
   _eagerLoadAssociations: AssociationSpec[];
@@ -587,6 +588,7 @@ function unscopeBang(
           break;
         case "leftOuterJoins":
           this._joinClauses = this._joinClauses.filter((j) => j.type !== "left");
+          this._leftOuterJoinsValues = [];
           break;
         case "includes":
           // Rails: `unscope(:includes)` clears includes only — preload
@@ -642,8 +644,11 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
 }
 
 function leftOuterJoinsBang(this: QueryMethodsHost, ...args: string[]): any {
+  // Mirrors Rails left_outer_joins! which stores into left_outer_joins_values
+  // (separate from joins_values / _joinValues which is the inner-join path).
   for (const arg of args) {
-    this._joinValues.push(arg);
+    if (!this._leftOuterJoinsValues.includes(arg as AssociationSpec))
+      this._leftOuterJoinsValues.push(arg as AssociationSpec);
   }
   return this;
 }
@@ -812,6 +817,7 @@ const STRUCTURAL_FIELDS: ReadonlyArray<[string, keyof QueryMethodsHost]> = [
   ["rawOrder", "_rawOrderClauses"],
   ["joins", "_joinClauses"],
   ["joinValues", "_joinValues"],
+  ["leftOuterJoinsValues", "_leftOuterJoinsValues"],
   ["limit", "_limitValue"],
   ["offset", "_offsetValue"],
   ["lock", "_lockValue"],
@@ -1842,11 +1848,17 @@ function eachJoinDependencies(
 }
 
 function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] {
-  // Mirror Rails: joins | left_outer_joins | eager_load | includes.
-  // _joinClauses store SQL join targets (table names), not association names.
-  // Only association specs from eagerLoad/includes can be resolved via JoinDependency.
+  // Mirror Rails build_join_dependencies (query_methods.rb:1735-1745):
+  // joins | left_outer_joins | eager_load | includes association specs.
+  // _joinClauses store pre-resolved SQL (table name + ON string), not association
+  // names, so only _leftOuterJoinsValues, eagerLoad, and includes contribute here.
   const joinNames: AssociationSpec[] = [];
 
+  if (this._leftOuterJoinsValues.length > 0) {
+    for (const a of this._leftOuterJoinsValues) {
+      if (!joinNames.includes(a)) joinNames.push(a);
+    }
+  }
   if (this._eagerLoadAssociations.length > 0) {
     for (const a of this._eagerLoadAssociations) {
       if (!joinNames.includes(a)) joinNames.push(a);
@@ -1961,15 +1973,14 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   };
 
   // Mirror Rails build_join_buckets (query_methods.rb:1844–1876):
-  // Detect stashed joins from _eagerLoadAssociations only — includes may resolve
-  // via preload (no joins) and is not a reliable stashed signal. When stashed
-  // joins are present, non-LeadingJoin explicit nodes go to join_node (after
-  // alias-tracker joins). When absent, all explicit nodes go to leading_join
-  // (before named joins), matching Rails' else branch: `!LeadingJoin &&
-  // (stashed_eager_load || stashed_left_joins)` is false → leading_join.
-  // Guard the call: buildJoinDependencies always returns at least [primaryJD]
-  // even when associations are empty, so we check first to avoid false positives.
-  const hasAssocStashed = this._eagerLoadAssociations.length > 0;
+  // Stashed signal: _eagerLoadAssociations (stashed_eager_load) OR
+  // _leftOuterJoinsValues (stashed_left_joins). When present, non-LeadingJoin
+  // explicit nodes go to join_node (after alias-tracker joins). When absent,
+  // all explicit nodes go to leading_join (before named joins), matching Rails'
+  // else branch. Guard: buildJoinDependencies always returns [primaryJD] even
+  // when empty, so check first to avoid false positives.
+  const hasAssocStashed =
+    this._eagerLoadAssociations.length > 0 || this._leftOuterJoinsValues.length > 0;
   const stashedJoins = hasAssocStashed ? buildJoinDependencies.call(this) : [];
   const hasStashed = stashedJoins.length > 0;
   buckets.stashed_join.push(...stashedJoins);
@@ -1988,7 +1999,8 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
 }
 
 function buildJoins(this: QueryMethodsHost, arel: any): void {
-  const hasEagerAssocs = this._eagerLoadAssociations.length > 0;
+  const hasEagerAssocs =
+    this._eagerLoadAssociations.length > 0 || this._leftOuterJoinsValues.length > 0;
   if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasEagerAssocs) return;
 
   const buckets = buildJoinBuckets.call(this);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1970,20 +1970,54 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
     leading_join: [],
     join_node: [],
     stashed_join: [],
+    named_join: [],
   };
 
-  // Mirror Rails build_join_buckets (query_methods.rb:1844–1876):
-  // Stashed signal: _eagerLoadAssociations (stashed_eager_load) OR
-  // _leftOuterJoinsValues (stashed_left_joins). When present, non-LeadingJoin
-  // explicit nodes go to join_node (after alias-tracker joins). When absent,
-  // all explicit nodes go to leading_join (before named joins), matching Rails'
-  // else branch. Guard: buildJoinDependencies always returns [primaryJD] even
-  // when empty, so check first to avoid false positives.
-  const hasAssocStashed =
-    this._eagerLoadAssociations.length > 0 || this._leftOuterJoinsValues.length > 0;
-  const stashedJoins = hasAssocStashed ? buildJoinDependencies.call(this) : [];
-  const hasStashed = stashedJoins.length > 0;
-  buckets.stashed_join.push(...stashedJoins);
+  // Mirror Rails build_join_buckets (query_methods.rb:1828–1876):
+  // When left_outer_joins_values is non-empty, Rails runs select_named_joins on
+  // them to build stashed_left_joins. If joins_values is also empty, it returns
+  // early with OuterJoin type and named_join populated. Otherwise the left-outer
+  // JoinDependency is prepended to stashed_left_joins.
+  if (this._leftOuterJoinsValues.length > 0) {
+    const stashedLeft: JoinDependency[] = [];
+    const namedLeft = selectNamedJoins.call(
+      this,
+      this._leftOuterJoinsValues as string[],
+      stashedLeft,
+    );
+
+    if (this._joinValues.length === 0 && this._joinClauses.length === 0) {
+      // Only left outer joins — short-circuit (query_methods.rb:1838-1842).
+      buckets.named_join.push(...namedLeft);
+      buckets.stashed_join.push(...stashedLeft);
+      return buckets;
+    }
+
+    const leftJd = constructJoinDependency.call(
+      this,
+      namedLeft as AssociationSpec[],
+      Nodes.OuterJoin,
+    );
+    stashedLeft.unshift(leftJd);
+    buckets.stashed_join.push(...stashedLeft);
+  }
+
+  // Stashed eager signal: _eagerLoadAssociations (stashed_eager_load equivalent).
+  // _leftOuterJoinsValues is already handled above, so only eager is added here
+  // to avoid double-inclusion. Guard: check non-empty before calling to avoid
+  // constructing an empty primary JD.
+  if (this._eagerLoadAssociations.length > 0) {
+    const eagerStash: JoinDependency[] = [];
+    const namedEager = selectNamedJoins.call(
+      this,
+      this._eagerLoadAssociations as string[],
+      eagerStash,
+    );
+    const eagerJd = constructJoinDependency.call(this, namedEager as AssociationSpec[], null);
+    eagerStash.unshift(eagerJd);
+    buckets.stashed_join.push(...eagerStash);
+  }
+  const hasStashed = buckets.stashed_join.length > 0;
 
   for (const v of this._joinValues) {
     const node: Nodes.Join =
@@ -2007,6 +2041,7 @@ function buildJoins(this: QueryMethodsHost, arel: any): void {
   const leadingJoins = buckets.leading_join as unknown[];
   const joinNodes = buckets.join_node as unknown[];
   const stashedJoins = buckets.stashed_join as JoinDependency[];
+  const namedJoins = buckets.named_join as AssociationSpec[];
 
   for (const j of leadingJoins) arel.source.right.push(j);
 
@@ -2023,9 +2058,15 @@ function buildJoins(this: QueryMethodsHost, arel: any): void {
     }
   }
 
-  // Stashed join dependencies (eager_load/includes) — generate join SQL via
-  // joinConstraints and push directly to join_sources (mirrors build_joins:1896).
-  if (stashedJoins.length > 0) {
+  // Named left outer joins (short-circuit path: only left_outer_joins_values,
+  // no explicit joins). Rails processes these as named_join → OuterJoin type.
+  if (namedJoins.length > 0) {
+    const jd = constructJoinDependency.call(this, namedJoins, Nodes.OuterJoin);
+    const constraintNodes = jd.joinConstraints(stashedJoins);
+    for (const node of constraintNodes) arel.source.right.push(node);
+  } else if (stashedJoins.length > 0) {
+    // Stashed join dependencies (eager_load or left_outer combined with explicit
+    // joins) — generate join SQL via joinConstraints (mirrors build_joins:1896).
     const [primary, ...rest] = stashedJoins;
     const constraintNodes = primary.joinConstraints(rest);
     for (const node of constraintNodes) arel.source.right.push(node);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2004,8 +2004,9 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
 
   // Stashed eager signal: _eagerLoadAssociations (stashed_eager_load equivalent).
   // _leftOuterJoinsValues is already handled above, so only eager is added here
-  // to avoid double-inclusion. Guard: check non-empty before calling to avoid
-  // constructing an empty primary JD.
+  // to avoid double-inclusion. Only push a primary JD when namedEager has at least
+  // one string association — non-string specs (hashes/nested) skip constructJoinDependency
+  // and would produce an empty JD that still sets hasStashed, incorrectly changing routing.
   if (this._eagerLoadAssociations.length > 0) {
     const eagerStash: JoinDependency[] = [];
     const namedEager = selectNamedJoins.call(
@@ -2013,9 +2014,12 @@ function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
       this._eagerLoadAssociations as string[],
       eagerStash,
     );
-    const eagerJd = constructJoinDependency.call(this, namedEager as AssociationSpec[], null);
-    eagerStash.unshift(eagerJd);
-    buckets.stashed_join.push(...eagerStash);
+    const hasJoinableEager = (namedEager as AssociationSpec[]).some((a) => typeof a === "string");
+    if (hasJoinableEager) {
+      const eagerJd = constructJoinDependency.call(this, namedEager as AssociationSpec[], null);
+      eagerStash.unshift(eagerJd);
+    }
+    if (eagerStash.length > 0) buckets.stashed_join.push(...eagerStash);
   }
   const hasStashed = buckets.stashed_join.length > 0;
 

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -87,7 +87,9 @@ export function mergeBang(this: any, other: any): any {
     // mergeJoins (preserve original order across all join stores)
     this._joinClauses.push(...(other._joinClauses ?? []));
     this._joinValues.push(...(other._joinValues ?? []));
-    this._leftOuterJoinsValues.push(...(other._leftOuterJoinsValues ?? []));
+    for (const v of other._leftOuterJoinsValues ?? []) {
+      if (!this._leftOuterJoinsValues.includes(v)) this._leftOuterJoinsValues.push(v);
+    }
     // sticky none
     if (other._isNone) this._isNone = true;
   } else if (typeof other === "object" && other !== null) {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -84,9 +84,10 @@ export function mergeBang(this: any, other: any): any {
         ...(this._eagerLoadAssociations ?? []),
         ...other._eagerLoadAssociations,
       ];
-    // mergeJoins (preserve original order across both join stores: _joinClauses and _joinValues)
+    // mergeJoins (preserve original order across all join stores)
     this._joinClauses.push(...(other._joinClauses ?? []));
     this._joinValues.push(...(other._joinValues ?? []));
+    this._leftOuterJoinsValues.push(...(other._leftOuterJoinsValues ?? []));
     // sticky none
     if (other._isNone) this._isNone = true;
   } else if (typeof other === "object" && other !== null) {


### PR DESCRIPTION
Implements `left_outer_joins_values` deferred from #929.

## Rails source

Rails keeps `left_outer_joins_values` separate from `joins_values` (`query_methods.rb:889-891`). In `build_join_buckets`, it drives the `stashed_left_joins` signal and the early-return path when only left outer joins are present. Rails accepts `Hash`, `Symbol`, and `Array` association specs via `select_association_list` (query_methods.rb:1810-1821).

## Changes

- **`_leftOuterJoinsValues: AssociationSpec[]`** — new field mirroring `left_outer_joins_values`. Wired through `_clone`, `isEmpty`, `unscope("leftOuterJoins")`, `STRUCTURAL_FIELDS`, `merger.ts`, `spawn-methods.ts` (all with `|=` deduplication semantics).
- **`leftJoins(assoc)` (no explicit `ON`)** — deferred to `_leftOuterJoinsValues`; explicit SQL form unchanged.
- **`leftOuterJoinsBang`** — fixed: was incorrectly pushing to `_joinValues` (inner-join path); now pushes to `_leftOuterJoinsValues` with deduplication. Accepts `AssociationSpec[]` matching Rails.
- **`_applyJoinsToManager`** — processes `_leftOuterJoinsValues` via `constructJoinDependency(OuterJoin) + joinConstraints`; filters `pendingLeftOuter` against `_eagerLoadAssociations` and `_includesToPromoteFromReferences()`.
- **`buildJoinBuckets`** — short-circuit for left-outer-only; otherwise prepends left-outer JD to stash. Short-circuit requires no eager stash. Eager stash only fires when `namedEager` has at least one string association.
- **`buildJoins` / `buildJoinDependencies`** — include `_leftOuterJoinsValues`.
- **`referencesEagerLoadedTables`** — resolves table names from `_leftOuterJoinsValues` via `_resolveAssociationJoin`.
- **`_addAssocJoin`** — accepts `ReadonlyArray<unknown>`; skips when association is already covered.

## Known gap: non-string AssociationSpec in constructJoinDependency

`leftOuterJoinsBang` correctly accepts `AssociationSpec[]` — Rails' `left_outer_joins!` accepts `Hash`, `Symbol`, and `Array` specs. The silent no-op for non-string specs is a pre-existing gap in `constructJoinDependency` (line 1120: `if (typeof name !== "string") continue`), not introduced by this PR. When `constructJoinDependency` is extended to handle hash/array specs, `left_outer_joins(:posts, posts: :comments)` will work automatically.

## Divergence from Rails: duplicate-join avoidance

Rails' `apply_join_dependency` calls `except(:includes, :eager_load, :preload)` before `build_join_buckets`, so there's no structural overlap. Any same-table conflict is resolved by the alias tracker. Our alias tracker is stubbed, so we pre-filter `pendingLeftOuter` against the eager-covered set. When alias tracking is implemented, this filter can be removed.

## Deferred

- Non-string `AssociationSpec` support in `constructJoinDependency` (hash/array nested association specs)
- Cross-model `merge_outer_joins`
- `finder_methods#apply_join_dependency` limitable-reflections check
- `stashed_left_joins` when `left_outer_joins_values` contains `CTEJoin`
- Full alias-tracking