### PR TITLE
refactor(activesupport): TimeWithZone constructor takes Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -3,6 +3,7 @@ import { Duration } from "../duration.js";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { travelTo } from "../testing-helpers.js";
+import { instantFromDate } from "../testing/temporal-helpers.js";
 import {
   getZone,
   setZone,
@@ -28,7 +29,8 @@ describe("TimeWithZoneTest", () => {
   });
 
   // @twz = 2000-01-01 00:00:00 UTC in Eastern = 1999-12-31 19:00:00 EST
-  const maketwz = () => new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+  const maketwz = () =>
+    new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
 
   it("utc", () => {
     const twz = maketwz();
@@ -89,27 +91,29 @@ describe("TimeWithZoneTest", () => {
   it("utc?", () => {
     const twz = maketwz();
     expect(twz.isUtc()).toBe(false);
-    expect(new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), utcZone).isUtc()).toBe(true);
+    expect(new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), utcZone).isUtc()).toBe(
+      true,
+    );
   });
 
   it("formatted offset", () => {
     const twz = maketwz();
     expect(twz.formattedOffset()).toBe("-05:00");
-    const summer = new TimeWithZone(new Date(Date.UTC(2000, 5, 1)), eastern);
+    const summer = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 5, 1))), eastern);
     expect(summer.formattedOffset()).toBe("-04:00");
   });
 
   it("dst?", () => {
     const twz = maketwz();
     expect(twz.dst()).toBe(false);
-    const summer = new TimeWithZone(new Date(Date.UTC(2000, 5, 1)), eastern);
+    const summer = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 5, 1))), eastern);
     expect(summer.dst()).toBe(true);
   });
 
   it("zone", () => {
     const twz = maketwz();
     expect(twz.zone).toBe("EST");
-    const summer = new TimeWithZone(new Date(Date.UTC(2000, 5, 1)), eastern);
+    const summer = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 5, 1))), eastern);
     expect(summer.zone).toBe("EDT");
   });
 
@@ -226,14 +230,20 @@ describe("TimeWithZoneTest", () => {
   it("compare with time with zone", () => {
     const twz = maketwz();
     expect(
-      twz.compareTo(new TimeWithZone(new Date(Date.UTC(1999, 11, 31, 23, 59, 59)), utcZone)),
+      twz.compareTo(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(1999, 11, 31, 23, 59, 59))), utcZone),
+      ),
     ).toBe(1);
-    expect(twz.compareTo(new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), utcZone))).toBe(
-      0,
-    );
-    expect(twz.compareTo(new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 1)), utcZone))).toBe(
-      -1,
-    );
+    expect(
+      twz.compareTo(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), utcZone),
+      ),
+    ).toBe(0);
+    expect(
+      twz.compareTo(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 1))), utcZone),
+      ),
+    ).toBe(-1);
   });
 
   it("between?", () => {
@@ -327,43 +337,65 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("before", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 0)), eastern);
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 0))),
+      eastern,
+    );
     expect(
-      twz.isBefore(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 11, 59, 59)), eastern)),
+      twz.isBefore(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 11, 59, 59))), eastern),
+      ),
     ).toBe(false);
-    expect(twz.isBefore(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 0)), eastern))).toBe(
-      false,
-    );
-    expect(twz.isBefore(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 1)), eastern))).toBe(
-      true,
-    );
+    expect(
+      twz.isBefore(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 0))), eastern),
+      ),
+    ).toBe(false);
+    expect(
+      twz.isBefore(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 1))), eastern),
+      ),
+    ).toBe(true);
   });
 
   it("after", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 0)), eastern);
-    expect(twz.isAfter(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 11, 59, 59)), eastern))).toBe(
-      true,
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 0))),
+      eastern,
     );
-    expect(twz.isAfter(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 0)), eastern))).toBe(
-      false,
-    );
-    expect(twz.isAfter(new TimeWithZone(new Date(Date.UTC(2017, 2, 6, 12, 0, 1)), eastern))).toBe(
-      false,
-    );
+    expect(
+      twz.isAfter(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 11, 59, 59))), eastern),
+      ),
+    ).toBe(true);
+    expect(
+      twz.isAfter(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 0))), eastern),
+      ),
+    ).toBe(false);
+    expect(
+      twz.isAfter(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2017, 2, 6, 12, 0, 1))), eastern),
+      ),
+    ).toBe(false);
   });
 
   it("eql?", () => {
     const twz = maketwz();
-    expect(twz.eql(new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), eastern))).toBe(true);
+    expect(
+      twz.eql(new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), eastern)),
+    ).toBe(true);
     expect(twz.eql(new Date(Date.UTC(2000, 0, 1)))).toBe(true);
