### PR TITLE
refactor(activesupport): swap TimeWithZone internals to Temporal.ZonedDateTime

### DIFF
--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -5,10 +5,11 @@
  * Mirrors the Rails API: https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html
  */
 
-import { TimeZone, getLocalComponents } from "./values/time-zone.js";
+import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
 import { getZone } from "./time-zone-config.js";
+import { Temporal } from "./temporal.js";
 
 /**
  * Options for the change() method.
@@ -84,14 +85,21 @@ function daysInMonth(year: number, month: number): number {
 }
 
 export class TimeWithZone {
-  /** The underlying UTC instant */
-  private readonly _utc: Date;
+  /** The underlying zoned instant */
+  private readonly _zoned: Temporal.ZonedDateTime;
   /** The timezone */
   private readonly _timeZone: TimeZone;
 
   constructor(utcTime: Date, timeZone: TimeZone) {
-    this._utc = new Date(utcTime.getTime());
+    this._zoned = Temporal.Instant.fromEpochMilliseconds(utcTime.getTime()).toZonedDateTimeISO(
+      timeZone.tzinfo,
+    );
     this._timeZone = timeZone;
+  }
+
+  /** Internal: derive a Date for legacy method bodies and TimeZone helpers. */
+  private get _utc(): Date {
+    return new Date(this._zoned.epochMilliseconds);
   }
 
   // ---------------------------------------------------------------------------
@@ -169,7 +177,16 @@ export class TimeWithZone {
     second: number;
     millisecond: number;
   } {
-    return getLocalComponents(this._timeZone.tzinfo, this._utc);
+    const z = this._zoned;
+    return {
+      year: z.year,
+      month: z.month,
+      day: z.day,
+      hour: z.hour,
+      minute: z.minute,
+      second: z.second,
+      millisecond: z.millisecond,
+    };
   }
 
   get year(): number {

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -89,6 +89,8 @@ export class TimeWithZone {
   private readonly _zoned: Temporal.ZonedDateTime;
   /** The timezone */
   private readonly _timeZone: TimeZone;
+  /** Lazily-derived Date snapshot for legacy method bodies and TimeZone helpers. */
+  private _utcCache?: Date;
 
   constructor(utcTime: Date, timeZone: TimeZone) {
     this._zoned = Temporal.Instant.fromEpochMilliseconds(utcTime.getTime()).toZonedDateTimeISO(
@@ -97,9 +99,8 @@ export class TimeWithZone {
     this._timeZone = timeZone;
   }
 
-  /** Internal: derive a Date for legacy method bodies and TimeZone helpers. */
   private get _utc(): Date {
-    return new Date(this._zoned.epochMilliseconds);
+    return (this._utcCache ??= new Date(this._zoned.epochMilliseconds));
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -89,18 +89,15 @@ export class TimeWithZone {
   private readonly _zoned: Temporal.ZonedDateTime;
   /** The timezone */
   private readonly _timeZone: TimeZone;
-  /** Lazily-derived Date snapshot for legacy method bodies and TimeZone helpers. */
-  private _utcCache?: Date;
+  /** Cached Date snapshot for legacy method bodies and TimeZone helpers. */
+  private readonly _utc: Date;
 
   constructor(utcTime: Date, timeZone: TimeZone) {
     this._zoned = Temporal.Instant.fromEpochMilliseconds(utcTime.getTime()).toZonedDateTimeISO(
       timeZone.tzinfo,
     );
     this._timeZone = timeZone;
-  }
-
-  private get _utc(): Date {
-    return (this._utcCache ??= new Date(this._zoned.epochMilliseconds));
+    this._utc = new Date(this._zoned.epochMilliseconds);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 8a of the Temporal migration. Pure internals refactor — `TimeWithZone` now stores `_zoned: Temporal.ZonedDateTime` instead of `_utc: Date`. All 117 `time-with-zone.test.ts` tests + 165 `core-ext/time-with-zone.test.ts` tests pass unmodified.

- `_local()` reads ZDT fields directly (`year`, `month`, …, `millisecond`).
- An eagerly-cached `_utc` field (`new Date(_zoned.epochMilliseconds)`, computed once in the constructor) keeps every other method body and the `TimeZone.abbreviation/utcOffsetAt/isDst` helpers unchanged. Eager init is required so the snapshot is in place before `Object.freeze` runs (Rails ports a `freeze` test that preloads instance variables).
- Constructor still accepts `Date`. The "no Date interop" decision (constructor rejects `Date`) and the public-surface flip (return Temporal types from `utc()`, `localtime()`, `toDate()`, …) move to **PR 8b**.

### Behavior note

Constructing with an invalid `Date` (i.e. `new Date(NaN)`) now throws a `RangeError` at construction (raised by `Temporal.Instant.fromEpochMilliseconds`) instead of silently storing NaN and propagating garbage through every method. Rails' `TimeWithZone#initialize` has no equivalent NaN-`Time` state to be faithful to — fail-fast matches the implicit Rails invariant that the wrapped time is valid.

## Test plan

- [x] `vitest run packages/activesupport/src/time-with-zone.test.ts` — 117/117 pass
- [x] `vitest run packages/activesupport/src/core-ext/time-with-zone.test.ts` — 165/165 (+ 7 skipped)
- [x] `vitest run packages/activesupport` — 3603/3603 pass
- [x] `pnpm typecheck`
- [x] `api:compare` delta on `time_with_zone.rb` — 0 (45/54 unchanged)