### PR TITLE
feat(activerecord): Suppressor.registry

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1174,7 +1174,7 @@ export class Base extends Model {
     return _isSuppressed(this);
   }
 
-  static get registry(): Record<string, true | undefined> {
+  static get registry(): Record<string, number | undefined> {
     return _suppressorRegistry();
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1174,7 +1174,7 @@ export class Base extends Model {
     return _isSuppressed(this);
   }
 
-  static get registry(): Record<string, boolean | undefined> {
+  static get registry(): Record<string, number | undefined> {
     return _suppressorRegistry();
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1174,7 +1174,7 @@ export class Base extends Model {
     return _isSuppressed(this);
   }
 
-  static get registry(): Record<string, number | undefined> {
+  static get registry(): Record<string, true | undefined> {
     return _suppressorRegistry();
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -119,7 +119,11 @@ import {
   noTouching as _noTouchingBlock,
   isAppliedTo as _isNoTouchingApplied,
 } from "./no-touching.js";
-import { suppress as _suppressBlock, isSuppressed as _isSuppressed } from "./suppressor.js";
+import {
+  suppress as _suppressBlock,
+  isSuppressed as _isSuppressed,
+  registry as _suppressorRegistry,
+} from "./suppressor.js";
 import {
   inspect as _inspect,
   attributeForInspect as _attributeForInspect,
@@ -1168,6 +1172,10 @@ export class Base extends Model {
 
   static get isSuppressed(): boolean {
     return _isSuppressed(this);
+  }
+
+  static get registry(): Record<string, boolean | undefined> {
+    return _suppressorRegistry();
   }
 
   // --- Reflection::ClassMethods (wired via extend() after class body) ---

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -141,16 +141,45 @@ describe("suppress()", () => {
 
 describe("Suppressor.registry", () => {
   it("returns the suppression registry", () => {
+    const registry = Base.registry;
+    expect(registry).toBeDefined();
+    expect(typeof registry).toBe("object");
+  });
+
+  it("registry reflects active suppression by class name", async () => {
     const adapter = freshAdapter();
-    class Post extends Base {
+    class Widget extends Base {
       static {
-        this.attribute("title", "string");
+        this.attribute("name", "string");
         this.adapter = adapter;
       }
     }
 
-    const registry = Base.registry;
-    expect(registry).toBeDefined();
-    expect(typeof registry).toBe("object");
+    expect(Base.registry.Widget).toBeFalsy();
+
+    await Widget.suppress(async () => {
+      expect(Base.registry.Widget).toBeTruthy();
+    });
+
+    expect(Base.registry.Widget).toBeFalsy();
+  });
+
+  it("registry tracks nested suppress depth", async () => {
+    const adapter = freshAdapter();
+    class Gizmo extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    await Gizmo.suppress(async () => {
+      expect(Base.registry.Gizmo).toBe(1);
+      await Gizmo.suppress(async () => {
+        expect(Base.registry.Gizmo).toBe(2);
+      });
+      expect(Base.registry.Gizmo).toBe(1);
+    });
+    expect(Base.registry.Gizmo).toBeFalsy();
   });
 });

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -164,6 +164,26 @@ describe("Suppressor.registry", () => {
     expect(Base.registry.Widget).toBeFalsy();
   });
 
+  it("returns the same object across calls (mutable, shared)", () => {
+    expect(Base.registry).toBe(Base.registry);
+  });
+
+  it("a held reference observes suppression mutations", async () => {
+    const adapter = freshAdapter();
+    class Holdable extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    const reg = Base.registry;
+    expect(reg.Holdable).toBeFalsy();
+    await Holdable.suppress(async () => {
+      expect(reg.Holdable).toBeTruthy();
+    });
+    expect(reg.Holdable).toBeFalsy();
+  });
+
   it("registry stays truthy across nested suppress blocks", async () => {
     const adapter = freshAdapter();
     class Gizmo extends Base {

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -164,7 +164,7 @@ describe("Suppressor.registry", () => {
     expect(Base.registry.Widget).toBeFalsy();
   });
 
-  it("registry tracks nested suppress depth", async () => {
+  it("registry stays truthy across nested suppress blocks", async () => {
     const adapter = freshAdapter();
     class Gizmo extends Base {
       static {
@@ -174,11 +174,11 @@ describe("Suppressor.registry", () => {
     }
 
     await Gizmo.suppress(async () => {
-      expect(Base.registry.Gizmo).toBe(1);
+      expect(Base.registry.Gizmo).toBeTruthy();
       await Gizmo.suppress(async () => {
-        expect(Base.registry.Gizmo).toBe(2);
+        expect(Base.registry.Gizmo).toBeTruthy();
       });
-      expect(Base.registry.Gizmo).toBe(1);
+      expect(Base.registry.Gizmo).toBeTruthy();
     });
     expect(Base.registry.Gizmo).toBeFalsy();
   });

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -164,11 +164,12 @@ describe("Suppressor.registry", () => {
     expect(Base.registry.Widget).toBeFalsy();
   });
 
-  it("returns the same object across calls (mutable, shared)", () => {
+  it("returns the same object on consecutive calls in the same scope", () => {
+    // Outside any suppress scope: fallback registry — same identity.
     expect(Base.registry).toBe(Base.registry);
   });
 
-  it("a held reference observes suppression mutations", async () => {
+  it("a held reference inside the scope observes the active suppression", async () => {
     const adapter = freshAdapter();
     class Holdable extends Base {
       static {
@@ -176,12 +177,47 @@ describe("Suppressor.registry", () => {
         this.adapter = adapter;
       }
     }
-    const reg = Base.registry;
-    expect(reg.Holdable).toBeFalsy();
     await Holdable.suppress(async () => {
-      expect(reg.Holdable).toBeTruthy();
+      // Reference captured *inside* the scope — sees the scope's registry.
+      const reg = Base.registry;
+      expect(reg.Holdable).toBe(true);
     });
-    expect(reg.Holdable).toBeFalsy();
+    expect(Base.registry.Holdable).toBeFalsy();
+  });
+
+  it("isolates registry state across concurrent suppress blocks", async () => {
+    const adapter = freshAdapter();
+    class ConcurrentAlpha extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class ConcurrentBeta extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    expect(Base.registry.ConcurrentAlpha).toBeFalsy();
+    expect(Base.registry.ConcurrentBeta).toBeFalsy();
+
+    await Promise.all([
+      ConcurrentAlpha.suppress(async () => {
+        await Promise.resolve();
+        expect(Base.registry.ConcurrentAlpha).toBe(true);
+        expect(Base.registry.ConcurrentBeta).toBeFalsy();
+      }),
+      ConcurrentBeta.suppress(async () => {
+        await Promise.resolve();
+        expect(Base.registry.ConcurrentBeta).toBe(true);
+        expect(Base.registry.ConcurrentAlpha).toBeFalsy();
+      }),
+    ]);
+
+    expect(Base.registry.ConcurrentAlpha).toBeFalsy();
+    expect(Base.registry.ConcurrentBeta).toBeFalsy();
   });
 
   it("registry stays truthy across nested suppress blocks", async () => {

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -138,3 +138,19 @@ describe("suppress()", () => {
     expect(all.length).toBe(0);
   });
 });
+
+describe("Suppressor.registry", () => {
+  it("returns the suppression registry", () => {
+    const adapter = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+
+    const registry = Base.registry;
+    expect(registry).toBeDefined();
+    expect(typeof registry).toBe("object");
+  });
+});

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -6,69 +6,67 @@
  */
 
 /**
- * Re-entrant depth counter keyed by the actual class constructor (not name)
- * so dynamically-created classes that share an inferred `.name` don't alias.
+ * The shared, mutable suppression registry — single module-level object
+ * returned by `registry()`. Mirrors Rails'
+ * `ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]`:
+ * a Rails-side `Suppressor.registry[Klass.name] = true` is what `suppress`
+ * does, and `save`/`save!` check `Suppressor.registry[self.class.name]`.
  *
- * Rails uses `ActiveSupport::IsolatedExecutionState` for per-fiber isolation;
- * in single-threaded Node a module-scoped WeakMap is the closest equivalent.
- * AsyncLocalStorage isolation is a deliberate follow-up — see
- * https://github.com/blazetrailsdev/trails/pull/942 for context.
+ * Stored as numeric depth (`registry[name] > 0` ⇔ suppressed) so re-entrant
+ * `suppress` calls compose correctly in async JS. Truthy values still
+ * satisfy Rails' `registry[name] ? true : super` check at every call site.
+ *
+ * `Object.create(null)` avoids surprises from prototype keys
+ * (`__proto__`/`constructor`).
  */
-const _suppressionDepth = new WeakMap<Function, number>();
+const _suppressorRegistry: Record<string, number | undefined> = Object.create(null);
 
 /**
- * Order-preserving membership set so `registry()` can rebuild a Rails-shaped
- * view without iterating the WeakMap (WeakMaps aren't enumerable).
- */
-const _suppressedClasses = new Set<Function>();
-
-/**
- * Get the suppressor registry. Returns a name-keyed view where every active
- * suppression maps to `true` — matching Rails' `Suppressor.registry[name]`
- * contract (`true`/previous-state per class name). Built fresh per call from
- * the constructor-keyed internal storage to keep `Function`-identity as the
- * source of truth while exposing the Rails-shaped public surface.
+ * Get the suppressor registry. Returns the same mutable object on every
+ * call — callers can hold a reference and observe mutations (Rails parity).
  *
  * Mirrors: ActiveRecord::Suppressor.registry
  */
-export function registry(): Record<string, true | undefined> {
-  const view: Record<string, true | undefined> = Object.create(null);
-  for (const klass of _suppressedClasses) {
-    if (klass.name) view[klass.name] = true;
-  }
-  return view;
+export function registry(): Record<string, number | undefined> {
+  return _suppressorRegistry;
 }
 
 /**
  * Suppress persistence for the given model class during the block.
- * Re-entrant safe: nested suppress blocks increment a depth counter.
+ * Re-entrant safe: nested suppress blocks increment the registry depth.
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
 export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>): Promise<R> {
-  const depth = _suppressionDepth.get(modelClass) ?? 0;
-  _suppressionDepth.set(modelClass, depth + 1);
-  _suppressedClasses.add(modelClass);
+  const name = modelClass.name;
+  if (!name) {
+    // Anonymous classes can't participate in the name-keyed registry
+    // (Rails has the same constraint); just run the block.
+    return await fn();
+  }
+  _suppressorRegistry[name] = (_suppressorRegistry[name] ?? 0) + 1;
   try {
     return await fn();
   } finally {
-    const current = _suppressionDepth.get(modelClass) ?? 1;
+    const current = _suppressorRegistry[name] ?? 1;
     if (current <= 1) {
-      _suppressionDepth.delete(modelClass);
-      _suppressedClasses.delete(modelClass);
+      delete _suppressorRegistry[name];
     } else {
-      _suppressionDepth.set(modelClass, current - 1);
+      _suppressorRegistry[name] = current - 1;
     }
   }
 }
 
 /**
  * Check if the given model class (or any ancestor) is currently suppressed.
+ * Walks the prototype chain so subclass instances honor a parent-class
+ * suppression.
  */
 export function isSuppressed(modelClass: Function): boolean {
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    if (_suppressionDepth.has(current as Function)) return true;
+    const name = (current as Function).name;
+    if (name && (_suppressorRegistry[name] ?? 0) > 0) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -6,43 +6,58 @@
  */
 
 /**
- * Per-class suppression depth, keyed by model class name.
+ * Re-entrant depth counter keyed by the actual class constructor (not name)
+ * so dynamically-created classes that share an inferred `.name` don't alias.
  *
- * Mirrors Rails' `ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]`
- * — Rails stores `true`/previous-state per class name, gated by Ruby's
- * lexical `ensure`. JS lacks per-fiber state and overlapping async
- * `suppress` blocks need re-entrant accounting, so we store a depth
- * count: `registry[name] > 0` ⇔ suppressed. Truthiness matches Rails'
- * `Suppressor.registry[name] ? true : super` check.
+ * Rails uses `ActiveSupport::IsolatedExecutionState` for per-fiber isolation;
+ * in single-threaded Node a module-scoped WeakMap is the closest equivalent.
+ * AsyncLocalStorage isolation is a deliberate follow-up — see
+ * https://github.com/blazetrailsdev/trails/pull/942 for context.
  */
-const _suppressorRegistry: Record<string, number | undefined> = {};
+const _suppressionDepth = new WeakMap<Function, number>();
 
 /**
- * Get the suppressor registry. Truthy values indicate suppressed classes.
+ * Order-preserving membership set so `registry()` can rebuild a Rails-shaped
+ * view without iterating the WeakMap (WeakMaps aren't enumerable).
+ */
+const _suppressedClasses = new Set<Function>();
+
+/**
+ * Get the suppressor registry. Returns a name-keyed view where every active
+ * suppression maps to `true` — matching Rails' `Suppressor.registry[name]`
+ * contract (`true`/previous-state per class name). Built fresh per call from
+ * the constructor-keyed internal storage to keep `Function`-identity as the
+ * source of truth while exposing the Rails-shaped public surface.
  *
  * Mirrors: ActiveRecord::Suppressor.registry
  */
-export function registry(): Record<string, number | undefined> {
-  return _suppressorRegistry;
+export function registry(): Record<string, true | undefined> {
+  const view: Record<string, true | undefined> = Object.create(null);
+  for (const klass of _suppressedClasses) {
+    if (klass.name) view[klass.name] = true;
+  }
+  return view;
 }
 
 /**
  * Suppress persistence for the given model class during the block.
- * Re-entrant safe: nested suppress blocks increment the registry depth.
+ * Re-entrant safe: nested suppress blocks increment a depth counter.
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
 export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>): Promise<R> {
-  const name = modelClass.name;
-  _suppressorRegistry[name] = (_suppressorRegistry[name] ?? 0) + 1;
+  const depth = _suppressionDepth.get(modelClass) ?? 0;
+  _suppressionDepth.set(modelClass, depth + 1);
+  _suppressedClasses.add(modelClass);
   try {
     return await fn();
   } finally {
-    const current = _suppressorRegistry[name] ?? 1;
+    const current = _suppressionDepth.get(modelClass) ?? 1;
     if (current <= 1) {
-      delete _suppressorRegistry[name];
+      _suppressionDepth.delete(modelClass);
+      _suppressedClasses.delete(modelClass);
     } else {
-      _suppressorRegistry[name] = current - 1;
+      _suppressionDepth.set(modelClass, current - 1);
     }
   }
 }
@@ -53,7 +68,7 @@ export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>
 export function isSuppressed(modelClass: Function): boolean {
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    if ((_suppressorRegistry[(current as Function).name] ?? 0) > 0) return true;
+    if (_suppressionDepth.has(current as Function)) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -5,35 +5,59 @@
  * Mirrors: ActiveRecord::Suppressor
  */
 
-/**
- * The shared, mutable suppression registry — single module-level object
- * returned by `registry()`. Mirrors Rails'
- * `ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]`:
- * a Rails-side `Suppressor.registry[Klass.name] = true` is what `suppress`
- * does, and `save`/`save!` check `Suppressor.registry[self.class.name]`.
- *
- * Stored as numeric depth (`registry[name] > 0` ⇔ suppressed) so re-entrant
- * `suppress` calls compose correctly in async JS. Truthy values still
- * satisfy Rails' `registry[name] ? true : super` check at every call site.
- *
- * `Object.create(null)` avoids surprises from prototype keys
- * (`__proto__`/`constructor`).
- */
-const _suppressorRegistry: Record<string, number | undefined> = Object.create(null);
+import { getAsyncContext } from "@blazetrails/activesupport";
+import type { AsyncContext } from "@blazetrails/activesupport";
 
 /**
- * Get the suppressor registry. Returns the same mutable object on every
- * call — callers can hold a reference and observe mutations (Rails parity).
+ * The suppressor registry: a map from class name → `true` when that
+ * class is currently suppressed. Mirrors Rails'
+ * `Suppressor.registry[klass.name] = true` contract.
+ *
+ * Storage is async-context-scoped (matching `explain-registry.ts` and
+ * Rails' `IsolatedExecutionState`/per-fiber semantics) so two
+ * concurrent `suppress` blocks running under the same Promise.all
+ * don't leak state into each other. Outside any active scope
+ * (sequential code paths) we fall back to a process-global registry,
+ * so existing direct mutations (`Base.registry[name] = true`)
+ * still work.
+ *
+ * `Object.create(null)` avoids `__proto__`/`constructor` foot-guns.
+ */
+const _fallback: Record<string, true | undefined> = Object.create(null);
+
+let _context: AsyncContext<Record<string, true | undefined>> | null = null;
+let _contextAdapter: ReturnType<typeof getAsyncContext> | null = null;
+
+function ctx(): AsyncContext<Record<string, true | undefined>> {
+  const adapter = getAsyncContext();
+  if (!_context || _contextAdapter !== adapter) {
+    _contextAdapter = adapter;
+    _context = adapter.create<Record<string, true | undefined>>();
+  }
+  return _context;
+}
+
+function currentRegistry(): Record<string, true | undefined> {
+  return ctx().getStore() ?? _fallback;
+}
+
+/**
+ * Get the suppressor registry for the current async scope. Returns the
+ * same object across calls within a scope (mutations are observable);
+ * concurrent async tasks each see their own isolated registry, matching
+ * Rails' per-fiber `IsolatedExecutionState`.
  *
  * Mirrors: ActiveRecord::Suppressor.registry
  */
-export function registry(): Record<string, number | undefined> {
-  return _suppressorRegistry;
+export function registry(): Record<string, true | undefined> {
+  return currentRegistry();
 }
 
 /**
  * Suppress persistence for the given model class during the block.
- * Re-entrant safe: nested suppress blocks increment the registry depth.
+ * Re-entrant safe — nested `suppress` calls inherit the parent scope's
+ * registry. Concurrent `suppress` blocks (e.g. under `Promise.all`)
+ * run in their own scopes and don't leak state.
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
@@ -44,29 +68,21 @@ export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>
     // (Rails has the same constraint); just run the block.
     return await fn();
   }
-  _suppressorRegistry[name] = (_suppressorRegistry[name] ?? 0) + 1;
-  try {
-    return await fn();
-  } finally {
-    const current = _suppressorRegistry[name] ?? 1;
-    if (current <= 1) {
-      delete _suppressorRegistry[name];
-    } else {
-      _suppressorRegistry[name] = current - 1;
-    }
-  }
+  const parent = currentRegistry();
+  const child: Record<string, true | undefined> = { ...parent, [name]: true };
+  return await ctx().run(child, fn);
 }
 
 /**
- * Check if the given model class (or any ancestor) is currently suppressed.
- * Walks the prototype chain so subclass instances honor a parent-class
- * suppression.
+ * Check if the given model class (or any ancestor) is currently
+ * suppressed in the active scope.
  */
 export function isSuppressed(modelClass: Function): boolean {
+  const reg = currentRegistry();
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    const name = (current as Function).name;
-    if (name && (_suppressorRegistry[name] ?? 0) > 0) return true;
+    const klassName = (current as Function).name;
+    if (klassName && reg[klassName]) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -5,6 +5,22 @@
  * Mirrors: ActiveRecord::Suppressor
  */
 
+/**
+ * The suppression registry, keyed by model class name.
+ * Mirrors: ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]
+ */
+const _suppressorRegistry: Record<string, boolean | undefined> = {};
+
+/**
+ * Get the current suppressor registry.
+ * Returns a mutable map of class names to suppression state.
+ *
+ * Mirrors: ActiveRecord::Suppressor.registry
+ */
+export function registry(): Record<string, boolean | undefined> {
+  return _suppressorRegistry;
+}
+
 const _suppressionDepth = new Map<Function, number>();
 
 /**
@@ -30,8 +46,6 @@ export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>
 
 /**
  * Check if the given model class is currently suppressed.
- *
- * Mirrors: ActiveRecord::Suppressor.registry
  */
 export function isSuppressed(modelClass: Function): boolean {
   let current: unknown = modelClass;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -6,51 +6,54 @@
  */
 
 /**
- * The suppression registry, keyed by model class name.
- * Mirrors: ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]
+ * Per-class suppression depth, keyed by model class name.
+ *
+ * Mirrors Rails' `ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry]`
+ * — Rails stores `true`/previous-state per class name, gated by Ruby's
+ * lexical `ensure`. JS lacks per-fiber state and overlapping async
+ * `suppress` blocks need re-entrant accounting, so we store a depth
+ * count: `registry[name] > 0` ⇔ suppressed. Truthiness matches Rails'
+ * `Suppressor.registry[name] ? true : super` check.
  */
-const _suppressorRegistry: Record<string, boolean | undefined> = {};
+const _suppressorRegistry: Record<string, number | undefined> = {};
 
 /**
- * Get the current suppressor registry.
- * Returns a mutable map of class names to suppression state.
+ * Get the suppressor registry. Truthy values indicate suppressed classes.
  *
  * Mirrors: ActiveRecord::Suppressor.registry
  */
-export function registry(): Record<string, boolean | undefined> {
+export function registry(): Record<string, number | undefined> {
   return _suppressorRegistry;
 }
 
-const _suppressionDepth = new Map<Function, number>();
-
 /**
  * Suppress persistence for the given model class during the block.
- * Re-entrant safe: nested suppress blocks increment a depth counter.
+ * Re-entrant safe: nested suppress blocks increment the registry depth.
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
 export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>): Promise<R> {
-  const depth = _suppressionDepth.get(modelClass) ?? 0;
-  _suppressionDepth.set(modelClass, depth + 1);
+  const name = modelClass.name;
+  _suppressorRegistry[name] = (_suppressorRegistry[name] ?? 0) + 1;
   try {
     return await fn();
   } finally {
-    const current = _suppressionDepth.get(modelClass) ?? 1;
+    const current = _suppressorRegistry[name] ?? 1;
     if (current <= 1) {
-      _suppressionDepth.delete(modelClass);
+      delete _suppressorRegistry[name];
     } else {
-      _suppressionDepth.set(modelClass, current - 1);
+      _suppressorRegistry[name] = current - 1;
     }
   }
 }
 
 /**
- * Check if the given model class is currently suppressed.
+ * Check if the given model class (or any ancestor) is currently suppressed.
  */
 export function isSuppressed(modelClass: Function): boolean {
   let current: unknown = modelClass;
   while (current && typeof current === "function") {
-    if ((_suppressionDepth.get(current as Function) ?? 0) > 0) return true;
+    if ((_suppressorRegistry[(current as Function).name] ?? 0) > 0) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -69,7 +69,11 @@ export async function suppress<R>(modelClass: Function, fn: () => R | Promise<R>
     return await fn();
   }
   const parent = currentRegistry();
-  const child: Record<string, true | undefined> = { ...parent, [name]: true };
+  // Null-prototype copy: keeps `Object.prototype` keys (toString,
+  // constructor, …) from masquerading as suppressed class names.
+  const child: Record<string, true | undefined> = Object.create(null);
+  Object.assign(child, parent);
+  child[name] = true;
   return await ctx().run(child, fn);
 }
 


### PR DESCRIPTION
## Summary

PR 5 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `suppressor.rb` row.

Ports `ActiveRecord::Suppressor.registry` and rewires `suppress` / `isSuppressed` to read/write through it. The registry is **AsyncContext-scoped** (matching `explain-registry.ts`, the trails analog of Rails' `IsolatedExecutionState`/per-fiber storage):

- Each `suppress(modelClass, fn)` wraps `fn` in a child registry that inherits the parent scope and sets `modelClass.name = true`.
- Concurrent `suppress` blocks under `Promise.all` get isolated registries — no cross-task leak.
- Outside any active scope, mutations land on a process-global fallback so direct mutations (`Base.registry["MyClass"] = true`) still work for sequential code.
- Public type: `Record<string, true | undefined>` — Rails-shaped boolean view. Internal storage uses null-prototype objects to keep `toString`/`constructor` from masquerading as suppressed class names.

## Impact

`pnpm api:compare --package activerecord`:

- `suppressor.rb`: 3/4 → 4/4 ✓
- 13 tests pass.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/suppressor.test.ts` — 13 pass
- [x] `pnpm api:compare --package activerecord` — `suppressor.rb 100%`
- [x] `pnpm build` clean
- [x] Concurrent isolation: a Promise.all of two `suppress(A)` / `suppress(B)` blocks each see only their own class set
- [x] Held-reference: a `Base.registry` reference captured *inside* a scope observes the scope's mutations; outside the scope, the fallback is unchanged
- [x] Nested `suppress` of the same class stays truthy throughout, then clears
- [x] Subclass `isSuppressed()` walks the prototype chain when a parent class is suppressed