### PR TITLE
chore(api-compare): exclude unported subsystems

### DIFF
--- a/scripts/api-compare/excluded-files.ts
+++ b/scripts/api-compare/excluded-files.ts
@@ -98,6 +98,26 @@ export const EXCLUDED_FILES: ExcludedFile[] = [
     testFile: "encryption/encrypted_fixtures_test.rb",
     reason: "Encrypts YAML fixture rows on load. Excluded transitively with fixtures.rb.",
   },
+  {
+    pattern: "destroy_association_async_job.rb",
+    reason:
+      "ActiveJob subclass that backs `dependent: :destroy_async`. Trails has not " +
+      "ported ActiveJob; async destroy is out of scope until a job framework lands.",
+  },
+  {
+    pattern: "dynamic_matchers.rb",
+    reason:
+      "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` " +
+      "at call time. No TS analog — Proxy-based dispatch can't infer attribute lists at " +
+      "compile time, and `findBy({ ... })` already covers the use case idiomatically.",
+  },
+  {
+    pattern: "railties/controller_runtime.rb",
+    reason:
+      "Railties ActionController integration that logs DB runtime per request. " +
+      "Trails has not ported Railties / ActionController; reintroduce when a web " +
+      "framework integration lands.",
+  },
 ];
 
 export function isExcluded(file: string): boolean {


### PR DESCRIPTION
## Summary

PR 1 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Adds three file-level exclusions for Rails sources that don't have a TS counterpart and aren't on the porting roadmap:

- `destroy_association_async_job.rb` — ActiveJob is not ported; async destroy is out of scope until a job framework lands.
- `dynamic_matchers.rb` — Ruby `method_missing` magic that synthesizes `find_by_<attr>` at call time. No TS analog; `findBy({ ... })` covers the use case idiomatically.
- `railties/controller_runtime.rb` — Railties / ActionController integration; not ported.

## Impact

`pnpm api:compare --package activerecord`:

- Before: `2695/2760 (97.6%)`
- After: `2692/2745 (98.1%)`

12 methods removed from the missing list with no behavior change.

## Test plan

- [x] `pnpm api:compare --package activerecord` reports 98.1% with the three patterns excluded
- [x] No source files touched outside `scripts/api-compare/excluded-files.ts`