### PR TITLE
perf(website): exclude API reference from local search index + cache VitePress build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,8 +415,6 @@ jobs:
             packages/website/docs/.vitepress/cache
             packages/website/node_modules/.vite
           key: vitepress-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}
-          restore-keys: |
-            vitepress-v1-${{ runner.os }}-
       - run: pnpm --filter @blazetrails/website exec svelte-kit sync
       - name: Build SvelteKit
         run: pnpm --filter @blazetrails/website run build:sw && pnpm --filter @blazetrails/website exec vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,10 +414,9 @@ jobs:
           path: |
             packages/website/docs/.vitepress/cache
             packages/website/node_modules/.vite
-          key: vitepress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}-${{ github.sha }}
+          key: vitepress-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}
           restore-keys: |
-            vitepress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}-
-            vitepress-${{ runner.os }}-
+            vitepress-v1-${{ runner.os }}-
       - run: pnpm --filter @blazetrails/website exec svelte-kit sync
       - name: Build SvelteKit
         run: pnpm --filter @blazetrails/website run build:sw && pnpm --filter @blazetrails/website exec vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,16 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Cache VitePress + Vite build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/website/docs/.vitepress/cache
+            packages/website/node_modules/.vite
+          key: vitepress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}-${{ github.sha }}
+          restore-keys: |
+            vitepress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/website/docs/.vitepress/config.ts') }}-
+            vitepress-${{ runner.os }}-
       - run: pnpm --filter @blazetrails/website exec svelte-kit sync
       - name: Build SvelteKit
         run: pnpm --filter @blazetrails/website run build:sw && pnpm --filter @blazetrails/website exec vite build

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -63,9 +63,12 @@ export default defineConfig({
       chunkSizeWarningLimit: 1500,
       rollupOptions: {
         output: {
+          // Split the typedoc-generated API reference into one chunk per
+          // package. Without this, Rollup minifies the whole API surface
+          // as a single >500kB chunk, dominating the build phase.
           manualChunks(id) {
-            const apiMatch = id.match(/\/api\/@blazetrails\/([^/]+)\//);
-            if (apiMatch) return `api-${apiMatch[1]}`;
+            const m = id.match(/\/docs\/api\/@blazetrails\/([^/]+)\//);
+            if (m) return `bt-api-${m[1]}`;
           },
         },
       },

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -62,9 +62,8 @@ export default defineConfig({
         // navigable via the sidebar; losing in-page search there is the
         // accepted tradeoff for a much smaller, faster build.
         _render(src, env, md) {
-          const html = md.render(src, env);
           if (env.relativePath?.startsWith("api/")) return "";
-          return html;
+          return md.render(src, env);
         },
       },
     },

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -55,22 +55,16 @@ export default defineConfig({
 
     search: {
       provider: "local",
-    },
-  },
-
-  vite: {
-    build: {
-      chunkSizeWarningLimit: 1500,
-      rollupOptions: {
-        output: {
-          // Split the typedoc-generated API reference into one chunk per
-          // package. Without this, Rollup minifies the whole API surface
-          // as a single >500kB chunk, dominating the build phase.
-          manualChunks(id) {
-            const normalizedId = id.replace(/\\/g, "/");
-            const m = normalizedId.match(/\/docs\/api\/@blazetrails\/([^/]+)\//);
-            if (m) return `bt-api-${m[1]}`;
-          },
+      options: {
+        // Exclude the typedoc-generated API reference from the local
+        // search index. Indexing it inflates the search-index chunk to
+        // ~17MB and dominates the VitePress bundle phase. The API is
+        // navigable via the sidebar; losing in-page search there is the
+        // accepted tradeoff for a much smaller, faster build.
+        _render(src, env, md) {
+          const html = md.render(src, env);
+          if (env.relativePath?.startsWith("api/")) return "";
+          return html;
         },
       },
     },

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -57,4 +57,18 @@ export default defineConfig({
       provider: "local",
     },
   },
+
+  vite: {
+    build: {
+      chunkSizeWarningLimit: 1500,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            const apiMatch = id.match(/\/api\/@blazetrails\/([^/]+)\//);
+            if (apiMatch) return `api-${apiMatch[1]}`;
+          },
+        },
+      },
+    },
+  },
 });

--- a/packages/website/docs/.vitepress/config.ts
+++ b/packages/website/docs/.vitepress/config.ts
@@ -67,7 +67,8 @@ export default defineConfig({
           // package. Without this, Rollup minifies the whole API surface
           // as a single >500kB chunk, dominating the build phase.
           manualChunks(id) {
-            const m = id.match(/\/docs\/api\/@blazetrails\/([^/]+)\//);
+            const normalizedId = id.replace(/\\/g, "/");
+            const m = normalizedId.match(/\/docs\/api\/@blazetrails\/([^/]+)\//);
             if (m) return `bt-api-${m[1]}`;
           },
         },


### PR DESCRIPTION
## Summary

The `Website` CI job ran ~10–11 minutes; the bottleneck was VitePress's `building client + server bundles` phase. Local investigation showed the dominant chunk was the **VitePress local search index at 17 MB** (`@localSearchIndexroot.*.js`), bloated because every typedoc-generated API page was being indexed.

## Measured impact (CI, run [25108268377](https://github.com/blazetrailsdev/trails/actions/runs/25108268377/job/73575137952))

| | Before | After | Δ |
|---|---|---|---|
| Website job total | 10m48s | **4m40s** | −57% |
| VitePress `build complete` | 495.77s | **137.03s** | −72% |
| `building client + server bundles` | ~8m15s | **2m16s** | −72% |
| Local search index chunk | 17 MB | **66 KB** | −260× |

This run was a cache miss (first push of the new key) — the speedup is purely from the search-index fix. Future runs should hit the cache and shave more.

## Changes

- **Exclude `/api/*` from the local search index** via `themeConfig.search.options._render`, short-circuiting before `md.render` so API pages skip rendering entirely. The API reference stays navigable through the sidebar; in-page search inside the API is the accepted tradeoff.
- **CI cache** for `packages/website/docs/.vitepress/cache` and `packages/website/node_modules/.vite`, keyed on `hashFiles(pnpm-lock.yaml, .vitepress/config.ts)` with a `v1` prefix. No `restore-keys` fallback — Vite/VitePress caches aren't guaranteed forward-compatible across config/lockfile changes.

> An earlier revision tried Rollup `manualChunks` to split the API reference per package. Local verification showed VitePress already emits per-page chunks for the API markdown, so the override was a no-op against the real hotspot. Dropped in favor of the search-index fix.

## Test plan

- [x] `pnpm --filter @blazetrails/website run docs:build` succeeds locally.
- [x] CI `Website` job 4m40s on this PR vs 10m48s baseline.
- [ ] Confirm a follow-up push hits the cache and shows a further drop.
- [ ] Confirm site still renders + sidebar navigation works for `/api/`.