### PR TITLE
fix(activesupport): drop string index signature from Included<>

### DIFF
--- a/packages/activesupport/src/include.test.ts
+++ b/packages/activesupport/src/include.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
-import { include, extend, included, extended, type Included } from "./include.js";
+import { include, extend, included, extended, type Included, type Extended } from "./include.js";
 
 describe("include", () => {
   it("copies instance methods onto the prototype", () => {
@@ -240,5 +240,29 @@ describe("Included<>", () => {
     };
     type T = Included<typeof Mod>;
     expectTypeOf<T>().toEqualTypeOf<{ greet: () => string }>();
+  });
+});
+
+describe("Extended<>", () => {
+  // Extended<> shares its implementation with Included<> via the internal
+  // CallableMethods<> helper. Mirror the Included<> regression assertions
+  // so a future divergence in either type's behavior fails its own test.
+  it("does not introduce a string index signature into the merged type", () => {
+    const Mod = {
+      connectedTo(this: unknown, role: string): number {
+        return role.length;
+      },
+    };
+    type T = Extended<typeof Mod>;
+    expectTypeOf<T>().toEqualTypeOf<{ connectedTo: (role: string) => number }>();
+  });
+
+  it("strips the this parameter and skips non-method properties", () => {
+    const Mod = {
+      establish(this: { tag: string }): void {},
+      pool: 5 as const,
+    };
+    type T = Extended<typeof Mod>;
+    expectTypeOf<T>().toEqualTypeOf<{ establish: () => void }>();
   });
 });

--- a/packages/activesupport/src/include.test.ts
+++ b/packages/activesupport/src/include.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { include, extend, included, extended } from "./include.js";
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { include, extend, included, extended, type Included } from "./include.js";
 
 describe("include", () => {
   it("copies instance methods onto the prototype", () => {
@@ -198,5 +198,47 @@ describe("extend", () => {
       },
     });
     expect((User as any).findByName()).toBe("found");
+  });
+});
+
+describe("Included<>", () => {
+  // Regression for https://github.com/blazetrailsdev/trails/pull/967 —
+  // when Included<> was constrained over `Record<string, Function>`, the
+  // resulting mapped type carried a string index signature that propagated
+  // into the merging class and forced every subclass field to be
+  // function-typed. Mixing into a class with non-method fields broke.
+  it("does not introduce a string index signature into the merged type", () => {
+    const Mod = {
+      hello(this: unknown, name: string): string {
+        return `hi ${name}`;
+      },
+    };
+    type T = Included<typeof Mod>;
+    expectTypeOf<T>().toEqualTypeOf<{ hello: (name: string) => string }>();
+    // A class with non-function fields can extend the Included<> interface
+    // without TS demanding those fields conform to the function signature.
+    /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging,
+                      @typescript-eslint/no-empty-object-type */
+    interface Host extends T {}
+    class Host {
+      readonly count: number = 0;
+      readonly label: string = "";
+    }
+    const h = new Host();
+    expect(h.count).toBe(0);
+    expect(h.label).toBe("");
+    /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging,
+                     @typescript-eslint/no-empty-object-type */
+  });
+
+  it("strips the this parameter and skips non-method properties", () => {
+    const Mod = {
+      greet(this: { name: string }): string {
+        return this.name;
+      },
+      version: 1 as const,
+    };
+    type T = Included<typeof Mod>;
+    expectTypeOf<T>().toEqualTypeOf<{ greet: () => string }>();
   });
 });

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -35,14 +35,23 @@ export const extended = Symbol.for("@blazetrails/activesupport:extended");
  *
  * Usage:
  *   export interface Relation<T> extends Included<typeof QueryMethodBangs> {}