-    expect(twz.eql(new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), TimeZone.find("Hawaii")))).toBe(
-      true,
-    );
+    expect(
+      twz.eql(
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), TimeZone.find("Hawaii")),
+      ),
+    ).toBe(true);
     expect(twz.eql(new Date(Date.UTC(2000, 0, 1, 0, 0, 1)))).toBe(false);
   });
 
   it("plus with integer", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.plus(5);
     expect(result.hour).toBe(19);
     expect(result.min).toBe(0);
@@ -371,7 +403,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("plus with duration", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.plus(Duration.days(5));
     // 1999-12-31 + 5 days = 2000-01-05, local time stays 19:00
     expect(result.day).toBe(5);
@@ -381,7 +413,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("minus with integer", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.minus(5);
     expect(result.hour).toBe(18);
     expect(result.min).toBe(59);
@@ -389,7 +421,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("minus with duration", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.minus(Duration.days(5));
     expect(result.day).toBe(26);
     expect(result.month).toBe(12);
@@ -397,20 +429,20 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("minus with time", () => {
-    const twz2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2)), utcZone);
+    const twz2 = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 2))), utcZone);
     expect(twz2.minus(new Date(Date.UTC(2000, 0, 1)))).toBe(86400);
   });
 
   it("minus with time with zone", () => {
-    const twz1 = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), utcZone);
-    const twz2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2)), utcZone);
+    const twz1 = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), utcZone);
+    const twz2 = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 2))), utcZone);
     expect(twz2.minus(twz1)).toBe(86400);
   });
 
   it("plus and minus enforce spring dst rules", () => {
     // 2006-04-02 06:59:59 UTC = 2006-04-02 01:59:59 EST (1 sec before DST)
     const utc = new Date(Date.UTC(2006, 3, 2, 6, 59, 59));
-    let twz = new TimeWithZone(utc, eastern);
+    let twz = new TimeWithZone(instantFromDate(utc), eastern);
     expect(twz.hour).toBe(1);
     expect(twz.min).toBe(59);
     expect(twz.sec).toBe(59);
@@ -437,7 +469,7 @@ describe("TimeWithZoneTest", () => {
   it("plus and minus enforce fall dst rules", () => {
     // 2006-10-29 05:59:59 UTC = 2006-10-29 01:59:59 EDT (1 sec before DST end)
     const utc = new Date(Date.UTC(2006, 9, 29, 5, 59, 59));
-    let twz = new TimeWithZone(utc, eastern);
+    let twz = new TimeWithZone(instantFromDate(utc), eastern);
     expect(twz.hour).toBe(1);
     expect(twz.min).toBe(59);
     expect(twz.sec).toBe(59);
@@ -464,7 +496,10 @@ describe("TimeWithZoneTest", () => {
   it("to a", () => {
     // Rails: [45, 30, 5, 1, 2, 2000, 2, 32, false, "HST"]
     const hawaii = TimeZone.find("Hawaii");
-    const twzH = new TimeWithZone(new Date(Date.UTC(2000, 1, 1, 15, 30, 45)), hawaii);
+    const twzH = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 1, 1, 15, 30, 45))),
+      hawaii,
+    );
     expect(twzH.sec).toBe(45);
     expect(twzH.min).toBe(30);
     expect(twzH.hour).toBe(5);
@@ -479,49 +514,61 @@ describe("TimeWithZoneTest", () => {
 
   it("to f", () => {
     const hawaii = TimeZone.find("Hawaii");
-    const twzH = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), hawaii);
+    const twzH = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), hawaii);
     expect(twzH.toF()).toBe(946684800.0);
   });
 
   it("to i", () => {
     const hawaii = TimeZone.find("Hawaii");
-    const twzH = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), hawaii);
+    const twzH = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), hawaii);
     expect(twzH.toI()).toBe(946684800);
   });
 
   it("to date", () => {
     // 1 sec before midnight Jan 1 EST
-    const beforeMidnight = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 4, 59, 59)), eastern);
+    const beforeMidnight = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 4, 59, 59))),
+      eastern,
+    );
     expect(beforeMidnight.year).toBe(1999);
     expect(beforeMidnight.month).toBe(12);
     expect(beforeMidnight.day).toBe(31);
 
     // midnight Jan 1 EST
-    const atMidnight = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 5, 0, 0)), eastern);
+    const atMidnight = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 5, 0, 0))),
+      eastern,
+    );
     expect(atMidnight.year).toBe(2000);
     expect(atMidnight.month).toBe(1);
     expect(atMidnight.day).toBe(1);
 
     // 1 sec before midnight Jan 2 EST
-    const beforeMidnight2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2, 4, 59, 59)), eastern);
+    const beforeMidnight2 = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 2, 4, 59, 59))),
+      eastern,
+    );
     expect(beforeMidnight2.year).toBe(2000);
     expect(beforeMidnight2.month).toBe(1);
     expect(beforeMidnight2.day).toBe(1);
 
     // midnight Jan 2 EST
-    const atMidnight2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2, 5, 0, 0)), eastern);
+    const atMidnight2 = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 2, 5, 0, 0))),
+      eastern,
+    );
     expect(atMidnight2.year).toBe(2000);
     expect(atMidnight2.month).toBe(1);
     expect(atMidnight2.day).toBe(2);
   });
 
   it("acts like time", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.actsLikeTime()).toBe(true);
   });
 
   it("blank?", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.isBlank()).toBe(false);
   });
 
@@ -532,7 +579,7 @@ describe("TimeWithZoneTest", () => {
 
   it("utc to local conversion with far future datetime", () => {
     // 2050-01-01 00:00:00 UTC → 2049-12-31 19:00:00 EST
-    const twz = new TimeWithZone(new Date(Date.UTC(2050, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2050, 0, 1, 0, 0, 0))), eastern);
     expect(twz.year).toBe(2049);
     expect(twz.month).toBe(12);
     expect(twz.day).toBe(31);
@@ -739,7 +786,7 @@ describe("TimeWithZoneTest", () => {
     expect(forward.zone).toBe("EDT");
   });
   it("plus with integer when self wraps datetime", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     const result = twz.plus(5);
     expect(result.hour).toBe(19);
     expect(result.min).toBe(0);
@@ -749,12 +796,12 @@ describe("TimeWithZoneTest", () => {
   it.skip("no limit on times");
 
   it("plus with invalid argument", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), eastern);
     expect(() => twz.plus({} as any)).toThrow();
   });
 
   it("minus with integer when self wraps datetime", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     const result = twz.minus(5);
     expect(result.hour).toBe(18);
     expect(result.min).toBe(59);
@@ -762,42 +809,54 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("minus with time precision", () => {
-    const twz2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2, 23, 59, 59, 999)), utcZone);
+    const twz2 = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 2, 23, 59, 59, 999))),
+      utcZone,
+    );
     const t1 = new Date(Date.UTC(2000, 0, 2, 0, 0, 0, 1));
     const diff = twz2.minus(t1);
     expect(diff).toBeCloseTo(86399.998, 3);
   });
 
   it("minus with time with zone without preserve configured", () => {
-    const twz1 = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), utcZone);
-    const twz2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 2)), utcZone);
+    const twz1 = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), utcZone);
+    const twz2 = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 2))), utcZone);
     expect(twz2.minus(twz1)).toBe(86400);
   });
 
   it("minus with time with zone precision", () => {
-    const twz1 = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 1)), utcZone);
-    const twz2 = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 23, 59, 59, 999)), utcZone);
+    const twz1 = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 1))),
+      utcZone,
+    );
+    const twz2 = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 23, 59, 59, 999))),
+      utcZone,
+    );
     expect(twz2.minus(twz1)).toBeCloseTo(86399.998, 3);
   });
 
   it("minus with datetime precision", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 23, 59, 59, 999)), utcZone);
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 23, 59, 59, 999))),
+      utcZone,
+    );
     const dt = new Date(Date.UTC(2000, 0, 1));
     expect(twz.minus(dt)).toBeCloseTo(86399.999, 3);
   });
 
   it("minus with wrapped datetime", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 2)), utcZone);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 2))), utcZone);
     expect(twz.minus(new Date(Date.UTC(2000, 0, 1)))).toBe(86400);
   });
 
   it("to i with wrapped datetime", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     expect(twz.toI()).toBe(946684800);
   });
 
   it("time at", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), utcZone);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), utcZone);
     expect(twz.toI()).toBe(Math.floor(new Date(Date.UTC(2000, 0, 1)).getTime() / 1000));
   });
 
