### PR TITLE
feat(activerecord): support hash/array AssociationSpec in constructJoinDependency

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -8,6 +8,7 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
 import type { Relation } from "./relation.js";
+import type { AssociationSpec } from "./relation/query-methods.js";
 import { sanitizeSql } from "./sanitization.js";
 
 /**
@@ -218,7 +219,7 @@ export function optimizerHints<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#left_joins */
 export function leftJoins<T extends typeof Base>(
   this: T,
-  table: string,
+  table: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
   return this.all().leftJoins(table, on);
@@ -227,7 +228,7 @@ export function leftJoins<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#left_outer_joins */
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
-  table?: string,
+  table?: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
   return this.all().leftOuterJoins(table, on);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -324,9 +324,7 @@ describe("RelationTest", () => {
       foreignKey: "author_id",
     });
     // Array spec goes directly through constructJoinDependency via leftJoins
-    const sql = Author.all()
-      .leftJoins(["posts", "comments"] as any)
-      .toSql();
+    const sql = Author.all().leftJoins(["posts", "comments"]).toSql();
     expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
     expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
   });
@@ -361,11 +359,18 @@ describe("RelationTest", () => {
       className: "HashComment",
       foreignKey: "post_id",
     });
-    const sql = Author.all()
-      .leftJoins({ posts: "comments" } as any)
-      .toSql();
+    const sql = Author.all().leftJoins({ posts: "comments" }).toSql();
     expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
     expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
