### PR TITLE
ci: phase 0 — concurrency, prettier gate, skip strictness, timing report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,7 +646,10 @@ jobs:
           NEEDS_JSON: ${{ toJSON(needs) }}
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           PARITY_SQLITE: ${{ needs.changes.outputs.parity_sqlite }}
+          PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
+          PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
         run: |
+          set -euo pipefail
           echo "$NEEDS_JSON"
           # Hard failures: failure or cancelled.
           bad=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
@@ -658,46 +661,65 @@ jobs:
           # Allow-list jobs that may legitimately skip, conditioned on the
           # gate that produced the skip. Anything else skipping means a gate
           # mis-evaluated and downstream silently passed.
-          parity_jobs='schema-parity-rails schema-parity-trails schema-parity-diff query-parity-frozen-at query-parity-rails query-parity-trails query-parity-diff'
-          while read -r job result; do
-            [ "$result" = "skipped" ] || continue
-            case "$job" in
-              changes|ci) continue ;;
-            esac
-            if [ "$DOCS_ONLY" = "true" ]; then
-              continue
-            fi
-            if [ "$PARITY_SQLITE" != "true" ] && echo "$parity_jobs" | grep -qw "$job"; then
-              continue
-            fi
-            echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY parity_sqlite=$PARITY_SQLITE)"
-            exit 1
-          done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
+          unexpected=0
+          # Docs-only legitimately skips every gated downstream.
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "docs_only=true — all downstream skips are expected."
+          else
+            any_parity=false
+            for v in "$PARITY_SQLITE" "$PARITY_POSTGRES" "$PARITY_MYSQL"; do
+              [ "$v" = "true" ] && any_parity=true
+            done
+            while read -r job result; do
+              [ "$result" = "skipped" ] || continue
+              case "$job" in
+                changes|ci) continue ;;
+                schema-parity-rails|schema-parity-trails|schema-parity-diff|\
+                query-parity-frozen-at|query-parity-rails|query-parity-trails|query-parity-diff)
+                  # Parity skip is legitimate when no parity gate is on.
+                  [ "$any_parity" = "false" ] && continue
+                  ;;
+              esac
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
+              unexpected=1
+            done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
+          fi
+          [ "$unexpected" -eq 0 ] || exit 1
           echo "All jobs passed or were intentionally skipped."
 
