### PR TITLE
feat(actioncontroller): extract envForRequest helper

### DIFF
--- a/packages/actionpack/src/actioncontroller/renderer.test.ts
+++ b/packages/actionpack/src/actioncontroller/renderer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { Renderer } from "./renderer.js";
+
+describe("Renderer", () => {
+  describe("envForRequest (via .env getter)", () => {
+    it("returns a copy of @env when HTTP_HOST is set, even with routes", () => {
+      const controller = { _routes: { defaultEnv: { HTTP_HOST: "default.example.com" } } };
+      const renderer = new Renderer(controller, { http_host: "explicit.example.com" });
+
+      const env = renderer.env;
+
+      expect(env.HTTP_HOST).toBe("explicit.example.com");
+    });
+
+    it("returns a copy of @env when controller has no routes", () => {
+      const renderer = new Renderer({}, { method: "post" });
+
+      const env = renderer.env;
+
+      expect(env.REQUEST_METHOD).toBe("POST");
+    });
+
+    it("merges routes.defaultEnv beneath @env when no HTTP_HOST in @env", () => {
+      const controller = {
+        _routes: { defaultEnv: { HTTP_HOST: "default.example.com", SCRIPT_NAME: "/app" } },
+      };
+      const renderer = new Renderer(controller, { method: "get" });
+
+      const env = renderer.env;
+
+      expect(env).toEqual({
+        HTTP_HOST: "default.example.com",
+        SCRIPT_NAME: "/app",
+        REQUEST_METHOD: "GET",
+      });
+    });
+
+    it("@env entries override routes.defaultEnv on the same key", () => {
+      const controller = {
+        _routes: { defaultEnv: { SCRIPT_NAME: "/old", HTTP_HOST: "default.example.com" } },
+      };
+      const renderer = new Renderer(controller, { script_name: "/new" });
+
+      const env = renderer.env;
+
+      expect(env.SCRIPT_NAME).toBe("/new");
+      expect(env.HTTP_HOST).toBe("default.example.com");
+    });
+  });
+
+  describe("normalizeEnv", () => {
+    it("translates :https to HTTPS on/off", () => {
+      expect(Renderer.normalizeEnv({ https: true }).HTTPS).toBe("on");
+      expect(Renderer.normalizeEnv({ https: false }).HTTPS).toBe("off");
+    });
+
+    it("uppercases :method into REQUEST_METHOD", () => {
+      expect(Renderer.normalizeEnv({ method: "get" }).REQUEST_METHOD).toBe("GET");
+      expect(Renderer.normalizeEnv({ method: "post" }).REQUEST_METHOD).toBe("POST");
+    });
+
+    it("translates known rack keys", () => {
+      const env = Renderer.normalizeEnv({
+        http_host: "example.com",
+        script_name: "/app",
+        input: "stdin",
+      });
+      expect(env.HTTP_HOST).toBe("example.com");
+      expect(env.SCRIPT_NAME).toBe("/app");
+      expect(env["rack.input"]).toBe("stdin");
+    });
+
+    it("defaults HTTPS to off and SCRIPT_NAME to '' when HTTP_HOST is set", () => {
+      const env = Renderer.normalizeEnv({ http_host: "example.com" });
+      expect(env.HTTPS).toBe("off");
+      expect(env.SCRIPT_NAME).toBe("");
+    });
+
+    it("derives rack.url_scheme from HTTPS", () => {
+      expect(
+        Renderer.normalizeEnv({ http_host: "example.com", https: true })["rack.url_scheme"],
+      ).toBe("https");
+      expect(
+        Renderer.normalizeEnv({ http_host: "example.com", https: false })["rack.url_scheme"],
+      ).toBe("http");
+    });
+  });
+});

--- a/packages/actionpack/src/actioncontroller/renderer.ts
+++ b/packages/actionpack/src/actioncontroller/renderer.ts
@@ -9,24 +9,39 @@
 
 import { Metal } from "./metal.js";
 
