### PR TITLE
feat(activerecord): Serialization#serializableHash

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -47,6 +47,7 @@ export { DirtyTracker } from "./dirty.js";
 export { CallbackChain } from "./callbacks.js";
 export type { CallbackConditions } from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
+export type { SerializeOptions } from "./serialization.js";
 export { Type } from "./type/value.js";
 export { typeRegistry } from "./type/registry.js";
 

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -31,10 +31,19 @@ export function serializableHash(
   record: AnyRecord,
   options: SerializeOptions = {},
 ): Record<string, unknown> {
-  // Get keys without materializing all values
+  // Models can override `attributeNamesForSerialization` to scope which
+  // attributes appear (Rails' private `attribute_names_for_serialization`
+  // hook). When absent, fall back to the underlying attribute store.
   const attrStore = record._attributes;
   let keys: string[];
-  if (attrStore && typeof attrStore.keys === "function" && !(attrStore instanceof Map)) {
+  if (
+    typeof (record as { attributeNamesForSerialization?: () => string[] })
+      .attributeNamesForSerialization === "function"
+  ) {
+    keys = (
+      record as { attributeNamesForSerialization: () => string[] }
+    ).attributeNamesForSerialization();
+  } else if (attrStore && typeof attrStore.keys === "function" && !(attrStore instanceof Map)) {
     keys = attrStore.keys();
   } else if (attrStore instanceof Map) {
     keys = Array.from(attrStore.keys());

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -91,6 +91,7 @@ import * as LockingOptimistic from "./locking/optimistic.js";
 import * as LockingPessimistic from "./locking/pessimistic.js";
 import * as Translation from "./translation.js";
 import * as Sanitization from "./sanitization.js";
+import * as Serialization from "./serialization.js";
 import * as Querying from "./querying.js";
 import { include, extend, type Included, type ParameterFilter } from "@blazetrails/activesupport";
 import {
@@ -2974,6 +2975,8 @@ include(Base, {
   cacheKey: _cacheKey,
   cacheKeyWithVersion: _cacheKeyWithVersion,
   cacheVersion: _cacheVersion,
+  // Serialization
+  serializableHash: Serialization.serializableHash,
   // AttributeMethods
   hasAttribute: _hasAttribute,
   attributePresent: _attributePresent,
@@ -2997,6 +3000,9 @@ include(Base, {
   readAttributeForValidation: _Validations.readAttributeForValidation,
   validate: _Validations.validate,
   customValidationContext: _Validations.customValidationContext,
+});
+include(Base, {
+  attributeNamesForSerialization: Serialization.attributeNamesForSerialization,
 });
 
 // Register Model's super methods for the Validations module.

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -102,9 +102,32 @@ describe("SerializationTest", () => {
     Vehicle.adapter = adapter;
 
     const car = new Vehicle({ id: 1, name: "Camry", type: "Car" });
-    const hash = (car as any).serializableHash();
+    const hash = car.serializableHash();
     expect(hash).toMatchObject({ id: 1, name: "Camry" });
     expect(hash).not.toHaveProperty("type");
+  });
+
+  // Mirrors Rails' `private def attribute_names_for_serialization;
+  // attribute_names; end` hook — overriding it must actually affect
+  // serializableHash output.
+  it("respects an overridden attributeNamesForSerialization", () => {
+    class SecretModel extends Base {
+      attributeNamesForSerialization() {
+        // Only expose "name"; hide other attributes from serialization.
+        return ["name"];
+      }
+    }
+    SecretModel._tableName = "secrets";
+    SecretModel.attribute("id", "integer");
+    SecretModel.attribute("name", "string");
+    SecretModel.attribute("ssn", "string");
+    SecretModel.adapter = adapter;
+
+    const s = new SecretModel({ id: 1, name: "Visible", ssn: "111-22-3333" });
+    const hash = s.serializableHash();
+    expect(hash).toMatchObject({ name: "Visible" });
+    expect(hash).not.toHaveProperty("ssn");
+    expect(hash).not.toHaveProperty("id");
   });
 
   it("does not duplicate the inheritance column when caller already passes it in except", () => {
@@ -119,7 +142,7 @@ describe("SerializationTest", () => {
     const car = new Vehicle({ id: 1, name: "Camry", type: "Car" });
     // Caller redundantly excludes "type" — final except list should still
     // be deduped (Ruby's `|=` set-union semantics).
-    const hash = (car as any).serializableHash({ except: ["type"] });
+    const hash = car.serializableHash({ except: ["type"] });
     expect(hash).not.toHaveProperty("type");
     expect(hash).toMatchObject({ id: 1, name: "Camry" });
   });

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -88,6 +88,41 @@ describe("SerializationTest", () => {
   it.skip("find records by serialized attributes through join", () => {
     /* needs associations + serialized columns */
   });
+
+  // Mirrors ActiveRecord::Serialization#serializable_hash — when a model
+  // declares an inheritance column (STI), serializableHash must exclude
+  // it without callers having to pass `except`.
+  it("excludes the inheritance column from serializable_hash for STI models", () => {
+    class Vehicle extends Base {}
+    Vehicle._tableName = "vehicles";
+    Vehicle.attribute("id", "integer");
+    Vehicle.attribute("name", "string");
+    Vehicle.attribute("type", "string");
+    Vehicle.inheritanceColumn = "type";
+    Vehicle.adapter = adapter;
+
+    const car = new Vehicle({ id: 1, name: "Camry", type: "Car" });
+    const hash = (car as any).serializableHash();
+    expect(hash).toMatchObject({ id: 1, name: "Camry" });
+    expect(hash).not.toHaveProperty("type");
+  });
+
+  it("does not duplicate the inheritance column when caller already passes it in except", () => {
+    class Vehicle extends Base {}
+    Vehicle._tableName = "vehicles";
+    Vehicle.attribute("id", "integer");
+    Vehicle.attribute("name", "string");
+    Vehicle.attribute("type", "string");
+    Vehicle.inheritanceColumn = "type";
+    Vehicle.adapter = adapter;
+
+    const car = new Vehicle({ id: 1, name: "Camry", type: "Car" });
+    // Caller redundantly excludes "type" — final except list should still
+    // be deduped (Ruby's `|=` set-union semantics).
+    const hash = (car as any).serializableHash({ except: ["type"] });
+    expect(hash).not.toHaveProperty("type");
+    expect(hash).toMatchObject({ id: 1, name: "Camry" });
+  });
 });
 
 describe("toXml() on Base", () => {

--- a/packages/activerecord/src/serialization.ts
+++ b/packages/activerecord/src/serialization.ts
@@ -16,10 +16,14 @@ export function serializableHash(this: Base, options?: SerializeOptions): Record
   if (inheritanceCol && klass.hasAttribute(inheritanceCol)) {
     options = options ? { ...options } : {};
 
-    // Normalize except to an array of strings
-    options.except = Array.from(options.except || []).map((v) => String(v));
-    // Add the inheritance column to the except list
-    options.except = [...new Set(options.except), inheritanceCol];
+    // Mirror Ruby's `Array(x)`: nil → [], scalar → [scalar], array → array.
+    // `Array.from("type")` would split a string into characters, so we
+    // can't blindly use it here.
+    const raw = (options as { except?: unknown }).except;
+    const exceptArray =
+      raw == null ? [] : Array.isArray(raw) ? raw : [raw as string | number | symbol];
+    // Mirrors: `options[:except] |= Array(inheritance_column)` (set union).
+    options.except = [...new Set(exceptArray.map((v) => String(v))), inheritanceCol];
   }
 
   return amSerializableHash(this, options);

--- a/packages/activerecord/src/serialization.ts
+++ b/packages/activerecord/src/serialization.ts
@@ -1,15 +1,6 @@
 import { serializableHash as amSerializableHash } from "@blazetrails/activemodel";
+import type { SerializeOptions } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
-
-/**
- * Serialization options for filtering attributes.
- */
-interface SerializeOptions {
-  only?: string[];
-  except?: string[];
-  methods?: string[];
-  include?: Record<string, SerializeOptions> | string[] | string;
-}
 
 /**
  * Wrapper around ActiveModel serialization to handle ActiveRecord-specific

--- a/packages/activerecord/src/serialization.ts
+++ b/packages/activerecord/src/serialization.ts
@@ -23,7 +23,7 @@ export function serializableHash(this: Base, options?: SerializeOptions): Record
     const exceptArray =
       raw == null ? [] : Array.isArray(raw) ? raw : [raw as string | number | symbol];
     // Mirrors: `options[:except] |= Array(inheritance_column)` (set union).
-    options.except = [...new Set(exceptArray.map((v) => String(v))), inheritanceCol];
+    options.except = [...new Set([...exceptArray.map((v) => String(v)), inheritanceCol])];
   }
 
   return amSerializableHash(this, options);

--- a/packages/activerecord/src/serialization.ts
+++ b/packages/activerecord/src/serialization.ts
@@ -1,0 +1,50 @@
+import { serializableHash as amSerializableHash } from "@blazetrails/activemodel";
+import type { Base } from "./base.js";
+
+/**
+ * Serialization options for filtering attributes.
+ */
+interface SerializeOptions {
+  only?: string[];
+  except?: string[];
+  methods?: string[];
+  include?: Record<string, SerializeOptions> | string[] | string;
+}
+
+/**
+ * Wrapper around ActiveModel serialization to handle ActiveRecord-specific
+ * concerns like inheritance columns (STI).
+ *
+ * Mirrors: ActiveRecord::Serialization#serializable_hash
+ */
+export function serializableHash(this: Base, options?: SerializeOptions): Record<string, unknown> {
+  // When a model uses STI, we need to exclude the inheritance column
+  // from the serialized output (it's just for internal type routing).
+  const klass = this.constructor as typeof Base;
+  const inheritanceCol = klass.inheritanceColumn;
+  if (inheritanceCol && klass.hasAttribute(inheritanceCol)) {
+    options = options ? { ...options } : {};
+
+    // Normalize except to an array of strings
+    options.except = Array.from(options.except || []).map((v) => String(v));
+    // Add the inheritance column to the except list
+    options.except = [...new Set(options.except), inheritanceCol];
+  }
+
+  return amSerializableHash(this, options);
+}
+
+// private
+
+/**
+ * Filters attribute names for serialization. Returns the list of attribute
+ * names that should be included in serialization.
+ *
+ * In ActiveRecord, this is overridable per model (e.g., to exclude certain attrs).
+ * The base implementation just delegates to the attribute_names method.
+ *
+ * Mirrors: ActiveRecord::Serialization.private#attribute_names_for_serialization
+ */
+export function attributeNamesForSerialization(this: Base): string[] {
+  return this.attributeNames();
+}


### PR DESCRIPTION
## Summary

Port `Serialization#serializableHash` (public) and `attribute_names_for_serialization` (private) from Rails.

This is PR 6 of docs/api-compare-100-plan.md.

**Rails source:** activerecord/lib/active_record/serialization.rb

The implementation wraps ActiveModel's serializableHash to handle ActiveRecord-specific concerns: excluding the inheritance column (type) from STI serialization output, since it's only used for internal routing.

**api:compare delta:**
- Before: serialization.rb 0% (missing impl)
- After:  serialization.rb 100% ✓

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/serialization.test.ts` — all 12 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm api:compare --package activerecord` — serialization.rb at 100%
- [x] LOC: 61 (under 300 ceiling)