+      # Informational only — never fails the run. Captures peer-job
+      # durations from the same workflow run; CI's own duration is excluded
+      # because it isn't final at the time of this query.
       - name: Job timing report
         if: ${{ always() }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          echo "### Job durations (longest first)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Job | Status | Duration |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|--------|----------|" >> "$GITHUB_STEP_SUMMARY"
-          gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
-            | jq -r '
-                .jobs[]
-                | select(.name != "CI")
-                | select(.started_at != null and .completed_at != null)
-                | {
-                    name,
-                    conclusion,
-                    seconds: ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601))
-                  }
-                | [.seconds, .name, .conclusion] | @tsv
-              ' \
+          set -uo pipefail
+          {
+            echo "### Job durations (longest first)"
+            echo ""
+            echo "| Job | Status | Duration |"
+            echo "|-----|--------|----------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if ! gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" > /tmp/jobs.json; then
+            echo "_(timing report unavailable: gh api failed)_" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -r '
+            .jobs[]
+            | select(.name != "CI")
+            | select(.started_at != null and .completed_at != null)
+            | [
+                ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601)),
+                .name,
+                (.conclusion // "running")
+              ]
+            | @tsv
+          ' /tmp/jobs.json \
             | sort -rn \
             | awk -F'\t' '{
                 s=$1; m=int(s/60); r=s-m*60;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+# Cancel superseded runs on PR pushes; keep main/schedule runs intact so
+# post-merge sweeps and timing reports aren't lost.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Preflight that sets `docs_only=true` when every changed path is under
   # top-level `docs/`. Downstream jobs gate on this via `if:` so they're
@@ -135,6 +141,8 @@ jobs:
       - run: pnpm lint
   prettier:
     name: Prettier
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -630,16 +638,68 @@ jobs:
       - query-parity-trails
       - query-parity-diff
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     steps:
-      - name: Fail if any required job failed or was cancelled
+      - name: Fail if any required job failed, was cancelled, or unexpectedly skipped
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          PARITY_SQLITE: ${{ needs.changes.outputs.parity_sqlite }}
         run: |
           echo "$NEEDS_JSON"
+          # Hard failures: failure or cancelled.
           bad=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
           if [ -n "$bad" ]; then
             echo "Failed/cancelled jobs:"
             echo "$bad"
             exit 1
           fi
+          # Allow-list jobs that may legitimately skip, conditioned on the
+          # gate that produced the skip. Anything else skipping means a gate
+          # mis-evaluated and downstream silently passed.
+          parity_jobs='schema-parity-rails schema-parity-trails schema-parity-diff query-parity-frozen-at query-parity-rails query-parity-trails query-parity-diff'
+          while read -r job result; do
+            [ "$result" = "skipped" ] || continue
+            case "$job" in
+              changes|ci) continue ;;
+            esac
+            if [ "$DOCS_ONLY" = "true" ]; then
+              continue
+            fi
+            if [ "$PARITY_SQLITE" != "true" ] && echo "$parity_jobs" | grep -qw "$job"; then
+              continue
+            fi
+            echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY parity_sqlite=$PARITY_SQLITE)"
+            exit 1
+          done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           echo "All jobs passed or were intentionally skipped."
+
+      - name: Job timing report
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          echo "### Job durations (longest first)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Status | Duration |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|--------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+            | jq -r '
+                .jobs[]
+                | select(.name != "CI")
+                | select(.started_at != null and .completed_at != null)
+                | {
+                    name,
+                    conclusion,
+                    seconds: ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601))
+                  }
+                | [.seconds, .name, .conclusion] | @tsv
+              ' \
+            | sort -rn \
+            | awk -F'\t' '{
+                s=$1; m=int(s/60); r=s-m*60;
+                printf("| %s | %s | %dm%02ds |\n", $2, $3, m, r)
+              }' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Phase 0 — free wins + measurement, no behavior risk for the happy path. Sets up data collection so subsequent optimization phases can be prioritized from numbers rather than guesses.

- **`concurrency:`** at workflow top cancels superseded PR runs; keeps `main` and scheduled runs intact (so post-merge sweeps and timing reports aren't lost).
- **`prettier` gated on `changes`** — previously ran on every PR, including docs-only.
- **Aggregate `ci` skip-strictness** — only allows skips that match the gate that should produce them: docs-only short-circuits everything; parity-job skips are legitimate iff no parity gate (`parity_sqlite|postgres|mysql`) is on. Anything else skipping means a gate misevaluated and downstream silently passed.
- **Job timing report** appended to the run summary via `gh api .../jobs`, sorted longest-first. Uses `continue-on-error` and degrades to a one-line note if the API call fails — never blocks a green run.

## Why now (data from this 24-core box)

| Metric | Value |
|---|---|
| Cold `pnpm build` | 57s |
| Warm `pnpm build` | 1.2s |
| `dist/` total | 47 MB (27 MB activerecord) |
| `.tsbuildinfo` total | 1.2 MB |

Composite project incremental rebuild is essentially free. That argues for `actions/cache` keyed on source hash over artifact upload as the next-phase strategy for shared build output.

## Test plan

- [ ] **Concurrency:** force-push to this branch — earlier in-progress runs should show "cancelled".
- [ ] **Prettier gate:** open a docs-only follow-up PR — `Prettier` job should be `skipped` and aggregate `ci` should still pass.
- [ ] **Skip-strictness happy path:** this PR's run completes green with `Run job timing report` summary populated.
- [ ] **Skip-strictness sad path (manual one-off):** temporarily flip a gated job's `if:` to `false` on a throwaway branch — aggregate `ci` should fail with `Unexpectedly skipped job: <name>`.
- [ ] **Timing report:** the run summary on this PR contains a `### Job durations (longest first)` table with one row per peer job.

## Notes for review

- This PR is intentionally measurement-only. The numbers from this run drive prioritization of phase 1 (shared build output, SQLite parallel tests).
- Branch protection should already point at the aggregate `CI` job, not individual jobs (per the existing comment at the top of `changes`). The new strictness check makes that aggregate strictly more correct, not less.