### PR TITLE
feat(activemodel): translation accessor + serialize-cast-value + apply-seconds-precision

### DIFF
--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -13,3 +13,15 @@
 export interface API {
   isPersisted(): boolean;
 }
+
+import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
+
+/**
+ * Rails: ActiveModel::API includes Validations, which extends Translation,
+ * so `API.raise_on_missing_translations` reaches the Translation singleton
+ * accessor (translation.rb:25). Surface the same accessor here so callers
+ * can read/write it via `API.raiseOnMissingTranslations(...)`.
+ */
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  return translationRaise(value);
+}

--- a/packages/activemodel/src/translation.test.ts
+++ b/packages/activemodel/src/translation.test.ts
@@ -160,3 +160,26 @@ describe("ActiveModelI18nTests", () => {
     expect(Child.humanAttributeName("first_name")).toBe("First name");
   });
 });
+
+describe("raise_on_missing_translations accessor", () => {
+  // Mirrors the singleton attr_accessor :raise_on_missing_translations
+  // from translation.rb:25 — reachable through the host modules that
+  // include/extend Translation in Rails (api.rb, validations.rb).
+  it("toggles the shared singleton via Translation, API, and Validations", async () => {
+    const translation = await import("./translation.js");
+    const api = await import("./api.js");
+    const validations = await import("./validations.js");
+    const original = translation.raiseOnMissingTranslations();
+    try {
+      api.raiseOnMissingTranslations(true);
+      expect(translation.raiseOnMissingTranslations()).toBe(true);
+      expect(validations.raiseOnMissingTranslations()).toBe(true);
+
+      validations.raiseOnMissingTranslations(false);
+      expect(api.raiseOnMissingTranslations()).toBe(false);
+      expect(translation.raiseOnMissingTranslations()).toBe(false);
+    } finally {
+      translation.raiseOnMissingTranslations(original);
+    }
+  });
+});

--- a/packages/activemodel/src/type.test.ts
+++ b/packages/activemodel/src/type.test.ts
@@ -14,3 +14,61 @@ describe("TypeTest", () => {
     expect(type.cast("hello")).toBe("custom:hello");
   });
 });
