### PR TITLE
feat(activerecord): QueryLogs tags formatter

### DIFF
--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -263,7 +263,20 @@ describe("QueryLogs.tagsFormatter", () => {
     expect(logs.tagsFormatter).toBe("legacy");
   });
 
-  it("falls back to 'legacy' for custom formatters", () => {
+  it("tracks formatter = SQLCommenter (class value)", () => {
+    const logs = new QueryLogs();
+    logs.formatter = SQLCommenter;
+    expect(logs.tagsFormatter).toBe("sqlcommenter");
+  });
+
+  it("tracks formatter = LegacyFormatter (class value)", () => {
+    const logs = new QueryLogs();
+    logs.formatter = SQLCommenter;
+    logs.formatter = LegacyFormatter;
+    expect(logs.tagsFormatter).toBe("legacy");
+  });
+
+  it("falls back to 'legacy' for unknown custom formatters", () => {
     const logs = new QueryLogs();
     logs.formatter = SQLCommenter;
     logs.formatter = {

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -245,6 +245,35 @@ describe("QueryLogs.formatter =", () => {
   });
 });
 
+describe("QueryLogs.tagsFormatter", () => {
+  it("defaults to legacy", () => {
+    expect(new QueryLogs().tagsFormatter).toBe("legacy");
+  });
+
+  it("tracks formatter = 'sqlcommenter'", () => {
+    const logs = new QueryLogs();
+    logs.formatter = "sqlcommenter";
+    expect(logs.tagsFormatter).toBe("sqlcommenter");
+  });
+
+  it("tracks formatter = 'legacy'", () => {
+    const logs = new QueryLogs();
+    logs.formatter = "sqlcommenter";
+    logs.formatter = "legacy";
+    expect(logs.tagsFormatter).toBe("legacy");
+  });
+
+  it("falls back to 'legacy' for custom formatters", () => {
+    const logs = new QueryLogs();
+    logs.formatter = SQLCommenter;
+    logs.formatter = {
+      format: (k: string, v: unknown) => `${k}=${v}`,
+      join: (pairs: string[]) => pairs.join(";"),
+    };
+    expect(logs.tagsFormatter).toBe("legacy");
+  });
+});
+
 describe("SQLCommenter", () => {
   it("formats as OpenTelemetry key='value' with URL-encoding", () => {
     expect(SQLCommenter.format("app", "My App")).toBe("app='My%20App'");

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -114,8 +114,16 @@ export class QueryLogs {
       // Accept anything with the right call shape — an instance, a
       // const object, or a class / function with static `format` /
       // `join` (matches how Rails' singleton-class formatters are
-      // invoked: `MyFormatter.format(k, v)`).
-      this._tagsFormatter = "legacy"; // fallback when custom formatter
+      // invoked: `MyFormatter.format(k, v)`). Detect the known
+      // built-ins so `tagsFormatter` stays accurate when the caller
+      // passes the class value directly (`logs.formatter = SQLCommenter`).
+      if (format === SQLCommenter) {
+        this._tagsFormatter = "sqlcommenter";
+      } else if (format === LegacyFormatter) {
+        this._tagsFormatter = "legacy";
+      } else {
+        this._tagsFormatter = "legacy"; // unknown custom formatter
+      }
       this._formatter = format as QueryLogsFormatter;
     } else {
       // Describe the bad value without dumping a full function body

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -258,27 +258,20 @@ export class QueryLogs {
   // private
 
   private escapeSqlComment(content: string): string {
-    // Sanitize a string to appear within a SQL comment.
     // Mirrors: ActiveRecord::QueryLogs#escape_sql_comment
-    return String(content).replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
+    return escapeComment(content);
   }
 }
 
-/**
- * Sanitize a string for safe inclusion in a SQL comment.
- * Mirrors: ActiveRecord::QueryLogs.escape_sql_comment
- */
+// Sanitize a string for safe inclusion in a SQL comment by neutralising
+// any internal "*/" and "/*" sequences (turns them into "* /" / "/ *").
+//
+// Partial port of ActiveRecord::QueryLogs#escape_sql_comment
+// (query_logs.rb:219-228). Rails additionally strips a leading
+// `\A\s*/\*\+?\s?` and a trailing `\s?\*/\s*\Z` before escaping; trails
+// intentionally omits that strip so bare-marker inputs round-trip
+// through escape rather than collapsing to an empty string — the
+// existing "escaping bad comments" test cases encode that.
 export function escapeComment(content: string): string {
-  let s = content;
-  // The Rails method (query_logs.rb:219-223) removes surrounding comment
-  // markers only if they're at the beginning or end of the whole string,
-  // which prevents wrapping a value that's ITSELF a marker like "*/" or "/*".
-  // The regex {\A\s*/\*\+?\s?|\s?\*/\s*\Z} matches:
-  //   - start: optional space, then "/*" optionally followed by "+", optionally followed by space
-  //   - OR end: optional space, then "*/", optional space before end
-  // But our test cases pass raw markers ("*/", "/*") which don't have
-  // that structure. The test expects them to still be escaped internally.
-  // So skip the marker-stripping and just do the escaping:
-  s = s.replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
-  return s;
+  return String(content).replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
 }

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -256,30 +256,11 @@ export class QueryLogs {
   }
 
   // private
-  private rebuildHandlers(): void {
-    // Rebuild internal handler cache when tags or taggings change.
-    // The current implementation doesn't use a handler pattern — it
-    // directly evaluates tags in tagContent(). This stub documents
-    // the Rails pattern for reference (Rails uses handlers to defer
-    // evaluation and cache results across queries).
-    // Mirrors: ActiveRecord::QueryLogs#rebuild_handlers
-  }
-
-  private buildHandler(name: string, handler?: TagValue | TagHandler): void {
-    // Build a single tag handler from a name and optional custom handler.
-    // In Rails, this returns a handler object that wraps the tag's value
-    // fetch. The TS implementation directly evaluates tags, so this is
-    // a documentation stub.
-    // Mirrors: ActiveRecord::QueryLogs#build_handler
-  }
 
   private escapeSqlComment(content: string): string {
     // Sanitize a string to appear within a SQL comment.
-    // Escapes /* and */ to prevent SQL comment injection.
     // Mirrors: ActiveRecord::QueryLogs#escape_sql_comment
-    let comment = String(content);
-    comment = comment.replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
-    return comment;
+    return String(content).replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
   }
 }
 

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -7,7 +7,7 @@
  * controller, action, etc.) to help trace queries back to application code.
  */
 
-import { ConfigurationError, NotImplementedError } from "./errors.js";
+import { ConfigurationError } from "./errors.js";
 import { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
 import type { TagValue, QueryLogsFormatter } from "./query-logs-formatter.js";
 
@@ -38,6 +38,7 @@ export class GetKeyHandler {
  */
 export class QueryLogs {
   private _tags: TagDefinition[] = [];
+  private _tagsFormatter: "legacy" | "sqlcommenter" = "legacy";
   private _formatter: QueryLogsFormatter = LegacyFormatter;
   private _prependComment = false;
   private _cacheEnabled = false;
@@ -51,6 +52,14 @@ export class QueryLogs {
 
   get tags(): TagDefinition[] {
     return this._tags;
+  }
+
+  /**
+   * Get the current tags formatter type ("legacy" or "sqlcommenter").
+   * Mirrors: ActiveRecord::QueryLogs.tags_formatter
+   */
+  get tagsFormatter(): "legacy" | "sqlcommenter" {
+    return this._tagsFormatter;
   }
 
   set tags(tags: TagDefinition[]) {
@@ -91,8 +100,10 @@ export class QueryLogs {
 
   set formatter(format: "legacy" | "sqlcommenter" | QueryLogsFormatter) {
     if (format === "legacy") {
+      this._tagsFormatter = "legacy";
       this._formatter = LegacyFormatter;
     } else if (format === "sqlcommenter") {
+      this._tagsFormatter = "sqlcommenter";
       this._formatter = SQLCommenter;
     } else if (
       format !== null &&
@@ -104,6 +115,7 @@ export class QueryLogs {
       // const object, or a class / function with static `format` /
       // `join` (matches how Rails' singleton-class formatters are
       // invoked: `MyFormatter.format(k, v)`).
+      this._tagsFormatter = "legacy"; // fallback when custom formatter
       this._formatter = format as QueryLogsFormatter;
     } else {
       // Describe the bad value without dumping a full function body
@@ -240,7 +252,34 @@ export class QueryLogs {
   private uncachedComment(): string | null {
     const content = this.tagContent();
     if (!content) return null;
-    return `/*${escapeComment(content)}*/`;
+    return `/*${this.escapeSqlComment(content)}*/`;
+  }
+
+  // private
+  private rebuildHandlers(): void {
+    // Rebuild internal handler cache when tags or taggings change.
+    // The current implementation doesn't use a handler pattern — it
+    // directly evaluates tags in tagContent(). This stub documents
+    // the Rails pattern for reference (Rails uses handlers to defer
+    // evaluation and cache results across queries).
+    // Mirrors: ActiveRecord::QueryLogs#rebuild_handlers
+  }
+
+  private buildHandler(name: string, handler?: TagValue | TagHandler): void {
+    // Build a single tag handler from a name and optional custom handler.
+    // In Rails, this returns a handler object that wraps the tag's value
+    // fetch. The TS implementation directly evaluates tags, so this is
+    // a documentation stub.
+    // Mirrors: ActiveRecord::QueryLogs#build_handler
+  }
+
+  private escapeSqlComment(content: string): string {
+    // Sanitize a string to appear within a SQL comment.
+    // Escapes /* and */ to prevent SQL comment injection.
+    // Mirrors: ActiveRecord::QueryLogs#escape_sql_comment
+    let comment = String(content);
+    comment = comment.replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
+    return comment;
   }
 }
 
@@ -250,23 +289,15 @@ export class QueryLogs {
  */
 export function escapeComment(content: string): string {
   let s = content;
-  // Replace comment markers to prevent SQL comment injection
+  // The Rails method (query_logs.rb:219-223) removes surrounding comment
+  // markers only if they're at the beginning or end of the whole string,
+  // which prevents wrapping a value that's ITSELF a marker like "*/" or "/*".
+  // The regex {\A\s*/\*\+?\s?|\s?\*/\s*\Z} matches:
+  //   - start: optional space, then "/*" optionally followed by "+", optionally followed by space
+  //   - OR end: optional space, then "*/", optional space before end
+  // But our test cases pass raw markers ("*/", "/*") which don't have
+  // that structure. The test expects them to still be escaped internally.
+  // So skip the marker-stripping and just do the escaping:
   s = s.replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
   return s;
-}
-
-function rebuildHandlers(): never {
-  throw new NotImplementedError("ActiveRecord::QueryLogs#rebuild_handlers is not implemented");
-}
-
-function buildHandler(name: any, handler?: any): never {
-  throw new NotImplementedError("ActiveRecord::QueryLogs#build_handler is not implemented");
-}
-
-function escapeSqlComment(content: any): never {
-  throw new NotImplementedError("ActiveRecord::QueryLogs#escape_sql_comment is not implemented");
-}
-
-function tagContent(connection: any): never {
-  throw new NotImplementedError("ActiveRecord::QueryLogs#tag_content is not implemented");
 }


### PR DESCRIPTION
## Summary

PR 7 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `query_logs.rb` row at the public-API level.

**Public surface (this PR):**
- `tagsFormatter` getter on `QueryLogs` returning `"legacy"` / `"sqlcommenter"` (defaults to `"legacy"`, falls back to `"legacy"` for custom formatters). Mirrors [Rails `query_logs.rb` `tags_formatter`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/query_logs.rb).
- `formatter` setter now keeps `tagsFormatter` in sync.
- Private `escapeSqlComment` consolidated to delegate to the exported `escapeComment` helper (avoids two implementations of the same regex pair).

**Privates not ported:** Rails' private `rebuildHandlers` and `buildHandler` were removed in e64fddf9 — the previous draft kept empty no-op methods, which CLAUDE.md prohibits ("Do NOT add empty stubs"). trails QueryLogs uses a different architecture (direct tag evaluation in `tagContent()`); a Rails-faithful port would require introducing `ZeroArityHandler` / `IdentityHandler` and a separate `@taggings` store — out of scope here, separable follow-up.

## Impact

`pnpm api:compare --package activerecord`:

- `query_logs.rb`: 8/9 → 9/9 ✓ (public)

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/query-logs.test.ts` — 39 pass / 2 skipped
- [x] `pnpm api:compare --package activerecord` shows `query_logs.rb 100%`
- [x] `pnpm build` clean
- [x] New `tagsFormatter` tests cover default + each formatter path (legacy / sqlcommenter / custom)