### PR TITLE
feat(activerecord): per-attribute confirmation, challenge, and salt for hasSecurePassword

### DIFF
--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -616,6 +616,7 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     (u as any).recoveryPasswordChallenge = "   ";
     expect((u as any).recoveryPasswordChallenge).toBeNull();
     const valid = await u.validate();
+    expect(valid).toBe(true);
     expect((u as any).errors.messages["recovery_password_challenge"]).toBeUndefined();
   });
 

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -531,7 +531,8 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     (u as any).recoveryPasswordConfirmation = "different";
     const valid = await u.validate();
     expect(valid).toBe(false);
-    expect((u as any).errors.fullMessages.join(", ")).toMatch(/confirmation/i);
+    // Error keyed to recovery_password_confirmation (Rails snake_case parity)
+    expect((u as any).errors.messages["recovery_password_confirmation"]).toBeDefined();
   });
 
   it("passes validation when confirmation matches", async () => {
@@ -554,7 +555,8 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     (u as any).recoveryPasswordChallenge = "wrongpassword";
     const valid = await u.validate();
     expect(valid).toBe(false);
-    expect((u as any).errors.fullMessages.join(", ")).toMatch(/invalid/i);
+    // Error keyed to recovery_password_challenge (Rails snake_case parity)
+    expect((u as any).errors.messages["recovery_password_challenge"]).toBeDefined();
   });
 
   it("challenge validation passes with correct current password", async () => {

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -478,11 +478,18 @@ describe("SecurePasswordTest", () => {
 
 describe("hasSecurePassword — per-attribute confirmation, challenge, and salt", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => { adapter = freshAdapter(); });
+  beforeEach(() => {
+    adapter = freshAdapter();
+  });
 
   const makeModel = () => {
     class User extends Base {
-      static { this._tableName = "users"; this.attribute("id", "integer"); this.attribute("email", "string"); this.attribute("recovery_password_digest", "string"); }
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("email", "string");
+        this.attribute("recovery_password_digest", "string");
+      }
     }
     hasSecurePassword(User, "recovery_password", { validations: true });
     User.adapter = adapter;

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -561,4 +561,25 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     const valid = await u.validate();
     expect(valid).toBe(true);
   });
+
+  it("challenge validation checks current digest after multiple saves", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "first";
+    await u.save({ validate: false });
+
+    // Second save — update password
+    (u as any).recovery_password = "second";
+    await u.save({ validate: false });
+
+    // Now challenge must match "second", not "first"
+    (u as any).recovery_password = "third";
+    (u as any).recoveryPasswordChallenge = "first"; // old — should fail
+    expect(await u.validate()).toBe(false);
+
+    (u as any).errors.clear?.();
+    (u as any).recovery_password = "third";
+    (u as any).recoveryPasswordChallenge = "second"; // current — should pass
+    expect(await u.validate()).toBe(true);
+  });
 });

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -524,7 +524,7 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     (u as any).recoveryPasswordConfirmation = "different";
     const valid = await u.validate();
     expect(valid).toBe(false);
-    expect((u as any).errors.fullMessages().join(", ")).toMatch(/confirmation/i);
+    expect((u as any).errors.fullMessages.join(", ")).toMatch(/confirmation/i);
   });
 
   it("passes validation when confirmation matches", async () => {
@@ -532,6 +532,32 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     const u = new User({});
     (u as any).recovery_password = "secret123";
     (u as any).recoveryPasswordConfirmation = "secret123";
+    const valid = await u.validate();
+    expect(valid).toBe(true);
+  });
+
+  it("challenge validation rejects wrong current password", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "original";
+    await u.save({ validate: false });
+
+    // Now change with wrong challenge
+    (u as any).recovery_password = "newpassword";
+    (u as any).recoveryPasswordChallenge = "wrongpassword";
+    const valid = await u.validate();
+    expect(valid).toBe(false);
+    expect((u as any).errors.fullMessages.join(", ")).toMatch(/invalid/i);
+  });
+
+  it("challenge validation passes with correct current password", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "original";
+    await u.save({ validate: false });
+
+    (u as any).recovery_password = "newpassword";
+    (u as any).recoveryPasswordChallenge = "original";
     const valid = await u.validate();
     expect(valid).toBe(true);
   });

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -475,3 +475,64 @@ describe("SecurePasswordTest", () => {
     expect(notFound).toBeNull();
   });
 });