+ *
+ * Implementation note: the parameter is intentionally unconstrained
+ * (no `M extends Module`). Constraining over `Record<string, Function>`
+ * forces a string index signature into every `Included<M>`, which in
+ * turn forces every property on the merging class — and on every
+ * subclass — to be assignable to `(...args: unknown[]) => unknown`.
+ * That breaks any class that mixes `Included<>` and also has non-method
+ * fields (e.g. arel's `Attribute` with `relation`, `name`, `caster`).
+ * Filtering function-typed keys via `M[K] extends Function` keeps the
+ * resulting type tight to the literal keys of the passed module.
  */
-export type Included<M extends Module> = {
-  [K in keyof M as K extends string ? K : never]: M[K] extends (
-    this: any,
-    ...args: infer A
-  ) => infer R
-    ? (...args: A) => R
-    : never;
+export type Included<M> = {
+  [K in keyof M as K extends string
+    ? M[K] extends (this: any, ...args: any[]) => any
+      ? K
+      : never
+    : never]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
 };
 
 export function include(klass: AnyClass, mod: Module | AnyClass): void {

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -36,17 +36,19 @@ export const extended = Symbol.for("@blazetrails/activesupport:extended");
  * Usage:
  *   export interface Relation<T> extends Included<typeof QueryMethodBangs> {}
  *
- * Implementation note: the parameter is intentionally unconstrained
- * (no `M extends Module`). Constraining over `Record<string, Function>`
- * forces a string index signature into every `Included<M>`, which in
- * turn forces every property on the merging class — and on every
- * subclass — to be assignable to `(...args: unknown[]) => unknown`.
+ * Implementation note: the parameter is constrained to `object` rather
+ * than the runtime `Module = Record<string, Function>`. The runtime
+ * shape forces a string index signature into every `Included<M>`,
+ * which in turn forces every property on the merging class — and on
+ * every subclass — to be assignable to `(...args: unknown[]) => unknown`.
  * That breaks any class that mixes `Included<>` and also has non-method
  * fields (e.g. arel's `Attribute` with `relation`, `name`, `caster`).
- * Filtering function-typed keys via `M[K] extends Function` keeps the
- * resulting type tight to the literal keys of the passed module.
+ * `object` is wide enough to accept any module literal but carries no
+ * index signature. Filtering callable keys via
+ * `M[K] extends (this: any, ...args: any[]) => any` then keeps the
+ * resulting type tight to the literal method keys of the passed module.
  */
-export type Included<M> = {
+export type Included<M extends object> = {
   [K in keyof M as K extends string
     ? M[K] extends (this: any, ...args: any[]) => any
       ? K
@@ -120,13 +122,15 @@ export function include(klass: AnyClass, mod: Module | AnyClass): void {
  *   extend(Base, ConnectionHandlingMethods);
  *   const TypedBase = Base as unknown as BaseStatic;
  */
-export type Extended<M extends Module> = {
-  [K in keyof M as K extends string ? K : never]: M[K] extends (
-    this: any,
-    ...args: infer A
-  ) => infer R
-    ? (...args: A) => R
-    : never;
+// See the implementation note on `Included<>` — the `object` constraint
+// + callable-key filter avoids leaking a string index signature into
+// classes that merge with this type.
+export type Extended<M extends object> = {
+  [K in keyof M as K extends string
+    ? M[K] extends (this: any, ...args: any[]) => any
+      ? K
+      : never
+    : never]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
 };
 
 /**

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -30,31 +30,38 @@ export const included = Symbol.for("@blazetrails/activesupport:included");
 export const extended = Symbol.for("@blazetrails/activesupport:extended");
 
 /**
- * Derive instance method types from an included module object.
- * Strips the `this` parameter from each function signature.
+ * Shared between `Included<>` and `Extended<>`: filter `M` down to its
+ * callable string-keyed properties and strip the `this` parameter from
+ * each signature.
  *
- * Usage:
- *   export interface Relation<T> extends Included<typeof QueryMethodBangs> {}
- *
- * Implementation note: the parameter is constrained to `object` rather
- * than the runtime `Module = Record<string, Function>`. The runtime
- * shape forces a string index signature into every `Included<M>`,
- * which in turn forces every property on the merging class — and on
- * every subclass — to be assignable to `(...args: unknown[]) => unknown`.
- * That breaks any class that mixes `Included<>` and also has non-method
- * fields (e.g. arel's `Attribute` with `relation`, `name`, `caster`).
- * `object` is wide enough to accept any module literal but carries no
- * index signature. Filtering callable keys via
- * `M[K] extends (this: any, ...args: any[]) => any` then keeps the
- * resulting type tight to the literal method keys of the passed module.
+ * Implementation note: `M` is constrained to `object` rather than the
+ * runtime `Module = Record<string, Function>`. The runtime shape forces
+ * a string index signature into every result, which propagates into
+ * any merging class — and every subclass — and demands every property
+ * be assignable to `(...args: unknown[]) => unknown`. That breaks
+ * classes mixing this type and also having non-method fields (e.g.
+ * arel's `Attribute` with `relation`, `name`, `caster`). `object` is
+ * wide enough to accept any module literal but carries no index
+ * signature. Filtering callable keys via
+ * `M[K] extends (this: any, ...args: any[]) => any` keeps the result
+ * tight to the literal method keys of the passed module.
  */
-export type Included<M extends object> = {
+type CallableMethods<M extends object> = {
   [K in keyof M as K extends string
     ? M[K] extends (this: any, ...args: any[]) => any
       ? K
       : never
     : never]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
 };
+
+/**
+ * Derive instance method types from an included module object.
+ * Strips the `this` parameter from each function signature.
+ *
+ * Usage:
+ *   export interface Relation<T> extends Included<typeof QueryMethodBangs> {}
+ */
+export type Included<M extends object> = CallableMethods<M>;
 
 export function include(klass: AnyClass, mod: Module | AnyClass): void {
   const descriptors: PropertyDescriptorMap = {};
@@ -122,16 +129,7 @@ export function include(klass: AnyClass, mod: Module | AnyClass): void {
  *   extend(Base, ConnectionHandlingMethods);
  *   const TypedBase = Base as unknown as BaseStatic;
  */
-// See the implementation note on `Included<>` — the `object` constraint
-// + callable-key filter avoids leaking a string index signature into
-// classes that merge with this type.
-export type Extended<M extends object> = {
-  [K in keyof M as K extends string
-    ? M[K] extends (this: any, ...args: any[]) => any
-      ? K
-      : never
-    : never]: M[K] extends (this: any, ...args: infer A) => infer R ? (...args: A) => R : never;
-};
+export type Extended<M extends object> = CallableMethods<M>;
 
 /**
  * Ruby-style `extend` for mixing module methods onto a class as static methods.


### PR DESCRIPTION
## Summary

`Included<M extends Record<string, Function>>` forced a string index signature into every resulting mapped type. Merged onto a class via declaration merging, that index signature propagated to all subclasses and demanded all properties be function-typed — blocking any class that mixes `Included<>` and also has data fields.

Hit in #967: arel's `Attribute extends Node` declares `relation`, `name`, `caster` (none functions), so TS rejected the whole class once `Included<typeof FactoryMethods>` was applied to `Node`.

Drops the constraint from the type-only `Included<>` helper and instead filters the mapped output to function-typed keys of the literal module. The runtime `include()` / `extend()` signatures keep their structural \`Module\` constraint since they iterate values.

## Unblocks

- #967 can stop hand-rolling explicit method lists in node.ts and tree-manager.ts and just use \`Included<typeof FactoryMethods>\` again.

## Test plan

- [x] New \`describe(\"Included<>\")\` block with two type-level + runtime regression tests
- [x] \`pnpm typecheck\` — full repo clean
- [x] \`pnpm vitest run packages/activesupport/ packages/arel/\` — 4622/4622 passing