+
+describe("Type#itselfIfSerializeCastValueCompatible", () => {
+  // Mirrors serialize_cast_value.rb:9-12 — compatible when
+  // serialize_cast_value is defined at or above serialize in the
+  // ancestor chain. Subclasses that override only `serialize` push it
+  // below the inherited cast-value owner and become incompatible.
+  it("base Type is compatible (both methods at the base class)", () => {
+    class Base extends Types.Type<string> {
+      readonly name = "base";
+      cast(v: unknown) {
+        return v as string;
+      }
+    }
+    expect(new Base().itselfIfSerializeCastValueCompatible()).toBeInstanceOf(Base);
+  });
+
+  it("subclass that overrides only serialize is incompatible", () => {
+    class SerializeOnly extends Types.Type<string> {
+      readonly name = "serialize_only";
+      cast(v: unknown) {
+        return v as string;
+      }
+      override serialize(v: unknown) {
+        return `s:${v}`;
+      }
+    }
+    expect(new SerializeOnly().itselfIfSerializeCastValueCompatible()).toBeNull();
+  });
+
+  it("subclass that overrides both stays compatible", () => {
+    class Both extends Types.Type<string> {
+      readonly name = "both";
+      cast(v: unknown) {
+        return v as string;
+      }
+      override serialize(v: unknown) {
+        return `s:${v}`;
+      }
+      override serializeCastValue(v: string | null) {
+        return `c:${v}`;
+      }
+    }
+    expect(new Both().itselfIfSerializeCastValueCompatible()).toBeInstanceOf(Both);
+  });
+
+  it("subclass overriding only serializeCastValue stays compatible", () => {
+    class CastOnly extends Types.Type<string> {
+      readonly name = "cast_only";
+      cast(v: unknown) {
+        return v as string;
+      }
+      override serializeCastValue(v: string | null) {
+        return `c:${v}`;
+      }
+    }
+    expect(new CastOnly().itselfIfSerializeCastValueCompatible()).toBeInstanceOf(CastOnly);
+  });
+});

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { applySecondsPrecision } from "./time-value.js";
+
+// Mirrors ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
+// (time_value.rb:24-34). Truncation, not rounding — verify each
+// precision boundary against the Temporal types Rails would touch.
+describe("applySecondsPrecision", () => {
+  const dt = Temporal.PlainDateTime.from("2024-01-02T03:04:05.123456789");
+
+  it("returns value unchanged when precision is undefined", () => {
+    expect(applySecondsPrecision.call({}, dt)).toBe(dt);
+  });
+
+  it("returns value unchanged for precision >= 9 (full nanosecond keep)", () => {
+    expect(applySecondsPrecision.call({ precision: 9 }, dt)).toBe(dt);
+  });
+
+  it("rejects non-integer precision", () => {
+    expect(applySecondsPrecision.call({ precision: 3.5 }, dt)).toBe(dt);
+  });
+
+  it("rejects out-of-range precision", () => {
+    expect(applySecondsPrecision.call({ precision: -1 }, dt)).toBe(dt);
+    expect(applySecondsPrecision.call({ precision: 10 }, dt)).toBe(dt);
+  });
+
+  it("precision 0 truncates to whole seconds", () => {
+    const r = applySecondsPrecision.call({ precision: 0 }, dt) as Temporal.PlainDateTime;
+    expect(r.millisecond).toBe(0);
+    expect(r.microsecond).toBe(0);
+    expect(r.nanosecond).toBe(0);
+  });
+
+  it("precision 3 keeps milliseconds, drops micros + nanos", () => {
+    const r = applySecondsPrecision.call({ precision: 3 }, dt) as Temporal.PlainDateTime;
+    expect(r.millisecond).toBe(123);
+    expect(r.microsecond).toBe(0);
+    expect(r.nanosecond).toBe(0);
+  });
+
+  it("precision 6 keeps micros, drops nanos", () => {
+    const r = applySecondsPrecision.call({ precision: 6 }, dt) as Temporal.PlainDateTime;
+    expect(r.millisecond).toBe(123);
+    expect(r.microsecond).toBe(456);
+    expect(r.nanosecond).toBe(0);
+  });
+
+  it("precision 8 keeps two of three nano digits", () => {
+    const r = applySecondsPrecision.call({ precision: 8 }, dt) as Temporal.PlainDateTime;
+    expect(r.millisecond).toBe(123);
+    expect(r.microsecond).toBe(456);
+    expect(r.nanosecond).toBe(780);
+  });
+
+  it("truncates rather than rounds (789 → 780 at precision 8, not 790)", () => {
+    const r = applySecondsPrecision.call({ precision: 8 }, dt) as Temporal.PlainDateTime;
+    expect(r.nanosecond).toBe(780);
+  });
+
+  it("works on Temporal.Instant via .round()", () => {
+    const inst = Temporal.Instant.from("2024-01-02T03:04:05.123456789Z");
+    const r = applySecondsPrecision.call({ precision: 3 }, inst) as Temporal.Instant;
+    // Compare via the same field path Temporal uses for Instant->ZDT.
+    const zdt = r.toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(123);
+    expect(zdt.microsecond).toBe(0);
+    expect(zdt.nanosecond).toBe(0);
+  });
+
+  it("passes PlainDate (no .round) through unchanged", () => {
+    const d = Temporal.PlainDate.from("2024-01-02");
+    expect(applySecondsPrecision.call({ precision: 3 }, d)).toBe(d);
+  });
+
+  it("passes null/undefined through unchanged", () => {
+    expect(applySecondsPrecision.call({ precision: 3 }, null)).toBeNull();
+    expect(applySecondsPrecision.call({ precision: 3 }, undefined)).toBeUndefined();
+  });
+});

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -47,8 +47,10 @@ export function applySecondsPrecision<T>(this: { precision?: number }, value: T)
   const precision = this.precision;
   if (precision === undefined || precision === null) return value;
   // Reject precisions outside the 0-9 nanosecond window so we never
