### PR TITLE
feat(actionpack): freshWhen/stale and CookieOptions accept Temporal.Instant

### DIFF
--- a/packages/actionpack/src/actioncontroller/base.ts
+++ b/packages/actionpack/src/actioncontroller/base.ts
@@ -6,7 +6,7 @@
  */
 
 import { getFs, getPath, getCrypto, Notifications } from "@blazetrails/activesupport";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { Metal } from "./metal.js";
 import { FlashHash } from "../actiondispatch/flash.js";
 import { RequestForgeryProtection } from "../actiondispatch/request-forgery-protection.js";
@@ -409,10 +409,12 @@ export class Base extends Metal {
       this.setHeader("etag", etag);
     }
     if (options.lastModified) {
+      // Positively identify Date so cross-realm or polyfill-variant
+      // Temporal.Instant values still take the Instant branch.
       const lm =
-        options.lastModified instanceof Temporal.Instant
-          ? new Date(options.lastModified.epochMilliseconds)
-          : options.lastModified;
+        options.lastModified instanceof Date
+          ? options.lastModified
+          : new Date(options.lastModified.epochMilliseconds);
       this.setHeader("last-modified", lm.toUTCString());
     }
     if (options.public) {

--- a/packages/actionpack/src/actioncontroller/base.ts
+++ b/packages/actionpack/src/actioncontroller/base.ts
@@ -6,6 +6,7 @@
  */
 
 import { getFs, getPath, getCrypto, Notifications } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Metal } from "./metal.js";
 import { FlashHash } from "../actiondispatch/flash.js";
 import { RequestForgeryProtection } from "../actiondispatch/request-forgery-protection.js";
@@ -398,13 +399,21 @@ export class Base extends Metal {
   // --- Caching / Conditional GET ---
 
   /** Check if the response should be fresh (304 Not Modified). */
-  freshWhen(options: { etag?: string; lastModified?: Date; public?: boolean }): void {
+  freshWhen(options: {
+    etag?: string;
+    lastModified?: Date | Temporal.Instant;
+    public?: boolean;
+  }): void {
     if (options.etag) {
       const etag = this._generateEtag(options.etag);
       this.setHeader("etag", etag);
     }
     if (options.lastModified) {
-      this.setHeader("last-modified", options.lastModified.toUTCString());
+      const lm =
+        options.lastModified instanceof Temporal.Instant
+          ? new Date(options.lastModified.epochMilliseconds)
+          : options.lastModified;
+      this.setHeader("last-modified", lm.toUTCString());
     }
     if (options.public) {
       this.setHeader("cache-control", "public");
@@ -416,7 +425,11 @@ export class Base extends Metal {
   }
 
   /** Check if the resource is stale. Returns true if a re-render is needed. */
-  stale(options: { etag?: string; lastModified?: Date; public?: boolean }): boolean {
+  stale(options: {
+    etag?: string;
+    lastModified?: Date | Temporal.Instant;
+    public?: boolean;
+  }): boolean {
     this.freshWhen(options);
     return !this.performed;
   }

--- a/packages/actionpack/src/actioncontroller/base.ts
+++ b/packages/actionpack/src/actioncontroller/base.ts
@@ -409,12 +409,12 @@ export class Base extends Metal {
       this.setHeader("etag", etag);
     }
     if (options.lastModified) {
-      // Positively identify Date so cross-realm or polyfill-variant
-      // Temporal.Instant values still take the Instant branch.
-      const lm =
-        options.lastModified instanceof Date
-          ? options.lastModified
-          : new Date(options.lastModified.epochMilliseconds);
+      // Realm-safe Date check: instanceof breaks across realms (vm/iframe)
+      // for both Date and Temporal.Instant. Use the brand string instead.
+      const isDate = Object.prototype.toString.call(options.lastModified) === "[object Date]";
+      const lm = isDate
+        ? (options.lastModified as Date)
+        : new Date((options.lastModified as Temporal.Instant).epochMilliseconds);
       this.setHeader("last-modified", lm.toUTCString());
     }
     if (options.public) {

--- a/packages/actionpack/src/actioncontroller/controller/caching.test.ts
+++ b/packages/actionpack/src/actioncontroller/controller/caching.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "../base.js";
 import { Request } from "../../actiondispatch/request.js";
 import { Response } from "../../actiondispatch/response.js";
@@ -36,6 +37,19 @@ describe("FragmentCachingTest", () => {
     class C extends Base {
       async show() {
         this.freshWhen({ lastModified: date });
+        if (!this.performed) this.render({ plain: "content" });
+      }
+    }
+    const c = new C();
+    await c.dispatch("show", makeRequest(), makeResponse());
+    expect(c.getHeader("last-modified")).toBe("Sat, 15 Jun 2024 12:00:00 GMT");
+  });
+
+  it("freshWhen accepts a Temporal.Instant lastModified", async () => {
+    const instant = Temporal.Instant.from("2024-06-15T12:00:00Z");
+    class C extends Base {
+      async show() {
+        this.freshWhen({ lastModified: instant });
         if (!this.performed) this.render({ plain: "content" });
       }
     }

--- a/packages/actionpack/src/actiondispatch/response.ts
+++ b/packages/actionpack/src/actiondispatch/response.ts
@@ -4,6 +4,8 @@
  * Represents an HTTP response with status, headers, and body.
  */
 
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
 export class Response {
   private _status: number;
   private _headers: Record<string, string>;
@@ -217,7 +219,7 @@ export interface CookieOptions {
   value: string;
   path?: string;
   domain?: string;
-  expires?: Date;
+  expires?: Date | Temporal.Instant;
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: "strict" | "lax" | "none";

--- a/packages/actionpack/src/actiondispatch/response.ts
+++ b/packages/actionpack/src/actiondispatch/response.ts
@@ -4,7 +4,7 @@
  * Represents an HTTP response with status, headers, and body.
  */
 
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import type { CookieExpires } from "./cookies.js";
 
 export class Response {
   private _status: number;
@@ -219,7 +219,7 @@ export interface CookieOptions {
   value: string;
   path?: string;
   domain?: string;
-  expires?: Date | Temporal.Instant;
+  expires?: CookieExpires;
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: "strict" | "lax" | "none";


### PR DESCRIPTION
## Summary

PR 9b of the Temporal migration's external-boundary audit. Widens the remaining `Date`-typed boundary fields in actionpack to accept `Temporal.Instant` directly:

- `actioncontroller#freshWhen` and `#stale` `lastModified` → `Date | Temporal.Instant`. Converted to a Date for the `last-modified` header's RFC 7231 `toUTCString` rendering.
- `actiondispatch/response.ts` `CookieOptions.expires` → `Date | Temporal.Instant`, mirroring PR #986's `CookieJarOptions` / `SetCookieOptions` widening.

Adds a `freshWhen` test covering an `Instant` `lastModified` and asserting the resulting `Last-Modified` header carries the expected RFC 7231 value.

## Test plan

- [x] `vitest run packages/actionpack` — 1793/1793 pass
- [x] `pnpm typecheck`
- [x] Diff size: 37 LOC under the 300 ceiling