### PR TITLE
feat(activerecord): add overloads to leftJoins/leftOuterJoins for compile-time safety

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -8,6 +8,7 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
 import type { Relation } from "./relation.js";
+import { argumentError } from "./relation/query-methods.js";
 import type { AssociationSpec } from "./relation/query-methods.js";
 import { sanitizeSql } from "./sanitization.js";
 
@@ -234,7 +235,7 @@ export function leftJoins<T extends typeof Base>(
   const rel = this.all();
   if (on !== undefined) {
     if (typeof table !== "string")
-      throw new Error("leftJoins(table, on) requires a string table name");
+      throw argumentError("leftJoins(table, on) requires a string table name");
     return rel.leftJoins(table, on);
   }
   return rel.leftJoins(table);
@@ -260,7 +261,7 @@ export function leftOuterJoins<T extends typeof Base>(
   if (table === undefined) return rel.leftOuterJoins();
   if (on !== undefined) {
     if (typeof table !== "string")
-      throw new Error("leftJoins(table, on) requires a string table name");
+      throw argumentError("leftOuterJoins(table, on) requires a string table name");
     return rel.leftOuterJoins(table, on);
   }
   return rel.leftOuterJoins(table);

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -219,19 +219,39 @@ export function optimizerHints<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#left_joins */
 export function leftJoins<T extends typeof Base>(
   this: T,
+  table: string,
+  on: string,
+): Relation<InstanceType<T>>;
+export function leftJoins<T extends typeof Base>(
+  this: T,
+  table: AssociationSpec | AssociationSpec[],
+): Relation<InstanceType<T>>;
+export function leftJoins<T extends typeof Base>(
+  this: T,
   table: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
-  return this.all().leftJoins(table, on);
+  if (on && typeof table === "string") return this.all().leftJoins(table, on);
+  return this.all().leftJoins(table as AssociationSpec | AssociationSpec[]);
 }
 
 /** Mirrors: ActiveRecord::Querying#left_outer_joins */
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
+  table: string,
+  on: string,
+): Relation<InstanceType<T>>;
+export function leftOuterJoins<T extends typeof Base>(
+  this: T,
+  table?: AssociationSpec | AssociationSpec[],
+): Relation<InstanceType<T>>;
+export function leftOuterJoins<T extends typeof Base>(
+  this: T,
   table?: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
-  return this.all().leftOuterJoins(table, on);
+  if (on && typeof table === "string") return this.all().leftOuterJoins(table, on);
+  return this.all().leftOuterJoins(table);
 }
 
 /** Mirrors: ActiveRecord::Querying#none */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -231,8 +231,15 @@ export function leftJoins<T extends typeof Base>(
   table: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
-  if (on && typeof table === "string") return this.all().leftJoins(table, on);
-  return this.all().leftJoins(table as AssociationSpec | AssociationSpec[]);
+  const rel = this.all();
+  if (on !== undefined) {
+    // Delegate via cast so Relation.leftJoins' runtime validation fires for non-string table.
+    return (rel.leftJoins as (t: string, o: string) => Relation<InstanceType<T>>)(
+      table as string,
+      on,
+    );
+  }
+  return rel.leftJoins(table as AssociationSpec | AssociationSpec[]);
 }
 
 /** Mirrors: ActiveRecord::Querying#left_outer_joins */
@@ -250,8 +257,14 @@ export function leftOuterJoins<T extends typeof Base>(
   table?: AssociationSpec | AssociationSpec[],
   on?: string,
 ): Relation<InstanceType<T>> {
-  if (on && typeof table === "string") return this.all().leftOuterJoins(table, on);
-  return this.all().leftOuterJoins(table);
+  const rel = this.all();
+  if (on !== undefined) {
+    return (rel.leftOuterJoins as (t: string, o: string) => Relation<InstanceType<T>>)(
+      table as string,
+      on,
+    );
+  }
+  return rel.leftOuterJoins(table);
 }
 
 /** Mirrors: ActiveRecord::Querying#none */

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -233,16 +233,15 @@ export function leftJoins<T extends typeof Base>(
 ): Relation<InstanceType<T>> {
   const rel = this.all();
   if (on !== undefined) {
-    // Delegate via cast so Relation.leftJoins' runtime validation fires for non-string table.
-    return (rel.leftJoins as (t: string, o: string) => Relation<InstanceType<T>>)(
-      table as string,
-      on,
-    );
+    if (typeof table !== "string")
+      throw new Error("leftJoins(table, on) requires a string table name");
+    return rel.leftJoins(table, on);
   }
-  return rel.leftJoins(table as AssociationSpec | AssociationSpec[]);
+  return rel.leftJoins(table);
 }
 
 /** Mirrors: ActiveRecord::Querying#left_outer_joins */
+export function leftOuterJoins<T extends typeof Base>(this: T): Relation<InstanceType<T>>;
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
   table: string,
@@ -250,7 +249,7 @@ export function leftOuterJoins<T extends typeof Base>(
 ): Relation<InstanceType<T>>;
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
-  table?: AssociationSpec | AssociationSpec[],
+  table: AssociationSpec | AssociationSpec[],
 ): Relation<InstanceType<T>>;
 export function leftOuterJoins<T extends typeof Base>(
   this: T,
@@ -258,13 +257,12 @@ export function leftOuterJoins<T extends typeof Base>(
   on?: string,
 ): Relation<InstanceType<T>> {
   const rel = this.all();
-  if (on !== undefined) {
-    return (rel.leftOuterJoins as (t: string, o: string) => Relation<InstanceType<T>>)(
-      table as string,
-      on,
-    );
-  }
   if (table === undefined) return rel.leftOuterJoins();
+  if (on !== undefined) {
+    if (typeof table !== "string")
+      throw new Error("leftJoins(table, on) requires a string table name");
+    return rel.leftOuterJoins(table, on);
+  }
   return rel.leftOuterJoins(table);
 }
 

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -264,6 +264,7 @@ export function leftOuterJoins<T extends typeof Base>(
       on,
     );
   }
