### PR TITLE
feat(arel): mix expression-node modules into NodeExpression/SqlLiteral/Function (arel → 100%)

### DIFF
--- a/packages/arel/src/alias-predication.ts
+++ b/packages/arel/src/alias-predication.ts
@@ -1,5 +1,23 @@
+import { As } from "./nodes/binary.js";
 import type { Node } from "./nodes/node.js";
+import { SqlLiteral } from "./nodes/sql-literal.js";
 
-export interface AliasPredication {
-  as(aliasName: string): Node;
+/**
+ * AliasPredication — `as` mixin.
+ *
+ * Mirrors: Arel::AliasPredication (activerecord/lib/arel/alias_predication.rb).
+ */
+export interface AliasPredicationModule {
+  // Return type is `Node` (rather than `As`) because some classes override
+  // `as` with self-returning behavior that mutates an internal alias slot:
+  // Rails' Function.as / Table.as / SelectManager.as all return `this` after
+  // setting an internal alias, while AliasPredication's own implementation
+  // returns an `As` wrapper. The widened return type accommodates both.
+  as(other: string): Node;
 }
+
+export const AliasPredication: AliasPredicationModule = {
+  as(this: Node, other: string): As {
+    return new As(this, new SqlLiteral(other, { retryable: true }));
+  },
+};

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { Nodes } from "./index.js";
+
+// Behavior tests for the mixin surface added in this PR — Expressions,
+// AliasPredication, OrderPredications, FilterPredications,
+// WindowPredications, and the trailing Predications methods (when, concat,
+// contains, overlaps, quotedArray). Verifies the methods are reachable on
+// the right hosts AND build the AST shape Rails would.
+//
+// Receivers are SqlLiteral / Function / InfixOperation rather than
+// Attribute, because Attribute pre-dates this PR and ships hand-rolled
+// versions of count/sum/concat/contains/overlaps that return different
+// node types (NamedFunction, generic InfixOperation). Aligning Attribute
+// with Rails' Predications semantics is a separate refactor.
+
+describe("Expressions mixin (on SqlLiteral)", () => {
+  const lit = new Nodes.SqlLiteral("col");
+
+  it("count/sum/maximum/minimum/average build the typed aggregate subclasses", () => {
+    expect(lit.count()).toBeInstanceOf(Nodes.Count);
+    expect(lit.sum()).toBeInstanceOf(Nodes.Sum);
+    expect(lit.maximum()).toBeInstanceOf(Nodes.Max);
+    expect(lit.minimum()).toBeInstanceOf(Nodes.Min);
+    expect(lit.average()).toBeInstanceOf(Nodes.Avg);
+  });
+
+  it("count(true) sets the distinct flag on the Count node", () => {
+    expect((lit.count(true) as { distinct: boolean }).distinct).toBe(true);
+    expect((lit.count() as { distinct: boolean }).distinct).toBe(false);
+  });
+
+  it("extract builds an Extract node carrying the field", () => {
+    const e = lit.extract("year");
+    expect(e).toBeInstanceOf(Nodes.Extract);
+    expect((e as { field: string }).field).toBe("year");
+  });
+});
+
+describe("AliasPredication mixin", () => {
+  it("on SqlLiteral wraps the receiver in an As node", () => {
+    const aliased = new Nodes.SqlLiteral("MAX(x)").as("m");
+    expect(aliased).toBeInstanceOf(Nodes.As);
+  });
+
+  it("on Function sets the alias and returns self (Rails Function#as)", () => {
+    const sum = new Nodes.SqlLiteral("col").sum();
+    const aliased = sum.as("total");
+    expect(aliased).toBe(sum);
+    expect((sum as { alias: { value: string } | null }).alias?.value).toBe("total");
+  });
+});
+
+describe("OrderPredications mixin (on SqlLiteral)", () => {
+  it("asc/desc wrap in Ascending / Descending", () => {
+    const lit = new Nodes.SqlLiteral("col");
+    expect(lit.asc()).toBeInstanceOf(Nodes.Ascending);
+    expect(lit.desc()).toBeInstanceOf(Nodes.Descending);
+  });
+});
+
+describe("WindowPredications.over (mixed into Function)", () => {
+  const sum = new Nodes.SqlLiteral("col").sum();
+
+  it("with no argument builds an Over node with null right", () => {
+    const o = sum.over();
+    expect(o).toBeInstanceOf(Nodes.Over);
+    expect((o as { right: unknown }).right).toBe(null);
+  });
+
+  it("accepts a window-name string and a Node expr", () => {
+    expect(sum.over("w")).toBeInstanceOf(Nodes.Over);
+    expect(sum.over(new Nodes.SqlLiteral("PARTITION BY x"))).toBeInstanceOf(Nodes.Over);
+  });
+});
+
+describe("FilterPredications.filter (mixed into Function)", () => {
+  it("wraps in a Filter node carrying the predicate", () => {
+    const sum = new Nodes.SqlLiteral("col").sum();
+    const f = sum.filter(new Nodes.SqlLiteral("active"));
+    expect(f).toBeInstanceOf(Nodes.Filter);
+  });
+});
+
+describe("Predications trailing methods on SqlLiteral", () => {
+  const lit = new Nodes.SqlLiteral("col");
+
+  it("when opens a Case", () => {
+    expect(lit.when("active")).toBeInstanceOf(Nodes.Case);
+  });
+
+  it("concat builds a Concat infix node (Rails: ||)", () => {
+    const c = lit.concat(new Nodes.SqlLiteral("other"));
+    expect(c).toBeInstanceOf(Nodes.Concat);
+  });
+
+  it("contains / overlaps build the @> / && infix nodes", () => {
+    const arr = new Nodes.SqlLiteral("ARRAY[1,2]");
+    expect(lit.contains(arr)).toBeInstanceOf(Nodes.Contains);
+    expect(lit.overlaps(arr)).toBeInstanceOf(Nodes.Overlaps);
+  });
+
+  it("quotedArray maps each element through quotedNode", () => {
+    const out = lit.quotedArray([1, "x"]);
+    expect(Array.isArray(out)).toBe(true);
+    expect(out.length).toBe(2);
+    expect(out[0]).toBeInstanceOf(Nodes.Node);
+  });
+});

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Nodes } from "./index.js";
+import { Nodes, Visitors } from "./index.js";
+
+const compile = (n: Nodes.Node): string => new Visitors.ToSql().compile(n);
 
 // Behavior tests for the mixin surface added in this PR — Expressions,
 // AliasPredication, OrderPredications, FilterPredications,
