### PR TITLE
feat(activerecord): SecurePassword.authenticateBy

### DIFF
--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { performance } from "node:perf_hooks";
 import { Base } from "./index.js";
 import { hasSecurePassword } from "./secure-password.js";
 import { setTokenForSecret } from "./generates-token-for.js";

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -411,25 +411,28 @@ describe("SecurePasswordTest", () => {
   });
 
   // Rails: test "authenticate_by takes the same amount of time regardless
-  // of whether record is found" — verify the constant-time mitigation by
-  // showing that the not-found path still spends substantial time hashing
-  // (PBKDF2 with 10k iterations is multiple ms; a no-op short-circuit
-  // would return in microseconds). Mirrors Rails' `new(passwords)` BCrypt
-  // trigger at secure_password.rb:55.
+  // of whether record is found" — both the not-found path and the
+  // found-but-wrong-password path must run the password hash so a timing
+  // attacker can't distinguish them. Compare elapsed times relative to
+  // each other rather than against an absolute threshold (which is flaky
+  // across hardware): the not-found run should not be substantially
+  // shorter than the wrong-password run.
+  // Mirrors Rails' `new(passwords)` BCrypt trigger at secure_password.rb:55.
   it("authenticate_by takes the same amount of time regardless of whether record is found", async () => {
-    const User = makeUser();
+    const { User, user } = await createUser();
 
-    const start = performance.now();
-    const result = await (User as any).authenticateBy({
-      token: "no-such-token",
-      password: PASSWORD,
-    });
-    const elapsedMs = performance.now() - start;
+    const t0 = performance.now();
+    expect(await User.authenticateBy({ token: user.token, password: "wrong" })).toBeNull();
+    const wrongPasswordMs = performance.now() - t0;
 
-    expect(result).toBeNull();
-    // PBKDF2 hashing should take meaningful time. A no-op return path
-    // would complete sub-millisecond; we expect ≥5ms in practice.
-    expect(elapsedMs).toBeGreaterThan(5);
+    const t1 = performance.now();
+    expect(await User.authenticateBy({ token: "no-such-token", password: PASSWORD })).toBeNull();
+    const notFoundMs = performance.now() - t1;
+
+    // The not-found path should be at least ~30% as long as the
+    // wrong-password path (both hash; a no-op short-circuit would be
+    // orders of magnitude faster).
+    expect(notFoundMs).toBeGreaterThan(wrongPasswordMs * 0.3);
   });
 
   // Rails: test "authenticate_by requires at least one password"

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -292,14 +292,173 @@ describe("password reset token", () => {
 });
 
 describe("SecurePasswordTest", () => {
-  it.skip("authenticate_by authenticates when password is correct", () => {});
-  it.skip("authenticate_by does not authenticate when password is incorrect", () => {});
-  it.skip("authenticate_by takes the same amount of time regardless of whether record is found", () => {});
-  it.skip("authenticate_by short circuits when password is nil", () => {});
-  it.skip("authenticate_by short circuits when password is an empty string", () => {});
-  it.skip("authenticate_by finds record using multiple attributes", () => {});
-  it.skip("authenticate_by authenticates using multiple passwords", () => {});
-  it.skip("authenticate_by requires at least one password", () => {});
-  it.skip("authenticate_by requires at least one attribute", () => {});
-  it.skip("authenticate_by accepts any object that implements to_h", () => {});
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
+
+  // Builds a User class with the union of attributes used across these tests.
+  // Per-test attribute differences in Rails are immaterial for these tests
+  // (sqlite ignores unread columns); a single shared class halves the LOC
+  // here without changing behavior.
+  const makeUser = () => {
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("token", "string");
+        this.attribute("email", "string");
+        this.attribute("password_digest", "string");
+        this.attribute("auth_token_digest", "string");
+        this.attribute("recovery_password_digest", "string");
+        this.adapter = adapter;
+      }
+    }
+    hasSecurePassword(User, { validations: false });
+    return User as typeof User & {
+      authenticateBy(attrs: unknown): Promise<InstanceType<typeof User> | null>;
+    };
+  };
+
+  const PASSWORD = "mUc3m00RsqyRe";
+
+  const createUser = async (extra: Record<string, unknown> = {}) => {
+    const User = makeUser();
+    const user = new User({ token: "abc123", ...extra });
+    (user as any).password = PASSWORD;
+    await user.save();
+    return { User, user };
+  };
+
+  // Rails: test "authenticate_by authenticates when password is correct"
+  it("authenticate_by authenticates when password is correct", async () => {
+    const { User, user } = await createUser();
+    const found = await User.authenticateBy({ token: user.token, password: PASSWORD });
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(user.id);
+    expect(found?.token).toBe(user.token);
+  });
+
+  // Rails: test "authenticate_by does not authenticate when password is incorrect"
+  it("authenticate_by does not authenticate when password is incorrect", async () => {
+    const { User, user } = await createUser();
+    const found = await User.authenticateBy({ token: user.token, password: "wrong" });
+    expect(found).toBeNull();
+  });
+
+  // Rails: test "authenticate_by short circuits when password is nil"
+  it("authenticate_by short circuits when password is nil", async () => {
+    const User = makeUser();
+    expect(await User.authenticateBy({ token: "abc123", password: null })).toBeNull();
+  });
+
+  // Rails: test "authenticate_by short circuits when password is an empty string"
+  it("authenticate_by short circuits when password is an empty string", async () => {
+    const User = makeUser();
+    expect(await User.authenticateBy({ token: "abc123", password: "" })).toBeNull();
+  });
+
+  // Rails: test "authenticate_by finds record using multiple attributes"
+  it("authenticate_by finds record using multiple attributes", async () => {
+    const { User, user } = await createUser({ email: "test@example.com" });
+    const found = await User.authenticateBy({
+      token: user.token,
+      email: user.email,
+      password: PASSWORD,
+    });
+    expect(found?.id).toBe(user.id);
+
+    const notFound = await User.authenticateBy({
+      token: user.token,
+      email: "wrong@example.com",
+      password: PASSWORD,
+    });
+    expect(notFound).toBeNull();
+  });
+
+  // Rails: test "authenticate_by authenticates using multiple passwords"
+  it("authenticate_by authenticates using multiple passwords", async () => {
+    const User = makeUser();
+    hasSecurePassword(User, "recovery_password", { validations: false });
+    const RECOVERY = "recovery-secret";
+    const user = new User({ token: "abc123" });
+    (user as any).password = PASSWORD;
+    (user as any).recovery_password = RECOVERY;
+    await user.save();
+
+    const ok = await User.authenticateBy({
+      token: user.token,
+      password: PASSWORD,
+      recovery_password: RECOVERY,
+    });
+    expect(ok?.id).toBe(user.id);
+
+    expect(
+      await User.authenticateBy({
+        token: user.token,
+        password: "wrong",
+        recovery_password: RECOVERY,
+      }),
+    ).toBeNull();
+    expect(
+      await User.authenticateBy({
+        token: user.token,
+        password: PASSWORD,
+        recovery_password: "wrong",
+      }),
+    ).toBeNull();
+  });
+
+  // Rails: test "authenticate_by takes the same amount of time regardless
+  // of whether record is found" — verify the constant-time mitigation by
+  // showing that the not-found path still spends substantial time hashing
+  // (PBKDF2 with 10k iterations is multiple ms; a no-op short-circuit
+  // would return in microseconds). Mirrors Rails' `new(passwords)` BCrypt
+  // trigger at secure_password.rb:55.
+  it("authenticate_by takes the same amount of time regardless of whether record is found", async () => {
+    const User = makeUser();
+
+    const start = performance.now();
+    const result = await (User as any).authenticateBy({
+      token: "no-such-token",
+      password: PASSWORD,
+    });
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    // PBKDF2 hashing should take meaningful time. A no-op return path
+    // would complete sub-millisecond; we expect ≥5ms in practice.
+    expect(elapsedMs).toBeGreaterThan(5);
+  });
+
+  // Rails: test "authenticate_by requires at least one password"
+  it("authenticate_by requires at least one password", async () => {
+    const User = makeUser();
+    await expect(User.authenticateBy({ token: "abc123" })).rejects.toThrow(
+      "One or more password arguments are required",
+    );
+  });
+
+  // Rails: test "authenticate_by requires at least one attribute"
+  it("authenticate_by requires at least one attribute", async () => {
+    const User = makeUser();
+    await expect(User.authenticateBy({ password: "abc123" })).rejects.toThrow(
+      "One or more finder arguments are required",
+    );
+  });
+
+  // Rails: test "authenticate_by accepts any object that implements to_h"
+  it("authenticate_by accepts any object that implements to_h", async () => {
+    const { User, user } = await createUser();
+    const found = await User.authenticateBy({
+      toH: () => ({ token: user.token, password: PASSWORD }),
+    });
+    expect(found?.id).toBe(user.id);
+
+    const notFound = await User.authenticateBy({
+      toH: () => ({ token: "wrong", password: PASSWORD }),
+    });
+    expect(notFound).toBeNull();
+  });
 });

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -452,6 +452,15 @@ describe("SecurePasswordTest", () => {
     );
   });
 
