### PR TITLE
feat(activemodel): expose Attributes mixin host with Rails-faithful constructor

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -218,10 +218,10 @@ export function attributes(attrs: AttributeSet): Record<string, unknown> {
  * Concrete mixin host for `ActiveModel::Attributes`. Rails ships
  * `Attributes` as a module included into a model; in TS this class is
  * the canonical instance-side surface. `Model` composes the same
- * behavior into its own constructor (model.ts:1201) for ergonomic
- * subclassing without forcing inheritance from `Attributes`, but any
- * lighter-weight host that wants the bare attribute machinery can
- * extend this class directly.
+ * behavior into its own constructor for ergonomic subclassing without
+ * forcing inheritance from `Attributes`, but any lighter-weight host
+ * that wants the bare attribute machinery can extend this class
+ * directly.
  *
  * Mirrors: ActiveModel::Attributes (instance side, attributes.rb:31-160)
  */
@@ -234,8 +234,12 @@ export class Attributes {
    *     @attributes = self.class._default_attributes.deep_dup
    *     super
    *   end
+   *
+   * The rest parameter mirrors Rails' `(*)` splat: subclasses can
+   * forward arbitrary arguments via `super(...args)` even though this
+   * base ignores them.
    */
-  constructor() {
+  constructor(..._args: unknown[]) {
     const ctor = this.constructor as { _defaultAttributes?(): AttributeSet };
     this._attributes = ctor._defaultAttributes
       ? ctor._defaultAttributes().deepDup()

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -32,16 +32,6 @@ export interface AttributeDefinition {
   source?: "user" | "schema";
 }
 
-/**
- * Attributes module contract.
- *
- * Mirrors: ActiveModel::Attributes
- */
-export interface Attributes {
-  readonly attributes: Record<string, unknown>;
-  attributeNames(): string[];
-}
-
 // ---------------------------------------------------------------------------
 // Class methods — Mirrors: ActiveModel::Attributes::ClassMethods
 // ---------------------------------------------------------------------------
@@ -222,4 +212,43 @@ export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): 
  */
 export function attributes(attrs: AttributeSet): Record<string, unknown> {
   return attrs.toHash();
+}
+
+/**
+ * Concrete mixin host for `ActiveModel::Attributes`. Rails ships
+ * `Attributes` as a module included into a model; in TS this class is
+ * the canonical instance-side surface. `Model` composes the same
+ * behavior into its own constructor (model.ts:1201) for ergonomic
+ * subclassing without forcing inheritance from `Attributes`, but any
+ * lighter-weight host that wants the bare attribute machinery can
+ * extend this class directly.
+ *
+ * Mirrors: ActiveModel::Attributes (instance side, attributes.rb:31-160)
+ */
+export class Attributes {
+  _attributes: AttributeSet;
+
+  /**
+   * Mirrors: attributes.rb:106-109
+   *   def initialize(*) # :nodoc:
+   *     @attributes = self.class._default_attributes.deep_dup
+   *     super
+   *   end
+   */
+  constructor() {
+    const ctor = this.constructor as { _defaultAttributes?(): AttributeSet };
+    this._attributes = ctor._defaultAttributes
+      ? ctor._defaultAttributes().deepDup()
+      : new AttributeSet();
+  }
+
+  /** Mirrors: attributes.rb:131-133 — `def attributes; @attributes.to_hash; end` */
+  get attributes(): Record<string, unknown> {
+    return this._attributes.toHash();
+  }
+
+  /** Mirrors: attributes.rb:146-148 — `def attribute_names; @attributes.keys; end` */
+  attributeNames(): string[] {
+    return Array.from(this._attributes.keys());
+  }
 }

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -249,6 +249,6 @@ export class Attributes {
 
   /** Mirrors: attributes.rb:146-148 — `def attribute_names; @attributes.keys; end` */
   attributeNames(): string[] {
-    return Array.from(this._attributes.keys());
+    return this._attributes.keys();
   }
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -30,6 +30,8 @@ export {
   resetDefaultAttributes,
   registerWithSuperclass,
 } from "./attribute-registration.js";
+export { Attributes } from "./attributes.js";
+export type { AttributeDefinition } from "./attributes.js";
 export { Attribute, FromDatabase, FromUser, WithCastValue } from "./attribute.js";
 export { UserProvidedDefault } from "./attribute/user-provided-default.js";
 export { AttributeSet } from "./attribute-set.js";


### PR DESCRIPTION
## Summary
Replaces the bare `Attributes` interface in `attributes.ts` with a concrete class mirroring `ActiveModel::Attributes`'s instance side (Rails `attributes.rb:31-160`). The constructor implements the Rails `initialize` contract:

```ruby
def initialize(*) # :nodoc:
  @attributes = self.class._default_attributes.deep_dup
  super
end
```

`Model` continues to compose the same behavior in its own constructor (`model.ts:1201`) for ergonomic subclassing without forcing inheritance from `Attributes`; this class is for lighter-weight hosts that want the bare attribute machinery directly.

## Impact
- `pnpm api:compare --package activemodel`: **424/433 → 425/433** (97.9% → 98.2%). Closes 1 of the remaining 9 missing methods (`initialize → constructor` row for `attributes.rb`).
- Two `attribute_missing` rows remain (`attributes.rb`, `dirty.rb`); deferred to a follow-up because trails' existing `attributeMissing(name)` is a divergent fallback hook called from `readAttribute`, misnamed after Rails' dispatch helper. A faithful fix requires reworking `Model.readAttribute` and the corresponding tests — bigger than one PR's worth of work.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1554/1554 passing
- [x] `pnpm api:compare --package activemodel` — 425/433