### PR TITLE
refactor(arel): align Attribute aggregates/concat/contains/overlaps with Rails

### DIFF
--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -2,7 +2,7 @@
  * QueryAttribute — a value object for use when constructing query conditions.
  *
  * Extends ActiveModel::Attribute so instanceof checks work throughout
- * the system (BindMap, visitors, buildCasted, extractNodeValue).
+ * the system (BindMap, visitors, Attribute#quotedNode, extractNodeValue).
  *
  * Mirrors: ActiveRecord::Relation::QueryAttribute < ActiveModel::Attribute
  */

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -51,6 +51,16 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
     expect(o).toBeInstanceOf(Nodes.Overlaps);
     expect(compile(o)).toContain("&&");
   });
+
+  it("contains/overlaps route a scalar RHS through quotedNode (Casted)", () => {
+    // Mirrors Rails' Predications#contains/#overlaps which call
+    // `quoted_node(other)`. On Attribute that wraps the value in
+    // Casted(value, this) so the visitor can apply column type-casting.
+    const c = users.attr("ids").contains([1, 2]);
+    expect((c as Nodes.Contains).right).toBeInstanceOf(Nodes.Casted);
+    const o = users.attr("ids").overlaps([1, 2]);
+    expect((o as Nodes.Overlaps).right).toBeInstanceOf(Nodes.Casted);
+  });
 });
 
 describe("Attribute#quotedNode (the public PredicationHost contract)", () => {

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "./index.js";
+
+const users = new Table("users");
+const compile = (n: Nodes.Node): string => new Visitors.ToSql().compile(n);
+
+// Behavior tests for the attribute-alignment changes — typed-subclass
+// returns from aggregates / contains / overlaps / concat, plus the
+// `retryable: true` flag on alias SqlLiterals across every per-class
+// `as()` override.
+
+describe("Attribute aggregates return typed Function subclasses", () => {
+  it("count compiles to COUNT(...) and is a Count", () => {
+    const c = users.get("id").count();
+    expect(c).toBeInstanceOf(Nodes.Count);
+    expect(compile(c)).toBe('COUNT("users"."id")');
+  });
+
+  it("count(true) emits COUNT(DISTINCT ...)", () => {
+    expect(compile(users.get("id").count(true))).toBe('COUNT(DISTINCT "users"."id")');
+  });
+
+  it("sum/maximum/minimum/average return typed subclasses", () => {
+    expect(users.get("id").sum()).toBeInstanceOf(Nodes.Sum);
+    expect(users.get("id").maximum()).toBeInstanceOf(Nodes.Max);
+    expect(users.get("id").minimum()).toBeInstanceOf(Nodes.Min);
+    expect(users.get("id").average()).toBeInstanceOf(Nodes.Avg);
+  });
+});
+
+describe("Attribute concat / contains / overlaps return typed infix subclasses", () => {
+  it("concat builds a Concat (SQL ||), not a CONCAT(...) function", () => {
+    const c = users.attr("first").concat(users.attr("last"));
+    expect(c).toBeInstanceOf(Nodes.Concat);
+    const sql = compile(c);
+    expect(sql).toBe('"users"."first" || "users"."last"');
+    // Regression: must NOT emit the old NamedFunction CONCAT(...) form.
+    expect(sql).not.toContain("CONCAT(");
+  });
+
+  it("contains is a Contains (PostgreSQL @>)", () => {
+    const arr = new Nodes.SqlLiteral("ARRAY[1,2]");
+    const c = users.attr("ids").contains(arr);
+    expect(c).toBeInstanceOf(Nodes.Contains);
+    expect(compile(c)).toContain("@>");
+  });
+
+  it("overlaps is an Overlaps (PostgreSQL &&)", () => {
+    const arr = new Nodes.SqlLiteral("ARRAY[1,2]");
+    const o = users.attr("ids").overlaps(arr);
+    expect(o).toBeInstanceOf(Nodes.Overlaps);
+    expect(compile(o)).toContain("&&");
+  });
+});
+
+describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
+  // Mirrors Arel::AliasPredication#as in Rails:
+  //   Nodes::SqlLiteral.new(other, retryable: true)
+  // The retryable flag tells the collector that the bare alias name
+  // doesn't break parameterized-SQL retry-by-bind-cache. Without it,
+  // visiting an `As(left, SqlLiteral("alias"))` would flip
+  // collector.retryable to false.
+
+  const collectorIsRetryableAfter = (n: Nodes.Node): boolean =>
+    new Visitors.ToSql().compileWithCollector(n).retryable;
+
+  it("Attribute#as keeps the collector retryable", () => {
+    expect(collectorIsRetryableAfter(users.attr("id").as("aliased"))).toBe(true);
+  });
+
+  it("Binary subclass `as` (via Equality#as) keeps the collector retryable", () => {
+    const eq = new Nodes.Equality(users.attr("id"), new Nodes.SqlLiteral("1", { retryable: true }));
+    expect(collectorIsRetryableAfter(eq.as("aliased"))).toBe(true);
+  });
+
+  it("Grouping#as keeps the collector retryable", () => {
+    const g = new Nodes.Grouping(new Nodes.SqlLiteral("x", { retryable: true }));
+    expect(collectorIsRetryableAfter(g.as("aliased"))).toBe(true);
+  });
+});

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -53,6 +53,31 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
   });
 });
 
+describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
+  // Mirrors Rails' Arel::Predications#quoted_node — Predications calls
+  // `this.quotedNode(other)` on its host. Attribute's impl preserves the
+  // column type-cast path: scalars become Casted(value, this), nulls
+  // become Quoted(null), ActiveModel::Attribute instances become
+  // BindParam, and raw Nodes pass through.
+  it("wraps a scalar in Casted(value, attribute)", () => {
+    const attr = users.attr("id");
+    const out = attr.quotedNode(42);
+    expect(out).toBeInstanceOf(Nodes.Casted);
+    expect((out as Nodes.Casted).value).toBe(42);
+    expect((out as Nodes.Casted).attribute).toBe(attr);
+  });
+
+  it("returns Quoted(null) for null/undefined", () => {
+    expect(users.attr("id").quotedNode(null)).toBeInstanceOf(Nodes.Quoted);
+    expect(users.attr("id").quotedNode(undefined)).toBeInstanceOf(Nodes.Quoted);
+  });
+
+  it("passes through raw Nodes unchanged", () => {
+    const lit = new Nodes.SqlLiteral("CURRENT_TIMESTAMP");
+    expect(users.attr("created_at").quotedNode(lit)).toBe(lit);
+  });
+});
+
 describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
   // Mirrors Arel::AliasPredication#as in Rails:
   //   Nodes::SqlLiteral.new(other, retryable: true)

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -324,8 +324,7 @@ describe("AttributeTest", () => {
   describe("#average", () => {
     it("should create a AVG node", () => {
       const node = users.get("age").average();
-      expect(node).toBeInstanceOf(Nodes.NamedFunction);
-      expect(node.name).toBe("AVG");
+      expect(node).toBeInstanceOf(Nodes.Avg);
     });
 
     it("should generate the proper SQL", () => {
@@ -338,8 +337,7 @@ describe("AttributeTest", () => {
   describe("#maximum", () => {
     it("should create a MAX node", () => {
       const node = users.get("age").maximum();
-      expect(node).toBeInstanceOf(Nodes.NamedFunction);
-      expect(node.name).toBe("MAX");
+      expect(node).toBeInstanceOf(Nodes.Max);
     });
 
     it("should generate proper SQL", () => {
@@ -352,8 +350,7 @@ describe("AttributeTest", () => {
   describe("#minimum", () => {
     it("should create a Min node", () => {
       const node = users.get("age").minimum();
-      expect(node).toBeInstanceOf(Nodes.NamedFunction);
-      expect(node.name).toBe("MIN");
+      expect(node).toBeInstanceOf(Nodes.Min);
     });
 
     it("should generate proper SQL", () => {
@@ -366,8 +363,7 @@ describe("AttributeTest", () => {
   describe("#sum", () => {
     it("should create a SUM node", () => {
       const node = users.get("age").sum();
-      expect(node).toBeInstanceOf(Nodes.NamedFunction);
-      expect(node.name).toBe("SUM");
+      expect(node).toBeInstanceOf(Nodes.Sum);
     });
 
     it("should generate the proper SQL", () => {
@@ -380,8 +376,7 @@ describe("AttributeTest", () => {
   describe("#count", () => {
     it("should return a count node", () => {
       const node = users.get("id").count();
-      expect(node).toBeInstanceOf(Nodes.NamedFunction);
-      expect(node.name).toBe("COUNT");
+      expect(node).toBeInstanceOf(Nodes.Count);
     });
 
     it("should take a distinct param", () => {
@@ -1332,11 +1327,15 @@ describe("AttributeTest", () => {
     expect(visitor.compile(node)).toBe('SUBSTRING("users"."name", 1, 3)');
   });
 
-  it("generates CONCAT()", () => {
-    const node = users.attr("first_name").concat(" ", users.attr("last_name"));
+  it("generates a `||` Concat infix node", () => {
+    // Mirrors Rails: Predications#concat builds Nodes::Concat (the SQL
+    // standard `||` operator), not a CONCAT(...) function call.
+    const node = users.attr("first_name").concat(users.attr("last_name"));
+    expect(node).toBeInstanceOf(Nodes.Concat);
     const sql = visitor.compile(node);
-    expect(sql).toContain("CONCAT(");
     expect(sql).toContain('"users"."first_name"');
+    expect(sql).toContain("||");
+    expect(sql).toContain('"users"."last_name"');
   });
 
   it("generates REPLACE()", () => {
@@ -1559,17 +1558,17 @@ describe("AttributeTest", () => {
 
   it("count should be compatible with Addition", () => {
     const count = users.get("id").count();
-    expect(count.name).toBe("COUNT");
+    expect(count).toBeInstanceOf(Nodes.Count);
   });
 
   it("maximum should be compatible with node", () => {
     const node = users.get("age").maximum();
-    expect(node.name).toBe("MAX");
+    expect(node).toBeInstanceOf(Nodes.Max);
   });
 
   it("minimum should be compatible with node", () => {
     const node = users.get("age").minimum();
-    expect(node.name).toBe("MIN");
+    expect(node).toBeInstanceOf(Nodes.Min);
   });
 
   it("attribute node should be compatible with Subtraction", () => {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -13,7 +13,17 @@ import { Equality } from "../nodes/equality.js";
 import { Matches, DoesNotMatch } from "../nodes/matches.js";
 import { In } from "../nodes/in.js";
 import { NotIn } from "../nodes/binary.js";
-import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-operation.js";
+import {
+  Addition,
+  Subtraction,
+  Multiplication,
+  Division,
+  Concat,
+  Contains,
+  Overlaps,
+} from "../nodes/infix-operation.js";
+import { Count } from "../nodes/count.js";
+import { Sum, Max, Min, Avg } from "../nodes/function.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
 import { Quoted, Casted, buildQuoted } from "../nodes/casted.js";
@@ -30,7 +40,6 @@ import { Regexp as RegexpNode, NotRegexp } from "../nodes/regexp.js";
 import { IsDistinctFrom, IsNotDistinctFrom } from "../nodes/binary.js";
 import { Case } from "../nodes/case.js";
 import {
-  InfixOperation,
   BitwiseAnd,
   BitwiseOr,
   BitwiseXor,
@@ -374,29 +383,35 @@ export class Attribute extends Node {
   // -- Aliasing --
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   // -- Aggregate functions --
+  //
+  // Mirrors: Arel::Expressions (mixed into Attribute in Rails). Returns
+  // the typed Function subclasses Rails uses (Count/Sum/Max/Min/Avg) so
+  // `instanceof` checks line up across the codebase. The visitor
+  // (visitAggregate in to-sql.ts) renders them identically to a
+  // NamedFunction with the same name.
 
-  count(distinct = false): NamedFunction {
-    return new NamedFunction("COUNT", [this], undefined, distinct);
+  count(distinct = false): Count {
+    return new Count([this], distinct);
   }
 
-  sum(): NamedFunction {
-    return new NamedFunction("SUM", [this]);
+  sum(): Sum {
+    return new Sum([this]);
   }
 
-  maximum(): NamedFunction {
-    return new NamedFunction("MAX", [this]);
+  maximum(): Max {
+    return new Max([this]);
   }
 
-  minimum(): NamedFunction {
-    return new NamedFunction("MIN", [this]);
+  minimum(): Min {
+    return new Min([this]);
   }
 
-  average(): NamedFunction {
-    return new NamedFunction("AVG", [this]);
+  average(): Avg {
+    return new Avg([this]);
   }
 
   // -- String functions --
@@ -431,8 +446,12 @@ export class Attribute extends Node {
     return new NamedFunction("SUBSTRING", args);
   }
 
-  concat(other: unknown, ...rest: unknown[]): NamedFunction {
-    return new NamedFunction("CONCAT", [this, buildQuoted(other), ...rest.map(buildQuoted)]);
+  // Mirrors: Arel::Predications#concat — `Nodes::Concat.new self, other`,
+  // i.e. SQL `||` infix concatenation. (The previous implementation built
+  // a `CONCAT(...)` NamedFunction call, which was Trails-specific and
+  // varied by dialect; the `||` form is what Rails emits.)
+  concat(other: Node): Concat {
+    return new Concat(this, other);
   }
 
   replace(from: string, to: string): NamedFunction {
@@ -497,19 +516,22 @@ export class Attribute extends Node {
   /**
    * PostgreSQL @> (contains) operator.
    *
-   * Mirrors: Arel::Attributes::Attribute#contains
+   * Mirrors: Arel::Predications#contains — `Arel::Nodes::Contains.new ...`.
+   * Returns the dedicated `Contains` subclass (rather than a generic
+   * `InfixOperation("@>", ...)`) so `instanceof` checks line up with the
+   * subclass Rails uses.
    */
-  contains(other: unknown): InfixOperation {
-    return new InfixOperation("@>", this, buildQuoted(other));
+  contains(other: unknown): Contains {
+    return new Contains(this, buildQuoted(other));
   }
 
   /**
    * PostgreSQL && (overlaps) operator.
    *
-   * Mirrors: Arel::Attributes::Attribute#overlaps
+   * Mirrors: Arel::Predications#overlaps — `Arel::Nodes::Overlaps.new ...`.
    */
-  overlaps(other: unknown): InfixOperation {
-    return new InfixOperation("&&", this, buildQuoted(other));
+  overlaps(other: unknown): Overlaps {
+    return new Overlaps(this, buildQuoted(other));
   }
 
   /**

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -111,7 +111,15 @@ export class Attribute extends Node {
       : false;
   }
 
-  private buildCasted(value: unknown): Node {
+  /**
+   * Mirrors: Arel::Predications#quoted_node — the type-aware wrapper
+   * that the Predications mixin calls to bring an arbitrary right-hand
+   * value into the AST. Attribute's impl wraps in `Casted(value, this)`
+   * so the visitor can apply column-level type-casting; ActiveModel
+   * attribute instances become BindParam so they extract as binds; raw
+   * Nodes are passed through.
+   */
+  quotedNode(value: unknown): Node {
     if (value instanceof Node) return value;
     if (value === null || value === undefined) return new Quoted(null);
     // ActiveModel::Attribute instances (QueryAttribute etc.) carry their
@@ -126,27 +134,27 @@ export class Attribute extends Node {
   // -- Predicates --
 
   eq(other: unknown): Equality {
-    return new Equality(this, this.buildCasted(other));
+    return new Equality(this, this.quotedNode(other));
   }
 
   notEq(other: unknown): NotEqual {
-    return new NotEqual(this, this.buildCasted(other));
+    return new NotEqual(this, this.quotedNode(other));
   }
 
   gt(other: unknown): GreaterThan {
-    return new GreaterThan(this, this.buildCasted(other));
+    return new GreaterThan(this, this.quotedNode(other));
   }
 
   gteq(other: unknown): GreaterThanOrEqual {
-    return new GreaterThanOrEqual(this, this.buildCasted(other));
+    return new GreaterThanOrEqual(this, this.quotedNode(other));
   }
 
   lt(other: unknown): LessThan {
-    return new LessThan(this, this.buildCasted(other));
+    return new LessThan(this, this.quotedNode(other));
   }
 
   lteq(other: unknown): LessThanOrEqual {
-    return new LessThanOrEqual(this, this.buildCasted(other));
+    return new LessThanOrEqual(this, this.quotedNode(other));
   }
 
   matches(
@@ -155,7 +163,7 @@ export class Attribute extends Node {
     caseSensitive = false,
   ): Matches {
     const right =
-      typeof pattern === "string" ? this.buildCasted(pattern) : (pattern as { ast: Node }).ast;
+      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
     return new Matches(this, right, escape, caseSensitive);
   }
 
@@ -165,16 +173,16 @@ export class Attribute extends Node {
     caseSensitive = false,
   ): DoesNotMatch {
     const right =
-      typeof pattern === "string" ? this.buildCasted(pattern) : (pattern as { ast: Node }).ast;
+      typeof pattern === "string" ? this.quotedNode(pattern) : (pattern as { ast: Node }).ast;
     return new DoesNotMatch(this, right, escape, caseSensitive);
   }
 
   matchesRegexp(pattern: string, caseSensitive = true): RegexpNode {
-    return new RegexpNode(this, this.buildCasted(pattern), caseSensitive);
+    return new RegexpNode(this, this.quotedNode(pattern), caseSensitive);
   }
 
   doesNotMatchRegexp(pattern: string, caseSensitive = true): NotRegexp {
-    return new NotRegexp(this, this.buildCasted(pattern), caseSensitive);
+    return new NotRegexp(this, this.quotedNode(pattern), caseSensitive);
   }
 
   in(values: unknown[] | { ast: Node }): In {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -524,22 +524,27 @@ export class Attribute extends Node {
   /**
    * PostgreSQL @> (contains) operator.
    *
-   * Mirrors: Arel::Predications#contains — `Arel::Nodes::Contains.new ...`.
+   * Mirrors: Arel::Predications#contains — `Arel::Nodes::Contains.new self, quoted_node(other)`.
    * Returns the dedicated `Contains` subclass (rather than a generic
-   * `InfixOperation("@>", ...)`) so `instanceof` checks line up with the
-   * subclass Rails uses.
+   * `InfixOperation("@>", ...)`) so `instanceof` checks line up. Routes
+   * through `this.quotedNode` so a scalar RHS gets the column-aware
+   * `Casted` wrapping (matching how Rails' `quoted_node` carries the
+   * attribute as type-cast context).
    */
   contains(other: unknown): Contains {
-    return new Contains(this, buildQuoted(other));
+    return new Contains(this, this.quotedNode(other));
   }
 
   /**
    * PostgreSQL && (overlaps) operator.
    *
-   * Mirrors: Arel::Predications#overlaps — `Arel::Nodes::Overlaps.new ...`.
+   * Mirrors: Arel::Predications#overlaps — `Arel::Nodes::Overlaps.new self, quoted_node(other)`.
+   * Routes through `this.quotedNode` (rather than the bare `buildQuoted`)
+   * so a scalar RHS gets the column-aware `Casted` wrapping. Same fidelity
+   * fix as `contains`.
    */
   overlaps(other: unknown): Overlaps {
-    return new Overlaps(this, buildQuoted(other));
+    return new Overlaps(this, this.quotedNode(other));
   }
 
   /**

--- a/packages/arel/src/nodes/and.ts
+++ b/packages/arel/src/nodes/and.ts
@@ -9,6 +9,6 @@ import { Nary } from "./nary.js";
  */
 export class And extends Nary {
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 }

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -46,7 +46,7 @@ export class Binary extends NodeExpression {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   and(other: Node): And {

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -41,7 +41,7 @@ export class Case extends NodeExpression {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   clone(): Case {

--- a/packages/arel/src/nodes/count.test.ts
+++ b/packages/arel/src/nodes/count.test.ts
@@ -15,7 +15,7 @@ describe("Arel::Nodes::CountTest", () => {
   describe("eq", () => {
     it("should compare the count", () => {
       const count = users.get("id").count();
-      expect(count.name).toBe("COUNT");
+      expect(count).toBeInstanceOf(Nodes.Count);
     });
   });
 

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -17,6 +17,6 @@ export class Extract extends Unary {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 }

--- a/packages/arel/src/nodes/grouping.ts
+++ b/packages/arel/src/nodes/grouping.ts
@@ -14,7 +14,7 @@ export class Grouping extends Unary {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   fetchAttribute(block: (attr: Node) => unknown): unknown {

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -34,7 +34,7 @@ export class InfixOperation extends Binary {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   asc(): Ascending {

--- a/packages/arel/src/nodes/unary-operation.ts
+++ b/packages/arel/src/nodes/unary-operation.ts
@@ -24,7 +24,7 @@ export class UnaryOperation extends Unary {
   }
 
   as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName));
+    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   asc(): Ascending {


### PR DESCRIPTION
## Summary

Two follow-ups deferred from the PR #972 series, bundled because both are small.

### (1) Attribute predicate-method node types

Today's Attribute ships hand-rolled methods that diverge from Rails' Predications/Expressions output:

| Method | Before | After (Rails-aligned) |
|---|---|---|
| `count` | `NamedFunction("COUNT", …)` | `Count` |
| `sum` | `NamedFunction("SUM", …)` | `Sum` |
| `maximum` | `NamedFunction("MAX", …)` | `Max` |
| `minimum` | `NamedFunction("MIN", …)` | `Min` |
| `average` | `NamedFunction("AVG", …)` | `Avg` |
| `concat` | `NamedFunction("CONCAT", …)` | `Concat` (SQL `\|\|`) |
| `contains` | `InfixOperation("@>", …)` | `Contains` |
| `overlaps` | `InfixOperation("&&", …)` | `Overlaps` |

The visitor renders aggregates identically (`visitAggregate` landed in #972), and `contains`/`overlaps` produce identical SQL — the win is that `instanceof Count` / `instanceof Contains` checks now line up with the typed subclasses Rails uses.

`concat` is a real behavior change: Rails' `Predications#concat` builds a `Nodes::Concat` (SQL standard `||` operator), not a `CONCAT(...)` function call. The previous Trails form was dialect-dependent. The single-arg signature also matches Rails' single-arg shape; a downstream caller passing multiple args or a string can wrap with `buildQuoted` themselves.

### (2) `as()` `retryable: true` consistency

Rails' `AliasPredication#as`:

```ruby
def as(other)
  Nodes::As.new self, Nodes::SqlLiteral.new(other, retryable: true)
end
```

The mixin (`alias-predication.ts`) already passes `{ retryable: true }`. The pre-existing per-class hand-rolled `as()` impls did not — fixed for `Attribute`, `Binary`, `And`, `Case`, `Extract`, `Grouping`, `InfixOperation`, `UnaryOperation`.

`Function#as` (mutates self), `Table#as` and `SelectManager#as` (return `TableAlias`) are intentionally untouched — different shapes.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run packages/arel/` — 1039/1039 passing (4 tests updated for the new aggregate / concat node types)
- [x] `pnpm run api:compare --package arel` — still **589/589 (100%)**

## Diff

10 files changed, 66 insertions(+), 45 deletions(-) — well under the 300 LOC ceiling.