+
+describe("hasSecurePassword — per-attribute confirmation, challenge, and salt", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => { adapter = freshAdapter(); });
+
+  const makeModel = () => {
+    class User extends Base {
+      static { this._tableName = "users"; this.attribute("id", "integer"); this.attribute("email", "string"); this.attribute("recovery_password_digest", "string"); }
+    }
+    hasSecurePassword(User, "recovery_password", { validations: true });
+    User.adapter = adapter;
+    return User;
+  };
+
+  it("defines recoveryPasswordConfirmation getter/setter", () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recoveryPasswordConfirmation = "secret";
+    expect((u as any).recoveryPasswordConfirmation).toBe("secret");
+  });
+
+  it("defines recoveryPasswordChallenge getter/setter", () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recoveryPasswordChallenge = "old";
+    expect((u as any).recoveryPasswordChallenge).toBe("old");
+  });
+
+  it("defines recoveryPasswordSalt getter returning null when no digest", () => {
+    const User = makeModel();
+    const u = new User({});
+    expect((u as any).recoveryPasswordSalt).toBeNull();
+  });
+
+  it("recoveryPasswordSalt returns salt after password is set", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "secret123";
+    await u.save({ validate: false });
+    expect((u as any).recoveryPasswordSalt).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("validates recovery_password_confirmation mismatch", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "secret123";
+    (u as any).recoveryPasswordConfirmation = "different";
+    const valid = await u.validate();
+    expect(valid).toBe(false);
+    expect((u as any).errors.fullMessages().join(", ")).toMatch(/confirmation/i);
+  });
+
+  it("passes validation when confirmation matches", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "secret123";
+    (u as any).recoveryPasswordConfirmation = "secret123";
+    const valid = await u.validate();
+    expect(valid).toBe(true);
+  });
+});

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -592,6 +592,33 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     expect(valid).toBe(true);
   });
 
