### PR TITLE
feat(api-compare): detect TS-side include() wiring + const-object modules

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -220,6 +220,44 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
           line,
           file: relPath,
         });
+      } else if (ts.isVariableStatement(node) && isExported(node)) {
+        // Capture `export const X = { method() {...}, ... }` as a module.
+        // This is the shape every `include(Host, Mod)` mixin uses
+        // (see activesupport/src/include.ts), so without recording these
+        // the include-detection pass below has nothing to fold in.
+        for (const decl of node.declarationList.declarations) {
+          if (!decl.name || !ts.isIdentifier(decl.name)) continue;
+          if (!decl.initializer || !ts.isObjectLiteralExpression(decl.initializer)) continue;
+          const methods: MethodInfo[] = [];
+          for (const prop of decl.initializer.properties) {
+            let mname: string | null = null;
+            if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
+              mname = prop.name.text;
+            } else if (
+              ts.isPropertyAssignment(prop) &&
+              ts.isIdentifier(prop.name) &&
+              (ts.isFunctionExpression(prop.initializer) || ts.isArrowFunction(prop.initializer))
+            ) {
+              mname = prop.name.text;
+            }
+            if (!mname) continue;
+            const line =
+              prop.getSourceFile().getLineAndCharacterOfPosition(prop.getStart()).line + 1;
+            methods.push({ name: mname, visibility: "public", params: [], line, file: relPath });
+          }
+          if (methods.length === 0) continue;
+          const modKey = `${relPath}:${decl.name.text}`;
+          if (info.modules[modKey] || info.classes[modKey]) continue;
+          info.modules[modKey] = {
+            name: decl.name.text,
+            file: relPath,
+            includes: [],
+            extends: [],
+            instanceMethods: methods,
+            classMethods: [],
+          };
+          fileHasClassOrModule = true;
+        }
       } else if (
         (ts.isFunctionDeclaration(node) || ts.isVariableStatement(node)) &&
         !isExported(node)
@@ -405,6 +443,93 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
     if (sourceModule) {
       info.modules[key] = { ...sourceModule, name: re.localName, file: re.fromFile };
     }
+  }
+
+  // Include-detection pass: every top-level `include(Host, Mod)` call
+  // (from `@blazetrails/activesupport`) is recorded as `Host.extends +=
+  // Mod`, so compare.ts's existing `getInherited` walker folds Mod's
+  // methods into Host's TS surface. Without this the host class's file
+  // looks empty of the mixed-in methods even when Rails reports them
+  // as part of the host's effective surface (see arel #814).
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.fileName.startsWith(srcDir)) continue;
+    if (sourceFile.fileName.endsWith(".test.ts")) continue;
+    if (sourceFile.fileName.endsWith(".d.ts")) continue;
+
+    let importsInclude = false;
+    ts.forEachChild(sourceFile, (n) => {
+      if (
+        !ts.isImportDeclaration(n) ||
+        !ts.isStringLiteral(n.moduleSpecifier) ||
+        n.moduleSpecifier.text !== "@blazetrails/activesupport" ||
+        !n.importClause?.namedBindings ||
+        !ts.isNamedImports(n.importClause.namedBindings)
+      ) {
+        return;
+      }
+      for (const el of n.importClause.namedBindings.elements) {
+        if ((el.propertyName ?? el.name).text === "include") importsInclude = true;
+      }
+    });
+    if (!importsInclude) continue;
+
+    ts.forEachChild(sourceFile, (n) => {
+      if (!ts.isExpressionStatement(n)) return;
+      const call = n.expression;
+      if (!ts.isCallExpression(call)) return;
+      if (!ts.isIdentifier(call.expression) || call.expression.text !== "include") return;
+      if (call.arguments.length < 2) return;
+      const [hostArg, modArg] = call.arguments;
+      if (!ts.isIdentifier(hostArg)) return;
+
+      const hostSym0 = checker.getSymbolAtLocation(hostArg);
+      if (!hostSym0) return;
+      const hostSym =
+        hostSym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(hostSym0) : hostSym0;
+      let hostDecl: ts.Declaration | undefined =
+        hostSym.valueDeclaration ?? hostSym.declarations?.[0];
+      let hostName: string = hostSym.name;
+      // Some sites bind the class through a const cast first, e.g.
+      // `const _NodeExpression = NodeExpression as unknown as new (...) => ...`.
+      // Walk the type's construct signature back to the original class.
+      if (!hostDecl || !ts.isClassDeclaration(hostDecl)) {
+        const t = checker.getTypeAtLocation(hostArg);
+        const ctorSigs = t.getConstructSignatures();
+        const inst = ctorSigs[0]?.getReturnType();
+        const sym = inst?.getSymbol();
+        const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+        if (decl && ts.isClassDeclaration(decl) && sym) {
+          hostDecl = decl;
+          hostName = sym.name;
+        } else {
+          return;
+        }
+      }
+      const hostFile = path.relative(srcDir, hostDecl.getSourceFile().fileName).replace(/\\/g, "/");
+      const hostKey = `${hostFile}:${hostName}`;
+      const hostInfo = info.classes[hostKey];
+      if (!hostInfo) return;
+
+      // Resolve the module name. Imports may rebind it (`import { Math
+      // as MathMixin }`), so follow the alias to the original symbol's
+      // name when possible. Property access (`Mod.InstanceMethods`)
+      // takes the rightmost segment.
+      let modName: string | null = null;
+      if (ts.isIdentifier(modArg)) {
+        const sym0 = checker.getSymbolAtLocation(modArg);
+        if (sym0) {
+          const sym = sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
+          modName = sym.name;
+        } else {
+          modName = modArg.text;
+        }
+      } else if (ts.isPropertyAccessExpression(modArg) && ts.isIdentifier(modArg.name)) {
+        modName = modArg.name.text;
+      }
+      if (!modName) return;
+
+      if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
+    });
   }
 
   return info;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -221,30 +221,13 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
           file: relPath,
         });
       } else if (ts.isVariableStatement(node) && isExported(node)) {
-        // Capture `export const X = { method() {...}, ... }` as a module.
-        // This is the shape every `include(Host, Mod)` mixin uses
-        // (see activesupport/src/include.ts), so without recording these
-        // the include-detection pass below has nothing to fold in.
+        // Capture `export const X = { method() {...}, foo, bar: ... }`
+        // as a module. This is the shape every `include(Host, Mod)`
+        // mixin uses (see activesupport/src/include.ts).
         for (const decl of node.declarationList.declarations) {
           if (!decl.name || !ts.isIdentifier(decl.name)) continue;
           if (!decl.initializer || !ts.isObjectLiteralExpression(decl.initializer)) continue;
-          const methods: MethodInfo[] = [];
-          for (const prop of decl.initializer.properties) {
-            let mname: string | null = null;
-            if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
-              mname = prop.name.text;
-            } else if (
-              ts.isPropertyAssignment(prop) &&
-              ts.isIdentifier(prop.name) &&
-              (ts.isFunctionExpression(prop.initializer) || ts.isArrowFunction(prop.initializer))
-            ) {
-              mname = prop.name.text;
-            }
-            if (!mname) continue;
-            const line =
-              prop.getSourceFile().getLineAndCharacterOfPosition(prop.getStart()).line + 1;
-            methods.push({ name: mname, visibility: "public", params: [], line, file: relPath });
-          }
+          const methods = harvestObjectLiteralMethods(decl.initializer, checker, relPath);
           if (methods.length === 0) continue;
           const modKey = `${relPath}:${decl.name.text}`;
           if (info.modules[modKey] || info.classes[modKey]) continue;
@@ -510,52 +493,58 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
       const hostInfo = info.classes[hostKey];
       if (!hostInfo) return;
 
+      const pushMethods = (methods: MethodInfo[]): void => {
+        for (const m of methods) {
+          if (hostInfo.instanceMethods.some((existing) => existing.name === m.name)) continue;
+          hostInfo.instanceMethods.push({ ...m, file: hostInfo.file });
+        }
+      };
+
       // Inline object literal: `include(Host, { foo() {...}, bar: ... })`.
-      // No module name to reference; push the methods directly onto the
-      // host's own instanceMethods so they appear at the host's TS file.
+      // No module name to reference — push methods straight onto the host.
       if (ts.isObjectLiteralExpression(modArg)) {
-        for (const prop of modArg.properties) {
-          let mname: string | null = null;
-          if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
-            mname = prop.name.text;
-          } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
-            mname = prop.name.text;
-          } else if (ts.isShorthandPropertyAssignment(prop)) {
-            mname = prop.name.text;
-          }
-          if (!mname) continue;
-          if (hostInfo.instanceMethods.some((m) => m.name === mname)) continue;
-          const line = prop.getSourceFile().getLineAndCharacterOfPosition(prop.getStart()).line + 1;
-          hostInfo.instanceMethods.push({
-            name: mname,
-            visibility: "public",
-            params: [],
-            line,
-            file: hostInfo.file,
-          });
+        pushMethods(harvestObjectLiteralMethods(modArg, checker, hostInfo.file ?? ""));
+        return;
+      }
+
+      // Property access: `include(Host, NS.InstanceMethods)`. The bare
+      // name "InstanceMethods" collides heavily across files (every
+      // concern declares one), so we can't push it onto host.extends
+      // and rely on path-proximity resolution. Resolve the property
+      // symbol back to its declaration and push its methods directly.
+      if (ts.isPropertyAccessExpression(modArg) && ts.isIdentifier(modArg.name)) {
+        const sym0 = checker.getSymbolAtLocation(modArg);
+        const resolved =
+          sym0 && sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
+        const propDecl = resolved?.valueDeclaration ?? resolved?.declarations?.[0];
+        if (
+          propDecl &&
+          ts.isVariableDeclaration(propDecl) &&
+          propDecl.initializer &&
+          ts.isObjectLiteralExpression(propDecl.initializer)
+        ) {
+          pushMethods(
+            harvestObjectLiteralMethods(propDecl.initializer, checker, hostInfo.file ?? ""),
+          );
         }
         return;
       }
 
