### PR TITLE
refactor(activesupport): TimeWithZone#localtime/toDate/time return Temporal types

### DIFF
--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -41,7 +41,9 @@ describe("TimeWithZoneTest", () => {
 
   it("time", () => {
     const twz = maketwz();
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 19, 0, 0));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(
+      Date.UTC(1999, 11, 31, 19, 0, 0),
+    );
   });
 
   it("time zone", () => {
@@ -86,7 +88,7 @@ describe("TimeWithZoneTest", () => {
   it("localtime", () => {
     const twz = maketwz();
     const local = twz.localtime();
-    expect(local).toBeInstanceOf(Date);
+    expect(local).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
   it("utc?", () => {

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -91,6 +91,22 @@ describe("TimeWithZoneTest", () => {
     expect(local).toBeInstanceOf(Temporal.PlainDateTime);
   });
 
+  it("localtime with offset", () => {
+    // @twz UTC instant = 2000-01-01 00:00:00 UTC.
+    // -7h offset → wall-clock 1999-12-31 17:00:00.
+    const twz = maketwz();
+    const local = twz.localtime(-7 * 3600);
+    expect(local).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(local.year).toBe(1999);
+    expect(local.month).toBe(12);
+    expect(local.day).toBe(31);
+    expect(local.hour).toBe(17);
+    expect(local.minute).toBe(0);
+    // getlocal alias mirrors localtime
+    const aliased = twz.getlocal(-7 * 3600);
+    expect(aliased.toString()).toBe(local.toString());
+  });
+
   it("utc?", () => {
     const twz = maketwz();
     expect(twz.isUtc()).toBe(false);

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -154,9 +154,9 @@ describe("TimeWithZoneTest", () => {
   it("toDate() returns a Date for just the date portion", () => {
     const twz = eastern.local(2024, 3, 15, 10, 30, 0);
     const date = twz.toDate();
-    expect(date.getFullYear()).toBe(2024);
-    expect(date.getMonth()).toBe(2); // 0-indexed
-    expect(date.getDate()).toBe(15);
+    expect(date.year).toBe(2024);
+    expect(date.month).toBe(3); // Temporal months are 1-indexed
+    expect(date.day).toBe(15);
   });
 
   it("inTimeZone() converts to a different timezone", () => {

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -107,12 +107,9 @@ export class TimeWithZone {
     return this._timeZone;
   }
 
-  /** Returns the local time as a Date (wall-clock time expressed as UTC Date) */
-  get time(): Date {
-    const l = this._local();
-    return new Date(
-      Date.UTC(l.year, l.month - 1, l.day, l.hour, l.minute, l.second, l.millisecond),
-    );
+  /** Returns the local wall-clock time as a Temporal.PlainDateTime. */
+  get time(): Temporal.PlainDateTime {
+    return this._zoned.toPlainDateTime();
   }
 
   /** Timezone abbreviation (e.g., "EST", "EDT") */
@@ -269,26 +266,28 @@ export class TimeWithZone {
   }
 
   /**
-   * Returns local time as a Date (in the system timezone, adjusted to represent
-   * the same wall clock time as in this zone).
+   * Returns the local wall-clock time as a Temporal.PlainDateTime.
+   * If `utcOffsetOverride` is provided (in seconds), the result is the wall-clock
+   * time at that offset from UTC.
    */
-  localtime(utcOffsetOverride?: number): Date {
+  localtime(utcOffsetOverride?: number): Temporal.PlainDateTime {
     if (utcOffsetOverride !== undefined) {
-      return new Date(this._utc.getTime() + utcOffsetOverride * 1000);
+      const shifted = Temporal.Instant.fromEpochMilliseconds(
+        this._utc.getTime() + utcOffsetOverride * 1000,
+      );
+      return shifted.toZonedDateTimeISO("UTC").toPlainDateTime();
     }
-    const l = this._local();
-    return new Date(l.year, l.month - 1, l.day, l.hour, l.minute, l.second, l.millisecond);
+    return this._zoned.toPlainDateTime();
   }
 
   /** Alias for localtime() */
-  getlocal(utcOffset?: number): Date {
+  getlocal(utcOffset?: number): Temporal.PlainDateTime {
     return this.localtime(utcOffset);
   }
 
-  /** Returns a Date representing this instant */
-  toDate(): Date {
-    const l = this._local();
-    return new Date(l.year, l.month - 1, l.day);
+  /** Returns a Temporal.PlainDate representing the local date. */
+  toDate(): Temporal.PlainDate {
+    return this._zoned.toPlainDate();
   }
 
   /** Returns the UTC instant. */

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -273,7 +273,7 @@ export class TimeWithZone {
   localtime(utcOffsetOverride?: number): Temporal.PlainDateTime {
     if (utcOffsetOverride !== undefined) {
       const shifted = Temporal.Instant.fromEpochMilliseconds(
-        this._utc.getTime() + utcOffsetOverride * 1000,
+        Math.trunc(this._utc.getTime() + utcOffsetOverride * 1000),
       );
       return shifted.toZonedDateTimeISO("UTC").toPlainDateTime();
     }

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -513,7 +513,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -521,7 +521,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -529,7 +529,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -537,7 +537,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -545,7 +545,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -553,7 +553,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 15));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -561,7 +561,7 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)");
     const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
-    expect(twz.time.getTime()).toBe(Date.UTC(1999, 11, 31, 12));
+    expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
 


### PR DESCRIPTION
## Summary

PR 8d of the Temporal migration — completes the public-surface flip on `TimeWithZone`:

- `time` getter → `Temporal.PlainDateTime` (`_zoned.toPlainDateTime()`)
- `localtime(utcOffset?)`, `getlocal(utcOffset?)` → `Temporal.PlainDateTime`. The offset variant shifts the instant by `utcOffset` seconds and reads the result as a UTC PlainDateTime (preserves Rails' "wall-clock at the supplied offset" semantics).
- `toDate()` → `Temporal.PlainDate` (`_zoned.toPlainDate()`)

Tests updated mechanically:
- `twz.time.getTime()` → `twz.time.toZonedDateTime("UTC").epochMilliseconds`
- `date.getFullYear/Month/Date()` → `date.year / date.month / date.day` (Temporal months are 1-indexed; the `getMonth() === 2` → `month === 3` flip)
- `localtime()` instance check switched to `Temporal.PlainDateTime`

This wraps the `TimeWithZone` public-API Temporal flip planned across PRs 8a–8d. The class no longer surfaces `Date` anywhere in its return types; remaining `Date` usage is bounded to the cached internal `_utc` field.

## Test plan

- [x] `vitest run packages/activesupport` — 3603/3603 pass
- [x] `pnpm typecheck`
- [x] Diff size: 57 LOC under the 300 ceiling