-  // hand Temporal#round a non-integer or out-of-range roundingIncrement
-  // (matches the guard in type/time.ts and type/date-time.ts).
+  // hand Temporal#round a non-integer or out-of-range roundingIncrement.
+  // Pass-through (rather than coercing to a default) matches Rails'
+  // apply_seconds_precision, which returns value unchanged when the
+  // guard fails (time_value.rb:25 `return value unless precision...`).
   if (!Number.isInteger(precision) || precision < 0 || precision > 9) return value;
   if (value === null || value === undefined) return value;
   // Temporal types (Instant, PlainDateTime, PlainTime, ZonedDateTime)

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -46,11 +46,11 @@ type Roundable<T> = {
 export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {
   const precision = this.precision;
   if (precision === undefined || precision === null) return value;
-  // Reject precisions outside the 0-9 nanosecond window so we never
-  // hand Temporal#round a non-integer or out-of-range roundingIncrement.
-  // Pass-through (rather than coercing to a default) matches Rails'
-  // apply_seconds_precision, which returns value unchanged when the
-  // guard fails (time_value.rb:25 `return value unless precision...`).
+  // Rails' guard only covers nil/falsey precision (and values that do
+  // not respond to `nsec`). This additional pass-through for invalid
+  // numeric precision is trails-specific and preserves the current
+  // behavior instead of coercing to a default — Temporal#round would
+  // otherwise reject a non-integer or out-of-range roundingIncrement.
   if (!Number.isInteger(precision) || precision < 0 || precision > 9) return value;
   if (value === null || value === undefined) return value;
   // Temporal types (Instant, PlainDateTime, PlainTime, ZonedDateTime)

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -36,9 +36,10 @@ type Roundable<T> = {
  *     end
  *   end
  *
- * Truncates sub-second precision on Temporal types that carry a
- * `nanosecond` field (PlainDateTime, PlainTime, ZonedDateTime, Instant).
- * Values without nanosecond resolution (PlainDate, primitives) pass
+ * Truncates sub-second precision on Temporal types that expose a
+ * `round({ smallestUnit, roundingIncrement, roundingMode })` method —
+ * Instant, PlainDateTime, PlainTime, and ZonedDateTime. Values without
+ * sub-second resolution (PlainDate, primitives) lack `.round` and pass
  * through unchanged.
  */
 export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -45,6 +45,10 @@ type Roundable<T> = {
 export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {
   const precision = this.precision;
   if (precision === undefined || precision === null) return value;
+  // Reject precisions outside the 0-9 nanosecond window so we never
+  // hand Temporal#round a non-integer or out-of-range roundingIncrement
+  // (matches the guard in type/time.ts and type/date-time.ts).
+  if (!Number.isInteger(precision) || precision < 0 || precision > 9) return value;
   if (value === null || value === undefined) return value;
   // Temporal types (Instant, PlainDateTime, PlainTime, ZonedDateTime)
   // expose a `round` method that accepts `roundingIncrement` and

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -6,10 +6,11 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 export interface TimeValue {
+  precision?: number;
   serializeCastValue(value: unknown): string | null;
   typeCastForSchema(value: unknown): string;
   userInputInTimeZone(value: unknown, zone?: string): Temporal.ZonedDateTime | null;
-  applySecondsPrecision<T>(value: T): T;
+  applySecondsPrecision<T>(this: TimeValue, value: T): T;
 }
 
 type Roundable<T> = {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -9,6 +9,46 @@ export interface TimeValue {
   serializeCastValue(value: unknown): string | null;
   typeCastForSchema(value: unknown): string;
   userInputInTimeZone(value: unknown, zone?: string): Temporal.ZonedDateTime | null;
+  applySecondsPrecision<T>(value: T): T;
+}
+
+type WithNanos = { nanosecond: number; with: (fields: { nanosecond: number }) => unknown };
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
+ * (time_value.rb:24-34)
+ *
+ *   def apply_seconds_precision(value)
+ *     return value unless precision && value.respond_to?(:nsec)
+ *     number_of_insignificant_digits = 9 - precision
+ *     round_power = 10**number_of_insignificant_digits
+ *     rounded_off_nsec = value.nsec % round_power
+ *     if rounded_off_nsec > 0
+ *       value.change(nsec: value.nsec - rounded_off_nsec)
+ *     else
+ *       value
+ *     end
+ *   end
+ *
+ * Truncates sub-second precision on Temporal types that carry a
+ * `nanosecond` field (PlainDateTime, PlainTime, ZonedDateTime, Instant).
+ * Values without nanosecond resolution (PlainDate, primitives) pass
+ * through unchanged.
+ */
+export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {
+  const precision = this.precision;
+  if (precision === undefined || precision === null) return value;
+  if (value === null || value === undefined) return value;
+  const nsHolder = value as unknown as WithNanos;
+  if (typeof nsHolder.nanosecond !== "number") return value;
+  if (typeof nsHolder.with !== "function") return value;
+  const nsec = nsHolder.nanosecond;
+  const insignificantDigits = 9 - precision;
+  if (insignificantDigits <= 0) return value;
+  const roundPower = 10 ** insignificantDigits;
+  const remainder = nsec % roundPower;
+  if (remainder === 0) return value;
+  return nsHolder.with({ nanosecond: nsec - remainder }) as unknown as T;
 }
 
 export function serializeTimeValue(value: unknown): string | null {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -12,11 +12,12 @@ export interface TimeValue {
   applySecondsPrecision<T>(value: T): T;
 }
 
-type SubSecondHolder = {
-  millisecond: number;
-  microsecond: number;
-  nanosecond: number;
-  with: (fields: { millisecond: number; microsecond: number; nanosecond: number }) => unknown;
+type Roundable<T> = {
+  round: (options: {
+    smallestUnit: "second" | "millisecond" | "microsecond" | "nanosecond";
+    roundingIncrement?: number;
+    roundingMode: "trunc";
+  }) => T;
 };
 
 /**
@@ -44,29 +45,36 @@ export function applySecondsPrecision<T>(this: { precision?: number }, value: T)
   const precision = this.precision;
   if (precision === undefined || precision === null) return value;
   if (value === null || value === undefined) return value;
-  const holder = value as unknown as SubSecondHolder;
-  // Temporal splits sub-second into three 0-999 fields. Reconstruct
-  // the full 0-999_999_999 nanosecond count Rails' `value.nsec` returns.
-  if (
-    typeof holder.millisecond !== "number" ||
-    typeof holder.microsecond !== "number" ||
-    typeof holder.nanosecond !== "number" ||
-    typeof holder.with !== "function"
-  ) {
-    return value;
-  }
-  const insignificantDigits = 9 - precision;
-  if (insignificantDigits <= 0) return value;
-  const roundPower = 10 ** insignificantDigits;
-  const totalNsec = holder.millisecond * 1_000_000 + holder.microsecond * 1_000 + holder.nanosecond;
-  const remainder = totalNsec % roundPower;
-  if (remainder === 0) return value;
-  const truncated = totalNsec - remainder;
-  return holder.with({
-    millisecond: Math.floor(truncated / 1_000_000),
-    microsecond: Math.floor((truncated % 1_000_000) / 1_000),
-    nanosecond: truncated % 1_000,
-  }) as unknown as T;
+  // Temporal types (Instant, PlainDateTime, PlainTime, ZonedDateTime)
+  // expose a `round` method that accepts `roundingIncrement` and
+  // `roundingMode: "trunc"`, which together match Rails' "drop the
+  // insignificant trailing nanos" semantics. Values without `.round`
+  // (PlainDate, primitives) lack sub-second resolution and pass
+  // through unchanged.
+  const roundable = value as unknown as Partial<Roundable<T>>;
+  if (typeof roundable.round !== "function") return value;
+  if (precision >= 9) return value;
+  const opts =
+    precision <= 0
+      ? { smallestUnit: "second" as const, roundingMode: "trunc" as const }
+      : precision <= 3
+        ? {
+            smallestUnit: "millisecond" as const,
+            roundingIncrement: 10 ** (3 - precision),
+            roundingMode: "trunc" as const,
+          }
+        : precision <= 6
+          ? {
+              smallestUnit: "microsecond" as const,
+              roundingIncrement: 10 ** (6 - precision),
+              roundingMode: "trunc" as const,
+            }
+          : {
+              smallestUnit: "nanosecond" as const,
+              roundingIncrement: 10 ** (9 - precision),
+              roundingMode: "trunc" as const,
+            };
+  return (roundable as Roundable<T>).round(opts);
 }
 
 export function serializeTimeValue(value: unknown): string | null {

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -12,7 +12,12 @@ export interface TimeValue {
   applySecondsPrecision<T>(value: T): T;
 }
 
-type WithNanos = { nanosecond: number; with: (fields: { nanosecond: number }) => unknown };
+type SubSecondHolder = {
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+  with: (fields: { millisecond: number; microsecond: number; nanosecond: number }) => unknown;
+};
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
@@ -39,16 +44,29 @@ export function applySecondsPrecision<T>(this: { precision?: number }, value: T)
   const precision = this.precision;
   if (precision === undefined || precision === null) return value;
   if (value === null || value === undefined) return value;
-  const nsHolder = value as unknown as WithNanos;
-  if (typeof nsHolder.nanosecond !== "number") return value;
-  if (typeof nsHolder.with !== "function") return value;
-  const nsec = nsHolder.nanosecond;
+  const holder = value as unknown as SubSecondHolder;
+  // Temporal splits sub-second into three 0-999 fields. Reconstruct
+  // the full 0-999_999_999 nanosecond count Rails' `value.nsec` returns.
+  if (
+    typeof holder.millisecond !== "number" ||
+    typeof holder.microsecond !== "number" ||
+    typeof holder.nanosecond !== "number" ||
+    typeof holder.with !== "function"
+  ) {
+    return value;
+  }
   const insignificantDigits = 9 - precision;
   if (insignificantDigits <= 0) return value;
   const roundPower = 10 ** insignificantDigits;
-  const remainder = nsec % roundPower;
+  const totalNsec = holder.millisecond * 1_000_000 + holder.microsecond * 1_000 + holder.nanosecond;
+  const remainder = totalNsec % roundPower;
   if (remainder === 0) return value;
-  return nsHolder.with({ nanosecond: nsec - remainder }) as unknown as T;
+  const truncated = totalNsec - remainder;
+  return holder.with({
+    millisecond: Math.floor(truncated / 1_000_000),
+    microsecond: Math.floor((truncated % 1_000_000) / 1_000),
+    nanosecond: truncated % 1_000,
+  }) as unknown as T;
 }
 
 export function serializeTimeValue(value: unknown): string | null {

--- a/packages/activemodel/src/type/serialize-cast-value.ts
+++ b/packages/activemodel/src/type/serialize-cast-value.ts
@@ -33,18 +33,31 @@ export namespace SerializeCastValue {
   }
 }
 
-export function itselfIfSerializeCastValueCompatible(type: {
-  serialize(value: unknown): unknown;
-  serializeCastValue?(value: unknown): unknown;
-}): typeof type | null {
-  if (typeof type.serializeCastValue === "function") {
-    return type;
-  }
-  return null;
+/**
+ * Standalone equivalents of `Type#itselfIfSerializeCastValueCompatible`
+ * and `Type.serializeCastValueCompatible`. Both delegate to the
+ * Rails-faithful ancestor-depth check on `Type` so a single source of
+ * truth governs compatibility — see `type/value.ts`. Direct method/
+ * static access on a `Type` instance is preferred; these wrappers
+ * exist for callers that hold a structurally-typed reference rather
+ * than a `Type` subclass.
+ */
+type CompatibleType = {
+  itselfIfSerializeCastValueCompatible?: () => unknown;
+};
+
+type CompatibleCtor = {
+  serializeCastValueCompatible?: () => boolean;
+};
+
+export function itselfIfSerializeCastValueCompatible<T extends CompatibleType>(type: T): T | null {
+  return typeof type.itselfIfSerializeCastValueCompatible === "function"
+    ? (type.itselfIfSerializeCastValueCompatible() as T | null)
+    : null;
 }
 
-export function serializeCastValueCompatible(typeCtor: {
-  prototype: { serializeCastValue?(value: unknown): unknown };
-}): boolean {
-  return typeof typeCtor.prototype.serializeCastValue === "function";
+export function serializeCastValueCompatible(typeCtor: CompatibleCtor): boolean {
+  return typeof typeCtor.serializeCastValueCompatible === "function"
+    ? typeCtor.serializeCastValueCompatible()
+    : false;
 }

--- a/packages/activemodel/src/type/serialize-cast-value.ts
+++ b/packages/activemodel/src/type/serialize-cast-value.ts
@@ -42,17 +42,17 @@ export namespace SerializeCastValue {
  * exist for callers that hold a structurally-typed reference rather
  * than a `Type` subclass.
  */
-type CompatibleType = {
-  itselfIfSerializeCastValueCompatible?: () => unknown;
+type CompatibleType<T> = {
+  itselfIfSerializeCastValueCompatible?: () => T | null;
 };
 
 type CompatibleCtor = {
   serializeCastValueCompatible?: () => boolean;
 };
 
-export function itselfIfSerializeCastValueCompatible<T extends CompatibleType>(type: T): T | null {
+export function itselfIfSerializeCastValueCompatible<T>(type: CompatibleType<T>): T | null {
   return typeof type.itselfIfSerializeCastValueCompatible === "function"
-    ? (type.itselfIfSerializeCastValueCompatible() as T | null)
+    ? type.itselfIfSerializeCastValueCompatible()
     : null;
 }
 

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -71,7 +71,14 @@ export abstract class Type<T = unknown> {
    * defined at or above serialize.
    */
   static serializeCastValueCompatible(this: { _serializeCastValueCompatible?: boolean }): boolean {
-    if (this._serializeCastValueCompatible !== undefined) return this._serializeCastValueCompatible;
+    // Per-class memoization: JS static properties are inherited, so a
+    // subclass that overrides serialize/serializeCastValue would otherwise
+    // reuse a parent's cached result. Only treat the cache as set when it
+    // is an own property of THIS constructor — Rails caches in @ivars on
+    // the class object itself for the same reason (serialize_cast_value.rb:9-12).
+    if (Object.hasOwn(this, "_serializeCastValueCompatible")) {
+      return this._serializeCastValueCompatible as boolean;
+    }
     let proto: object | null = (this as unknown as { prototype: object }).prototype;
     let serializeDepth = -1;
     let castDepth = -1;
@@ -87,7 +94,13 @@ export abstract class Type<T = unknown> {
       depth++;
     }
     const result = castDepth >= 0 && serializeDepth >= 0 && castDepth <= serializeDepth;
-    this._serializeCastValueCompatible = result;
+    // Define as own property so subclasses don't read this through the
+    // static prototype chain.
+    Object.defineProperty(this, "_serializeCastValueCompatible", {
+      value: result,
+      writable: true,
+      configurable: true,
+    });
     return result;
   }
 

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -48,11 +48,11 @@ export abstract class Type<T = unknown> {
    * Returns `this` when the type's serialize path can short-circuit
    * through serialize_cast_value (i.e. the subclass has overridden
    * serialize_cast_value at the same level or above its `serialize`
-   * override). Returns null otherwise. Serialization dispatch can use
-   * this predicate to pick the cast-value fast-path over a redundant
-   * `serialize` call (Rails wires that dispatcher at
-   * `serialize_cast_value.rb:25-33`; trails callers do the same check
-   * inline against this method's truthiness).
+   * override). Returns null otherwise. Callers can use this predicate
+   * to choose the cast-value fast-path via `serializeCastValue(...)`
+   * instead of a redundant `serialize(...)` call. Rails wires that
+   * dispatcher at `serialize_cast_value.rb:25-33`; trails callers do
+   * the same check inline against this method's truthiness.
    */
   itselfIfSerializeCastValueCompatible(): this | null {
     return (

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -37,6 +37,44 @@ export abstract class Type<T = unknown> {
     return value;
   }
 
+  /**
+   * Mirrors: ActiveModel::Type::SerializeCastValue#itself_if_serialize_cast_value_compatible
+   * (serialize_cast_value.rb:36-38)
+   *
+   *   def itself_if_serialize_cast_value_compatible
+   *     self if self.class.serialize_cast_value_compatible?
+   *   end
+   *
+   * Returns `this` when the type's serialize path can short-circuit
+   * through serialize_cast_value (i.e. the subclass has overridden
+   * serialize_cast_value at the same level or above its `serialize`
+   * override). Returns null otherwise. Used by SerializeCastValue.
+   * serialize to skip a redundant cast on already-cast values.
+   */
+  itselfIfSerializeCastValueCompatible(): this | null {
+    // Rails: ancestors.index(serialize_cast_value.owner) <= ancestors.index(serialize.owner).
+    // A type is compatible when serialize_cast_value is defined at or
+    // above serialize in the ancestor chain — i.e. a subclass that
+    // overrides serialize MUST also override serialize_cast_value to
+    // remain compatible. Walk the prototype chain to find each
+    // method's defining ancestor.
+    let proto: object | null = Object.getPrototypeOf(this);
+    let serializeDepth = -1;
+    let castDepth = -1;
+    let depth = 0;
+    while (proto && proto !== Object.prototype) {
+      if (serializeDepth < 0 && Object.prototype.hasOwnProperty.call(proto, "serialize")) {
+        serializeDepth = depth;
+      }
+      if (castDepth < 0 && Object.prototype.hasOwnProperty.call(proto, "serializeCastValue")) {
+        castDepth = depth;
+      }
+      proto = Object.getPrototypeOf(proto);
+      depth++;
+    }
+    return castDepth >= 0 && serializeDepth >= 0 && castDepth <= serializeDepth ? this : null;
+  }
+
   isSerializable(_value: unknown): boolean {
     return true;
   }

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -48,8 +48,9 @@ export abstract class Type<T = unknown> {
    * Returns `this` when the type's serialize path can short-circuit
    * through serialize_cast_value (i.e. the subclass has overridden
    * serialize_cast_value at the same level or above its `serialize`
-   * override). Returns null otherwise. Used by SerializeCastValue.
-   * serialize to skip a redundant cast on already-cast values.
+   * override). Returns null otherwise. The Rails dispatcher
+   * `SerializeCastValue.serialize(type, value)` uses this predicate to
+   * pick the cast-value fast-path over a redundant `serialize` call.
    */
   itselfIfSerializeCastValueCompatible(): this | null {
     return (

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -52,13 +52,26 @@ export abstract class Type<T = unknown> {
    * serialize to skip a redundant cast on already-cast values.
    */
   itselfIfSerializeCastValueCompatible(): this | null {
-    // Rails: ancestors.index(serialize_cast_value.owner) <= ancestors.index(serialize.owner).
-    // A type is compatible when serialize_cast_value is defined at or
-    // above serialize in the ancestor chain — i.e. a subclass that
-    // overrides serialize MUST also override serialize_cast_value to
-    // remain compatible. Walk the prototype chain to find each
-    // method's defining ancestor.
-    let proto: object | null = Object.getPrototypeOf(this);
+    return (
+      this.constructor as unknown as { serializeCastValueCompatible(): boolean }
+    ).serializeCastValueCompatible()
+      ? this
+      : null;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Type::SerializeCastValue::ClassMethods#serialize_cast_value_compatible?
+   * (serialize_cast_value.rb:9-12). Result is memoized on the class:
+   *
+   *   return @serialize_cast_value_compatible if defined?(@serialize_cast_value_compatible)
+   *
+   * Walks the prototype chain to compare ancestor depth of `serialize`
+   * vs `serializeCastValue` — compatible when serializeCastValue is
+   * defined at or above serialize.
+   */
+  static serializeCastValueCompatible(this: { _serializeCastValueCompatible?: boolean }): boolean {
+    if (this._serializeCastValueCompatible !== undefined) return this._serializeCastValueCompatible;
+    let proto: object | null = (this as unknown as { prototype: object }).prototype;
     let serializeDepth = -1;
     let castDepth = -1;
     let depth = 0;
@@ -72,7 +85,9 @@ export abstract class Type<T = unknown> {
       proto = Object.getPrototypeOf(proto);
       depth++;
     }
-    return castDepth >= 0 && serializeDepth >= 0 && castDepth <= serializeDepth ? this : null;
+    const result = castDepth >= 0 && serializeDepth >= 0 && castDepth <= serializeDepth;
+    this._serializeCastValueCompatible = result;
+    return result;
   }
 
   isSerializable(_value: unknown): boolean {

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -48,9 +48,11 @@ export abstract class Type<T = unknown> {
    * Returns `this` when the type's serialize path can short-circuit
    * through serialize_cast_value (i.e. the subclass has overridden
    * serialize_cast_value at the same level or above its `serialize`
-   * override). Returns null otherwise. The Rails dispatcher
-   * `SerializeCastValue.serialize(type, value)` uses this predicate to
-   * pick the cast-value fast-path over a redundant `serialize` call.
+   * override). Returns null otherwise. Serialization dispatch can use
+   * this predicate to pick the cast-value fast-path over a redundant
+   * `serialize` call (Rails wires that dispatcher at
+   * `serialize_cast_value.rb:25-33`; trails callers do the same check
+   * inline against this method's truthiness).
    */
   itselfIfSerializeCastValueCompatible(): this | null {
     return (

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -2,6 +2,17 @@ import type { Errors } from "./errors.js";
 import type { ConditionalOptions } from "./validator.js";
 import { I18n } from "./i18n.js";
 
+import { raiseOnMissingTranslations as translationRaise } from "./translation.js";
+
+/**
+ * Rails: ActiveModel::Validations extends Translation (validations.rb:43),
+ * so the singleton accessor surfaces on Validations directly. Mirror that
+ * here so callers can read/write via `Validations.raiseOnMissingTranslations(...)`.
+ */
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  return translationRaise(value);
+}
+
 /**
  * Validations mixin contract — provides the validation lifecycle.
  *


### PR DESCRIPTION
## Summary
Three Rails-faithful additions clearing four `api:compare` rows:

- **`Type#itselfIfSerializeCastValueCompatible`** (`type/value.ts`) — mirrors `serialize_cast_value.rb:36-38`. Backed by a memoized static `serializeCastValueCompatible()` using `Object.hasOwn` + `Object.defineProperty` for per-class caching.
- **`TimeValueHelpers#applySecondsPrecision`** (`type/helpers/time-value.ts`) — mirrors `time_value.rb:24-34`. Uses `Temporal#round({ smallestUnit, roundingIncrement, roundingMode: "trunc" })` covering `Instant`, `PlainDateTime`, `PlainTime`, `ZonedDateTime`.
- **`API.raiseOnMissingTranslations` / `Validations.raiseOnMissingTranslations`** (`api.ts`, `validations.ts`) — surfaces the `Translation` singleton accessor (`translation.rb:25`).

Standalone helpers in `type/serialize-cast-value.ts` now delegate to `Type`'s Rails-faithful methods (single source of truth).

## Impact
- `pnpm api:compare --package activemodel`: **425/433 → 429/433** (98.2% → 99.1%).
- Remaining gaps not in this PR: 2 `attribute_missing` rows (deferred from PR #974) and 2 `serializers/json.rb` rows (PR 4).

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1571 / 1571 passing
- [x] `pnpm api:compare --package activemodel` — 429/433
- [x] New focused coverage: `time-value.test.ts` (12 tests for `applySecondsPrecision` precision boundaries + Instant), `type.test.ts` (4 tests for the `serializeCastValueCompatible` matrix), `translation.test.ts` (1 test for the shared `raiseOnMissingTranslations` singleton).

## Copilot review history (11 rounds, converged)

Round 11 produced no new comments — review loop converged. Resolved over the prior rounds:

- Static-property cache leakage on `serializeCastValueCompatible` → `Object.hasOwn` + `Object.defineProperty` per-class memoization.
- `applySecondsPrecision` originally only handled split sub-second fields → rewritten on `Temporal#round` so `Instant` is covered.
- Multiple docstring polishes around `SerializeCastValue.serialize` (Rails dispatcher trails hasn't ported) → reworded to point at the Rails source line.
- `TimeValue` interface now exposes `precision?: number` and `this: TimeValue` binding.
- Compatibility-matrix tests, precision-boundary tests, translation-singleton test added.
- Duplicate `serializeCastValueCompatible` semantics → standalone helpers now delegate to `Type`'s Rails-faithful methods.
- Standalone helper generic typing tightened (`CompatibleType<T>` so wrapped method returns `T | null` directly).
- `time-value.ts` precision-guard comment reworded to clearly distinguish Rails' nil-precision pass-through from trails' additional invalid-precision guard.

Ready for human review.