-      // Resolve the module name. Imports may rebind it (`import { Math
-      // as MathMixin }`), so follow the alias to the original symbol's
-      // name when possible. Property access (`Mod.InstanceMethods`)
-      // takes the rightmost segment.
-      let modName: string | null = null;
+      // Bare identifier: `include(Host, Mod)`. Imports may rebind
+      // (`import { Math as MathMixin }`), so follow the alias to the
+      // original symbol's name and push it onto host.extends so
+      // compare.ts's getInherited() walker resolves it via tsByShort.
       if (ts.isIdentifier(modArg)) {
         const sym0 = checker.getSymbolAtLocation(modArg);
+        let modName: string;
         if (sym0) {
           const sym = sym0.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym0) : sym0;
           modName = sym.name;
         } else {
           modName = modArg.text;
         }
-      } else if (ts.isPropertyAccessExpression(modArg) && ts.isIdentifier(modArg.name)) {
-        modName = modArg.name.text;
+        if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
       }
-      if (!modName) return;
-
-      if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
     });
   }
 
@@ -588,6 +577,52 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
  *
  * Caller must already have ensured `node` is not exported.
  */
+/**
+ * Extract method names from an object literal — covers the four shapes
+ * Rails-style mixin modules use:
+ *
+ *   export const Mod = {
+ *     foo() { ... },                         // MethodDeclaration
+ *     bar: function () { ... },              // PropertyAssignment + FunctionExpression
+ *     baz: () => { ... },                    // PropertyAssignment + ArrowFunction
+ *     qux,                                   // ShorthandPropertyAssignment
+ *     quux: SomeNamespace.qux,               // PropertyAssignment + identifier/property-access (callable)
+ *   };
+ *
+ * Used both for `export const Mod = { ... }` module discovery and for
+ * resolving inline / property-access mod args to `include(Host, Mod)`.
+ */
+export function harvestObjectLiteralMethods(
+  obj: ts.ObjectLiteralExpression,
+  checker: ts.TypeChecker,
+  file: string,
+): MethodInfo[] {
+  const out: MethodInfo[] = [];
+  for (const prop of obj.properties) {
+    let mname: string | null = null;
+    if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
+      mname = prop.name.text;
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      mname = prop.name.text;
+    } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+      const init = prop.initializer;
+      if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
+        mname = prop.name.text;
+      } else {
+        // `foo: bar` / `foo: NS.bar` — count if the RHS resolves to a
+        // callable. Catches `readAttributeForValidation:
+        // _Validations.readAttributeForValidation` etc.
+        const t = checker.getTypeAtLocation(init);
+        if (t.getCallSignatures().length > 0) mname = prop.name.text;
+      }
+    }
+    if (!mname) continue;
+    const line = prop.getSourceFile().getLineAndCharacterOfPosition(prop.getStart()).line + 1;
+    out.push({ name: mname, visibility: "public", params: [], line, file });
+  }
+  return out;
+}
+
 export function extractFileLocalHelpers(
   node: ts.FunctionDeclaration | ts.VariableStatement,
   relPath: string,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -510,6 +510,33 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
       const hostInfo = info.classes[hostKey];
       if (!hostInfo) return;
 
+      // Inline object literal: `include(Host, { foo() {...}, bar: ... })`.
+      // No module name to reference; push the methods directly onto the
+      // host's own instanceMethods so they appear at the host's TS file.
+      if (ts.isObjectLiteralExpression(modArg)) {
+        for (const prop of modArg.properties) {
+          let mname: string | null = null;
+          if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
+            mname = prop.name.text;
+          } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+            mname = prop.name.text;
+          } else if (ts.isShorthandPropertyAssignment(prop)) {
+            mname = prop.name.text;
+          }
+          if (!mname) continue;
+          if (hostInfo.instanceMethods.some((m) => m.name === mname)) continue;
+          const line = prop.getSourceFile().getLineAndCharacterOfPosition(prop.getStart()).line + 1;
+          hostInfo.instanceMethods.push({
+            name: mname,
+            visibility: "public",
+            params: [],
+            line,
+            file: hostInfo.file,
+          });
+        }
+        return;
+      }
+
       // Resolve the module name. Imports may rebind it (`import { Math
       // as MathMixin }`), so follow the alias to the original symbol's
       // name when possible. Property access (`Mod.InstanceMethods`)


