### PR TITLE
fix(scripts): use tsc --build in typecheck hook

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -17,4 +17,13 @@ const tscPath = path.join(
 // (<1s warm via .tsbuildinfo), matching what CI's `pnpm build` does
 // before its typecheck step.
 const result = spawnSync(tscPath, ["--build"], { stdio: "inherit" });
+
+if (result.error) {
+  console.error("✗ Failed to start TypeScript compiler.");
+  console.error(`  tsc: ${tscPath}`);
+  console.error(`  cwd: ${process.cwd()}`);
+  console.error(`  ${result.error.name}: ${result.error.message}`);
+  process.exit(1);
+}
+
 process.exit(result.status ?? 1);

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -1,25 +1,20 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 
-const repoRoot = process.cwd();
 const tscPath = path.join(
-  repoRoot,
+  process.cwd(),
   "node_modules",
   ".bin",
   process.platform === "win32" ? "tsc.cmd" : "tsc",
 );
 
-const projects = [
-  "packages/activesupport/tsconfig.json",
-  "packages/arel/tsconfig.json",
-  "packages/activemodel/tsconfig.json",
-  "packages/activerecord/tsconfig.json",
-  "packages/rack/tsconfig.json",
-  "packages/actionpack/tsconfig.json",
-  "packages/trailties/tsconfig.json",
-];
-
-for (const project of projects) {
-  const result = spawnSync(tscPath, ["-p", project, "--noEmit"], { stdio: "inherit" });
-  if (result.status !== 0) process.exit(result.status ?? 1);
-}
+// `tsc --build` is project-references-aware (each tsconfig.json under
+// `packages/*` uses `composite: true` with `references` to upstream
+// packages). Per-project `tsc -p ... --noEmit` cannot resolve those
+// references, so it fails on a fresh clone where `dist/` is empty —
+// the very state every pre-commit hook starts in. `--build` populates
+// dist/ on the first run (~60s cold) and is incremental thereafter
+// (<1s warm via .tsbuildinfo), matching what CI's `pnpm build` does
+// before its typecheck step.
+const result = spawnSync(tscPath, ["--build"], { stdio: "inherit" });
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

The pre-commit hook (`scripts/typecheck.mjs`) currently runs `tsc -p <pkg>/tsconfig.json --noEmit` for each package. But every `packages/*/tsconfig.json` uses `composite: true` with `references` to upstream workspace packages — and `tsc -p` does not traverse references. Even after `pnpm build` populates `dist/`, the per-package `--noEmit` invocation cannot resolve `@blazetrails/*` imports through the upstream `package.json#types`, so it errors with `TS2307: Cannot find module '@blazetrails/...'` for every reference.

I verified this empirically against a clean `origin/main` checkout: with all `dist/` directories and `.tsbuildinfo` files removed, `pnpm build` succeeds, but the existing `pnpm typecheck` immediately reports 60+ "Cannot find module" errors. CI papers over the inconsistency by running `pnpm build` and `pnpm typecheck` as separate steps where the second is effectively redundant — but locally, the hook just fails on every fresh worktree, which is exactly the state every recent agent-driven PR (#952, #953, plus several Wave 0 attempts in `docs/actioncontroller-privates-plan.md`) hit. They had to either `--no-verify` or got stuck.

## Fix

Replace the per-package loop with a single `tsc --build`. That command is project-references-aware. Cost profile:

- **Cold (no `dist/`, no `.tsbuildinfo`)**: ~60s, populates `dist/` once.
- **Warm (incremental via `.tsbuildinfo`)**: <1s.

Both `dist/` and `*.tsbuildinfo` are already gitignored, so the hook's emit side effect cannot leak into commits. The hook now matches what CI's `pnpm build` step does, making the local and CI stories consistent.

## Verification

- Cold run on a clean `origin/main` checkout (commit `03da5d1d`) with no `dist/` or `.tsbuildinfo`: ✅ exits 0.
- Warm second run: ✅ <1s, exits 0.
- Confirmed the OLD script fails *even after* `pnpm build` succeeds, isolating the fix as a genuine correction rather than just hiding the symptom.

## Test plan

- [ ] Run `pnpm typecheck` after a fresh `pnpm install` (no prior `pnpm build`) and confirm it succeeds.
- [ ] Confirm the husky pre-commit hook is no longer flaky on fresh worktrees.
- [ ] Confirm `git status` is clean after the hook runs (no untracked emit artifacts leaking).