### PR TITLE
feat(actionpack): cookie expires accepts Temporal.Instant

### DIFF
--- a/packages/actionpack/src/actiondispatch/cookies.ts
+++ b/packages/actionpack/src/actiondispatch/cookies.ts
@@ -5,6 +5,16 @@
  */
 
 import { getCrypto } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
+/** Cookie expiry — accept either a Date or a Temporal.Instant from AR/AM. */
+export type CookieExpires = Date | Temporal.Instant;
+
+function toUTCString(expires: CookieExpires): string {
+  return expires instanceof Temporal.Instant
+    ? new Date(expires.epochMilliseconds).toUTCString()
+    : expires.toUTCString();
+}
 
 export interface CookieJarOptions {
   secret?: string;
@@ -15,14 +25,14 @@ export interface CookieJarOptions {
   httpOnly?: boolean;
   domain?: string;
   path?: string;
-  expires?: Date;
+  expires?: CookieExpires;
 }
 
 export interface SetCookieOptions {
   value: string;
   path?: string;
   domain?: string;
-  expires?: Date;
+  expires?: CookieExpires;
   maxAge?: number;
   secure?: boolean;
   httpOnly?: boolean;
@@ -307,7 +317,7 @@ function formatSetCookie(name: string, opts: SetCookieOptions, defaults: CookieJ
   const path = opts.path ?? defaults.path ?? "/";
   header += `; path=${path}`;
   if (opts.domain ?? defaults.domain) header += `; domain=${opts.domain ?? defaults.domain}`;
-  if (opts.expires) header += `; expires=${opts.expires.toUTCString()}`;
+  if (opts.expires) header += `; expires=${toUTCString(opts.expires)}`;
   if (opts.maxAge !== undefined) header += `; max-age=${opts.maxAge}`;
   if (opts.secure ?? defaults.secure) header += "; secure";
   if (opts.httpOnly ?? defaults.httpOnly) header += "; HttpOnly";

--- a/packages/actionpack/src/actiondispatch/dispatch/cookies.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/cookies.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { CookieJar } from "../cookies.js";
 
 describe("CookieJarTest", () => {
@@ -133,6 +134,15 @@ describe("CookiesTest", () => {
     jar.set("user_name", { value: "david", expires });
     const headers = jar.getSetCookieHeaders();
     expect(headers[0]).toContain("expires=");
+  });
+
+  it("setting cookie expires from a Temporal.Instant", () => {
+    const jar = new CookieJar();
+    // Pin to a known instant so the rendered RFC 7231 string is deterministic.
+    const instant = Temporal.Instant.from("2030-04-15T12:00:00Z");
+    jar.set("user_name", { value: "david", expires: instant });
+    const headers = jar.getSetCookieHeaders();
+    expect(headers[0]).toContain(`expires=${new Date(instant.epochMilliseconds).toUTCString()}`);
   });
 
   it("setting cookie for fourteen days with symbols", () => {

--- a/packages/actionpack/src/actiondispatch/dispatch/cookies.test.ts
+++ b/packages/actionpack/src/actiondispatch/dispatch/cookies.test.ts
@@ -142,7 +142,7 @@ describe("CookiesTest", () => {
     const instant = Temporal.Instant.from("2030-04-15T12:00:00Z");
     jar.set("user_name", { value: "david", expires: instant });
     const headers = jar.getSetCookieHeaders();
-    expect(headers[0]).toContain(`expires=${new Date(instant.epochMilliseconds).toUTCString()}`);
+    expect(headers[0]).toContain("expires=Mon, 15 Apr 2030 12:00:00 GMT");
   });
 
   it("setting cookie for fourteen days with symbols", () => {


### PR DESCRIPTION
## Summary

PR 9 (cookies slice) of the Temporal migration's external-boundary audit. Widens `CookieJarOptions.expires` and `SetCookieOptions.expires` from `Date` to `Date | Temporal.Instant` (`CookieExpires`), so application code can pass `model.expires_at` directly without converting through `Date`.

The instant is rendered to RFC 7231 via `new Date(instant.epochMilliseconds).toUTCString()` at the serialization point (RFC 7231 cookie expiry strings are by spec the format `Date#toUTCString` produces).

Adds a round-trip test that pins a known instant and verifies the `Set-Cookie` header carries the expected `expires=` value.

The matching widening for `actioncontroller#freshWhen`/`stale` `lastModified` and `actiondispatch/response.ts` cookie expires lands in **PR 9b**.

## Test plan

- [x] `vitest run packages/actionpack/src/actiondispatch/dispatch/cookies.test.ts` — 49/49 pass
- [x] `vitest run packages/actionpack` — 1792/1792 pass
- [x] `pnpm typecheck`
- [x] Diff size: 28 LOC under the 300 ceiling