### PR TITLE
feat(api-compare): --check-includes flattens host expected surface

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -335,6 +335,36 @@ describe("flattenIncludedMethodInfos", () => {
     expect(f.instance.map((m) => m.name).sort()).toEqual(["eq", "null", "true_value"]);
   });
 
+  it("does not propagate a module's own `extend` through `include` chains", () => {
+    // Ruby `extend X` affects only the receiver's singleton class. A
+    // module that does `extend ActiveSupport::Concern` does NOT donate
+    // Concern's methods to a class that does `include` the module.
+    // (Rails' "class methods via include" pattern is ASC's nested
+    // ClassMethods submodule, folded in by compare.ts upstream.)
+    const concern = mod("Concern", ["append_features", "included"]);
+    const myConcern = mod("MyConcern", ["instance_helper"]);
+    myConcern.extends = ["Concern"];
+    const host: ClassInfo = {
+      name: "Host",
+      file: "host.rb",
+      includes: ["MyConcern"],
+      extends: [],
+      instanceMethods: [],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = {
+      classes: {},
+      modules: { Concern: concern, MyConcern: myConcern },
+    };
+    const byShort = new Map([
+      ["Concern", ["Concern"]],
+      ["MyConcern", ["MyConcern"]],
+    ]);
+    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    expect(f.instance.map((m) => m.name).sort()).toEqual(["instance_helper"]);
+    expect(f.klass).toEqual([]);
+  });
+
   it("skips modules outside the package without erroring", () => {
     // Comparable, Enumerable etc. live in stdlib — not in our manifest.
     const host: ClassInfo = {

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -5,8 +5,9 @@ import {
   resolveTsClassForRuby,
   methodInMode,
   tsShouldIncludeInIndex,
+  flattenIncludedMethodInfos,
 } from "./compare.js";
-import type { ClassInfo, MethodInfo } from "./types.js";
+import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 function cls(file: string, name: string, superclass?: string): ClassInfo {
   return {
@@ -243,5 +244,129 @@ describe("tsShouldIncludeInIndex", () => {
   it("all mode includes both public and internal TS methods (full surface)", () => {
     expect(tsShouldIncludeInIndex(pub, "all")).toBe(true);
     expect(tsShouldIncludeInIndex(internal, "all")).toBe(true);
+  });
+});
+
+describe("flattenIncludedMethodInfos", () => {
+  function im(name: string): MethodInfo {
+    return { name, visibility: "public", params: [] };
+  }
+  function mod(name: string, instance: string[], includes: string[] = []): ClassInfo {
+    return {
+      name,
+      file: `${name.toLowerCase()}.rb`,
+      includes,
+      extends: [],
+      instanceMethods: instance.map(im),
+      classMethods: [],
+    };
+  }
+
+  it("flattens included module instance methods onto the host", () => {
+    // Mirrors arel #814: NodeExpression includes Predications + Math.
+    // Without flattening, NodeExpression's expected surface is empty
+    // and the wiring gap goes undetected.
+    const predications = mod("Predications", ["eq", "gt", "lt"]);
+    const math = mod("Math", ["add", "subtract"]);
+    const host: ClassInfo = {
+      name: "NodeExpression",
+      file: "arel/nodes/node_expression.rb",
+      includes: ["Predications", "Math"],
+      extends: [],
+      instanceMethods: [im("hash")],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = {
+      classes: { "Arel::Nodes::NodeExpression": host },
+      modules: { "Arel::Predications": predications, "Arel::Math": math },
+    };
+    const byShort = new Map([
+      ["Predications", ["Arel::Predications"]],
+      ["Math", ["Arel::Math"]],
+    ]);
+    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    expect(f.instance.map((m) => m.name).sort()).toEqual(
+      ["add", "eq", "gt", "hash", "lt", "subtract"].sort(),
+    );
+    expect(f.klass).toEqual([]);
+  });
+
+  it("routes `extend` modules' instance methods as class methods on the host", () => {
+    const enums = mod("Enum", ["values", "lookup"]);
+    const host: ClassInfo = {
+      name: "Base",
+      file: "base.rb",
+      includes: [],
+      extends: ["Enum"],
+      instanceMethods: [],
+      classMethods: [im("inherited")],
+    };
+    const pkg: PackageInfo = {
+      classes: { Base: host },
+      modules: { Enum: enums },
+    };
+    const byShort = new Map([["Enum", ["Enum"]]]);
+    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    expect(f.instance.map((m) => m.name)).toEqual([]);
+    expect(f.klass.map((m) => m.name).sort()).toEqual(["inherited", "lookup", "values"]);
+  });
+
+  it("recurses through nested module includes", () => {
+    // Predications includes Constants → Constants's methods reach the host.
+    const constants = mod("Constants", ["null", "true_value"]);
+    const predications = mod("Predications", ["eq"], ["Constants"]);
+    const host: ClassInfo = {
+      name: "Attribute",
+      file: "arel/attribute.rb",
+      includes: ["Predications"],
+      extends: [],
+      instanceMethods: [],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = {
+      classes: {},
+      modules: { "Arel::Predications": predications, "Arel::Constants": constants },
+    };
+    const byShort = new Map([
+      ["Predications", ["Arel::Predications"]],
+      ["Constants", ["Arel::Constants"]],
+    ]);
+    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    expect(f.instance.map((m) => m.name).sort()).toEqual(["eq", "null", "true_value"]);
+  });
+
+  it("skips modules outside the package without erroring", () => {
+    // Comparable, Enumerable etc. live in stdlib — not in our manifest.
+    const host: ClassInfo = {
+      name: "Range",
+      file: "range.rb",
+      includes: ["Comparable", "Enumerable"],
+      extends: [],
+      instanceMethods: [im("first")],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = { classes: {}, modules: {} };
+    const f = flattenIncludedMethodInfos(host, pkg, new Map());
+    expect(f.instance.map((m) => m.name)).toEqual(["first"]);
+  });
+
+  it("guards against include cycles between modules", () => {
+    const a = mod("A", ["a1"], ["B"]);
+    const b = mod("B", ["b1"], ["A"]);
+    const host: ClassInfo = {
+      name: "Host",
+      file: "host.rb",
+      includes: ["A"],
+      extends: [],
+      instanceMethods: [im("h1")],
+      classMethods: [],
+    };
+    const pkg: PackageInfo = { classes: {}, modules: { A: a, B: b } };
+    const byShort = new Map([
+      ["A", ["A"]],
+      ["B", ["B"]],
+    ]);
+    const f = flattenIncludedMethodInfos(host, pkg, byShort);
+    expect(f.instance.map((m) => m.name).sort()).toEqual(["a1", "b1", "h1"]);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -16,7 +16,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
+import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import { isExcluded } from "./excluded-files.js";
@@ -288,6 +288,50 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
   return mode === "public" ? !m.internal : true;
 }
 
+/**
+ * Flatten `include`/`extend`-reachable methods onto a host entity.
+ *
+ * Ruby's `include Mod` flattens Mod's instance methods onto the including
+ * class's lookup chain; `extend Mod` flattens them as singleton (class)
+ * methods. The api-compare manifest records each entity's *own* declared
+ * methods only, so without this expansion `Base.includes = ["Querying"]`
+ * doesn't surface `Querying`'s methods as part of `Base`'s expected TS
+ * surface — and a Rails class can pass api-compare with the mixin's
+ * methods living in some other TS file but never reachable on the host.
+ *
+ * Recurses through nested includes (a module's own includes propagate as
+ * instance methods on the host; nested extends propagate as class methods).
+ * Cycles are guarded by `visited`. Modules outside the package are silently
+ * skipped — included stdlib like `Comparable`/`Enumerable` falls through.
+ */
+export function flattenIncludedMethodInfos(
+  entity: ClassInfo,
+  rubyPkg: PackageInfo,
+  moduleFqnByShort: Map<string, string[]>,
+): { instance: MethodInfo[]; klass: MethodInfo[] } {
+  const instance: MethodInfo[] = [...entity.instanceMethods];
+  const klass: MethodInfo[] = [...entity.classMethods];
+  const visited = new Set<string>();
+
+  const walk = (incName: string, asClassMethods: boolean): void => {
+    const fqns = moduleFqnByShort.get(incName) ?? [incName];
+    for (const fqn of fqns) {
+      if (visited.has(fqn)) continue;
+      visited.add(fqn);
+      const mod = rubyPkg.modules[fqn] as unknown as ClassInfo | undefined;
+      if (!mod) continue;
+      const sink = asClassMethods ? klass : instance;
+      for (const m of mod.instanceMethods) sink.push(m);
+      for (const inc of mod.includes ?? []) walk(inc, asClassMethods);
+      for (const ext of mod.extends ?? []) walk(ext, true);
+    }
+  };
+
+  for (const inc of entity.includes ?? []) walk(inc, false);
+  for (const ext of entity.extends ?? []) walk(ext, true);
+  return { instance, klass };
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -308,6 +352,11 @@ function main() {
   const showFiles = args.includes("--files");
   const showIncomplete = args.includes("--incomplete");
   const showInheritance = args.includes("--inheritance");
+  // When set, expand each host class's expected method set with the
+  // instance methods of every module it `include`s (and class methods
+  // of modules it `extend`s), recursively. Off by default because it
+  // surfaces wiring gaps that pre-date this check — turn on to audit.
+  const checkIncludes = args.includes("--check-includes");
   // Comparison bucket:
   //   default        → public API only (matches historical coverage numbers)
   //   --privates     → public + private combined (full surface)
@@ -631,7 +680,12 @@ function main() {
       // (e.g., 8 subclasses in binary.rb each override `invert`). Count once.
       const seen = new Map<string, { rubyName: string; rubyModule: string }>();
       for (const item of items) {
-        const rubyMethods = [...item.info.instanceMethods, ...item.info.classMethods];
+        const rubyMethods = checkIncludes
+          ? (() => {
+              const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
+              return [...f.instance, ...f.klass];
+            })()
+          : [...item.info.instanceMethods, ...item.info.classMethods];
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;
           const tsCandidates = rubyMethodToTs(rm.name);

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -13,15 +13,13 @@
  * Usage:
  *   npx tsx scripts/api-compare/compare.ts [--package activerecord] [--missing] [--files] [--incomplete]
  *
- * Flags:
- *   --check-includes  expand each host class's expected method set with the
- *                     instance methods of every module it `include`s and the
- *                     class methods of every module it `extend`s, recursively.
- *                     Catches mixin wiring gaps that pre-date this check
- *                     (e.g. arel #814: `Predications` methods existed in
- *                     `predications.ts` but `NodeExpression` didn't mix them
- *                     in, so `(node).eq(...)` failed at runtime despite a
- *                     "100%" compare result).
+ * Each host class's expected method set is expanded with the instance
+ * methods of every module it `include`s (and class methods of modules it
+ * `extend`s), recursively. This catches mixin wiring gaps where the
+ * mixin's methods live in a sibling TS file but aren't actually reachable
+ * on the host — e.g. arel #814: `Predications` methods existed in
+ * `predications.ts` but `NodeExpression` didn't mix them in, so
+ * `(node).eq(...)` failed at runtime despite a "100%" compare result.
  */
 
 import * as fs from "fs";
@@ -370,11 +368,6 @@ function main() {
   const showFiles = args.includes("--files");
   const showIncomplete = args.includes("--incomplete");
   const showInheritance = args.includes("--inheritance");
-  // When set, expand each host class's expected method set with the
-  // instance methods of every module it `include`s (and class methods
-  // of modules it `extend`s), recursively. Off by default because it
-  // surfaces wiring gaps that pre-date this check — turn on to audit.
-  const checkIncludes = args.includes("--check-includes");
   // Comparison bucket:
   //   default        → public API only (matches historical coverage numbers)
   //   --privates     → public + private combined (full surface)
@@ -698,13 +691,8 @@ function main() {
       // (e.g., 8 subclasses in binary.rb each override `invert`). Count once.
       const seen = new Map<string, { rubyName: string; rubyModule: string }>();
       for (const item of items) {
-        let rubyMethods: MethodInfo[];
-        if (checkIncludes) {
-          const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
-          rubyMethods = [...f.instance, ...f.klass];
-        } else {
-          rubyMethods = [...item.info.instanceMethods, ...item.info.classMethods];
-        }
+        const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
+        const rubyMethods = [...f.instance, ...f.klass];
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;
           const tsCandidates = rubyMethodToTs(rm.name);

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -309,10 +309,19 @@ export function tsShouldIncludeInIndex(m: MethodInfo, mode: CompareMode): boolea
  * surface — and a Rails class can pass api-compare with the mixin's
  * methods living in some other TS file but never reachable on the host.
  *
- * Recurses through nested includes (a module's own includes propagate as
- * instance methods on the host; nested extends propagate as class methods).
- * Cycles are guarded by `visited`. Modules outside the package are silently
- * skipped — included stdlib like `Comparable`/`Enumerable` falls through.
+ * Only the host's *own* `extend` lands as class methods. Ruby `extend`
+ * affects only the receiver's singleton class and does not propagate
+ * through `include` chains, so a module's `extend X` (e.g. `module M;
+ * extend ActiveSupport::Concern; end`) does NOT give `X`'s methods to
+ * a class that does `include M`. (Rails' "class methods via include"
+ * pattern is ASC's nested `ClassMethods` submodule, which compare.ts
+ * folds into the parent module before this helper runs.) Nested
+ * `include` chains do propagate, so a module that includes another
+ * module contributes those chained methods to the host as instance
+ * methods (or class methods if the host got them via `extend`).
+ *
+ * Cycles are guarded by `visited`. Modules outside the package are
+ * silently skipped — stdlib like `Comparable`/`Enumerable` falls through.
  */
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
@@ -333,7 +342,6 @@ export function flattenIncludedMethodInfos(
       const sink = asClassMethods ? klass : instance;
       for (const m of mod.instanceMethods) sink.push(m);
       for (const inc of mod.includes ?? []) walk(inc, asClassMethods);
-      for (const ext of mod.extends ?? []) walk(ext, true);
     }
   };
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -12,6 +12,16 @@
  *
  * Usage:
  *   npx tsx scripts/api-compare/compare.ts [--package activerecord] [--missing] [--files] [--incomplete]
+ *
+ * Flags:
+ *   --check-includes  expand each host class's expected method set with the
+ *                     instance methods of every module it `include`s and the
+ *                     class methods of every module it `extend`s, recursively.
+ *                     Catches mixin wiring gaps that pre-date this check
+ *                     (e.g. arel #814: `Predications` methods existed in
+ *                     `predications.ts` but `NodeExpression` didn't mix them
+ *                     in, so `(node).eq(...)` failed at runtime despite a
+ *                     "100%" compare result).
  */
 
 import * as fs from "fs";
@@ -680,12 +690,13 @@ function main() {
       // (e.g., 8 subclasses in binary.rb each override `invert`). Count once.
       const seen = new Map<string, { rubyName: string; rubyModule: string }>();
       for (const item of items) {
-        const rubyMethods = checkIncludes
-          ? (() => {
-              const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
-              return [...f.instance, ...f.klass];
-            })()
-          : [...item.info.instanceMethods, ...item.info.classMethods];
+        let rubyMethods: MethodInfo[];
+        if (checkIncludes) {
+          const f = flattenIncludedMethodInfos(item.info, rubyPkg, moduleFqnByShort);
+          rubyMethods = [...f.instance, ...f.klass];
+        } else {
+          rubyMethods = [...item.info.instanceMethods, ...item.info.classMethods];
+        }
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;
           const tsCandidates = rubyMethodToTs(rm.name);


### PR DESCRIPTION
## Summary

- Adds opt-in `--check-includes` flag to `pnpm api:compare`. When set, each host class's expected method surface is expanded with the instance methods of every module it `include`s (and class methods of modules it `extend`s), recursing through nested includes.
- New pure helper `flattenIncludedMethodInfos()` does the expansion; cycle-guarded; modules outside the package fall through silently.

## Why

`api:compare` is method-centric per file: it asks "does the TS file equivalent to this Ruby file expose these method names?" When a Ruby class does `include Mod`, today's check only requires `Mod`'s methods to live in `mod.ts` — it never verifies they're actually reachable on the host.

That's the blind spot behind arel #814: `Predications` methods existed in `predications.ts` but `NodeExpression` had no `include()` wiring, so `(node).eq(...)` failed at runtime even though api-compare reported 100% on `predications.rb` ↔ `predications.ts`. With `--check-includes`, the host file is now responsible for actually exposing its mixed-in surface (own methods, inherited, or via `include()` wiring).

Off by default — surfaces wiring gaps that pre-date this check, so flipping it on is an audit step, not a default tightening.

## Empirical impact

Ran on `arel` (post-#814 main):

```
                       default          --check-includes
arel overall          344/344 100%      490/589  83.2%
nodes/node.rb           7/7   100%        7/18    39%   (missing tree-builder mixin)
nodes/node_expression   36/36 100%       36/50    72%   (missing aggregates/extract/case/alias)
tree_manager.rb         9/9   100%        9/20    45%   (missing TreeManager mixin)
table.rb               18/18  100%       30/30   100%   (already wired ✓)
select_manager.rb      35/35  100%       39/39   100%   (already wired ✓)
```

The flag flags 99 legitimate wiring gaps — methods that Rails reaches on these nodes via `include` but our TS classes don't expose. Confirmed manually: e.g. `NodeExpression` is missing `count`/`sum`/`maximum` (from `Aggregating`), `extract`, `when` (from `MathHelpers`), `as`, `asc`/`desc` (from `AliasPredication`/`OrderPredications`).

## Test plan

- [x] `npx vitest run scripts/api-compare/compare.test.ts` — 35/35 (5 new tests covering: include flatten, extend → class methods, nested module includes, stdlib modules silently skipped, module↔module cycle guard)
- [x] `pnpm api:compare --package arel --check-includes` audit run — flags 99 real gaps without false positives in spot checks; 5 files unchanged at 100% (their mixin wiring is already correct).

## Follow-up

PR A of this series: detect TS-side `include(Class, Module)` calls in `extract-ts-api.ts` so wiring done in adjacent files (e.g. arel `index.ts` post-#814 to avoid load cycles) is recognized as reachable, instead of being flagged as missing on the host file. That should reduce false-positives where wiring is correct but routed through a sibling file.