### PR TITLE
fix(activerecord): treat file::memory: URI variants as in-memory in SQLiteDatabaseTasks

### DIFF
--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as activesupport from "@blazetrails/activesupport";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -145,28 +146,70 @@ describe("SQLiteDatabaseTasks", () => {
 });
 
 describe("SQLiteDatabaseTasks in-memory URI variants", () => {
+  let mockFs: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const assertNoFsWrites = () => {
+    const fsObj = activesupport.getFs();
+    const mkdirSpy = vi.spyOn(fsObj, "mkdirSync");
+    const writeSpy = vi.spyOn(fsObj, "writeFileSync");
+    const unlinkSpy = vi.spyOn(fsObj, "unlinkSync");
+    return { mkdirSpy, writeSpy, unlinkSpy };
+  };
+
   it("test_db_create_is_noop_for_file_memory_uri", async () => {
+    const { mkdirSpy, writeSpy } = assertNoFsWrites();
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
       database: "file::memory:?cache=shared",
     });
-    // Should not throw or create any file
     await expect(new SQLiteDatabaseTasks(config).create()).resolves.toBeUndefined();
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(writeSpy).not.toHaveBeenCalled();
   });
 
   it("test_db_drop_is_noop_for_file_memory_uri", async () => {
+    const { unlinkSpy } = assertNoFsWrites();
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
       database: "file::memory:?cache=shared",
     });
     await expect(new SQLiteDatabaseTasks(config).drop()).resolves.toBeUndefined();
+    expect(unlinkSpy).not.toHaveBeenCalled();
   });
 
   it("test_db_create_is_noop_for_canonical_memory", async () => {
+    const { mkdirSpy, writeSpy } = assertNoFsWrites();
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
       database: ":memory:",
     });
     await expect(new SQLiteDatabaseTasks(config).create()).resolves.toBeUndefined();
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("test_db_create_is_noop_for_named_file_memory_uri", async () => {
+    const { mkdirSpy, writeSpy } = assertNoFsWrites();
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "file:memdb1?mode=memory&cache=shared",
+    });
+    await expect(new SQLiteDatabaseTasks(config).create()).resolves.toBeUndefined();
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("test_db_drop_is_noop_for_named_file_memory_uri", async () => {
+    const { unlinkSpy } = assertNoFsWrites();
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "file:memdb1?mode=memory&cache=shared",
+    });
+    await expect(new SQLiteDatabaseTasks(config).drop()).resolves.toBeUndefined();
+    expect(unlinkSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -143,3 +143,30 @@ describe("SQLiteDatabaseTasks", () => {
     }
   });
 });
