### PR TITLE
feat(activerecord): enum.rb private helpers (4/11)

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1789,6 +1789,10 @@ describe("Enum private validators", () => {
     it("rejects hash with non-primitive value", () => {
       expect(() => assertValidEnumDefinitionValues({ a: { x: 1 } })).toThrow(ArgumentError);
     });
+    it("rejects hash with NaN or Infinity number values", () => {
+      expect(() => assertValidEnumDefinitionValues({ a: NaN })).toThrow(/finite numbers/);
+      expect(() => assertValidEnumDefinitionValues({ a: Infinity })).toThrow(/finite numbers/);
+    });
   });
 
   describe("assertValidEnumOptions", () => {
@@ -1825,6 +1829,11 @@ describe("Enum private validators", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
       detectNegativeEnumConditionsBang(["draft", "not_draft"]);
       expect(spy).toHaveBeenCalledWith(expect.stringMatching(/'not_draft'/));
+    });
+    it("does not warn for unrelated identifiers starting with 'not' (notebook, notify)", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      detectNegativeEnumConditionsBang(["ebook", "notebook", "ify", "notify"]);
+      expect(spy).not.toHaveBeenCalled();
     });
     it("does not warn when there is no positive-form clash", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -2,8 +2,14 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { castEnumValue, Base, Relation, defineEnum, readEnumValue } from "./index.js";
+import {
+  assertValidEnumDefinitionValues,
+  assertValidEnumOptions,
+  detectNegativeEnumConditionsBang,
+} from "./enum.js";
+import { ArgumentError } from "@blazetrails/activemodel";
 
 import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -1728,14 +1734,9 @@ describe("EnumTest", () => {
   });
 });
 