@@ -24,15 +26,22 @@ describe("Expressions mixin (on SqlLiteral)", () => {
     expect(lit.average()).toBeInstanceOf(Nodes.Avg);
   });
 
-  it("count(true) sets the distinct flag on the Count node", () => {
-    expect((lit.count(true) as { distinct: boolean }).distinct).toBe(true);
-    expect((lit.count() as { distinct: boolean }).distinct).toBe(false);
+  it("count(true) emits COUNT(DISTINCT ...)", () => {
+    expect(compile(lit.count())).toBe("COUNT(col)");
+    expect(compile(lit.count(true))).toBe("COUNT(DISTINCT col)");
   });
 
-  it("extract builds an Extract node carrying the field", () => {
+  it("sum/max/min/avg compile to the expected SQL function call", () => {
+    expect(compile(lit.sum())).toBe("SUM(col)");
+    expect(compile(lit.maximum())).toBe("MAX(col)");
+    expect(compile(lit.minimum())).toBe("MIN(col)");
+    expect(compile(lit.average())).toBe("AVG(col)");
+  });
+
+  it("extract compiles to EXTRACT(field FROM expr)", () => {
     const e = lit.extract("year");
     expect(e).toBeInstanceOf(Nodes.Extract);
-    expect((e as { field: string }).field).toBe("year");
+    expect(compile(e)).toBe("EXTRACT(YEAR FROM col)");
   });
 });
 
@@ -46,7 +55,7 @@ describe("AliasPredication mixin", () => {
     const sum = new Nodes.SqlLiteral("col").sum();
     const aliased = sum.as("total");
     expect(aliased).toBe(sum);
-    expect((sum as { alias: { value: string } | null }).alias?.value).toBe("total");
+    expect(compile(aliased)).toBe("SUM(col) AS total");
   });
 });
 