@@ -848,20 +907,26 @@ describe("TimeWithZoneTest", () => {
       timeZone: twz.timeZone.name,
     });
     const parsed = JSON.parse(json);
-    const restored = new TimeWithZone(new Date(parsed.utc), TimeZone.find(parsed.timeZone));
+    const restored = new TimeWithZone(
+      instantFromDate(new Date(parsed.utc)),
+      TimeZone.find(parsed.timeZone),
+    );
     expect(restored.utc().getTime()).toBe(twz.utc().getTime());
     expect(restored.timeZone.name).toBe(twz.timeZone.name);
     expect(restored.inspect()).toBe(twz.inspect());
   });
 
   it("marshal dump and load with tzinfo identifier", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     const json = JSON.stringify({
       utc: twz.utc().toISOString(),
       timeZone: twz.timeZone.tzinfo,
     });
     const parsed = JSON.parse(json);
-    const restored = new TimeWithZone(new Date(parsed.utc), TimeZone.find(parsed.timeZone));
+    const restored = new TimeWithZone(
+      instantFromDate(new Date(parsed.utc)),
+      TimeZone.find(parsed.timeZone),
+    );
     expect(restored.utc().getTime()).toBe(twz.utc().getTime());
     expect(restored.inspect()).toBe(twz.inspect());
   });
@@ -893,7 +958,10 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("date part value methods", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(1999, 11, 31, 19, 18, 17, 0)), eastern);
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(1999, 11, 31, 19, 18, 17, 0))),
+      eastern,
+    );
     expect(twz.year).toBe(1999);
     expect(twz.month).toBe(12);
     expect(twz.day).toBe(31);
@@ -905,22 +973,28 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("usec returns 0 when datetime is wrapped", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), eastern);
     expect(twz.usec).toBe(0);
   });
 
   it("usec returns sec fraction when datetime is wrapped", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500)), eastern);
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500))),
+      eastern,
+    );
     expect(twz.usec).toBe(500000);
   });
 
   it("nsec returns sec fraction when datetime is wrapped", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500)), eastern);
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500))),
+      eastern,
+    );
     expect(twz.nsec).toBe(500000000);
   });
 
   it("utc to local conversion saves period in instance variable", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), eastern);
     expect(twz.utcOffset).toBe(-5 * 3600);
     expect(twz.zone).toBe("EST");
   });
@@ -957,13 +1031,19 @@ describe("TimeWithZoneTest", () => {
 
   it("change at dst boundary", () => {
     // Time.at(1319936400) = 2011-10-30 02:00:00 UTC
-    const twz = new TimeWithZone(new Date(1319936400 * 1000), TimeZone.find("Madrid"));
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(1319936400 * 1000)),
+      TimeZone.find("Madrid"),
+    );
     const result = twz.change({ min: 0 });
     expect(result.getTime()).toBe(twz.getTime());
   });
 
   it("round at dst boundary", () => {
-    const twz = new TimeWithZone(new Date(1319936400 * 1000), TimeZone.find("Madrid"));
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(1319936400 * 1000)),
+      TimeZone.find("Madrid"),
+    );
     const result = twz.round();
     expect(result.getTime()).toBe(twz.getTime());
   });
