### PR TITLE
feat(activerecord): TestDatabases.createAndLoadSchema

### DIFF
--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -179,19 +179,18 @@ describe("TestDatabasesTest", () => {
     expect(mockReconstructFromSchema).toHaveBeenCalled();
   });
 
-  it("does not overwrite an unset Base.configurations with an empty registry", async () => {
+  it("calls establishConnection to load disk configs when configurations is unset", async () => {
     vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
-    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
-      undefined,
-    );
+    const mockEstablishConnection = vi
+      .spyOn(await import("./connection-handling.js"), "establishConnection")
+      .mockResolvedValue(undefined);
 
-    // No `configurations` set on the model — autoConnect should still
-    // be free to load from disk on the reconnect path. Persisting an
-    // empty registry would trip "No database configuration found…".
+    // No `configurations` set — should trigger establishConnection (disk-load path)
+    // then return early since configurations is still null after that.
     const mockModelClass = { configurations: undefined } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 1, { envName: "arunit" });
-    expect((mockModelClass as any).configurations).toBeUndefined();
+    expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
   });
 
   it("throws a clear error when neither database nor URL yields a name", async () => {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -100,7 +100,7 @@ describe("TestDatabasesTest", () => {
     expect(mockReconstructFromSchema).toHaveBeenCalled();
   });
 
-  it("order of configurations isnt changed by test databases", async () => {
+  it("order of configurations isn't changed by test databases", async () => {
     const mockReconstructFromSchema = vi
       .spyOn(DatabaseTasks, "reconstructFromSchema")
       .mockResolvedValue(undefined);
@@ -121,8 +121,12 @@ describe("TestDatabasesTest", () => {
 
     await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
 
-    const configNames = configs.map((c: any) => c.name);
-    expect(configNames).toEqual(["primary", "replica"]);
+    expect(mockReconstructFromSchema).toHaveBeenCalledTimes(configs.length);
+    const reconstructedNames = mockReconstructFromSchema.mock.calls.map(
+      (call: any[]) => call[0].name,
+    );
+    expect(reconstructedNames).toEqual(["primary", "replica"]);
+    expect(mockEstablishConnection).toHaveBeenCalled();
   });
 
   // URL-only configs (no explicit `database`) — e.g. sqlite paths

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -124,6 +124,47 @@ describe("TestDatabasesTest", () => {
     mockEstablishConnection.mockRestore();
   });
 
+  // Mirrors Rails' `ensure` semantics in test_databases.rb:18-21 — the env
+  // restore and reconnect must still happen if reconstruct_from_schema raises.
+  it("restores VERBOSE and re-establishes connection after schema load failure", async () => {
+    const error = new Error("schema load failed");
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockRejectedValue(error);
+    const connectionHandling = await import("./connection-handling.js");
+    const mockEstablishConnection = vi
+      .spyOn(connectionHandling, "establishConnection")
+      .mockResolvedValue(undefined);
+
+    const mockConfig: any = {};
+    Object.defineProperty(mockConfig, "_database", {
+      set(val: string) {
+        this.__database = val;
+      },
+    });
+    Object.defineProperty(mockConfig, "database", {
+      get() {
+        return this.__database || "test/db/primary.sqlite3";
+      },
+    });
+    mockConfig.adapter = "sqlite3";
+
+    const mockModelClass = {
+      configurations: { configsFor: vi.fn().mockReturnValue([mockConfig]) },
+    } as any as typeof Base;
+
+    const originalVerbose = process.env.VERBOSE;
+    process.env.VERBOSE = "1";
+
+    try {
+      await expect(createAndLoadSchema(mockModelClass, 7, { envName: "arunit" })).rejects.toThrow(
+        error,
+      );
+      expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
+      expect(process.env.VERBOSE).toBe("1");
+    } finally {
+      process.env.VERBOSE = originalVerbose;
+    }
+  });
+
   it("createAndMigrate runs migrations on all adapters", async () => {
     const adapter = createTestAdapter();
     const log: string[] = [];

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -161,7 +161,11 @@ describe("TestDatabasesTest", () => {
       expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
       expect(process.env.VERBOSE).toBe("1");
     } finally {
-      process.env.VERBOSE = originalVerbose;
+      if (originalVerbose === undefined) {
+        delete process.env.VERBOSE;
+      } else {
+        process.env.VERBOSE = originalVerbose;
+      }
     }
   });
 

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
@@ -7,6 +7,10 @@ import type { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 describe("TestDatabasesTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("databases are created", async () => {
     const mockReconstructFromSchema = vi
       .spyOn(DatabaseTasks, "reconstructFromSchema")

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -151,6 +151,49 @@ describe("TestDatabasesTest", () => {
     expect(dbConfig.database).toBe("test/db/primary.sqlite3-5");
   });
 
+  it("does not suffix in-memory SQLite databases", async () => {
+    const mockReconstructFromSchema = vi
+      .spyOn(DatabaseTasks, "reconstructFromSchema")
+      .mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
+
+    const mockConfig: any = { adapter: "sqlite3" };
+    let suffixed: string | undefined;
+    Object.defineProperty(mockConfig, "_database", {
+      set(val: string) {
+        suffixed = val;
+      },
+    });
+    Object.defineProperty(mockConfig, "database", { get: () => ":memory:" });
+
+    const mockModelClass = {
+      configurations: stubConfigurations([mockConfig]),
+    } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 7, { envName: "arunit" });
+    // _database setter must NOT have been called for an in-memory DB —
+    // suffixing `:memory:` would turn it into an on-disk path.
+    expect(suffixed).toBeUndefined();
+    expect(mockReconstructFromSchema).toHaveBeenCalled();
+  });
+
+  it("does not overwrite an unset Base.configurations with an empty registry", async () => {
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
+
+    // No `configurations` set on the model — autoConnect should still
+    // be free to load from disk on the reconnect path. Persisting an
+    // empty registry would trip "No database configuration found…".
+    const mockModelClass = { configurations: undefined } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 1, { envName: "arunit" });
+    expect((mockModelClass as any).configurations).toBeUndefined();
+  });
+
   it("throws a clear error when neither database nor URL yields a name", async () => {
     vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
     vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -3,8 +3,19 @@ import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-data
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
 import type { Base } from "./base.js";
-import type { DatabaseConfigurations } from "./database-configurations.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
+
+// Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
+// supplied stubbed configs. Mirrors the production shape — production code
+// calls `(this as any).configurations?.toH?.()` then `fromEnv(...)`, so the
+// real Base.configurations is a raw hash; createAndLoadSchema normalizes
+// either input. Tests use the post-normalization instance directly.
+const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
+  const dc = new DatabaseConfigurations([]);
+  vi.spyOn(dc, "configsFor").mockReturnValue(configs as never);
+  return dc;
+};
 
 describe("TestDatabasesTest", () => {
   afterEach(() => {
@@ -33,9 +44,7 @@ describe("TestDatabasesTest", () => {
     });
     mockConfig.adapter = "sqlite3";
 
-    const mockConfigurations = {
-      configsFor: vi.fn().mockReturnValue([mockConfig]),
-    } as any as DatabaseConfigurations;
+    const mockConfigurations = stubConfigurations([mockConfig]);
 
     const mockModelClass = {
       configurations: mockConfigurations,
@@ -74,9 +83,7 @@ describe("TestDatabasesTest", () => {
     });
     mockConfig.adapter = "sqlite3";
 
-    const mockConfigurations = {
-      configsFor: vi.fn().mockReturnValue([mockConfig]),
-    } as any as DatabaseConfigurations;
+    const mockConfigurations = stubConfigurations([mockConfig]);
 
     const mockModelClass = {
       configurations: mockConfigurations,
@@ -101,9 +108,7 @@ describe("TestDatabasesTest", () => {
       { database: "test/db/replica.sqlite3", adapter: "sqlite3", name: "replica" },
     ];
 
-    const mockConfigurations = {
-      configsFor: vi.fn().mockReturnValue(configs),
-    } as any as DatabaseConfigurations;
+    const mockConfigurations = stubConfigurations(configs);
 
     const mockModelClass = {
       configurations: mockConfigurations,
@@ -139,7 +144,7 @@ describe("TestDatabasesTest", () => {
     mockConfig.adapter = "sqlite3";
 
     const mockModelClass = {
-      configurations: { configsFor: vi.fn().mockReturnValue([mockConfig]) },
+      configurations: stubConfigurations([mockConfig]),
     } as any as typeof Base;
 
     const originalVerbose = process.env.VERBOSE;

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -121,37 +121,25 @@ describe("TestDatabasesTest", () => {
   });
 
   // URL-only configs (no explicit `database`) — e.g. sqlite paths
-  // embedded in the URL. The base name must be derived from the URL so
-  // suffixing produces `<dbpath>-<index>` rather than `undefined-<index>`.
+  // embedded in the URL. UrlConfig.database (#957) parses the URL,
+  // so the suffix lands on the parsed path rather than `undefined`.
   it("suffixes a URL-based config by deriving the database from configuration.url", async () => {
     vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
     vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
       undefined,
     );
 
-    const mockConfig: any = {
+    const { UrlConfig } = await import("./database-configurations/url-config.js");
+    const dbConfig = new UrlConfig("arunit", "primary", "test/db/primary.sqlite3", {
       adapter: "sqlite3",
-      configuration: { url: "test/db/primary.sqlite3" },
-    };
-    let suffixed: string | undefined;
-    Object.defineProperty(mockConfig, "_database", {
-      set(val: string) {
-        suffixed = val;
-        this.__database = val;
-      },
-    });
-    Object.defineProperty(mockConfig, "database", {
-      get() {
-        return this.__database; // initially undefined — URL parsing must kick in
-      },
     });
 
     const mockModelClass = {
-      configurations: stubConfigurations([mockConfig]),
+      configurations: stubConfigurations([dbConfig]),
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 5, { envName: "arunit" });
-    expect(suffixed).toBe("test/db/primary.sqlite3-5");
+    expect(dbConfig.database).toBe("test/db/primary.sqlite3-5");
   });
 
   it("throws a clear error when neither database nor URL yields a name", async () => {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -120,6 +120,59 @@ describe("TestDatabasesTest", () => {
     expect(configNames).toEqual(["primary", "replica"]);
   });
 
+  // URL-only configs (no explicit `database`) — e.g. sqlite paths
+  // embedded in the URL. The base name must be derived from the URL so
+  // suffixing produces `<dbpath>-<index>` rather than `undefined-<index>`.
+  it("suffixes a URL-based config by deriving the database from configuration.url", async () => {
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
+
+    const mockConfig: any = {
+      adapter: "sqlite3",
+      configuration: { url: "test/db/primary.sqlite3" },
+    };
+    let suffixed: string | undefined;
+    Object.defineProperty(mockConfig, "_database", {
+      set(val: string) {
+        suffixed = val;
+        this.__database = val;
+      },
+    });
+    Object.defineProperty(mockConfig, "database", {
+      get() {
+        return this.__database; // initially undefined — URL parsing must kick in
+      },
+    });
+
+    const mockModelClass = {
+      configurations: stubConfigurations([mockConfig]),
+    } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 5, { envName: "arunit" });
+    expect(suffixed).toBe("test/db/primary.sqlite3-5");
+  });
+
+  it("throws a clear error when neither database nor URL yields a name", async () => {
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
+
+    const mockConfig: any = { adapter: "sqlite3", configuration: {}, name: "primary" };
+    Object.defineProperty(mockConfig, "_database", { set() {} });
+    Object.defineProperty(mockConfig, "database", { get: () => undefined });
+
+    const mockModelClass = {
+      configurations: stubConfigurations([mockConfig]),
+    } as any as typeof Base;
+
+    await expect(createAndLoadSchema(mockModelClass, 1, { envName: "arunit" })).rejects.toThrow(
+      /Cannot suffix database name/,
+    );
+  });
+
   // Mirrors Rails' `ensure` semantics in test_databases.rb:18-21 — the env
   // restore and reconnect must still happen if reconstruct_from_schema raises.
   it("restores VERBOSE and re-establishes connection after schema load failure", async () => {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
-import { Base } from "./base.js";
+import type { Base } from "./base.js";
 import type { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
@@ -50,9 +50,6 @@ describe("TestDatabasesTest", () => {
       undefined,
     );
     expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
-
-    mockReconstructFromSchema.mockRestore();
-    mockEstablishConnection.mockRestore();
   });
 
   it("create databases after fork", async () => {
@@ -89,9 +86,6 @@ describe("TestDatabasesTest", () => {
 
     expect(mockConfig.database).toBe("test/db/primary.sqlite3-42");
     expect(mockReconstructFromSchema).toHaveBeenCalled();
-
-    mockReconstructFromSchema.mockRestore();
-    mockEstablishConnection.mockRestore();
   });
 
   it("order of configurations isnt changed by test databases", async () => {
@@ -119,9 +113,6 @@ describe("TestDatabasesTest", () => {
 
     const configNames = configs.map((c: any) => c.name);
     expect(configNames).toEqual(["primary", "replica"]);
-
-    mockReconstructFromSchema.mockRestore();
-    mockEstablishConnection.mockRestore();
   });
 
   // Mirrors Rails' `ensure` semantics in test_databases.rb:18-21 — the env

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,12 +1,124 @@
-import { describe, it, expect } from "vitest";
-import { createAndMigrate, eachDatabase } from "./test-databases.js";
+import { describe, it, expect, vi } from "vitest";
+import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
+import { Base } from "./base.js";
+import type { DatabaseConfigurations } from "./database-configurations.js";
+import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 describe("TestDatabasesTest", () => {
-  it.skip("databases are created", () => {});
-  it.skip("create databases after fork", () => {});
-  it.skip("order of configurations isnt changed by test databases", () => {});
+  it("databases are created", async () => {
+    const mockReconstructFromSchema = vi
+      .spyOn(DatabaseTasks, "reconstructFromSchema")
+      .mockResolvedValue(undefined);
+    const connectionHandling = await import("./connection-handling.js");
+    const mockEstablishConnection = vi
+      .spyOn(connectionHandling, "establishConnection")
+      .mockResolvedValue(undefined);
+
+    const mockConfig: any = {};
+    Object.defineProperty(mockConfig, "_database", {
+      set: function (val: string) {
+        this.__database = val;
+      },
+    });
+    Object.defineProperty(mockConfig, "database", {
+      get: function () {
+        return this.__database || "test/db/primary.sqlite3";
+      },
+    });
+    mockConfig.adapter = "sqlite3";
+
+    const mockConfigurations = {
+      configsFor: vi.fn().mockReturnValue([mockConfig]),
+    } as any as DatabaseConfigurations;
+
+    const mockModelClass = {
+      configurations: mockConfigurations,
+    } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 2, { envName: "arunit" });
+
+    expect(mockConfig.database).toBe("test/db/primary.sqlite3-2");
+    expect(mockReconstructFromSchema).toHaveBeenCalledWith(
+      mockConfig,
+      DatabaseTasks.schemaFormat,
+      undefined,
+    );
+    expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
+
+    mockReconstructFromSchema.mockRestore();
+    mockEstablishConnection.mockRestore();
+  });
+
+  it("create databases after fork", async () => {
+    const mockReconstructFromSchema = vi
+      .spyOn(DatabaseTasks, "reconstructFromSchema")
+      .mockResolvedValue(undefined);
+    const connectionHandling = await import("./connection-handling.js");
+    const mockEstablishConnection = vi
+      .spyOn(connectionHandling, "establishConnection")
+      .mockResolvedValue(undefined);
+
+    const mockConfig: any = {};
+    Object.defineProperty(mockConfig, "_database", {
+      set: function (val: string) {
+        this.__database = val;
+      },
+    });
+    Object.defineProperty(mockConfig, "database", {
+      get: function () {
+        return this.__database || "test/db/primary.sqlite3";
+      },
+    });
+    mockConfig.adapter = "sqlite3";
+
+    const mockConfigurations = {
+      configsFor: vi.fn().mockReturnValue([mockConfig]),
+    } as any as DatabaseConfigurations;
+
+    const mockModelClass = {
+      configurations: mockConfigurations,
+    } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
+
+    expect(mockConfig.database).toBe("test/db/primary.sqlite3-42");
+    expect(mockReconstructFromSchema).toHaveBeenCalled();
+
+    mockReconstructFromSchema.mockRestore();
+    mockEstablishConnection.mockRestore();
+  });
+
+  it("order of configurations isnt changed by test databases", async () => {
+    const mockReconstructFromSchema = vi
+      .spyOn(DatabaseTasks, "reconstructFromSchema")
+      .mockResolvedValue(undefined);
+    const mockEstablishConnection = vi
+      .spyOn(await import("./connection-handling.js"), "establishConnection")
+      .mockResolvedValue(undefined);
+
+    const configs = [
+      { database: "test/db/primary.sqlite3", adapter: "sqlite3", name: "primary" },
+      { database: "test/db/replica.sqlite3", adapter: "sqlite3", name: "replica" },
+    ];
+
+    const mockConfigurations = {
+      configsFor: vi.fn().mockReturnValue(configs),
+    } as any as DatabaseConfigurations;
+
+    const mockModelClass = {
+      configurations: mockConfigurations,
+    } as any as typeof Base;
+
+    await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
+
+    const configNames = configs.map((c: any) => c.name);
+    expect(configNames).toEqual(["primary", "replica"]);
+
+    mockReconstructFromSchema.mockRestore();
+    mockEstablishConnection.mockRestore();
+  });
 
   it("createAndMigrate runs migrations on all adapters", async () => {
     const adapter = createTestAdapter();

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { createTestAdapter } from "./test-adapter.js";
 import type { MigrationProxy } from "./migration.js";
@@ -18,7 +18,12 @@ const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
 };
 
 describe("TestDatabasesTest", () => {
+  let priorCurrent: DatabaseConfigurations | null;
+  beforeEach(() => {
+    priorCurrent = DatabaseConfigurations.current;
+  });
   afterEach(() => {
+    DatabaseConfigurations.current = priorCurrent;
     vi.restoreAllMocks();
   });
 

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -100,7 +100,7 @@ describe("TestDatabasesTest", () => {
     expect(mockReconstructFromSchema).toHaveBeenCalled();
   });
 
-  it("order of configurations isn't changed by test databases", async () => {
+  it("order of configurations isnt changed by test databases", async () => {
     const mockReconstructFromSchema = vi
       .spyOn(DatabaseTasks, "reconstructFromSchema")
       .mockResolvedValue(undefined);

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -179,18 +179,17 @@ describe("TestDatabasesTest", () => {
     expect(mockReconstructFromSchema).toHaveBeenCalled();
   });
 
-  it("calls establishConnection to load disk configs when configurations is unset", async () => {
+  it("does not overwrite an unset Base.configurations with an empty registry", async () => {
     vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
-    const mockEstablishConnection = vi
-      .spyOn(await import("./connection-handling.js"), "establishConnection")
-      .mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
 
-    // No `configurations` set — should trigger establishConnection (disk-load path)
-    // then return early since configurations is still null after that.
+    // No `configurations` — defensive early return; nothing to suffix.
+    // In Rails this never occurs (app boot sets configurations first).
     const mockModelClass = { configurations: undefined } as any as typeof Base;
-
     await createAndLoadSchema(mockModelClass, 1, { envName: "arunit" });
-    expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
+    expect((mockModelClass as any).configurations).toBeUndefined();
   });
 
   it("throws a clear error when neither database nor URL yields a name", async () => {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -40,6 +40,14 @@ export async function eachDatabase(
   }
 }
 
+// `:memory:` (canonical) plus the URI variants SQLite recognizes for an
+// in-memory database. See https://www.sqlite.org/inmemorydb.html.
+function isInMemorySqlite(name: string): boolean {
+  if (name === ":memory:") return true;
+  if (name.startsWith("file::memory:")) return true;
+  return /[?&]mode=memory(?:&|$)/.test(name);
+}
+
 /**
  * Create and load test schema(s) for parallelized test execution.
  *
@@ -63,11 +71,17 @@ export async function createAndLoadSchema(
   // regardless of whether `configurations` is already a registry, a raw
   // hash, or unset.
   const raw = (modelClass as any).configurations;
+  if (raw == null) {
+    // No in-memory configurations — let autoConnect's disk-load path
+    // handle the reconnect, and there's nothing to suffix in-memory.
+    // Falling through here would overwrite Base.configurations with an
+    // empty registry and trip "No database configuration found…".
+    return;
+  }
   const configurations =
     raw instanceof DatabaseConfigurations
       ? raw
-      : DatabaseConfigurations.fromEnv(typeof raw?.toH === "function" ? raw.toH() : (raw ?? {}));
-  if (!configurations) return;
+      : DatabaseConfigurations.fromEnv(typeof raw.toH === "function" ? raw.toH() : raw);
   // Persist the normalized registry back so later mutations (`_database`
   // suffixing) and the post-finally reconnect see the same instance.
   // Without this, a caller that supplied a raw OrderedOptions / hash
@@ -91,7 +105,14 @@ export async function createAndLoadSchema(
             `neither database nor a parseable URL is available`,
         );
       }
-      dbConfig._database = `${baseName}-${index}`;
+      // Skip suffixing for SQLite in-memory databases — `:memory:` and
+      // `file::memory:?...` are special-cased by SQLiteDatabaseTasks and
+      // are already per-process-isolated, so workers don't need a suffix.
+      // Suffixing would turn `:memory:` into `:memory:-2`, which the
+      // adapter would treat as an on-disk file path.
+      if (!isInMemorySqlite(baseName)) {
+        dbConfig._database = `${baseName}-${index}`;
+      }
       await DatabaseTasks.reconstructFromSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
     }
   } finally {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -41,28 +41,6 @@ export async function eachDatabase(
 }
 
 /**
- * Pull the database path out of a URL-shaped config when the explicit
- * `database` field isn't populated. trails' `UrlConfig` doesn't override
- * `database` to parse the URL the way Rails does, so URL-only configs
- * (e.g. `{ adapter: "sqlite3", url: "test/db/primary.sqlite3" }`)
- * present `dbConfig.database === undefined`. Mirrors Rails' fallback
- * behavior of `URI(url).path.delete_prefix("/")`.
- */
-function databaseFromUrl(dbConfig: { configuration?: { url?: string } }): string | undefined {
-  const url = dbConfig.configuration?.url;
-  if (typeof url !== "string" || url === "") return undefined;
-  // sqlite3 URLs are typically file paths (e.g. "test/db/foo.sqlite3"
-  // or "sqlite3:test/db/foo.sqlite3"). Try URL parsing first, fall
-  // through to the raw string if the URL has no scheme.
-  try {
-    const parsed = new URL(url);
-    return parsed.pathname.replace(/^\//, "") || parsed.host || undefined;
-  } catch {
-    return url;
-  }
-}
-
-/**
  * Create and load test schema(s) for parallelized test execution.
  *
  * For each configuration in the named environment, appends the index to
@@ -97,7 +75,10 @@ export async function createAndLoadSchema(
   try {
     const configs = configurations.configsFor({ envName });
     for (const dbConfig of configs) {
-      const baseName = dbConfig.database ?? databaseFromUrl(dbConfig);
+      // `dbConfig.database` falls back to URL parsing for URL-only configs
+      // (UrlConfig.database override landed in #957). Only fails for configs
+      // with neither an explicit `database` nor a parseable URL.
+      const baseName = dbConfig.database;
       if (!baseName) {
         throw new Error(
           `Cannot suffix database name for ${envName}/${dbConfig.name ?? "(unnamed)"}: ` +

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -89,14 +89,14 @@ export async function createAndLoadSchema(
       await DatabaseTasks.reconstructFromSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
     }
   } finally {
-    // Restore VERBOSE environment variable
+    // Rails ensure order: establish_connection first, then restore VERBOSE
+    // (test_databases.rb:18-21).
+    const { establishConnection } = await import("./connection-handling.js");
+    await establishConnection(modelClass);
     if (old !== undefined) {
       process.env.VERBOSE = old;
     } else {
       delete process.env.VERBOSE;
     }
-    // Re-establish connection to original database(s)
-    const { establishConnection } = await import("./connection-handling.js");
-    await establishConnection(modelClass);
   }
 }

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -45,7 +45,7 @@ export async function eachDatabase(
  *
  * For each configuration in the named environment, appends the index to
  * the database name, purges/creates the database, and loads the schema.
- * Finally re-establishes the connection to the original database(s).
+ * Finally re-establishes the connection so the worker uses the suffixed per-worker database.
  *
  * Called by ActiveSupport::Testing::Parallelization.after_fork_hook in
  * parallelized test workers (process i gets test databases with suffix `-i`).

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -65,28 +65,23 @@ export async function createAndLoadSchema(
   index: number,
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
-  // `Base.configurations` is a raw, OrderedOptions-shaped object with
-  // `.toH()` (matches `connection-handling.ts:81`'s usage). Normalize via
-  // `DatabaseConfigurations.fromEnv` so subsequent `.configsFor` is safe
-  // regardless of whether `configurations` is already a registry, a raw
-  // hash, or unset.
-  const raw = (modelClass as any).configurations;
+  // If configurations haven't been loaded yet, trigger autoConnect so the
+  // disk-load path populates them (mirrors Rails: configs are always loaded
+  // before create_and_load_schema is called via the after_fork_hook).
+  let raw = (modelClass as any).configurations;
   if (raw == null) {
-    // No in-memory configurations — let autoConnect's disk-load path
-    // handle the reconnect, and there's nothing to suffix in-memory.
-    // Falling through here would overwrite Base.configurations with an
-    // empty registry and trip "No database configuration found…".
-    return;
+    const { establishConnection } = await import("./connection-handling.js");
+    await establishConnection(modelClass);
+    raw = (modelClass as any).configurations;
   }
+  if (raw == null) return; // truly no config even after disk-load — nothing to do
+
+  // Normalize to a DatabaseConfigurations instance. Persist it back so
+  // _database mutations and the finally reconnect see the same registry.
   const configurations =
     raw instanceof DatabaseConfigurations
       ? raw
       : DatabaseConfigurations.fromEnv(typeof raw.toH === "function" ? raw.toH() : raw);
-  // Persist the normalized registry back so later mutations (`_database`
-  // suffixing) and the post-finally reconnect see the same instance.
-  // Without this, a caller that supplied a raw OrderedOptions / hash
-  // would re-normalize from the original (unmutated) source on the
-  // reconnect path and target the unsuffixed DB.
   (modelClass as any).configurations = configurations;
 
   const old = process.env.VERBOSE;

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -41,6 +41,28 @@ export async function eachDatabase(
 }
 
 /**
+ * Pull the database path out of a URL-shaped config when the explicit
+ * `database` field isn't populated. trails' `UrlConfig` doesn't override
+ * `database` to parse the URL the way Rails does, so URL-only configs
+ * (e.g. `{ adapter: "sqlite3", url: "test/db/primary.sqlite3" }`)
+ * present `dbConfig.database === undefined`. Mirrors Rails' fallback
+ * behavior of `URI(url).path.delete_prefix("/")`.
+ */
+function databaseFromUrl(dbConfig: { configuration?: { url?: string } }): string | undefined {
+  const url = dbConfig.configuration?.url;
+  if (typeof url !== "string" || url === "") return undefined;
+  // sqlite3 URLs are typically file paths (e.g. "test/db/foo.sqlite3"
+  // or "sqlite3:test/db/foo.sqlite3"). Try URL parsing first, fall
+  // through to the raw string if the URL has no scheme.
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.replace(/^\//, "") || parsed.host || undefined;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Create and load test schema(s) for parallelized test execution.
  *
  * For each configuration in the named environment, appends the index to
@@ -75,7 +97,14 @@ export async function createAndLoadSchema(
   try {
     const configs = configurations.configsFor({ envName });
     for (const dbConfig of configs) {
-      dbConfig._database = `${dbConfig.database}-${index}`;
+      const baseName = dbConfig.database ?? databaseFromUrl(dbConfig);
+      if (!baseName) {
+        throw new Error(
+          `Cannot suffix database name for ${envName}/${dbConfig.name ?? "(unnamed)"}: ` +
+            `neither database nor a parseable URL is available`,
+        );
+      }
+      dbConfig._database = `${baseName}-${index}`;
       await DatabaseTasks.reconstructFromSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
     }
   } finally {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -68,6 +68,12 @@ export async function createAndLoadSchema(
       ? raw
       : DatabaseConfigurations.fromEnv(typeof raw?.toH === "function" ? raw.toH() : (raw ?? {}));
   if (!configurations) return;
+  // Persist the normalized registry back so later mutations (`_database`
+  // suffixing) and the post-finally reconnect see the same instance.
+  // Without this, a caller that supplied a raw OrderedOptions / hash
+  // would re-normalize from the original (unmutated) source on the
+  // reconnect path and target the unsuffixed DB.
+  (modelClass as any).configurations = configurations;
 
   const old = process.env.VERBOSE;
   process.env.VERBOSE = "false";

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -8,7 +8,7 @@ import type { DatabaseAdapter } from "./adapter.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migrator } from "./migration.js";
 import type { Base } from "./base.js";
-import type { DatabaseConfigurations } from "./database-configurations.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 /**
@@ -57,7 +57,16 @@ export async function createAndLoadSchema(
   index: number,
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
-  const configurations = (modelClass as any).configurations as DatabaseConfigurations;
+  // `Base.configurations` is a raw, OrderedOptions-shaped object with
+  // `.toH()` (matches `connection-handling.ts:81`'s usage). Normalize via
+  // `DatabaseConfigurations.fromEnv` so subsequent `.configsFor` is safe
+  // regardless of whether `configurations` is already a registry, a raw
+  // hash, or unset.
+  const raw = (modelClass as any).configurations;
+  const configurations =
+    raw instanceof DatabaseConfigurations
+      ? raw
+      : DatabaseConfigurations.fromEnv(typeof raw?.toH === "function" ? raw.toH() : (raw ?? {}));
   if (!configurations) return;
 
   const old = process.env.VERBOSE;

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -7,6 +7,9 @@
 import type { DatabaseAdapter } from "./adapter.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migrator } from "./migration.js";
+import type { Base } from "./base.js";
+import type { DatabaseConfigurations } from "./database-configurations.js";
+import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 /**
  * Run migrations on each test database adapter.
@@ -34,5 +37,47 @@ export async function eachDatabase(
 ): Promise<void> {
   for (let i = 0; i < adapters.length; i++) {
     await callback(adapters[i], i);
+  }
+}
+
+/**
+ * Create and load test schema(s) for parallelized test execution.
+ *
+ * For each configuration in the named environment, appends the index to
+ * the database name, purges/creates the database, and loads the schema.
+ * Finally re-establishes the connection to the original database(s).
+ *
+ * Called by ActiveSupport::Testing::Parallelization.after_fork_hook in
+ * parallelized test workers (process i gets test databases with suffix `-i`).
+ *
+ * Mirrors: ActiveRecord::TestDatabases.create_and_load_schema
+ */
+export async function createAndLoadSchema(
+  modelClass: typeof Base,
+  index: number,
+  { envName }: { envName: string } = { envName: "test" },
+): Promise<void> {
+  const configurations = (modelClass as any).configurations as DatabaseConfigurations;
+  if (!configurations) return;
+
+  const old = process.env.VERBOSE;
+  process.env.VERBOSE = "false";
+
+  try {
+    const configs = configurations.configsFor({ envName });
+    for (const dbConfig of configs) {
+      (dbConfig as any)._database = `${dbConfig.database}-${index}`;
+      await DatabaseTasks.reconstructFromSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
+    }
+  } finally {
+    // Restore VERBOSE environment variable
+    if (old !== undefined) {
+      process.env.VERBOSE = old;
+    } else {
+      delete process.env.VERBOSE;
+    }
+    // Re-establish connection to original database(s)
+    const { establishConnection } = await import("./connection-handling.js");
+    await establishConnection(modelClass);
   }
 }

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -40,12 +40,12 @@ export async function eachDatabase(
   }
 }
 
-// `:memory:` (canonical) plus the URI variants SQLite recognizes for an
-// in-memory database. See https://www.sqlite.org/inmemorydb.html.
+// Only the canonical `:memory:` name is treated as in-memory by
+// SQLiteDatabaseTasks (create/drop skip it). URI variants like
+// `file::memory:?cache=shared` are not currently special-cased there,
+// so we match only what the task layer actually handles.
 function isInMemorySqlite(name: string): boolean {
-  if (name === ":memory:") return true;
-  if (name.startsWith("file::memory:")) return true;
-  return /[?&]mode=memory(?:&|$)/.test(name);
+  return name === ":memory:";
 }
 
 /**
@@ -65,16 +65,11 @@ export async function createAndLoadSchema(
   index: number,
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
-  // If configurations haven't been loaded yet, trigger autoConnect so the
-  // disk-load path populates them (mirrors Rails: configs are always loaded
-  // before create_and_load_schema is called via the after_fork_hook).
-  let raw = (modelClass as any).configurations;
-  if (raw == null) {
-    const { establishConnection } = await import("./connection-handling.js");
-    await establishConnection(modelClass);
-    raw = (modelClass as any).configurations;
-  }
-  if (raw == null) return; // truly no config even after disk-load — nothing to do
+  // Rails: configurations is always set before create_and_load_schema is
+  // called (app boots first). Guard here is defensive — if null, there is
+  // nothing to suffix and the finally reconnect handles the rest.
+  const raw = (modelClass as any).configurations;
+  if (raw == null) return;
 
   // Normalize to a DatabaseConfigurations instance. Persist it back so
   // _database mutations and the finally reconnect see the same registry.
@@ -100,11 +95,9 @@ export async function createAndLoadSchema(
             `neither database nor a parseable URL is available`,
         );
       }
-      // Skip suffixing for SQLite in-memory databases — `:memory:` and
-      // `file::memory:?...` are special-cased by SQLiteDatabaseTasks and
-      // are already per-process-isolated, so workers don't need a suffix.
-      // Suffixing would turn `:memory:` into `:memory:-2`, which the
-      // adapter would treat as an on-disk file path.
+      // Skip suffixing for the canonical SQLite in-memory database — `:memory:`
+      // is special-cased by SQLiteDatabaseTasks (create/drop are no-ops) and
+      // suffixing would turn it into an on-disk path like `:memory:-2`.
       if (!isInMemorySqlite(baseName)) {
         dbConfig._database = `${baseName}-${index}`;
       }
@@ -112,13 +105,17 @@ export async function createAndLoadSchema(
     }
   } finally {
     // Rails ensure order: establish_connection first, then restore VERBOSE
-    // (test_databases.rb:18-21).
+    // (test_databases.rb:18-21). Nest VERBOSE restore in its own finally so
+    // it always runs even if establishConnection throws.
     const { establishConnection } = await import("./connection-handling.js");
-    await establishConnection(modelClass);
-    if (old !== undefined) {
-      process.env.VERBOSE = old;
-    } else {
-      delete process.env.VERBOSE;
+    try {
+      await establishConnection(modelClass);
+    } finally {
+      if (old !== undefined) {
+        process.env.VERBOSE = old;
+      } else {
+        delete process.env.VERBOSE;
+      }
     }
   }
 }

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -66,7 +66,7 @@ export async function createAndLoadSchema(
   try {
     const configs = configurations.configsFor({ envName });
     for (const dbConfig of configs) {
-      (dbConfig as any)._database = `${dbConfig.database}-${index}`;
+      dbConfig._database = `${dbConfig.database}-${index}`;
       await DatabaseTasks.reconstructFromSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
     }
   } finally {


### PR DESCRIPTION
## Summary

PR 10 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `test_databases.rb` row.

Ports `ActiveRecord::TestDatabases.create_and_load_schema` ([Rails source](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/test_databases.rb)) — for each configuration in the named environment, appends the worker index to the database name, reconstructs the schema via `DatabaseTasks.reconstructFromSchema`, then re-establishes the connection. Mirrors Rails' `ensure`-based VERBOSE/connection cleanup.

## Impact

`pnpm api:compare --package activerecord`:

- `test_databases.rb`: 0/1 → 1/1 ✓
- 8 tests pass.

## Resolved concerns (across all review cycles)

- ✅ Persist normalized registry back onto `modelClass.configurations` so `_database` mutations are visible to `establishConnection`
- ✅ Null `configurations` guard — defensive early return (in Rails, configs are always set before this is called via the after_fork_hook)
- ✅ `isInMemorySqlite` narrowed to `":memory:"` only — matches what `SQLiteDatabaseTasks.create/drop` actually special-cases
- ✅ VERBOSE always restored: nested `try/finally` wraps `establishConnection` so VERBOSE is guaranteed to be restored even if reconnect throws
- ✅ Rails `ensure` order: `establish_connection` before VERBOSE restore
- ✅ `DatabaseConfigurations.current` snapshot/restore in tests (prevents global state leak across test files)
- ✅ `order of configurations isnt changed by test databases` asserts `mockReconstructFromSchema.mock.calls` order + count
- ✅ Test name kept as Rails spelling `isnt` (CLAUDE.md: never rename Rails-mirrored test names)
- ✅ URL-config support via #957's `UrlConfig.database` URL fallback
- ✅ Clear error when neither `database` nor a parseable URL is available
- ✅ Failure-path: VERBOSE restored + `establishConnection` called when `reconstructFromSchema` rejects

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/test-databases.test.ts` — 8 pass
- [x] `pnpm api:compare --package activerecord` — `test_databases.rb 100%`
- [x] `pnpm build` clean
- [x] Rails-mirrored: `databases are created`, `create databases after fork`, `order of configurations isnt changed by test databases`
- [x] Failure-path: VERBOSE restored + `establishConnection` still called when `reconstructFromSchema` rejects
- [x] URL-config: real `UrlConfig` exercises the URL-parsing fallback from #957
- [x] Missing-name: clear error when neither field nor URL yields a name