### PR TITLE
feat(arel): mix FactoryMethods into Node and TreeManager

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -459,14 +459,6 @@ export class Attribute extends Node {
     return new NamedFunction("FLOOR", [this]);
   }
 
-  // -- Type casting --
-
-  cast(asType: string): NamedFunction {
-    return new NamedFunction("CAST", [
-      new SqlLiteral(`${this.relation.name}.${this.name} AS ${asType}`),
-    ]);
-  }
-
   // -- Extract --
 
   extract(field: string): Extract {

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -52,6 +52,10 @@ describe("TestFactoryMethods", () => {
     const fn = users.cast(users.get("age"), "VARCHAR");
     expect(fn).toBeInstanceOf(Nodes.NamedFunction);
     expect(fn.name).toBe("CAST");
+    // Mirrors Rails: `cast` builds NamedFunction("CAST", [name.as(type)]),
+    // not a string-interpolated SqlLiteral. The compiled SQL must reference
+    // the column properly rather than "[object Object] AS VARCHAR".
+    expect(new Visitors.ToSql().compile(fn)).toBe('CAST("users"."age" AS VARCHAR)');
   });
 
   it("create true", () => {

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -65,4 +65,22 @@ describe("TestFactoryMethods", () => {
     expect(f).toBeInstanceOf(Nodes.False);
     expect(new Visitors.ToSql().compile(f)).toBe("FALSE");
   });
+
+  // Regression: verifies the include(Node, FactoryMethods) call in index.ts
+  // actually attached methods to Node.prototype. If that wiring is dropped,
+  // an arbitrary Node subclass (Equality below) silently loses the API.
+  describe("FactoryMethods is mixed into every Node subclass", () => {
+    const eq = users.get("id").eq(1);
+    it("createTrue available on Equality", () => {
+      expect(eq.createTrue()).toBeInstanceOf(Nodes.True);
+    });
+    it("grouping available on Equality", () => {
+      expect(eq.grouping(eq)).toBeInstanceOf(Nodes.Grouping);
+    });
+    it("createAnd available on Equality", () => {
+      const and = eq.createAnd([eq, eq]);
+      expect(and).toBeInstanceOf(Nodes.And);
+      expect(and.children.length).toBe(2);
+    });
+  });
 });

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -1,5 +1,6 @@
 import type { Node } from "./nodes/node.js";
 import { And } from "./nodes/and.js";
+import { As } from "./nodes/binary.js";
 import type { Join } from "./nodes/binary.js";
 import { False } from "./nodes/false.js";
 import { Grouping } from "./nodes/grouping.js";
@@ -14,16 +15,19 @@ import { On } from "./nodes/unary.js";
 /**
  * Mirrors: Arel::FactoryMethods (Ruby module mixed into Node and TreeManager).
  *
- * Apply with `include(Klass, FactoryMethods)` from @blazetrails/activesupport
- * and augment the class type with `Included<typeof FactoryMethods>`.
+ * Apply the runtime mixin with `include(Klass, FactoryMethods)` from
+ * @blazetrails/activesupport. Model the added methods in TypeScript by
+ * interface-merging `FactoryMethodsModule` (declared below) into the
+ * relevant class types — see Node, TreeManager, Table, and SelectManager.
  *
- * The explicit interface annotation below is load-bearing: without it, the
- * Node↔FactoryMethods type cycle (Node interface-merges
- * `Included<typeof FactoryMethods>`; FactoryMethods values reference Node)
- * forces tsc into a structural fallback when emitting composite .d.ts,
- * widening FactoryMethods to `Record<string, ...>` and reintroducing a
- * string index signature into Node. Pinning the type breaks the cycle
- * for declaration emit.
+ * Why an explicit `FactoryMethodsModule` interface (vs. deriving from
+ * `typeof FactoryMethods` via `Included<>`): the Node↔FactoryMethods
+ * type cycle (Node interface-merges this module; FactoryMethods values
+ * reference Node) forces tsc into a structural fallback when emitting
+ * composite .d.ts, widening `typeof FactoryMethods` to
+ * `Record<string, ...>` and reintroducing a string index signature into
+ * Node. Pinning the module type to a hand-written interface gives tsc
+ * a fixed point and avoids the fallback.
  */
 export interface FactoryMethodsModule {
   createTrue(): True;
@@ -90,7 +94,11 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new NamedFunction("COALESCE", exprs);
   },
 
+  // Mirrors: Arel::FactoryMethods#cast — `Nodes::NamedFunction.new "CAST",
+  // [name.as(type)]`. Builds an `As` AST node so the visitor compiles it
+  // correctly (`CAST(expr AS type)`); the previous string-interpolation
+  // form stringified Node instances as `"[object Object]"`.
   cast(expr: Node, type: string): NamedFunction {
-    return new NamedFunction("CAST", [new SqlLiteral(`${expr} AS ${type}`)]);
+    return new NamedFunction("CAST", [new As(expr, new SqlLiteral(type))]);
   },
 };

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -16,8 +16,34 @@ import { On } from "./nodes/unary.js";
  *
  * Apply with `include(Klass, FactoryMethods)` from @blazetrails/activesupport
  * and augment the class type with `Included<typeof FactoryMethods>`.