### PR DESCRIPTION
## Summary

Closes the false-positive class introduced by #959 where mixin wiring is correct in TS but lives in a sibling file. Three parts in \`extract-ts-api.ts\`:

1. Capture \`export const X = { method() {...}, ... }\` as a module entry. These were invisible — they aren't class declarations and the auto-module-from-file fallback skipped files that already declared a class/interface (e.g. \`predications.ts\` has \`interface PredicationHost\` plus \`const Predications = { eq, gt, ... }\` — the const was being lost).
2. Walk top-level \`include(Host, Mod)\` calls (from \`@blazetrails/activesupport\`). When \`Mod\` is a named binding/property access, push its name onto \`Host.extends\` so \`compare.ts\`'s existing \`getInherited()\` walker folds the methods in. When \`Mod\` is an inline object literal (e.g. \`include(Base, { foo() {}, ... })\`), push the methods straight onto \`Host.instanceMethods\` — same attribution as if they were declared on the class.
3. Resolve hosts through const-cast indirection. Arel uses \`const _NodeExpression = NodeExpression as unknown as new (...) => ...\` to preserve class identity through type narrowing; we follow \`getTypeAtLocation(hostArg).getConstructSignatures()[0].getReturnType().getSymbol()\` back to the original class declaration. Module identifier resolution follows import aliases too (\`import { Math as MathMixin }\` records as \`Math\`).

## Empirical impact

Clean build, comparing \`origin/main\` to this branch:

| package | baseline | with PR | Δ |
| - | - | - | - |
| arel | 71.0% (418/589) | 83.2% (490/589) | **+72** |
| activerecord | 87.3% (2871/3288) | 90.3% (2970/3288) | **+99** |
| activemodel | 95.8% (415/433) | 95.8% (415/433) | 0 |

Activemodel doesn't use \`include()\` yet; its remaining gaps are real mixin wiring still to be done in TS.

Per-file in arel:

\`\`\`
                  baseline   PR
node_expression    0/50      34/50    Predications + Math now reachable
infix_operation    0/52      39/52    Predications + Math
delete_manager     1/4       4/4      StatementMethods
update_manager     2/5       5/5      StatementMethods
\`\`\`

In activerecord, three \`include(Base, { ... })\` blocks in \`base.ts\` and one each in \`abstract-adapter.ts\` / \`test-adapter.ts\` / \`connection-pool/queue.ts\` get picked up by the inline-literal path.

## Test plan

- [x] \`npx vitest run scripts/api-compare/\` — 51/51 passes (no regressions in existing extractor tests)
- [x] Empirical \`pnpm api:compare\` runs — arel/activerecord numbers move strictly up; manual spot check of \`infix-operation.ts\`, \`delete-manager.ts\`, \`base.ts\` confirms the newly-counted methods are real

## Known gaps (follow-up)

- No new unit tests for the include-detection pass itself. The pass uses program-wide TypeChecker state and would need a multi-file virtual-program test harness to exercise in isolation. Existing test infra is single-file; refactoring to support that is out of scope here. Integration evidence (existing tests pass + empirical numbers monotonically up) is the practical validation.
- \`include(Host, Mod.SubMod)\` where \`SubMod\` is a property of a namespace and resolves to an object literal: we use the rightmost name (\`SubMod\`) but multiple includes can collide on that name. So far no observed wrong-attribution; would need a real conflict to reveal.