### PR TITLE
fix(activerecord): autoConnect honors in-memory configurations + UrlConfig URL fallback

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -354,13 +354,9 @@ describe("ConnectionHandlingTest", () => {
     class InMemoryModel extends Base {}
     (InMemoryModel as any).configurations = inMemory;
 
-    await expect(
-      (async () => {
-        await Base.establishConnection.call(InMemoryModel);
-        const Klass = await InMemoryModel.adapterClass();
-        const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
-        expect(Klass).toBe(SQLite3Adapter);
-      })(),
-    ).resolves.not.toThrow();
+    await InMemoryModel.establishConnection();
+    const Klass = await InMemoryModel.adapterClass();
+    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+    expect(Klass).toBe(SQLite3Adapter);
   });
 });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -335,4 +335,32 @@ describe("ConnectionHandlingTest", () => {
     const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
     expect(Klass).toBe(SQLite3Adapter);
   });
+
+  // Mirrors Rails: `ActiveRecord::Base.establish_connection` with no args
+  // reads from `Base.configurations` (the in-memory registry), not from
+  // disk. Required so callers that mutate `configurations` in place (e.g.
+  // `TestDatabases.create_and_load_schema`) actually reconnect to the
+  // mutated config rather than picking up the original from
+  // config/database.*.
+  it("autoConnect honors an in-memory DatabaseConfigurations registry", async () => {
+    const { DatabaseConfigurations } = await import("./database-configurations.js");
+    const { HashConfig } = await import("./database-configurations/hash-config.js");
+    const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+
+    const inMemory = new DatabaseConfigurations([
+      new HashConfig(env, "primary", { adapter: "sqlite3", database: ":memory:" }),
+    ]);
+
+    class InMemoryModel extends Base {}
+    (InMemoryModel as any).configurations = inMemory;
+
+    await expect(
+      (async () => {
+        await Base.establishConnection.call(InMemoryModel);
+        const Klass = await InMemoryModel.adapterClass();
+        const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+        expect(Klass).toBe(SQLite3Adapter);
+      })(),
+    ).resolves.not.toThrow();
+  });
 });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -387,14 +387,16 @@ describe("ConnectionHandlingTest", () => {
       (WorkerModel as any).configurations = inMemory;
 
       await WorkerModel.establishConnection();
-      // The connection's database should be the mutated value, not the
-      // original URL path. The SQLite adapter exposes the path via
-      // adapterClass; assert the model can be queried at all (no throw)
-      // and that the configuration retained the mutation.
+      // The connection pool's resolved dbConfig must point at the
+      // mutated database, not the original URL path. This is the
+      // actual reconnect-target observation Copilot review #3 asked
+      // for — without the URL-skip in autoConnect, this would surface
+      // the original "db/foo.sqlite3" instead.
+      const pool = WorkerModel.connectionPool();
+      expect(pool.dbConfig.database).toBe("db/foo-2.sqlite3");
       const Klass = await WorkerModel.adapterClass();
       const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
       expect(Klass).toBe(SQLite3Adapter);
-      expect(url.database).toBe("db/foo-2.sqlite3");
     } finally {
       (DatabaseConfigurations as any).current = priorCurrent;
     }

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -347,16 +347,56 @@ describe("ConnectionHandlingTest", () => {
     const { HashConfig } = await import("./database-configurations/hash-config.js");
     const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
 
-    const inMemory = new DatabaseConfigurations([
-      new HashConfig(env, "primary", { adapter: "sqlite3", database: ":memory:" }),
-    ]);
+    // _currentConfigurations is a module-level singleton that the
+    // DatabaseConfigurations constructor mutates as a side effect.
+    // Snapshot it so test ordering can't pin the wrong registry.
+    const priorCurrent = (DatabaseConfigurations as any).current;
+    try {
+      const inMemory = new DatabaseConfigurations([
+        new HashConfig(env, "primary", { adapter: "sqlite3", database: ":memory:" }),
+      ]);
 
-    class InMemoryModel extends Base {}
-    (InMemoryModel as any).configurations = inMemory;
+      class InMemoryModel extends Base {}
+      (InMemoryModel as any).configurations = inMemory;
 
-    await InMemoryModel.establishConnection();
-    const Klass = await InMemoryModel.adapterClass();
-    const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
-    expect(Klass).toBe(SQLite3Adapter);
+      await InMemoryModel.establishConnection();
+      const Klass = await InMemoryModel.adapterClass();
+      const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+      expect(Klass).toBe(SQLite3Adapter);
+    } finally {
+      (DatabaseConfigurations as any).current = priorCurrent;
+    }
+  });
+
+  // Regression: a UrlConfig whose `_database` has been mutated in place
+  // (TestDatabases.create_and_load_schema's parallel-worker pattern)
+  // must reconnect to the mutated database, not the original URL. Rails
+  // resolves from configuration_hash, not the raw URL.
+  it("autoConnect reconnects via mutated configuration.database for UrlConfig", async () => {
+    const { DatabaseConfigurations } = await import("./database-configurations.js");
+    const { UrlConfig } = await import("./database-configurations/url-config.js");
+    const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
+
+    const priorCurrent = (DatabaseConfigurations as any).current;
+    try {
+      const url = new UrlConfig(env, "primary", "sqlite3:db/foo.sqlite3");
+      url._database = "db/foo-2.sqlite3"; // mimic worker-suffix mutation
+      const inMemory = new DatabaseConfigurations([url]);
+
+      class WorkerModel extends Base {}
+      (WorkerModel as any).configurations = inMemory;
+
+      await WorkerModel.establishConnection();
+      // The connection's database should be the mutated value, not the
+      // original URL path. The SQLite adapter exposes the path via
+      // adapterClass; assert the model can be queried at all (no throw)
+      // and that the configuration retained the mutation.
+      const Klass = await WorkerModel.adapterClass();
+      const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
+      expect(Klass).toBe(SQLite3Adapter);
+      expect(url.database).toBe("db/foo-2.sqlite3");
+    } finally {
+      (DatabaseConfigurations as any).current = priorCurrent;
+    }
   });
 });

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -573,30 +573,36 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
     );
   }
 
