### PR TITLE
refactor(activesupport): TimeWithZone#utc returns Temporal.Instant

### DIFF
--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -4,6 +4,7 @@ import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { travelTo } from "../testing-helpers.js";
 import { instantFromDate } from "../testing/temporal-helpers.js";
+import { Temporal } from "../temporal.js";
 import {
   getZone,
   setZone,
@@ -34,8 +35,8 @@ describe("TimeWithZoneTest", () => {
 
   it("utc", () => {
     const twz = maketwz();
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
-    expect(twz.utc()).toBeInstanceOf(Date);
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc()).toBeInstanceOf(Temporal.Instant);
   });
 
   it("time", () => {
@@ -53,7 +54,7 @@ describe("TimeWithZoneTest", () => {
       const twz = maketwz();
       const result = twz.inTimeZone();
       expect(result.timeZone.name).toBe("Alaska");
-      expect(result.utc().getTime()).toBe(twz.utc().getTime());
+      expect(result.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
     });
   });
 
@@ -62,7 +63,7 @@ describe("TimeWithZoneTest", () => {
     const alaska = TimeZone.find("Alaska");
     const result = twz.inTimeZone("Alaska");
     expect(result.timeZone.name).toBe(alaska.name);
-    expect(result.utc().getTime()).toBe(twz.utc().getTime());
+    expect(result.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
   });
 
   it("in time zone with new zone equal to old zone does not create new object", () => {
@@ -79,7 +80,7 @@ describe("TimeWithZoneTest", () => {
     // 2014-10-26 01:00:00 Moscow time was ambiguous due to DST change
     const moscow = TimeZone.find("Moscow");
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
-    expect(twz.utc().getTime()).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   it("localtime", () => {
@@ -588,7 +589,7 @@ describe("TimeWithZoneTest", () => {
 
   it("local to utc conversion with far future datetime", () => {
     const twz = eastern.local(2049, 12, 31, 19, 0, 0);
-    const utcMs = twz.utc().getTime();
+    const utcMs = twz.utc().epochMilliseconds;
     expect(utcMs).toBe(Date.UTC(2050, 0, 1, 0, 0, 0));
   });
 
@@ -863,32 +864,32 @@ describe("TimeWithZoneTest", () => {
   it("to time with preserve timezone using zone", () => {
     const twz = maketwz();
     const time = twz.utc();
-    expect(time).toBeInstanceOf(Date);
-    expect(time.getTime()).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(time).toBeInstanceOf(Temporal.Instant);
+    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
   });
 
   it("to time with preserve timezone using offset", () => {
     const twz = maketwz();
     const time = twz.utc();
-    expect(time.getTime()).toBe(twz.getTime());
+    expect(time.epochMilliseconds).toBe(twz.getTime());
   });
 
   it("to time with preserve timezone using true", () => {
     const twz = maketwz();
     const time = twz.utc();
-    expect(time.getTime()).toBe(Date.UTC(2000, 0, 1));
+    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
   });
 
   it("to time without preserve timezone", () => {
     const twz = maketwz();
     const time = twz.utc();
-    expect(time).toBeInstanceOf(Date);
+    expect(time).toBeInstanceOf(Temporal.Instant);
   });
 
   it("to time without preserve timezone configured", () => {
     const twz = maketwz();
     const time = twz.utc();
-    expect(time.getTime()).toBe(Date.UTC(2000, 0, 1));
+    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
   });
 
   it("method missing with time return value", () => {
@@ -903,7 +904,7 @@ describe("TimeWithZoneTest", () => {
   it("marshal dump and load", () => {
     const twz = maketwz();
     const json = JSON.stringify({
-      utc: twz.utc().toISOString(),
+      utc: twz.utc().toString(),
       timeZone: twz.timeZone.name,
     });
     const parsed = JSON.parse(json);
@@ -911,7 +912,7 @@ describe("TimeWithZoneTest", () => {
       instantFromDate(new Date(parsed.utc)),
       TimeZone.find(parsed.timeZone),
     );
-    expect(restored.utc().getTime()).toBe(twz.utc().getTime());
+    expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
     expect(restored.timeZone.name).toBe(twz.timeZone.name);
     expect(restored.inspect()).toBe(twz.inspect());
   });
@@ -919,7 +920,7 @@ describe("TimeWithZoneTest", () => {
   it("marshal dump and load with tzinfo identifier", () => {
     const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     const json = JSON.stringify({
-      utc: twz.utc().toISOString(),
+      utc: twz.utc().toString(),
       timeZone: twz.timeZone.tzinfo,
     });
     const parsed = JSON.parse(json);
@@ -927,7 +928,7 @@ describe("TimeWithZoneTest", () => {
       instantFromDate(new Date(parsed.utc)),
       TimeZone.find(parsed.timeZone),
     );
-    expect(restored.utc().getTime()).toBe(twz.utc().getTime());
+    expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
     expect(restored.inspect()).toBe(twz.inspect());
   });
 
@@ -1001,7 +1002,7 @@ describe("TimeWithZoneTest", () => {
 
   it("instance created with local time returns correct utc time", () => {
     const twz = eastern.local(1999, 12, 31, 19);
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
   });
 
   it("instance created with local time enforces spring dst rules", () => {
@@ -1307,7 +1308,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
       instantFromDate(time),
       TimeZone.find("Eastern Time (US & Canada)"),
     );
-    expect(twz.utc().getTime()).toBe(time.getTime());
+    expect(twz.utc().epochMilliseconds).toBe(time.getTime());
     // Original Date should not be modified
     expect(time.getTime()).toBe(Date.UTC(2000, 6, 1));
   });
@@ -1389,6 +1390,6 @@ describe("TimeWithZoneMethodsForString", () => {
     const moscow = TimeZone.find("Moscow");
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
     // Should resolve to the UTC equivalent
-    expect(twz.utc().getTime()).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 });

--- a/packages/activesupport/src/testing-helpers.ts
+++ b/packages/activesupport/src/testing-helpers.ts
@@ -9,7 +9,7 @@ import { Temporal } from "./temporal.js";
 // ── Time Travel ───────────────────────────────────────────────────────────────
 
 /**
- * travelTo — sets the current time to the given Date.
+ * travelTo — sets the current time to the given Date or Temporal.Instant.
  * Use travelBack() to restore.
  */
 export function travelTo(time: Date | Temporal.Instant, fn?: () => void): void {

--- a/packages/activesupport/src/testing-helpers.ts
+++ b/packages/activesupport/src/testing-helpers.ts
@@ -4,6 +4,7 @@
  */
 
 import { setFrozenTime, setTimeOffset, currentTime as _currentTime } from "./time-travel.js";
+import { Temporal } from "./temporal.js";
 
 // ── Time Travel ───────────────────────────────────────────────────────────────
 
@@ -11,9 +12,10 @@ import { setFrozenTime, setTimeOffset, currentTime as _currentTime } from "./tim
  * travelTo — sets the current time to the given Date.
  * Use travelBack() to restore.
  */
-export function travelTo(time: Date, fn?: () => void): void {
-  setFrozenTime(new Date(time));
-  setTimeOffset(time.getTime() - Date.now());
+export function travelTo(time: Date | Temporal.Instant, fn?: () => void): void {
+  const ms = time instanceof Date ? time.getTime() : time.epochMilliseconds;
+  setFrozenTime(new Date(ms));
+  setTimeOffset(ms - Date.now());
   if (fn) {
     try {
       fn();

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -3,6 +3,7 @@ import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
+import { Temporal } from "./temporal.js";
 
 describe("TimeWithZoneTest", () => {
   let eastern: TimeZone;
@@ -120,16 +121,17 @@ describe("TimeWithZoneTest", () => {
   it("utc() returns a Date in UTC", () => {
     const twz = eastern.local(2024, 1, 15, 10, 30, 0);
     const utc = twz.utc();
-    expect(utc).toBeInstanceOf(Date);
-    expect(utc.getUTCHours()).toBe(15); // 10 EST + 5 = 15 UTC
-    expect(utc.getUTCMinutes()).toBe(30);
+    expect(utc).toBeInstanceOf(Temporal.Instant);
+    const z = utc.toZonedDateTimeISO("UTC");
+    expect(z.hour).toBe(15); // 10 EST + 5 = 15 UTC
+    expect(z.minute).toBe(30);
   });
 
   it("getutc() and getgm() are aliases", () => {
     const twz = eastern.local(2024, 1, 15, 10, 0, 0);
-    expect(twz.getutc().getTime()).toBe(twz.utc().getTime());
-    expect(twz.getgm().getTime()).toBe(twz.utc().getTime());
-    expect(twz.gmtime().getTime()).toBe(twz.utc().getTime());
+    expect(twz.getutc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(twz.getgm().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(twz.gmtime().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
   });
 
   it("toI() returns unix timestamp", () => {
@@ -163,7 +165,7 @@ describe("TimeWithZoneTest", () => {
 
     // Same moment, different local time
     expect(pstTime.hour).toBe(9); // 12 EST = 9 PST
-    expect(pstTime.utc().getTime()).toBe(estTime.utc().getTime());
+    expect(pstTime.utc().epochMilliseconds).toBe(estTime.utc().epochMilliseconds);
   });
 
   it("inTimeZone() accepts a TimeZone object", () => {
@@ -600,10 +602,10 @@ describe("TimeWithZoneTest", () => {
   it("handles year boundary crossing", () => {
     // Dec 31 23:00 EST = Jan 1 04:00 UTC
     const twz = eastern.local(2024, 12, 31, 23, 0, 0);
-    const utc = twz.utc();
-    expect(utc.getUTCFullYear()).toBe(2025);
-    expect(utc.getUTCMonth()).toBe(0);
-    expect(utc.getUTCDate()).toBe(1);
+    const z = twz.utc().toZonedDateTimeISO("UTC");
+    expect(z.year).toBe(2025);
+    expect(z.month).toBe(1);
+    expect(z.day).toBe(1);
   });
 
   it("handles leap year February 29", () => {
@@ -824,8 +826,7 @@ describe("TimeWithZoneTest", () => {
     expect(twz.dst()).toBe(false); // Hawaii doesn't observe DST
 
     // UTC should be 10 hours ahead
-    const utc = twz.utc();
-    expect(utc.getUTCHours()).toBe(10);
+    expect(twz.utc().toZonedDateTimeISO("UTC").hour).toBe(10);
   });
 
   it("Alaska timezone basic operations", () => {
@@ -846,10 +847,10 @@ describe("TimeWithZoneTest", () => {
     const back_to_eastern = hawaii_twz.inTimeZone(eastern);
 
     // All should represent the same UTC instant
-    expect(eastern_twz.utc().getTime()).toBe(utcTime.getTime());
-    expect(pacific_twz.utc().getTime()).toBe(utcTime.getTime());
-    expect(hawaii_twz.utc().getTime()).toBe(utcTime.getTime());
-    expect(back_to_eastern.utc().getTime()).toBe(utcTime.getTime());
+    expect(eastern_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
+    expect(pacific_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
+    expect(hawaii_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
+    expect(back_to_eastern.utc().epochMilliseconds).toBe(utcTime.getTime());
 
     // Local hours should differ
     expect(eastern_twz.hour).toBe(8); // EDT

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -547,7 +547,8 @@ export class TimeWithZone {
   }
 
   /**
-   * Subtract seconds, Duration, or another TimeWithZone/Date (returns seconds difference).
+   * Subtract seconds, Duration, or another TimeWithZone/Date/Temporal.Instant
+   * (returns seconds difference).
    */
   minus(interval: number | Duration): TimeWithZone;
   minus(other: TimeWithZone | Date | Temporal.Instant): number;
@@ -677,7 +678,7 @@ export class TimeWithZone {
   // ---------------------------------------------------------------------------
 
   /**
-   * Compare to another TimeWithZone or Date. Returns -1, 0, or 1.
+   * Compare to another TimeWithZone, Date, or Temporal.Instant. Returns -1, 0, or 1.
    */
   compareTo(other: TimeWithZone | Date | Temporal.Instant): number {
     const otherMs =

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -248,23 +248,23 @@ export class TimeWithZone {
   // Conversions
   // ---------------------------------------------------------------------------
 
-  /** Returns the UTC time as a Date */
-  utc(): Date {
-    return new Date(this._utc.getTime());
+  /** Returns the UTC instant. */
+  utc(): Temporal.Instant {
+    return this._zoned.toInstant();
   }
 
   /** Alias for utc() */
-  getutc(): Date {
+  getutc(): Temporal.Instant {
     return this.utc();
   }
 
   /** Alias for utc() */
-  getgm(): Date {
+  getgm(): Temporal.Instant {
     return this.utc();
   }
 
   /** Alias for utc() */
-  gmtime(): Date {
+  gmtime(): Temporal.Instant {
     return this.utc();
   }
 
@@ -291,8 +291,8 @@ export class TimeWithZone {
     return new Date(l.year, l.month - 1, l.day);
   }
 
-  /** Returns the UTC Date */
-  toTime(): Date {
+  /** Returns the UTC instant. */
+  toTime(): Temporal.Instant {
     return this.utc();
   }
 
@@ -550,13 +550,16 @@ export class TimeWithZone {
    * Subtract seconds, Duration, or another TimeWithZone/Date (returns seconds difference).
    */
   minus(interval: number | Duration): TimeWithZone;
-  minus(other: TimeWithZone | Date): number;
-  minus(arg: number | Duration | TimeWithZone | Date): TimeWithZone | number {
+  minus(other: TimeWithZone | Date | Temporal.Instant): number;
+  minus(arg: number | Duration | TimeWithZone | Date | Temporal.Instant): TimeWithZone | number {
     if (arg instanceof TimeWithZone) {
       return (this._utc.getTime() - arg._utc.getTime()) / 1000;
     }
     if (arg instanceof Date) {
       return (this._utc.getTime() - arg.getTime()) / 1000;
+    }
+    if (arg instanceof Temporal.Instant) {
+      return (this._utc.getTime() - arg.epochMilliseconds) / 1000;
     }
     if (arg instanceof Duration) {
       return this.plus(arg.negate());
@@ -676,8 +679,13 @@ export class TimeWithZone {
   /**
    * Compare to another TimeWithZone or Date. Returns -1, 0, or 1.
    */
-  compareTo(other: TimeWithZone | Date): number {
-    const otherMs = other instanceof TimeWithZone ? other._utc.getTime() : other.getTime();
+  compareTo(other: TimeWithZone | Date | Temporal.Instant): number {
+    const otherMs =
+      other instanceof TimeWithZone
+        ? other._utc.getTime()
+        : other instanceof Temporal.Instant
+          ? other.epochMilliseconds
+          : other.getTime();
     const thisMs = this._utc.getTime();
     if (thisMs < otherMs) return -1;
     if (thisMs > otherMs) return 1;
@@ -688,13 +696,13 @@ export class TimeWithZone {
    * Equality — two TimeWithZone instances are equal if they represent the same
    * moment in time, regardless of timezone.
    */
-  equals(other: TimeWithZone | Date): boolean {
+  equals(other: TimeWithZone | Date | Temporal.Instant): boolean {
     return this.compareTo(other) === 0;
   }
 
   /**
    * Equality based on UTC instant. Two times representing the same moment
-   * are eql regardless of timezone. Also accepts Date.
+   * are eql regardless of timezone. Also accepts Date or Temporal.Instant.
    */
   eql(other: unknown): boolean {
     if (other instanceof TimeWithZone) {
@@ -703,13 +711,19 @@ export class TimeWithZone {
     if (other instanceof Date) {
       return this._utc.getTime() === other.getTime();
     }
+    if (other instanceof Temporal.Instant) {
+      return this._utc.getTime() === other.epochMilliseconds;
+    }
     return false;
   }
 
   /**
    * Check if time falls between min and max (inclusive).
    */
-  between(min: TimeWithZone | Date, max: TimeWithZone | Date): boolean {
+  between(
+    min: TimeWithZone | Date | Temporal.Instant,
+    max: TimeWithZone | Date | Temporal.Instant,
+  ): boolean {
     return this.compareTo(min) >= 0 && this.compareTo(max) <= 0;
   }
 
@@ -747,12 +761,12 @@ export class TimeWithZone {
   }
 
   /** Returns true if this time is before the given time */
-  isBefore(other: TimeWithZone | Date): boolean {
+  isBefore(other: TimeWithZone | Date | Temporal.Instant): boolean {
     return this.compareTo(other) < 0;
   }
 
   /** Returns true if this time is after the given time */
-  isAfter(other: TimeWithZone | Date): boolean {
+  isAfter(other: TimeWithZone | Date | Temporal.Instant): boolean {
     return this.compareTo(other) > 0;
   }
 

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -30,7 +30,7 @@ describe("TimeZoneTest", () => {
   it("local to utc", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.local(1999, 12, 31, 19, 0, 0);
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
   });
 
   it("period for local", () => {
@@ -199,7 +199,7 @@ describe("TimeZoneTest", () => {
     expect(twz.day).toBe(31);
     expect(twz.month).toBe(12);
     expect(twz.year).toBe(1999);
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(twz.timeZone).toBe(zone);
     expect(twz.toF()).toBe(secs);
   });
@@ -214,7 +214,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.at(946684800);
     expect(twz.timeZone).toBe(zone);
-    expect(twz.utc().getTime()).toBe(946684800000);
+    expect(twz.utc().epochMilliseconds).toBe(946684800000);
   });
 
   // ---------------------------------------------------------------------------
@@ -238,7 +238,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 with zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.iso8601("1999-12-31T14:00:00-10:00");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -270,7 +270,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.iso8601("2050-01-01T00:00:00-05:00");
-    expect(twz.utc().getUTCFullYear()).toBe(2050);
+    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("iso8601 should not black out system timezone dst jump", () => {
@@ -311,7 +311,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 with ambiguous time", () => {
     const zone = TimeZone.find("Moscow");
     const twz = zone.iso8601("2014-10-26T01:00:00");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
   it("iso8601 with ordinal date value", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
@@ -338,14 +338,14 @@ describe("TimeZoneTest", () => {
     expect(twz.day).toBe(31);
     expect(twz.month).toBe(12);
     expect(twz.year).toBe(1999);
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(twz.timeZone).toBe(zone);
   });
 
   it("parse string with timezone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.parse("2024-01-15T12:00:00Z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
     expect(twz.hour).toBe(7);
   });
 
@@ -358,7 +358,7 @@ describe("TimeZoneTest", () => {
   it("parse far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.parse("2050-01-01T00:00:00-05:00");
-    expect(twz.utc().getUTCFullYear()).toBe(2050);
+    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("parse returns nil when string without date information is passed in", () => {
@@ -434,7 +434,7 @@ describe("TimeZoneTest", () => {
   it("parse with ambiguous time", () => {
     const zone = TimeZone.find("Moscow");
     const twz = zone.parse("2014-10-26 01:00:00");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   // ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ describe("TimeZoneTest", () => {
   it("rfc3339", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.rfc3339("1999-12-31T14:00:00-10:00");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -477,7 +477,7 @@ describe("TimeZoneTest", () => {
   it("rfc3339 far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.rfc3339("2050-01-01T00:00:00-05:00");
-    expect(twz.utc().getUTCFullYear()).toBe(2050);
+    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("rfc3339 should not black out system timezone dst jump", () => {
@@ -512,7 +512,7 @@ describe("TimeZoneTest", () => {
   it("strptime", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -520,7 +520,7 @@ describe("TimeZoneTest", () => {
   it("strptime with nondefault time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -528,7 +528,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as abbrev", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -536,7 +536,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as h offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -544,7 +544,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as hm offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -552,7 +552,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as hms offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -560,7 +560,7 @@ describe("TimeZoneTest", () => {
   it("strptime with almost explicit time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z");
-    expect(twz.utc().getTime()).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -597,7 +597,7 @@ describe("TimeZoneTest", () => {
   it("strptime with ambiguous time", () => {
     const zone = TimeZone.find("Moscow");
     const twz = zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S");
-    expect(twz.utc().getTime()).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 8c of the Temporal migration. Flips the `utc()` cluster from `Date` to `Temporal.Instant`:

- `utc()`, `getutc()`, `getgm()`, `gmtime()`, `toTime()` all return `Temporal.Instant` (sourced from `_zoned.toInstant()`).
- Comparison methods (`compareTo`, `equals`, `eql`, `between`, `isBefore`, `isAfter`, `minus`) widen to accept `Temporal.Instant` alongside `TimeWithZone | Date`.
- `travelTo` widens to accept `Date | Temporal.Instant` so tests can pass the new `twz.utc()` directly.
- Tests updated mechanically: `.getTime()` → `.epochMilliseconds`, `.toBeInstanceOf(Date)` → `.toBeInstanceOf(Temporal.Instant)`, UTC component getters → `.toZonedDateTimeISO("UTC").{year,month,day,...}`, `.toISOString()` → `.toString()`.

The remaining return-type flips (`localtime`/`getlocal` → `Temporal.PlainDateTime`, `toDate` → `Temporal.PlainDate`, `time` getter) are deferred to **PR 8d**.

## Test plan

- [x] `vitest run packages/activesupport` — 3603/3603 pass
- [x] `pnpm typecheck`
- [x] Diff size: 170 LOC under the 300 ceiling