@@ -1055,11 +1135,11 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("in time zone", () => {
     useZone("Alaska", () => {
-      const result = new TimeWithZone(t, TimeZone.find("Alaska"));
+      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska"));
       expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
     useZone("Hawaii", () => {
-      const result = new TimeWithZone(t, TimeZone.find("Hawaii"));
+      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii"));
       expect(result.inspect()).toBe("1999-12-31 14:00:00.000000000 HST -10:00");
     });
   });
@@ -1072,11 +1152,11 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("in time zone with argument", () => {
     useZone("Eastern Time (US & Canada)", () => {
-      const alaska = new TimeWithZone(t, TimeZone.find("Alaska"));
+      const alaska = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska"));
       expect(alaska.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
-      const hawaii = new TimeWithZone(t, TimeZone.find("Hawaii"));
+      const hawaii = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii"));
       expect(hawaii.inspect()).toBe("1999-12-31 14:00:00.000000000 HST -10:00");
-      const utcTwz = new TimeWithZone(t, TimeZone.find("UTC"));
+      const utcTwz = new TimeWithZone(instantFromDate(t), TimeZone.find("UTC"));
       expect(utcTwz.inspect()).toBe("2000-01-01 00:00:00.000000000 UTC +00:00");
     });
   });
@@ -1087,7 +1167,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("in time zone with time local instance", () => {
     const time = new Date(Date.UTC(2000, 0, 1, 0, 0, 0)); // UTC midnight
-    const result = new TimeWithZone(time, TimeZone.find("Alaska"));
+    const result = new TimeWithZone(instantFromDate(time), TimeZone.find("Alaska"));
     expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
   });
 
@@ -1223,7 +1303,10 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("time in time zone doesnt affect receiver", () => {
     const time = new Date(Date.UTC(2000, 6, 1));
-    const twz = new TimeWithZone(time, TimeZone.find("Eastern Time (US & Canada)"));
+    const twz = new TimeWithZone(
+      instantFromDate(time),
+      TimeZone.find("Eastern Time (US & Canada)"),
+    );
     expect(twz.utc().getTime()).toBe(time.getTime());
     // Original Date should not be modified
     expect(time.getTime()).toBe(Date.UTC(2000, 6, 1));
@@ -1274,7 +1357,10 @@ describe("TimeWithZoneMethodsForString", () => {
 
   it("in time zone", () => {
     useZone("Alaska", () => {
-      const result = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), TimeZone.find("Alaska"));
+      const result = new TimeWithZone(
+        instantFromDate(new Date(Date.UTC(2000, 0, 1))),
+        TimeZone.find("Alaska"),
+      );
       expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
   });
@@ -1286,7 +1372,10 @@ describe("TimeWithZoneMethodsForString", () => {
 
   it("in time zone with argument", () => {
     useZone("Eastern Time (US & Canada)", () => {
-      const alaska = new TimeWithZone(new Date(Date.UTC(2000, 0, 1)), TimeZone.find("Alaska"));
+      const alaska = new TimeWithZone(
+        instantFromDate(new Date(Date.UTC(2000, 0, 1))),
+        TimeZone.find("Alaska"),
+      );
       expect(alaska.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
   });

--- a/packages/activesupport/src/temporal.ts
+++ b/packages/activesupport/src/temporal.ts
@@ -1,1 +1,8 @@
-export { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "@js-temporal/polyfill";
+
+export { Temporal };
+
+/** Bridge a JS Date to a Temporal.Instant (truncated to integer milliseconds). */
+export function instantFrom(date: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
+}

--- a/packages/activesupport/src/temporal.ts
+++ b/packages/activesupport/src/temporal.ts
@@ -2,7 +2,7 @@ import { Temporal } from "@js-temporal/polyfill";
 
 export { Temporal };
 
-/** Bridge a JS Date to a Temporal.Instant (truncated to integer milliseconds). */
+/** Bridge a JS Date to a Temporal.Instant. */
 export function instantFrom(date: Date): Temporal.Instant {
   return Temporal.Instant.fromEpochMilliseconds(date.getTime());
 }

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -22,3 +22,8 @@ export function plainTime(iso: string): Temporal.PlainTime {
 export function zonedDateTime(iso: string): Temporal.ZonedDateTime {
   return Temporal.ZonedDateTime.from(iso);
 }
+
+/** Test bridge: build an Instant from a Date. */
+export function instantFromDate(date: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
+}

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -1,5 +1,9 @@
 /**
- * Temporal test helpers. Test files use these instead of `new Date(...)`.
+ * Temporal test helpers for fixtures in tests.
+ *
+ * Prefer these helpers over direct `Temporal.*.from(...)` calls. `Date`
+ * fixtures are allowed only when immediately converted to a
+ * `Temporal.Instant` via `instantFromDate(...)`, never used directly.
  */
 import { Temporal, instantFrom } from "../temporal.js";
 

--- a/packages/activesupport/src/testing/temporal-helpers.ts
+++ b/packages/activesupport/src/testing/temporal-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Temporal test helpers. Test files use these instead of `new Date(...)`.
  */
-import { Temporal } from "../temporal.js";
+import { Temporal, instantFrom } from "../temporal.js";
 
 export function instant(iso: string): Temporal.Instant {
   return Temporal.Instant.from(iso);
@@ -23,7 +23,5 @@ export function zonedDateTime(iso: string): Temporal.ZonedDateTime {
   return Temporal.ZonedDateTime.from(iso);
 }
 
-/** Test bridge: build an Instant from a Date. */
-export function instantFromDate(date: Date): Temporal.Instant {
-  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
-}
+/** Test bridge: build an Instant from a Date. Re-export of the production helper. */
+export const instantFromDate = instantFrom;

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
+import { instantFromDate } from "./testing/temporal-helpers.js";
 
 describe("TimeWithZoneTest", () => {
   let eastern: TimeZone;
@@ -53,7 +54,7 @@ describe("TimeWithZoneTest", () => {
   it("returns correct local components", () => {
     // 2024-01-15 15:30:45 UTC
     const utcDate = new Date(Date.UTC(2024, 0, 15, 15, 30, 45, 123));
-    const twz = new TimeWithZone(utcDate, eastern);
+    const twz = new TimeWithZone(instantFromDate(utcDate), eastern);
 
     // EST is UTC-5
     expect(twz.year).toBe(2024);
@@ -68,7 +69,7 @@ describe("TimeWithZoneTest", () => {
   it("handles day boundary crossing", () => {
     // 2024-01-16 03:00:00 UTC -> 2024-01-15 22:00:00 EST
     const utcDate = new Date(Date.UTC(2024, 0, 16, 3, 0, 0));
-    const twz = new TimeWithZone(utcDate, eastern);
+    const twz = new TimeWithZone(instantFromDate(utcDate), eastern);
 
     expect(twz.day).toBe(15);
     expect(twz.hour).toBe(22);
@@ -133,7 +134,7 @@ describe("TimeWithZoneTest", () => {
 
   it("toI() returns unix timestamp", () => {
     const utcDate = new Date(Date.UTC(2024, 0, 15, 0, 0, 0));
-    const twz = new TimeWithZone(utcDate, eastern);
+    const twz = new TimeWithZone(instantFromDate(utcDate), eastern);
     expect(twz.toI()).toBe(Math.floor(utcDate.getTime() / 1000));
   });
 
@@ -144,7 +145,7 @@ describe("TimeWithZoneTest", () => {
 
   it("toF() returns float timestamp", () => {
     const utcDate = new Date(Date.UTC(2024, 0, 15, 0, 0, 0, 500));
-    const twz = new TimeWithZone(utcDate, utcZone);
+    const twz = new TimeWithZone(instantFromDate(utcDate), utcZone);
     expect(twz.toF()).toBeCloseTo(utcDate.getTime() / 1000, 3);
   });
 
@@ -584,7 +585,7 @@ describe("TimeWithZoneTest", () => {
 
   it("getTime() returns milliseconds", () => {
     const utcDate = new Date(Date.UTC(2024, 0, 15, 0, 0, 0));
-    const twz = new TimeWithZone(utcDate, eastern);
+    const twz = new TimeWithZone(instantFromDate(utcDate), eastern);
     expect(twz.getTime()).toBe(utcDate.getTime());
   });
 
@@ -618,11 +619,11 @@ describe("TimeWithZoneTest", () => {
   // ---------------------------------------------------------------------------
   // ---------------------------------------------------------------------------
   // Tests ported from time_with_zone_test.rb (formerly "Rails parity: TimeWithZoneTest")
-  // Each test creates its own twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern)
+  // Each test creates its own twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern)
   // Local: 1999-12-31 19:00:00 EST (-05:00)
   // ---------------------------------------------------------------------------
   it("usec returns 0 when no fractional", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.usec).toBe(0);
   });
 
@@ -664,7 +665,7 @@ describe("TimeWithZoneTest", () => {
   // ---------------------------------------------------------------------------
 
   it("change year", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ year: 2001 });
     expect(result.year).toBe(2001);
     expect(result.month).toBe(12);
@@ -673,7 +674,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("change month", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ month: 3 });
     expect(result.month).toBe(3);
     expect(result.day).toBe(31);
@@ -681,7 +682,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("change month clamps day (Feb has fewer days)", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ month: 2 });
     expect(result.month).toBe(2);
     // 1999 is not a leap year, Feb has 28 days; original day is 31 -> clamped
@@ -691,14 +692,14 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("change day", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ day: 15 });
     expect(result.day).toBe(15);
     expect(result.hour).toBe(19);
   });
 
   it("change hour resets min and sec", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ hour: 6 });
     expect(result.hour).toBe(6);
     expect(result.min).toBe(0);
@@ -706,7 +707,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("change min keeps hour", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ min: 15 });
     expect(result.hour).toBe(19);
     expect(result.min).toBe(15);
@@ -714,7 +715,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("change sec", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.change({ sec: 30 });
     expect(result.hour).toBe(19);
     expect(result.min).toBe(0);
@@ -726,7 +727,7 @@ describe("TimeWithZoneTest", () => {
   // ---------------------------------------------------------------------------
 
   it("advance years", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ years: 2 });
     expect(result.year).toBe(2001);
     expect(result.month).toBe(12);
@@ -735,7 +736,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("advance months", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ months: 3 });
     expect(result.month).toBe(3);
     expect(result.day).toBe(31);
@@ -743,7 +744,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("advance days", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ days: 4 });
     expect(result.month).toBe(1);
     expect(result.day).toBe(4);
@@ -751,7 +752,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("advance hours", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ hours: 6 });
     expect(result.day).toBe(1);
     expect(result.hour).toBe(1);
@@ -760,14 +761,14 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("advance minutes", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ minutes: 15 });
     expect(result.hour).toBe(19);
     expect(result.min).toBe(15);
   });
 
   it("advance seconds", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.advance({ seconds: 30 });
     expect(result.hour).toBe(19);
     expect(result.min).toBe(0);
@@ -779,27 +780,27 @@ describe("TimeWithZoneTest", () => {
   // ---------------------------------------------------------------------------
 
   it("to fs rfc822", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.toFs("rfc822")).toBe(twz.rfc2822());
   });
 
   it("to fs rfc2822", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.toFs("rfc2822")).toBe(twz.rfc2822());
   });
 
   it("to fs iso8601", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.toFs("iso8601")).toBe(twz.xmlschema());
   });
 
   it("strftime with composite format", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.strftime("%Y-%m-%d %H:%M:%S %Z %z")).toBe("1999-12-31 19:00:00 EST -0500");
   });
 
   it("JSON serialization uses ISO 8601 with 3 fraction digits", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const json = JSON.stringify({ time: twz });
     expect(JSON.parse(json).time).toBe(twz.asJson());
   });
@@ -838,7 +839,7 @@ describe("TimeWithZoneTest", () => {
 
   it("converting between multiple timezones preserves the instant", () => {
     const utcTime = new Date(Date.UTC(2024, 6, 15, 12, 0, 0));
-    const eastern_twz = new TimeWithZone(utcTime, eastern);
+    const eastern_twz = new TimeWithZone(instantFromDate(utcTime), eastern);
     const pacific_twz = eastern_twz.inTimeZone(pacific);
     const hawaii = TimeZone.find("Hawaii");
     const hawaii_twz = pacific_twz.inTimeZone(hawaii);
@@ -861,7 +862,7 @@ describe("TimeWithZoneTest", () => {
   // ---------------------------------------------------------------------------
   it("calculates seconds since midnight correctly", () => {
     // 1999-12-31 19:00:00 EST = 19 * 3600 seconds since midnight
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const expectedSeconds = 19 * 3600;
     const actualSeconds = twz.hour * 3600 + twz.min * 60 + twz.sec;
     expect(actualSeconds).toBe(expectedSeconds);
@@ -871,7 +872,7 @@ describe("TimeWithZoneTest", () => {
   // Duration arithmetic with Duration class (from time_with_zone_test.rb)
   // ---------------------------------------------------------------------------
   it("plus Duration.days(5)", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.plus(Duration.days(5));
     expect(result.day).toBe(5);
     expect(result.month).toBe(1);
@@ -880,7 +881,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("minus Duration.days(5)", () => {
-    const twz = new TimeWithZone(new Date(Date.UTC(2000, 0, 1, 0, 0, 0)), eastern);
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     const result = twz.minus(Duration.days(5));
     expect(result.day).toBe(26);
     expect(result.month).toBe(12);

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -9,7 +9,7 @@ import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
 import { getZone } from "./time-zone-config.js";
-import { Temporal } from "./temporal.js";
+import { Temporal, instantFrom } from "./temporal.js";
 
 /**
  * Options for the change() method.
@@ -726,18 +726,12 @@ export class TimeWithZone {
   }
 
   isToday(): boolean {
-    const now = new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
-      this._timeZone,
-    );
+    const now = new TimeWithZone(instantFrom(currentTime()), this._timeZone);
     return this.year === now.year && this.month === now.month && this.day === now.day;
   }
 
   isTomorrow(): boolean {
-    const now = new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
-      this._timeZone,
-    );
+    const now = new TimeWithZone(instantFrom(currentTime()), this._timeZone);
     const tomorrow = now.advance({ days: 1 });
     return (
       this.year === tomorrow.year && this.month === tomorrow.month && this.day === tomorrow.day
@@ -745,10 +739,7 @@ export class TimeWithZone {
   }
 
   isYesterday(): boolean {
-    const now = new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
-      this._timeZone,
-    );
+    const now = new TimeWithZone(instantFrom(currentTime()), this._timeZone);
     const yesterday = now.advance({ days: -1 });
     return (
       this.year === yesterday.year && this.month === yesterday.month && this.day === yesterday.day

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -92,10 +92,8 @@ export class TimeWithZone {
   /** Cached Date snapshot for legacy method bodies and TimeZone helpers. */
   private readonly _utc: Date;
 
-  constructor(utcTime: Date, timeZone: TimeZone) {
-    this._zoned = Temporal.Instant.fromEpochMilliseconds(utcTime.getTime()).toZonedDateTimeISO(
-      timeZone.tzinfo,
-    );
+  constructor(instant: Temporal.Instant, timeZone: TimeZone) {
+    this._zoned = instant.toZonedDateTimeISO(timeZone.tzinfo);
     this._timeZone = timeZone;
     this._utc = new Date(this._zoned.epochMilliseconds);
   }
@@ -322,7 +320,7 @@ export class TimeWithZone {
     }
     const tz = typeof zone === "string" ? TimeZone.find(zone) : zone;
     if (tz.tzinfo === this._timeZone.tzinfo) return this;
-    return new TimeWithZone(this._utc, tz);
+    return new TimeWithZone(this._zoned.toInstant(), tz);
   }
 
   // ---------------------------------------------------------------------------
@@ -531,7 +529,10 @@ export class TimeWithZone {
       }
       // Fixed duration — advance from UTC
       const ms = interval.inSeconds() * 1000;
-      return new TimeWithZone(new Date(this._utc.getTime() + ms), this._timeZone);
+      return new TimeWithZone(
+        Temporal.Instant.fromEpochMilliseconds(this._utc.getTime() + ms),
+        this._timeZone,
+      );
     }
     if (typeof interval !== "number") {
       const desc =
@@ -539,7 +540,10 @@ export class TimeWithZone {
       throw new TypeError(`no implicit conversion of ${desc} into number`);
     }
     // Number of seconds
-    return new TimeWithZone(new Date(this._utc.getTime() + interval * 1000), this._timeZone);
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(Math.trunc(this._utc.getTime() + interval * 1000)),
+      this._timeZone,
+    );
   }
 
   /**
@@ -626,7 +630,10 @@ export class TimeWithZone {
     if (options.seconds) ms += options.seconds * 1000;
 
     if (ms !== 0) {
-      return new TimeWithZone(new Date(newLocal._utc.getTime() + ms), this._timeZone);
+      return new TimeWithZone(
+        Temporal.Instant.fromEpochMilliseconds(newLocal._utc.getTime() + ms),
+        this._timeZone,
+      );
     }
 
     return newLocal;
@@ -719,12 +726,18 @@ export class TimeWithZone {
   }
 
   isToday(): boolean {
-    const now = new TimeWithZone(currentTime(), this._timeZone);
+    const now = new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
+      this._timeZone,
+    );
     return this.year === now.year && this.month === now.month && this.day === now.day;
   }
 
   isTomorrow(): boolean {
-    const now = new TimeWithZone(currentTime(), this._timeZone);
+    const now = new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
+      this._timeZone,
+    );
     const tomorrow = now.advance({ days: 1 });
     return (
       this.year === tomorrow.year && this.month === tomorrow.month && this.day === tomorrow.day
@@ -732,7 +745,10 @@ export class TimeWithZone {
   }
 
   isYesterday(): boolean {
-    const now = new TimeWithZone(currentTime(), this._timeZone);
+    const now = new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()),
+      this._timeZone,
+    );
     const yesterday = now.advance({ days: -1 });
     return (
       this.year === yesterday.year && this.month === yesterday.month && this.day === yesterday.day
@@ -853,7 +869,7 @@ export class TimeWithZone {
     const ms = this._utc.getTime();
     const precisionMs = precision * 1000;
     const rounded = Math.round(ms / precisionMs) * precisionMs;
-    return new TimeWithZone(new Date(rounded), this._timeZone);
+    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(rounded), this._timeZone);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -870,7 +870,7 @@ export class TimeWithZone {
     const precisionMs = precision * 1000;
     const rounded = Math.round(ms / precisionMs) * precisionMs;
     return new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(Math.round(rounded)),
+      Temporal.Instant.fromEpochMilliseconds(Math.trunc(rounded)),
       this._timeZone,
     );
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -530,7 +530,7 @@ export class TimeWithZone {
       // Fixed duration — advance from UTC
       const ms = interval.inSeconds() * 1000;
       return new TimeWithZone(
-        Temporal.Instant.fromEpochMilliseconds(this._utc.getTime() + ms),
+        Temporal.Instant.fromEpochMilliseconds(Math.trunc(this._utc.getTime() + ms)),
         this._timeZone,
       );
     }
@@ -631,7 +631,7 @@ export class TimeWithZone {
 
     if (ms !== 0) {
       return new TimeWithZone(
-        Temporal.Instant.fromEpochMilliseconds(newLocal._utc.getTime() + ms),
+        Temporal.Instant.fromEpochMilliseconds(Math.trunc(newLocal._utc.getTime() + ms)),
         this._timeZone,
       );
     }
@@ -869,7 +869,10 @@ export class TimeWithZone {
     const ms = this._utc.getTime();
     const precisionMs = precision * 1000;
     const rounded = Math.round(ms / precisionMs) * precisionMs;
-    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(rounded), this._timeZone);
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(Math.round(rounded)),
+      this._timeZone,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -9,7 +9,7 @@
 import { TimeZone } from "./values/time-zone.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { currentTime } from "./time-travel.js";
-import { Temporal } from "./temporal.js";
+import { instantFrom } from "./temporal.js";
 
 // NOTE: Zone state is stored in module-level variables, mirroring Rails'
 // thread-local Time.zone. This is process-wide and NOT safe for concurrent
@@ -145,7 +145,7 @@ export function findZoneBang(zone: unknown): TimeZone | null | false {
 export function current(): TimeWithZone | Date {
   const zone = getZone();
   if (zone) {
-    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()), zone);
+    return new TimeWithZone(instantFrom(currentTime()), zone);
   }
   return currentTime();
 }

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -9,6 +9,7 @@
 import { TimeZone } from "./values/time-zone.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { currentTime } from "./time-travel.js";
+import { Temporal } from "./temporal.js";
 
 // NOTE: Zone state is stored in module-level variables, mirroring Rails'
 // thread-local Time.zone. This is process-wide and NOT safe for concurrent
@@ -144,7 +145,7 @@ export function findZoneBang(zone: unknown): TimeZone | null | false {
 export function current(): TimeWithZone | Date {
   const zone = getZone();
   if (zone) {
-    return new TimeWithZone(currentTime(), zone);
+    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(currentTime().getTime()), zone);
   }
   return currentTime();
 }

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { TimeZone } from "./values/time-zone.js";
 import { TimeWithZone } from "./time-with-zone.js";
+import { instantFromDate } from "./testing/temporal-helpers.js";
 
 describe("TimeZoneTest", () => {
   // ---------------------------------------------------------------------------
@@ -9,7 +10,7 @@ describe("TimeZoneTest", () => {
   it("utc to local", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const utcDate = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
-    const twz = new TimeWithZone(utcDate, zone);
+    const twz = new TimeWithZone(instantFromDate(utcDate), zone);
     expect(twz.year).toBe(1999);
     expect(twz.month).toBe(12);
     expect(twz.day).toBe(31);
@@ -21,7 +22,7 @@ describe("TimeZoneTest", () => {
   it("utc to local with fractional seconds", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const utcDate = new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500));
-    const twz = new TimeWithZone(utcDate, zone);
+    const twz = new TimeWithZone(instantFromDate(utcDate), zone);
     expect(twz.msec).toBe(500);
     expect(twz.hour).toBe(19);
   });

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -6,6 +6,7 @@
 
 import { TimeWithZone } from "../time-with-zone.js";
 import { Temporal } from "../temporal.js";
+import { currentTime } from "../time-travel.js";
 
 function instantOf(date: Date): Temporal.Instant {
   return Temporal.Instant.fromEpochMilliseconds(date.getTime());
@@ -313,7 +314,7 @@ export class TimeZone {
    * Current time in this timezone.
    */
   now(): TimeWithZone {
-    return new TimeWithZone(Temporal.Now.instant(), this);
+    return new TimeWithZone(instantOf(currentTime()), this);
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -5,6 +5,11 @@
  */
 
 import { TimeWithZone } from "../time-with-zone.js";
+import { Temporal } from "../temporal.js";
+
+function instantOf(date: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
+}
 
 // Rails maps friendly names to IANA zones
 const MAPPING: Record<string, string> = {
@@ -308,7 +313,7 @@ export class TimeZone {
    * Current time in this timezone.
    */
   now(): TimeWithZone {
-    return new TimeWithZone(new Date(), this);
+    return new TimeWithZone(Temporal.Now.instant(), this);
   }
 
   /**
@@ -340,7 +345,7 @@ export class TimeZone {
       local1.hour === hour &&
       local1.minute === minute
     ) {
-      return new TimeWithZone(utc1, this);
+      return new TimeWithZone(instantOf(utc1), this);
     }
 
     // The offset at the computed UTC may differ — try with that offset
@@ -355,13 +360,13 @@ export class TimeZone {
       local2.hour === hour &&
       local2.minute === minute
     ) {
-      return new TimeWithZone(utc2, this);
+      return new TimeWithZone(instantOf(utc2), this);
     }
 
     // Neither candidate maps back — the requested time is in a DST gap.
     // Spring forward: use the earlier UTC (utc1), which the Intl API already
     // adjusted to the post-transition time (e.g., 2:00 AM → 3:00 AM EDT).
-    return new TimeWithZone(utc1, this);
+    return new TimeWithZone(instantOf(utc1), this);
   }
 
   /**
@@ -411,7 +416,7 @@ export class TimeZone {
     if (isNaN(date.getTime())) {
       throw new Error(`Could not parse time: "${str}"`);
     }
-    return new TimeWithZone(date, this);
+    return new TimeWithZone(instantOf(date), this);
   }
 
   /**
@@ -624,14 +629,14 @@ export class TimeZone {
     }
 
     if (epochMs !== null) {
-      return new TimeWithZone(new Date(epochMs), this);
+      return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(epochMs), this);
     }
 
     if (explicitOffsetSeconds !== null) {
       // The parsed time was in an explicit offset — convert to UTC then to this zone
       const utcMs =
         Date.UTC(year, month - 1, day, hour, minute, second, ms) - explicitOffsetSeconds * 1000;
-      return new TimeWithZone(new Date(utcMs), this);
+      return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(utcMs), this);
     }
 
     // No explicit offset — interpret as local time in this zone
@@ -642,7 +647,7 @@ export class TimeZone {
    * Create a TimeWithZone from a Unix timestamp.
    */
   at(secondsSinceEpoch: number): TimeWithZone {
-    return new TimeWithZone(new Date(secondsSinceEpoch * 1000), this);
+    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(secondsSinceEpoch * 1000), this);
   }
 
   /**
@@ -767,7 +772,7 @@ export class TimeZone {
     if (isNaN(date.getTime())) {
       throw new Error("invalid date");
     }
-    return new TimeWithZone(date, this);
+    return new TimeWithZone(instantOf(date), this);
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -647,7 +647,10 @@ export class TimeZone {
    * Create a TimeWithZone from a Unix timestamp.
    */
   at(secondsSinceEpoch: number): TimeWithZone {
-    return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(secondsSinceEpoch * 1000), this);
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochMilliseconds(Math.trunc(secondsSinceEpoch * 1000)),
+      this,
+    );
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -5,12 +5,8 @@
  */
 
 import { TimeWithZone } from "../time-with-zone.js";
-import { Temporal } from "../temporal.js";
+import { Temporal, instantFrom } from "../temporal.js";
 import { currentTime } from "../time-travel.js";
-
-function instantOf(date: Date): Temporal.Instant {
-  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
-}
 
 // Rails maps friendly names to IANA zones
 const MAPPING: Record<string, string> = {
@@ -314,7 +310,7 @@ export class TimeZone {
    * Current time in this timezone.
    */
   now(): TimeWithZone {
-    return new TimeWithZone(instantOf(currentTime()), this);
+    return new TimeWithZone(instantFrom(currentTime()), this);
   }
 
   /**
@@ -346,7 +342,7 @@ export class TimeZone {
       local1.hour === hour &&
       local1.minute === minute
     ) {
-      return new TimeWithZone(instantOf(utc1), this);
+      return new TimeWithZone(instantFrom(utc1), this);
     }
 
     // The offset at the computed UTC may differ — try with that offset
@@ -361,13 +357,13 @@ export class TimeZone {
       local2.hour === hour &&
       local2.minute === minute
     ) {
-      return new TimeWithZone(instantOf(utc2), this);
+      return new TimeWithZone(instantFrom(utc2), this);
     }
 
     // Neither candidate maps back — the requested time is in a DST gap.
     // Spring forward: use the earlier UTC (utc1), which the Intl API already
     // adjusted to the post-transition time (e.g., 2:00 AM → 3:00 AM EDT).
-    return new TimeWithZone(instantOf(utc1), this);
+    return new TimeWithZone(instantFrom(utc1), this);
   }
 
   /**
@@ -417,7 +413,7 @@ export class TimeZone {
     if (isNaN(date.getTime())) {
       throw new Error(`Could not parse time: "${str}"`);
     }
-    return new TimeWithZone(instantOf(date), this);
+    return new TimeWithZone(instantFrom(date), this);
   }
 
   /**
@@ -776,7 +772,7 @@ export class TimeZone {
     if (isNaN(date.getTime())) {
       throw new Error("invalid date");
     }
-    return new TimeWithZone(instantOf(date), this);
+    return new TimeWithZone(instantFrom(date), this);
   }
 
   /**


### PR DESCRIPTION
## Summary

PR 8b of the Temporal migration. Narrows the `TimeWithZone` constructor signature from `(Date, TimeZone)` to `(Temporal.Instant, TimeZone)` — `Date` is now rejected at the type level, matching the *no Date interop* decision from the migration plan.

- Production callsites in `time-zone.ts` and `time-zone-config.ts` pass `Temporal.Instant`. `TimeZone#now` is sourced from `currentTime()` so it remains time-travel aware.
- A shared `instantFrom(date)` helper in `temporal.ts` centralizes Date→Instant bridging across `time-zone.ts`, `time-zone-config.ts`, and `time-with-zone.ts`. The test-only `instantFromDate` is now a thin alias of the production helper.
- Tests use `instantFromDate(date)` so existing `Date.UTC(...)` test fixtures keep working without rewriting every assertion. Rewriting tests to construct Instants directly is left to **PR 8c** alongside the return-type flip.
- Arithmetic paths (`plus(seconds: number)`, `advance()`, `round()`, `TimeZone#at(seconds)`) `Math.trunc` the computed epoch-millis before calling `Temporal.Instant.fromEpochMilliseconds`, preserving the toward-zero truncation that `new Date(ms)` did silently.

The public-surface flip (return Temporal types from `utc()`, `localtime()`, `toDate()`, etc., and widen comparison-method arg types) lands in **PR 8c**.

## Review status

Copilot review cycles complete (7 rounds). The final pass surfaced **no new comments** — all prior concerns are resolved:

- Fractional-millisecond regressions in `plus`/`advance`/`round`/`TimeZone#at` (`Math.trunc`/`Math.round` applied).
- `TimeZone#now()` time-travel awareness restored via `currentTime()`.
- `instantFrom` centralized; test helper `instantFromDate` now a re-export.
- `temporal-helpers.ts` header documents the "Date fixtures only via `instantFromDate`" pattern.
- The pre-existing fail-fast on invalid `Date` (`Temporal.Instant.fromEpochMilliseconds(NaN)` throws `RangeError`) was discussed and accepted as Rails-faithful (Ruby has no NaN-`Time` state to mirror).

Requesting human review.

## Test plan

- [x] `vitest run packages/activesupport` — 3603/3603 pass (626 skipped unchanged)
- [x] `pnpm typecheck`
- [x] `api:compare` delta on `time_with_zone.rb` and `values/time_zone.rb` — 0