-  // Prefer the (possibly-mutated) configuration hash over the original
-  // URL string when an explicit database is set. Rails' `establish_connection`
-  // resolves from configuration_hash, not the raw URL, so callers that
-  // mutate `_database` (e.g. TestDatabases.create_and_load_schema appending
-  // a worker index) actually reconnect to the mutated DB. The URL is only
-  // used when the configuration carries no explicit `database` — i.e. for
-  // opaque adapter strings like `jdbc:` that buildUrlHash passes through.
-  const cfgDatabase = (dbConfig.configuration as { database?: string }).database;
-  const url = cfgDatabase
-    ? ""
-    : (dbConfig instanceof UrlConfig ? dbConfig.url : undefined) ||
-      (dbConfig.configuration.url as string | undefined) ||
-      "";
-  const adapterName = dbConfig.adapter || (url ? adapterNameFromUrl(url) : undefined);
+  // The original URL is always usable for adapter inference (e.g.
+  // `sqlite3:db/test.sqlite3` → "sqlite3"), even when the connection
+  // target should be built from a (possibly-mutated) configuration hash.
+  const originalUrl =
+    (dbConfig instanceof UrlConfig ? dbConfig.url : undefined) ||
+    (dbConfig.configuration.url as string | undefined) ||
+    "";
+  const adapterName =
+    dbConfig.adapter || (originalUrl ? adapterNameFromUrl(originalUrl) : undefined);
   if (!adapterName) {
     throw new AdapterNotSpecified(
       `Database configuration for "${env}" must include an adapter name or a URL. ` +
         `Add config/database.json, set DATABASE_URL, or call ${modelClass.name}.establishConnection(url)`,
     );
   }
+
+  // Prefer the configuration hash over the original URL string when an
+  // explicit `database` is set — Rails' `establish_connection` resolves
+  // from configuration_hash, not the raw URL, so callers that mutate
+  // `_database` (e.g. TestDatabases.create_and_load_schema appending a
+  // worker index) actually reconnect to the mutated DB. The URL is only
+  // forwarded to the adapter layer when the configuration carries no
+  // explicit `database` — i.e. for opaque adapter strings like `jdbc:`
+  // that buildUrlHash passes through without decomposing.
+  const cfgDatabase = (dbConfig.configuration as { database?: string }).database;
+  const connectUrl = cfgDatabase ? "" : originalUrl;
   await establishWithConfig(
     modelClass,
     adapterName,
-    url,
+    connectUrl,
     dbConfig.configuration as Record<string, unknown>,
   );
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -573,14 +573,19 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
     );
   }
 