+ *
+ * The explicit interface annotation below is load-bearing: without it, the
+ * Node↔FactoryMethods type cycle (Node interface-merges
+ * `Included<typeof FactoryMethods>`; FactoryMethods values reference Node)
+ * forces tsc into a structural fallback when emitting composite .d.ts,
+ * widening FactoryMethods to `Record<string, ...>` and reintroducing a
+ * string index signature into Node. Pinning the type breaks the cycle
+ * for declaration emit.
  */
-export const FactoryMethods = {
+export interface FactoryMethodsModule {
+  createTrue(): True;
+  createFalse(): False;
+  createTableAlias(relation: Node, name: string): TableAlias;
+  createJoin(
+    to: Node,
+    constraint?: Node | null,
+    klass?: new (left: Node, right: Node | null) => Join,
+  ): Join;
+  createStringJoin(to: string | Node): StringJoin;
+  createAnd(clauses: Node[]): And;
+  createOn(expr: Node): On;
+  grouping(expr: Node): Grouping;
+  lower(column: Node): NamedFunction;
+  coalesce(...exprs: Node[]): NamedFunction;
+  cast(expr: Node, type: string): NamedFunction;
+}
+
+export const FactoryMethods: FactoryMethodsModule = {
   createTrue(): True {
     return new True();
   },

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -1,8 +1,70 @@
 import type { Node } from "./nodes/node.js";
+import { And } from "./nodes/and.js";
+import type { Join } from "./nodes/binary.js";
+import { False } from "./nodes/false.js";
+import { Grouping } from "./nodes/grouping.js";
+import { InnerJoin } from "./nodes/inner-join.js";
+import { NamedFunction } from "./nodes/named-function.js";
+import { SqlLiteral } from "./nodes/sql-literal.js";
+import { StringJoin } from "./nodes/string-join.js";
+import { TableAlias } from "./nodes/table-alias.js";
+import { True } from "./nodes/true.js";
+import { On } from "./nodes/unary.js";
 
-export interface FactoryMethods {
-  createStringJoin(to: string | Node): Node;
-  createTableAlias(relation: Node, name: string): Node;
-  createJoin(to: Node, constraint?: Node): Node;
-  grouping(expr: Node): Node;
-}
+/**
+ * Mirrors: Arel::FactoryMethods (Ruby module mixed into Node and TreeManager).
+ *
+ * Apply with `include(Klass, FactoryMethods)` from @blazetrails/activesupport
+ * and augment the class type with `Included<typeof FactoryMethods>`.
+ */
+export const FactoryMethods = {
+  createTrue(): True {
+    return new True();
+  },
+
+  createFalse(): False {
+    return new False();
+  },
+
+  createTableAlias(relation: Node, name: string): TableAlias {
+    return new TableAlias(relation, name);
+  },
+
+  createJoin(
+    to: Node,
+    constraint?: Node | null,
+    klass?: new (left: Node, right: Node | null) => Join,
+  ): Join {
+    const JoinKlass = klass ?? InnerJoin;
+    return new JoinKlass(to, constraint ?? null);
+  },
+
+  createStringJoin(to: string | Node): StringJoin {
+    const node = typeof to === "string" ? new SqlLiteral(to) : to;
+    return new StringJoin(node, null);
+  },
+
+  createAnd(clauses: Node[]): And {
+    return new And(clauses);
+  },
+
+  createOn(expr: Node): On {
+    return new On(expr);
+  },
+
+  grouping(expr: Node): Grouping {
+    return new Grouping(expr);
+  },
+
+  lower(column: Node): NamedFunction {
+    return new NamedFunction("LOWER", [column]);
+  },
+
+  coalesce(...exprs: Node[]): NamedFunction {
+    return new NamedFunction("COALESCE", exprs);
+  },
+
+  cast(expr: Node, type: string): NamedFunction {
+    return new NamedFunction("CAST", [new SqlLiteral(`${expr} AS ${type}`)]);
+  },
+};

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -46,8 +46,12 @@ const _Node = Node as unknown as new (...args: any[]) => Node;
 const _NodeExpression = NodeExpression as unknown as new (...args: any[]) => NodeExpression;
 const _TreeManager = TreeManager as unknown as new (...args: any[]) => TreeManager;
 /* eslint-enable @typescript-eslint/no-explicit-any */
-include(_Node, FactoryMethods);
-include(_TreeManager, FactoryMethods);
+// The cast matches include()'s runtime constraint. FactoryMethods is
+// typed as the explicit FactoryMethodsModule interface (no index
+// signature) to break the Node ↔ FactoryMethods type cycle.
+type RuntimeModule = Record<string, (...args: unknown[]) => unknown>;
+include(_Node, FactoryMethods as unknown as RuntimeModule);
+include(_TreeManager, FactoryMethods as unknown as RuntimeModule);
 include(_NodeExpression, Predications);
 include(_NodeExpression, MathMixin);
 include(InfixOperation, Predications);

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -6,7 +6,8 @@ export { SelectManager } from "./select-manager.js";
 export { InsertManager } from "./insert-manager.js";
 export { UpdateManager } from "./update-manager.js";
 export { DeleteManager } from "./delete-manager.js";
-export { TreeManager } from "./tree-manager.js";
+import { TreeManager } from "./tree-manager.js";
+export { TreeManager };
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
 export { quoteArrayLiteral } from "./quote-array.js";
 
@@ -34,13 +35,19 @@ _registerCteFactory((name, relation) => new Cte(name, relation));
 // the mixin modules transitively import those files via their target-node
 // imports, creating a module-load cycle.
 import { include } from "@blazetrails/activesupport";
+import { Node } from "./nodes/node.js";
 import { NodeExpression } from "./nodes/node-expression.js";
 import { InfixOperation } from "./nodes/infix-operation.js";
 import { Predications } from "./predications.js";
 import { Math as MathMixin } from "./math.js";
+import { FactoryMethods } from "./factory-methods.js";
 /* eslint-disable @typescript-eslint/no-explicit-any -- abstract class coercion for include() */
+const _Node = Node as unknown as new (...args: any[]) => Node;
 const _NodeExpression = NodeExpression as unknown as new (...args: any[]) => NodeExpression;
+const _TreeManager = TreeManager as unknown as new (...args: any[]) => TreeManager;
 /* eslint-enable @typescript-eslint/no-explicit-any */
+include(_Node, FactoryMethods);
+include(_TreeManager, FactoryMethods);
 include(_NodeExpression, Predications);
 include(_NodeExpression, MathMixin);
 include(InfixOperation, Predications);

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -1,8 +1,11 @@
 /**
  * Base class for all AST nodes in Arel.
  *
- * Mirrors: Arel::Nodes::Node
+ * Mirrors: Arel::Nodes::Node — which `include`s Arel::FactoryMethods.
+ * Runtime mixin wiring lives in ../index.ts to avoid a module-load cycle
+ * (factory-methods.ts imports concrete node subclasses).
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class Node {
   abstract accept<T>(visitor: NodeVisitor<T>): T;
 
@@ -165,4 +168,30 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
   }
 
   return String(value);
+}
+
+// Methods supplied by the FactoryMethods mixin (runtime wiring in ../index.ts).
+// Declared explicitly rather than via `Included<typeof FactoryMethods>` because
+// that helper introduces an index signature that breaks property typing on Node
+// subclasses (e.g. Attribute's `relation`, `name`, etc.).
+//
+// Forward-declared types here (vs. importing the concrete classes) avoid a
+// module-load cycle: factory-methods.ts imports Node-extending subclasses.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface Node {
+  createTrue(): import("./true.js").True;
+  createFalse(): import("./false.js").False;
+  createTableAlias(relation: Node, name: string): import("./table-alias.js").TableAlias;
+  createJoin(
+    to: Node,
+    constraint?: Node | null,
+    klass?: new (left: Node, right: Node | null) => import("./binary.js").Join,
+  ): import("./binary.js").Join;
+  createStringJoin(to: string | Node): import("./string-join.js").StringJoin;
+  createAnd(clauses: Node[]): import("./and.js").And;
+  createOn(expr: Node): import("./unary.js").On;
+  grouping(expr: Node): import("./grouping.js").Grouping;
+  lower(column: Node): import("./named-function.js").NamedFunction;
+  coalesce(...exprs: Node[]): import("./named-function.js").NamedFunction;
+  cast(expr: Node, type: string): import("./named-function.js").NamedFunction;
 }

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -171,27 +171,14 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
 }
 
 // Methods supplied by the FactoryMethods mixin (runtime wiring in ../index.ts).
-// Declared explicitly rather than via `Included<typeof FactoryMethods>` because
-// that helper introduces an index signature that breaks property typing on Node
-// subclasses (e.g. Attribute's `relation`, `name`, etc.).
-//
-// Forward-declared types here (vs. importing the concrete classes) avoid a
-// module-load cycle: factory-methods.ts imports Node-extending subclasses.
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface Node {
-  createTrue(): import("./true.js").True;
-  createFalse(): import("./false.js").False;
-  createTableAlias(relation: Node, name: string): import("./table-alias.js").TableAlias;
-  createJoin(
-    to: Node,
-    constraint?: Node | null,
-    klass?: new (left: Node, right: Node | null) => import("./binary.js").Join,
-  ): import("./binary.js").Join;
-  createStringJoin(to: string | Node): import("./string-join.js").StringJoin;
-  createAnd(clauses: Node[]): import("./and.js").And;
-  createOn(expr: Node): import("./unary.js").On;
-  grouping(expr: Node): import("./grouping.js").Grouping;
-  lower(column: Node): import("./named-function.js").NamedFunction;
-  coalesce(...exprs: Node[]): import("./named-function.js").NamedFunction;
-  cast(expr: Node, type: string): import("./named-function.js").NamedFunction;
-}
+// The aliased import keeps this type-only — pulling factory-methods.ts into
+// the static import graph here would create a module-load cycle, since it
+// imports concrete Node subclasses. The explicit `FactoryMethodsModule`
+// interface (vs. `Included<typeof FactoryMethods>`) is required: under
+// composite/declaration emit, the cycle Node ↔ FactoryMethods would force
+// tsc to fall back to a structural shape with a string index signature.
+type _FactoryMethodsModule = import("../factory-methods.js").FactoryMethodsModule;
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type,
+   @typescript-eslint/no-unsafe-declaration-merging */
+export interface Node extends _FactoryMethodsModule {}

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -529,8 +529,8 @@ export class SelectManager extends TreeManager {
   // -- FactoryMethods (via TreeManager) --
   // createTrue/createFalse/createTableAlias/createStringJoin/createAnd/
   // createOn/grouping/lower/coalesce/cast are mixed in from
-  // Arel::FactoryMethods (see ../factory-methods.ts and the include() call
-  // in ../index.ts). createJoin is overridden below because Rails' Arel
+  // Arel::FactoryMethods (see ./factory-methods.ts and the include() call
+  // in ./index.ts). createJoin is overridden below because Rails' Arel
   // wraps the constraint in an `On` node when sourced from a SelectManager.
 
   private static readonly defaultJoinConstructor = InnerJoin;

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -34,6 +34,7 @@ import { InsertManager } from "./insert-manager.js";
  *
  * Mirrors: Arel::SelectManager
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SelectManager extends TreeManager {
   readonly ast: SelectStatement;
 
@@ -542,7 +543,7 @@ export class SelectManager extends TreeManager {
 
   createJoin(
     to: Node,
-    constraint?: Node,
+    constraint?: Node | null,
     klass?: new (left: Node, right: Node | null) => Join,
   ): Join {
     const JoinKlass =
@@ -586,3 +587,11 @@ export class SelectManager extends TreeManager {
     return this;
   }
 }
+
+// Surface the inherited FactoryMethods on select-manager.ts so api:compare
+// matches them against select_manager.rb.
+type _FactoryMethodsModule = import("./factory-methods.js").FactoryMethodsModule;
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type,
+   @typescript-eslint/no-unsafe-declaration-merging */
+export interface SelectManager extends _FactoryMethodsModule {}

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -24,11 +24,8 @@ import { DeleteManager } from "./delete-manager.js";
 import type { UpdateValues } from "./crud.js";
 import { Comment } from "./nodes/comment.js";
 import { Lateral } from "./nodes/unary.js";
-import { True } from "./nodes/true.js";
-import { False } from "./nodes/false.js";
 import { And } from "./nodes/and.js";
 import { Grouping } from "./nodes/grouping.js";
-import { NamedFunction } from "./nodes/named-function.js";
 import { JoinSource } from "./nodes/join-source.js";
 import { InsertManager } from "./insert-manager.js";
 
@@ -529,31 +526,12 @@ export class SelectManager extends TreeManager {
   }
 
   // -- FactoryMethods (via TreeManager) --
+  // createTrue/createFalse/createTableAlias/createStringJoin/createAnd/
+  // createOn/grouping/lower/coalesce/cast are mixed in from
+  // Arel::FactoryMethods (see ../factory-methods.ts and the include() call
+  // in ../index.ts). createJoin is overridden below because Rails' Arel
+  // wraps the constraint in an `On` node when sourced from a SelectManager.
 
-  /**
-   * Factory: create a TRUE node.
-   */
-  createTrue(): True {
-    return new True();
-  }
-
-  /**
-   * Factory: create a FALSE node.
-   */
-  createFalse(): False {
-    return new False();
-  }
-
-  /**
-   * Factory: create a TableAlias node.
-   */
-  createTableAlias(relation: Node, name: string): TableAlias {
-    return new TableAlias(relation, name);
-  }
-
-  /**
-   * Factory: create a join node.
-   */
   private static readonly defaultJoinConstructor = InnerJoin;
 
   private static isJoinConstructor(
@@ -572,14 +550,6 @@ export class SelectManager extends TreeManager {
         ? klass
         : SelectManager.defaultJoinConstructor;
     return new JoinKlass(to, constraint ? new On(constraint) : null);
-  }
-
-  /**
-   * Factory: create a StringJoin node.
-   */
-  createStringJoin(to: string | Node): StringJoin {
-    const node = typeof to === "string" ? new SqlLiteral(to) : to;
-    return new StringJoin(node, null);
   }
 
   /**
@@ -614,47 +584,5 @@ export class SelectManager extends TreeManager {
   appendJoinNode(node: Join): this {
     this.core.source.right.push(node);
     return this;
-  }
-
-  /**
-   * Factory: create an AND node.
-   */
-  createAnd(nodes: Node[]): And {
-    return new And(nodes);
-  }
-
-  /**
-   * Factory: create an On node.
-   */
-  createOn(expr: Node): On {
-    return new On(expr);
-  }
-
-  /**
-   * Factory: create a Grouping node.
-   */
-  grouping(expr: Node): Grouping {
-    return new Grouping(expr);
-  }
-
-  /**
-   * Factory: LOWER function.
-   */
-  lower(column: Node): NamedFunction {
-    return new NamedFunction("LOWER", [column]);
-  }
-
-  /**
-   * Factory: COALESCE function.
-   */
-  coalesce(...args: Node[]): NamedFunction {
-    return new NamedFunction("COALESCE", args);
-  }
-
-  /**
-   * Factory: CAST function.
-   */
-  cast(expr: Node, type: string): NamedFunction {
-    return new NamedFunction("CAST", [new SqlLiteral(`${expr} AS ${type}`)]);
   }
 }

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -4,15 +4,8 @@ import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Node, NodeVisitor } from "./nodes/node.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
-import { StringJoin } from "./nodes/string-join.js";
 import type { Join } from "./nodes/binary.js";
-import { On } from "./nodes/unary.js";
 import { TableAlias } from "./nodes/table-alias.js";
-import { True } from "./nodes/true.js";
-import { False } from "./nodes/false.js";
-import { And } from "./nodes/and.js";
-import { Grouping } from "./nodes/grouping.js";
-import { NamedFunction } from "./nodes/named-function.js";
 
 /**
  * Table — represents a database table.
@@ -108,34 +101,6 @@ export class Table extends Node {
   createJoin(to: Node | string, constraint?: Node | string | null, klass?: typeof InnerJoin): Join {
     const JoinClass = klass && typeof klass === "function" ? klass : InnerJoin;
     return new JoinClass(to as Node, (constraint ?? null) as Node | null);
-  }
-
-  /**
-   * Factory: create a StringJoin node.
-   *
-   * Mirrors: Arel::Table#create_string_join
-   */
-  createStringJoin(to: string | Node): StringJoin {
-    const node = typeof to === "string" ? new SqlLiteral(to) : to;
-    return new StringJoin(node, null);
-  }
-
-  /**
-   * Factory: create an On node.
-   *
-   * Mirrors: Arel::Table#create_on
-   */
-  createOn(expr: Node): On {
-    return new On(expr);
-  }
-
-  /**
-   * Factory: create a TableAlias node.
-   *
-   * Mirrors: Arel::Table#create_table_alias
-   */
-  createTableAlias(relation: Node, name: string): TableAlias {
-    return new TableAlias(relation, name);
   }
 
   /**
@@ -240,69 +205,6 @@ export class Table extends Node {
    */
   as(aliasName: string): TableAlias {
     return new TableAlias(this, aliasName);
-  }
-
-  /**
-   * Factory: create a TRUE node.
-   *
-   * Mirrors: Arel::FactoryMethods#create_true
-   */
-  createTrue(): True {
-    return new True();
-  }
-
-  /**
-   * Factory: create a FALSE node.
-   *
-   * Mirrors: Arel::FactoryMethods#create_false
-   */
-  createFalse(): False {
-    return new False();
-  }
-
-  /**
-   * Factory: create an AND node.
-   *
-   * Mirrors: Arel::FactoryMethods#create_and
-   */
-  createAnd(nodes: Node[]): And {
-    return new And(nodes);
-  }
-
-  /**
-   * Factory: create a Grouping node.
-   *
-   * Mirrors: Arel::FactoryMethods#grouping
-   */
-  grouping(expr: Node): Grouping {
-    return new Grouping(expr);
-  }
-
-  /**
-   * Factory: LOWER function.
-   *
-   * Mirrors: Arel::FactoryMethods#lower
-   */
-  lower(column: Node): NamedFunction {
-    return new NamedFunction("LOWER", [column]);
-  }
-
-  /**
-   * Factory: COALESCE function.
-   *
-   * Mirrors: Arel::FactoryMethods#coalesce
-   */
-  coalesce(...args: Node[]): NamedFunction {
-    return new NamedFunction("COALESCE", args);
-  }
-
-  /**
-   * Factory: CAST function.
-   *
-   * Mirrors: Arel::FactoryMethods#cast
-   */
-  cast(expr: Node, type: string): NamedFunction {
-    return new NamedFunction("CAST", [new SqlLiteral(`${expr} AS ${type}`)]);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -12,6 +12,7 @@ import { TableAlias } from "./nodes/table-alias.js";
  *
  * Mirrors: Arel::Table
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Table extends Node {
   static engine: unknown = null;
 
@@ -211,3 +212,12 @@ export class Table extends Node {
     return visitor.visit(this);
   }
 }
+
+// Surface the inherited FactoryMethods on table.ts so api:compare
+// matches them against table.rb (Rails Arel's `Table` includes
+// FactoryMethods directly, expecting the methods to belong here).
+type _FactoryMethodsModule = import("./factory-methods.js").FactoryMethodsModule;
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type,
+   @typescript-eslint/no-unsafe-declaration-merging */
+export interface Table extends _FactoryMethodsModule {}

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -58,6 +58,7 @@ export class StatementMethods {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class TreeManager {
   abstract readonly ast: Node;
 
@@ -75,4 +76,24 @@ export abstract class TreeManager {
     // would always be the generic visitor.
     return this.ast.toSql();
   }
+}
+
+// Methods supplied by the FactoryMethods mixin (runtime wiring in ./index.ts).
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface TreeManager {
+  createTrue(): import("./nodes/true.js").True;
+  createFalse(): import("./nodes/false.js").False;
+  createTableAlias(relation: Node, name: string): import("./nodes/table-alias.js").TableAlias;
+  createJoin(
+    to: Node,
+    constraint?: Node | null,
+    klass?: new (left: Node, right: Node | null) => import("./nodes/binary.js").Join,
+  ): import("./nodes/binary.js").Join;
+  createStringJoin(to: string | Node): import("./nodes/string-join.js").StringJoin;
+  createAnd(clauses: Node[]): import("./nodes/and.js").And;
+  createOn(expr: Node): import("./nodes/unary.js").On;
+  grouping(expr: Node): import("./nodes/grouping.js").Grouping;
+  lower(column: Node): import("./nodes/named-function.js").NamedFunction;
+  coalesce(...exprs: Node[]): import("./nodes/named-function.js").NamedFunction;
+  cast(expr: Node, type: string): import("./nodes/named-function.js").NamedFunction;
 }

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -79,21 +79,10 @@ export abstract class TreeManager {
 }
 
 // Methods supplied by the FactoryMethods mixin (runtime wiring in ./index.ts).
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface TreeManager {
-  createTrue(): import("./nodes/true.js").True;
-  createFalse(): import("./nodes/false.js").False;
-  createTableAlias(relation: Node, name: string): import("./nodes/table-alias.js").TableAlias;
-  createJoin(
-    to: Node,
-    constraint?: Node | null,
-    klass?: new (left: Node, right: Node | null) => import("./nodes/binary.js").Join,
-  ): import("./nodes/binary.js").Join;
-  createStringJoin(to: string | Node): import("./nodes/string-join.js").StringJoin;
-  createAnd(clauses: Node[]): import("./nodes/and.js").And;
-  createOn(expr: Node): import("./nodes/unary.js").On;
-  grouping(expr: Node): import("./nodes/grouping.js").Grouping;
-  lower(column: Node): import("./nodes/named-function.js").NamedFunction;
-  coalesce(...exprs: Node[]): import("./nodes/named-function.js").NamedFunction;
-  cast(expr: Node, type: string): import("./nodes/named-function.js").NamedFunction;
-}
+// See node.ts for why this uses the explicit `FactoryMethodsModule` interface
+// rather than `Included<typeof FactoryMethods>`.
+type _FactoryMethodsModule = import("./factory-methods.js").FactoryMethodsModule;
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type,
+   @typescript-eslint/no-unsafe-declaration-merging */
+export interface TreeManager extends _FactoryMethodsModule {}


### PR DESCRIPTION
## Summary

PR 1 of the **arel → 100% on api:compare** plan.

Promotes `factory-methods.ts` from a stub interface to a real module object containing all 11 Rails `Arel::FactoryMethods` implementations, then physically mixes it into `Node` and `TreeManager` via `include()` from `@blazetrails/activesupport` — matching how Ruby Arel includes the module into both classes. Then deletes the hand-rolled duplicates from `Table` and `SelectManager` that the mixin now supersedes.

## Coverage impact

| File | Before | After |
|---|---|---|
| `nodes/node.rb` | 7/18 (39%) | **18/18 (100%)** |
| `tree_manager.rb` | 9/20 (45%) | **20/20 (100%)** |
| **arel overall** | 490/589 (83.2%) | **512/589 (86.9%)** |

PRs 2 and 3 will close the remaining 77 mixin gaps (Math/Expressions/AliasPredication/OrderPredications on NodeExpression/InfixOperation/SqlLiteral/Function).

## Behavioral changes worth flagging

- **`Attribute#cast(asType: string)` removed.** This was a Trails-only deviation; Rails' `Arel::Attributes::Attribute` does not define `cast`, it inherits the 2-arg form from FactoryMethods via Node. No callers in the repo.
- **Table and SelectManager lose hand-rolled factory methods** that are now provided by the mixin. Two non-trivial overrides are kept and called out in code:
  - `Table#createJoin` (wider signature: accepts a string `to`)
  - `SelectManager#createJoin` (wraps the constraint in an `On` node)

## Implementation note

The interface declaration on `Node`/`TreeManager` lists each method explicitly rather than using `Included<typeof FactoryMethods>` from activesupport. The `Included<>` helper is constrained over `Module = Record<string, Function>`, which propagates a string index signature into the merged class type and breaks property typing on subclasses like `Attribute` (whose `relation`, `name`, `caster` fields are not `Function`-typed). Fixing that helper is out of scope for this PR.

## Test plan

- [x] `pnpm -F @blazetrails/arel test` — 1024/1024 passing (3 new regression tests verifying the mixin attached to Node.prototype)
- [x] `pnpm typecheck`
- [x] `pnpm run api:compare --package arel` — `nodes/node.rb` and `tree_manager.rb` at 100%
- [x] No diff to `pnpm run api:compare --package arel` for `table.rb` or `select_manager.rb` (deletions are mixin-equivalent)