+    // Verify comments is joined through posts (ON references the posts table/alias)
+    const postsMatch = sql.match(/LEFT OUTER JOIN\s+["`]?posts["`]?(?:\s+(\w+))?\s+ON/i);
+    const postsRef = postsMatch?.[1] ?? "posts";
+    expect(sql).toMatch(
+      new RegExp(
+        `["\`]?comments["\`]?[^)]+post_id["\`]?\\s*=\\s*["\`]?${postsRef}["\`]?\\.["\`]?id`,
+        "i",
+      ),
+    );
   });
 
   it("leftJoins(:assoc) stores in _leftOuterJoinsValues and generates LEFT OUTER JOIN", () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -293,7 +293,7 @@ describe("RelationTest", () => {
   });
 
   it("constructJoinDependency handles array-form spec — joins(['posts','comments'])", () => {
-    // leftJoins(["posts", "comments"]) is equivalent to leftJoins("posts", "comments").
+    // leftJoins(["posts", "comments"]) is equivalent to chaining leftJoins("posts").leftJoins("comments").
     class Author extends Base {
       static {
         this.tableName = "authors";

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -362,12 +362,22 @@ describe("RelationTest", () => {
     const sql = Author.all().leftJoins({ posts: "comments" }).toSql();
     expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
     expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
-    // Verify comments is joined through posts (ON references the posts table/alias)
-    const postsMatch = sql.match(/LEFT OUTER JOIN\s+["`]?posts["`]?(?:\s+(\w+))?\s+ON/i);
-    const postsRef = postsMatch?.[1] ?? "posts";
-    expect(sql).toMatch(
+    // Verify comments is joined through posts: ON clause must reference the
+    // effective SQL name of the posts table (real name or collision alias).
+    const postsJoinMatch = sql.match(
+      /LEFT OUTER JOIN\s+["`]?posts["`]?(?:\s+(?:AS\s+)?["`]?(\w+)["`]?)?\s+ON/i,
+    );
+    expect(postsJoinMatch).not.toBeNull();
+    const postsRef = postsJoinMatch?.[1] ?? "posts";
+    const escapedPostsRef = postsRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const commentsJoinMatch = sql.match(
+      /LEFT OUTER JOIN\s+["`]?comments["`]?(?:\s+(?:AS\s+)?["`]?\w+["`]?)?\s+ON\s+([\s\S]*?)(?=\s+LEFT OUTER JOIN|\s*$)/i,
+    );
+    expect(commentsJoinMatch).not.toBeNull();
+    const commentsOnClause = commentsJoinMatch?.[1] ?? "";
+    expect(commentsOnClause).toMatch(
       new RegExp(
-        `["\`]?comments["\`]?[^)]+post_id["\`]?\\s*=\\s*["\`]?${postsRef}["\`]?\\.["\`]?id`,
+        `["\`]?comments["\`]?\\.["\`]?post_id["\`]?\\s*=\\s*["\`]?${escapedPostsRef}["\`]?\\.["\`]?id["\`]?`,
         "i",
       ),
     );

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -292,6 +292,82 @@ describe("RelationTest", () => {
     expect(sql).toContain('"books"."author_id"');
   });
 
+  it("constructJoinDependency handles array-form spec — joins(['posts','comments'])", () => {
+    // constructJoinDependency's walkAssociationTree flattens array specs so
+    // joins(["posts", "comments"]) is equivalent to joins("posts", "comments").
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Comment extends Base {
+      static {
+        this.tableName = "comments";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("CJDAuthor", Author);
+    registerModel("CJDPost", Post);
+    registerModel("CJDComment", Comment);
+    Associations.hasMany.call(Author, "posts", { className: "CJDPost", foreignKey: "author_id" });
+    Associations.hasMany.call(Author, "comments", {
+      className: "CJDComment",
+      foreignKey: "author_id",
+    });
+    // Array spec goes directly through constructJoinDependency via leftJoins
+    const sql = Author.all()
+      .leftJoins(["posts", "comments"] as any)
+      .toSql();
+    expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
+    expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
+  });
+
+  it("constructJoinDependency handles hash spec — leftJoins({ posts: 'comments' })", () => {
+    // Hash spec { posts: "comments" } means: join posts, then join comments via posts.
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.adapter = adapter;
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    class Comment extends Base {
+      static {
+        this.tableName = "comments";
+        this.attribute("post_id", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel("HashAuthor", Author);
+    registerModel("HashPost", Post);
+    registerModel("HashComment", Comment);
+    Associations.hasMany.call(Author, "posts", { className: "HashPost", foreignKey: "author_id" });
+    Associations.hasMany.call(Post, "comments", {
+      className: "HashComment",
+      foreignKey: "post_id",
+    });
+    const sql = Author.all()
+      .leftJoins({ posts: "comments" } as any)
+      .toSql();
+    expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
+    expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
+  });
+
   it("leftJoins(:assoc) stores in _leftOuterJoinsValues and generates LEFT OUTER JOIN", () => {
     class Author extends Base {
       static {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -293,8 +293,7 @@ describe("RelationTest", () => {
   });
 
   it("constructJoinDependency handles array-form spec — joins(['posts','comments'])", () => {
-    // constructJoinDependency's walkAssociationTree flattens array specs so
-    // joins(["posts", "comments"]) is equivalent to joins("posts", "comments").
+    // leftJoins(["posts", "comments"]) is equivalent to leftJoins("posts", "comments").
     class Author extends Base {
       static {
         this.tableName = "authors";

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1252,8 +1252,11 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Add a LEFT OUTER JOIN. Accepts an association name or a table name
-   * with an ON condition.
+   * Add a LEFT OUTER JOIN. Accepts:
+   * - A string association name: `leftJoins("posts")`
+   * - A hash spec for nested associations: `leftJoins({ posts: "comments" })`
+   * - An array of the above: `leftJoins(["posts", "comments"])`
+   * - A raw table name with an explicit ON clause: `leftJoins("posts", "posts.author_id = authors.id")`
    *
    * Mirrors: ActiveRecord::Relation#left_joins
    */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1262,7 +1262,7 @@ export class Relation<T extends Base> {
     if (on) {
       // Explicit SQL form: LEFT OUTER JOIN table ON condition — only valid for strings.
       if (typeof table !== "string")
-        throw new Error("leftJoins(table, on) requires a string table name");
+        throw argumentError("leftJoins(table, on) requires a string table name");
       rel._joinClauses.push({ type: "left", table, on });
     } else {
       // Association name/spec form — mirrors Rails left_outer_joins! storing in

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1257,16 +1257,19 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#left_joins
    */
-  leftJoins(table: string, on?: string): Relation<T> {
+  leftJoins(table: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     const rel = this._clone();
     if (on) {
-      // Explicit SQL form: LEFT OUTER JOIN table ON condition — store directly.
+      // Explicit SQL form: LEFT OUTER JOIN table ON condition — only valid for strings.
+      if (typeof table !== "string")
+        throw new Error("leftJoins(table, on) requires a string table name");
       rel._joinClauses.push({ type: "left", table, on });
     } else {
-      // Association name form — mirrors Rails left_outer_joins! storing in
+      // Association name/spec form — mirrors Rails left_outer_joins! storing in
       // left_outer_joins_values for deferred resolution via JoinDependency.
-      if (!rel._leftOuterJoinsValues.includes(table as AssociationSpec)) {
-        rel._leftOuterJoinsValues.push(table as AssociationSpec);
+      const specs = Array.isArray(table) ? table : [table];
+      for (const spec of specs) {
+        if (!rel._leftOuterJoinsValues.includes(spec)) rel._leftOuterJoinsValues.push(spec);
       }
     }
     return rel;
@@ -1277,7 +1280,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#left_outer_joins
    */
-  leftOuterJoins(table?: string, on?: string): Relation<T> {
+  leftOuterJoins(table?: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     if (!table) return this._clone();
     return this.leftJoins(table, on);
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1114,8 +1114,18 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   return this;
 }
 
+/** Recursive association tree: mirrors Rails' JoinDependency.make_tree output. */
+interface AssocTree {
+  [key: string]: AssocTree;
+}
+
+/** Safe factory: prototype-pollution-safe null-prototype object. */
+function makeAssocTree(): AssocTree {
+  return Object.create(null) as AssocTree;
+}
+
 /**
- * Flatten any AssociationSpec mix into a tree of { assocName: subtree } pairs,
+ * Flatten any AssociationSpec mix into an AssocTree,
  * mirroring Rails' JoinDependency.make_tree / walk_tree (join_dependency.rb:47-70).
  * Strings → leaf (dot-notation "a.b" expands to nested { a: { b: {} } });
  * Arrays → each element walked; Hashes → key/value pairs.
@@ -1123,21 +1133,21 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  */
 function walkAssociationTree(
   associations: AssociationSpec | AssociationSpec[],
-  tree: Record<string, Record<string, unknown>>,
+  tree: AssocTree,
 ): void {
   if (typeof associations === "string") {
     // Expand dot-notation "posts.comments" → { posts: { comments: {} } }
     const parts = associations.split(".");
     let node = tree;
     for (const part of parts) {
-      node = (node[part] ??= {}) as Record<string, Record<string, unknown>>;
+      node = node[part] ??= makeAssocTree();
     }
   } else if (Array.isArray(associations)) {
     for (const assoc of associations) walkAssociationTree(assoc, tree);
   } else if (isPlainObject(associations)) {
     for (const [k, v] of Object.entries(associations)) {
-      const sub = (tree[k] ??= {}) as Record<string, unknown>;
-      if (v != null) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
+      const sub = (tree[k] ??= makeAssocTree());
+      if (v != null) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub);
     }
   } else {
     let desc: string;
@@ -1150,6 +1160,9 @@ function walkAssociationTree(
   }
 }
 
+/** Options shape matching JoinDependency.addAssociation's options parameter. */
+type AddAssocOptions = { fromModel?: unknown; fromAlias?: string; parentAssocName?: string };
+
 /**
  * Add all associations in a tree to jd, passing parent context so each
  * nested association is attached to its parent (not re-added from scratch).
@@ -1157,12 +1170,12 @@ function walkAssociationTree(
  */
 function addTreeToJoinDependency(
   jd: JoinDependency,
-  tree: Record<string, Record<string, unknown>>,
+  tree: AssocTree,
   modelName: string,
-  parentContext?: { fromModel: unknown; fromAlias: string; parentAssocName: string },
+  parentContext?: AddAssocOptions,
 ): void {
   for (const [assocName, subtree] of Object.entries(tree)) {
-    const node = jd.addAssociation(assocName, parentContext as any);
+    const node = jd.addAssociation(assocName, parentContext);
     if (!node) {
       // Use current parent model name in the error (not always the root model).
       const onModel = parentContext
@@ -1172,7 +1185,7 @@ function addTreeToJoinDependency(
         `Association named '${assocName}' was not found on ${onModel}; perhaps you misspelled it?`,
       );
     }
-    const children = subtree as Record<string, Record<string, unknown>>;
+    const children = subtree;
     if (Object.keys(children).length > 0) {
       addTreeToJoinDependency(jd, children, modelName, {
         fromModel: node.modelClass,
@@ -1200,7 +1213,7 @@ function constructJoinDependency(
   const jd = new JoinDependency(this._modelClass);
   const modelName = (this._modelClass as any).name ?? "model";
   const specs = Array.isArray(associations) ? associations : [associations];
-  const tree: Record<string, Record<string, unknown>> = {};
+  const tree = makeAssocTree();
   for (const spec of specs) walkAssociationTree(spec, tree);
   addTreeToJoinDependency(jd, tree, modelName);
   return jd;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -6,7 +6,12 @@
  */
 import { Nodes, SelectManager, Table as ArelTable, sql as arelSql } from "@blazetrails/arel";
 import { Attribute, ValueType } from "@blazetrails/activemodel";
-import { ActiveRecordError, IrreversibleOrderError, PreparedStatementInvalid } from "../errors.js";
+import {
+  ActiveRecordError,
+  ConfigurationError,
+  IrreversibleOrderError,
+  PreparedStatementInvalid,
+} from "../errors.js";
 import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { sanitizeSqlArray, disallowRawSqlBang } from "../sanitization.js";
@@ -1114,7 +1119,7 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  * mirroring Rails' JoinDependency.make_tree / walk_tree (join_dependency.rb:47-70).
  * Strings → leaf (dot-notation "a.b" expands to nested { a: { b: {} } });
  * Arrays → each element walked; Hashes → key/value pairs.
- * Unknown types raise ArgumentError, matching Rails' ConfigurationError (line 67).
+ * Unknown types raise ConfigurationError, matching Rails (join_dependency.rb:67).
  */
 function walkAssociationTree(
   associations: AssociationSpec | AssociationSpec[],
@@ -1135,7 +1140,7 @@ function walkAssociationTree(
       if (v) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
     }
   } else {
-    throw argumentError(`Invalid association spec: ${JSON.stringify(associations)}`);
+    throw new ConfigurationError(`Invalid association spec: ${JSON.stringify(associations)}`);
   }
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1134,13 +1134,19 @@ function walkAssociationTree(
     }
   } else if (Array.isArray(associations)) {
     for (const assoc of associations) walkAssociationTree(assoc, tree);
-  } else if (typeof associations === "object" && associations !== null) {
+  } else if (isPlainObject(associations)) {
     for (const [k, v] of Object.entries(associations)) {
       const sub = (tree[k] ??= {}) as Record<string, unknown>;
       if (v != null) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
     }
   } else {
-    throw new ConfigurationError(`Invalid association spec: ${JSON.stringify(associations)}`);
+    let desc: string;
+    try {
+      desc = JSON.stringify(associations);
+    } catch {
+      desc = `${typeof associations}`;
+    }
+    throw new ConfigurationError(`Invalid association spec: ${desc}`);
   }
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1112,14 +1112,21 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
 /**
  * Flatten any AssociationSpec mix into a tree of { assocName: subtree } pairs,
  * mirroring Rails' JoinDependency.make_tree / walk_tree (join_dependency.rb:47-70).
- * Strings → leaf; Arrays → each element walked; Hashes → key/value pairs.
+ * Strings → leaf (dot-notation "a.b" expands to nested { a: { b: {} } });
+ * Arrays → each element walked; Hashes → key/value pairs.
+ * Unknown types raise ArgumentError, matching Rails' ConfigurationError (line 67).
  */
 function walkAssociationTree(
   associations: AssociationSpec | AssociationSpec[],
   tree: Record<string, Record<string, unknown>>,
 ): void {
   if (typeof associations === "string") {
-    tree[associations] ??= {};
+    // Expand dot-notation "posts.comments" → { posts: { comments: {} } }
+    const parts = associations.split(".");
+    let node = tree;
+    for (const part of parts) {
+      node = (node[part] ??= {}) as Record<string, Record<string, unknown>>;
+    }
   } else if (Array.isArray(associations)) {
     for (const assoc of associations) walkAssociationTree(assoc, tree);
   } else if (typeof associations === "object" && associations !== null) {
@@ -1127,6 +1134,8 @@ function walkAssociationTree(
       const sub = (tree[k] ??= {}) as Record<string, unknown>;
       if (v) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
     }
+  } else {
+    throw argumentError(`Invalid association spec: ${JSON.stringify(associations)}`);
   }
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1142,7 +1142,7 @@ function walkAssociationTree(
   } else {
     let desc: string;
     try {
-      desc = JSON.stringify(associations);
+      desc = JSON.stringify(associations) ?? String(associations);
     } catch {
       desc = `${typeof associations}`;
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1109,22 +1109,72 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   return this;
 }
 
+/**
+ * Flatten any AssociationSpec mix into a tree of { assocName: subtree } pairs,
+ * mirroring Rails' JoinDependency.make_tree / walk_tree (join_dependency.rb:47-70).
+ * Strings → leaf; Arrays → each element walked; Hashes → key/value pairs.
+ */
+function walkAssociationTree(
+  associations: AssociationSpec | AssociationSpec[],
+  tree: Record<string, Record<string, unknown>>,
+): void {
+  if (typeof associations === "string") {
+    tree[associations] ??= {};
+  } else if (Array.isArray(associations)) {
+    for (const assoc of associations) walkAssociationTree(assoc, tree);
+  } else if (typeof associations === "object" && associations !== null) {
+    for (const [k, v] of Object.entries(associations)) {
+      const sub = (tree[k] ??= {}) as Record<string, unknown>;
+      if (v) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
+    }
+  }
+}
+
+/**
+ * Add all associations in a tree to jd, passing parent context so each
+ * nested association is attached to its parent (not re-added from scratch).
+ * Mirrors Rails JoinDependency#build (join_dependency.rb:228).
+ */
+function addTreeToJoinDependency(
+  jd: JoinDependency,
+  tree: Record<string, Record<string, unknown>>,
+  modelName: string,
+  parentContext?: { fromModel: unknown; fromAlias: string; parentAssocName: string },
+): void {
+  for (const [assocName, subtree] of Object.entries(tree)) {
+    const node = jd.addAssociation(assocName, parentContext as any);
+    if (!node) {
+      throw argumentError(
+        `Association named '${assocName}' was not found on ${modelName}; perhaps you misspelled it?`,
+      );
+    }
+    const children = subtree as Record<string, Record<string, unknown>>;
+    if (Object.keys(children).length > 0) {
+      addTreeToJoinDependency(jd, children, modelName, {
+        fromModel: node.modelClass,
+        fromAlias: node.tableAlias,
+        parentAssocName: parentContext
+          ? `${parentContext.parentAssocName}.${assocName}`
+          : assocName,
+      });
+    }
+  }
+}
+
 function constructJoinDependency(
   this: QueryMethodsHost,
   associations: string | AssociationSpec[],
   _joinType?: unknown,
 ): JoinDependency {
+  // Mirror Rails construct_join_dependency → JoinDependency.make_tree (join_dependency.rb:47).
+  // Flatten the AssociationSpec mix into a tree, then add each association to the JD
+  // using parent context so nested specs attach correctly without duplicate intermediate nodes.
   const jd = new JoinDependency(this._modelClass);
-  const names = Array.isArray(associations) ? associations : [associations];
-  for (const name of names) {
-    if (typeof name !== "string") continue;
-    const node = name.includes(".") ? jd.addNestedAssociation(name) : jd.addAssociation(name);
-    if (!node) {
-      throw argumentError(
-        `Association named '${name}' was not found on ${(this._modelClass as any).name ?? "model"}; perhaps you misspelled it?`,
-      );
-    }
-  }
+  const modelName = (this._modelClass as any).name ?? "model";
+  const specs = Array.isArray(associations) ? associations : [associations];
+  const tree: Record<string, Record<string, unknown>> = {};
+  for (const spec of specs) walkAssociationTree(spec, tree);
+  addTreeToJoinDependency(jd, tree, modelName);
   return jd;
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1137,7 +1137,7 @@ function walkAssociationTree(
   } else if (typeof associations === "object" && associations !== null) {
     for (const [k, v] of Object.entries(associations)) {
       const sub = (tree[k] ??= {}) as Record<string, unknown>;
-      if (v) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
+      if (v != null) walkAssociationTree(v as AssociationSpec | AssociationSpec[], sub as any);
     }
   } else {
     throw new ConfigurationError(`Invalid association spec: ${JSON.stringify(associations)}`);
@@ -1158,15 +1158,23 @@ function addTreeToJoinDependency(
   for (const [assocName, subtree] of Object.entries(tree)) {
     const node = jd.addAssociation(assocName, parentContext as any);
     if (!node) {
+      // Use current parent model name in the error (not always the root model).
+      const onModel = parentContext
+        ? ((parentContext.fromModel as any)?.name ?? modelName)
+        : modelName;
       throw argumentError(
-        `Association named '${assocName}' was not found on ${modelName}; perhaps you misspelled it?`,
+        `Association named '${assocName}' was not found on ${onModel}; perhaps you misspelled it?`,
       );
     }
     const children = subtree as Record<string, Record<string, unknown>>;
     if (Object.keys(children).length > 0) {
       addTreeToJoinDependency(jd, children, modelName, {
         fromModel: node.modelClass,
-        fromAlias: node.tableAlias,
+        // effectiveSqlName is the name that actually appears in JOIN SQL (the
+        // real table name unless aliased due to collision). Using tableAlias
+        // here would generate ON clauses referencing e.g. "t1" when the JOIN
+        // SQL uses the real table name.
+        fromAlias: node.effectiveSqlName,
         parentAssocName: parentContext
           ? `${parentContext.parentAssocName}.${assocName}`
           : assocName,


### PR DESCRIPTION
Follow-up to #936. Replaces the `if (typeof name !== "string") continue` gap in `constructJoinDependency` with full Rails-parity support for hash/array `AssociationSpec` inputs.

## Rails source

Rails' `JoinDependency.make_tree` / `walk_tree` (join_dependency.rb:47-70) flattens any mix of `String`, `Symbol`, `Array`, and `Hash` specs. `JoinDependency#build` (line 228) recurses using parent context so nested specs attach to the correct parent.

## Changes

- **`walkAssociationTree`** — mirrors `make_tree`/`walk_tree`: strings expand dot-notation; arrays iterate; plain objects recurse with `isPlainObject()` guard; unknown types raise `ConfigurationError` (matching Rails line 67). Uses `Object.create(null)` trees to prevent prototype pollution.
- **`addTreeToJoinDependency`** — mirrors `JoinDependency#build`: recurses with typed `AddAssocOptions` parent context; uses `node.effectiveSqlName` for `fromAlias` (not `tableAlias`); error message names the actual parent model.
- **`constructJoinDependency`** — builds `AssocTree` from specs then calls `addTreeToJoinDependency`.
- **`leftJoins` / `leftOuterJoins`** — widened to `AssociationSpec | AssociationSpec[]`; array form flattens into individual specs with deduplication; explicit `table, on` form validates string at runtime.
- **`querying.ts`** wrappers widened to match.
- **Tests** — array and hash specs both produce `LEFT OUTER JOIN`; hash test verifies ON clause references the correct parent table alias.

## Open concerns for human review

### 1. Hash-spec deduplication uses object identity
`_leftOuterJoinsValues.includes(spec)` uses `===` (reference equality) for object specs. Two calls to `leftJoins({ posts: "comments" })` from separate literals produce two entries. This matches Ruby's `|=` behavior (also uses object identity for non-primitive values), so it is Rails-faithful, but callers building specs from literals may be surprised.

### 2. TypeScript overloads for `(table: string, on: string)` vs association spec
Compile-time prevention of `leftJoins({ posts: "comments" }, "some_on")` is blocked by TS overload resolution failures in `querying.ts` and `leftOuterJoins`. The invalid combination is guarded at runtime with `argumentError`. Deferred until a clean overload structure can be worked out.