+  it("nil assignment clears the digest immediately", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "secret123";
+    await u.save({ validate: false });
+    expect(u._readAttribute("recovery_password_digest")).toBeTruthy();
+
+    (u as any).recovery_password = null;
+    expect(u._readAttribute("recovery_password_digest")).toBeNull();
+    await u.save({ validate: false });
+    expect(u._readAttribute("recovery_password_digest")).toBeNull();
+  });
+
+  it("blank challenge is treated as absent and does not trigger challenge validation", async () => {
+    const User = makeModel();
+    const u = new User({});
+    (u as any).recovery_password = "original";
+    await u.save({ validate: false });
+
+    // Blank challenge should normalize to null — no validation error
+    (u as any).recovery_password = "newpassword";
+    (u as any).recoveryPasswordChallenge = "   ";
+    expect((u as any).recoveryPasswordChallenge).toBeNull();
+    const valid = await u.validate();
+    expect((u as any).errors.messages["recovery_password_challenge"]).toBeUndefined();
+  });
+
   it("challenge validation checks current digest after multiple saves", async () => {
     const User = makeModel();
     const u = new User({});

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -524,6 +524,27 @@ describe("hasSecurePassword — per-attribute confirmation, challenge, and salt"
     expect((u as any).recoveryPasswordSalt).toMatch(/^[0-9a-f]+$/);
   });
 
+  it("recoveryPasswordSalt returns null for malformed digest (no separator)", () => {
+    const User = makeModel();
+    const u = new User({});
+    u.writeAttribute("recovery_password_digest", "noseparator");
+    expect((u as any).recoveryPasswordSalt).toBeNull();
+  });
+
+  it("recoveryPasswordSalt returns null for malformed digest (empty salt)", () => {
+    const User = makeModel();
+    const u = new User({});
+    u.writeAttribute("recovery_password_digest", ":hashonly");
+    expect((u as any).recoveryPasswordSalt).toBeNull();
+  });
+
+  it("recoveryPasswordSalt returns null for malformed digest (empty hash)", () => {
+    const User = makeModel();
+    const u = new User({});
+    u.writeAttribute("recovery_password_digest", "saltonly:");
+    expect((u as any).recoveryPasswordSalt).toBeNull();
+  });
+
   it("validates recovery_password_confirmation mismatch", async () => {
     const User = makeModel();
     const u = new User({});

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,7 +1,8 @@
-import { getCrypto, camelize, pbkdf2Async } from "@blazetrails/activesupport";
+import { getCrypto, camelize, humanize, pbkdf2Async } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
+import { attributeBeforeLastSave } from "./attribute-methods/dirty.js";
 
 /**
  * Secure password support using PBKDF2 (Web Crypto API).
@@ -177,35 +178,40 @@ export function hasSecurePassword(
   // Add validations — mirrors Rails' validates_presence_of, validates_confirmation_of,
   // and challenge validation in has_secure_password.
   if (runValidations) {
-    const attrLabel = attribute.charAt(0).toUpperCase() + attribute.slice(1).replace(/_./g, (s) => s.slice(1).toUpperCase());
+    const attrLabel = humanize(attribute);
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
+      const rawPasswordPresent =
+        rawPassword !== null && rawPassword !== undefined && rawPassword !== "";
 
       // Presence: mirrors `record.errors.add(attribute, :blank) unless digest.present?`
-      // Fires on every validate — catches both new records without passwords
-      // and existing records whose digest was explicitly cleared.
-      if (!record._readAttribute(digestAttr)) {
+      // In Rails, password= immediately sets the digest (BCrypt). In trails,
+      // hashing defers to beforeSave, so we also check the in-flight raw password
+      // to avoid false :blank errors before the first save.
+      if (!record._readAttribute(digestAttr) && !rawPasswordPresent) {
         record.errors.add(attribute, "blank");
       }
 
       // Confirmation: mirrors `validates_confirmation_of attribute, allow_blank: true`
-      // Skip when password is blank (allow_blank: true).
       const confirmation = record[confirmationKey];
-      const passwordPresent = rawPassword !== null && rawPassword !== undefined && rawPassword !== "";
-      if (passwordPresent && confirmation !== null && confirmation !== undefined && rawPassword !== confirmation) {
+      if (
+        rawPasswordPresent &&
+        confirmation !== null &&
+        confirmation !== undefined &&
+        rawPassword !== confirmation
+      ) {
         record.errors.add(confirmationProp, "confirmation", {
-          message: `doesn't match ${attrLabel}`,
+          attribute: attrLabel,
         });
       }
 
-      // Challenge validation: current password must verify against stored digest
-      // Mirrors: validates_with ActiveModel::SecurePassword::PasswordChallenge
+      // Challenge: verify current password against the pre-change digest.
+      // Mirrors Rails' challenge validation using dirty tracking's "was" value
+      // (`#{attribute}_digest_was`). Falls back to current digest if no prior
+      // save exists (e.g. new record — challenge validation fails gracefully).
       const challenge = record[challengeKey];
       if (challenge !== null && challenge !== undefined) {
-        const digestWas =
-          typeof record._readAttributeBeforeLastSave === "function"
-            ? record._readAttributeBeforeLastSave(digestAttr)
-            : record._readAttribute(digestAttr);
+        const digestWas = attributeBeforeLastSave(record, digestAttr) ?? record._readAttribute(digestAttr);
         if (!digestWas || !verifyPassword(String(challenge), digestWas as string)) {
           record.errors.add(challengeProp, "invalid");
         }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -56,7 +56,7 @@ export function hasSecurePassword(
   const runValidations = options.validations !== false;
   const digestAttr = `${attribute}_digest`;
 
-  // Store the raw password and confirmation temporarily (cleared after hashing).
+  // Store the raw password, confirmation, and challenge temporarily (all cleared after hashing).
   const passwordKey = Symbol(`${attribute}`);
   const confirmationKey = Symbol(`${attribute}_confirmation`);
   const challengeKey = Symbol(`${attribute}_challenge`);

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -112,10 +112,10 @@ export function hasSecurePassword(
     },
     set: function (value: string | null) {
       // Rails uses present? to gate challenge validation — normalize blank to null.
-      (this as any)[challengeKey] =
-        value === null || value === undefined || (typeof value === "string" && !value.trim())
-          ? null
-          : value;
+      // Use isBlank after coercion so non-string blanks (false, [], etc.) are also caught.
+      const coerced =
+        value === null || value === undefined ? null : typeof value === "string" ? value : String(value);
+      (this as any)[challengeKey] = coerced === null || isBlank(coerced) ? null : coerced;
     },
     configurable: true,
   });

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -56,10 +56,15 @@ export function hasSecurePassword(
   const runValidations = options.validations !== false;
   const digestAttr = `${attribute}_digest`;
 
-  // Store the raw password, confirmation, and challenge temporarily (all cleared after hashing).
+  // Store the raw password, confirmation, and challenge temporarily.
+  // Cleared only when a non-blank password is hashed in beforeSave.
   const passwordKey = Symbol(`${attribute}`);
   const confirmationKey = Symbol(`${attribute}_confirmation`);
   const challengeKey = Symbol(`${attribute}_challenge`);
+
+  // Camelized base for property names (e.g. "recovery_password" → "recoveryPassword").
+  const camelBase =
+    camelize(attribute).charAt(0).toLowerCase() + camelize(attribute).slice(1);
 
   // Define setter/getter for the configured secure-password attribute
   // (e.g. password / recovery_password).
@@ -80,7 +85,7 @@ export function hasSecurePassword(
   });
 
   // {attribute}_confirmation — Rails: attr_accessor :"#{attribute}_confirmation"
-  const confirmationProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Confirmation`;
+  const confirmationProp = `${camelBase}Confirmation`;
   Object.defineProperty(modelClass.prototype, confirmationProp, {
     get: function () {
       return (this as any)[confirmationKey] ?? null;
@@ -93,7 +98,7 @@ export function hasSecurePassword(
 
   // {attribute}_challenge — Rails: attr_accessor :"#{attribute}_challenge"
   // Used to verify the current password before changing it.
-  const challengeProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Challenge`;
+  const challengeProp = `${camelBase}Challenge`;
   Object.defineProperty(modelClass.prototype, challengeProp, {
     get: function () {
       return (this as any)[challengeKey] ?? null;
@@ -110,7 +115,7 @@ export function hasSecurePassword(
 
   // {attribute}_salt — returns the salt portion of the stored digest.
   // Mirrors: define_method("#{attribute}_salt") in InstanceMethodsOnActivation
-  const saltProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Salt`;
+  const saltProp = `${camelBase}Salt`;
   Object.defineProperty(modelClass.prototype, saltProp, {
     get: function (this: Base) {
       const digest = this._readAttribute(digestAttr) as string | null;
@@ -166,7 +171,7 @@ export function hasSecurePassword(
   // invalidation to round-trip through the DB.
   modelClass.beforeSave(function (record: Base) {
     const rawPassword = (record as any)[passwordKey];
-    // Rails `password=` setter skips hashing for empty strings
+    // Rails `password=` setter skips hashing for blank values (nil or empty/whitespace)
     // (active_model/secure_password.rb) — an empty password is not a
     // valid password, so we leave the existing digest untouched.
     if (rawPassword != null && !isBlank(rawPassword)) {

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -56,12 +56,14 @@ export function hasSecurePassword(
   const runValidations = options.validations !== false;
   const digestAttr = `${attribute}_digest`;
 
-  // Store the raw password temporarily for hashing during save
+  // Store the raw password and confirmation temporarily (cleared after hashing).
   const passwordKey = Symbol(`${attribute}`);
   const confirmationKey = Symbol(`${attribute}_confirmation`);
+  const challengeKey = Symbol(`${attribute}_challenge`);
 
   // Define setter/getter for the configured secure-password attribute
   // (e.g. password / recovery_password).
+  // Mirrors: attr_reader + define_method("#{attribute}=") in InstanceMethodsOnActivation
   Object.defineProperty(modelClass.prototype, attribute, {
     get: function () {
       return (this as any)[passwordKey] ?? null;
@@ -72,21 +74,46 @@ export function hasSecurePassword(
     configurable: true,
   });
 
-  // password_confirmation setter/getter — only for the default attribute,
-  // matching the surface most apps rely on. Per-attribute confirmation is
-  // a separable follow-up.
-  if (isDefaultAttribute) {
-    Object.defineProperty(modelClass.prototype, "passwordConfirmation", {
-      get: function () {
-        return (this as any)[confirmationKey] ?? null;
-      },
-      set: function (value: string | null) {
-        (this as any)[confirmationKey] = value;
-      },
-      configurable: true,
-    });
+  // {attribute}_confirmation — Rails: attr_accessor :"#{attribute}_confirmation"
+  const confirmationProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Confirmation`;
+  Object.defineProperty(modelClass.prototype, confirmationProp, {
+    get: function () {
+      return (this as any)[confirmationKey] ?? null;
+    },
+    set: function (value: string | null) {
+      (this as any)[confirmationKey] = value;
+    },
+    configurable: true,
+  });
 
+  // {attribute}_challenge — Rails: attr_accessor :"#{attribute}_challenge"
+  // Used to verify the current password before changing it.
+  const challengeProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Challenge`;
+  Object.defineProperty(modelClass.prototype, challengeProp, {
+    get: function () {
+      return (this as any)[challengeKey] ?? null;
+    },
+    set: function (value: string | null) {
+      (this as any)[challengeKey] = value;
+    },
+    configurable: true,
+  });
+
+  // {attribute}_salt — returns the salt portion of the stored digest.
+  // Mirrors: define_method("#{attribute}_salt") in InstanceMethodsOnActivation
+  const saltProp = `${camelize(attribute).charAt(0).toLowerCase()}${camelize(attribute).slice(1)}Salt`;
+  Object.defineProperty(modelClass.prototype, saltProp, {
+    get: function (this: Base) {
+      const digest = this._readAttribute(digestAttr) as string | null;
+      if (!digest) return null;
+      return digest.split(":")[0] ?? null;
+    },
+    configurable: true,
+  });
+
+  if (isDefaultAttribute) {
     // `authenticate` (no suffix) is a Rails convenience for the default attribute.
+    // Mirrors: alias_method :authenticate, :authenticate_password
     Object.defineProperty(modelClass.prototype, "authenticate", {
       value: function (this: Base, password: string): Base | false {
         const digest = this._readAttribute(digestAttr);
@@ -134,33 +161,48 @@ export function hasSecurePassword(
     if (rawPassword != null && rawPassword !== "") {
       const digest = hashPassword(rawPassword);
       record.writeAttribute(digestAttr, digest);
-      // Clear the raw password after hashing so subsequent saves don't
-      // rehash with a new random salt (changing the digest on every save
-      // would invalidate outstanding password-reset tokens).
+      // Clear the raw password, confirmation, and challenge after hashing
+      // so subsequent saves don't rehash with a new random salt.
       (record as any)[passwordKey] = null;
       (record as any)[confirmationKey] = null;
+      (record as any)[challengeKey] = null;
     }
   });
 
-  // Add validations (only wired for the default `password` attribute today;
-  // per-attribute validations would mean parameterizing the `errors.add`
-  // keys and message — separable from authenticate_by parity).
-  if (runValidations && isDefaultAttribute) {
+  // Add validations — mirrors Rails' validates_presence_of, validates_confirmation_of,
+  // and challenge validation in has_secure_password.
+  if (runValidations) {
+    const attrLabel = attribute.charAt(0).toUpperCase() + attribute.slice(1).replace(/_./g, (s) => s.slice(1).toUpperCase());
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
       const isNew = record.isNewRecord();
 
-      // Password must be present on create or when explicitly set
+      // Presence on create (or when digest is absent): mirrors validates_presence_of
       if (isNew && (rawPassword === null || rawPassword === undefined || rawPassword === "")) {
-        record.errors.add("password", "blank");
+        if (!record._readAttribute(digestAttr)) {
+          record.errors.add(attribute, "blank");
+        }
       }
 
-      // Password confirmation must match if provided
+      // Confirmation must match if provided: mirrors validates_confirmation_of
       const confirmation = record[confirmationKey];
       if (confirmation !== null && confirmation !== undefined && rawPassword !== confirmation) {
-        record.errors.add("password_confirmation", "confirmation", {
-          message: "doesn't match Password",
+        record.errors.add(confirmationProp, "confirmation", {
+          message: `doesn't match ${attrLabel}`,
         });
+      }
+
+      // Challenge validation: current password must verify against stored digest
+      // Mirrors: validates_with ActiveModel::SecurePassword::PasswordChallenge
+      const challenge = record[challengeKey];
+      if (challenge !== null && challenge !== undefined) {
+        const digestWas =
+          typeof record._readAttributeBeforeLastSave === "function"
+            ? record._readAttributeBeforeLastSave(digestAttr)
+            : record._readAttribute(digestAttr);
+        if (!digestWas || !verifyPassword(String(challenge), digestWas as string)) {
+          record.errors.add(challengeProp, "invalid");
+        }
       }
     });
   }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -2,7 +2,6 @@ import { getCrypto, camelize, humanize, pbkdf2Async } from "@blazetrails/actives
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
-import { attributeBeforeLastSave } from "./attribute-methods/dirty.js";
 
 /**
  * Secure password support using PBKDF2 (Web Crypto API).
@@ -100,7 +99,11 @@ export function hasSecurePassword(
       return (this as any)[challengeKey] ?? null;
     },
     set: function (value: string | null) {
-      (this as any)[challengeKey] = value;
+      // Rails uses present? to gate challenge validation — normalize blank to null.
+      (this as any)[challengeKey] =
+        value === null || value === undefined || (typeof value === "string" && !value.trim())
+          ? null
+          : value;
     },
     configurable: true,
   });
@@ -112,7 +115,9 @@ export function hasSecurePassword(
     get: function (this: Base) {
       const digest = this._readAttribute(digestAttr) as string | null;
       if (!digest) return null;
-      return digest.split(":")[0] ?? null;
+      const colonIdx = digest.indexOf(":");
+      if (colonIdx === -1) return null; // malformed digest — no salt/hash separator
+      return digest.slice(0, colonIdx);
     },
     configurable: true,
   });
@@ -178,7 +183,11 @@ export function hasSecurePassword(
   // Add validations — mirrors Rails' validates_presence_of, validates_confirmation_of,
   // and challenge validation in has_secure_password.
   if (runValidations) {
-    const attrLabel = humanize(attribute);
+    // humanAttributeName respects i18n overrides when available; fall back to humanize.
+    const attrLabel =
+      typeof (modelClass as any).humanAttributeName === "function"
+        ? (modelClass as any).humanAttributeName(attribute)
+        : humanize(attribute);
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
       const rawPasswordPresent =
@@ -206,12 +215,14 @@ export function hasSecurePassword(
       }
 
       // Challenge: verify current password against the pre-change digest.
-      // Mirrors Rails' challenge validation using dirty tracking's "was" value
-      // (`#{attribute}_digest_was`). Falls back to current digest if no prior
-      // save exists (e.g. new record — challenge validation fails gracefully).
+      // Mirrors Rails' `#{attribute}_digest_was` via attributeWas — the
+      // value before the current unsaved change, not before the last save.
       const challenge = record[challengeKey];
       if (challenge !== null && challenge !== undefined) {
-        const digestWas = attributeBeforeLastSave(record, digestAttr) ?? record._readAttribute(digestAttr);
+        const digestWas =
+          typeof record.attributeWas === "function"
+            ? record.attributeWas(digestAttr)
+            : record._readAttribute(digestAttr);
         if (!digestWas || !verifyPassword(String(challenge), digestWas as string)) {
           record.errors.add(challengeProp, "invalid");
         }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -76,7 +76,11 @@ export function hasSecurePassword(
     set: function (value: string | null) {
       // Normalize non-string non-nil values to string to match Ruby's implicit to_s.
       const normalized =
-        value === null || value === undefined ? value : typeof value === "string" ? value : String(value);
+        value === null || value === undefined
+          ? value
+          : typeof value === "string"
+            ? value
+            : String(value);
       (this as any)[passwordKey] = normalized;
       // Rails: nil assignment clears the digest immediately
       // (active_model/secure_password.rb InstanceMethodsOnActivation)

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -112,14 +112,14 @@ export function hasSecurePassword(
     },
     set: function (value: string | null) {
       // Rails uses present? to gate challenge validation — normalize blank to null.
-      // Use isBlank after coercion so non-string blanks (false, [], etc.) are also caught.
-      const coerced =
-        value === null || value === undefined
-          ? null
-          : typeof value === "string"
-            ? value
-            : String(value);
-      (this as any)[challengeKey] = coerced === null || isBlank(coerced) ? null : coerced;
+      // Check isBlank BEFORE coercion so non-string blanks (false, [], {}) are
+      // caught as blank rather than stringified to non-blank ("false", "[object Object]").
+      if (value === null || value === undefined || isBlank(value as unknown as string)) {
+        (this as any)[challengeKey] = null;
+        return;
+      }
+      const coerced = typeof value === "string" ? value : String(value);
+      (this as any)[challengeKey] = coerced;
     },
     configurable: true,
   });
@@ -129,8 +129,8 @@ export function hasSecurePassword(
   const saltProp = `${camelBase}Salt`;
   Object.defineProperty(modelClass.prototype, saltProp, {
     get: function (this: Base) {
-      const digest = this._readAttribute(digestAttr) as string | null;
-      if (!digest) return null;
+      const digest = this._readAttribute(digestAttr);
+      if (!digest || typeof digest !== "string") return null;
       const colonIdx = digest.indexOf(":");
       if (colonIdx === -1) return null; // no separator — malformed
       const saltHex = digest.slice(0, colonIdx);
@@ -245,7 +245,11 @@ export function hasSecurePassword(
           typeof record.attributeWas === "function"
             ? record.attributeWas(digestAttr)
             : record._readAttribute(digestAttr);
-        if (!digestWas || !verifyPassword(String(challenge), digestWas as string)) {
+        if (
+          !digestWas ||
+          typeof digestWas !== "string" ||
+          !verifyPassword(String(challenge), digestWas)
+        ) {
           // Rails keys to `#{attribute}_challenge` (snake_case) for i18n parity.
           record.errors.add(`${attribute}_challenge`, "invalid");
         }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -70,6 +70,11 @@ export function hasSecurePassword(
     },
     set: function (value: string | null) {
       (this as any)[passwordKey] = value;
+      // Rails: nil assignment clears the digest immediately
+      // (active_model/secure_password.rb InstanceMethodsOnActivation)
+      if (value === null || value === undefined) {
+        this.writeAttribute?.(digestAttr, null);
+      }
     },
     configurable: true,
   });
@@ -175,18 +180,19 @@ export function hasSecurePassword(
     const attrLabel = attribute.charAt(0).toUpperCase() + attribute.slice(1).replace(/_./g, (s) => s.slice(1).toUpperCase());
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
-      const isNew = record.isNewRecord();
 
-      // Presence on create (or when digest is absent): mirrors validates_presence_of
-      if (isNew && (rawPassword === null || rawPassword === undefined || rawPassword === "")) {
-        if (!record._readAttribute(digestAttr)) {
-          record.errors.add(attribute, "blank");
-        }
+      // Presence: mirrors `record.errors.add(attribute, :blank) unless digest.present?`
+      // Fires on every validate — catches both new records without passwords
+      // and existing records whose digest was explicitly cleared.
+      if (!record._readAttribute(digestAttr)) {
+        record.errors.add(attribute, "blank");
       }
 
-      // Confirmation must match if provided: mirrors validates_confirmation_of
+      // Confirmation: mirrors `validates_confirmation_of attribute, allow_blank: true`
+      // Skip when password is blank (allow_blank: true).
       const confirmation = record[confirmationKey];
-      if (confirmation !== null && confirmation !== undefined && rawPassword !== confirmation) {
+      const passwordPresent = rawPassword !== null && rawPassword !== undefined && rawPassword !== "";
+      if (passwordPresent && confirmation !== null && confirmation !== undefined && rawPassword !== confirmation) {
         record.errors.add(confirmationProp, "confirmation", {
           message: `doesn't match ${attrLabel}`,
         });

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -63,8 +63,7 @@ export function hasSecurePassword(
   const challengeKey = Symbol(`${attribute}_challenge`);
 
   // Camelized base for property names (e.g. "recovery_password" → "recoveryPassword").
-  const camelBase =
-    camelize(attribute).charAt(0).toLowerCase() + camelize(attribute).slice(1);
+  const camelBase = camelize(attribute).charAt(0).toLowerCase() + camelize(attribute).slice(1);
 
   // Define setter/getter for the configured secure-password attribute
   // (e.g. password / recovery_password).

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,4 +1,4 @@
-import { getCrypto, camelize, humanize, pbkdf2Async } from "@blazetrails/activesupport";
+import { getCrypto, camelize, humanize, isBlank, pbkdf2Async } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { generatesTokenFor } from "./token-for.js";
@@ -169,7 +169,7 @@ export function hasSecurePassword(
     // Rails `password=` setter skips hashing for empty strings
     // (active_model/secure_password.rb) — an empty password is not a
     // valid password, so we leave the existing digest untouched.
-    if (rawPassword != null && rawPassword !== "") {
+    if (rawPassword != null && !isBlank(rawPassword)) {
       const digest = hashPassword(rawPassword);
       record.writeAttribute(digestAttr, digest);
       // Clear the raw password, confirmation, and challenge after hashing
@@ -190,8 +190,7 @@ export function hasSecurePassword(
         : humanize(attribute);
     modelClass.validate(function (record: any) {
       const rawPassword = record[passwordKey];
-      const rawPasswordPresent =
-        rawPassword !== null && rawPassword !== undefined && rawPassword !== "";
+      const rawPasswordPresent = rawPassword != null && !isBlank(rawPassword);
 
       // Presence: mirrors `record.errors.add(attribute, :blank) unless digest.present?`
       // In Rails, password= immediately sets the digest (BCrypt). In trails,
@@ -209,7 +208,9 @@ export function hasSecurePassword(
         confirmation !== undefined &&
         rawPassword !== confirmation
       ) {
-        record.errors.add(confirmationProp, "confirmation", {
+        // Rails keys the error to the underscored `#{attribute}_confirmation`
+        // so humanAttributeName and i18n lookups work correctly.
+        record.errors.add(`${attribute}_confirmation`, "confirmation", {
           attribute: attrLabel,
         });
       }
@@ -224,7 +225,8 @@ export function hasSecurePassword(
             ? record.attributeWas(digestAttr)
             : record._readAttribute(digestAttr);
         if (!digestWas || !verifyPassword(String(challenge), digestWas as string)) {
-          record.errors.add(challengeProp, "invalid");
+          // Rails keys to `#{attribute}_challenge` (snake_case) for i18n parity.
+          record.errors.add(`${attribute}_challenge`, "invalid");
         }
       }
     });

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -114,7 +114,11 @@ export function hasSecurePassword(
       // Rails uses present? to gate challenge validation — normalize blank to null.
       // Use isBlank after coercion so non-string blanks (false, [], etc.) are also caught.
       const coerced =
-        value === null || value === undefined ? null : typeof value === "string" ? value : String(value);
+        value === null || value === undefined
+          ? null
+          : typeof value === "string"
+            ? value
+            : String(value);
       (this as any)[challengeKey] = coerced === null || isBlank(coerced) ? null : coerced;
     },
     configurable: true,

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -62,8 +62,9 @@ export function hasSecurePassword(
   const confirmationKey = Symbol(`${attribute}_confirmation`);
   const challengeKey = Symbol(`${attribute}_challenge`);
 
-  // Camelized base for property names (e.g. "recovery_password" → "recoveryPassword").
-  const camelBase = camelize(attribute).charAt(0).toLowerCase() + camelize(attribute).slice(1);
+  // lowerCamelCase base for property names (e.g. "recovery_password" → "recoveryPassword").
+  // Uses camelize(..., "lower") for correct acronym handling (e.g. "api_key" → "apiKey").
+  const camelBase = camelize(attribute, "lower");
 
   // Define setter/getter for the configured secure-password attribute
   // (e.g. password / recovery_password).
@@ -73,11 +74,14 @@ export function hasSecurePassword(
       return (this as any)[passwordKey] ?? null;
     },
     set: function (value: string | null) {
-      (this as any)[passwordKey] = value;
+      // Normalize non-string non-nil values to string to match Ruby's implicit to_s.
+      const normalized =
+        value === null || value === undefined ? value : typeof value === "string" ? value : String(value);
+      (this as any)[passwordKey] = normalized;
       // Rails: nil assignment clears the digest immediately
       // (active_model/secure_password.rb InstanceMethodsOnActivation)
-      if (value === null || value === undefined) {
-        this.writeAttribute?.(digestAttr, null);
+      if (normalized === null || normalized === undefined) {
+        this.writeAttribute(digestAttr, null);
       }
     },
     configurable: true,
@@ -170,10 +174,10 @@ export function hasSecurePassword(
   // invalidation to round-trip through the DB.
   modelClass.beforeSave(function (record: Base) {
     const rawPassword = (record as any)[passwordKey];
-    // Rails `password=` setter skips hashing for blank values (nil or empty/whitespace)
-    // (active_model/secure_password.rb) — an empty password is not a
-    // valid password, so we leave the existing digest untouched.
-    if (rawPassword != null && !isBlank(rawPassword)) {
+    // Rails `password=` setter skips hashing only for nil and empty string
+    // (`elsif !unencrypted_password.empty?` in InstanceMethodsOnActivation) —
+    // whitespace-only passwords ARE hashed in Rails.
+    if (rawPassword != null && rawPassword !== "") {
       const digest = hashPassword(rawPassword);
       record.writeAttribute(digestAttr, digest);
       // Clear the raw password, confirmation, and challenge after hashing
@@ -187,20 +191,22 @@ export function hasSecurePassword(
   // Add validations — mirrors Rails' validates_presence_of, validates_confirmation_of,
   // and challenge validation in has_secure_password.
   if (runValidations) {
-    // humanAttributeName respects i18n overrides when available; fall back to humanize.
-    const attrLabel =
-      typeof (modelClass as any).humanAttributeName === "function"
-        ? (modelClass as any).humanAttributeName(attribute)
-        : humanize(attribute);
     modelClass.validate(function (record: any) {
+      // Compute inside the callback so it reflects the runtime I18n locale.
+      const attrLabel =
+        typeof (record.constructor as any).humanAttributeName === "function"
+          ? (record.constructor as any).humanAttributeName(attribute)
+          : humanize(attribute);
       const rawPassword = record[passwordKey];
+      // Mirrors Rails: `!empty?` for hashing/presence; `allow_blank: true` for confirmation.
+      const rawPasswordNotEmpty = rawPassword != null && rawPassword !== "";
       const rawPasswordPresent = rawPassword != null && !isBlank(rawPassword);
 
       // Presence: mirrors `record.errors.add(attribute, :blank) unless digest.present?`
       // In Rails, password= immediately sets the digest (BCrypt). In trails,
       // hashing defers to beforeSave, so we also check the in-flight raw password
       // to avoid false :blank errors before the first save.
-      if (!record._readAttribute(digestAttr) && !rawPasswordPresent) {
+      if (!record._readAttribute(digestAttr) && !rawPasswordNotEmpty) {
         record.errors.add(attribute, "blank");
       }
 

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -57,7 +57,7 @@ export function hasSecurePassword(
   const digestAttr = `${attribute}_digest`;
 
   // Store the raw password, confirmation, and challenge temporarily.
-  // Cleared only when a non-blank password is hashed in beforeSave.
+  // Cleared only when a non-empty password is hashed in beforeSave.
   const passwordKey = Symbol(`${attribute}`);
   const confirmationKey = Symbol(`${attribute}_confirmation`);
   const challengeKey = Symbol(`${attribute}_challenge`);
@@ -128,8 +128,11 @@ export function hasSecurePassword(
       const digest = this._readAttribute(digestAttr) as string | null;
       if (!digest) return null;
       const colonIdx = digest.indexOf(":");
-      if (colonIdx === -1) return null; // malformed digest — no salt/hash separator
-      return digest.slice(0, colonIdx);
+      if (colonIdx === -1) return null; // no separator — malformed
+      const saltHex = digest.slice(0, colonIdx);
+      const hashHex = digest.slice(colonIdx + 1);
+      if (!saltHex || !hashHex) return null; // empty salt or empty hash — malformed
+      return saltHex;
     },
     configurable: true,
   });


### PR DESCRIPTION
Deferred from #946. Rails' `has_secure_password` adds `{attribute}_confirmation`, `{attribute}_challenge`, and `{attribute}_salt` for **every** attribute, not just the default `password`.

## Changes

- Per-attribute `{attribute}Confirmation` / `{attribute}Challenge` getter/setter for all attributes
- Challenge setter: `isBlank` checked before coercion so non-string blanks normalize to null
- Per-attribute `{attribute}Salt` getter — `typeof string` guard; null for nil/malformed digests
- Challenge validation: `typeof string` guard on `digestWas` prevents runtime throw
- Nil assignment to password clears digest immediately (Rails parity)
- `beforeSave` hashing uses `!== ""` (Rails `!empty?`) — whitespace passwords hash
- Non-string passwords coerced via `String(value)` (Ruby `to_s` parity)
- Validations parameterized per attribute; snake_case error keys (`${attribute}_confirmation`, `${attribute}_challenge`); `attributeWas` for dirty tracking
- `camelize(attribute, "lower")` for correct acronym handling

## Tests

Per-attribute confirmation/challenge/salt, malformed digest edge cases (no separator, empty salt, empty hash, non-string digest), nil clears digest, blank challenge treated as absent, two-save challenge cycle.

---

Copilot review #13: **no comments** — implementation is clean.

**Ready for human merge review.**