### PR TITLE
fix(arel): Postgres dialect formatting for grouping/lateral nodes

### DIFF
--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -167,7 +167,8 @@ describe("PostgresTest", () => {
     it("should know how to generate parenthesis when supplied with many Dimensions", () => {
       const mgr = users.project(star).group(new Nodes.Cube([users.get("id"), users.get("name")]));
       const sql = new Visitors.PostgreSQL().compile(mgr.ast);
-      expect(sql).toContain('CUBE("users"."id", "users"."name")');
+      // Rails Postgres formats grouping elements with spaces inside parens.
+      expect(sql).toContain('CUBE( "users"."id", "users"."name" )');
     });
 
     it("should know how to visit with array arguments", () => {
@@ -350,5 +351,56 @@ describe("PostgresTest", () => {
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("'{\"O''Reilly\"}'");
     });
+  });
+});
+
+// Audit follow-up: Postgres dialect overrides for grouping-element
+// formatting (spaces inside parens), Cube/Rollup/GroupingSet wrapping,
+// Lateral parens-only-when-needed, and explicit IsDistinctFrom
+// overrides (behaviorally identical to base, kept for fidelity).
+describe("PostgreSQL dialect overrides (audit follow-up)", () => {
+  const users = new Table("users");
+  const compile = (n: Nodes.Node): string => new Visitors.PostgreSQL().compile(n);
+
+  it("GroupingElement renders with spaces inside parens", () => {
+    const ge = new Nodes.GroupingElement([users.get("a"), users.get("b")]);
+    expect(compile(ge)).toBe('( "users"."a", "users"."b" )');
+  });
+
+  it("Cube emits `CUBE( … )` with spaces", () => {
+    const c = new Nodes.Cube([users.get("a"), users.get("b")]);
+    expect(compile(c)).toBe('CUBE( "users"."a", "users"."b" )');
+  });
+
+  it("Rollup emits `ROLLUP( … )` with spaces", () => {
+    const r = new Nodes.Rollup([users.get("a"), users.get("b")]);
+    expect(compile(r)).toBe('ROLLUP( "users"."a", "users"."b" )');
+  });
+
+  it("GroupingSet emits `GROUPING SETS( … )` with spaces", () => {
+    const g = new Nodes.GroupingSet([users.get("a"), users.get("b")]);
+    expect(compile(g)).toBe('GROUPING SETS( "users"."a", "users"."b" )');
+  });
+
+  it("Lateral does not double-wrap an inner Grouping", () => {
+    // Inner is already a Grouping (renders its own parens) — Postgres'
+    // grouping_parentheses helper should not add another set.
+    const inner = new Nodes.Grouping(new Nodes.SqlLiteral("SELECT 1"));
+    expect(compile(new Nodes.Lateral(inner))).toBe("LATERAL (SELECT 1)");
+  });
+
+  it("Lateral wraps a non-Grouping inner expression in parens", () => {
+    const inner = new Nodes.SqlLiteral("SELECT 1");
+    expect(compile(new Nodes.Lateral(inner))).toBe("LATERAL (SELECT 1)");
+  });
+
+  it("IsNotDistinctFrom uses standard SQL keyword on Postgres", () => {
+    const node = users.get("a").isNotDistinctFrom(users.get("b"));
+    expect(compile(node)).toBe('"users"."a" IS NOT DISTINCT FROM "users"."b"');
+  });
+
+  it("IsDistinctFrom uses standard SQL keyword on Postgres", () => {
+    const node = users.get("a").isDistinctFrom(users.get("b"));
+    expect(compile(node)).toBe('"users"."a" IS DISTINCT FROM "users"."b"');
   });
 });

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -382,13 +382,12 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     expect(compile(g)).toBe('GROUPING SETS( "users"."a", "users"."b" )');
   });
 
