### PR TITLE
test(api-compare): virtual-program harness for include() detection

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -8,8 +8,14 @@
 
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
-import { resolveRelModule, extractClass, extractFileLocalHelpers } from "./extract-ts-api.js";
-import type { ClassInfo, MethodInfo } from "./types.js";
+import * as path from "path";
+import {
+  resolveRelModule,
+  extractClass,
+  extractFileLocalHelpers,
+  extractFromProgram,
+} from "./extract-ts-api.js";
+import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 function extractFromSource(source: string, className = "Foo"): ClassInfo {
   const filename = "virtual.ts";
@@ -212,5 +218,182 @@ describe("extractClass — internal tagging", () => {
     const ps = info.classMethods.find((m) => m.name === "privStatic")!;
     expect(ps.visibility).toBe("private");
     expect(ps.internal).toBe(true);
+  });
+});
+
+/**
+ * Multi-file virtual-program harness: spin up a TypeScript program from
+ * an in-memory map of `path → source`, then run `extractFromProgram`
+ * against it. Lets us exercise the include() detection pass which
+ * needs program-wide TypeChecker state across multiple files.
+ */
+function extractFromFiles(srcDir: string, files: Record<string, string>): PackageInfo {
+  // Synthesize an `@blazetrails/activesupport` stub so the include()
+  // detection's bare-specifier check succeeds in the virtual program.
+  const ASC_PATH = "/_node_modules/@blazetrails/activesupport.ts";
+  const all: Record<string, string> = {
+    [ASC_PATH]: `export function include(klass: any, mod: any): void {}`,
+  };
+  for (const [rel, text] of Object.entries(files)) all[`${srcDir}/${rel}`] = text;
+
+  const fileNames = Object.keys(files).map((p) => `${srcDir}/${p}`);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) =>
+      all[name] != null
+        ? ts.createSourceFile(name, all[name], ts.ScriptTarget.Latest, true)
+        : undefined,
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => undefined,
+    getCurrentDirectory: () => "/",
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name in all,
+    readFile: (name) => all[name],
+    resolveModuleNames: (moduleNames, containingFile) =>
+      moduleNames.map((m) => {
+        if (m === "@blazetrails/activesupport") {
+          return { resolvedFileName: ASC_PATH, extension: ts.Extension.Ts };
+        }
+        if (m.startsWith("./") || m.startsWith("../")) {
+          const dir = path.posix.dirname(containingFile);
+          const noExt = m.replace(/\.js$/, "");
+          const candidate = path.posix.normalize(`${dir}/${noExt}.ts`);
+          if (candidate in all) return { resolvedFileName: candidate, extension: ts.Extension.Ts };
+        }
+        return undefined;
+      }),
+  };
+  const program = ts.createProgram(
+    fileNames,
+    { noLib: true, target: ts.ScriptTarget.Latest, module: ts.ModuleKind.ESNext },
+    host,
+  );
+  return extractFromProgram(program, srcDir);
+}
+
+describe("extractFromProgram — include() detection", () => {
+  it("records `export const X = { ... }` as a module with method names", () => {
+    const info = extractFromFiles("/p", {
+      "predications.ts": `
+        export const Predications = {
+          eq() {},
+          gt: function () {},
+          lt: () => {},
+        };
+      `,
+    });
+    const mod = info.modules["predications.ts:Predications"];
+    expect(mod).toBeDefined();
+    expect(mod.instanceMethods.map((m) => m.name).sort()).toEqual(["eq", "gt", "lt"]);
+  });
+
+  it("captures shorthand-property and callable-RHS object members", () => {
+    // Mirrors packages/activerecord/src/locking/pessimistic.ts — bug
+    // flagged in PR #961 review.
+    const info = extractFromFiles("/p", {
+      "pessimistic.ts": `
+        export function lockBang(): void {}
+        export function withLock(): void {}
+        function _readForValidation(): string { return ""; }
+        export const InstanceMethods = {
+          lockBang,
+          withLock,
+          readAttributeForValidation: _readForValidation,
+        };
+      `,
+    });
+    const mod = info.modules["pessimistic.ts:InstanceMethods"];
+    expect(mod.instanceMethods.map((m) => m.name).sort()).toEqual([
+      "lockBang",
+      "readAttributeForValidation",
+      "withLock",
+    ]);
+  });
+
+  it("pushes a bare-identifier mod arg onto host.extends", () => {
+    const info = extractFromFiles("/p", {
+      "math.ts": `export const Math = { add() {}, mul() {} };`,
+      "node.ts": `
+        export class Node {}
+      `,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { Node } from "./node.js";
+        import { Math } from "./math.js";
+        include(Node, Math);
+      `,
+    });
+    expect(info.classes["node.ts:Node"].extends).toContain("Math");
+  });
+
+  it("follows import aliases (`Math as MathMixin`) to the original module name", () => {
+    const info = extractFromFiles("/p", {
+      "math.ts": `export const Math = { add() {} };`,
+      "node.ts": `export class Node {}`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { Node } from "./node.js";
+        import { Math as MathMixin } from "./math.js";
+        include(Node, MathMixin);
+      `,
+    });
+    expect(info.classes["node.ts:Node"].extends).toContain("Math");
+  });
+
+  it("resolves property-access mod arg by harvesting the declaration's methods directly", () => {
+    // Mirrors `include(Base, LockingPessimistic.InstanceMethods)`. The
+    // bare name "InstanceMethods" collides across files, so methods
+    // must be pushed onto the host directly rather than via name lookup.
+    const info = extractFromFiles("/p", {
+      "pessimistic.ts": `
+        export function lockBang(): void {}
+        export const InstanceMethods = { lockBang };
+      `,
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import * as LockingPessimistic from "./pessimistic.js";
+        import { Base } from "./base.js";
+        include(Base, LockingPessimistic.InstanceMethods);
+      `,
+    });
+    const base = info.classes["base.ts:Base"];
+    expect(base.instanceMethods.map((m) => m.name)).toContain("lockBang");
+    // Should NOT push "InstanceMethods" onto extends — that's the
+    // collision-prone path the fix avoids.
+    expect(base.extends).not.toContain("InstanceMethods");
+  });
+
+  it("pushes inline object-literal mod methods directly onto the host", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `export class Base {}`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { Base } from "./base.js";
+        include(Base, { foo() {}, bar: () => {}, baz: function () {} });
+      `,
+    });
+    expect(info.classes["base.ts:Base"].instanceMethods.map((m) => m.name).sort()).toEqual([
+      "bar",
+      "baz",
+      "foo",
+    ]);
+  });
+
+  it("resolves a const-cast host (`const _X = X as unknown as new (...) => X`)", () => {
+    // Mirrors arel/index.ts post-#814.
+    const info = extractFromFiles("/p", {
+      "predications.ts": `export const Predications = { eq() {} };`,
+      "node-expression.ts": `export class NodeExpression {}`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { NodeExpression } from "./node-expression.js";
+        import { Predications } from "./predications.js";
+        const _NodeExpression = NodeExpression as unknown as new (...args: any[]) => NodeExpression;
+        include(_NodeExpression, Predications);
+      `,
+    });
+    expect(info.classes["node-expression.ts:NodeExpression"].extends).toContain("Predications");
   });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -381,6 +381,39 @@ describe("extractFromProgram — include() detection", () => {
     ]);
   });
 
+  it("ignores `include()` calls when the file doesn't import from @blazetrails/activesupport", () => {
+    // A local `include` function with the same name shouldn't be
+    // confused for the activesupport mixin — the detection pass keys
+    // off the import specifier.
+    const info = extractFromFiles("/p", {
+      "node.ts": `export class Node {}`,
+      "math.ts": `export const Math = { add() {} };`,
+      "wire.ts": `
+        import { Node } from "./node.js";
+        import { Math } from "./math.js";
+        function include(a: any, b: any) {}
+        include(Node, Math);
+      `,
+    });
+    expect(info.classes["node.ts:Node"].extends).not.toContain("Math");
+  });
+
+  it("dedupes repeated include() calls for the same (host, mod) pair", () => {
+    const info = extractFromFiles("/p", {
+      "node.ts": `export class Node {}`,
+      "math.ts": `export const Math = { add() {} };`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { Node } from "./node.js";
+        import { Math } from "./math.js";
+        include(Node, Math);
+        include(Node, Math);
+      `,
+    });
+    const ext = info.classes["node.ts:Node"].extends.filter((e) => e === "Math");
+    expect(ext).toHaveLength(1);
+  });
+
   it("resolves a const-cast host (`const _X = X as unknown as new (...) => X`)", () => {
     // Mirrors arel/index.ts post-#814.
     const info = extractFromFiles("/p", {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -51,8 +51,6 @@ interface PendingReExport {
 
 function extractPackage(pkgName: string, srcDir: string): PackageInfo {
   const files = getAllTsFiles(srcDir);
-  const info: PackageInfo = { classes: {}, modules: {}, fileFunctions: {} };
-  const pendingReExports: PendingReExport[] = [];
 
   // Create a TypeScript program
   const dirName = PACKAGE_DIR_OVERRIDES[pkgName] ?? pkgName;
@@ -80,6 +78,17 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
   }
 
   const program = ts.createProgram(files, compilerOptions);
+  return extractFromProgram(program, srcDir);
+}
+
+/**
+ * Walk `program`'s source files and produce a PackageInfo. Split out
+ * from `extractPackage` so tests can drive it with synthetic in-memory
+ * programs without needing a real package directory + tsconfig.
+ */
+export function extractFromProgram(program: ts.Program, srcDir: string): PackageInfo {
+  const info: PackageInfo = { classes: {}, modules: {}, fileFunctions: {} };
+  const pendingReExports: PendingReExport[] = [];
   const checker = program.getTypeChecker();
 
   for (const sourceFile of program.getSourceFiles()) {


### PR DESCRIPTION
## Summary

Follow-up to #961 closing its known gap. Refactors \`extractPackage\` to expose \`extractFromProgram(program, srcDir)\` and adds a vitest harness (\`extractFromFiles\`) that builds an in-memory TypeScript program from a path→source map. A custom \`resolveModuleNames\` shim maps the \`@blazetrails/activesupport\` bare specifier to a virtual stub, so the include-detection pass actually fires in tests.

## New tests

- \`export const X = { ... }\` records as a module
- shorthand-property + callable-RHS object members captured (regression for the Copilot review on #961)
- bare-identifier mod arg → \`host.extends\`
- import alias rename (\`Math as MathMixin\`) → original module name
- property-access \`Mod.InstanceMethods\` → methods harvested directly onto host (asserts no name push to extends — the path #961's review fix avoided)
- inline object-literal include arg
- const-cast host (\`const _X = X as unknown as new (...) => X\`) — mirrors arel \`index.ts\` post-#814

## Test plan

- [x] \`npx vitest run scripts/api-compare/\` — 58/58 (15 + 7 new)
- [x] \`pnpm api:compare\` — manifest output unchanged on real packages (refactor only adds an export, no behavioral change)