### PR TITLE
feat(activerecord): Coders::JSON dump/load

### DIFF
--- a/packages/activerecord/src/coders/json.ts
+++ b/packages/activerecord/src/coders/json.ts
@@ -6,20 +6,14 @@ import { ActiveSupportJSON } from "@blazetrails/activesupport";
  *
  * Mirrors: ActiveRecord::Coders::JSON
  */
-export const JSON = {
-  /**
-   * Mirrors: ActiveRecord::Coders::JSON.dump
-   */
-  dump(obj: unknown): string {
+export class JSON {
+  static dump(obj: unknown): string {
     return ActiveSupportJSON.encode(obj);
-  },
+  }
 
-  /**
-   * Mirrors: ActiveRecord::Coders::JSON.load
-   */
-  load(json: unknown): unknown {
+  static load(json: unknown): unknown {
     if (json == null || json === "") return null;
     if (typeof json !== "string") return json;
     return ActiveSupportJSON.decode(json);
-  },
-};
+  }
+}


### PR DESCRIPTION
## Summary

PR 2 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `coders/json.rb` row in api:compare.

The `dump`/`load` implementations already existed in `coders/json.ts` as object-literal methods; api:compare's TS extractor only matches functions/class methods, so it reported 0/2. Converting the object literal to a `class JSON` with `static dump`/`static load` makes them visible without changing behavior.

Mirrors Rails' [`module ActiveRecord::Coders::JSON`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/coders/json.rb) (`self.dump` / `self.load`).

## Impact

`pnpm api:compare --package activerecord`:

- `coders/json.rb`: 0/2 → 2/2 ✓
- Overall: `2695/2760 (97.6%)` → `2697/2760 (97.7%)` (independent of #938; both PRs branch from `origin/main`)

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/coders/json.test.ts` (2 passed — Rails-mirrored: empty string and nil → null)
- [x] `pnpm exec vitest run packages/activerecord/src/serialization.test.ts` (12 passed, 1 skipped — consumer of `CodersJSON`)
- [x] `pnpm build` clean
- [x] `pnpm api:compare --package activerecord` shows `coders/json.rb 100%`