### PR TITLE
fix(arel): MySQL dialect overrides (UnqualifiedColumn, Bin, IS DISTINCT FROM, REGEXP, Cte)

### DIFF
--- a/packages/arel/src/nodes/bin.test.ts
+++ b/packages/arel/src/nodes/bin.test.ts
@@ -26,8 +26,9 @@ describe("TestBin", () => {
   });
 
   it("mysql to sql", () => {
+    // Rails MySQL: visit_Arel_Nodes_Bin emits `CAST(... AS BINARY)`.
     const node = new Nodes.Bin(new Nodes.SqlLiteral("zomg"));
     const sql = new Visitors.MySQL().compile(node);
-    expect(sql).toBe("BINARY zomg");
+    expect(sql).toBe("CAST(zomg AS BINARY)");
   });
 });

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -147,35 +147,31 @@ describe("MysqlTest", () => {
     });
   });
 
+  // MySQL renders IS [NOT] DISTINCT FROM via the `<=>` null-safe equality
+  // operator (Rails arel/visitors/mysql.rb). The standard
+  // `IS [NOT] DISTINCT FROM` form is only supported on MySQL 8.0.14+;
+  // the operator form works on every supported MySQL version.
   describe("Nodes::IsNotDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isNotDistinctFrom(posts.get("user_id"));
-      const sql = new Visitors.MySQL().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
-      expect(sql).toContain('"users"."id"');
-      expect(sql).toContain('"posts"."user_id"');
+      expect(new Visitors.MySQL().compile(node)).toBe('"users"."id" <=> "posts"."user_id"');
     });
 
     it("should handle nil", () => {
       const node = users.get("name").isNotDistinctFrom(null);
-      const sql = new Visitors.MySQL().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
-      expect(sql).toContain('"users"."name"');
-      expect(sql).toContain("NULL");
+      expect(new Visitors.MySQL().compile(node)).toBe('"users"."name" <=> NULL');
     });
 
     it("should construct a valid generic SQL statement", () => {
       const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
-      const sql = new Visitors.MySQL().compile(node);
-      expect(sql).toContain("IS NOT DISTINCT FROM");
+      expect(new Visitors.MySQL().compile(node)).toBe('"users"."name" <=> 1');
     });
   });
 
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isDistinctFrom(posts.get("user_id"));
-      const sql = new Visitors.MySQL().compile(node);
-      expect(sql).toContain("IS DISTINCT FROM");
+      expect(new Visitors.MySQL().compile(node)).toBe('NOT "users"."id" <=> "posts"."user_id"');
     });
   });
 
@@ -193,5 +189,50 @@ describe("MysqlTest", () => {
       const sql = new Visitors.MySQL().compile(stmt.ast);
       expect(sql).not.toContain("NOT MATERIALIZED");
     });
+  });
+});
+
+// Audit follow-up: verify the MySQL dialect overrides land on the
+// previously-missing visit methods (Bin / UnqualifiedColumn /
+// IsDistinctFrom / IsNotDistinctFrom / Regexp / NotRegexp / Cte).
+describe("MySQL dialect overrides (audit follow-up)", () => {
+  const users = new Table("users");
+  const compile = (n: Nodes.Node): string => new Visitors.MySQL().compile(n);
+
+  it("Bin uses CAST(... AS BINARY) (mirrors Rails)", () => {
+    expect(compile(new Nodes.Bin(users.get("name")))).toBe('CAST("users"."name" AS BINARY)');
+  });
+
+  it("UnqualifiedColumn delegates to its inner expression", () => {
+    expect(compile(new Nodes.UnqualifiedColumn(users.get("name")))).toBe('"users"."name"');
+  });
+
+  it("IsNotDistinctFrom uses MySQL `<=>` operator", () => {
+    const node = new Nodes.IsNotDistinctFrom(users.get("a"), users.get("b"));
+    expect(compile(node)).toBe('"users"."a" <=> "users"."b"');
+  });
+
+  it("IsDistinctFrom uses MySQL `NOT ... <=>` operator", () => {
+    const node = new Nodes.IsDistinctFrom(users.get("a"), users.get("b"));
+    expect(compile(node)).toBe('NOT "users"."a" <=> "users"."b"');
+  });
+
+  it("Regexp uses MySQL REGEXP keyword (not Postgres `~`)", () => {
+    const node = new Nodes.Regexp(users.get("name"), new Nodes.SqlLiteral("'^a'"));
+    expect(compile(node)).toBe('"users"."name" REGEXP \'^a\'');
+  });
+
+  it("NotRegexp uses MySQL NOT REGEXP keyword", () => {
+    const node = new Nodes.NotRegexp(users.get("name"), new Nodes.SqlLiteral("'^a'"));
+    expect(compile(node)).toBe('"users"."name" NOT REGEXP \'^a\'');
+  });
+
+  it("Cte uses backtick-quoted identifiers (not double quotes)", () => {
+    const inner = new SelectManager(users).project(users.get("id"));
+    const cte = new Nodes.Cte("recent", inner.ast);
+    expect(compile(cte)).toMatch(/^`recent` AS \(/);
+    // Embedded backticks must be doubled.
+    const weird = new Nodes.Cte("we`ird", inner.ast);
+    expect(compile(weird)).toMatch(/^`we``ird` AS \(/);
   });
 });

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -207,14 +207,37 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
     expect(compile(new Nodes.UnqualifiedColumn(users.get("name")))).toBe('"users"."name"');
   });
 