+
+describe("SQLiteDatabaseTasks in-memory URI variants", () => {
+  it("test_db_create_is_noop_for_file_memory_uri", async () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "file::memory:?cache=shared",
+    });
+    // Should not throw or create any file
+    await expect(new SQLiteDatabaseTasks(config).create()).resolves.toBeUndefined();
+  });
+
+  it("test_db_drop_is_noop_for_file_memory_uri", async () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: "file::memory:?cache=shared",
+    });
+    await expect(new SQLiteDatabaseTasks(config).drop()).resolves.toBeUndefined();
+  });
+
+  it("test_db_create_is_noop_for_canonical_memory", async () => {
+    const config = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: ":memory:",
+    });
+    await expect(new SQLiteDatabaseTasks(config).create()).resolves.toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -146,8 +146,6 @@ describe("SQLiteDatabaseTasks", () => {
 });
 
 describe("SQLiteDatabaseTasks in-memory URI variants", () => {
-  let mockFs: ReturnType<typeof vi.spyOn>;
-
   afterEach(() => {
     vi.restoreAllMocks();
   });

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -152,9 +152,9 @@ describe("SQLiteDatabaseTasks in-memory URI variants", () => {
 
   const assertNoFsWrites = () => {
     const fsObj = activesupport.getFs();
-    const mkdirSpy = vi.spyOn(fsObj, "mkdirSync");
-    const writeSpy = vi.spyOn(fsObj, "writeFileSync");
-    const unlinkSpy = vi.spyOn(fsObj, "unlinkSync");
+    const mkdirSpy = vi.spyOn(fsObj, "mkdirSync").mockImplementation(() => undefined);
+    const writeSpy = vi.spyOn(fsObj, "writeFileSync").mockImplementation(() => undefined as any);
+    const unlinkSpy = vi.spyOn(fsObj, "unlinkSync").mockImplementation(() => undefined);
     return { mkdirSpy, writeSpy, unlinkSpy };
   };
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -48,10 +48,11 @@ export class SQLiteDatabaseTasks {
     const fs = getFs();
     const path = getPath();
     const dbPath = this.resolveDbPath();
-    if (!isInMemoryDatabase(dbPath) && fs.existsSync(dbPath)) {
+    const inMemory = isInMemoryDatabase(dbPath);
+    if (!inMemory && fs.existsSync(dbPath)) {
       throw new DatabaseAlreadyExists(`Database '${dbPath}' already exists`);
     }
-    if (!isInMemoryDatabase(dbPath)) {
+    if (!inMemory) {
       fs.mkdirSync(path.dirname(dbPath), { recursive: true });
       fs.writeFileSync(dbPath, "");
     }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -25,7 +25,10 @@ import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../
 function isInMemoryDatabase(name: string): boolean {
   if (name === ":memory:") return true;
   if (!name.startsWith("file:")) return false;
-  return name.startsWith("file::memory:") || name.includes("mode=memory");
+  if (name.startsWith("file::memory:")) return true;
+  const q = name.indexOf("?");
+  if (q === -1) return false;
+  return new URLSearchParams(name.slice(q + 1)).get("mode") === "memory";
 }
 
 export class SQLiteDatabaseTasks {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -16,14 +16,16 @@ import { DatabaseTasks } from "./database-tasks.js";
 import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 
 /**
- * True for SQLite in-memory database names: the canonical `:memory:` and
- * the URI `file::memory:` variants (with optional query params).
- * Matches what SQLite itself treats as in-memory per https://www.sqlite.org/inmemorydb.html.
+ * True for SQLite in-memory database names. Mirrors `SQLite3Adapter._isMemoryFilename`
+ * so both the adapter and task layer agree on what is in-memory.
+ *
+ * Covers: `:memory:`, `file::memory:?...`, and named in-memory URIs like
+ * `file:memdb1?mode=memory&cache=shared` (see https://www.sqlite.org/inmemorydb.html).
  */
 function isInMemoryDatabase(name: string): boolean {
   if (name === ":memory:") return true;
-  if (name.startsWith("file::memory:")) return true;
-  return false;
+  if (!name.startsWith("file:")) return false;
+  return name.startsWith("file::memory:") || name.includes("mode=memory");
 }
 
 export class SQLiteDatabaseTasks {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -15,6 +15,17 @@ import type { DatabaseConfig } from "../database-configurations/database-config.
 import { DatabaseTasks } from "./database-tasks.js";
 import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 
+/**
+ * True for SQLite in-memory database names: the canonical `:memory:` and
+ * the URI `file::memory:` variants (with optional query params).
+ * Matches what SQLite itself treats as in-memory per https://www.sqlite.org/inmemorydb.html.
+ */
+function isInMemoryDatabase(name: string): boolean {
+  if (name === ":memory:") return true;
+  if (name.startsWith("file::memory:")) return true;
+  return false;
+}
+
 export class SQLiteDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
   private readonly root: string;
@@ -32,10 +43,10 @@ export class SQLiteDatabaseTasks {
     const fs = getFs();
     const path = getPath();
     const dbPath = this.resolveDbPath();
-    if (dbPath !== ":memory:" && fs.existsSync(dbPath)) {
+    if (!isInMemoryDatabase(dbPath) && fs.existsSync(dbPath)) {
       throw new DatabaseAlreadyExists(`Database '${dbPath}' already exists`);
     }
-    if (dbPath !== ":memory:") {
+    if (!isInMemoryDatabase(dbPath)) {
       fs.mkdirSync(path.dirname(dbPath), { recursive: true });
       fs.writeFileSync(dbPath, "");
     }
@@ -44,7 +55,7 @@ export class SQLiteDatabaseTasks {
   async drop(): Promise<void> {
     const fs = getFs();
     const dbPath = this.resolveDbPath();
-    if (dbPath === ":memory:") return;
+    if (isInMemoryDatabase(dbPath)) return;
     try {
       fs.unlinkSync(dbPath);
     } catch (error: unknown) {
@@ -265,7 +276,7 @@ export class SQLiteDatabaseTasks {
     // Per PathAdapter contract, a missing isAbsolute means the adapter
     // doesn't model relative/absolute distinctions (e.g. a VFS) — treat
     // every path as already absolute.
-    if (database === ":memory:") return database;
+    if (isInMemoryDatabase(database)) return database;
     if (!path.isAbsolute || path.isAbsolute(database)) return database;
     return path.join(this.root, database);
   }

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -16,11 +16,14 @@ import { DatabaseTasks } from "./database-tasks.js";
 import { NoDatabaseError, DatabaseAlreadyExists, NotImplementedError } from "../errors.js";
 
 /**
- * True for SQLite in-memory database names. Mirrors `SQLite3Adapter._isMemoryFilename`
- * so both the adapter and task layer agree on what is in-memory.
+ * True for SQLite in-memory database names per the SQLite URI spec
+ * (https://www.sqlite.org/inmemorydb.html): `:memory:`, `file::memory:?...`,
+ * and named in-memory URIs whose query string contains a real `mode=memory`
+ * parameter (e.g. `file:memdb1?mode=memory&cache=shared`).
  *
- * Covers: `:memory:`, `file::memory:?...`, and named in-memory URIs like
- * `file:memdb1?mode=memory&cache=shared` (see https://www.sqlite.org/inmemorydb.html).
+ * Uses `URLSearchParams` rather than substring matching so paths that happen
+ * to contain the text `mode=memory` are not misclassified. `SQLite3Adapter`
+ * currently uses a broader substring check — aligning it is a follow-up.
  */
 function isInMemoryDatabase(name: string): boolean {
   if (name === ":memory:") return true;


### PR DESCRIPTION
Deferred from #943. `SQLiteDatabaseTasks.create` and `drop` only special-cased the canonical `":memory:"` name, so URI-form in-memory databases were treated as on-disk paths.

## Changes

- Adds `isInMemoryDatabase(name)` helper covering `:memory:`, `file::memory:` URI prefix, and `file:...?mode=memory` URIs (via `URLSearchParams` — avoids false positives like `file:/tmp/mode=memory.sqlite3`). Mirrors `SQLite3Adapter._isMemoryFilename` so both layers agree.
- Replaces all bare `=== ":memory:"` / `!== ":memory:"` checks in `create`, `drop`, and `resolveDbPath` with the helper.

## Tests

Five new tests under `SQLiteDatabaseTasks in-memory URI variants`:
- `file::memory:?cache=shared` create is a no-op (asserts no `mkdirSync`/`writeFileSync`)
- `file::memory:?cache=shared` drop is a no-op (asserts no `unlinkSync`)
- `:memory:` create is a no-op
- `file:memdb1?mode=memory&cache=shared` create is a no-op
- `file:memdb1?mode=memory&cache=shared` drop is a no-op