+interface RoutesLike {
+  defaultEnv?: Record<string, unknown>;
+}
+
 export class Renderer {
   private _controller: unknown;
   private _defaults: Record<string, unknown>;
+  private _env: Record<string, unknown>;
   private _lastStatus: number = 200;
   private _lastContentType: string = "text/html; charset=utf-8";
 
-  constructor(controller: unknown, defaults: Record<string, unknown> = {}) {
+  constructor(
+    controller: unknown,
+    env: Record<string, unknown> | null | undefined,
+    defaults: Record<string, unknown> = {},
+  ) {
     this._controller = controller;
     this._defaults = defaults;
+    this._env = Renderer.normalizeEnv(defaults);
+    if (env) Object.assign(this._env, Renderer.normalizeEnv(env));
   }
 
-  static for(controller: unknown, defaults: Record<string, unknown> = {}): Renderer {
-    return new Renderer(controller, defaults);
+  static for(
+    controller: unknown,
+    env: Record<string, unknown> | null = null,
+    defaults: Record<string, unknown> = {},
+  ): Renderer {
+    return new Renderer(controller, env, defaults);
   }
 
-  /** Derive a new Renderer with updated env (Rails: Renderer#new). */
-  new(env: Record<string, unknown> = {}): Renderer {
-    return new Renderer(this._controller, { ...this._defaults, ...env });
+  /** Derive a new Renderer with the given Rack env (Rails: Renderer#new). */
+  new(env: Record<string, unknown> | null = null): Renderer {
+    return new Renderer(this._controller, env, this._defaults);
   }
 
   render(options: Record<string, unknown> = {}): string {
@@ -73,12 +88,32 @@ export class Renderer {
     return this._controller;
   }
 
+  /** The normalized Rack env that would be passed to a request. */
+  get env(): Record<string, unknown> {
+    return this.envForRequest();
+  }
+
   withDefaults(defaults: Record<string, unknown>): Renderer {
-    return new Renderer(this._controller, { ...this._defaults, ...defaults });
+    return new Renderer(this._controller, this._env, { ...this._defaults, ...defaults });
   }
 
   renderToString(options: Record<string, unknown> = {}): string {
     return this.render(options);
+  }
+
+  /**
+   * Build the Rack env for a request. Mirrors Rails:
+   *   env_for_request: if @env has HTTP_HOST or controller has no routes,
+   *   return a copy of @env; otherwise merge @env on top of the routes'
+   *   default_env so explicit overrides win.
+   */
+  private envForRequest(): Record<string, unknown> {
+    const routes = (this._controller as { _routes?: RoutesLike | null } | null | undefined)
+      ?._routes;
+    if ("HTTP_HOST" in this._env || !routes) {
+      return { ...this._env };
+    }
+    return { ...(routes.defaultEnv ?? {}), ...this._env };
   }
 
   private static RACK_KEY_TRANSLATION: Record<string, string> = {


### PR DESCRIPTION
## Summary

Extract the private `envForRequest` method on `Renderer`, mirroring Rails `Renderer#env_for_request` exactly:

- Returns a copy of the normalized `@env` when `HTTP_HOST` is already set or no routes are present.
- Otherwise merges the routes' `default_env` beneath `@env` so explicit overrides win.

Also aligns surrounding state with Rails so the extracted method has well-defined inputs:

- Constructor signature changes from `(controller, defaults?)` to **`(controller, env, defaults?)`** — same shape as Rails' `Renderer#initialize`. No other callers in the repo (only `Renderer.for(controller)` from `metal/rendering.ts`, which still works with defaulted `env`/`defaults`).
- `Renderer#new(env)` now constructs `(controller, env, @defaults)` — matches Rails' "create a new renderer using the same controller, but with a new Rack env" by retaining defaults rather than merging the env into them.
- New public `env` getter delegates to `envForRequest`, used by tests so they can exercise the three Rails branches without reaching into privates.

## API parity

- `renderer.rb` now reports **9/9 (100%)** under `pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --privates`.

## Test plan

- [x] 9 tests in `renderer.test.ts` cover the three Rails branches of `env_for_request` (`HTTP_HOST` set, no routes, route-defaults merge with override) and all of `normalizeEnv`.
- [x] `pnpm build` clean from a wiped `dist/` + `*.tsbuildinfo`.
- [x] No production-side `as any` casts; the one cast inside `envForRequest` narrows `unknown` to `{ _routes?: RoutesLike | null }`.

## Plan reference

Implements PR **P8** of `docs/actioncontroller-privates-plan.md`.