### PR TITLE
feat(activerecord): callbacks.rb private methods

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -69,6 +69,7 @@ import { Association as AssociationInstance } from "./associations/association.j
 import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
 import * as ConnectionHandling from "./connection-handling.js";
 import * as ModelSchema from "./model-schema.js";
+import { createOrUpdate, _createRecord, _updateRecord } from "./callbacks.js";
 // Lazy-loaded to avoid pulling node:crypto into browser bundles
 let _signedIdModule: typeof import("./signed-id.js") | null = null;
 let _signedIdModulePromise: Promise<typeof import("./signed-id.js")> | null = null;
@@ -3012,6 +3013,11 @@ include(Base, {
 include(Base, {
   attributeNamesForSerialization: Serialization.attributeNamesForSerialization,
 });
+
+// Attach callback private methods
+(Base.prototype as any).createOrUpdate = createOrUpdate;
+(Base.prototype as any)._createRecord = _createRecord;
+(Base.prototype as any)._updateRecord = _updateRecord;
 
 // Register Model's super methods for the Validations module.
 // Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid)

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -69,7 +69,11 @@ import { Association as AssociationInstance } from "./associations/association.j
 import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
 import * as ConnectionHandling from "./connection-handling.js";
 import * as ModelSchema from "./model-schema.js";
-import { createOrUpdate, _createRecord, _updateRecord } from "./callbacks.js";
+import {
+  createOrUpdate as callbacksCreateOrUpdate,
+  _createRecord as callbacksCreateRecord,
+  _updateRecord as callbacksUpdateRecord,
+} from "./callbacks.js";
 // Lazy-loaded to avoid pulling node:crypto into browser bundles
 let _signedIdModule: typeof import("./signed-id.js") | null = null;
 let _signedIdModulePromise: Promise<typeof import("./signed-id.js")> | null = null;
@@ -3015,9 +3019,9 @@ include(Base, {
 });
 
 for (const [name, fn] of [
-  ["createOrUpdate", createOrUpdate],
-  ["_createRecord", _createRecord],
-  ["_updateRecord", _updateRecord],
+  ["createOrUpdate", callbacksCreateOrUpdate],
+  ["_createRecord", callbacksCreateRecord],
+  ["_updateRecord", callbacksUpdateRecord],
 ] as const) {
   Object.defineProperty(Base.prototype, name, {
     value: fn,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3014,10 +3014,18 @@ include(Base, {
   attributeNamesForSerialization: Serialization.attributeNamesForSerialization,
 });
 
-// Attach callback private methods
-(Base.prototype as any).createOrUpdate = createOrUpdate;
-(Base.prototype as any)._createRecord = _createRecord;
-(Base.prototype as any)._updateRecord = _updateRecord;
+for (const [name, fn] of [
+  ["createOrUpdate", createOrUpdate],
+  ["_createRecord", _createRecord],
+  ["_updateRecord", _updateRecord],
+] as const) {
+  Object.defineProperty(Base.prototype, name, {
+    value: fn,
+    configurable: true,
+    writable: true,
+    enumerable: false,
+  });
+}
 
 // Register Model's super methods for the Validations module.
 // Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid)

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -1767,6 +1767,25 @@ describe("CallbacksTest", () => {
     expect(String((item as any).updated_at)).toEqual(String(before));
   });
 
+  // Regression — _updateRecord must not auto-touch updated_at when the record
+  // has no dirty changes (Rails no-op).
+  it("update_record does not touch updated_at when there are no changes", async () => {
+    class Item extends Base {
+      static {
+        this._tableName = "no_change_items";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    const item = await Item.create({ name: "first" });
+    const before = (item as any).updated_at;
+    // Don't mutate name — no changes.
+    await (item as any)._updateRecord();
+    expect(String((item as any).updated_at)).toEqual(String(before));
+  });
+
   // Rails: test "halt callback chain with false"
   it("before save throwing abort", async () => {
     class Immutable extends Base {

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -1722,6 +1722,51 @@ describe("CallbacksTest", () => {
     expect(await Protected.count()).toBe(1);
   });
 
+  // Regression — _updateRecord (the Rails-style wrapper) must keep updated_at
+  // and updated_on in sync when both columns exist. Prior to the _skipTouch
+  // toggle, the inner _performUpdate would re-write updated_at after the
+  // outer wrapper, leaving updated_on pinned to the original timestamp.
+  it("update_record keeps updated_at and updated_on in sync", async () => {
+    class Item extends Base {
+      static {
+        this._tableName = "items";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("updated_at", "datetime");
+        this.attribute("updated_on", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    const item = await Item.create({ name: "first" });
+    item.name = "second";
+    await (item as any)._updateRecord();
+    const updatedAt = (item as any).updated_at;
+    const updatedOn = (item as any).updated_on;
+    expect(updatedAt).toBeDefined();
+    expect(updatedOn).toBeDefined();
+    expect(String(updatedAt)).toEqual(String(updatedOn));
+  });
+
+  // Regression — _updateRecord must respect recordTimestamps=false on both
+  // the outer wrapper and the inner _performUpdate auto-touch.
+  it("update_record respects recordTimestamps=false", async () => {
+    class Item extends Base {
+      static {
+        this._tableName = "no_ts_items";
+        this.attribute("id", "integer");
+        this.attribute("name", "string");
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+        (this as any).recordTimestamps = false;
+      }
+    }
+    const item = await Item.create({ name: "first" });
+    const before = (item as any).updated_at;
+    item.name = "second";
+    await (item as any)._updateRecord();
+    expect(String((item as any).updated_at)).toEqual(String(before));
+  });
+
   // Rails: test "halt callback chain with false"
   it("before save throwing abort", async () => {
     class Immutable extends Base {

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -270,12 +270,15 @@ export function _updateRecord(this: any): Promise<boolean> {
       }
     }
     if (!this._performUpdate) throw new Error("_performUpdate not implemented");
-    // _performUpdate also auto-touches updated_at; skip its inner write when the
-    // outer wrapper just handled timestamps, or when recordTimestamps is disabled
-    // (so timestamp columns truly stay unchanged). Rails: Timestamp#_update_record
-    // writes once via record_update_timestamps; super does not.
+    // _performUpdate also auto-touches updated_at; skip its inner write when:
+    //   - the outer wrapper just handled timestamps, OR
+    //   - recordTimestamps is disabled, OR
+    //   - there are no dirty changes (Rails no-op — don't auto-touch and don't
+    //     desync updated_at vs updated_on by writing inside the inner layer).
+    // Rails: Timestamp#_update_record writes once via record_update_timestamps;
+    // super does not.
     const previousSkipTouch = this._skipTouch;
-    const skipInnerTouch = wroteTimestamps || ctor.recordTimestamps === false;
+    const skipInnerTouch = wroteTimestamps || ctor.recordTimestamps === false || !hasChanges;
     if (skipInnerTouch) this._skipTouch = true;
     try {
       await this._performUpdate();

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -271,10 +271,12 @@ export function _updateRecord(this: any): Promise<boolean> {
     }
     if (!this._performUpdate) throw new Error("_performUpdate not implemented");
     // _performUpdate also auto-touches updated_at; skip its inner write when the
-    // outer wrapper just handled timestamps so updated_at stays in sync with
-    // updated_on (Rails: Timestamp#_update_record writes once; super does not).
+    // outer wrapper just handled timestamps, or when recordTimestamps is disabled
+    // (so timestamp columns truly stay unchanged). Rails: Timestamp#_update_record
+    // writes once via record_update_timestamps; super does not.
     const previousSkipTouch = this._skipTouch;
-    if (wroteTimestamps) this._skipTouch = true;
+    const skipInnerTouch = wroteTimestamps || ctor.recordTimestamps === false;
+    if (skipInnerTouch) this._skipTouch = true;
     try {
       await this._performUpdate();
     } finally {

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -259,7 +259,8 @@ export function _updateRecord(this: any): Promise<boolean> {
     // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)
     // and the shared currentTimeFromProperTimezone() helper (Temporal.Instant).
     const hasChanges = Object.keys(this.changes ?? {}).length > 0;
-    if (!this._skipTouch && ctor.recordTimestamps !== false && hasChanges) {
+    const wroteTimestamps = !this._skipTouch && ctor.recordTimestamps !== false && hasChanges;
+    if (wroteTimestamps) {
       const time = currentTimeFromProperTimezone();
       const updateAttrs = timestampAttributesForUpdateInModel.call(ctor);
       for (const col of updateAttrs) {
@@ -269,7 +270,16 @@ export function _updateRecord(this: any): Promise<boolean> {
       }
     }
     if (!this._performUpdate) throw new Error("_performUpdate not implemented");
-    await this._performUpdate();
+    // _performUpdate also auto-touches updated_at; skip its inner write when the
+    // outer wrapper just handled timestamps so updated_at stays in sync with
+    // updated_on (Rails: Timestamp#_update_record writes once; super does not).
+    const previousSkipTouch = this._skipTouch;
+    if (wroteTimestamps) this._skipTouch = true;
+    try {
+      await this._performUpdate();
+    } finally {
+      this._skipTouch = previousSkipTouch;
+    }
     if (this._pendingOperation) {
       await this._pendingOperation;
       this._pendingOperation = null;

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -227,12 +227,12 @@ function registerCallback(
 // persistence work directly in their respective callback chains.
 // ---------------------------------------------------------------------------
 
-function createOrUpdate(this: any): Promise<boolean> {
+export function createOrUpdate(this: any): Promise<boolean> {
   // Rails: _run_save_callbacks { super }
   return (this._createOrUpdate as () => Promise<boolean>).call(this);
 }
 
-function _createRecord(this: any): Promise<boolean> {
+export function _createRecord(this: any): Promise<boolean> {
   // Rails: _run_create_callbacks { super } — returns whether callbacks completed.
   const ctor = this.constructor as any;
   return ctor._callbackChain.runCallbacks("create", this, async () => {
@@ -248,7 +248,7 @@ function _createRecord(this: any): Promise<boolean> {
   });
 }
 
-function _updateRecord(this: any): Promise<boolean> {
+export function _updateRecord(this: any): Promise<boolean> {
   // Rails: _run_update_callbacks { record_update_timestamps { super } } — returns boolean.
   // record_update_timestamps writes updated_at/updated_on when @_touch_record
   // and should_record_timestamps? are true, then yields to the actual update.

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -228,7 +228,10 @@ function registerCallback(
 // ---------------------------------------------------------------------------
 
 export function createOrUpdate(this: any): Promise<boolean> {
-  // Rails: _run_save_callbacks { super }
+  // Rails: Callbacks#create_or_update wraps super in _run_save_callbacks.
+  // In trails, save's before/after callback chain runs inside _createOrUpdate
+  // (base.ts: runBefore("save") → dispatch create/update → runAfter("save")),
+  // so this wrapper just delegates and the callback ordering still matches.
   return (this._createOrUpdate as () => Promise<boolean>).call(this);
 }
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -565,7 +565,7 @@ export async function save<T extends SaveRecord>(
 
   // Mirrors: ActiveRecord::Transactions#save
   try {
-    return await withTransactionReturningStatus(self, () => self._createOrUpdate());
+    return await withTransactionReturningStatus(self, () => self.createOrUpdate());
   } finally {
     self._skipTouch = false;
   }


### PR DESCRIPTION
## Summary

Close the private-API gap for Rails' `activerecord/lib/active_record/callbacks.rb`.
Export and wire three private methods (`createOrUpdate`, `_createRecord`, `_updateRecord`)
from callbacks.ts to Base.prototype.

Resolves 0/3 private methods → 3/3 (100%) for callbacks.rb.

See docs/private-api-parity-100-plan.md Tier 1 stragglers section.