@@ -61,15 +70,22 @@ describe("OrderPredications mixin (on SqlLiteral)", () => {
 describe("WindowPredications.over (mixed into Function)", () => {
   const sum = new Nodes.SqlLiteral("col").sum();
 
-  it("with no argument builds an Over node with null right", () => {
-    const o = sum.over();
-    expect(o).toBeInstanceOf(Nodes.Over);
-    expect((o as { right: unknown }).right).toBe(null);
+  it("with no argument compiles to OVER ()", () => {
+    expect(compile(sum.over())).toBe("SUM(col) OVER ()");
   });
 
-  it("accepts a window-name string and a Node expr", () => {
-    expect(sum.over("w")).toBeInstanceOf(Nodes.Over);
-    expect(sum.over(new Nodes.SqlLiteral("PARTITION BY x"))).toBeInstanceOf(Nodes.Over);
+  it("with a string wraps it in SqlLiteral and emits OVER name", () => {
+    // Regression for copilot review #1: a bare string would otherwise be
+    // rendered as a quoted value (`OVER 'w'`), breaking SQL.
+    expect(compile(sum.over("w"))).toBe("SUM(col) OVER w");
+  });
+
+  it("NamedFunction#over with a NamedWindow doubles embedded quotes in the name", () => {
+    // Regression for copilot review #4: `replace(/"/g, '""')` so a name
+    // containing `"` doesn't escape the identifier.
+    const fn = new Nodes.NamedFunction("MY_FN", [new Nodes.SqlLiteral("x")]);
+    const win = new Nodes.NamedWindow('weird"name');
+    expect(compile(fn.over(win))).toBe('MY_FN(x) OVER "weird""name"');
   });
 });
 

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -74,15 +74,15 @@ describe("WindowPredications.over (mixed into Function)", () => {
     expect(compile(sum.over())).toBe("SUM(col) OVER ()");
   });
 
-  it("with a string wraps it in SqlLiteral and emits OVER name", () => {
-    // Regression for copilot review #1: a bare string would otherwise be
-    // rendered as a quoted value (`OVER 'w'`), breaking SQL.
+  it("with a string emits OVER <name> as a raw SQL fragment", () => {
+    // A bare string window name must render as SQL (`OVER w`), not as a
+    // quoted value (`OVER 'w'`) — the latter is invalid SQL.
     expect(compile(sum.over("w"))).toBe("SUM(col) OVER w");
   });
 
   it("NamedFunction#over with a NamedWindow doubles embedded quotes in the name", () => {
-    // Regression for copilot review #4: `replace(/"/g, '""')` so a name
-    // containing `"` doesn't escape the identifier.
+    // Embedded `"` characters in a window name must be doubled when quoting
+    // the identifier so they do not terminate it early.
     const fn = new Nodes.NamedFunction("MY_FN", [new Nodes.SqlLiteral("x")]);
     const win = new Nodes.NamedWindow('weird"name');
     expect(compile(fn.over(win))).toBe('MY_FN(x) OVER "weird""name"');

--- a/packages/arel/src/expressions.ts
+++ b/packages/arel/src/expressions.ts
@@ -1,9 +1,40 @@
+import { Count } from "./nodes/count.js";
+import { Extract } from "./nodes/extract.js";
+import { Sum, Max, Min, Avg } from "./nodes/function.js";
 import type { Node } from "./nodes/node.js";
 
-export interface Expressions {
-  count(distinct?: boolean): Node;
-  sum(): Node;
-  maximum(): Node;
-  minimum(): Node;
-  average(): Node;
+/**
+ * Expressions — aggregate-function mixin.
+ *
+ * Mirrors: Arel::Expressions (activerecord/lib/arel/expressions.rb).
+ * Mixed into NodeExpression and SqlLiteral via include() in ./index.ts.
+ */
+export interface ExpressionsModule {
+  count(distinct?: boolean): Count;
+  sum(): Sum;
+  maximum(): Max;
+  minimum(): Min;
+  average(): Avg;
+  extract(field: string): Extract;
 }
+
+export const Expressions: ExpressionsModule = {
+  count(this: Node, distinct = false): Count {
+    return new Count([this], distinct);
+  },
+  sum(this: Node): Sum {
+    return new Sum([this]);
+  },
+  maximum(this: Node): Max {
+    return new Max([this]);
+  },
+  minimum(this: Node): Min {
+    return new Min([this]);
+  },
+  average(this: Node): Avg {
+    return new Avg([this]);
+  },
+  extract(this: Node, field: string): Extract {
+    return new Extract(this, field);
+  },
+};

--- a/packages/arel/src/filter-predications.ts
+++ b/packages/arel/src/filter-predications.ts
@@ -1,5 +1,17 @@
+import { Filter } from "./nodes/filter.js";
 import type { Node } from "./nodes/node.js";
 
-export interface FilterPredications {
-  filter(expr: Node): Node;
+/**
+ * FilterPredications — `filter` mixin.
+ *
+ * Mirrors: Arel::FilterPredications (activerecord/lib/arel/filter_predications.rb).
+ */
+export interface FilterPredicationsModule {
+  filter(expr: Node): Filter;
 }
+
+export const FilterPredications: FilterPredicationsModule = {
+  filter(this: Node, expr: Node): Filter {
+    return new Filter(this, expr);
+  },
+};

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -38,24 +38,51 @@ import { include } from "@blazetrails/activesupport";
 import { Node } from "./nodes/node.js";
 import { NodeExpression } from "./nodes/node-expression.js";
 import { InfixOperation } from "./nodes/infix-operation.js";
+import { Function as FunctionNode } from "./nodes/function.js";
 import { Predications } from "./predications.js";
 import { Math as MathMixin } from "./math.js";
 import { FactoryMethods } from "./factory-methods.js";
+import { Expressions } from "./expressions.js";
+import { AliasPredication } from "./alias-predication.js";
+import { OrderPredications } from "./order-predications.js";
+import { FilterPredications } from "./filter-predications.js";
+import { WindowPredications } from "./window-predications.js";
 /* eslint-disable @typescript-eslint/no-explicit-any -- abstract class coercion for include() */
 const _Node = Node as unknown as new (...args: any[]) => Node;
 const _NodeExpression = NodeExpression as unknown as new (...args: any[]) => NodeExpression;
 const _TreeManager = TreeManager as unknown as new (...args: any[]) => TreeManager;
+const _SqlLiteral = SqlLiteral as unknown as new (...args: any[]) => SqlLiteral;
 /* eslint-enable @typescript-eslint/no-explicit-any */
-// The cast matches include()'s runtime constraint. FactoryMethods is
-// typed as the explicit FactoryMethodsModule interface (no index
-// signature) to break the Node ↔ FactoryMethods type cycle.
+// Modules typed as explicit module interfaces (no string index sig) need
+// a cast to satisfy include()'s runtime constraint. The cast is type-only
+// and runtime semantics are unchanged — include() iterates Object.keys.
 type RuntimeModule = Record<string, (...args: unknown[]) => unknown>;
-include(_Node, FactoryMethods as unknown as RuntimeModule);
-include(_TreeManager, FactoryMethods as unknown as RuntimeModule);
+const asRuntime = <T>(m: T): RuntimeModule => m as unknown as RuntimeModule;
+include(_Node, asRuntime(FactoryMethods));
+include(_TreeManager, asRuntime(FactoryMethods));
+// Mirrors Rails: Arel::Nodes::NodeExpression includes Expressions,
+// Predications, AliasPredication, OrderPredications, Math.
 include(_NodeExpression, Predications);
 include(_NodeExpression, MathMixin);
+include(_NodeExpression, asRuntime(Expressions));
+include(_NodeExpression, asRuntime(AliasPredication));
+include(_NodeExpression, asRuntime(OrderPredications));
+// InfixOperation extends Binary (not NodeExpression) but includes the
+// same surface in Rails.
 include(InfixOperation, Predications);
 include(InfixOperation, MathMixin);
+include(InfixOperation, asRuntime(Expressions));
+include(InfixOperation, asRuntime(AliasPredication));
+include(InfixOperation, asRuntime(OrderPredications));
+// SqlLiteral < String in Rails; includes Expressions, Predications,
+// AliasPredication, OrderPredications.
+include(_SqlLiteral, Predications);
+include(_SqlLiteral, asRuntime(Expressions));
+include(_SqlLiteral, asRuntime(AliasPredication));
+include(_SqlLiteral, asRuntime(OrderPredications));
+// Function includes WindowPredications and FilterPredications.
+include(FunctionNode, asRuntime(WindowPredications));
+include(FunctionNode, asRuntime(FilterPredications));
 
 /**
  * Arel.sql() — escape hatch for raw SQL.

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -24,12 +24,16 @@ export class Case extends NodeExpression {
     this.default = defaultValue ? new Else(defaultValue) : null;
   }
 
-  when(condition: Node | unknown, result?: Node | unknown): this {
+  // Property-form override (vs. `when(...) {}`): Predications.when is
+  // mixed into NodeExpression as a property via Included<>, and Case
+  // overrides with self-mutating semantics (Rails: builds When clauses
+  // on this.conditions, returns self).
+  when = (condition: Node | unknown, result?: Node | unknown): this => {
     const whenNode = buildQuoted(condition);
     const thenNode = buildQuoted(result === undefined ? null : result);
     this.conditions.push(new When(whenNode, thenNode));
     return this;
-  }
+  };
 
   else(result: Node | unknown): this {
     this.default = new Else(buildQuoted(result === undefined ? null : result));

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -2,6 +2,9 @@ import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
 
+// Rails: Arel::Nodes::Function includes WindowPredications and
+// FilterPredications. Runtime mixin wiring lives in ../index.ts.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Function extends NodeExpression {
   readonly expressions: Node[];
   alias: Node | null;
@@ -43,3 +46,8 @@ export class Sum extends Function {}
 export class Max extends Function {}
 export class Min extends Function {}
 export class Avg extends Function {}
+
+type _WindowPredications = import("../window-predications.js").WindowPredicationsModule;
+type _FilterPredications = import("../filter-predications.js").FilterPredicationsModule;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface Function extends _WindowPredications, _FilterPredications {}

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -138,8 +138,15 @@ export class Overlaps extends InfixOperation {
 // Inline `typeof import(...)` keeps the mixin modules out of this file's
 // static import graph (math.ts imports InfixOperation for its class
 // references; a static reverse import would cycle).
+// See node-expression.ts for why these use the explicit module interfaces.
+type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
+type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
+type _Expressions = import("../expressions.js").ExpressionsModule;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface InfixOperation
   extends
     Included<typeof import("../predications.js").Predications>,
-    Included<typeof import("../math.js").Math> {}
+    Included<typeof import("../math.js").Math>,
+    _Expressions,
+    _AliasPredication,
+    _OrderPredications {}

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -29,7 +29,13 @@ export class NamedFunction extends Function {
   over = (window?: Window | NamedWindow | string | null): Over => {
     if (!window) return new Over(this, null);
     if (typeof window === "string") return new Over(this, new SqlLiteral(window));
-    if (window instanceof NamedWindow) return new Over(this, new SqlLiteral(`"${window.name}"`));
+    if (window instanceof NamedWindow) {
+      // Match the identifier-quoting policy used elsewhere in ToSql:
+      // double up embedded quotes so a name like `w"x` doesn't escape
+      // the identifier and produce malformed (or injectable) SQL.
+      const escaped = window.name.replace(/"/g, '""');
+      return new Over(this, new SqlLiteral(`"${escaped}"`));
+    }
     return new Over(this, window);
   };
 

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -19,16 +19,19 @@ export class NamedFunction extends Function {
   }
 
   /**
-   * Apply a window to this function call.
+   * Apply a window to this function call. Property-form override (vs.
+   * `over(...) {}`) — the inherited WindowPredications.over is mixed
+   * into Function as a property via Included<>, and NamedFunction's
+   * version widens the signature to accept Window/NamedWindow/string.
    *
    * Mirrors: `OVER` support on Arel functions.
    */
-  over(window?: Window | NamedWindow | string | null): Over {
+  over = (window?: Window | NamedWindow | string | null): Over => {
     if (!window) return new Over(this, null);
     if (typeof window === "string") return new Over(this, new SqlLiteral(window));
     if (window instanceof NamedWindow) return new Over(this, new SqlLiteral(`"${window.name}"`));
     return new Over(this, window);
-  }
+  };
 
   accept<T>(visitor: NodeVisitor<T>): T {
     return visitor.visit(this);

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -50,8 +50,18 @@ export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node):
 // this file's static import graph (they transitively depend on node
 // classes that extend NodeExpression), while still giving TypeScript the
 // method-surface signatures via declaration merging.
+// AliasPredication / OrderPredications use their explicit module interfaces
+// (method-syntax) so subclasses like Function/Grouping/UnaryOperation that
+// override `as`/`asc`/`desc` with method declarations don't trip the
+// property-vs-method override error.
+type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
+type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
+type _Expressions = import("../expressions.js").ExpressionsModule;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface NodeExpression
   extends
     Included<typeof import("../predications.js").Predications>,
-    Included<typeof import("../math.js").Math> {}
+    Included<typeof import("../math.js").Math>,
+    _Expressions,
+    _AliasPredication,
+    _OrderPredications {}

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,6 +1,7 @@
 import type { Included } from "@blazetrails/activesupport";
 import { Node, NodeVisitor } from "./node.js";
 import { Fragments } from "./fragments.js";
+import { buildQuoted } from "./casted.js";
 
 /**
  * SqlLiteral — a raw SQL string passed through unescaped.
@@ -28,6 +29,12 @@ export class SqlLiteral extends Node {
 
   fetchAttribute(_block?: (attr: Node) => unknown): unknown {
     return undefined;
+  }
+
+  // Required by the Predications mixin (mirrors Rails' private
+  // Predications#quoted_node, which calls `Nodes.build_quoted(other, self)`).
+  quotedNode(other: unknown): Node {
+    return other instanceof Node ? other : buildQuoted(other, this);
   }
 
   join(other: Node): Fragments {

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,11 +1,15 @@
+import type { Included } from "@blazetrails/activesupport";
 import { Node, NodeVisitor } from "./node.js";
 import { Fragments } from "./fragments.js";
 
 /**
  * SqlLiteral — a raw SQL string passed through unescaped.
  *
- * Mirrors: Arel::Nodes::SqlLiteral
+ * Mirrors: Arel::Nodes::SqlLiteral. Rails extends `String` and includes
+ * Expressions, Predications, AliasPredication, OrderPredications. The
+ * runtime mixin wiring lives in ../index.ts to avoid module-load cycles.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SqlLiteral extends Node {
   readonly value: string;
   retryableFlag = false;
@@ -40,3 +44,14 @@ export class SqlLiteral extends Node {
     return visitor.visit(this);
   }
 }
+
+type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
+type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
+type _Expressions = import("../expressions.js").ExpressionsModule;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SqlLiteral
+  extends
+    Included<typeof import("../predications.js").Predications>,
+    _Expressions,
+    _AliasPredication,
+    _OrderPredications {}

--- a/packages/arel/src/order-predications.ts
+++ b/packages/arel/src/order-predications.ts
@@ -1,6 +1,22 @@
+import { Ascending } from "./nodes/ascending.js";
+import { Descending } from "./nodes/descending.js";
 import type { Node } from "./nodes/node.js";
 
-export interface OrderPredications {
-  asc(): Node;
-  desc(): Node;
+/**
+ * OrderPredications — `asc` / `desc` mixin.
+ *
+ * Mirrors: Arel::OrderPredications (activerecord/lib/arel/order_predications.rb).
+ */
+export interface OrderPredicationsModule {
+  asc(): Ascending;
+  desc(): Descending;
 }
+
+export const OrderPredications: OrderPredicationsModule = {
+  asc(this: Node): Ascending {
+    return new Ascending(this);
+  },
+  desc(this: Node): Descending {
+    return new Descending(this);
+  },
+};

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -20,6 +20,8 @@ import { Or } from "./nodes/or.js";
 import { Not } from "./nodes/unary.js";
 import { Grouping } from "./nodes/grouping.js";
 import { True } from "./nodes/true.js";
+import { Case } from "./nodes/case.js";
+import { Concat, Contains, Overlaps } from "./nodes/infix-operation.js";
 
 /**
  * Host contract for the Predications mixin.
@@ -299,5 +301,20 @@ export const Predications = {
   },
   notInAll(this: PredicationHost & { notIn(o: unknown[]): Node }, others: unknown[][]): Grouping {
     return groupedAll(others.map((o) => this.notIn(o)));
+  },
+  when(this: PredicationHost, right: unknown): Case {
+    return new Case(this as unknown as Node).when(this.quotedNode(right));
+  },
+  concat(this: Node, other: Node): Concat {
+    return new Concat(this, other);
+  },
+  contains(this: PredicationHost, other: unknown): Contains {
+    return new Contains(this as unknown as Node, this.quotedNode(other));
+  },
+  overlaps(this: PredicationHost, other: unknown): Overlaps {
+    return new Overlaps(this as unknown as Node, this.quotedNode(other));
+  },
+  quotedArray(this: PredicationHost, others: unknown[]): Node[] {
+    return others.map((v) => this.quotedNode(v));
   },
 };

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -182,6 +182,11 @@ export class ToSql implements NodeVisitor<SQLString> {
     // Functions
     if (node instanceof Nodes.NamedFunction) return this.visitNamedFunction(node);
     if (node instanceof Nodes.Exists) return this.visitExists(node);
+    if (node instanceof Nodes.Count) return this.visitAggregate(node, "COUNT");
+    if (node instanceof Nodes.Sum) return this.visitAggregate(node, "SUM");
+    if (node instanceof Nodes.Max) return this.visitAggregate(node, "MAX");
+    if (node instanceof Nodes.Min) return this.visitAggregate(node, "MIN");
+    if (node instanceof Nodes.Avg) return this.visitAggregate(node, "AVG");
 
     // Advanced grouping
     if (node instanceof Nodes.Cube) return this.visitCube(node);
@@ -835,6 +840,19 @@ export class ToSql implements NodeVisitor<SQLString> {
     this.collector.retryable = false;
     this.collector.append(node.name);
     this.collector.append("(");
+    if (node.distinct) this.collector.append("DISTINCT ");
+    this.visitArray(node.expressions, ", ");
+    this.collector.append(")");
+    if (node.alias) {
+      this.collector.append(" AS ");
+      this.visit(node.alias);
+    }
+    return this.collector;
+  }
+
+  private visitAggregate(node: Nodes.Function, name: string): SQLString {
+    this.collector.retryable = false;
+    this.collector.append(`${name}(`);
     if (node.distinct) this.collector.append("DISTINCT ");
     this.visitArray(node.expressions, ", ");
     this.collector.append(")");

--- a/packages/arel/src/window-predications.ts
+++ b/packages/arel/src/window-predications.ts
@@ -8,22 +8,22 @@ import { SqlLiteral } from "./nodes/sql-literal.js";
  * Mirrors: Arel::WindowPredications (activerecord/lib/arel/window_predications.rb).
  */
 export interface WindowPredicationsModule {
-  // Rails accepts any expr (`def over(expr = nil)`); allow Node, a
-  // trusted raw SQL string fragment, or null. Subclasses (e.g.
-  // NamedFunction) widen further to accept Window / NamedWindow. String
-  // arguments are passed through via SqlLiteral and emitted verbatim —
-  // use NamedWindow for window names you want surfaced as AST nodes
-  // (with proper identifier quoting) rather than as trusted SQL.
+  // Rails accepts any expr (`def over(expr = nil)`) and renders it
+  // through the Over-node visitor unchanged. We accept Node, a trusted
+  // raw SQL string fragment, or null. NamedFunction#over widens further
+  // to handle NamedWindow specifically (rendering it as a quoted name
+  // reference); the base mixin defers to whatever the Over visitor does
+  // with whatever Node it's given — passing a NamedWindow here renders
+  // an inline window definition (`OVER "name" AS (...)`), matching Rails.
   over(expr?: Node | string | null): Over;
 }
 
 export const WindowPredications: WindowPredicationsModule = {
   over(this: Node, expr: Node | string | null = null): Over {
-    // String arguments are wrapped in SqlLiteral and rendered verbatim
-    // (raw SQL fragment) in the OVER clause — they are not escaped as
-    // identifiers. Without this wrapping the visitor would treat the
-    // string as a value and emit `OVER 'w'` instead of `OVER w`. Pass a
-    // NamedWindow when you want identifier-quoted output.
+    // String arguments are wrapped in SqlLiteral and emitted verbatim
+    // (trusted raw SQL fragment) in the OVER clause — they are not
+    // escaped as identifiers. Without this wrapping the visitor would
+    // treat the string as a value and emit `OVER 'w'` instead of `OVER w`.
     const right = typeof expr === "string" ? new SqlLiteral(expr) : (expr as Node | null);
     return new Over(this, right);
   },

--- a/packages/arel/src/window-predications.ts
+++ b/packages/arel/src/window-predications.ts
@@ -1,5 +1,6 @@
 import type { Node } from "./nodes/node.js";
 import { Over } from "./nodes/over.js";
+import { SqlLiteral } from "./nodes/sql-literal.js";
 
 /**
  * WindowPredications — `over` mixin.
@@ -15,6 +16,9 @@ export interface WindowPredicationsModule {
 
 export const WindowPredications: WindowPredicationsModule = {
   over(this: Node, expr: Node | string | null = null): Over {
-    return new Over(this, expr as Node | null);
+    // Wrap a window-name string in SqlLiteral so the visitor renders it as
+    // a bare identifier (`OVER w`) rather than a quoted value (`OVER 'w'`).
+    const right = typeof expr === "string" ? new SqlLiteral(expr) : (expr as Node | null);
+    return new Over(this, right);
   },
 };

--- a/packages/arel/src/window-predications.ts
+++ b/packages/arel/src/window-predications.ts
@@ -9,15 +9,21 @@ import { SqlLiteral } from "./nodes/sql-literal.js";
  */
 export interface WindowPredicationsModule {
   // Rails accepts any expr (`def over(expr = nil)`); allow Node, a
-  // window-name string, or null. Subclasses (e.g. NamedFunction) widen
-  // further to accept Window / NamedWindow.
+  // trusted raw SQL string fragment, or null. Subclasses (e.g.
+  // NamedFunction) widen further to accept Window / NamedWindow. String
+  // arguments are passed through via SqlLiteral and emitted verbatim —
+  // use NamedWindow for window names you want surfaced as AST nodes
+  // (with proper identifier quoting) rather than as trusted SQL.
   over(expr?: Node | string | null): Over;
 }
 
 export const WindowPredications: WindowPredicationsModule = {
   over(this: Node, expr: Node | string | null = null): Over {
-    // Wrap a window-name string in SqlLiteral so the visitor renders it as
-    // a bare identifier (`OVER w`) rather than a quoted value (`OVER 'w'`).
+    // String arguments are wrapped in SqlLiteral and rendered verbatim
+    // (raw SQL fragment) in the OVER clause — they are not escaped as
+    // identifiers. Without this wrapping the visitor would treat the
+    // string as a value and emit `OVER 'w'` instead of `OVER w`. Pass a
+    // NamedWindow when you want identifier-quoted output.
     const right = typeof expr === "string" ? new SqlLiteral(expr) : (expr as Node | null);
     return new Over(this, right);
   },

--- a/packages/arel/src/window-predications.ts
+++ b/packages/arel/src/window-predications.ts
@@ -1,5 +1,20 @@
 import type { Node } from "./nodes/node.js";
+import { Over } from "./nodes/over.js";
 
-export interface WindowPredications {
-  over(window?: unknown): Node;
+/**
+ * WindowPredications — `over` mixin.
+ *
+ * Mirrors: Arel::WindowPredications (activerecord/lib/arel/window_predications.rb).
+ */
+export interface WindowPredicationsModule {
+  // Rails accepts any expr (`def over(expr = nil)`); allow Node, a
+  // window-name string, or null. Subclasses (e.g. NamedFunction) widen
+  // further to accept Window / NamedWindow.
+  over(expr?: Node | string | null): Over;
 }
+
+export const WindowPredications: WindowPredicationsModule = {
+  over(this: Node, expr: Node | string | null = null): Over {
+    return new Over(this, expr as Node | null);
+  },
+};


### PR DESCRIPTION
## Summary

Closes the remaining 77 api:compare gaps and brings **arel to 100% (589/589 methods)**.

Promotes the five interface stubs (`expressions.ts`, `alias-predication.ts`, `order-predications.ts`, `filter-predications.ts`, `window-predications.ts`) into real module objects whose implementations mirror the corresponding Rails `arel/*.rb` files. Adds the five trailing methods Rails' `Predications` has that we were missing (`when`, `concat`, `contains`, `overlaps`, `quotedArray`).

Wires the runtime mixins in `index.ts`:
- **NodeExpression & InfixOperation:** + Expressions, AliasPredication, OrderPredications (already had Predications + Math).
- **SqlLiteral:** + Predications, Expressions, AliasPredication, OrderPredications. Rails `Arel::Nodes::SqlLiteral < String` includes the same surface.
- **Function:** + WindowPredications, FilterPredications.

## Coverage impact

| File | Before | After |
|---|---|---|
| `nodes/function.rb` | 5/7 (71%) | **7/7 (100%)** |
| `nodes/infix_operation.rb` | 41/52 (79%) | **52/52 (100%)** |
| `nodes/node_expression.rb` | 36/50 (72%) | **50/50 (100%)** |
| `nodes/sql_literal.rb` | 3/53 (6%) | **53/53 (100%)** |
| **arel overall** | 512/589 (86.9%) | **589/589 (100%)** ✅ |

## Type plumbing

Each module exports an explicit `ModuleInterface` (e.g. `AliasPredicationModule`) used for class type augmentation. The explicit interface (vs. `Included<typeof X>`) is required because subclasses override `as`, `asc`, `desc`, `when`, `over` with method-syntax declarations whose return types don't match what the parent mixin would produce — the explicit-interface approach lets them coexist via interface declaration merging.

`AliasPredicationModule.as` widens its return type to `Node` rather than `As` because Rails has multiple classes (`Function`, `Table`, `SelectManager`) override `as` with self-mutating semantics that return `this` instead of an `As` wrapper.

Two narrow overrides converted to property syntax to satisfy property-vs-method override checks:
- `Case#when` (mutates `this.conditions`, returns self — Rails: `case.rb`)
- `NamedFunction#over` (widens accepted input to `Window | NamedWindow | string`)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run packages/arel/` — 1024/1024 passing
- [x] `pnpm run api:compare --package arel` — 589/589 (100%)