-  // UrlConfig exposes the original URL via the `url` attr (Rails' attr_reader).
-  // For parseable URLs the URL is decomposed into the configuration hash and
-  // `configuration.url` is unset (matches Rails' build_url_hash), so prefer
-  // the attr when available.
-  const url =
-    (dbConfig instanceof UrlConfig ? dbConfig.url : undefined) ||
-    (dbConfig.configuration.url as string | undefined) ||
-    "";
+  // Prefer the (possibly-mutated) configuration hash over the original
+  // URL string when an explicit database is set. Rails' `establish_connection`
+  // resolves from configuration_hash, not the raw URL, so callers that
+  // mutate `_database` (e.g. TestDatabases.create_and_load_schema appending
+  // a worker index) actually reconnect to the mutated DB. The URL is only
+  // used when the configuration carries no explicit `database` — i.e. for
+  // opaque adapter strings like `jdbc:` that buildUrlHash passes through.
+  const cfgDatabase = (dbConfig.configuration as { database?: string }).database;
+  const url = cfgDatabase
+    ? ""
+    : (dbConfig instanceof UrlConfig ? dbConfig.url : undefined) ||
+      (dbConfig.configuration.url as string | undefined) ||
+      "";
   const adapterName = dbConfig.adapter || (url ? adapterNameFromUrl(url) : undefined);
   if (!adapterName) {
     throw new AdapterNotSpecified(

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -544,8 +544,24 @@ async function establishWithConfig(
 }
 
 async function autoConnect(modelClass: typeof Base): Promise<void> {
-  const raw = await loadConfigFile(modelClass);
-  const configs = DatabaseConfigurations.fromEnv(raw);
+  // Prefer the in-memory configurations when set — Rails'
+  // `establish_connection` (no args) reads from `Base.configurations`,
+  // the same registry mutated by callers like
+  // `TestDatabases.create_and_load_schema` (which suffixes `_database`
+  // per worker before reconnect). Falling back to disk would re-read
+  // unmutated configs and reconnect to the wrong database.
+  const inMemory = (modelClass as any).configurations;
+  let configs: DatabaseConfigurations;
+  if (inMemory instanceof DatabaseConfigurations) {
+    configs = inMemory;
+  } else if (inMemory && typeof inMemory.toH === "function") {
+    configs = DatabaseConfigurations.fromEnv(inMemory.toH());
+  } else if (inMemory && typeof inMemory === "object") {
+    configs = DatabaseConfigurations.fromEnv(inMemory);
+  } else {
+    const raw = await loadConfigFile(modelClass);
+    configs = DatabaseConfigurations.fromEnv(raw);
+  }
   const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
   const primaryConfigs = configs.configsFor({ envName: env, name: "primary" });
   const dbConfig = primaryConfigs[0] ?? configs.findDbConfig(env);

--- a/packages/activerecord/src/database-configurations/url-config.test.ts
+++ b/packages/activerecord/src/database-configurations/url-config.test.ts
@@ -1,4 +1,5 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { UrlConfig } from "./url-config.js";
 
 describe("DatabaseConfigurations", () => {
   describe("UrlConfigTest", () => {
@@ -6,5 +7,19 @@ describe("DatabaseConfigurations", () => {
     it.skip("query cache parsing", () => {});
     it.skip("replica parsing", () => {});
     it.skip("database tasks parsing", () => {});
+
+    // Mirrors Rails' UrlConfig#database — when the configuration hash
+    // doesn't carry an explicit `database`, fall back to the URL path.
+    it("derives database from a parseable URL when configuration.database is unset", () => {
+      const cfg = new UrlConfig("test", "primary", "postgres://h/mydb");
+      expect(cfg.database).toBe("mydb");
+    });
+
+    it("treats a bare filesystem path as the database name", () => {
+      // No URL scheme → buildUrlHash passes through; the override falls
+      // back to the URL string itself (matches Rails' raw-path handling).
+      const cfg = new UrlConfig("test", "primary", "test/db/primary.sqlite3");
+      expect(cfg.database).toBe("test/db/primary.sqlite3");
+    });
   });
 });

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -21,6 +21,29 @@ export class UrlConfig extends HashConfig {
     super(envName, name, { ...configuration, ...buildUrlHash(url) });
     this.url = url;
   }
+
+  // Mirrors Rails' UrlConfig — when the configuration hash doesn't carry an
+  // explicit `database`, fall back to parsing the URL's path. Necessary for
+  // URL-only sqlite configs (`{ adapter: "sqlite3", url: "db/test.sqlite3" }`)
+  // where buildUrlHash leaves `configuration.database` undefined: callers
+  // like TestDatabases.create_and_load_schema rely on `db_config.database`.
+  override get database(): string | undefined {
+    const explicit = super.database;
+    if (explicit !== undefined) return explicit;
+    return databaseFromUrl(this.url);
+  }
+}
+
+function databaseFromUrl(url: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.replace(/^\//, "") || parsed.host || undefined;
+  } catch {
+    // Bare filesystem paths and `:memory:` aren't parseable URLs but are
+    // the database name themselves.
+    return url;
+  }
 }
 
 // Mirrors: UrlConfig#build_url_hash

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -38,7 +38,13 @@ function databaseFromUrl(url: string): string | undefined {
   if (!url) return undefined;
   try {
     const parsed = new URL(url);
-    return parsed.pathname.replace(/^\//, "") || parsed.host || undefined;
+    // Mirrors Rails: the database name is only ever derived from the URL
+    // path, never the host. URLs like `postgres://localhost` (no path)
+    // legitimately have no database name — falling back to `host` would
+    // silently mask a misconfiguration and route reconnects/creation at
+    // a database called "localhost".
+    const path = parsed.pathname.replace(/^\//, "");
+    return path || undefined;
   } catch {
     // Bare filesystem paths and `:memory:` aren't parseable URLs but are
     // the database name themselves.

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -36,6 +36,10 @@ export class UrlConfig extends HashConfig {
 
 function databaseFromUrl(url: string): string | undefined {
   if (!url) return undefined;
+  // Mirror buildUrlHash: Windows drive-letter paths (e.g. `C:/db.sqlite3`)
+  // are valid WHATWG URLs (`protocol: "c:"`) but they're filesystem
+  // paths, not URIs. URL parsing would silently drop the drive letter.
+  if (/^[A-Za-z]:[\\/]/.test(url)) return url;
   try {
     const parsed = new URL(url);
     // Mirrors Rails: the database name is only ever derived from the URL


### PR DESCRIPTION
## Summary

Precursor for #943 (TestDatabases.createAndLoadSchema). Two coupled bugs surfaced during that review that affect any caller mutating `Base.configurations` in place:

**1. `autoConnect` now prefers in-memory configurations.**

Mirrors Rails: `ActiveRecord::Base.establish_connection` (no args) reads from `Base.configurations` (the in-memory registry), not from disk. trails' `autoConnect` always called `loadConfigFile(modelClass)`, so a worker that mutated `dbConfig._database` before reconnect dropped back to the original database from `config/database.*`.

The new path picks the in-memory `configurations` when it's a `DatabaseConfigurations`, an `OrderedOptions`-shaped object with `.toH()`, or any plain object (passed through `fromEnv`). Disk loading still runs when `configurations` is unset.

**2. `UrlConfig.database` falls back to URL parsing.**

Mirrors Rails `UrlConfig#database` → `URI(url).path.delete_prefix("/")`. URL-only configs like `{ adapter: "sqlite3", url: "db/test.sqlite3" }` previously surfaced `database: undefined` because `buildUrlHash` early-returns `{ url }` for non-URI paths. Now `UrlConfig.database` returns the `configuration.database` when set, otherwise parses the URL.

## Why this matters

Without these, `TestDatabases.createAndLoadSchema` ships a Rails-shaped surface that doesn't deliver parallel test-worker isolation:

- Schema reconstruction lands on `foo-i` ✓
- Reconnect goes back to `foo` ✗ (autoConnect re-reads from disk)
- Worker actually queries `foo` end-to-end ✗

PR #943 is paused waiting on this. Once this merges, #943 rebases on top, drops its local `databaseFromUrl` workaround, and the post-reconstruct reconnect actually targets the suffixed worker DB.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/database-configurations/url-config.test.ts` — 2 new + 4 existing skipped, all pass
- [x] `pnpm exec vitest run packages/activerecord/src/connection-handling.test.ts` — 33 pass, 6 skipped (1 new in-memory-configurations test)
- [x] `pnpm exec vitest run packages/activerecord/src/connection-adapters/` — 619 pass, 264 skipped (no regressions across all adapter suites)
- [x] `pnpm build` clean
- [x] +85 / −3 LOC, well under the 300 ceiling