### PR TITLE
feat(activerecord): QueryAttribute#valueForDatabase

### DIFF
--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -96,6 +96,16 @@ describe("QueryAttribute", () => {
     expect(attr.isInfinite()).toBe(true);
   });
 
+  it("isInfinite handles Ruby-style duck-typed `infinite()` (nil for finite, 1/-1 for infinite)", () => {
+    const finite = { infinite: () => null };
+    const positiveInf = { infinite: () => 1 };
+    const negativeInf = { infinite: () => -1 };
+    const passthrough = { cast: (v: unknown) => v, serialize: (v: unknown) => v };
+    expect(new QueryAttribute("x", finite, passthrough).isInfinite()).toBe(false);
+    expect(new QueryAttribute("x", positiveInf, passthrough).isInfinite()).toBe(true);
+    expect(new QueryAttribute("x", negativeInf, passthrough).isInfinite()).toBe(true);
+  });
+
   it("equals compares name, value, and type", () => {
     const a = new QueryAttribute("age", "25", intType);
     const b = new QueryAttribute("age", "25", intType);

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -87,6 +87,15 @@ describe("QueryAttribute", () => {
     expect(new QueryAttribute("x", 999, intType).isInfinite()).toBe(false);
   });
 
+  it("isInfinite checks valueForDatabase for serializable types", () => {
+    const expandingType = {
+      cast: (v: unknown) => v,
+      serialize: (_v: unknown) => Infinity,
+    };
+    const attr = new QueryAttribute("x", "anything", expandingType);
+    expect(attr.isInfinite()).toBe(true);
+  });
+
   it("equals compares name, value, and type", () => {
     const a = new QueryAttribute("age", "25", intType);
     const b = new QueryAttribute("age", "25", intType);

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -57,13 +57,19 @@ export class QueryAttribute extends Attribute {
     return QueryAttribute.withCastValue(this.name, value, this.type);
   }
 
+  override get valueForDatabase(): unknown {
+    return super.valueForDatabase;
+  }
+
   isNil(): boolean {
     return this.valueBeforeTypeCast === null || this.valueBeforeTypeCast === undefined;
   }
 
   isInfinite(): boolean {
-    const v = this.valueBeforeTypeCast;
-    return v === Infinity || v === -Infinity;
+    return (
+      isInfinity(this.valueBeforeTypeCast) ||
+      (this.isSerializable() && isInfinity(this.valueForDatabase))
+    );
   }
 
   isUnboundable(): boolean {
@@ -71,7 +77,10 @@ export class QueryAttribute extends Attribute {
   }
 }
 
+// private
+
 function isInfinity(value: unknown): boolean {
+  if (value === Infinity || value === -Infinity) return true;
   return (
     value !== null &&
     value !== undefined &&

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -81,10 +81,10 @@ export class QueryAttribute extends Attribute {
 
 function isInfinity(value: unknown): boolean {
   if (value === Infinity || value === -Infinity) return true;
-  return (
-    value !== null &&
-    value !== undefined &&
-    typeof (value as any).infinite === "function" &&
-    (value as any).infinite() !== 0
-  );
+  if (value === null || value === undefined) return false;
+  const fn = (value as { infinite?: unknown }).infinite;
+  if (typeof fn !== "function") return false;
+  const result = (fn as () => unknown).call(value);
+  // Mirrors Ruby truthiness — Float#infinite? returns nil/1/-1; only 1/-1 are truthy.
+  return result != null && result !== false && result !== 0;
 }

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -85,6 +85,6 @@ function isInfinity(value: unknown): boolean {
   const fn = (value as { infinite?: unknown }).infinite;
   if (typeof fn !== "function") return false;
   const result = (fn as () => unknown).call(value);
-  // Mirrors Ruby truthiness — Float#infinite? returns nil/1/-1; only 1/-1 are truthy.
-  return result != null && result !== false && result !== 0;
+  // Mirrors Ruby truthiness for duck-typed infinite() results: only nil/false are falsey.
+  return result != null && result !== false;
 }

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -85,6 +85,6 @@ function isInfinity(value: unknown): boolean {
   const fn = (value as { infinite?: unknown }).infinite;
   if (typeof fn !== "function") return false;
   const result = (fn as () => unknown).call(value);
-  // Mirrors Ruby truthiness for duck-typed infinite() results: only nil/false are falsey.
+  // Mirrors Ruby truthiness for duck-typed infinite() results: only nil/false are falsy.
   return result != null && result !== false;
 }


### PR DESCRIPTION
## Summary

PR 3 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `relation/query_attribute.rb` row.

**`valueForDatabase` override** — added on `QueryAttribute` so api:compare detects the symbol on the subclass. Mirrors Rails [`relation/query_attribute.rb:26-29`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/query_attribute.rb#L26-L29) which redefines `value_for_database` for the same memoization reason. The TS override delegates to the parent `Attribute` getter, which already memoizes via a private `_valueForDatabase` field — no behavior change.

**`isInfinite` rewired** — was checking only `valueBeforeTypeCast`. Now mirrors Rails [`infinite?`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/query_attribute.rb#L42-L44) by also checking `valueForDatabase` when the type is serializable. The file-local `isInfinity` helper (Rails' `private infinity?`) was already present; this PR makes it usable for JS-native `Infinity`/`-Infinity` in addition to duck-typed `.infinite()`.

## Impact

`pnpm api:compare --package activerecord`:

- `relation/query_attribute.rb`: 5/6 → 6/6 ✓
- Overall: `2697/2760 (97.7%)` → `2698/2760 (97.8%)` (vs. origin/main snapshot at the time of branching)

## Test plan

- [x] 9 passing tests in `query-attribute.test.ts`, including a new test asserting `isInfinite()` returns true when the type's `serialize` produces `Infinity` (the new serializable-path coverage)
- [x] `pnpm build` clean
- [x] `pnpm api:compare --package activerecord` shows `relation/query_attribute.rb 100%`

No Rails test file (`query_attribute_test.rb`) exists to mirror — confirmed via `find scripts/api-compare/.rails-source/activerecord/test -name "query_attribute*"`.