+  it("authenticate_by treats undefined identifier values as missing (not IS NULL)", async () => {
+    const User = makeUser();
+    // `undefined` would otherwise flow through PredicateBuilder as `IS NULL`
+    // and could authenticate a record whose token is actually NULL.
+    await expect(User.authenticateBy({ token: undefined, password: PASSWORD })).rejects.toThrow(
+      "One or more finder arguments are required",
+    );
+  });
+
   // Rails: test "authenticate_by accepts any object that implements to_h"
   it("authenticate_by accepts any object that implements to_h", async () => {
     const { User, user } = await createUser();

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,6 +1,19 @@
 import { getCrypto } from "@blazetrails/activesupport";
+import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
+
+/**
+ * `password` → `Password`; `recovery_password` → `RecoveryPassword`.
+ * Matches the underscore-to-camelCase convention used by `secure-token.ts`
+ * so attribute names with underscores produce the expected method names.
+ */
+function camelize(attr: string): string {
+  return (
+    attr.charAt(0).toUpperCase() +
+    attr.slice(1).replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+  );
+}
 
 /**
  * Secure password support using PBKDF2 (Web Crypto API).
@@ -45,18 +58,22 @@ function verifyPassword(password: string, digest: string): boolean {
  */
 export function hasSecurePassword(
   modelClass: typeof Base,
-  options: { validations?: boolean; resetToken?: boolean } = {},
+  attributeOrOptions: string | { validations?: boolean; resetToken?: boolean } = {},
+  maybeOptions: { validations?: boolean; resetToken?: boolean } = {},
 ): void {
+  // Mirrors Rails: `has_secure_password(attribute = :password, validations: true, reset_token: true)`
+  const attribute = typeof attributeOrOptions === "string" ? attributeOrOptions : "password";
+  const options = typeof attributeOrOptions === "string" ? maybeOptions : attributeOrOptions;
+  const isDefaultAttribute = attribute === "password";
   const runValidations = options.validations !== false;
-  const attribute = "password";
   const digestAttr = `${attribute}_digest`;
 
   // Store the raw password temporarily for hashing during save
-  const passwordKey = Symbol("password");
-  const confirmationKey = Symbol("password_confirmation");
+  const passwordKey = Symbol(`${attribute}`);
+  const confirmationKey = Symbol(`${attribute}_confirmation`);
 
-  // password setter/getter
-  Object.defineProperty(modelClass.prototype, "password", {
+  // ${attribute} setter/getter (e.g. password / recovery_password)
+  Object.defineProperty(modelClass.prototype, attribute, {
     get: function () {
       return (this as any)[passwordKey] ?? null;
     },
@@ -66,24 +83,49 @@ export function hasSecurePassword(
     configurable: true,
   });
 
-  // password_confirmation setter/getter
-  Object.defineProperty(modelClass.prototype, "passwordConfirmation", {
-    get: function () {
-      return (this as any)[confirmationKey] ?? null;
-    },
-    set: function (value: string | null) {
-      (this as any)[confirmationKey] = value;
-    },
-    configurable: true,
-  });
+  // password_confirmation setter/getter — only for the default attribute,
+  // matching the surface most apps rely on. Per-attribute confirmation is
+  // a separable follow-up.
+  if (isDefaultAttribute) {
+    Object.defineProperty(modelClass.prototype, "passwordConfirmation", {
+      get: function () {
+        return (this as any)[confirmationKey] ?? null;
+      },
+      set: function (value: string | null) {
+        (this as any)[confirmationKey] = value;
+      },
+      configurable: true,
+    });
 
-  // authenticate method
-  Object.defineProperty(modelClass.prototype, "authenticate", {
+    // `authenticate` (no suffix) is a Rails convenience for the default attribute.
+    Object.defineProperty(modelClass.prototype, "authenticate", {
+      value: function (this: Base, password: string): Base | false {
+        const digest = this._readAttribute(digestAttr);
+        if (!digest) return false;
+        return verifyPassword(password, digest as string) ? this : false;
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  // authenticate${Attribute} method (for authenticate_by to call)
+  // e.g., authenticatePassword, authenticateRecoveryPassword
+  const authenticateMethodName = `authenticate${camelize(attribute)}`;
+  Object.defineProperty(modelClass.prototype, authenticateMethodName, {
     value: function (this: Base, password: string): Base | false {
       const digest = this._readAttribute(digestAttr);
       if (!digest) return false;
       return verifyPassword(password, digest as string) ? this : false;
     },
+    writable: true,
+    configurable: true,
+  });
+
+  // Static authenticateBy class method
+  // Mirrors: ActiveRecord::SecurePassword.authenticate_by
+  Object.defineProperty(modelClass, "authenticateBy", {
+    value: authenticateBy,
     writable: true,
     configurable: true,
   });
@@ -108,8 +150,10 @@ export function hasSecurePassword(
     }
   });
 
-  // Add validations
-  if (runValidations) {
+  // Add validations (only wired for the default `password` attribute today;
+  // per-attribute validations would mean parameterizing the `errors.add`
+  // keys and message — separable from authenticate_by parity).
+  if (runValidations && isDefaultAttribute) {
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
       const isNew = record.isNewRecord();
@@ -192,6 +236,93 @@ export function hasSecurePassword(
       writable: true,
       configurable: true,
     });
+  }
+}
+
+/**
+ * Authenticates a record by finding it via non-password attributes,
+ * then verifying password attributes. Returns the record on success,
+ * null if authentication fails.
+ *
+ * Mirrors: ActiveRecord::SecurePassword.authenticate_by
+ *
+ * Given a set of attributes, finds a record using the non-password
+ * attributes, and then authenticates that record using the password
+ * attributes. Returns the record if authentication succeeds; otherwise,
+ * returns null.
+ *
+ * Regardless of whether a record is found, authenticateBy will
+ * cryptographically digest the given password attributes. This behavior
+ * helps mitigate timing-based enumeration attacks, wherein an attacker can
+ * determine if a passworded record exists even without knowing the password.
+ *
+ * Raises an ArgumentError if the set of attributes doesn't contain at
+ * least one password and one non-password attribute.
+ */
+export async function authenticateBy(
+  this: typeof Base,
+  attributes: Record<string, unknown> | { toH(): Record<string, unknown> },
+): Promise<Base | null> {
+  // Convert to plain object if it has toH method
+  const attrs =
+    typeof (attributes as any).toH === "function"
+      ? (attributes as any).toH()
+      : (attributes as Record<string, unknown>);
+
+  const passwordEntries: Array<[string, unknown]> = [];
+  const identifierEntries: Array<[string, unknown]> = [];
+
+  for (const [name, value] of Object.entries(attrs)) {
+    // Check if this is a password attribute (the _digest variant exists but name doesn't)
+    const digestName = `${name}_digest`;
+    if (!(this as any).hasAttribute?.(name) && (this as any).hasAttribute?.(digestName)) {
+      passwordEntries.push([name, value]);
+    } else {
+      identifierEntries.push([name, value]);
+    }
+  }
+
+  if (passwordEntries.length === 0) {
+    throw new ArgumentError("One or more password arguments are required");
+  }
+  if (identifierEntries.length === 0) {
+    throw new ArgumentError("One or more finder arguments are required");
+  }
+
+  // Short-circuit: if any password is nil or empty, return null immediately
+  for (const [, value] of passwordEntries) {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+  }
+
+  // Convert entries back to objects for findBy
+  const passwords = Object.fromEntries(passwordEntries);
+  const identifiers = Object.fromEntries(identifierEntries);
+
+  // Try to find the record
+  const record = await (this as any).findBy(identifiers);
+  if (record) {
+    // Authenticate all password attributes
+    let allAuthenticated = true;
+    for (const [name] of passwordEntries) {
+      const value = passwords[name] as string;
+      const methodName = `authenticate${camelize(name)}`;
+      const authenticateMethod = (record as any)[methodName];
+      if (typeof authenticateMethod !== "function" || !authenticateMethod.call(record, value)) {
+        allAuthenticated = false;
+        break;
+      }
+    }
+    return allAuthenticated ? record : null;
+  } else {
+    // Even if record is not found, hash the passwords to mitigate timing attacks
+    for (const [name] of passwordEntries) {
+      const value = passwords[name] as string;
+      // Hash (but discard) to consume time
+      hashPassword(value);
+    }
+    return null;
   }
 }
 

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -111,13 +111,16 @@ export function hasSecurePassword(
     configurable: true,
   });
 
-  // Static authenticateBy class method
-  // Mirrors: ActiveRecord::SecurePassword.authenticate_by
-  Object.defineProperty(modelClass, "authenticateBy", {
-    value: authenticateBy,
-    writable: true,
-    configurable: true,
-  });
+  // Static authenticateBy — attached once per class (Rails: ClassMethods
+  // module included once). Skip if already defined so multiple
+  // hasSecurePassword calls don't redundantly redefine the same function.
+  if (!(modelClass as any).authenticateBy) {
+    Object.defineProperty(modelClass, "authenticateBy", {
+      value: authenticateBy,
+      writable: true,
+      configurable: true,
+    });
+  }
 
   // Hook into save to hash the password. Use writeAttribute (not
   // _attributes.set) so the dirty tracker marks the column changed and

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -239,10 +239,14 @@ export function hasSecurePassword(
  * attributes. Returns the record if authentication succeeds; otherwise,
  * returns null.
  *
- * Regardless of whether a record is found, authenticateBy will
- * cryptographically digest the given password attributes. This behavior
- * helps mitigate timing-based enumeration attacks, wherein an attacker can
- * determine if a passworded record exists even without knowing the password.
+ * When password attributes are valid non-empty strings, authenticateBy
+ * cryptographically digests them even if no matching record is found.
+ * That mitigates timing-based enumeration attacks where an attacker can
+ * determine if a passworded record exists even without knowing the
+ * password. Invalid password inputs (nil, empty string, non-string) are
+ * still short-circuited to `null` without hashing — they're not valid
+ * Rails password values and the timing-attack channel only exists for
+ * legitimate inputs.
  *
  * Raises an ArgumentError if the set of attributes doesn't contain at
  * least one password and one non-password attribute.

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -60,7 +60,8 @@ export function hasSecurePassword(
   const passwordKey = Symbol(`${attribute}`);
   const confirmationKey = Symbol(`${attribute}_confirmation`);
 
-  // ${attribute} setter/getter (e.g. password / recovery_password)
+  // Define setter/getter for the configured secure-password attribute
+  // (e.g. password / recovery_password).
   Object.defineProperty(modelClass.prototype, attribute, {
     get: function () {
       return (this as any)[passwordKey] ?? null;
@@ -299,12 +300,16 @@ export async function authenticateBy(
   // Try to find the record
   const record = await (this as any).findBy(identifiers);
   if (record) {
-    // Authenticate all password attributes. Mirrors Rails:
-    // `record.public_send(:"authenticate_#{name}", value)` — if the method
-    // doesn't exist, Ruby raises NoMethodError. Throwing here matches that
-    // semantic and avoids a timing-attack channel where a misconfigured
-    // model (digest column without hasSecurePassword) silently shortcuts
-    // out of the hash work that the not-found path always performs.
+    // Authenticate every password attribute without early-exit. Mirrors
+    // Rails: `record.public_send(:"authenticate_#{name}", value)` — if
+    // the method doesn't exist, Ruby raises NoMethodError. Throwing here
+    // matches that semantic and avoids a timing-attack channel where a
+    // misconfigured model (digest column without hasSecurePassword)
+    // silently shortcuts out of the hash work that the not-found path
+    // always performs. Likewise, accumulate `allAuthenticated` rather
+    // than `break`-ing on the first wrong password so multi-password
+    // models spend the same hash-work whether the first or last password
+    // is wrong (Rails uses `count == size` for the same reason).
     let allAuthenticated = true;
     for (const [name] of passwordEntries) {
       const value = passwords[name] as string;
@@ -318,7 +323,8 @@ export async function authenticateBy(
       }
       if (!authenticateMethod.call(record, value)) {
         allAuthenticated = false;
-        break;
+        // Don't break — keep going so the hash work is independent
+        // of which (or how many) passwords are wrong.
       }
     }
     return allAuthenticated ? record : null;

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -308,11 +308,19 @@ export async function authenticateBy(
     }
   }
 
-  // Convert entries back to objects for findBy
-  const passwords = Object.fromEntries(passwordEntries);
-  const identifiers = Object.fromEntries(identifierEntries);
+  // Strip `undefined` identifier values before hitting findBy. trails'
+  // PredicateBuilder treats `undefined` the same as `null` and emits
+  // `IS NULL`, so a caller destructuring a missing field could otherwise
+  // authenticate a record whose identifier is actually NULL. Re-check
+  // the "at least one finder arg" invariant after filtering.
+  const definedIdentifierEntries = identifierEntries.filter(([, v]) => v !== undefined);
+  if (definedIdentifierEntries.length === 0) {
+    throw new ArgumentError("One or more finder arguments are required");
+  }
 
-  // Try to find the record
+  const passwords = Object.fromEntries(passwordEntries);
+  const identifiers = Object.fromEntries(definedIdentifierEntries);
+
   const record = await (this as any).findBy(identifiers);
   if (record) {
     // Authenticate every password attribute without early-exit. Mirrors
@@ -346,15 +354,17 @@ export async function authenticateBy(
   } else {
     // Even if no record is found, hash the supplied passwords so the
     // not-found path takes comparable time to a successful authenticate.
-    // Use the async pbkdf2 here (rather than the sync hashPassword used
-    // by the password setter) so the mitigation doesn't block the event
-    // loop on every cache miss / invalid identifier — important under
-    // login load and when this path is the most-frequent caller.
-    const salt = getCrypto().randomBytes(SALT_LENGTH);
+    // Use `pbkdf2Async` here (rather than the sync hashPassword used by
+    // the password setter) to prefer the threadpool path when the
+    // crypto adapter supports it — important under login load and when
+    // this path is the most-frequent caller. Adapters without an async
+    // `pbkdf2` fall back to `pbkdf2Sync` wrapped in a deferred promise.
+    const crypto = getCrypto();
+    const salt = crypto.randomBytes(SALT_LENGTH);
     for (const [name] of passwordEntries) {
       const value = passwords[name] as string;
       // Result discarded — we only care about the elapsed CPU time.
-      await pbkdf2Async(getCrypto(), value, salt, ITERATIONS, KEY_LENGTH, "sha256");
+      await pbkdf2Async(crypto, value, salt, ITERATIONS, KEY_LENGTH, "sha256");
     }
     return null;
   }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,19 +1,7 @@
-import { getCrypto } from "@blazetrails/activesupport";
+import { getCrypto, camelize } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
-
-/**
- * `password` → `Password`; `recovery_password` → `RecoveryPassword`.
- * Matches the underscore-to-camelCase convention used by `secure-token.ts`
- * so attribute names with underscores produce the expected method names.
- */
-function camelize(attr: string): string {
-  return (
-    attr.charAt(0).toUpperCase() +
-    attr.slice(1).replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
-  );
-}
 
 /**
  * Secure password support using PBKDF2 (Web Crypto API).
@@ -303,13 +291,24 @@ export async function authenticateBy(
   // Try to find the record
   const record = await (this as any).findBy(identifiers);
   if (record) {
-    // Authenticate all password attributes
+    // Authenticate all password attributes. Mirrors Rails:
+    // `record.public_send(:"authenticate_#{name}", value)` — if the method
+    // doesn't exist, Ruby raises NoMethodError. Throwing here matches that
+    // semantic and avoids a timing-attack channel where a misconfigured
+    // model (digest column without hasSecurePassword) silently shortcuts
+    // out of the hash work that the not-found path always performs.
     let allAuthenticated = true;
     for (const [name] of passwordEntries) {
       const value = passwords[name] as string;
       const methodName = `authenticate${camelize(name)}`;
       const authenticateMethod = (record as any)[methodName];
-      if (typeof authenticateMethod !== "function" || !authenticateMethod.call(record, value)) {
+      if (typeof authenticateMethod !== "function") {
+        throw new TypeError(
+          `${(this as typeof Base).name}#${methodName} is not defined — ` +
+            `did you call hasSecurePassword(model, "${name}")?`,
+        );
+      }
+      if (!authenticateMethod.call(record, value)) {
         allAuthenticated = false;
         break;
       }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -277,9 +277,13 @@ export async function authenticateBy(
     throw new ArgumentError("One or more finder arguments are required");
   }
 
-  // Short-circuit: if any password is nil or empty, return null immediately
+  // Short-circuit: if any password is nil, empty, or not a string,
+  // return null immediately. Non-string values would otherwise flow
+  // through `as string` casts into PBKDF2 and either misbehave or
+  // throw — Rails' Ruby version coerces via `to_s` but in TS treating
+  // them as auth failure is the safer parity.
   for (const [, value] of passwordEntries) {
-    if (value === null || value === undefined || value === "") {
+    if (typeof value !== "string" || value === "") {
       return null;
     }
   }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -254,20 +254,16 @@ export function hasSecurePassword(
  */
 export async function authenticateBy(
   this: typeof Base,
-  attributes:
-    | Record<string, unknown>
-    | { toH(): Record<string, unknown> }
-    | { to_h(): Record<string, unknown> },
+  attributes: Record<string, unknown> | { toH(): Record<string, unknown> },
 ): Promise<Base | null> {
-  // Convert to plain object via either the JS-style `toH` (canonical
-  // trails camelCase) or Rails-style `to_h` (so Ruby/Rails values like
-  // ActionController::Parameters interop without translation).
+  // Convert to a plain object if the input has a `toH()` method
+  // (trails' camelCase analog of Rails' `to_h`). trails is camelCase-only
+  // — callers passing Ruby/Rails-shaped values must translate to `toH()`
+  // at the boundary.
   const attrs =
     typeof (attributes as any).toH === "function"
       ? (attributes as any).toH()
-      : typeof (attributes as any).to_h === "function"
-        ? (attributes as any).to_h()
-        : (attributes as Record<string, unknown>);
+      : (attributes as Record<string, unknown>);
 
   const passwordEntries: Array<[string, unknown]> = [];
   const identifierEntries: Array<[string, unknown]> = [];

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -254,13 +254,20 @@ export function hasSecurePassword(
  */
 export async function authenticateBy(
   this: typeof Base,
-  attributes: Record<string, unknown> | { toH(): Record<string, unknown> },
+  attributes:
+    | Record<string, unknown>
+    | { toH(): Record<string, unknown> }
+    | { to_h(): Record<string, unknown> },
 ): Promise<Base | null> {
-  // Convert to plain object if it has toH method
+  // Convert to plain object via either the JS-style `toH` (canonical
+  // trails camelCase) or Rails-style `to_h` (so Ruby/Rails values like
+  // ActionController::Parameters interop without translation).
   const attrs =
     typeof (attributes as any).toH === "function"
       ? (attributes as any).toH()
-      : (attributes as Record<string, unknown>);
+      : typeof (attributes as any).to_h === "function"
+        ? (attributes as any).to_h()
+        : (attributes as Record<string, unknown>);
 
   const passwordEntries: Array<[string, unknown]> = [];
   const identifierEntries: Array<[string, unknown]> = [];
@@ -283,10 +290,11 @@ export async function authenticateBy(
   }
 
   // Short-circuit: if any password is nil, empty, or not a string,
-  // return null immediately. Non-string values would otherwise flow
-  // through `as string` casts into PBKDF2 and either misbehave or
-  // throw — Rails' Ruby version coerces via `to_s` but in TS treating
-  // them as auth failure is the safer parity.
+  // return null immediately. Intentional divergence from Rails:
+  // Ruby's `to_s` coerces silently, but in TS a non-string value
+  // (object, number) reaching PBKDF2 either throws or silently
+  // stringifies to garbage like `[object Object]`. Treating it as
+  // auth failure is safer than coercing.
   for (const [, value] of passwordEntries) {
     if (typeof value !== "string" || value === "") {
       return null;
@@ -329,11 +337,17 @@ export async function authenticateBy(
     }
     return allAuthenticated ? record : null;
   } else {
-    // Even if record is not found, hash the passwords to mitigate timing attacks
+    // Even if no record is found, hash the supplied passwords so the
+    // not-found path takes comparable time to a successful authenticate.
+    // Use the async pbkdf2 here (rather than the sync hashPassword used
+    // by the password setter) so the mitigation doesn't block the event
+    // loop on every cache miss / invalid identifier — important under
+    // login load and when this path is the most-frequent caller.
+    const salt = getCrypto().randomBytes(SALT_LENGTH);
     for (const [name] of passwordEntries) {
       const value = passwords[name] as string;
-      // Hash (but discard) to consume time
-      hashPassword(value);
+      // Result discarded — we only care about the elapsed CPU time.
+      await getCrypto().pbkdf2(value, salt, ITERATIONS, KEY_LENGTH, "sha256");
     }
     return null;
   }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,4 +1,4 @@
-import { getCrypto, camelize } from "@blazetrails/activesupport";
+import { getCrypto, camelize, pbkdf2Async } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
@@ -259,13 +259,21 @@ export async function authenticateBy(
   this: typeof Base,
   attributes: Record<string, unknown> | { toH(): Record<string, unknown> },
 ): Promise<Base | null> {
+  // Reject non-objects up front so a stray null/undefined produces a
+  // clear error instead of "Cannot read properties of null (reading
+  // 'toH')" deep in the call chain.
+  if (attributes === null || typeof attributes !== "object") {
+    throw new ArgumentError(
+      "authenticateBy expects an object of attributes (or one with a toH() method)",
+    );
+  }
   // Convert to a plain object if the input has a `toH()` method
   // (trails' camelCase analog of Rails' `to_h`). trails is camelCase-only
   // — callers passing Ruby/Rails-shaped values must translate to `toH()`
   // at the boundary.
   const attrs =
-    typeof (attributes as any).toH === "function"
-      ? (attributes as any).toH()
+    typeof (attributes as { toH?: unknown }).toH === "function"
+      ? (attributes as { toH(): Record<string, unknown> }).toH()
       : (attributes as Record<string, unknown>);
 
   const passwordEntries: Array<[string, unknown]> = [];
@@ -346,7 +354,7 @@ export async function authenticateBy(
     for (const [name] of passwordEntries) {
       const value = passwords[name] as string;
       // Result discarded — we only care about the elapsed CPU time.
-      await getCrypto().pbkdf2(value, salt, ITERATIONS, KEY_LENGTH, "sha256");
+      await pbkdf2Async(getCrypto(), value, salt, ITERATIONS, KEY_LENGTH, "sha256");
     }
     return null;
   }

--- a/packages/activesupport/src/crypto-adapter.ts
+++ b/packages/activesupport/src/crypto-adapter.ts
@@ -44,6 +44,19 @@ export interface CryptoAdapter {
     keylen: number,
     digest: string,
   ): Buffer;
+  /**
+   * Async PBKDF2 — runs on Node's crypto threadpool rather than the
+   * main thread. Prefer this over `pbkdf2Sync` on hot per-request
+   * paths (e.g. authenticate_by's not-found timing mitigation) so the
+   * event loop stays responsive under login load.
+   */
+  pbkdf2(
+    password: string | Uint8Array,
+    salt: string | Uint8Array,
+    iterations: number,
+    keylen: number,
+    digest: string,
+  ): Promise<Buffer>;
   timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean;
 }
 
@@ -101,6 +114,14 @@ function wrapNodeCrypto(nodeCrypto: typeof import("node:crypto")): CryptoAdapter
     },
     pbkdf2Sync(password, salt, iterations, keylen, digest): Buffer {
       return nodeCrypto.pbkdf2Sync(password, salt, iterations, keylen, digest);
+    },
+    pbkdf2(password, salt, iterations, keylen, digest): Promise<Buffer> {
+      return new Promise((resolve, reject) => {
+        nodeCrypto.pbkdf2(password, salt, iterations, keylen, digest, (err, key) => {
+          if (err) reject(err);
+          else resolve(key);
+        });
+      });
     },
     timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
       return nodeCrypto.timingSafeEqual(a, b);

--- a/packages/activesupport/src/crypto-adapter.ts
+++ b/packages/activesupport/src/crypto-adapter.ts
@@ -45,12 +45,14 @@ export interface CryptoAdapter {
     digest: string,
   ): Buffer;
   /**
-   * Async PBKDF2 — runs on Node's crypto threadpool rather than the
-   * main thread. Prefer this over `pbkdf2Sync` on hot per-request
-   * paths (e.g. authenticate_by's not-found timing mitigation) so the
-   * event loop stays responsive under login load.
+   * Async PBKDF2 — when implemented, runs on a threadpool so hot
+   * per-request paths don't block the event loop. **Optional**: callers
+   * should go through `pbkdf2Async(adapter, ...)` below, which falls
+   * back to wrapping `pbkdf2Sync` in `Promise.resolve` for adapters that
+   * don't ship an async implementation. Marking this optional keeps
+   * downstream custom adapters source-compatible.
    */
-  pbkdf2(
+  pbkdf2?(
     password: string | Uint8Array,
     salt: string | Uint8Array,
     iterations: number,
@@ -58,6 +60,25 @@ export interface CryptoAdapter {
     digest: string,
   ): Promise<Buffer>;
   timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean;
+}
+
+/**
+ * Use the adapter's async `pbkdf2` when available, otherwise wrap the
+ * sync implementation. Lets call sites prefer the threadpool path
+ * without breaking adapters that only implement `pbkdf2Sync`.
+ */
+export function pbkdf2Async(
+  adapter: CryptoAdapter,
+  password: string | Uint8Array,
+  salt: string | Uint8Array,
+  iterations: number,
+  keylen: number,
+  digest: string,
+): Promise<Buffer> {
+  if (typeof adapter.pbkdf2 === "function") {
+    return adapter.pbkdf2(password, salt, iterations, keylen, digest);
+  }
+  return Promise.resolve(adapter.pbkdf2Sync(password, salt, iterations, keylen, digest));
 }
 
 export interface HashAdapter {

--- a/packages/activesupport/src/crypto-adapter.ts
+++ b/packages/activesupport/src/crypto-adapter.ts
@@ -78,7 +78,12 @@ export function pbkdf2Async(
   if (typeof adapter.pbkdf2 === "function") {
     return adapter.pbkdf2(password, salt, iterations, keylen, digest);
   }
-  return Promise.resolve(adapter.pbkdf2Sync(password, salt, iterations, keylen, digest));
+  // Defer the sync call so a synchronous throw becomes a Promise
+  // rejection — keeps the function's async contract intact for `.catch`
+  // callers regardless of how the underlying adapter behaves.
+  return Promise.resolve().then(() =>
+    adapter.pbkdf2Sync(password, salt, iterations, keylen, digest),
+  );
 }
 
 export interface HashAdapter {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -13,6 +13,7 @@ export {
   getCrypto,
   getCryptoAsync,
   cryptoAdapterConfig,
+  pbkdf2Async,
 } from "./crypto-adapter.js";
 export type {
   CryptoAdapter,


### PR DESCRIPTION
## Summary

PR 4 of 15 from [`docs/api-compare-100-plan.md`](../blob/main/docs/api-compare-100-plan.md). Closes the `secure_password.rb` row.

Ports `ActiveRecord::SecurePassword.authenticate_by` ([Rails source](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/secure_password.rb)). Given a hash of attributes, partitions them into password vs. identifier columns (a column is treated as a password if `_digest` exists but the column itself doesn't), then calls `findBy(identifiers)` and verifies each password via `authenticate_${name}` on the record. Returns the record on success; `null` otherwise. Hashes the supplied passwords even when no record is found, mirroring Rails' `new(passwords)` BCrypt-trigger that mitigates timing-based enumeration.

`hasSecurePassword` accepts an `attribute` parameter (Rails' `has_secure_password(attribute = :password, ...)` overload) so models can register multiple secure-password columns.

`authenticateBy`'s not-found timing mitigation calls `pbkdf2Async(adapter, ...)` (new exported helper from `@blazetrails/activesupport`) — uses the adapter's async `pbkdf2` when present, falls back to wrapping `pbkdf2Sync` for adapters that don't ship one. The fallback defers via `Promise.resolve().then(...)` so a synchronous adapter exception becomes a rejection. `CryptoAdapter.pbkdf2` is **optional** (no breaking change for downstream adapters).

Throws `ArgumentError` when input is non-object, has no password keys, or has no identifier keys (post-`undefined`-filter). Throws `TypeError` if a model declares a `*_digest` column without a corresponding `hasSecurePassword` registration (mirrors Rails' `NoMethodError`).

## Impact

`pnpm api:compare --package activerecord`:

- `secure_password.rb`: 0/1 → 1/1 ✓
- 23 tests pass.

## ⚠️ Hit max Copilot review cycles (10) — human review requested

**Final review (#10) generated no new comments — Copilot has nothing left to flag.** All 9 prior cycles' actionable concerns are addressed (or replied to with Rails-source justification). PR is ready for human merge review.

**Resolved across cycles:**

- ✅ Camelize underscored attribute names via shared `@blazetrails/activesupport` `camelize` (review #2)
- ✅ Throw `TypeError` on missing `authenticate${Name}` instead of silent null (review #2)
- ✅ Use `ArgumentError` from activemodel (earlier cycle)
- ✅ Drop `break` on first wrong password — accumulator loop, all hashes evaluated (review #6)
- ✅ Comment placeholder no longer reads like an interpolation bug (review #6)
- ✅ Constant-time mitigation: docstring honest about valid-input-only guarantee (review #5)
- ✅ Async PBKDF2 on the not-found mitigation path via `pbkdf2Async` helper (reviews #6, #7)
- ✅ `CryptoAdapter.pbkdf2` is optional + `pbkdf2Async` helper (review #8) — no downstream breakage
- ✅ Reject non-object `attributes` with clear `ArgumentError` (review #8)
- ✅ Filter `undefined` identifier values before `findBy` to prevent `IS NULL` auth-bypass (review #9) — test pinning behavior
- ✅ Cache `getCrypto()` once per call (review #9)
- ✅ Comment matches actual fallback semantics ("prefers threadpool when supported") (review #9)
- ✅ `pbkdf2Async` sync-fallback defers to keep async contract intact (review #9)

**Replied (intentional divergences / out of scope):**

- Test name `accepts any object that implements to_h` preserved per CLAUDE.md "NEVER rename or reword Rails-mirrored test names".
- Non-string password values are rejected as auth failure rather than coerced via `to_s` — intentional TS-side divergence (silent `[object Object]` stringification into PBKDF2 would be worse than refusing).
- `pbkdf2Sync` still backs the password-setter `beforeSave` hook — by design (one call per `save`, not a per-request hot path).
- Per-attribute validations only wired for the default `password` attribute — known gap, separable follow-up (`errors.add` keys would need parameterization).

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/secure-password.test.ts` — 23 pass
- [x] `pnpm api:compare --package activerecord` — `secure_password.rb 100%`
- [x] `pnpm build` clean
- [x] Multi-password: `hasSecurePassword(User, "recovery_password")` registers a second authenticator; `authenticateBy` accepts both
- [x] No early-exit on first wrong password (timing parity across positions)
- [x] `authenticate${Name}` not registered → `TypeError`
- [x] Non-string / null / empty password values short-circuit to null without hashing
- [x] Non-object / null `attributes` → `ArgumentError`
- [x] `undefined` identifier values → `ArgumentError` (no `IS NULL` auth-bypass)
- [x] Constant-time mitigation: not-found path takes comparable time to wrong-password path
- [x] Async PBKDF2 via adapter helper, sync fallback preserves async contract