+  it("UnqualifiedColumn renders an UPDATE SET assignment without dialect drift", () => {
+    // The override exists so `UPDATE t SET col = col + 1` works on
+    // MySQL — the LHS of the assignment must compile cleanly through
+    // the inner Attribute. Regression coverage: any future change to
+    // visitUnqualifiedColumn that throws or short-circuits would
+    // break this end-to-end shape.
+    const lhs = new Nodes.UnqualifiedColumn(users.get("counter"));
+    const sql = compile(new Nodes.Assignment(lhs, new Nodes.SqlLiteral("1")));
+    expect(sql).toContain('"users"."counter"');
+    expect(sql).toContain("=");
+    expect(sql).toContain("1");
+  });
+
   it("IsNotDistinctFrom uses MySQL `<=>` operator", () => {
     const node = new Nodes.IsNotDistinctFrom(users.get("a"), users.get("b"));
     expect(compile(node)).toBe('"users"."a" <=> "users"."b"');
   });
 
+  it("IsNotDistinctFrom handles NULL on the right (Rails: `<=> NULL`)", () => {
+    const node = users.get("name").isNotDistinctFrom(null);
+    expect(compile(node)).toBe('"users"."name" <=> NULL');
+  });
+
   it("IsDistinctFrom uses MySQL `NOT ... <=>` operator", () => {
     const node = new Nodes.IsDistinctFrom(users.get("a"), users.get("b"));
     expect(compile(node)).toBe('NOT "users"."a" <=> "users"."b"');
+  });
+
+  it("IsDistinctFrom handles NULL on the right (Rails: `NOT … <=> NULL`)", () => {
+    const node = users.get("name").isDistinctFrom(null);
+    expect(compile(node)).toBe('NOT "users"."name" <=> NULL');
   });
 
   it("Regexp uses MySQL REGEXP keyword (not Postgres `~`)", () => {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -107,13 +107,67 @@ export class MySQL extends ToSql {
     return this.collector;
   }
 
+  // Mirrors Rails' MySQL visitor: `CAST(expr AS BINARY)` (the explicit
+  // cast form) rather than the prefix-`BINARY ` operator the previous
+  // Trails impl used. Both force binary comparison; this matches Rails'
+  // emitted SQL.
   protected override visitBin(node: Nodes.Bin): SQLString {
-    this.collector.append("BINARY ");
+    this.collector.append("CAST(");
     if (node.expr instanceof Node) {
       this.visit(node.expr);
     } else if (node.expr !== null) {
       this.collector.append(String(node.expr));
     }
+    this.collector.append(" AS BINARY)");
+    return this.collector;
+  }
+
+  // MySQL renders an UnqualifiedColumn by visiting its inner expression
+  // (typically an Attribute). Rails delegates with `visit o.expr` —
+  // unlike the base ToSql which special-cases the bare name. The
+  // relation prefix this leaves on for an Attribute is fine: MySQL's
+  // `UPDATE t SET x = t.x + 1` is valid.
+  protected override visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
+    if (node.expr instanceof Node) {
+      this.visit(node.expr);
+    } else if (node.expr !== null) {
+      this.collector.append(String(node.expr));
+    }
+    return this.collector;
+  }
+
+  // MySQL's null-safe equality is `<=>`. The standard `IS [NOT] DISTINCT
+  // FROM` is supported only on MySQL 8.0.14+; the operator form works
+  // on every MySQL version.
+  protected override visitIsNotDistinctFrom(node: Nodes.IsNotDistinctFrom): SQLString {
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" <=> ");
+    this.visitNodeOrValue(node.right);
+    return this.collector;
+  }
+
+  protected override visitIsDistinctFrom(node: Nodes.IsDistinctFrom): SQLString {
+    this.collector.append("NOT ");
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" <=> ");
+    this.visitNodeOrValue(node.right);
+    return this.collector;
+  }
+
+  // MySQL uses `REGEXP` / `NOT REGEXP`, not the SQL-standard `~` /
+  // `!~` (which is Postgres). Mirrors Rails MySQL's `infix_value`
+  // helper — same shape as visitMatches.
+  protected override visitRegexp(node: Nodes.Regexp): SQLString {
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" REGEXP ");
+    this.visitNodeOrValue(node.right);
+    return this.collector;
+  }
+
+  protected override visitNotRegexp(node: Nodes.NotRegexp): SQLString {
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" NOT REGEXP ");
+    this.visitNodeOrValue(node.right);
     return this.collector;
   }
 