-  it("Lateral does not double-wrap an inner Grouping (vs base which does)", () => {
-    // Inner is already a Grouping (renders its own parens) — Postgres'
-    // `grouping_parentheses` helper should not add another set. The
-    // base ToSql unconditionally wraps, producing `LATERAL ((expr))` —
-    // pin the divergence so it can't silently regress.
+  it("Lateral does not double-wrap an inner Grouping", () => {
+    // Inner is already a Grouping (renders its own parens), so the
+    // PostgreSQL visitor should not add another set — Rails Postgres
+    // uses a `grouping_parentheses` helper that wraps only when the
+    // inner isn't a Grouping.
     const inner = new Nodes.Grouping(new Nodes.SqlLiteral("SELECT 1"));
-    expect(new Visitors.ToSql().compile(new Nodes.Lateral(inner))).toBe("LATERAL ((SELECT 1))");
     expect(compile(new Nodes.Lateral(inner))).toBe("LATERAL (SELECT 1)");
   });
 

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -382,10 +382,13 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     expect(compile(g)).toBe('GROUPING SETS( "users"."a", "users"."b" )');
   });
 
-  it("Lateral does not double-wrap an inner Grouping", () => {
+  it("Lateral does not double-wrap an inner Grouping (vs base which does)", () => {
     // Inner is already a Grouping (renders its own parens) — Postgres'
-    // grouping_parentheses helper should not add another set.
+    // `grouping_parentheses` helper should not add another set. The
+    // base ToSql unconditionally wraps, producing `LATERAL ((expr))` —
+    // pin the divergence so it can't silently regress.
     const inner = new Nodes.Grouping(new Nodes.SqlLiteral("SELECT 1"));
+    expect(new Visitors.ToSql().compile(new Nodes.Lateral(inner))).toBe("LATERAL ((SELECT 1))");
     expect(compile(new Nodes.Lateral(inner))).toBe("LATERAL (SELECT 1)");
   });
 

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -56,6 +56,70 @@ export class PostgreSQL extends ToSql {
     }
     return super.quote(value);
   }
+
+  // Mirrors Rails Postgres formatting: `( expr )` with spaces inside
+  // the parens. The base ToSql renders `(expr)` without spaces, so
+  // override to match Rails' `visit_Arel_Nodes_GroupingElement`.
+  protected override visitGroupingElement(node: Nodes.GroupingElement): SQLString {
+    this.collector.append("( ");
+    for (let i = 0; i < node.expressions.length; i++) {
+      if (i > 0) this.collector.append(", ");
+      this.visit(node.expressions[i]);
+    }
+    this.collector.append(" )");
+    return this.collector;
+  }
+
+  // Cube/Rollup/GroupingSet: emit `CUBE` / `ROLLUP` / `GROUPING SETS`
+  // followed by `grouping_array_or_grouping_element` formatting — same
+  // `( ... )` shape with spaces. Mirrors Rails Postgres.
+  protected override visitCube(node: Nodes.Cube): SQLString {
+    this.collector.append("CUBE");
+    return this.visitGroupingElement(node);
+  }
+
+  protected override visitRollup(node: Nodes.Rollup): SQLString {
+    this.collector.append("ROLLUP");
+    return this.visitGroupingElement(node);
+  }
+
+  protected override visitGroupingSet(node: Nodes.GroupingSet): SQLString {
+    this.collector.append("GROUPING SETS");
+    return this.visitGroupingElement(node);
+  }
+
+  // Lateral: only add wrapping parens when the inner isn't already a
+  // Grouping (Rails: `grouping_parentheses`). Trails' base unconditionally
+  // wraps, so a `LATERAL (grouping)` pre-existing parens would
+  // produce `LATERAL ((expr))`.
+  protected override visitLateral(node: Nodes.Lateral): SQLString {
+    this.collector.append("LATERAL ");
+    if (node.subquery instanceof Nodes.Grouping) {
+      this.visit(node.subquery);
+    } else {
+      this.collector.append("(");
+      this.visit(node.subquery);
+      this.collector.append(")");
+    }
+    return this.collector;
+  }
+
+  // Postgres natively supports `IS [NOT] DISTINCT FROM`. Behaviorally
+  // identical to the base ToSql visitor; the explicit override mirrors
+  // Rails' Postgres visitor for fidelity (no behavior change).
+  protected override visitIsNotDistinctFrom(node: Nodes.IsNotDistinctFrom): SQLString {
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" IS NOT DISTINCT FROM ");
+    this.visitNodeOrValue(node.right);
+    return this.collector;
+  }
+
+  protected override visitIsDistinctFrom(node: Nodes.IsDistinctFrom): SQLString {
+    this.visitNodeOrValue(node.left);
+    this.collector.append(" IS DISTINCT FROM ");
+    this.visitNodeOrValue(node.right);
+    return this.collector;
+  }
 }
 
 /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1128,7 +1128,7 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   // -- Advanced grouping --
 
