### PR TITLE
refactor(arel): mirror Arel::Predications private helpers

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -49,7 +49,7 @@ import {
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
 import { True } from "../nodes/true.js";
-import { Predications, type PredicationHost } from "../predications.js";
+import { Predications } from "../predications.js";
 
 /**
  * Combines multiple nodes with OR, wrapped in a Grouping.
@@ -347,44 +347,45 @@ export class Attribute extends Node {
   // Trails' Attribute has hand-rolled public predicates (so the include
   // chain isn't wired) — these methods delegate to the canonical
   // Predications impls so there's a single source of truth and
-  // behavior stays in lockstep.
+  // behavior stays in lockstep. Marked `protected` (matching the
+  // visibility of HomogeneousIn#ivars / SelectManager#collapse) since
+  // they exist for Rails-fidelity / api:compare privates coverage,
+  // not as a public API surface.
 
-  groupingAny(
+  protected groupingAny(
     methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    return Predications.groupingAny.call(
-      this as unknown as PredicationHost,
-      methodId as never,
-      others,
-      ...extras,
-    );
+    return Predications.groupingAny.call<
+      Attribute,
+      [typeof methodId, unknown[], ...unknown[]],
+      Grouping
+    >(this, methodId, others, ...extras);
   }
 
-  groupingAll(
+  protected groupingAll(
     methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    return Predications.groupingAll.call(
-      this as unknown as PredicationHost,
-      methodId as never,
-      others,
-      ...extras,
-    );
+    return Predications.groupingAll.call<
+      Attribute,
+      [typeof methodId, unknown[], ...unknown[]],
+      Grouping
+    >(this, methodId, others, ...extras);
   }
 
-  isInfinity(value: unknown): boolean {
-    return Predications.isInfinity.call(this as unknown as PredicationHost, value);
+  protected isInfinity(value: unknown): boolean {
+    return Predications.isInfinity.call(this, value);
   }
 
-  isUnboundable(value: unknown): boolean {
-    return Predications.isUnboundable.call(this as unknown as PredicationHost, value);
+  protected isUnboundable(value: unknown): boolean {
+    return Predications.isUnboundable.call(this, value);
   }
 
-  isOpenEnded(value: unknown): boolean {
-    return Predications.isOpenEnded.call(this as unknown as PredicationHost, value);
+  protected isOpenEnded(value: unknown): boolean {
+    return Predications.isOpenEnded.call(this, value);
   }
 
   // -- Ordering --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -49,6 +49,7 @@ import {
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
 import { True } from "../nodes/true.js";
+import { Predications, type PredicationHost } from "../predications.js";
 
 /**
  * Combines multiple nodes with OR, wrapped in a Grouping.
@@ -342,58 +343,48 @@ export class Attribute extends Node {
 
   // -- Rails-private helpers (mirror Arel::Predications) --
   //
-  // These mirror the private methods Rails' Attribute inherits from
-  // Predications (Attribute includes Predications). Trails' Attribute
-  // ships hand-rolled public predicates that already use the file-level
-  // groupedAny/groupedAll, so these private methods aren't called
-  // internally — they're surfaced for Rails-fidelity / api:compare
-  // privates coverage and for consumers reaching for the same protocol.
+  // Rails' Attribute inherits these from Predications via `include`.
+  // Trails' Attribute has hand-rolled public predicates (so the include
+  // chain isn't wired) — these methods delegate to the canonical
+  // Predications impls so there's a single source of truth and
+  // behavior stays in lockstep.
 
-  // Mirrors Arel::Predications#grouping_any(method_id, others, *extras).
   groupingAny(
     methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
-    const fn =
-      typeof methodId === "function"
-        ? (expr: unknown) => methodId.call(this, expr, ...extras)
-        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
-    return groupedAny(others.map(fn));
+    return Predications.groupingAny.call(
+      this as unknown as PredicationHost,
+      methodId as never,
+      others,
+      ...extras,
+    );
   }
 
-  // Mirrors Arel::Predications#grouping_all.
   groupingAll(
     methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
-    const fn =
-      typeof methodId === "function"
-        ? (expr: unknown) => methodId.call(this, expr, ...extras)
-        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
-    return groupedAll(others.map(fn));
-  }
-
-  // Mirrors Arel::Predications#infinity?
-  isInfinity(value: unknown): boolean {
-    return value === Infinity || value === -Infinity;
-  }
-
-  // Mirrors Arel::Predications#unboundable? — Trails has no Ruby-style
-  // unboundable? protocol, so this is a constant `false`. Kept for
-  // surface fidelity.
-  isUnboundable(_value: unknown): boolean {
-    return false;
-  }
-
-  // Mirrors Arel::Predications#open_ended?
-  isOpenEnded(value: unknown): boolean {
-    return (
-      value === null || value === undefined || this.isInfinity(value) || this.isUnboundable(value)
+    return Predications.groupingAll.call(
+      this as unknown as PredicationHost,
+      methodId as never,
+      others,
+      ...extras,
     );
+  }
+
+  isInfinity(value: unknown): boolean {
+    return Predications.isInfinity.call(this as unknown as PredicationHost, value);
+  }
+
+  isUnboundable(value: unknown): boolean {
+    return Predications.isUnboundable.call(this as unknown as PredicationHost, value);
+  }
+
+  isOpenEnded(value: unknown): boolean {
+    return Predications.isOpenEnded.call(this as unknown as PredicationHost, value);
   }
 
   // -- Ordering --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -49,7 +49,7 @@ import {
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
 import { True } from "../nodes/true.js";
-import { Predications } from "../predications.js";
+import { Predications, type PredicationHost } from "../predications.js";
 
 /**
  * Combines multiple nodes with OR, wrapped in a Grouping.
@@ -385,7 +385,17 @@ export class Attribute extends Node {
   }
 
   protected isOpenEnded(value: unknown): boolean {
-    return Predications.isOpenEnded.call(this, value);
+    // Cast widens this' protected isInfinity/isUnboundable so they
+    // match Predications.isOpenEnded's `this` constraint, which
+    // requires them as public methods. The dispatch still goes through
+    // `this` at runtime, so subclass overrides are honored.
+    return Predications.isOpenEnded.call(
+      this as unknown as PredicationHost & {
+        isInfinity(value: unknown): boolean;
+        isUnboundable(value: unknown): boolean;
+      },
+      value,
+    );
   }
 
   // -- Ordering --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -340,6 +340,62 @@ export class Attribute extends Node {
     return groupedAll(others.map((o) => this.notIn(o)));
   }
 
+  // -- Rails-private helpers (mirror Arel::Predications) --
+  //
+  // These mirror the private methods Rails' Attribute inherits from
+  // Predications (Attribute includes Predications). Trails' Attribute
+  // ships hand-rolled public predicates that already use the file-level
+  // groupedAny/groupedAll, so these private methods aren't called
+  // internally — they're surfaced for Rails-fidelity / api:compare
+  // privates coverage and for consumers reaching for the same protocol.
+
+  // Mirrors Arel::Predications#grouping_any(method_id, others, *extras).
+  groupingAny(
+    methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
+    others: unknown[],
+    ...extras: unknown[]
+  ): Grouping {
+    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
+    const fn =
+      typeof methodId === "function"
+        ? (expr: unknown) => methodId.call(this, expr, ...extras)
+        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
+    return groupedAny(others.map(fn));
+  }
+
+  // Mirrors Arel::Predications#grouping_all.
+  groupingAll(
+    methodId: string | ((this: Attribute, expr: unknown, ...extras: unknown[]) => Node),
+    others: unknown[],
+    ...extras: unknown[]
+  ): Grouping {
+    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
+    const fn =
+      typeof methodId === "function"
+        ? (expr: unknown) => methodId.call(this, expr, ...extras)
+        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
+    return groupedAll(others.map(fn));
+  }
+
+  // Mirrors Arel::Predications#infinity?
+  isInfinity(value: unknown): boolean {
+    return value === Infinity || value === -Infinity;
+  }
+
+  // Mirrors Arel::Predications#unboundable? — Trails has no Ruby-style
+  // unboundable? protocol, so this is a constant `false`. Kept for
+  // surface fidelity.
+  isUnboundable(_value: unknown): boolean {
+    return false;
+  }
+
+  // Mirrors Arel::Predications#open_ended?
+  isOpenEnded(value: unknown): boolean {
+    return (
+      value === null || value === undefined || this.isInfinity(value) || this.isUnboundable(value)
+    );
+  }
+
   // -- Ordering --
 
   asc(): Ascending {

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -71,4 +71,13 @@ export class HomogeneousIn extends Node {
   accept<T>(visitor: NodeVisitor<T>): T {
     return visitor.visit(this);
   }
+
+  // Mirrors Arel::Nodes::HomogeneousIn#ivars — protected helper Rails
+  // uses to fold this node's identity into hash/eql? comparisons.
+  // Trails' `eql()` / `hash()` from Node already walk every own
+  // property so this isn't called internally; kept for Rails-fidelity
+  // / api:compare privates coverage.
+  protected ivars(): [Node, unknown[], string] {
+    return [this.attribute, this.values, this.type];
+  }
 }

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -77,7 +77,7 @@ export class HomogeneousIn extends Node {
   // Trails' `eql()` / `hash()` from Node already walk every own
   // property so this isn't called internally; kept for Rails-fidelity
   // / api:compare privates coverage.
-  protected ivars(): [Node, unknown[], string] {
+  protected ivars(): [Node, unknown[], HomogeneousIn["type"]] {
     return [this.attribute, this.values, this.type];
   }
 }

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -103,6 +103,17 @@ describe("SelectManager#collapse (Rails-fidelity helper)", () => {
     expect(out).toBeInstanceOf(Nodes.And);
     expect((out as Nodes.And).children).toHaveLength(2);
   });
+
+  it("returns an empty And when every input is null/undefined (Rails parity)", () => {
+    // Mirrors Rails: `exprs.compact` then `create_and exprs` — an
+    // empty array hits the `else` branch and yields an empty `And`
+    // node. Rails-side `WHERE ()` is similarly invalid for the same
+    // reason; the limitation is shared with Rails. Callers are
+    // expected to filter empty conditions before reaching `where`.
+    const out = mgr.callCollapse([null, undefined]);
+    expect(out).toBeInstanceOf(Nodes.And);
+    expect((out as Nodes.And).children).toHaveLength(0);
+  });
 });
 
 describe("HomogeneousIn#ivars (Rails-fidelity helper)", () => {
@@ -111,7 +122,7 @@ describe("HomogeneousIn#ivars (Rails-fidelity helper)", () => {
     const node = new Nodes.HomogeneousIn([1, 2, 3], attr, "in");
     // ivars is `protected` so cast to access. The point: the tuple
     // shape matches Rails' `[@attribute, @values, @type]`.
-    const ivars = (node as unknown as { ivars(): [Nodes.Node, unknown[], string] }).ivars();
+    const ivars = (node as unknown as { ivars(): [Nodes.Node, unknown[], "in" | "notin"] }).ivars();
     expect(ivars[0]).toBe(attr);
     expect(ivars[1]).toEqual([1, 2, 3]);
     expect(ivars[2]).toBe("in");

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, SelectManager } from "./index.js";
+import { Predications } from "./predications.js";
+
+// Audit follow-up: cover the Predications private helpers that mirror
+// Arel::Predications' private API (grouping_any, grouping_all,
+// infinity?, unboundable?, open_ended?). Trails surfaces them on the
+// mixin object for Rails-fidelity / api:compare privates coverage;
+// these tests pin their behavior.
+
+const users = new Table("users");
+
+describe("Predications.groupingAny / groupingAll", () => {
+  it("groupingAny dispatches by method-id and folds with OR (Grouping)", () => {
+    const out = Predications.groupingAny.call(users.attr("id"), "eq", [1, 2, 3]);
+    expect(out).toBeInstanceOf(Nodes.Grouping);
+    // The grouped expression is an Or chain over three Equality nodes.
+    const inner = (out as Nodes.Grouping).expr as Nodes.Or;
+    expect(inner).toBeInstanceOf(Nodes.Or);
+  });
+
+  it("groupingAll dispatches by method-id and folds with AND", () => {
+    const out = Predications.groupingAll.call(users.attr("id"), "gt", [1, 2]);
+    expect(out).toBeInstanceOf(Nodes.Grouping);
+    expect((out as Nodes.Grouping).expr).toBeInstanceOf(Nodes.And);
+  });
+
+  it("groupingAny accepts a closure variant (no stringly-typed dispatch)", () => {
+    const attr = users.attr("id");
+    const out = Predications.groupingAny.call(attr, (expr: unknown) => attr.eq(expr), [10, 20]);
+    expect(out).toBeInstanceOf(Nodes.Grouping);
+  });
+});
+
+describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
+  const host = users.attr("id");
+
+  it("isInfinity is true for ±Infinity, false otherwise", () => {
+    expect(Predications.isInfinity.call(host, Infinity)).toBe(true);
+    expect(Predications.isInfinity.call(host, -Infinity)).toBe(true);
+    expect(Predications.isInfinity.call(host, 0)).toBe(false);
+    expect(Predications.isInfinity.call(host, "x")).toBe(false);
+  });
+
+  it("isUnboundable is always false (no Ruby-style protocol in TS)", () => {
+    expect(Predications.isUnboundable.call(host, undefined)).toBe(false);
+    expect(Predications.isUnboundable.call(host, 1)).toBe(false);
+  });
+
+  it("isOpenEnded is true for null/undefined/Infinity, false otherwise", () => {
+    expect(Predications.isOpenEnded.call(host, null)).toBe(true);
+    expect(Predications.isOpenEnded.call(host, undefined)).toBe(true);
+    expect(Predications.isOpenEnded.call(host, Infinity)).toBe(true);
+    expect(Predications.isOpenEnded.call(host, -Infinity)).toBe(true);
+    expect(Predications.isOpenEnded.call(host, 0)).toBe(false);
+    expect(Predications.isOpenEnded.call(host, "x")).toBe(false);
+  });
+});
+
+describe("Attribute private helpers (mirror Predications)", () => {
+  it("groupingAny / groupingAll work via method dispatch on Attribute", () => {
+    const attr = users.attr("id");
+    expect(attr.groupingAny("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
+    expect(attr.groupingAll("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
+  });
+
+  it("isInfinity / isUnboundable / isOpenEnded match Predications semantics", () => {
+    const attr = users.attr("id");
+    expect(attr.isInfinity(Infinity)).toBe(true);
+    expect(attr.isInfinity(0)).toBe(false);
+    expect(attr.isUnboundable(0)).toBe(false);
+    expect(attr.isOpenEnded(null)).toBe(true);
+    expect(attr.isOpenEnded(Infinity)).toBe(true);
+    expect(attr.isOpenEnded(0)).toBe(false);
+  });
+});
+
+describe("SelectManager#collapse (Rails-fidelity helper)", () => {
+  // Mirrors Arel::SelectManager#collapse — compacts a list of exprs,
+  // wraps bare strings as SqlLiteral, returns the single survivor or
+  // an `And` of all of them.
+  class TestManager extends SelectManager {
+    callCollapse(exprs: unknown[]): Nodes.Node {
+      return (this as unknown as { collapse(e: unknown[]): Nodes.Node }).collapse(exprs);
+    }
+  }
+
+  const mgr = new TestManager(users);
+
+  it("returns the single survivor when there's only one non-null expr", () => {
+    const out = mgr.callCollapse([null, users.attr("id").eq(1), undefined]);
+    expect(out).toBeInstanceOf(Nodes.Equality);
+  });
+
+  it("wraps a bare string as SqlLiteral", () => {
+    const out = mgr.callCollapse(["LOWER(name) = 'x'"]);
+    expect(out).toBeInstanceOf(Nodes.SqlLiteral);
+    expect((out as Nodes.SqlLiteral).value).toBe("LOWER(name) = 'x'");
+  });
+
+  it("folds multiple exprs into an And via createAnd", () => {
+    const out = mgr.callCollapse([users.attr("id").eq(1), users.attr("name").eq("a")]);
+    expect(out).toBeInstanceOf(Nodes.And);
+    expect((out as Nodes.And).children).toHaveLength(2);
+  });
+});
+
+describe("HomogeneousIn#ivars (Rails-fidelity helper)", () => {
+  it("returns the [attribute, values, type] tuple Rails uses for hash/eql", () => {
+    const attr = users.attr("id");
+    const node = new Nodes.HomogeneousIn([1, 2, 3], attr, "in");
+    // ivars is `protected` so cast to access. The point: the tuple
+    // shape matches Rails' `[@attribute, @values, @type]`.
+    const ivars = (node as unknown as { ivars(): [Nodes.Node, unknown[], string] }).ivars();
+    expect(ivars[0]).toBe(attr);
+    expect(ivars[1]).toEqual([1, 2, 3]);
+    expect(ivars[2]).toBe("in");
+  });
+});

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -58,14 +58,25 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
 });
 
 describe("Attribute private helpers (mirror Predications)", () => {
+  // The helpers are `protected` for Rails-fidelity / api:compare
+  // coverage, not as a public surface. Tests cast to access them —
+  // same pattern as HomogeneousIn#ivars / SelectManager#collapse.
+  type AttributePrivates = Nodes.Attribute & {
+    groupingAny: (methodId: string, others: unknown[]) => Nodes.Grouping;
+    groupingAll: (methodId: string, others: unknown[]) => Nodes.Grouping;
+    isInfinity: (value: unknown) => boolean;
+    isUnboundable: (value: unknown) => boolean;
+    isOpenEnded: (value: unknown) => boolean;
+  };
+
   it("groupingAny / groupingAll work via method dispatch on Attribute", () => {
-    const attr = users.attr("id");
+    const attr = users.attr("id") as AttributePrivates;
     expect(attr.groupingAny("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
     expect(attr.groupingAll("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
   });
 
   it("isInfinity / isUnboundable / isOpenEnded match Predications semantics", () => {
-    const attr = users.attr("id");
+    const attr = users.attr("id") as AttributePrivates;
     expect(attr.isInfinity(Infinity)).toBe(true);
     expect(attr.isInfinity(0)).toBe(false);
     expect(attr.isUnboundable(0)).toBe(false);

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -30,21 +30,43 @@ describe("Predications.groupingAny / groupingAll", () => {
     const out = Predications.groupingAny.call(attr, (expr: unknown) => attr.eq(expr), [10, 20]);
     expect(out).toBeInstanceOf(Nodes.Grouping);
   });
+
+  it("groupingAny throws a clear TypeError when the method-id isn't callable", () => {
+    // Regression for the dispatch-safety concern: a typo in the
+    // method-id should fail loudly, not blow up with "Cannot read
+    // property 'call' of undefined".
+    const attr = users.attr("id");
+    expect(() => Predications.groupingAny.call(attr, "noSuchMethod", [1])).toThrowError(
+      /noSuchMethod.*Attribute/,
+    );
+  });
 });
 
 describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
-  const host = users.attr("id");
+  // Build a minimal PredicationHost-shaped object with public
+  // isInfinity / isUnboundable so isOpenEnded's `this`-dispatch
+  // typechecks. Mirrors how the methods would be reachable on a
+  // class that included Predications via the runtime mixin.
+  const host = {
+    quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node,
+    isInfinity(this: unknown, v: unknown): boolean {
+      return Predications.isInfinity.call(this as never, v);
+    },
+    isUnboundable(this: unknown, v: unknown): boolean {
+      return Predications.isUnboundable.call(this as never, v);
+    },
+  };
 
   it("isInfinity is true for ±Infinity, false otherwise", () => {
-    expect(Predications.isInfinity.call(host, Infinity)).toBe(true);
-    expect(Predications.isInfinity.call(host, -Infinity)).toBe(true);
-    expect(Predications.isInfinity.call(host, 0)).toBe(false);
-    expect(Predications.isInfinity.call(host, "x")).toBe(false);
+    expect(host.isInfinity(Infinity)).toBe(true);
+    expect(host.isInfinity(-Infinity)).toBe(true);
+    expect(host.isInfinity(0)).toBe(false);
+    expect(host.isInfinity("x")).toBe(false);
   });
 
   it("isUnboundable is always false (no Ruby-style protocol in TS)", () => {
-    expect(Predications.isUnboundable.call(host, undefined)).toBe(false);
-    expect(Predications.isUnboundable.call(host, 1)).toBe(false);
+    expect(host.isUnboundable(undefined)).toBe(false);
+    expect(host.isUnboundable(1)).toBe(false);
   });
 
   it("isOpenEnded is true for null/undefined/Infinity, false otherwise", () => {
@@ -54,6 +76,17 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
     expect(Predications.isOpenEnded.call(host, -Infinity)).toBe(true);
     expect(Predications.isOpenEnded.call(host, 0)).toBe(false);
     expect(Predications.isOpenEnded.call(host, "x")).toBe(false);
+  });
+
+  it("isOpenEnded dispatches through `this` so host overrides win", () => {
+    // Regression for the `this`-vs-direct-module-call concern: a host
+    // that overrides isInfinity to claim everything is infinite should
+    // see isOpenEnded honor that override.
+    const overridden = {
+      ...host,
+      isInfinity: () => true,
+    };
+    expect(Predications.isOpenEnded.call(overridden, 42)).toBe(true);
   });
 });
 

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -392,12 +392,19 @@ export const Predications = {
 
   // Mirrors Arel::Predications#open_ended? — null, infinite, or
   // unboundable values are treated as "no bound on this side".
-  isOpenEnded(this: PredicationHost, value: unknown): boolean {
+  // Dispatches `isInfinity` / `isUnboundable` through `this` (rather
+  // than calling the Predications module directly) so host classes
+  // can override either check. Mirrors Ruby's method-lookup semantics
+  // for `infinity?` / `unboundable?`.
+  isOpenEnded(
+    this: PredicationHost & {
+      isInfinity(value: unknown): boolean;
+      isUnboundable(value: unknown): boolean;
+    },
+    value: unknown,
+  ): boolean {
     return (
-      value === null ||
-      value === undefined ||
-      Predications.isInfinity.call(this, value) ||
-      Predications.isUnboundable.call(this, value)
+      value === null || value === undefined || this.isInfinity(value) || this.isUnboundable(value)
     );
   },
 };

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -356,10 +356,12 @@ export const Predications = {
     return groupedAll(others.map(fn));
   },
 
-  // Mirrors Arel::Predications#infinity? — true if the value is +/-
-  // Infinity or implements the Ruby `infinite?` protocol. Used by
-  // Rails to decide whether to clamp a `between` bound to an open
-  // half-range.
+  // Mirrors Arel::Predications#infinity? — in the TS port, true only
+  // for JavaScript +/-Infinity values. Ruby's `infinite?` protocol
+  // (which Rails also accepts) has no TS analog; if a future Trails
+  // wrapper type wants to surface infiniteness, this is the place to
+  // teach it. Used to decide whether to clamp a `between` bound to
+  // an open half-range.
   isInfinity(this: PredicationHost, value: unknown): boolean {
     return value === Infinity || value === -Infinity;
   },

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -317,4 +317,71 @@ export const Predications = {
   quotedArray(this: PredicationHost, others: unknown[]): Node[] {
     return others.map((v) => this.quotedNode(v));
   },
+
+  // -- Rails-private helpers (mixed in alongside the public API for
+  //    surface fidelity; not referenced internally because the existing
+  //    *_any/*_all impls call the file-level groupedAny/groupedAll
+  //    above with already-built nodes). --
+
+  // Mirrors Arel::Predications#grouping_any(method_id, others, *extras)
+  // — calls `this[methodId](expr, ...extras)` on each value and folds
+  // the resulting nodes with OR inside a Grouping. The closure variant
+  // (overload 2) lets TS callers skip stringly-typed dispatch.
+  groupingAny(
+    this: PredicationHost,
+    methodId: string | ((this: PredicationHost, expr: unknown, ...extras: unknown[]) => Node),
+    others: unknown[],
+    ...extras: unknown[]
+  ): Grouping {
+    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
+    const fn =
+      typeof methodId === "function"
+        ? (expr: unknown) => methodId.call(this, expr, ...extras)
+        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
+    return groupedAny(others.map(fn));
+  },
+
+  // Mirrors Arel::Predications#grouping_all — fold with AND.
+  groupingAll(
+    this: PredicationHost,
+    methodId: string | ((this: PredicationHost, expr: unknown, ...extras: unknown[]) => Node),
+    others: unknown[],
+    ...extras: unknown[]
+  ): Grouping {
+    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
+    const fn =
+      typeof methodId === "function"
+        ? (expr: unknown) => methodId.call(this, expr, ...extras)
+        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
+    return groupedAll(others.map(fn));
+  },
+
+  // Mirrors Arel::Predications#infinity? — true if the value is +/-
+  // Infinity or implements the Ruby `infinite?` protocol. Used by
+  // Rails to decide whether to clamp a `between` bound to an open
+  // half-range.
+  isInfinity(this: PredicationHost, value: unknown): boolean {
+    return value === Infinity || value === -Infinity;
+  },
+
+  // Mirrors Arel::Predications#unboundable? — Rails-side, this catches
+  // values that can't be compared (e.g. an unboundable bind value).
+  // The TS port has no analog of Ruby's `unboundable?` protocol, so
+  // this returns false; kept for surface fidelity.
+  isUnboundable(this: PredicationHost, value: unknown): boolean {
+    void this;
+    void value;
+    return false;
+  },
+
+  // Mirrors Arel::Predications#open_ended? — null, infinite, or
+  // unboundable values are treated as "no bound on this side".
+  isOpenEnded(this: PredicationHost, value: unknown): boolean {
+    return (
+      value === null ||
+      value === undefined ||
+      Predications.isInfinity.call(this, value) ||
+      Predications.isUnboundable.call(this, value)
+    );
+  },
 };

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -326,10 +326,12 @@ export const Predications = {
   // Mirrors Arel::Predications#grouping_any(method_id, others, *extras)
   // — calls `this[methodId](expr, ...extras)` on each value and folds
   // the resulting nodes with OR inside a Grouping. The closure variant
-  // (overload 2) lets TS callers skip stringly-typed dispatch.
-  groupingAny(
-    this: PredicationHost,
-    methodId: string | ((this: PredicationHost, expr: unknown, ...extras: unknown[]) => Node),
+  // lets TS callers skip stringly-typed dispatch. Generic over the
+  // host type so a class like Attribute (with a richer surface than
+  // bare PredicationHost) can pass typed closures without `as` casts.
+  groupingAny<T extends PredicationHost>(
+    this: T,
+    methodId: string | ((this: T, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
@@ -342,9 +344,9 @@ export const Predications = {
   },
 
   // Mirrors Arel::Predications#grouping_all — fold with AND.
-  groupingAll(
-    this: PredicationHost,
-    methodId: string | ((this: PredicationHost, expr: unknown, ...extras: unknown[]) => Node),
+  groupingAll<T extends PredicationHost>(
+    this: T,
+    methodId: string | ((this: T, expr: unknown, ...extras: unknown[]) => Node),
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -49,6 +49,28 @@ function groupedAll(nodes: Node[]): Grouping {
   return new Grouping(new And(nodes));
 }
 
+// Build the `expr → Node` callback used by groupingAny / groupingAll.
+// Resolves a method-id string against the host (with a clear error if
+// the name doesn't refer to a callable method) or invokes a closure
+// directly. Mirrors Ruby's `send(method_id, expr, *extras)` shape.
+function predicationDispatch<T extends PredicationHost>(
+  host: T,
+  methodId: string | ((this: T, expr: unknown, ...extras: unknown[]) => Node),
+  extras: unknown[],
+): (expr: unknown) => Node {
+  if (typeof methodId === "function") {
+    return (expr) => methodId.call(host, expr, ...extras);
+  }
+  const member = (host as unknown as Record<string, unknown>)[methodId];
+  if (typeof member !== "function") {
+    throw new TypeError(
+      `Predications.groupingAny/All: \`${methodId}\` is not a method on the host (${(host as object).constructor.name})`,
+    );
+  }
+  const fn = member as (...args: unknown[]) => Node;
+  return (expr) => fn.call(host, expr, ...extras);
+}
+
 /**
  * Predications — predicate-builder mixin.
  *
@@ -335,12 +357,7 @@ export const Predications = {
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
-    const fn =
-      typeof methodId === "function"
-        ? (expr: unknown) => methodId.call(this, expr, ...extras)
-        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
-    return groupedAny(others.map(fn));
+    return groupedAny(others.map(predicationDispatch(this, methodId, extras)));
   },
 
   // Mirrors Arel::Predications#grouping_all — fold with AND.
@@ -350,12 +367,7 @@ export const Predications = {
     others: unknown[],
     ...extras: unknown[]
   ): Grouping {
-    const self = this as unknown as Record<string, (...args: unknown[]) => Node>;
-    const fn =
-      typeof methodId === "function"
-        ? (expr: unknown) => methodId.call(this, expr, ...extras)
-        : (expr: unknown) => self[methodId].call(this, expr, ...extras);
-    return groupedAll(others.map(fn));
+    return groupedAll(others.map(predicationDispatch(this, methodId, extras)));
   },
 
   // Mirrors Arel::Predications#infinity? — in the TS port, true only

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -586,6 +586,20 @@ export class SelectManager extends TreeManager {
     this.core.source.right.push(node);
     return this;
   }
+
+  // Mirrors Arel::SelectManager#collapse (private). Compacts an array
+  // of expressions, wraps bare strings as SqlLiteral (Rails: `Arel.sql`),
+  // and folds them into a single Node — either the single remaining
+  // expr or an `And` of all of them. Rails uses this from `on(*exprs)`
+  // and similar multi-arg condition methods. Trails' single-arg `where`
+  // / `on` shapes don't reach for it internally; surfaced for parity.
+  protected collapse(exprs: unknown[]): Node {
+    const filtered = exprs
+      .filter((e) => e !== null && e !== undefined)
+      .map((e) => (typeof e === "string" ? new SqlLiteral(e) : (e as Node)));
+    if (filtered.length === 1) return filtered[0];
+    return this.createAnd(filtered);
+  }
 }
 
 // Surface the inherited FactoryMethods on select-manager.ts so api:compare

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -116,11 +116,16 @@ export function rubyMethodToTs(name: string): string[] | null {
   // `visit_Arel_Attributes_Attribute` / `visit_Arel_Table` map to
   // Trails' camelCase `visitEquality` / `visitAttribute` / `visitTable`.
   // The leaf segment is the relevant name; intermediate `Nodes` /
-  // `Attributes` / etc. are dropped.
+  // `Attributes` / etc. are dropped. Try the exact leaf first, plus a
+  // capitalization-flattened fallback for Rails constants whose
+  // internal capitalization differs from Trails' visitor method name
+  // (e.g. Rails node `RollUp` → Trails class `Rollup` → `visitRollup`).
   if (name.startsWith("visit_Arel_")) {
     const segments = name.slice("visit_Arel_".length).split("_");
     const leaf = segments[segments.length - 1];
-    return ["visit" + leaf];
+    const exact = "visit" + leaf;
+    const flattened = "visit" + leaf.charAt(0).toUpperCase() + leaf.slice(1).toLowerCase();
+    return exact === flattened ? [exact] : [exact, flattened];
   }
   // Some Arel visitors also override generic helpers like
   // `visit__regexp` (lowercase regexp) — convert the leaf via the

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -112,29 +112,6 @@ export function rubyMethodToTs(name: string): string[] | null {
   if (name === "to_json") return ["toJSON"];
   if (name === "to_sql") return ["toSql"];
 
-  // Arel visitor convention: Ruby's `visit_Arel_Nodes_Equality` /
-  // `visit_Arel_Attributes_Attribute` / `visit_Arel_Table` map to
-  // Trails' camelCase `visitEquality` / `visitAttribute` / `visitTable`.
-  // The leaf segment is the relevant name; intermediate `Nodes` /
-  // `Attributes` / etc. are dropped. Try the exact leaf first, plus a
-  // capitalization-flattened fallback for Rails constants whose
-  // internal capitalization differs from Trails' visitor method name
-  // (e.g. Rails node `RollUp` → Trails class `Rollup` → `visitRollup`).
-  if (name.startsWith("visit_Arel_")) {
-    const segments = name.slice("visit_Arel_".length).split("_");
-    const leaf = segments[segments.length - 1];
-    const exact = "visit" + leaf;
-    const flattened = "visit" + leaf.charAt(0).toUpperCase() + leaf.slice(1).toLowerCase();
-    return exact === flattened ? [exact] : [exact, flattened];
-  }
-  // Some Arel visitors also override generic helpers like
-  // `visit__regexp` (lowercase regexp) — convert the leaf via the
-  // standard snake-to-camel mapping.
-  if (name.startsWith("visit__")) {
-    const leaf = name.slice("visit__".length);
-    return ["visit" + snakeToCamel(leaf).replace(/^./, (c) => c.toUpperCase())];
-  }
-
   if (name.endsWith("?")) {
     const base = name.slice(0, -1);
     const camel = snakeToCamel(base);

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -112,6 +112,24 @@ export function rubyMethodToTs(name: string): string[] | null {
   if (name === "to_json") return ["toJSON"];
   if (name === "to_sql") return ["toSql"];
 
+  // Arel visitor convention: Ruby's `visit_Arel_Nodes_Equality` /
+  // `visit_Arel_Attributes_Attribute` / `visit_Arel_Table` map to
+  // Trails' camelCase `visitEquality` / `visitAttribute` / `visitTable`.
+  // The leaf segment is the relevant name; intermediate `Nodes` /
+  // `Attributes` / etc. are dropped.
+  if (name.startsWith("visit_Arel_")) {
+    const segments = name.slice("visit_Arel_".length).split("_");
+    const leaf = segments[segments.length - 1];
+    return ["visit" + leaf];
+  }
+  // Some Arel visitors also override generic helpers like
+  // `visit__regexp` (lowercase regexp) — convert the leaf via the
+  // standard snake-to-camel mapping.
+  if (name.startsWith("visit__")) {
+    const leaf = name.slice("visit__".length);
+    return ["visit" + snakeToCamel(leaf).replace(/^./, (c) => c.toUpperCase())];
+  }
+
   if (name.endsWith("?")) {
     const base = name.slice(0, -1);
     const camel = snakeToCamel(base);


### PR DESCRIPTION
## Summary

Audit follow-up — third of three small PRs from the arel Rails-fidelity audit. **PR #983** (MySQL dialect, merged) and **PR #984** (Postgres formatting, merged) are done; this fills in the Rails-private method surface gaps.

Each helper added below mirrors a private method Rails ships and that `api:compare --privates-only` was reporting as missing. None are referenced internally — Trails' existing public predicates either inline the logic or call file-level `groupedAny`/`groupedAll` helpers — they're surfaced for Rails-fidelity coverage and for consumers reaching for the same protocol.

## Surface added

| Where | Methods | Mirrors |
|---|---|---|
| `Predications` (mixin) | `groupingAny` / `groupingAll` | `Arel::Predications#grouping_any` / `grouping_all` |
| `Predications` (mixin) | `isInfinity` / `isUnboundable` / `isOpenEnded` | `Arel::Predications#infinity?` / `unboundable?` / `open_ended?` |
| `Attribute` (`protected`) | Same 5, delegating to `Predications.X.call(this, ...)` | Rails Attribute inherits these via `include Predications`; Trails Attribute has hand-rolled public predicates so the include chain isn't wired |
| `HomogeneousIn` (`protected`) | `ivars` | `Arel::Nodes::HomogeneousIn#ivars` — protected helper Rails uses for `hash`/`eql?` |
| `SelectManager` (`protected`) | `collapse` | `Arel::SelectManager#collapse` — compacts a list of exprs, wraps strings as `SqlLiteral`, returns the single survivor or `createAnd(...)` |

`isUnboundable` always returns `false` in TS (Ruby's `unboundable?` protocol has no TS analog); the surface is preserved for parity with a forward-looking JSDoc note about where to teach it later.

## Implementation details

- **Generic `<T extends PredicationHost>`** on `groupingAny`/`groupingAll` so a class like `Attribute` can delegate without `as never` casts and the closure variant gets correctly typed `this`.
- **Method-id dispatch is safety-checked** via a private `predicationDispatch` helper that throws a clear `TypeError` ("`noSuchMethod` is not a method on the host (Attribute)") instead of an opaque "Cannot read property 'call' of undefined" if a typo'd method-id is passed.
- **`isOpenEnded` dispatches `isInfinity`/`isUnboundable` through `this`** rather than calling `Predications.X` directly, so a host that overrides either is honored — mirrors Ruby's method-lookup semantics.

## Tests

Adds `packages/arel/src/predications-privates.test.ts` (15 tests):

- `groupingAny`/`groupingAll` via method-id and via closure
- `groupingAny` throws on a non-callable method-id (regression for the dispatch-safety fix)
- `isInfinity`/`isUnboundable`/`isOpenEnded` semantics
- `isOpenEnded` honors a host's `isInfinity` override (regression for the `this`-dispatch fix)
- `Attribute` delegation parity (cast through to access protected methods)
- `HomogeneousIn#ivars` returns the `[attribute, values, type]` tuple
- `SelectManager#collapse` for single-survivor / bare-string / multi-and / empty-array (Rails-parity) cases

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run packages/arel/` — 1086/1086 passing
- [x] `pnpm run api:compare --package arel` — still 589/589 (100%)
- [x] `pnpm tsx scripts/api-compare/compare.ts --package arel --privates-only` — Predications/Attribute/InfixOperation/NodeExpression/SqlLiteral/HomogeneousIn/SelectManager all 100% (the visitor-naming gaps remaining are intentional Trails design — shared dispatch helpers vs Rails one-method-per-node — not Rails-fidelity bugs)