@@ -136,8 +190,12 @@ export class MySQL extends ToSql {
   }
 
   protected override visitCte(node: Nodes.Cte): SQLString {
-    // MySQL ignores MATERIALIZED / NOT MATERIALIZED modifiers.
-    this.collector.append(`"${node.name}" AS (`);
+    // MySQL identifiers are backtick-quoted, not double-quoted, and the
+    // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are
+    // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte which calls
+    // `quote_table_name` (which emits backticks on the MySQL adapter).
+    const escaped = node.name.replace(/`/g, "``");
+    this.collector.append(`\`${escaped}\` AS (`);
     this.visit(node.relation);
     this.collector.append(")");
     return this.collector;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1295,7 +1295,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
+  protected visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
     // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
     // qualifier so `SET col = col + 1` works in UPDATE statements.
     const attr = node.attribute as Partial<Nodes.Attribute> | undefined;


### PR DESCRIPTION
## Summary

Audit follow-up — first of three small PRs from a Rails-fidelity audit of arel that surfaced behavioral divergences in the per-dialect visitors. This PR fixes the MySQL ones; **PR B** (Postgres dialect formatting) and **PR C** (Predications privates + extractor naming) follow.

The MySQL visitor was missing dialect overrides Rails ships, so several queries emitted invalid or non-portable SQL.

## Fixes

| Method | Before | After (Rails-aligned) |
|---|---|---|
| `UnqualifiedColumn` | base behavior (kept `"table"."col"`) | `visit o.expr` — the override exists for `UPDATE t SET col = col + 1` paths |
| `Bin` | `BINARY x` (prefix operator) | `CAST(x AS BINARY)` (Rails form) |
| `IsNotDistinctFrom` | `IS NOT DISTINCT FROM` (base) — only MySQL 8.0.14+ | `<=>` null-safe equality (every MySQL version) |
| `IsDistinctFrom` | `IS DISTINCT FROM` (base) | `NOT ... <=>` |
| `Regexp` / `NotRegexp` | base fell through to Postgres `~` / `!~` | ` REGEXP ` / ` NOT REGEXP ` |
| `Cte` | `"name" AS (…)` (Postgres quoting) | `` `name` AS (…) `` (MySQL backticks, embedded backticks doubled) |

Each override is a 1:1 port of the corresponding `visit_Arel_Nodes_X` method in `activerecord/lib/arel/visitors/mysql.rb`.

## Tests

- Updated three pre-existing `mysql_test` cases that were pinning the buggy base-fallthrough output for `IS [NOT] DISTINCT FROM`. They now match the Rails MySQL test fixtures verbatim.
- Updated the `bin.test.ts` `mysql to sql` case to match the new `CAST(... AS BINARY)` shape.
- Added 9 new tests covering each dialect override (Bin / UnqualifiedColumn including an end-to-end `UPDATE SET` shape / IsNotDistinctFrom & IsDistinctFrom including NULL-on-right cases / Regexp / NotRegexp / Cte).

## Visibility

`visitUnqualifiedColumn` in the base ToSql changed from `private` to `protected` so the MySQL override compiles. No other call sites affected.

## Known follow-up gap (not fixed here)

The base ToSql `visitAttribute` and `visitTable` use double-quoted identifiers (Postgres style). On MySQL they should emit backticks (`` `users`.`name` ``). Fixing that touches every column reference under MySQL and is broader than this dialect-overrides PR — surfaced as a separate audit item to track.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run packages/arel/` — 1062/1062 passing
- [x] `pnpm run api:compare --package arel` — still 589/589 (100%)