### PR TITLE
feat(activemodel): JSON serializer mixin host with model_name + serializable_hash

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -50,6 +50,9 @@ export { CallbackChain } from "./callbacks.js";
 export type { CallbackConditions } from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
 export type { SerializeOptions } from "./serialization.js";
+// Aliased to avoid clobbering the global `JSON` namespace; consumers
+// can import as `JSONSerializer` or alias on import.
+export { JSON as JSONSerializer } from "./serializers/json.js";
 export { Type } from "./type/value.js";
 export { typeRegistry } from "./type/registry.js";
 

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -183,6 +183,15 @@ describe("Serializers::JSON host", () => {
     });
   });
 
+  it("asJson treats empty-string root as truthy (Rails parity)", () => {
+    const p = new Person();
+    p._name = "Hank";
+    p._age = 70;
+    // Ruby: `if root` is true for "", and `root == true` is false, so
+    // Rails wraps under the empty key.
+    expect(p.asJson({ root: "" })).toMatchObject({ "": { name: "Hank", age: 70 } });
+  });
+
   it("Model already implements the same surface ergonomically", () => {
     // Sanity: the JSON host is the canonical mixin form; Model continues
     // to compose asJson/fromJson directly (model.ts already mirrors json.rb).

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -138,9 +138,10 @@ describe("Serializers::JSON host", () => {
     expect(c.asJson()).toMatchObject({ author: { name: "Eve" } });
   });
 
-  it("fromJson rejects non-object JSON (Rails would NoMethodError)", () => {
-    expect(() => new Person().fromJson("42")).toThrow(/expected a JSON object/);
-    expect(() => new Person().fromJson("[1,2,3]")).toThrow(/expected a JSON object/);
+  it("fromJson rejects non-object JSON with shape-accurate diagnostics", () => {
+    expect(() => new Person().fromJson("42")).toThrow(/got number/);
+    expect(() => new Person().fromJson("[1,2,3]")).toThrow(/got array/);
+    expect(() => new Person().fromJson("null")).toThrow(/got null/);
   });
 
   it("fromJson with string includeRootInJson unwraps by that key, not first-value", () => {

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -96,6 +96,48 @@ describe("Serializers::JSON host", () => {
     expect(p._age).toBe(40);
   });
 
+  it("asJson coerces JSON-unsafe values (e.g. bigint)", () => {
+    class Big extends JSONHost {
+      static {
+        Object.defineProperty(this.prototype, "attributes", {
+          get() {
+            return { id: this._id };
+          },
+          set(this: { _id: bigint }, h: { id: bigint }) {
+            this._id = h.id;
+          },
+          configurable: true,
+        });
+      }
+      _id = 0n;
+    }
+    const b = new Big();
+    b._id = 9007199254740993n;
+    // Without coerceForJson, JSON.stringify(b.asJson()) would throw.
+    expect(() => globalThis.JSON.stringify(b.asJson())).not.toThrow();
+  });
+
+  it("includeRootInJson accepts a string custom root", () => {
+    class CustomRooted extends JSONHost {
+      static {
+        this.includeRootInJson = "author";
+        Object.defineProperty(this.prototype, "attributes", {
+          get() {
+            return { name: this._name };
+          },
+          set(this: { _name: string }, h: { name: string }) {
+            this._name = h.name;
+          },
+          configurable: true,
+        });
+      }
+      _name = "";
+    }
+    const c = new CustomRooted();
+    c._name = "Eve";
+    expect(c.asJson()).toMatchObject({ author: { name: "Eve" } });
+  });
+
   it("Model already implements the same surface ergonomically", () => {
     // Sanity: the JSON host is the canonical mixin form; Model continues
     // to compose asJson/fromJson directly (model.ts already mirrors json.rb).

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -144,7 +144,11 @@ describe("Serializers::JSON host", () => {
     expect(() => new Person().fromJson("null")).toThrow(/got null/);
   });
 
-  it("fromJson with string includeRootInJson unwraps by that key, not first-value", () => {
+  it("fromJson always unwraps via first-value semantics (Rails hash.values.first)", () => {
+    // Rails json.rb:147 — `hash = hash.values.first if include_root`,
+    // ignoring the configured root key. Pin that behavior explicitly so
+    // the read path stays Rails-faithful even when includeRootInJson is
+    // a string.
     class Keyed extends JSONHost {
       static {
         this.includeRootInJson = "data";
@@ -160,8 +164,28 @@ describe("Serializers::JSON host", () => {
       }
       _v = 0;
     }
-    const k = new Keyed().fromJson('{"meta":1,"data":{"v":7}}');
+    const k = new Keyed().fromJson('{"payload":{"v":7},"data":{"v":1}}');
     expect(k._v).toBe(7);
+  });
+
+  it("fromJson uses class-level includeRootInJson default when no second arg passed", () => {
+    class Defaulted extends JSONHost {
+      static {
+        this.includeRootInJson = true;
+        Object.defineProperty(this.prototype, "attributes", {
+          get() {
+            return { v: this._v };
+          },
+          set(this: { _v: number }, h: { v: number }) {
+            this._v = h.v;
+          },
+          configurable: true,
+        });
+      }
+      _v = 0;
+    }
+    const d = new Defaulted().fromJson('{"defaulted":{"v":99}}');
+    expect(d._v).toBe(99);
   });
 
   it("toJson returns a JSON string (matches Model#toJson)", () => {

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -138,6 +138,41 @@ describe("Serializers::JSON host", () => {
     expect(c.asJson()).toMatchObject({ author: { name: "Eve" } });
   });
 
+  it("fromJson rejects non-object JSON (Rails would NoMethodError)", () => {
+    expect(() => new Person().fromJson("42")).toThrow(/expected a JSON object/);
+    expect(() => new Person().fromJson("[1,2,3]")).toThrow(/expected a JSON object/);
+  });
+
+  it("fromJson with string includeRootInJson unwraps by that key, not first-value", () => {
+    class Keyed extends JSONHost {
+      static {
+        this.includeRootInJson = "data";
+        Object.defineProperty(this.prototype, "attributes", {
+          get() {
+            return { v: this._v };
+          },
+          set(this: { _v: number }, h: { v: number }) {
+            this._v = h.v;
+          },
+          configurable: true,
+        });
+      }
+      _v = 0;
+    }
+    const k = new Keyed().fromJson('{"meta":1,"data":{"v":7}}');
+    expect(k._v).toBe(7);
+  });
+
+  it("toJSON delegates to asJson (used by JSON.stringify)", () => {
+    const p = new Person();
+    p._name = "Frank";
+    p._age = 50;
+    expect(globalThis.JSON.parse(globalThis.JSON.stringify(p))).toMatchObject({
+      name: "Frank",
+      age: 50,
+    });
+  });
+
   it("Model already implements the same surface ergonomically", () => {
     // Sanity: the JSON host is the canonical mixin form; Model continues
     // to compose asJson/fromJson directly (model.ts already mirrors json.rb).

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -164,6 +164,15 @@ describe("Serializers::JSON host", () => {
     expect(k._v).toBe(7);
   });
 
+  it("toJson returns a JSON string (matches Model#toJson)", () => {
+    const p = new Person();
+    p._name = "Grace";
+    p._age = 60;
+    const s = p.toJson();
+    expect(typeof s).toBe("string");
+    expect(globalThis.JSON.parse(s)).toMatchObject({ name: "Grace", age: 60 });
+  });
+
   it("toJSON delegates to asJson (used by JSON.stringify)", () => {
     const p = new Person();
     p._name = "Frank";

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { JSON as JSONHost } from "./json.js";
+import { Model } from "../index.js";
+
+// Mirrors ActiveModel::Serializers::JSON (json.rb). Pinning the host
+// surface here so the mixin shape (model_name + serializable_hash +
+// as_json + from_json) doesn't regress.
+describe("Serializers::JSON host", () => {
+  class Person extends JSONHost {
+    static {
+      Object.defineProperty(this.prototype, "attributes", {
+        get() {
+          return { name: this._name, age: this._age };
+        },
+        set(this: { _name: string; _age: number }, h: { name: string; age: number }) {
+          this._name = h.name;
+          this._age = h.age;
+        },
+        configurable: true,
+      });
+    }
+    _name = "";
+    _age = 0;
+  }
+
+  it("modelName resolves to the subclass and is memoized per-class", () => {
+    expect(Person.modelName.name).toBe("Person");
+    // Memoized — repeat call returns same instance.
+    expect(Person.modelName).toBe(Person.modelName);
+
+    class Other extends JSONHost {}
+    expect(Other.modelName.name).toBe("Other");
+    expect(Other.modelName).not.toBe(Person.modelName);
+  });
+
+  it("serializableHash delegates to serialization helper", () => {
+    const p = new Person();
+    p._name = "Bob";
+    p._age = 22;
+    const h = p.serializableHash();
+    expect(h).toMatchObject({ name: "Bob", age: 22 });
+  });
+
+  it("asJson without root option returns the bare hash", () => {
+    const p = new Person();
+    p._name = "Bob";
+    p._age = 22;
+    expect(p.asJson()).toMatchObject({ name: "Bob", age: 22 });
+  });
+
+  it("asJson with root: true wraps under modelName.element", () => {
+    const p = new Person();
+    p._name = "Bob";
+    p._age = 22;
+    const wrapped = p.asJson({ root: true });
+    expect(wrapped).toHaveProperty(Person.modelName.element);
+  });
+
+  it("asJson with root: 'custom' wraps under that key", () => {
+    const p = new Person();
+    p._name = "Bob";
+    p._age = 22;
+    expect(p.asJson({ root: "author" })).toMatchObject({ author: { name: "Bob", age: 22 } });
+  });
+
+  it("includeRootInJson default applies when no root option passed", () => {
+    class Rooted extends JSONHost {
+      static {
+        this.includeRootInJson = true;
+        Object.defineProperty(this.prototype, "attributes", {
+          get() {
+            return { x: this._x };
+          },
+          set(this: { _x: number }, h: { x: number }) {
+            this._x = h.x;
+          },
+          configurable: true,
+        });
+      }
+      _x = 0;
+    }
+    const r = new Rooted();
+    r._x = 1;
+    expect(r.asJson()).toHaveProperty(Rooted.modelName.element);
+  });
+
+  it("fromJson round-trips through attributes setter", () => {
+    const p = new Person().fromJson('{"name":"Carol","age":30}');
+    expect(p._name).toBe("Carol");
+    expect(p._age).toBe(30);
+  });
+
+  it("fromJson with includeRoot strips the wrapping key", () => {
+    const p = new Person().fromJson('{"person":{"name":"Dan","age":40}}', true);
+    expect(p._name).toBe("Dan");
+    expect(p._age).toBe(40);
+  });
+
+  it("Model already implements the same surface ergonomically", () => {
+    // Sanity: the JSON host is the canonical mixin form; Model continues
+    // to compose asJson/fromJson directly (model.ts already mirrors json.rb).
+    expect(typeof Model.prototype.asJson).toBe("function");
+  });
+});

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -1,4 +1,4 @@
-import { serializableHash, type SerializeOptions } from "../serialization.js";
+import { serializableHash, coerceForJson, type SerializeOptions } from "../serialization.js";
 import { ModelName } from "../naming.js";
 
 /**
@@ -24,7 +24,9 @@ import { ModelName } from "../naming.js";
  */
 export class JSON {
   // Rails: included do; class_attribute :include_root_in_json, default: false; end
-  static includeRootInJson = false;
+  // Typed boolean | string to match Model.includeRootInJson — Rails
+  // accepts a string here too (treated as a custom root key by as_json).
+  static includeRootInJson: boolean | string = false;
 
   // Per-class memo so the static getter can be inherited without
   // recomputing or sharing state across subclasses (matches Model's
@@ -71,7 +73,11 @@ export class JSON {
       options && Object.prototype.hasOwnProperty.call(options, "root")
         ? options.root
         : ctor.includeRootInJson;
-    const hash = this.serializableHash(options);
+    // Rails calls `serializable_hash(options).as_json` — recursive
+    // JSON-coerce on the resulting hash. Mirror that with coerceForJson
+    // so JSON-unsafe values (bigint, undefined, cyclic refs, etc.)
+    // surface predictably, matching Model.asJson (model.ts:1708).
+    const hash = coerceForJson(this.serializableHash(options)) as Record<string, unknown>;
     if (!rootOpt) return hash;
     const rootKey = rootOpt === true ? ctor.modelName.element : (rootOpt as string);
     return { [rootKey]: hash };

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -88,7 +88,11 @@ export class JSON {
     // so JSON-unsafe values (bigint, undefined, cyclic refs, etc.)
     // surface predictably, matching Model.asJson (model.ts:1708).
     const hash = coerceForJson(this.serializableHash(options)) as Record<string, unknown>;
-    if (!rootOpt) return hash;
+    // Rails uses Ruby truthiness — only false/nil skip the wrap. JS
+    // falsiness would also skip an empty-string root key, which Rails
+    // would happily emit as `{ "" => hash }`. Match Rails semantics
+    // explicitly (json.rb:101-107).
+    if (rootOpt === false || rootOpt == null) return hash;
     const rootKey = rootOpt === true ? ctor.modelName.element : (rootOpt as string);
     return { [rootKey]: hash };
   }
@@ -112,14 +116,16 @@ export class JSON {
     if (!isPlainJsonObject(hash)) {
       throw new TypeError(`fromJson expected a JSON object, got ${describeJsonShape(hash)}`);
     }
-    if (root) {
-      // When includeRootInJson is a string, prefer the explicit key so
-      // multi-key payloads still unwrap deterministically; otherwise fall
-      // back to first-value semantics (Rails json.rb:147 hash.values.first).
+    // Rails truthiness: false/nil skip; empty string still triggers
+    // unwrap (json.rb:146-147). Match that explicitly.
+    if (root !== false && root != null) {
+      // When the resolved root setting is a string, prefer the explicit
+      // key so multi-key payloads still unwrap deterministically;
+      // otherwise fall back to first-value semantics (Rails json.rb:147
+      // hash.values.first).
       hash =
-        typeof ctor.includeRootInJson === "string" &&
-        Object.prototype.hasOwnProperty.call(hash, ctor.includeRootInJson)
-          ? (hash as Record<string, unknown>)[ctor.includeRootInJson]
+        typeof root === "string" && Object.prototype.hasOwnProperty.call(hash, root)
+          ? (hash as Record<string, unknown>)[root]
           : Object.values(hash as Record<string, unknown>)[0];
       if (!isPlainJsonObject(hash)) {
         throw new TypeError(

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -95,11 +95,46 @@ export class JSON {
   fromJson(json: string, includeRoot?: boolean): this {
     const ctor = this.constructor as typeof JSON;
     const root = includeRoot ?? ctor.includeRootInJson;
-    let hash = globalThis.JSON.parse(json) as Record<string, unknown>;
-    if (root) {
-      hash = Object.values(hash)[0] as Record<string, unknown>;
+    let hash = globalThis.JSON.parse(json) as unknown;
+    // Rails calls `hash.values.first` and raises NoMethodError if the
+    // decoded JSON isn't a Hash. Surface the same failure mode loudly
+    // instead of silently writing `undefined` into `attributes`.
+    if (hash === null || typeof hash !== "object" || Array.isArray(hash)) {
+      throw new TypeError(`fromJson expected a JSON object, got ${typeof hash}`);
     }
-    (this as unknown as { attributes: Record<string, unknown> }).attributes = hash;
+    if (root) {
+      // When includeRootInJson is a string, prefer the explicit key so
+      // multi-key payloads still unwrap deterministically; otherwise fall
+      // back to first-value semantics (Rails json.rb:147 hash.values.first).
+      hash =
+        typeof ctor.includeRootInJson === "string" &&
+        Object.prototype.hasOwnProperty.call(hash, ctor.includeRootInJson)
+          ? (hash as Record<string, unknown>)[ctor.includeRootInJson]
+          : Object.values(hash as Record<string, unknown>)[0];
+      if (hash === null || typeof hash !== "object" || Array.isArray(hash)) {
+        throw new TypeError(`fromJson root payload must be a JSON object, got ${typeof hash}`);
+      }
+    }
+    (this as unknown as { attributes: Record<string, unknown> }).attributes = hash as Record<
+      string,
+      unknown
+    >;
     return this;
+  }
+
+  /**
+   * `JSON.stringify(instance)` consults a `toJSON` method when present.
+   * Delegating to `asJson()` ensures the host runs the same coercion +
+   * root-wrapping as the Rails entry point. Mirrors Model.toJSON
+   * (model.ts) and matches the surface ActiveSupport adds on Object via
+   * `as_json` indirection in Rails.
+   */
+  toJSON(): Record<string, unknown> {
+    return this.asJson();
+  }
+
+  /** Lower-camel alias for callers that prefer the Ruby-style name. */
+  toJson(): Record<string, unknown> {
+    return this.toJSON();
   }
 }

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -1,6 +1,16 @@
 import { serializableHash, coerceForJson, type SerializeOptions } from "../serialization.js";
 import { ModelName } from "../naming.js";
 
+function isPlainJsonObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function describeJsonShape(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
 /**
  * JSON serializer mixin host.
  *
@@ -99,8 +109,8 @@ export class JSON {
     // Rails calls `hash.values.first` and raises NoMethodError if the
     // decoded JSON isn't a Hash. Surface the same failure mode loudly
     // instead of silently writing `undefined` into `attributes`.
-    if (hash === null || typeof hash !== "object" || Array.isArray(hash)) {
-      throw new TypeError(`fromJson expected a JSON object, got ${typeof hash}`);
+    if (!isPlainJsonObject(hash)) {
+      throw new TypeError(`fromJson expected a JSON object, got ${describeJsonShape(hash)}`);
     }
     if (root) {
       // When includeRootInJson is a string, prefer the explicit key so
@@ -111,8 +121,10 @@ export class JSON {
         Object.prototype.hasOwnProperty.call(hash, ctor.includeRootInJson)
           ? (hash as Record<string, unknown>)[ctor.includeRootInJson]
           : Object.values(hash as Record<string, unknown>)[0];
-      if (hash === null || typeof hash !== "object" || Array.isArray(hash)) {
-        throw new TypeError(`fromJson root payload must be a JSON object, got ${typeof hash}`);
+      if (!isPlainJsonObject(hash)) {
+        throw new TypeError(
+          `fromJson root payload must be a JSON object, got ${describeJsonShape(hash)}`,
+        );
       }
     }
     (this as unknown as { attributes: Record<string, unknown> }).attributes = hash as Record<

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -1,16 +1,91 @@
-import type { SerializeOptions } from "../serialization.js";
+import { serializableHash, type SerializeOptions } from "../serialization.js";
+import { Naming, type ModelName } from "../naming.js";
 
 /**
- * JSON serializer — provides as_json and from_json.
+ * JSON serializer mixin host.
  *
- * Mirrors: ActiveModel::Serializers::JSON
+ * Mirrors: ActiveModel::Serializers::JSON (json.rb:9-13)
  *
- * In Rails, this module is included into ActiveModel::Model and provides
- * as_json (returns a hash suitable for JSON encoding) and from_json
- * (populates a model from a JSON string). Model already implements
- * asJson() and fromJson().
+ *   module JSON
+ *     extend ActiveSupport::Concern
+ *     include ActiveModel::Serialization
+ *
+ *     included do
+ *       extend ActiveModel::Naming
+ *       class_attribute :include_root_in_json, instance_writer: false, default: false
+ *     end
+ *     ...
+ *
+ * Rails ships JSON as a module that pulls in `Serialization` (giving
+ * `serializable_hash`) and extends `Naming` (giving `model_name`).
+ * Trails' `Model` already wires up `asJson` / `fromJson`; this class
+ * is the canonical mixin host for lighter-weight adopters and the
+ * file-level Rails surface (`serializable_hash`, `model_name`).
  */
-export interface JSON {
-  asJson(options?: SerializeOptions): Record<string, unknown>;
-  fromJson(json: string, includeRoot?: boolean): this;
+export class JSON {
+  // Rails: included do; class_attribute :include_root_in_json, default: false; end
+  static includeRootInJson = false;
+
+  // Rails: included do; extend ActiveModel::Naming; end — surfaces
+  // model_name on the host class. Subclasses override to customize.
+  static get modelName(): ModelName {
+    return Naming.modelNameFromRecordOrClass(this as unknown as { modelName: ModelName });
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_hash
+   * (serialization.rb), included into JSON via `include
+   * ActiveModel::Serialization`. Delegates to the canonical
+   * implementation in `serialization.ts` so a subclass that mixes in
+   * the JSON host gets the same Rails semantics for `:only`, `:except`,
+   * `:methods`, `:include`.
+   */
+  serializableHash(options?: SerializeOptions): Record<string, unknown> {
+    return serializableHash(this as unknown as Parameters<typeof serializableHash>[0], options);
+  }
+
+  /**
+   * Mirrors: json.rb:96-108
+   *   def as_json(options = nil)
+   *     root = if options&.key?(:root) then options[:root] else include_root_in_json end
+   *     hash = serializable_hash(options).as_json
+   *     if root
+   *       root = model_name.element if root == true
+   *       { root => hash }
+   *     else
+   *       hash
+   *     end
+   *   end
+   */
+  asJson(options?: SerializeOptions & { root?: boolean | string }): Record<string, unknown> {
+    const ctor = this.constructor as typeof JSON;
+    const rootOpt =
+      options && Object.prototype.hasOwnProperty.call(options, "root")
+        ? options.root
+        : ctor.includeRootInJson;
+    const hash = this.serializableHash(options);
+    if (!rootOpt) return hash;
+    const rootKey = rootOpt === true ? ctor.modelName.element : (rootOpt as string);
+    return { [rootKey]: hash };
+  }
+
+  /**
+   * Mirrors: json.rb:144-149
+   *   def from_json(json, include_root = include_root_in_json)
+   *     hash = ActiveSupport::JSON.decode(json)
+   *     hash = hash.values.first if include_root
+   *     self.attributes = hash
+   *     self
+   *   end
+   */
+  fromJson(json: string, includeRoot?: boolean): this {
+    const ctor = this.constructor as typeof JSON;
+    const root = includeRoot ?? ctor.includeRootInJson;
+    let hash = globalThis.JSON.parse(json) as Record<string, unknown>;
+    if (root) {
+      hash = Object.values(hash)[0] as Record<string, unknown>;
+    }
+    (this as unknown as { attributes: Record<string, unknown> }).attributes = hash;
+    return this;
+  }
 }

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -145,8 +145,12 @@ export class JSON {
     return this.asJson();
   }
 
-  /** Lower-camel alias for callers that prefer the Ruby-style name. */
-  toJson(): Record<string, unknown> {
-    return this.toJSON();
+  /**
+   * Mirrors Ruby's `to_json` — encodes the model to a JSON string. Same
+   * shape as Model#toJson (model.ts:1720-1722) so JSONHost adopters
+   * stay compatible with Model-style consumers.
+   */
+  toJson(options?: SerializeOptions & { root?: boolean | string }): string {
+    return globalThis.JSON.stringify(this.asJson(options));
   }
 }

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -116,17 +116,12 @@ export class JSON {
     if (!isPlainJsonObject(hash)) {
       throw new TypeError(`fromJson expected a JSON object, got ${describeJsonShape(hash)}`);
     }
-    // Rails truthiness: false/nil skip; empty string still triggers
-    // unwrap (json.rb:146-147). Match that explicitly.
+    // Rails truthiness: false/nil skip; everything else (including
+    // empty string and any string root key) triggers unwrap via
+    // `hash.values.first` unconditionally — Rails ignores the configured
+    // root key on the read path (json.rb:146-147).
     if (root !== false && root != null) {
-      // When the resolved root setting is a string, prefer the explicit
-      // key so multi-key payloads still unwrap deterministically;
-      // otherwise fall back to first-value semantics (Rails json.rb:147
-      // hash.values.first).
-      hash =
-        typeof root === "string" && Object.prototype.hasOwnProperty.call(hash, root)
-          ? (hash as Record<string, unknown>)[root]
-          : Object.values(hash as Record<string, unknown>)[0];
+      hash = Object.values(hash as Record<string, unknown>)[0];
       if (!isPlainJsonObject(hash)) {
         throw new TypeError(
           `fromJson root payload must be a JSON object, got ${describeJsonShape(hash)}`,

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -106,7 +106,7 @@ export class JSON {
    *     self
    *   end
    */
-  fromJson(json: string, includeRoot?: boolean): this {
+  fromJson(json: string, includeRoot?: boolean | string): this {
     const ctor = this.constructor as typeof JSON;
     const root = includeRoot ?? ctor.includeRootInJson;
     let hash = globalThis.JSON.parse(json) as unknown;

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -1,5 +1,5 @@
 import { serializableHash, type SerializeOptions } from "../serialization.js";
-import { Naming, type ModelName } from "../naming.js";
+import { ModelName } from "../naming.js";
 
 /**
  * JSON serializer mixin host.
@@ -26,10 +26,18 @@ export class JSON {
   // Rails: included do; class_attribute :include_root_in_json, default: false; end
   static includeRootInJson = false;
 
+  // Per-class memo so the static getter can be inherited without
+  // recomputing or sharing state across subclasses (matches Model's
+  // model.ts:1179-1185 pattern).
+  protected static _modelName?: ModelName;
+
   // Rails: included do; extend ActiveModel::Naming; end — surfaces
   // model_name on the host class. Subclasses override to customize.
   static get modelName(): ModelName {
-    return Naming.modelNameFromRecordOrClass(this as unknown as { modelName: ModelName });
+    if (!this._modelName || this._modelName.name !== this.name) {
+      this._modelName = new ModelName(this.name, { klass: this as unknown as { name: string } });
+    }
+    return this._modelName;
   }
 
   /**


### PR DESCRIPTION
## Summary
Replaces the bare `JSON` interface in `serializers/json.ts` with a real class mirroring `ActiveModel::Serializers::JSON` (Rails `json.rb:9-13`):

```ruby
module JSON
  extend ActiveSupport::Concern
  include ActiveModel::Serialization
  included do
    extend ActiveModel::Naming
    class_attribute :include_root_in_json, instance_writer: false, default: false
  end
```

- `serializableHash()` delegates to `serialization.ts` (the same logic backing `Model.asJson`), surfacing Rails' `:only` / `:except` / `:methods` / `:include` semantics.
- Static `modelName` constructs `new ModelName(this.name, ...)` directly with per-class memoization, mirroring `Model.modelName` (`model.ts:1179-1185`). The `Naming.modelNameFromRecordOrClass` resolution path recurses on the very property it computes, so direct construction is the established trails pattern.
- `asJson` reproduces `json.rb:96-108` (root option resolution with explicit Rails-truthiness, `modelName.element` fallback, `coerceForJson` recursion analogous to Rails' `hash.as_json`).
- `fromJson` reproduces `json.rb:144-149` (decode → unwrap via `Object.values(hash)[0]` if includeRoot → assign attributes), with defensive validation that throws `TypeError` on non-object JSON (matching Rails' implicit `NoMethodError` on `hash.values` for non-Hash) and shape-accurate diagnostics distinguishing `null` / `array` / primitive types. `includeRoot` typed as `boolean | string` to match the class-level surface.
- Static `includeRootInJson: boolean | string = false` mirrors Rails `class_attribute` and `Model.includeRootInJson`.
- `toJSON` returns the hash (used by `JSON.stringify`); `toJson(options?)` returns a JSON string, matching `Model.toJson` (`model.ts:1720-1722`).
- Re-exported from `src/index.ts` as `JSONSerializer` (aliased to avoid shadowing the global `JSON`).

## Impact
- `pnpm api:compare --package activemodel`: **429/433 → 431/433** (99.1% → 99.5%). Closes the 2 `serializers/json.rb` rows (`serializable_hash`, `model_name`).
- Only the 2 deferred `attribute_missing` rows remain — scoped as PR 5 (Rails-faithful dispatcher port + rename trails' divergent fallback hook, no Proxy approach per design call).

## Notes / pre-existing divergences (not addressed here)
- `Model.fromJson` defaults `includeRoot` to `false` regardless of `Model.includeRootInJson`. Rails `json.rb:144` defaults to the class-level setting. JSONHost matches Rails; Model is the divergent one — flagging for a future Model fix outside this PR.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — passing (1582 total)
- [x] `pnpm api:compare --package activemodel` — 431/433
- [x] `json.test.ts` — 17 focused tests covering: modelName per-class memoization (no recursion), serializableHash delegation, asJson root-option matrix (none, root: true via modelName.element, root: 'custom' string, root: '' Rails truthiness, class-level boolean default, class-level string default), bigint round-trip via `JSON.stringify`, fromJson round-trip, fromJson with includeRoot (boolean default + first-value semantics regardless of configured key), fromJson defensive validation (non-object → shape-accurate `TypeError`), `toJSON` → asJson delegation, `toJson` → JSON string.

## Copilot review history (9 rounds, converged round 9)

Resolved over the prior rounds:

- **Round 1**: `includeRootInJson` widened to `boolean | string` to match Model; `asJson` runs through `coerceForJson` (Rails' `hash.as_json` recursion).
- **Round 2**: `fromJson` rejects non-object JSON (matching Rails' implicit `NoMethodError`); `toJSON` / `toJson` hooks added.
- **Round 3**: PR description aligned with the direct-construction `modelName` path; shape-accurate `null`/`array` diagnostics in `fromJson` errors.
- **Round 4**: `toJson` returns JSON string (matches `Model#toJson`).
- **Round 5**: Explicit Rails truthiness on root checks (empty string is truthy in Ruby).
- **Round 6**: Reverted to strict Rails `hash.values.first` unwrap in `fromJson` (an earlier review iteration had added key-based unwrap on the read path); test rewritten to assert first-value semantics; added missing class-level boolean-default test.
- **Round 7**: `fromJson(json, includeRoot?)` typed as `boolean | string`.
- **Round 8**: `JSON` host re-exported from `src/index.ts` as `JSONSerializer` (aliased to avoid clobbering global `JSON`).
- **Round 9**: No new comments — converged.

Self-review caught and fixed during the initial draft: infinite recursion in `static modelName`.

Ready for human review.