+  if (table === undefined) return rel.leftOuterJoins();
   return rel.leftOuterJoins(table);
 }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1264,7 +1264,7 @@ export class Relation<T extends Base> {
   leftJoins(table: AssociationSpec | AssociationSpec[]): Relation<T>;
   leftJoins(table: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     const rel = this._clone();
-    if (on) {
+    if (on !== undefined) {
       // Explicit SQL form: LEFT OUTER JOIN table ON condition — only valid for strings.
       if (typeof table !== "string")
         throw argumentError("leftJoins(table, on) requires a string table name");
@@ -1287,8 +1287,9 @@ export class Relation<T extends Base> {
    */
   leftOuterJoins(table?: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     if (!table) return this._clone();
-    // Route to the correct overload explicitly to satisfy TS overload resolution.
-    if (on && typeof table === "string") return this.leftJoins(table, on);
+    // Delegate to leftJoins so its runtime validation (non-string + on → argumentError) fires.
+    if (on !== undefined)
+      return (this.leftJoins as (t: string, o: string) => Relation<T>)(table as string, on);
     return this.leftJoins(table as AssociationSpec | AssociationSpec[]);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1268,7 +1268,8 @@ export class Relation<T extends Base> {
       // Explicit SQL form: LEFT OUTER JOIN table ON condition — only valid for strings.
       if (typeof table !== "string")
         throw argumentError("leftJoins(table, on) requires a string table name");
-      if (!on.trim()) throw argumentError("leftJoins(table, on) requires a non-empty ON condition");
+      if (typeof on !== "string" || !on.trim())
+        throw argumentError("leftJoins(table, on) requires a non-empty string ON condition");
       rel._joinClauses.push({ type: "left", table, on });
     } else {
       // Association name/spec form — mirrors Rails left_outer_joins! storing in

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1260,6 +1260,8 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#left_joins
    */
+  leftJoins(table: string, on: string): Relation<T>;
+  leftJoins(table: AssociationSpec | AssociationSpec[]): Relation<T>;
   leftJoins(table: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     const rel = this._clone();
     if (on) {
@@ -1285,7 +1287,9 @@ export class Relation<T extends Base> {
    */
   leftOuterJoins(table?: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     if (!table) return this._clone();
-    return this.leftJoins(table, on);
+    // Route to the correct overload explicitly to satisfy TS overload resolution.
+    if (on && typeof table === "string") return this.leftJoins(table, on);
+    return this.leftJoins(table as AssociationSpec | AssociationSpec[]);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1290,10 +1290,12 @@ export class Relation<T extends Base> {
   leftOuterJoins(table: AssociationSpec | AssociationSpec[]): Relation<T>;
   leftOuterJoins(table?: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
     if (table === undefined) return this._clone();
-    // Delegate to leftJoins so its runtime validation (non-string + on → argumentError) fires.
-    if (on !== undefined)
-      return (this.leftJoins as (t: string, o: string) => Relation<T>)(table as string, on);
-    return this.leftJoins(table as AssociationSpec | AssociationSpec[]);
+    if (on !== undefined) {
+      if (typeof table !== "string")
+        throw argumentError("leftJoins(table, on) requires a string table name");
+      return this.leftJoins(table, on);
+    }
+    return this.leftJoins(table);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1268,6 +1268,7 @@ export class Relation<T extends Base> {
       // Explicit SQL form: LEFT OUTER JOIN table ON condition — only valid for strings.
       if (typeof table !== "string")
         throw argumentError("leftJoins(table, on) requires a string table name");
+      if (!on.trim()) throw argumentError("leftJoins(table, on) requires a non-empty ON condition");
       rel._joinClauses.push({ type: "left", table, on });
     } else {
       // Association name/spec form — mirrors Rails left_outer_joins! storing in
@@ -1292,7 +1293,7 @@ export class Relation<T extends Base> {
     if (table === undefined) return this._clone();
     if (on !== undefined) {
       if (typeof table !== "string")
-        throw argumentError("leftJoins(table, on) requires a string table name");
+        throw argumentError("leftOuterJoins(table, on) requires a string table name");
       return this.leftJoins(table, on);
     }
     return this.leftJoins(table);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1285,8 +1285,11 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#left_outer_joins
    */
+  leftOuterJoins(): Relation<T>;
+  leftOuterJoins(table: string, on: string): Relation<T>;
+  leftOuterJoins(table: AssociationSpec | AssociationSpec[]): Relation<T>;
   leftOuterJoins(table?: AssociationSpec | AssociationSpec[], on?: string): Relation<T> {
-    if (!table) return this._clone();
+    if (table === undefined) return this._clone();
     // Delegate to leftJoins so its runtime validation (non-string + on → argumentError) fires.
     if (on !== undefined)
       return (this.leftJoins as (t: string, o: string) => Relation<T>)(table as string, on);


### PR DESCRIPTION
Deferred from #937. Adds TypeScript overloads so the two forms of \`leftJoins\` are statically distinct:

\`\`\`ts
leftJoins(table: string, on: string)              // explicit SQL form
leftJoins(table: AssociationSpec | AssociationSpec[])  // association spec form
\`\`\`

\`leftJoins({ posts: "comments" }, "some_on")\` is now a compile-time error.

**Key**: internal calls route explicitly via \`on !== undefined\` branching rather than forwarding \`(table, on?)\` generically — which is what caused overload resolution failures in the earlier attempt. Same overloads added to \`querying.ts\` wrappers.

---

## Remaining open Copilot concerns (hit 7-cycle limit — needs human review)

**Review #7 generated no new comments** — all prior rounds are resolved. Issues addressed across 7 cycles:

- `argumentError` instead of `new Error` throughout (relation.ts + querying.ts)
- Error messages corrected: `leftOuterJoins(table, on)` not `leftJoins(table, on)` where applicable
- `on !== undefined` instead of `if (on)` to handle empty-string edge case
- `typeof on !== "string"` guard added before `on.trim()` to produce `ArgumentError` (not `TypeError`) for JS/any consumers
- `@ts-expect-error` DX type tests added in `dx-tests/query-chaining.test-d.ts` covering both `querying.ts` static wrappers and `Relation` instance methods

**Ready for human merge.**