-  private visitCube(node: Nodes.Cube): SQLString {
+  protected visitCube(node: Nodes.Cube): SQLString {
     this.collector.append("CUBE(");
     const exprs = node.expressions;
     for (let i = 0; i < exprs.length; i++) {
@@ -1139,7 +1139,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitRollup(node: Nodes.Rollup): SQLString {
+  protected visitRollup(node: Nodes.Rollup): SQLString {
     this.collector.append("ROLLUP(");
     const exprs = node.expressions;
     for (let i = 0; i < exprs.length; i++) {
@@ -1150,7 +1150,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitGroupingElement(node: Nodes.GroupingElement): SQLString {
+  protected visitGroupingElement(node: Nodes.GroupingElement): SQLString {
     this.collector.append("(");
     const exprs = node.expressions;
     for (let i = 0; i < exprs.length; i++) {
@@ -1161,7 +1161,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitGroupingSet(node: Nodes.GroupingSet): SQLString {
+  protected visitGroupingSet(node: Nodes.GroupingSet): SQLString {
     this.collector.append("GROUPING SETS(");
     const exprs = node.expressions;
     for (let i = 0; i < exprs.length; i++) {
@@ -1180,7 +1180,7 @@ export class ToSql implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitLateral(node: Nodes.Lateral): SQLString {
+  protected visitLateral(node: Nodes.Lateral): SQLString {
     this.collector.append("LATERAL (");
     this.visit(node.subquery);
     this.collector.append(")");


### PR DESCRIPTION
## Summary

Audit follow-up — second of three small PRs from the arel Rails-fidelity audit. **PR #983** fixed MySQL dialect overrides; this fixes Postgres formatting; **PR C** (Predications privates + extractor naming) follows.

The Postgres visitor was inheriting base `ToSql` formatting for grouping-related nodes, producing SQL that didn't match Rails' Postgres output.

## Fixes

| Method | Before (base) | After (Rails Postgres) |
|---|---|---|
| `GroupingElement` | `(expr)` | `( expr )` (spaces inside parens) |
| `Cube` | `CUBE(a, b)` | `CUBE( a, b )` |
| `Rollup` | `ROLLUP(a, b)` | `ROLLUP( a, b )` |
| `GroupingSet` | `GROUPING SETS(a, b)` | `GROUPING SETS( a, b )` |
| `Lateral` (over a `Grouping`) | `LATERAL ((expr))` | `LATERAL (expr)` (no double-wrap) |
| `IsNotDistinctFrom` / `IsDistinctFrom` | (base, identical SQL) | explicit override mirrors Rails — no behavior change, fidelity only |

Each override is a 1:1 port of the corresponding `visit_Arel_Nodes_X` method in `activerecord/lib/arel/visitors/postgresql.rb`. Rails uses the helper `grouping_array_or_grouping_element` for the `Cube`/`Rollup`/`GroupingSet` shape and `grouping_parentheses` for `Lateral`'s wrap-only-if-needed behavior.

## Tests

- Updated one pre-existing `postgres_test` case that pinned the old no-space formatting.
- Added 8 new tests covering each override, including both branches of the new `Lateral` behavior (already-Grouping inner: don't double-wrap; bare expression inner: wrap once).

## Visibility

`visitCube`, `visitRollup`, `visitGroupingElement`, `visitGroupingSet`, `visitLateral` in the base `ToSql` changed from `private` to `protected` so the Postgres overrides compile. No other call sites affected.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run packages/arel/` — 1060/1060 passing
- [x] `pnpm run api:compare --package arel` — still 589/589 (100%)