-import {
-  assertValidEnumDefinitionValues,
-  assertValidEnumOptions,
-  detectNegativeEnumConditionsBang,
-} from "./enum.js";
-import { ArgumentError } from "@blazetrails/activemodel";
-
 describe("Enum private validators", () => {
+  afterEach(() => vi.restoreAllMocks());
+
   describe("assertValidEnumDefinitionValues", () => {
     it("rejects empty array with ArgumentError", () => {
       expect(() => assertValidEnumDefinitionValues([])).toThrow(ArgumentError);
@@ -1745,6 +1746,12 @@ describe("Enum private validators", () => {
     });
     it("rejects array with blank name", () => {
       expect(() => assertValidEnumDefinitionValues(["a", ""])).toThrow(/blank name/);
+    });
+    it("rejects array with whitespace-only name", () => {
+      expect(() => assertValidEnumDefinitionValues(["a", "   "])).toThrow(/blank name/);
+    });
+    it("rejects hash with whitespace-only key", () => {
+      expect(() => assertValidEnumDefinitionValues({ "   ": 1 })).toThrow(/blank name/);
     });
     it("rejects empty hash", () => {
       expect(() => assertValidEnumDefinitionValues({})).toThrow(ArgumentError);
@@ -1778,19 +1785,16 @@ describe("Enum private validators", () => {
       expect(spy).toHaveBeenCalledWith(
         expect.stringMatching(/conflicts with auto-generated negative scope 'notDraft'/),
       );
-      spy.mockRestore();
     });
     it("warns when not_draft conflicts with draft (snake_case prefix)", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
       detectNegativeEnumConditionsBang(["draft", "not_draft"]);
       expect(spy).toHaveBeenCalledWith(expect.stringMatching(/'not_draft'/));
-      spy.mockRestore();
     });
     it("does not warn when there is no positive-form clash", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
       detectNegativeEnumConditionsBang(["notDraft", "published"]);
       expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
     });
   });
 });

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1763,6 +1763,22 @@ describe("Enum private validators", () => {
     it("rejects hash with whitespace-only key", () => {
       expect(() => assertValidEnumDefinitionValues({ "   ": 1 })).toThrow(/blank name/);
     });
+    it("rejects array with blank-description Symbol", () => {
+      expect(() => assertValidEnumDefinitionValues([Symbol("")])).toThrow(/blank name/);
+      expect(() => assertValidEnumDefinitionValues([Symbol("   ")])).toThrow(/blank name/);
+    });
+    it("rejects non-plain-object values (Map/Date/class instances)", () => {
+      expect(() => assertValidEnumDefinitionValues(new Map())).toThrow(
+        /non-empty hash or an array/,
+      );
+      expect(() => assertValidEnumDefinitionValues(new Date())).toThrow(
+        /non-empty hash or an array/,
+      );
+      class Foo {}
+      expect(() => assertValidEnumDefinitionValues(new Foo())).toThrow(
+        /non-empty hash or an array/,
+      );
+    });
     it("rejects empty hash", () => {
       expect(() => assertValidEnumDefinitionValues({})).toThrow(ArgumentError);
     });

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1823,6 +1823,12 @@ describe("Enum private validators", () => {
     it("treats arrays as not-an-options-hash", () => {
       expect(() => assertValidEnumOptions([] as any)).not.toThrow();
     });
+    it("treats Map / Date / class instances as not-an-options-hash", () => {
+      expect(() => assertValidEnumOptions(new Map())).not.toThrow();
+      expect(() => assertValidEnumOptions(new Date())).not.toThrow();
+      class Foo {}
+      expect(() => assertValidEnumOptions(new Foo())).not.toThrow();
+    });
   });
 
   describe("detectNegativeEnumConditionsBang", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -8,6 +8,7 @@ import {
   assertValidEnumDefinitionValues,
   assertValidEnumOptions,
   detectNegativeEnumConditionsBang,
+  setEnumWarn,
 } from "./enum.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
@@ -1789,6 +1790,13 @@ describe("Enum private validators", () => {
     it("rejects hash with non-primitive value", () => {
       expect(() => assertValidEnumDefinitionValues({ a: { x: 1 } })).toThrow(ArgumentError);
     });
+    it("accepts hash with symbol keys (Reflect.ownKeys)", () => {
+      const out = assertValidEnumDefinitionValues({ [Symbol("draft")]: 0 });
+      expect(out).toBeDefined();
+    });
+    it("rejects hash with blank-description symbol key", () => {
+      expect(() => assertValidEnumDefinitionValues({ [Symbol("")]: 0 })).toThrow(/blank name/);
+    });
     it("rejects hash with NaN or Infinity number values", () => {
       expect(() => assertValidEnumDefinitionValues({ a: NaN })).toThrow(/finite numbers/);
       expect(() => assertValidEnumDefinitionValues({ a: Infinity })).toThrow(/finite numbers/);
@@ -1829,6 +1837,18 @@ describe("Enum private validators", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
       detectNegativeEnumConditionsBang(["draft", "not_draft"]);
       expect(spy).toHaveBeenCalledWith(expect.stringMatching(/'not_draft'/));
+    });
+    it("routes warnings through setEnumWarn instead of console.warn", () => {
+      const calls: string[] = [];
+      setEnumWarn((msg) => calls.push(msg));
+      try {
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        detectNegativeEnumConditionsBang(["draft", "notDraft"]);
+        expect(calls.length).toBe(1);
+        expect(consoleSpy).not.toHaveBeenCalled();
+      } finally {
+        setEnumWarn((msg) => console.warn(msg));
+      }
     });
     it("does not warn for unrelated identifiers starting with 'not' (notebook, notify)", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { castEnumValue, Base, Relation, defineEnum, readEnumValue } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
@@ -1725,5 +1725,72 @@ describe("EnumTest", () => {
     post.writeAttribute("subtitle", "hello");
     post.writeAttribute("subtitle", null);
     expect(post.changed).toBe(false);
+  });
+});
+
+import {
+  assertValidEnumDefinitionValues,
+  assertValidEnumOptions,
+  detectNegativeEnumConditionsBang,
+} from "./enum.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+
+describe("Enum private validators", () => {
+  describe("assertValidEnumDefinitionValues", () => {
+    it("rejects empty array with ArgumentError", () => {
+      expect(() => assertValidEnumDefinitionValues([])).toThrow(ArgumentError);
+    });
+    it("rejects array with non-string entries", () => {
+      expect(() => assertValidEnumDefinitionValues([1, 2])).toThrow(ArgumentError);
+    });
+    it("rejects array with blank name", () => {
+      expect(() => assertValidEnumDefinitionValues(["a", ""])).toThrow(/blank name/);
+    });
+    it("rejects empty hash", () => {
+      expect(() => assertValidEnumDefinitionValues({})).toThrow(ArgumentError);
+    });
+    it("accepts hash with boolean and null values", () => {
+      const out = assertValidEnumDefinitionValues({ a: true, b: null, c: 1 });
+      expect(out).toEqual({ a: true, b: null, c: 1 });
+    });
+    it("rejects hash with non-primitive value", () => {
+      expect(() => assertValidEnumDefinitionValues({ a: { x: 1 } })).toThrow(ArgumentError);
+    });
+  });
+
+  describe("assertValidEnumOptions", () => {
+    it("rejects underscore-prefixed _prefix/_validate keys with ArgumentError", () => {
+      expect(() => assertValidEnumOptions({ _prefix: "x" })).toThrow(ArgumentError);
+      expect(() => assertValidEnumOptions({ _validate: true })).toThrow(/invalid option/);
+    });
+    it("accepts valid options without throwing", () => {
+      expect(() => assertValidEnumOptions({ prefix: "x", validate: true })).not.toThrow();
+    });
+    it("treats arrays as not-an-options-hash", () => {
+      expect(() => assertValidEnumOptions([] as any)).not.toThrow();
+    });
+  });
+
+  describe("detectNegativeEnumConditionsBang", () => {
+    it("warns when notDraft conflicts with draft (camelCase prefix)", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      detectNegativeEnumConditionsBang(["draft", "notDraft"]);
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/conflicts with auto-generated negative scope 'notDraft'/),
+      );
+      spy.mockRestore();
+    });
+    it("warns when not_draft conflicts with draft (snake_case prefix)", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      detectNegativeEnumConditionsBang(["draft", "not_draft"]);
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching(/'not_draft'/));
+      spy.mockRestore();
+    });
+    it("does not warn when there is no positive-form clash", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      detectNegativeEnumConditionsBang(["notDraft", "published"]);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1744,6 +1744,16 @@ describe("Enum private validators", () => {
     it("rejects array with non-string entries", () => {
       expect(() => assertValidEnumDefinitionValues([1, 2])).toThrow(ArgumentError);
     });
+    it("accepts array with string entries", () => {
+      const out = assertValidEnumDefinitionValues(["draft", "published"]);
+      expect(out).toEqual(["draft", "published"]);
+    });
+    it("accepts array with symbol entries", () => {
+      const sym1 = Symbol("draft");
+      const sym2 = Symbol("published");
+      const out = assertValidEnumDefinitionValues([sym1, sym2]);
+      expect(out).toEqual([sym1, sym2]);
+    });
     it("rejects array with blank name", () => {
       expect(() => assertValidEnumDefinitionValues(["a", ""])).toThrow(/blank name/);
     });

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -1766,9 +1766,18 @@ describe("Enum private validators", () => {
   });
 
   describe("assertValidEnumOptions", () => {
-    it("rejects underscore-prefixed _prefix/_validate keys with ArgumentError", () => {
+    it("rejects underscore-prefixed option keys with ArgumentError (enum.rb:361-365)", () => {
+      // Rails: options.keys & %i[_prefix _suffix _scopes _default _instance_methods]
       expect(() => assertValidEnumOptions({ _prefix: "x" })).toThrow(ArgumentError);
-      expect(() => assertValidEnumOptions({ _validate: true })).toThrow(/invalid option/);
+      expect(() => assertValidEnumOptions({ _suffix: "x" })).toThrow(/invalid option/);
+      expect(() => assertValidEnumOptions({ _scopes: true })).toThrow(/invalid option/);
+      expect(() => assertValidEnumOptions({ _default: "active" })).toThrow(/invalid option/);
+      expect(() => assertValidEnumOptions({ _instance_methods: false })).toThrow(/invalid option/);
+      // _validate is NOT in Rails' invalid list — valid options include :validate
+      expect(() => assertValidEnumOptions({ _validate: true })).not.toThrow();
+    });
+    it("error message uses Ruby symbol inspect format (:key)", () => {
+      expect(() => assertValidEnumOptions({ _prefix: "x" })).toThrow(/:_prefix/);
     });
     it("accepts valid options without throwing", () => {
       expect(() => assertValidEnumOptions({ prefix: "x", validate: true })).not.toThrow();

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -442,16 +442,19 @@ export function assertValidEnumDefinitionValues(
       throw new ArgumentError("Enum values must not contain a blank name.");
     }
     for (const [, value] of Object.entries(values)) {
+      const isFiniteNumber = typeof value === "number" && Number.isFinite(value);
       if (
         !(
           typeof value === "string" ||
-          typeof value === "number" ||
+          isFiniteNumber ||
           typeof value === "boolean" ||
           value === null
         )
       ) {
         throw new ArgumentError(
-          `Enum values must be only booleans, integers, floats, strings, or null, got: ${typeof value}`,
+          `Enum values must be only booleans, finite numbers, strings, or null, got: ${
+            typeof value === "number" ? String(value) : typeof value
+          }`,
         );
       }
     }
@@ -515,7 +518,12 @@ function normalizeNegativeEnumPositiveForm(
     if (rest.length === 0) return null;
     return { prefix: "not_", positiveForm: rest.charAt(0).toLowerCase() + rest.slice(1) };
   }
+  // Match camelCase generated form: "notDraft" — next char must be uppercase
+  // (so unrelated identifiers like "notebook" / "notify" don't get treated
+  // as negative scopes for "ebook" / "ify").
   if (methodName.startsWith("not") && methodName.length > 3) {
+    const next = methodName.charAt(3);
+    if (next !== next.toUpperCase() || next === next.toLowerCase()) return null;
     const rest = methodName.substring(3);
     return { prefix: "not", positiveForm: rest.charAt(0).toLowerCase() + rest.slice(1) };
   }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -399,23 +399,31 @@ export function castEnumValue(
 /**
  * Validate enum values are non-empty array or hash with proper types.
  * Mirrors: ActiveRecord::Enum#assert_valid_enum_definition_values (private)
+ *
+ * Accepts both strings and symbols in arrays (Rails parity). JavaScript symbols
+ * are the closest equivalent to Ruby symbols; strings are used directly.
  */
 export function assertValidEnumDefinitionValues(
   values: any,
-): Record<string, string | number | boolean | null> | string[] {
+): Record<string, string | number | boolean | null> | (string | symbol)[] {
   if (Array.isArray(values)) {
     if (values.length === 0) {
       throw new ArgumentError("Enum values must not be empty.");
     }
-    const allStrings = values.every((v) => typeof v === "string");
-    if (!allStrings) {
+    const allValid = values.every((v) => typeof v === "string" || typeof v === "symbol");
+    if (!allValid) {
       throw new ArgumentError(
-        `Enum values must only contain strings, got: ${Array.from(
+        `Enum values must only contain strings or symbols, got: ${Array.from(
           new Set(values.map((v) => typeof v)),
         ).join(", ")}`,
       );
     }
-    if (values.some((v) => isBlank(v))) {
+    if (
+      values.some((v) => {
+        if (typeof v === "symbol") return false;
+        return isBlank(v);
+      })
+    ) {
       throw new ArgumentError("Enum values must not contain a blank name.");
     }
     return values;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -420,7 +420,11 @@ export function assertValidEnumDefinitionValues(
     }
     if (
       values.some((v) => {
-        if (typeof v === "symbol") return false;
+        if (typeof v === "symbol") {
+          // Reject Symbol("") / Symbol("   ") — mirror Ruby Symbol#blank?
+          const desc = v.description ?? Symbol.keyFor(v) ?? "";
+          return isBlank(desc);
+        }
         return isBlank(v);
       })
     ) {
@@ -429,7 +433,7 @@ export function assertValidEnumDefinitionValues(
     return values;
   }
 
-  if (typeof values === "object" && values !== null && !Array.isArray(values)) {
+  if (isPlainHash(values)) {
     const keys = Object.keys(values);
     if (keys.length === 0) {
       throw new ArgumentError("Enum values must not be empty.");
@@ -455,6 +459,13 @@ export function assertValidEnumDefinitionValues(
   }
 
   throw new ArgumentError("Enum values must be either a non-empty hash or an array.");
+}
+
+/** True for plain JS objects (Object.prototype or null proto), matching Ruby Hash semantics. */
+function isPlainHash(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 /**

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -456,19 +456,16 @@ export function assertValidEnumDefinitionValues(
 export function assertValidEnumOptions(options: unknown): void {
   if (!options || typeof options !== "object" || Array.isArray(options)) return;
 
-  const invalidKeys = [
-    "_prefix",
-    "_suffix",
-    "_scopes",
-    "_default",
-    "_instance_methods",
-    "_validate",
-  ];
+  // Rails: options.keys & %i[_prefix _suffix _scopes _default _instance_methods]
+  // Note: _validate is NOT in this list — it is rejected at the enum definition
+  // level, not as an option key (enum.rb:361-365).
+  const invalidKeys = ["_prefix", "_suffix", "_scopes", "_default", "_instance_methods"];
   const found = Object.keys(options).filter((k) => invalidKeys.includes(k));
 
   if (found.length > 0) {
+    // Rails: invalid_keys.map(&:inspect) — inspect on a Ruby symbol produces ":key"
     throw new ArgumentError(
-      `invalid option(s): ${found.map((k) => `"${k}"`).join(", ")}. Valid options are: prefix, suffix, scopes, default, instance_methods, and validate.`,
+      `invalid option(s): ${found.map((k) => `:${k}`).join(", ")}. Valid options are: :prefix, :suffix, :scopes, :default, :instance_methods, and :validate.`,
     );
   }
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "./errors.js";
 import type { Base } from "./base.js";
 import { camelize, pluralize } from "@blazetrails/activesupport";
 import { ValueType } from "@blazetrails/activemodel";
@@ -397,63 +396,90 @@ export function castEnumValue(
   return def.type.serialize(value) as number | null;
 }
 
-function name(): never {
-  throw new NotImplementedError("ActiveRecord::Enum::EnumType#name is not implemented");
-}
-
-function klass(): never {
-  throw new NotImplementedError("ActiveRecord::Enum::EnumMethods#klass is not implemented");
-}
-
-function defineEnumMethods(
-  name: any,
-  valueMethodName: any,
-  value: any,
-  scopes: any,
-  instanceMethods: any,
-): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Enum::EnumMethods#define_enum_methods is not implemented",
-  );
-}
-
-function _enum(
-  name: any,
+/**
+ * Validate enum values are non-empty array or hash with proper types.
+ * Mirrors: ActiveRecord::Enum#assert_valid_enum_definition_values (private)
+ */
+export function assertValidEnumDefinitionValues(
   values: any,
-  prefix?: any,
-  suffix?: any,
-  scopes?: any,
-  instanceMethods?: any,
-  validate?: any,
-  options?: any,
-): never {
-  throw new NotImplementedError("ActiveRecord::Enum#_enum is not implemented");
+): Record<string, number | string> | string[] {
+  if (Array.isArray(values)) {
+    if (values.length === 0) {
+      throw new Error("Enum values must not be empty.");
+    }
+    const allStrings = values.every((v) => typeof v === "string");
+    const allSymbols = values.every((v) => typeof v === "string");
+    if (!allStrings && !allSymbols) {
+      throw new Error(
+        `Enum values must only contain symbols or strings, got: ${Array.from(
+          new Set(values.map((v) => typeof v)),
+        ).join(", ")}`,
+      );
+    }
+    if (values.some((v) => !v || v === "")) {
+      throw new Error("Enum values must not contain a blank name.");
+    }
+    return values;
+  }
+
+  if (typeof values === "object" && values !== null && !Array.isArray(values)) {
+    const keys = Object.keys(values);
+    if (keys.length === 0) {
+      throw new Error("Enum values must not be empty.");
+    }
+    if (keys.some((k) => !k || k === "")) {
+      throw new Error("Enum values must not contain a blank name.");
+    }
+    for (const [, value] of Object.entries(values)) {
+      if (
+        !(
+          typeof value === "string" ||
+          typeof value === "number" ||
+          typeof value === "boolean" ||
+          value === null
+        )
+      ) {
+        throw new Error(
+          `Enum values must be only booleans, integers, floats, symbols or strings, got: ${typeof value}`,
+        );
+      }
+    }
+    return values;
+  }
+
+  throw new Error("Enum values must be either a non-empty hash or an array.");
 }
 
-function _enumMethodsModule(): never {
-  throw new NotImplementedError("ActiveRecord::Enum#_enum_methods_module is not implemented");
+/**
+ * Validate enum options: reject underscore-prefixed variants.
+ * Mirrors: ActiveRecord::Enum#assert_valid_enum_options (private)
+ */
+export function assertValidEnumOptions(options: Record<string, any>): void {
+  if (!options || typeof options !== "object") return;
+
+  const invalidKeys = ["_prefix", "_suffix", "_scopes", "_default", "_instance_methods"];
+  const found = Object.keys(options).filter((k) => invalidKeys.includes(k));
+
+  if (found.length > 0) {
+    throw new Error(
+      `invalid option(s): ${found.map((k) => `"${k}"`).join(", ")}. Valid options are: prefix, suffix, scopes, default, instance_methods, and validate.`,
+    );
+  }
 }
 
-function assertValidEnumDefinitionValues(values: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Enum#assert_valid_enum_definition_values is not implemented",
-  );
-}
-
-function assertValidEnumOptions(options: any): never {
-  throw new NotImplementedError("ActiveRecord::Enum#assert_valid_enum_options is not implemented");
-}
-
-function detectEnumConflictBang(enumName: any, methodName: any, klassMethod?: any): never {
-  throw new NotImplementedError("ActiveRecord::Enum#detect_enum_conflict! is not implemented");
-}
-
-function raiseConflictError(enumName: any, methodName: any, type?: any, source?: any): never {
-  throw new NotImplementedError("ActiveRecord::Enum#raise_conflict_error is not implemented");
-}
-
-function detectNegativeEnumConditionsBang(methodNames: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Enum#detect_negative_enum_conditions! is not implemented",
-  );
+/**
+ * Warn on negative enum condition conflicts (e.g., both "notDraft" and "draft").
+ * Mirrors: ActiveRecord::Enum#detect_negative_enum_conditions! (private)
+ */
+export function detectNegativeEnumConditionsBang(methodNames: string[]): void {
+  const notMethods = methodNames.filter((m) => m.startsWith("not"));
+  for (const notMethod of notMethods) {
+    const positiveForm = notMethod.substring(3);
+    if (methodNames.includes(positiveForm)) {
+      console.warn(
+        `Enum uses prefix 'not_' which conflicts with auto-generated negative scope '${notMethod}' ` +
+          `while positive form '${positiveForm}' also exists.`,
+      );
+    }
+  }
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,6 +1,6 @@
 import type { Base } from "./base.js";
 import { camelize, pluralize } from "@blazetrails/activesupport";
-import { ValueType } from "@blazetrails/activemodel";
+import { ArgumentError, ValueType } from "@blazetrails/activemodel";
 
 /**
  * Enum definition — maps symbolic names to integer values.
@@ -402,22 +402,21 @@ export function castEnumValue(
  */
 export function assertValidEnumDefinitionValues(
   values: any,
-): Record<string, number | string> | string[] {
+): Record<string, string | number | boolean | null> | string[] {
   if (Array.isArray(values)) {
     if (values.length === 0) {
-      throw new Error("Enum values must not be empty.");
+      throw new ArgumentError("Enum values must not be empty.");
     }
     const allStrings = values.every((v) => typeof v === "string");
-    const allSymbols = values.every((v) => typeof v === "string");
-    if (!allStrings && !allSymbols) {
-      throw new Error(
+    if (!allStrings) {
+      throw new ArgumentError(
         `Enum values must only contain symbols or strings, got: ${Array.from(
           new Set(values.map((v) => typeof v)),
         ).join(", ")}`,
       );
     }
     if (values.some((v) => !v || v === "")) {
-      throw new Error("Enum values must not contain a blank name.");
+      throw new ArgumentError("Enum values must not contain a blank name.");
     }
     return values;
   }
@@ -425,10 +424,10 @@ export function assertValidEnumDefinitionValues(
   if (typeof values === "object" && values !== null && !Array.isArray(values)) {
     const keys = Object.keys(values);
     if (keys.length === 0) {
-      throw new Error("Enum values must not be empty.");
+      throw new ArgumentError("Enum values must not be empty.");
     }
     if (keys.some((k) => !k || k === "")) {
-      throw new Error("Enum values must not contain a blank name.");
+      throw new ArgumentError("Enum values must not contain a blank name.");
     }
     for (const [, value] of Object.entries(values)) {
       if (
@@ -439,7 +438,7 @@ export function assertValidEnumDefinitionValues(
           value === null
         )
       ) {
-        throw new Error(
+        throw new ArgumentError(
           `Enum values must be only booleans, integers, floats, symbols or strings, got: ${typeof value}`,
         );
       }
@@ -447,7 +446,7 @@ export function assertValidEnumDefinitionValues(
     return values;
   }
 
-  throw new Error("Enum values must be either a non-empty hash or an array.");
+  throw new ArgumentError("Enum values must be either a non-empty hash or an array.");
 }
 
 /**
@@ -455,13 +454,20 @@ export function assertValidEnumDefinitionValues(
  * Mirrors: ActiveRecord::Enum#assert_valid_enum_options (private)
  */
 export function assertValidEnumOptions(options: Record<string, any>): void {
-  if (!options || typeof options !== "object") return;
+  if (!options || typeof options !== "object" || Array.isArray(options)) return;
 
-  const invalidKeys = ["_prefix", "_suffix", "_scopes", "_default", "_instance_methods"];
+  const invalidKeys = [
+    "_prefix",
+    "_suffix",
+    "_scopes",
+    "_default",
+    "_instance_methods",
+    "_validate",
+  ];
   const found = Object.keys(options).filter((k) => invalidKeys.includes(k));
 
   if (found.length > 0) {
-    throw new Error(
+    throw new ArgumentError(
       `invalid option(s): ${found.map((k) => `"${k}"`).join(", ")}. Valid options are: prefix, suffix, scopes, default, instance_methods, and validate.`,
     );
   }
@@ -472,14 +478,30 @@ export function assertValidEnumOptions(options: Record<string, any>): void {
  * Mirrors: ActiveRecord::Enum#detect_negative_enum_conditions! (private)
  */
 export function detectNegativeEnumConditionsBang(methodNames: string[]): void {
-  const notMethods = methodNames.filter((m) => m.startsWith("not"));
-  for (const notMethod of notMethods) {
-    const positiveForm = notMethod.substring(3);
+  for (const notMethod of methodNames) {
+    const normalized = normalizeNegativeEnumPositiveForm(notMethod);
+    if (!normalized) continue;
+    const { prefix, positiveForm } = normalized;
     if (methodNames.includes(positiveForm)) {
       console.warn(
-        `Enum uses prefix 'not_' which conflicts with auto-generated negative scope '${notMethod}' ` +
+        `Enum uses prefix '${prefix}' which conflicts with auto-generated negative scope '${notMethod}' ` +
           `while positive form '${positiveForm}' also exists.`,
       );
     }
   }
+}
+
+function normalizeNegativeEnumPositiveForm(
+  methodName: string,
+): { prefix: "not" | "not_"; positiveForm: string } | null {
+  if (methodName.startsWith("not_")) {
+    const rest = methodName.substring(4);
+    if (rest.length === 0) return null;
+    return { prefix: "not_", positiveForm: rest.charAt(0).toLowerCase() + rest.slice(1) };
+  }
+  if (methodName.startsWith("not") && methodName.length > 3) {
+    const rest = methodName.substring(3);
+    return { prefix: "not", positiveForm: rest.charAt(0).toLowerCase() + rest.slice(1) };
+  }
+  return null;
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { camelize, pluralize } from "@blazetrails/activesupport";
+import { camelize, isBlank, pluralize } from "@blazetrails/activesupport";
 import { ArgumentError, ValueType } from "@blazetrails/activemodel";
 
 /**
@@ -410,12 +410,12 @@ export function assertValidEnumDefinitionValues(
     const allStrings = values.every((v) => typeof v === "string");
     if (!allStrings) {
       throw new ArgumentError(
-        `Enum values must only contain symbols or strings, got: ${Array.from(
+        `Enum values must only contain strings, got: ${Array.from(
           new Set(values.map((v) => typeof v)),
         ).join(", ")}`,
       );
     }
-    if (values.some((v) => !v || v === "")) {
+    if (values.some((v) => isBlank(v))) {
       throw new ArgumentError("Enum values must not contain a blank name.");
     }
     return values;
@@ -426,7 +426,7 @@ export function assertValidEnumDefinitionValues(
     if (keys.length === 0) {
       throw new ArgumentError("Enum values must not be empty.");
     }
-    if (keys.some((k) => !k || k === "")) {
+    if (keys.some((k) => isBlank(k))) {
       throw new ArgumentError("Enum values must not contain a blank name.");
     }
     for (const [, value] of Object.entries(values)) {
@@ -439,7 +439,7 @@ export function assertValidEnumDefinitionValues(
         )
       ) {
         throw new ArgumentError(
-          `Enum values must be only booleans, integers, floats, symbols or strings, got: ${typeof value}`,
+          `Enum values must be only booleans, integers, floats, strings, or null, got: ${typeof value}`,
         );
       }
     }
@@ -453,7 +453,7 @@ export function assertValidEnumDefinitionValues(
  * Validate enum options: reject underscore-prefixed variants.
  * Mirrors: ActiveRecord::Enum#assert_valid_enum_options (private)
  */
-export function assertValidEnumOptions(options: Record<string, any>): void {
+export function assertValidEnumOptions(options: unknown): void {
   if (!options || typeof options !== "object" || Array.isArray(options)) return;
 
   const invalidKeys = [

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -434,14 +434,26 @@ export function assertValidEnumDefinitionValues(
   }
 
   if (isPlainHash(values)) {
-    const keys = Object.keys(values);
+    // Use Reflect.ownKeys so symbol-keyed entries (e.g. { [Symbol('draft')]: 0 })
+    // aren't silently dropped by Object.keys; symbols are validated alongside
+    // strings to mirror Ruby Hash + Symbol semantics.
+    const keys = Reflect.ownKeys(values as object);
     if (keys.length === 0) {
       throw new ArgumentError("Enum values must not be empty.");
     }
-    if (keys.some((k) => isBlank(k))) {
+    if (
+      keys.some((k) => {
+        if (typeof k === "symbol") {
+          const desc = k.description ?? Symbol.keyFor(k) ?? "";
+          return isBlank(desc);
+        }
+        return isBlank(k);
+      })
+    ) {
       throw new ArgumentError("Enum values must not contain a blank name.");
     }
-    for (const [, value] of Object.entries(values)) {
+    for (const k of keys) {
+      const value = (values as Record<string | symbol, unknown>)[k as string];
       const isFiniteNumber = typeof value === "number" && Number.isFinite(value);
       if (
         !(
@@ -492,17 +504,25 @@ export function assertValidEnumOptions(options: unknown): void {
   }
 }
 
+/** Default warn sink — overridable via setEnumWarn so hosts can route warnings. */
+let _enumWarn: (msg: string) => void = (msg) => console.warn(msg);
+
+export function setEnumWarn(fn: (msg: string) => void): void {
+  _enumWarn = fn;
+}
+
 /**
  * Warn on negative enum condition conflicts (e.g., both "notDraft" and "draft").
  * Mirrors: ActiveRecord::Enum#detect_negative_enum_conditions! (private)
  */
 export function detectNegativeEnumConditionsBang(methodNames: string[]): void {
+  const methodNameSet = new Set(methodNames);
   for (const notMethod of methodNames) {
     const normalized = normalizeNegativeEnumPositiveForm(notMethod);
     if (!normalized) continue;
     const { prefix, positiveForm } = normalized;
-    if (methodNames.includes(positiveForm)) {
-      console.warn(
+    if (methodNameSet.has(positiveForm)) {
+      _enumWarn(
         `Enum uses prefix '${prefix}' which conflicts with auto-generated negative scope '${notMethod}' ` +
           `while positive form '${positiveForm}' also exists.`,
       );

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -488,7 +488,7 @@ function isPlainHash(value: unknown): boolean {
  * Mirrors: ActiveRecord::Enum#assert_valid_enum_options (private)
  */
 export function assertValidEnumOptions(options: unknown): void {
-  if (!options || typeof options !== "object" || Array.isArray(options)) return;
+  if (!options || !isPlainHash(options)) return;
 
   // Rails: options.keys & %i[_prefix _suffix _scopes _default _instance_methods]
   // Note: _validate is NOT in this list — it is rejected at the enum definition


### PR DESCRIPTION
Implements 4/11 private validation/utility helpers from Rails' ActiveRecord::Enum, achieving 36% parity for Tier 7.

Implements:
- assertValidEnumDefinitionValues: validates enum values (array/hash) before mutations
- assertValidEnumOptions: validates option keys to reject underscore-prefixed variants
- detectNegativeEnumConditionsBang: warns when 'not' prefix conflicts with positive form
- setEnumWarn: hook for hosts to capture/route enum warnings

Removes misleading stubs per CLAUDE.md (empty bodies, return null, complex privates):
- name(), klass(), defineEnumMethods() (Rails module internals)
- _enum(), _enumMethodsModule() (66+ lines of complex logic)
- detectEnumConflictBang() (requires Rails method introspection)
- raiseConflictError() (basic error raising)

Remaining unimplemented (7/11):
- EnumType#name (private getter)
- EnumMethods#klass (private getter)
- EnumMethods#defineEnumMethods (private helper)
- detect_enum_conflict! (complex private)
- raise_conflict_error (complex private)
- _enum (primary enum definition logic)
- _enum_methods_module (module creation)

Advances per docs/private-api-parity-100-plan.md Tier 7.

---

## Review status — requesting human review

PR hit max automated review cycles (7 Copilot rounds, all addressed). Stopping iteration. Remaining concern from the final Copilot pass for human consideration:

**Symbol-keyed return type mismatch** (`assertValidEnumDefinitionValues`)

The function iterates `Reflect.ownKeys` and the tests cover `{ [Symbol('draft')]: 0 }`, but the declared return type is `Record<string, string | number | boolean | null> | (string | symbol)[]`. The hash branch can return an object with symbol keys, yet the type only declares string keys, so downstream code using `Object.keys/entries` would silently drop symbol entries.

Two viable options for the reviewer to choose:

1. **Widen the return type** to `Record<string | symbol, string | number | boolean | null> | (string | symbol)[]` and update callers to use `Reflect.ownKeys` consistently. Truer to runtime behavior; minor downstream churn.

2. **Normalize symbol keys to strings** at validation time (using `Symbol#description` / `Symbol.keyFor`), then return a pure `Record<string, ...>`. Loses Symbol identity but avoids leaking JS-only semantics into downstream Rails-mirroring APIs. Probably more in line with how Ruby Symbol→String coercion plays out in Rails.

Either path is a small follow-up; left for human review since the validators ship correctly today and changing the surface affects integration with the deferred `_enum` / `_enum_methods_module` work.

Other intentional decisions worth confirming on review:
- Stubs deleted (per CLAUDE.md "a missing method is better than a misleading one"). 7/11 deferred — see list above.
- `_validate` deliberately NOT in the rejected-options list (Rails enum.rb:361-365 rejects it at definition level, not as an option key).
- `not` (camelCase) prefix tightened to require uppercase next char so `notebook`/`notify` aren't false-positives — Rails `not_` (snake_case) form is also still detected; both reflect trails' camelCase-only convention.