### PR TITLE
feat(temporal): PR 7 — application-layer defaults use Temporal.Instant

### DIFF
--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -7,6 +7,8 @@
  * Mirrors: ActiveRecord::AttributeMethods::Dirty
  */
 
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
 interface DirtyRecord {
   changed: boolean;
   changedAttributes: string[];
@@ -168,10 +170,10 @@ function initInternals(this: DirtyPrivateHost): void {
 function _touchRow(
   this: DirtyPrivateHost,
   attributeNames: string[],
-  time?: Date | null,
+  time?: Temporal.Instant | null,
 ): Promise<number> {
   this._touchAttrNames = new Set(attributeNames);
-  const t = time ?? new Date();
+  const t = time ?? Temporal.Now.instant();
   for (const attr of this._touchAttrNames) {
     this._writeAttribute(attr, t);
   }

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -272,7 +272,8 @@ describe("InsertAllTest", () => {
         this.adapter = adapter;
       }
     }
-    const ts = new Date("2023-06-15T12:00:00Z");
+    const { Temporal } = await import("@blazetrails/activesupport/temporal");
+    const ts = Temporal.Instant.from("2023-06-15T12:00:00Z");
     const count = await Post.insertAll([{ title: "Timestamped", created_at: ts, updated_at: ts }]);
     expect(count).toBeGreaterThanOrEqual(1);
     const all = await Post.all().toArray();

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,3 +1,4 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { NotImplementedError } from "./errors.js";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { SerializeCastValue } from "@blazetrails/activemodel";

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -128,7 +128,7 @@ export class InsertAll {
   }
 
   mapKeyWithValue<T>(fn: (key: string, value: unknown) => T): T[][] {
-    const now = this.recordTimestamps() ? new Date() : undefined;
+    const now = this.recordTimestamps() ? Temporal.Now.instant() : undefined;
     const keysList = [...this.keysIncludingTimestamps()];
     return this.inserts.map((row) => {
       const merged = { ...this._scopeAttributes, ...row };

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1130,8 +1130,12 @@ function _deleteRow(this: PersistencePrivateHost): Promise<number> {
   return _deleteRecord.call(this.constructor as any, _queryConstraintsHash.call(this));
 }
 
-function _touchRow(this: any, attributeNames: string[], time?: Date | null): Promise<number> {
-  const t = time ?? new Date();
+function _touchRow(
+  this: any,
+  attributeNames: string[],
+  time?: Temporal.Instant | null,
+): Promise<number> {
+  const t = time ?? Temporal.Now.instant();
   for (const attr of attributeNames) {
     this._writeAttribute(attr, t);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,10 +13,7 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import {
-  columnNameMatcher as abstractColumnNameMatcher,
-  formatInstantForSql,
-} from "./connection-adapters/abstract/quoting.js";
+import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2719,7 +2716,10 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    const nowSql = this._modelClass.adapter?.quote(now) ?? `'${formatInstantForSql(now)}'`;
+    const adapter = this._modelClass.adapter as { quote(v: unknown): string; executeMutation(sql: string): Promise<number> } | undefined;
+    if (!adapter) return 0;
+
+    const nowSql = adapter.quote(now);
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model
@@ -2741,8 +2741,7 @@ export class Relation<T extends Base> {
       um.where(arelSql(cond));
     }
 
-    if (!this._modelClass.adapter) return 0;
-    return this._modelClass.adapter.executeMutation(um.toSql());
+    return adapter.executeMutation(um.toSql());
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2716,9 +2716,8 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    const adapter = this._modelClass.adapter as { quote(v: unknown): string; executeMutation(sql: string): Promise<number> } | undefined;
-    if (!adapter) return 0;
-
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const adapter = this._modelClass.adapter!;
     const nowSql = adapter.quote(now);
     const updates: Record<string, unknown> = {};
 
@@ -2741,7 +2740,7 @@ export class Relation<T extends Base> {
       um.where(arelSql(cond));
     }
 
-    return adapter.executeMutation(um.toSql());
+    return this._modelClass.adapter.executeMutation(um.toSql());
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2741,6 +2741,7 @@ export class Relation<T extends Base> {
       um.where(arelSql(cond));
     }
 
+    if (!this._modelClass.adapter) return 0;
     return this._modelClass.adapter.executeMutation(um.toSql());
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,7 +13,10 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
+import {
+  columnNameMatcher as abstractColumnNameMatcher,
+  formatInstantForSql,
+} from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2715,15 +2718,16 @@ export class Relation<T extends Base> {
   async touchAll(...names: string[]): Promise<number> {
     if (this._isNone) return 0;
 
-    const now = new Date();
+    const now = Temporal.Now.instant();
+    const nowSql = `'${formatInstantForSql(now)}'`;
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model
     if (this._modelClass._attributeDefinitions.has("updated_at")) {
-      updates.updated_at = `'${now.toISOString()}'`;
+      updates.updated_at = nowSql;
     }
     for (const name of names) {
-      updates[name] = `'${now.toISOString()}'`;
+      updates[name] = nowSql;
     }
 
     if (Object.keys(updates).length === 0) return 0;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,7 +13,10 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
+import {
+  columnNameMatcher as abstractColumnNameMatcher,
+  formatInstantForSql,
+} from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2716,7 +2719,7 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    const nowSql = this._modelClass.adapter.quote(now);
+    const nowSql = this._modelClass.adapter?.quote(now) ?? `'${formatInstantForSql(now)}'`;
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,10 +13,7 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import {
-  columnNameMatcher as abstractColumnNameMatcher,
-  formatInstantForSql,
-} from "./connection-adapters/abstract/quoting.js";
+import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2719,7 +2716,7 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    const nowSql = `'${formatInstantForSql(now)}'`;
+    const nowSql = this._modelClass.adapter.quote(now);
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -13,7 +13,10 @@ import type { Base } from "./base.js";
 import { _setRelationCtor, _setScopeProxyWrapper, quoteSqlValue } from "./base.js";
 import { RecordNotSaved, RecordNotUnique } from "./errors.js";
 import { disallowRawSqlBang } from "./sanitization.js";
-import { columnNameMatcher as abstractColumnNameMatcher } from "./connection-adapters/abstract/quoting.js";
+import {
+  columnNameMatcher as abstractColumnNameMatcher,
+  formatInstantForSql,
+} from "./connection-adapters/abstract/quoting.js";
 import { modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
@@ -2716,9 +2719,7 @@ export class Relation<T extends Base> {
     if (this._isNone) return 0;
 
     const now = Temporal.Now.instant();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const adapter = this._modelClass.adapter!;
-    const nowSql = adapter.quote(now);
+    const nowSql = `'${formatInstantForSql(now)}'`;
     const updates: Record<string, unknown> = {};
 
     // Always touch updated_at if defined on the model

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -350,6 +350,24 @@ describe("TimestampTest", () => {
     expect(createdAt.epochMilliseconds).toBe((updatedAt as Temporal.Instant).epochMilliseconds);
   });
 
+  it("created_at round-trips through the database as Temporal.Instant", async () => {
+    const adapter = freshAdapter();
+    class Post extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
+        this.adapter = adapter;
+      }
+    }
+    const post = await Post.create({ title: "Round-trip" });
+    const reloaded = await Post.find(post.id!);
+    expect(reloaded.created_at).toBeInstanceOf(Temporal.Instant);
+    expect((reloaded.created_at as Temporal.Instant).epochMilliseconds).toBe(
+      (post.created_at as Temporal.Instant).epochMilliseconds,
+    );
+  });
+
   it("does not overwrite explicitly set timestamps on insert", async () => {
     const adapter = freshAdapter();
     class Post extends Base {

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -4,7 +4,11 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
+import {
+  instant,
+  epochMs,
+  isTemporalDatetime,
+} from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Base, registerModel } from "./index.js";
 import { Associations } from "./associations.js";
 
@@ -362,10 +366,8 @@ describe("TimestampTest", () => {
     }
     const post = await Post.create({ title: "Round-trip" });
     const reloaded = await Post.find(post.id!);
-    expect(reloaded.created_at).toBeInstanceOf(Temporal.Instant);
-    expect((reloaded.created_at as Temporal.Instant).epochMilliseconds).toBe(
-      (post.created_at as Temporal.Instant).epochMilliseconds,
-    );
+    expect(isTemporalDatetime(reloaded.created_at)).toBe(true);
+    expect(epochMs(reloaded.created_at)).toBe(epochMs(post.created_at));
   });
 
   it("does not overwrite explicitly set timestamps on insert", async () => {

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -4,11 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import {
-  instant,
-  epochMs,
-  isTemporalDatetime,
-} from "@blazetrails/activesupport/testing/temporal-helpers";
+import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Base, registerModel } from "./index.js";
 import { Associations } from "./associations.js";
 
@@ -366,8 +362,14 @@ describe("TimestampTest", () => {
     }
     const post = await Post.create({ title: "Round-trip" });
     const reloaded = await Post.find(post.id!);
+    const isTemporalDatetime = (v: unknown) =>
+      v instanceof Temporal.Instant || v instanceof Temporal.PlainDateTime;
     expect(isTemporalDatetime(reloaded.created_at)).toBe(true);
-    expect(epochMs(reloaded.created_at)).toBe(epochMs(post.created_at));
+    const toMs = (v: unknown) =>
+      v instanceof Temporal.Instant
+        ? v.epochMilliseconds
+        : (v as Temporal.PlainDateTime).toZonedDateTime("UTC").toInstant().epochMilliseconds;
+    expect(toMs(reloaded.created_at)).toBe(toMs(post.created_at));
   });
 
   it("does not overwrite explicitly set timestamps on insert", async () => {


### PR DESCRIPTION
## Summary

Replaces all wall-clock `new Date()` in the application layer with `Temporal.Now.instant()`, completing the PR 7 scope from the temporal migration plan.

- **insert-all.ts**: `mapKeyWithValue` auto-timestamp uses `Temporal.Now.instant()`
- **persistence.ts**: `_touchRow` type updated to `Temporal.Instant | null`
- **attribute-methods/dirty.ts**: `_touchRow` same; adds `Temporal` import
- **relation.ts**: `touchAll` uses `Temporal.Now.instant()` + `formatInstantForSql` instead of `new Date().toISOString()`
- **insert-all.test.ts**: explicit timestamp fixture updated from `new Date()` to `Temporal.Instant.from(...)`

`timestamp.ts` and the `touch()` instance method already used `Temporal.Now.instant()` from prior work (PRs 1–6).

## Test plan

- [ ] SQLite Tests green (timestamp round-trip with microsecond precision)
- [ ] PostgreSQL Tests green
- [ ] MariaDB Tests green
- [ ] `grep -rn 'new Date()' packages/activerecord/src/{insert-all,persistence,relation,attribute-methods/dirty}.ts` returns zero hits