### PR TITLE
refactor(arel): Rails-style class-tagged visitor dispatch

### DIFF
--- a/packages/arel/src/errors.ts
+++ b/packages/arel/src/errors.ts
@@ -18,3 +18,29 @@ export class BindError extends ArelError {
     this.name = "BindError";
   }
 }
+
+/**
+ * Thrown when no visit method is registered for a node's runtime class
+ * (after walking the prototype chain).
+ *
+ * Rails raises a plain `TypeError("Cannot visit #{class}")` from
+ * `Arel::Visitors::Visitor#visit` (`activerecord/lib/arel/visitors/visitor.rb`).
+ * Trails throws this named subclass of `ArelError` instead — same
+ * condition, but a named error class is more idiomatic in TS (callers
+ * catch by `instanceof`), and `Visitors.UnsupportedVisitError` was already
+ * the public surface before the dispatch refactor. Pinned by
+ * `to-sql.test.ts` "unsupported input should raise UnsupportedVisitError".
+ */
+export class UnsupportedVisitError extends ArelError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedVisitError";
+  }
+}
+
+export class NotImplementedError extends ArelError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotImplementedError";
+  }
+}

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,5 +1,5 @@
 export { ToSql } from "./to-sql.js";
-export { UnsupportedVisitError, NotImplementedError } from "./to-sql.js";
+export { UnsupportedVisitError, NotImplementedError } from "../errors.js";
 export { MySQL } from "./mysql.js";
 export { PostgreSQL, PostgreSQLWithBinds } from "./postgresql.js";
 export { SQLite } from "./sqlite.js";

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -80,10 +80,13 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return [sqlCollector.value, binds];
   }
 
-  /** @internal */
-  // Rails passes the collector as a second arg through the visit chain;
-  // we route SQL through `this.collector` instance state instead, so the
-  // base's collector argument is unused here by design.
+  /**
+   * Rails passes the collector as a second arg through the visit chain;
+   * we route SQL through `this.collector` instance state instead, so the
+   * base's collector argument is unused here by design.
+   *
+   * @internal
+   */
   visit(node: Node): SQLString {
     return super.visit(node) as SQLString;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -4,6 +4,7 @@ import { Bind } from "../collectors/bind.js";
 import { Composite } from "../collectors/composite.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
+import { Visitor } from "./visitor.js";
 
 /**
  * Resolve a bind's database value. QueryAttribute exposes
@@ -37,7 +38,7 @@ export class NotImplementedError extends Error {
  *
  * Mirrors: Arel::Visitors::ToSql
  */
-export class ToSql implements NodeVisitor<SQLString> {
+export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   protected collector!: SQLString;
   private _inUpdateSet = false;
   protected _extractBinds = false;
@@ -86,134 +87,156 @@ export class ToSql implements NodeVisitor<SQLString> {
 
   /** @internal */
   visit(node: Node): SQLString {
-    if (node instanceof Nodes.SelectStatement) return this.visitSelectStatement(node);
-    if (node instanceof Nodes.SelectCore) return this.visitSelectCore(node);
-    if (node instanceof Nodes.InsertStatement) return this.visitInsertStatement(node);
-    if (node instanceof Nodes.UpdateStatement) return this.visitUpdateStatement(node);
-    if (node instanceof Nodes.DeleteStatement) return this.visitDeleteStatement(node);
+    try {
+      return super.visit(node) as SQLString;
+    } catch (e) {
+      if (e instanceof TypeError && e.message.startsWith("Cannot visit ")) {
+        throw new UnsupportedVisitError(`Unknown node type: ${node.constructor.name}`);
+      }
+      throw e;
+    }
+  }
 
+  // Per-class dispatch wrappers for shared helpers — mirrors Rails' per-method
+  // form (each operator/aggregate has its own visit method).
+  protected visitGreaterThan(node: Nodes.GreaterThan): SQLString {
+    return this.visitBinaryOp(node, ">");
+  }
+  protected visitGreaterThanOrEqual(node: Nodes.GreaterThanOrEqual): SQLString {
+    return this.visitBinaryOp(node, ">=");
+  }
+  protected visitLessThan(node: Nodes.LessThan): SQLString {
+    return this.visitBinaryOp(node, "<");
+  }
+  protected visitLessThanOrEqual(node: Nodes.LessThanOrEqual): SQLString {
+    return this.visitBinaryOp(node, "<=");
+  }
+  protected visitCount(node: Nodes.Count): SQLString {
+    return this.visitAggregate(node, "COUNT");
+  }
+  protected visitSum(node: Nodes.Sum): SQLString {
+    return this.visitAggregate(node, "SUM");
+  }
+  protected visitMax(node: Nodes.Max): SQLString {
+    return this.visitAggregate(node, "MAX");
+  }
+  protected visitMin(node: Nodes.Min): SQLString {
+    return this.visitAggregate(node, "MIN");
+  }
+  protected visitAvg(node: Nodes.Avg): SQLString {
+    return this.visitAggregate(node, "AVG");
+  }
+
+  static {
+    const d = ToSql.dispatchCache();
+    const reg = (ctor: abstract new (...a: never[]) => Node, m: string) => d.set(ctor as never, m);
+    // Statements
+    reg(Nodes.SelectStatement, "visitSelectStatement");
+    reg(Nodes.SelectCore, "visitSelectCore");
+    reg(Nodes.InsertStatement, "visitInsertStatement");
+    reg(Nodes.UpdateStatement, "visitUpdateStatement");
+    reg(Nodes.DeleteStatement, "visitDeleteStatement");
     // Set operations
-    if (node instanceof Nodes.UnionAll) return this.visitUnionAll(node);
-    if (node instanceof Nodes.Union) return this.visitUnion(node);
-    if (node instanceof Nodes.Intersect) return this.visitIntersect(node);
-    if (node instanceof Nodes.Except) return this.visitExcept(node);
-
+    reg(Nodes.UnionAll, "visitUnionAll");
+    reg(Nodes.Union, "visitUnion");
+    reg(Nodes.Intersect, "visitIntersect");
+    reg(Nodes.Except, "visitExcept");
     // CTE
-    if (node instanceof Nodes.WithRecursive) return this.visitWithRecursive(node);
-    if (node instanceof Nodes.With) return this.visitWith(node);
-    if (node instanceof Nodes.TableAlias) return this.visitTableAlias(node);
-
+    reg(Nodes.WithRecursive, "visitWithRecursive");
+    reg(Nodes.With, "visitWith");
+    reg(Nodes.TableAlias, "visitTableAlias");
+    reg(Nodes.Cte, "visitCte");
     // Joins
-    if (node instanceof Nodes.JoinSource) return this.visitJoinSource(node);
-    if (node instanceof Nodes.InnerJoin) return this.visitInnerJoin(node);
-    if (node instanceof Nodes.OuterJoin) return this.visitOuterJoin(node);
-    if (node instanceof Nodes.RightOuterJoin) return this.visitRightOuterJoin(node);
-    if (node instanceof Nodes.FullOuterJoin) return this.visitFullOuterJoin(node);
-    if (node instanceof Nodes.CrossJoin) return this.visitCrossJoin(node);
-    if (node instanceof Nodes.StringJoin) return this.visitStringJoin(node);
-    if (node instanceof Nodes.On) return this.visitOn(node);
-
-    // Predicates (must check specific subclasses before Binary)
-    if (node instanceof Nodes.Equality) return this.visitEquality(node);
-    if (node instanceof Nodes.NotEqual) return this.visitNotEqual(node);
-    if (node instanceof Nodes.GreaterThan) return this.visitBinaryOp(node, ">");
-    if (node instanceof Nodes.GreaterThanOrEqual) return this.visitBinaryOp(node, ">=");
-    if (node instanceof Nodes.LessThan) return this.visitBinaryOp(node, "<");
-    if (node instanceof Nodes.LessThanOrEqual) return this.visitBinaryOp(node, "<=");
-    if (node instanceof Nodes.Matches) return this.visitMatches(node);
-    if (node instanceof Nodes.DoesNotMatch) return this.visitDoesNotMatch(node);
-    if (node instanceof Nodes.In) return this.visitIn(node);
-    if (node instanceof Nodes.NotIn) return this.visitNotIn(node);
-    if (node instanceof Nodes.Between) return this.visitBetween(node);
-    if (node instanceof Nodes.Regexp) return this.visitRegexp(node);
-    if (node instanceof Nodes.NotRegexp) return this.visitNotRegexp(node);
-    if (node instanceof Nodes.IsDistinctFrom) return this.visitIsDistinctFrom(node);
-    if (node instanceof Nodes.IsNotDistinctFrom) return this.visitIsNotDistinctFrom(node);
-    if (node instanceof Nodes.Assignment) return this.visitAssignment(node);
-    if (node instanceof Nodes.As) return this.visitAs(node);
-
+    reg(Nodes.JoinSource, "visitJoinSource");
+    reg(Nodes.InnerJoin, "visitInnerJoin");
+    reg(Nodes.OuterJoin, "visitOuterJoin");
+    reg(Nodes.RightOuterJoin, "visitRightOuterJoin");
+    reg(Nodes.FullOuterJoin, "visitFullOuterJoin");
+    reg(Nodes.CrossJoin, "visitCrossJoin");
+    reg(Nodes.StringJoin, "visitStringJoin");
+    reg(Nodes.On, "visitOn");
+    // Predicates
+    reg(Nodes.Equality, "visitEquality");
+    reg(Nodes.NotEqual, "visitNotEqual");
+    reg(Nodes.GreaterThan, "visitGreaterThan");
+    reg(Nodes.GreaterThanOrEqual, "visitGreaterThanOrEqual");
+    reg(Nodes.LessThan, "visitLessThan");
+    reg(Nodes.LessThanOrEqual, "visitLessThanOrEqual");
+    reg(Nodes.Matches, "visitMatches");
+    reg(Nodes.DoesNotMatch, "visitDoesNotMatch");
+    reg(Nodes.In, "visitIn");
+    reg(Nodes.NotIn, "visitNotIn");
+    reg(Nodes.Between, "visitBetween");
+    reg(Nodes.Regexp, "visitRegexp");
+    reg(Nodes.NotRegexp, "visitNotRegexp");
+    reg(Nodes.IsDistinctFrom, "visitIsDistinctFrom");
+    reg(Nodes.IsNotDistinctFrom, "visitIsNotDistinctFrom");
+    reg(Nodes.Assignment, "visitAssignment");
+    reg(Nodes.As, "visitAs");
     // Unary
-    if (node instanceof Nodes.Ascending) return this.visitAscending(node);
-    if (node instanceof Nodes.Descending) return this.visitDescending(node);
-    if (node instanceof Nodes.Offset) return this.visitOffset(node);
-    if (node instanceof Nodes.Limit) return this.visitLimit(node);
-    if (node instanceof Nodes.Top) return this.visitTop(node);
-    if (node instanceof Nodes.Lock) return this.visitLock(node);
-    if (node instanceof Nodes.DistinctOn) return this.visitDistinctOn(node);
-    if (node instanceof Nodes.Bin) return this.visitBin(node);
-
+    reg(Nodes.Ascending, "visitAscending");
+    reg(Nodes.Descending, "visitDescending");
+    reg(Nodes.Offset, "visitOffset");
+    reg(Nodes.Limit, "visitLimit");
+    reg(Nodes.Top, "visitTop");
+    reg(Nodes.Lock, "visitLock");
+    reg(Nodes.DistinctOn, "visitDistinctOn");
+    reg(Nodes.Bin, "visitBin");
+    reg(Nodes.NullsFirst, "visitNullsFirst");
+    reg(Nodes.NullsLast, "visitNullsLast");
+    reg(Nodes.UnaryOperation, "visitUnaryOperation");
     // Boolean
-    if (node instanceof Nodes.And) return this.visitAnd(node);
-    if (node instanceof Nodes.Or) return this.visitOr(node);
-    if (node instanceof Nodes.Not) return this.visitNot(node);
-    if (node instanceof Nodes.Grouping) return this.visitGrouping(node);
-
+    reg(Nodes.And, "visitAnd");
+    reg(Nodes.Or, "visitOr");
+    reg(Nodes.Not, "visitNot");
+    reg(Nodes.Grouping, "visitGrouping");
     // Window
-    if (node instanceof Nodes.Over) return this.visitOver(node);
-    if (node instanceof Nodes.NamedWindow) return this.visitNamedWindow(node);
-    if (node instanceof Nodes.Window) return this.visitWindow(node);
-    if (node instanceof Nodes.Rows) return this.visitRows(node);
-    if (node instanceof Nodes.Range) return this.visitRange(node);
-    if (node instanceof Nodes.Preceding) return this.visitPreceding(node);
-    if (node instanceof Nodes.Following) return this.visitFollowing(node);
-    if (node instanceof Nodes.CurrentRow) return this.visitCurrentRow(node);
-
-    // Nulls ordering (must be before generic Unary)
-    if (node instanceof Nodes.NullsFirst) return this.visitNullsFirst(node);
-    if (node instanceof Nodes.NullsLast) return this.visitNullsLast(node);
-
-    // CTE node
-    if (node instanceof Nodes.Cte) return this.visitCte(node);
-
-    // UnaryOperation (must be before InfixOperation check)
-    if (node instanceof Nodes.UnaryOperation) return this.visitUnaryOperation(node);
-
-    // Filter
-    if (node instanceof Nodes.Filter) return this.visitFilter(node);
-
-    // Case / Extract / InfixOperation
-    if (node instanceof Nodes.Case) return this.visitCase(node);
-    if (node instanceof Nodes.Extract) return this.visitExtract(node);
-    if (node instanceof Nodes.Concat) return this.visitConcat(node);
-    if (node instanceof Nodes.InfixOperation) return this.visitInfixOperation(node);
-    if (node instanceof Nodes.BoundSqlLiteral) return this.visitBoundSqlLiteral(node);
-    if (node instanceof Nodes.BindParam) return this.visitBindParam(node);
-    if (node instanceof Nodes.Fragments) return this.visitFragments(node);
-
+    reg(Nodes.Over, "visitOver");
+    reg(Nodes.NamedWindow, "visitNamedWindow");
+    reg(Nodes.Window, "visitWindow");
+    reg(Nodes.Rows, "visitRows");
+    reg(Nodes.Range, "visitRange");
+    reg(Nodes.Preceding, "visitPreceding");
+    reg(Nodes.Following, "visitFollowing");
+    reg(Nodes.CurrentRow, "visitCurrentRow");
+    // Filter / Case / Extract / Infix
+    reg(Nodes.Filter, "visitFilter");
+    reg(Nodes.Case, "visitCase");
+    reg(Nodes.Extract, "visitExtract");
+    reg(Nodes.Concat, "visitConcat");
+    reg(Nodes.InfixOperation, "visitInfixOperation");
+    reg(Nodes.BoundSqlLiteral, "visitBoundSqlLiteral");
+    reg(Nodes.BindParam, "visitBindParam");
+    reg(Nodes.Fragments, "visitFragments");
     // Functions
-    if (node instanceof Nodes.NamedFunction) return this.visitNamedFunction(node);
-    if (node instanceof Nodes.Exists) return this.visitExists(node);
-    if (node instanceof Nodes.Count) return this.visitAggregate(node, "COUNT");
-    if (node instanceof Nodes.Sum) return this.visitAggregate(node, "SUM");
-    if (node instanceof Nodes.Max) return this.visitAggregate(node, "MAX");
-    if (node instanceof Nodes.Min) return this.visitAggregate(node, "MIN");
-    if (node instanceof Nodes.Avg) return this.visitAggregate(node, "AVG");
-
+    reg(Nodes.NamedFunction, "visitNamedFunction");
+    reg(Nodes.Exists, "visitExists");
+    reg(Nodes.Count, "visitCount");
+    reg(Nodes.Sum, "visitSum");
+    reg(Nodes.Max, "visitMax");
+    reg(Nodes.Min, "visitMin");
+    reg(Nodes.Avg, "visitAvg");
     // Advanced grouping
-    if (node instanceof Nodes.Cube) return this.visitCube(node);
-    if (node instanceof Nodes.Rollup) return this.visitRollup(node);
-    if (node instanceof Nodes.GroupingSet) return this.visitGroupingSet(node);
-    if (node instanceof Nodes.Group) return this.visitGroup(node);
-    if (node instanceof Nodes.GroupingElement) return this.visitGroupingElement(node);
-    if (node instanceof Nodes.Lateral) return this.visitLateral(node);
-    if (node instanceof Nodes.Comment) return this.visitComment(node);
-    if (node instanceof Nodes.HomogeneousIn) return this.visitHomogeneousIn(node);
-
+    reg(Nodes.Cube, "visitCube");
+    reg(Nodes.Rollup, "visitRollup");
+    reg(Nodes.GroupingSet, "visitGroupingSet");
+    reg(Nodes.Group, "visitGroup");
+    reg(Nodes.GroupingElement, "visitGroupingElement");
+    reg(Nodes.Lateral, "visitLateral");
+    reg(Nodes.Comment, "visitComment");
+    reg(Nodes.HomogeneousIn, "visitHomogeneousIn");
     // Boolean literals
-    if (node instanceof Nodes.True) return this.visitTrue(node);
-    if (node instanceof Nodes.False) return this.visitFalse(node);
-
+    reg(Nodes.True, "visitTrue");
+    reg(Nodes.False, "visitFalse");
     // Leaf nodes
-    if (node instanceof Nodes.Distinct) return this.visitDistinct(node);
-    if (node instanceof Nodes.SqlLiteral) return this.visitSqlLiteral(node);
-    if (node instanceof Nodes.Quoted) return this.visitQuoted(node);
-    if (node instanceof Nodes.Casted) return this.visitCasted(node);
-    if (node instanceof Nodes.UnqualifiedColumn) return this.visitUnqualifiedColumn(node);
-    if (node instanceof Nodes.Attribute) return this.visitAttribute(node);
-    if (node instanceof Nodes.ValuesList) return this.visitValuesList(node);
-    if (node instanceof Table) return this.visitTable(node);
-
-    throw new UnsupportedVisitError(`Unknown node type: ${node.constructor.name}`);
+    reg(Nodes.Distinct, "visitDistinct");
+    reg(Nodes.SqlLiteral, "visitSqlLiteral");
+    reg(Nodes.Quoted, "visitQuoted");
+    reg(Nodes.Casted, "visitCasted");
+    reg(Nodes.UnqualifiedColumn, "visitUnqualifiedColumn");
+    reg(Nodes.Attribute, "visitAttribute");
+    reg(Nodes.ValuesList, "visitValuesList");
+    reg(Table, "visitTable");
   }
 
   // -- Statements --

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -81,6 +81,9 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   /** @internal */
+  // Rails passes the collector as a second arg through the visit chain;
+  // we route SQL through `this.collector` instance state instead, so the
+  // base's collector argument is unused here by design.
   visit(node: Node): SQLString {
     return super.visit(node) as SQLString;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -4,7 +4,9 @@ import { Bind } from "../collectors/bind.js";
 import { Composite } from "../collectors/composite.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
-import { Visitor } from "./visitor.js";
+import { Visitor, UnsupportedVisitError, type NodeCtor } from "./visitor.js";
+
+export { UnsupportedVisitError };
 
 /**
  * Resolve a bind's database value. QueryAttribute exposes
@@ -17,13 +19,6 @@ export function resolveValueForDatabase(value: unknown): unknown {
   if (!value || typeof value !== "object" || !("valueForDatabase" in value)) return value;
   const v = (value as Record<string, unknown>).valueForDatabase;
   return typeof v === "function" ? (v as () => unknown).call(value) : v;
-}
-
-export class UnsupportedVisitError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "UnsupportedVisitError";
-  }
 }
 
 export class NotImplementedError extends Error {
@@ -87,14 +82,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   /** @internal */
   visit(node: Node): SQLString {
-    try {
-      return super.visit(node) as SQLString;
-    } catch (e) {
-      if (e instanceof TypeError && e.message.startsWith("Cannot visit ")) {
-        throw new UnsupportedVisitError(`Unknown node type: ${node.constructor.name}`);
-      }
-      throw e;
-    }
+    return super.visit(node) as SQLString;
   }
 
   // Per-class dispatch wrappers for shared helpers — mirrors Rails' per-method
@@ -129,7 +117,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   static {
     const d = ToSql.dispatchCache();
-    const reg = (ctor: abstract new (...a: never[]) => Node, m: string) => d.set(ctor as never, m);
+    const reg = (ctor: NodeCtor, m: string) => d.set(ctor, m);
     // Statements
     reg(Nodes.SelectStatement, "visitSelectStatement");
     reg(Nodes.SelectCore, "visitSelectCore");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -4,9 +4,8 @@ import { Bind } from "../collectors/bind.js";
 import { Composite } from "../collectors/composite.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
-import { Visitor, UnsupportedVisitError, type NodeCtor } from "./visitor.js";
-
-export { UnsupportedVisitError };
+import { Visitor, type NodeCtor } from "./visitor.js";
+import { UnsupportedVisitError, NotImplementedError } from "../errors.js";
 
 /**
  * Resolve a bind's database value. QueryAttribute exposes
@@ -19,13 +18,6 @@ export function resolveValueForDatabase(value: unknown): unknown {
   if (!value || typeof value !== "object" || !("valueForDatabase" in value)) return value;
   const v = (value as Record<string, unknown>).valueForDatabase;
   return typeof v === "function" ? (v as () => unknown).call(value) : v;
-}
-
-export class NotImplementedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NotImplementedError";
-  }
 }
 
 /**
@@ -123,7 +115,16 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   static {
     const d = ToSql.dispatchCache();
-    const reg = (ctor: NodeCtor, m: string) => d.set(ctor, m);
+    // Runtime guard: TS `keyof T` only exposes public members, and the
+    // visit methods are mostly protected, so we can't constrain `m` at
+    // compile time. Asserting here catches typos/renames the next time
+    // the static block runs (i.e. as soon as the file is imported).
+    const reg = (ctor: NodeCtor, m: string) => {
+      if (typeof (ToSql.prototype as unknown as Record<string, unknown>)[m] !== "function") {
+        throw new Error(`ToSql dispatch: method '${m}' is not defined on the prototype`);
+      }
+      d.set(ctor, m);
+    };
     // Statements
     reg(Nodes.SelectStatement, "visitSelectStatement");
     reg(Nodes.SelectCore, "visitSelectCore");

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,23 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { Node } from "../nodes/node.js";
-import { Visitor } from "./visitor.js";
+import { Visitor, UnsupportedVisitError } from "./visitor.js";
 
 class A extends Node {
-  accept<T>(_v: { visit(n: Node): T }): T {
-    return _v.visit(this);
+  accept<T>(v: { visit(n: Node): T }): T {
+    return v.visit(this);
   }
 }
 class B extends A {}
+class B2 extends B {}
 class C extends Node {
-  accept<T>(_v: { visit(n: Node): T }): T {
-    return _v.visit(this);
+  accept<T>(v: { visit(n: Node): T }): T {
+    return v.visit(this);
   }
 }
 
 class TestVisitor extends Visitor {
-  visited: string[] = [];
-  visitA(node: A): string {
-    this.visited.push(`A(${node.constructor.name})`);
+  visited: Array<{ node: string; collector: unknown }> = [];
+  visitA(node: A, collector?: unknown): string {
+    this.visited.push({ node: node.constructor.name, collector });
     return "A";
   }
   static {
@@ -29,12 +30,19 @@ describe("Visitor dispatch", () => {
   it("dispatches to a registered method", () => {
     const v = new TestVisitor();
     expect(v.accept(new A())).toBe("A");
+    expect(v.visited[0]?.node).toBe("A");
   });
 
   it("walks the prototype chain to find an ancestor's handler", () => {
     const v = new TestVisitor();
     expect(v.accept(new B())).toBe("A");
-    expect(v.visited).toEqual(["A(B)"]);
+    expect(v.visited).toEqual([{ node: "B", collector: undefined }]);
+  });
+
+  it("walks more than one level up the prototype chain", () => {
+    const v = new TestVisitor();
+    expect(v.accept(new B2())).toBe("A");
+    expect(v.visited[0]?.node).toBe("B2");
   });
 
   it("memoizes ancestor lookups in the cache", () => {
@@ -43,9 +51,17 @@ describe("Visitor dispatch", () => {
     expect(TestVisitor.dispatchCache().get(B)).toBe("visitA");
   });
 
-  it("throws TypeError for nodes with no handler", () => {
+  it("throws UnsupportedVisitError for nodes with no handler", () => {
     const v = new TestVisitor();
-    expect(() => v.accept(new C())).toThrow(/Cannot visit C/);
+    expect(() => v.accept(new C())).toThrow(UnsupportedVisitError);
+    expect(() => v.accept(new C())).toThrow(/Unknown node type: C/);
+  });
+
+  it("propagates the collector argument from accept through to the visit method", () => {
+    const v = new TestVisitor();
+    const collector = { sentinel: true };
+    v.accept(new A(), collector);
+    expect(v.visited[0]?.collector).toBe(collector);
   });
 
   it("each subclass has its own cache seeded from the parent", () => {
@@ -61,5 +77,16 @@ describe("Visitor dispatch", () => {
     expect(sub.accept(new A())).toBe("A");
     expect(sub.accept(new C())).toBe("C");
     expect(TestVisitor.dispatchCache().has(C)).toBe(false);
+  });
+
+  it("a subclass override of the visit method dispatches polymorphically", () => {
+    class Sub extends TestVisitor {
+      override visitA(_n: A): string {
+        return "Sub-A";
+      }
+    }
+    expect(new Sub().accept(new A())).toBe("Sub-A");
+    // Parent visitor still uses its own implementation.
+    expect(new TestVisitor().accept(new A())).toBe("A");
   });
 });

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { Node } from "../nodes/node.js";
+import { Node, NodeVisitor } from "../nodes/node.js";
 import { Visitor } from "./visitor.js";
 import { UnsupportedVisitError } from "../errors.js";
 
 class A extends Node {
-  accept<T>(v: { visit(n: Node): T }): T {
+  accept<T>(v: NodeVisitor<T>): T {
     return v.visit(this);
   }
 }
 class B extends A {}
 class B2 extends B {}
 class C extends Node {
-  accept<T>(v: { visit(n: Node): T }): T {
+  accept<T>(v: NodeVisitor<T>): T {
     return v.visit(this);
   }
 }

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { Node } from "../nodes/node.js";
+import { Visitor } from "./visitor.js";
+
+class A extends Node {
+  accept<T>(_v: { visit(n: Node): T }): T {
+    return _v.visit(this);
+  }
+}
+class B extends A {}
+class C extends Node {
+  accept<T>(_v: { visit(n: Node): T }): T {
+    return _v.visit(this);
+  }
+}
+
+class TestVisitor extends Visitor {
+  visited: string[] = [];
+  visitA(node: A): string {
+    this.visited.push(`A(${node.constructor.name})`);
+    return "A";
+  }
+  static {
+    this.dispatchCache().set(A, "visitA");
+  }
+}
+
+describe("Visitor dispatch", () => {
+  it("dispatches to a registered method", () => {
+    const v = new TestVisitor();
+    expect(v.accept(new A())).toBe("A");
+  });
+
+  it("walks the prototype chain to find an ancestor's handler", () => {
+    const v = new TestVisitor();
+    expect(v.accept(new B())).toBe("A");
+    expect(v.visited).toEqual(["A(B)"]);
+  });
+
+  it("memoizes ancestor lookups in the cache", () => {
+    const v = new TestVisitor();
+    v.accept(new B());
+    expect(TestVisitor.dispatchCache().get(B)).toBe("visitA");
+  });
+
+  it("throws TypeError for nodes with no handler", () => {
+    const v = new TestVisitor();
+    expect(() => v.accept(new C())).toThrow(/Cannot visit C/);
+  });
+
+  it("each subclass has its own cache seeded from the parent", () => {
+    class Sub extends TestVisitor {
+      visitC(_n: C): string {
+        return "C";
+      }
+      static {
+        this.dispatchCache().set(C, "visitC");
+      }
+    }
+    const sub = new Sub();
+    expect(sub.accept(new A())).toBe("A");
+    expect(sub.accept(new C())).toBe("C");
+    expect(TestVisitor.dispatchCache().has(C)).toBe(false);
+  });
+});

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -47,9 +47,19 @@ describe("Visitor dispatch", () => {
   });
 
   it("memoizes ancestor lookups in the cache", () => {
-    const v = new TestVisitor();
-    v.accept(new B());
-    expect(TestVisitor.dispatchCache().get(B)).toBe("visitA");
+    // Use a fresh subclass so we own the dispatch cache start state —
+    // earlier tests may already have populated TestVisitor's cache for B.
+    class FreshVisitor extends Visitor {
+      visitA(_n: A): string {
+        return "A";
+      }
+      static {
+        this.dispatchCache().set(A, "visitA");
+      }
+    }
+    expect(FreshVisitor.dispatchCache().has(B)).toBe(false);
+    new FreshVisitor().accept(new B());
+    expect(FreshVisitor.dispatchCache().get(B)).toBe("visitA");
   });
 
   it("throws UnsupportedVisitError for nodes with no handler", () => {

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Node } from "../nodes/node.js";
-import { Visitor, UnsupportedVisitError } from "./visitor.js";
+import { Visitor } from "./visitor.js";
+import { UnsupportedVisitError } from "../errors.js";
 
 class A extends Node {
   accept<T>(v: { visit(n: Node): T }): T {

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -58,6 +58,18 @@ describe("Visitor dispatch", () => {
     expect(() => v.accept(new C())).toThrow(/Unknown node type: C/);
   });
 
+  it("distinguishes a mis-registered method from an unknown node type", () => {
+    class BadVisitor extends Visitor {
+      static {
+        this.dispatchCache().set(A, "visitTypoed");
+      }
+    }
+    const v = new BadVisitor();
+    expect(() => v.accept(new A())).toThrow(
+      /Dispatch method 'visitTypoed' is not defined on BadVisitor for node A/,
+    );
+  });
+
   it("propagates the collector argument from accept through to the visit method", () => {
     const v = new TestVisitor();
     const collector = { sentinel: true };

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -4,7 +4,13 @@ import { Node } from "../nodes/node.js";
  * Thrown when no visit method is registered for a node's runtime class
  * (after walking the prototype chain).
  *
- * Mirrors the `TypeError` Rails raises in `Arel::Visitors::Visitor#visit`.
+ * Rails raises a plain `TypeError("Cannot visit #{class}")` from
+ * `Arel::Visitors::Visitor#visit` (`activerecord/lib/arel/visitors/visitor.rb`).
+ * Trails throws this named subclass instead — same condition, but a named
+ * error class is more idiomatic in TS (callers catch by `instanceof`), and
+ * `Visitors.UnsupportedVisitError` was already the public surface before
+ * the dispatch refactor. Pinned by `to-sql.test.ts` "unsupported input
+ * should raise UnsupportedVisitError".
  */
 export class UnsupportedVisitError extends Error {
   constructor(message: string) {

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -35,7 +35,7 @@ export abstract class Visitor {
   protected dispatch: Map<NodeCtor, string>;
 
   constructor() {
-    this.dispatch = (this.constructor as VisitorCtor).getDispatchCache();
+    this.dispatch = this.getDispatchCache();
   }
 
   accept(object: Node, collector?: unknown): unknown {
@@ -60,8 +60,12 @@ export abstract class Visitor {
     return cache;
   }
 
-  static getDispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
-    return this.dispatchCache();
+  /**
+   * Instance-side accessor mirroring Rails' private `get_dispatch_cache`.
+   * Returns the class-level dispatch cache for `this.constructor`.
+   */
+  protected getDispatchCache(): Map<NodeCtor, string> {
+    return (this.constructor as VisitorCtor).dispatchCache();
   }
 
   protected visit(object: Node, collector?: unknown): unknown {

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,6 +1,16 @@
 import { Node } from "../nodes/node.js";
 import { UnsupportedVisitError } from "../errors.js";
 
+/**
+ * Opaque dispatch-cache key for a Node subclass.
+ *
+ * The parameter list is `never[]` (not `unknown[]`) because the dispatch
+ * cache never constructs nodes — the ctor is used purely as a Map key. TS
+ * is contravariant in constructor parameter types, so `never[]` is the
+ * only signature that accepts ctors of arbitrary arity (e.g.
+ * `Binary(left, right)`, `BoundSqlLiteral(sql, binds)`). `unknown[]` would
+ * reject any ctor with a more-specific parameter type.
+ */
 export type NodeCtor = abstract new (...args: never[]) => Node;
 type VisitorCtor = typeof Visitor;
 
@@ -61,9 +71,18 @@ export abstract class Visitor {
   protected visit(object: Node, collector?: unknown): unknown {
     const ctor = object.constructor as NodeCtor;
     const methodName = this.resolveDispatch(ctor);
-    const fn = methodName ? (this as unknown as Record<string, unknown>)[methodName] : undefined;
-    if (typeof fn !== "function") {
+    if (!methodName) {
       throw new UnsupportedVisitError(`Unknown node type: ${ctor.name}`);
+    }
+    const fn = (this as unknown as Record<string, unknown>)[methodName];
+    if (typeof fn !== "function") {
+      // Cache hit but the instance has no such method — almost always a
+      // mis-registration (a typo'd method name landed in the dispatch
+      // cache). Distinct from the "no entry at all" case above so the
+      // failure mode is unambiguous.
+      throw new UnsupportedVisitError(
+        `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${ctor.name}`,
+      );
     }
     return (fn as (n: Node, c?: unknown) => unknown).call(this, object, collector);
   }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,23 +1,5 @@
 import { Node } from "../nodes/node.js";
-
-/**
- * Thrown when no visit method is registered for a node's runtime class
- * (after walking the prototype chain).
- *
- * Rails raises a plain `TypeError("Cannot visit #{class}")` from
- * `Arel::Visitors::Visitor#visit` (`activerecord/lib/arel/visitors/visitor.rb`).
- * Trails throws this named subclass instead — same condition, but a named
- * error class is more idiomatic in TS (callers catch by `instanceof`), and
- * `Visitors.UnsupportedVisitError` was already the public surface before
- * the dispatch refactor. Pinned by `to-sql.test.ts` "unsupported input
- * should raise UnsupportedVisitError".
- */
-export class UnsupportedVisitError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "UnsupportedVisitError";
-  }
-}
+import { UnsupportedVisitError } from "../errors.js";
 
 export type NodeCtor = abstract new (...args: never[]) => Node;
 type VisitorCtor = typeof Visitor;

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,6 +1,24 @@
 import { Node } from "../nodes/node.js";
 
 /**
+ * Thrown when no visit method is registered for a node's runtime class
+ * (after walking the prototype chain).
+ *
+ * Mirrors the `TypeError` Rails raises in `Arel::Visitors::Visitor#visit`.
+ */
+export class UnsupportedVisitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedVisitError";
+  }
+}
+
+export type NodeCtor = abstract new (...args: never[]) => Node;
+type VisitorCtor = typeof Visitor;
+
+const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
+
+/**
  * Base visitor with class-tagged dispatch.
  *
  * Mirrors: Arel::Visitors::Visitor (activerecord/lib/arel/visitors/visitor.rb).
@@ -13,11 +31,6 @@ import { Node } from "../nodes/node.js";
  * runtime constructor, falling back to the prototype chain (mirroring
  * Ruby's `klass.ancestors` walk).
  */
-type NodeCtor = abstract new (...args: never[]) => Node;
-type VisitorCtor = typeof Visitor;
-
-const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
-
 export abstract class Visitor {
   protected dispatch: Map<NodeCtor, string>;
 
@@ -53,26 +66,35 @@ export abstract class Visitor {
 
   protected visit(object: Node, collector?: unknown): unknown {
     const ctor = object.constructor as NodeCtor;
-    let methodName = this.dispatch.get(ctor);
-    if (!methodName) {
-      let cur: NodeCtor | null = ctor;
-      while (cur) {
-        const proto = Object.getPrototypeOf(cur.prototype) as object | null;
-        const parent = proto?.constructor as NodeCtor | undefined;
-        if (!parent || (parent as unknown) === Object) break;
-        const found = this.dispatch.get(parent);
-        if (found) {
-          methodName = found;
-          this.dispatch.set(ctor, found);
-          break;
-        }
-        cur = parent;
-      }
-    }
+    const methodName = this.resolveDispatch(ctor);
     const fn = methodName ? (this as unknown as Record<string, unknown>)[methodName] : undefined;
     if (typeof fn !== "function") {
-      throw new TypeError(`Cannot visit ${ctor.name}`);
+      throw new UnsupportedVisitError(`Unknown node type: ${ctor.name}`);
     }
     return (fn as (n: Node, c?: unknown) => unknown).call(this, object, collector);
+  }
+
+  /**
+   * Resolve the dispatch method name for `ctor`, walking the JS prototype
+   * chain to find an ancestor's handler when there is no direct entry.
+   * Mirrors Ruby's `klass.ancestors.find { |k| respond_to?(dispatch[k]) }`.
+   * Successful lookups are memoized into the cache, matching Rails.
+   */
+  private resolveDispatch(ctor: NodeCtor): string | undefined {
+    const direct = this.dispatch.get(ctor);
+    if (direct) return direct;
+    let cur: NodeCtor | null = ctor;
+    while (cur) {
+      const proto = Object.getPrototypeOf(cur.prototype) as object | null;
+      const parent = proto?.constructor as NodeCtor | undefined;
+      if (!parent || (parent as unknown) === Object) return undefined;
+      const found = this.dispatch.get(parent);
+      if (found) {
+        this.dispatch.set(ctor, found);
+        return found;
+      }
+      cur = parent;
+    }
+    return undefined;
   }
 }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,11 +1,78 @@
 import { Node } from "../nodes/node.js";
 
+/**
+ * Base visitor with class-tagged dispatch.
+ *
+ * Mirrors: Arel::Visitors::Visitor (activerecord/lib/arel/visitors/visitor.rb).
+ *
+ * Ruby uses `__send__("visit_#{klass.name.gsub('::','_')}")` keyed by the
+ * runtime class. We can't use string-named methods cleanly in TS without
+ * losing typecheck, so we keep camelCase method names and route through an
+ * explicit dispatch table: each `Visitor` subclass populates its own
+ * `dispatchCache` (a `Map<NodeCtor, methodName>`), and `visit` looks up the
+ * runtime constructor, falling back to the prototype chain (mirroring
+ * Ruby's `klass.ancestors` walk).
+ */
+type NodeCtor = abstract new (...args: never[]) => Node;
+type VisitorCtor = typeof Visitor;
+
+const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
+
 export abstract class Visitor {
-  constructor() {}
+  protected dispatch: Map<NodeCtor, string>;
+
+  constructor() {
+    this.dispatch = (this.constructor as VisitorCtor).getDispatchCache();
+  }
 
   accept(object: Node, collector?: unknown): unknown {
     return this.visit(object, collector);
   }
 
-  protected abstract visit(object: Node, collector?: unknown): unknown;
+  /**
+   * Per-class dispatch cache. Each subclass gets its own map seeded from
+   * its parent (mirrors Rails' `@dispatch_cache ||= ...` per-class ivar).
+   */
+  static dispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
+    let cache = PER_CLASS_CACHE.get(this);
+    if (!cache) {
+      const parent = Object.getPrototypeOf(this) as VisitorCtor | null;
+      const inherited =
+        parent && typeof parent.dispatchCache === "function" && parent !== this
+          ? parent.dispatchCache()
+          : undefined;
+      cache = new Map(inherited);
+      PER_CLASS_CACHE.set(this, cache);
+    }
+    return cache;
+  }
+
+  static getDispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
+    return this.dispatchCache();
+  }
+
+  protected visit(object: Node, collector?: unknown): unknown {
+    const ctor = object.constructor as NodeCtor;
+    let methodName = this.dispatch.get(ctor);
+    if (!methodName) {
+      let cur: NodeCtor | null = ctor;
+      while (cur) {
+        const proto = Object.getPrototypeOf(cur.prototype) as object | null;
+        const parent = proto?.constructor as NodeCtor | undefined;
+        if (!parent || (parent as unknown) === Object) break;
+        const found = this.dispatch.get(parent);
+        if (found) {
+          methodName = found;
+          this.dispatch.set(ctor, found);
+          break;
+        }
+        cur = parent;
+      }
+    }
+    const fn = methodName ? (this as unknown as Record<string, unknown>)[methodName] : undefined;
+    if (typeof fn !== "function") {
+      throw new TypeError(`Cannot visit ${ctor.name}`);
+    }
+    return (fn as (n: Node, c?: unknown) => unknown).call(this, object, collector);
+  }
 }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -45,6 +45,8 @@ export abstract class Visitor {
   /**
    * Per-class dispatch cache. Each subclass gets its own map seeded from
    * its parent (mirrors Rails' `@dispatch_cache ||= ...` per-class ivar).
+   *
+   * @internal
    */
   static dispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
     let cache = PER_CLASS_CACHE.get(this);


### PR DESCRIPTION
## Summary

First PR in the path to 100% on `pnpm api:compare --package arel --privates` (currently 638/820 = 77.8%, baseline 635 from #985).

Mirrors `Arel::Visitors::Visitor` (`activerecord/lib/arel/visitors/visitor.rb`) — the `dispatch` / `dispatch_cache` / `get_dispatch_cache` trio that drives every Arel visitor. Ruby uses `__send__("visit_#{klass.name.gsub('::','_')}")` keyed by the runtime class. We can't use string-named methods cleanly in TS without losing typecheck, so we keep camelCase method names and route through an explicit per-subclass dispatch table.

## What changed

- **`visitor.ts`** — `Visitor` is now a real base class with:
  - `static dispatchCache()` — per-class `Map<NodeCtor, methodName>` seeded from the parent's cache (mirrors Rails' `@dispatch_cache ||=` per-class ivar).
  - `protected getDispatchCache()` — instance accessor mirroring Rails' private `get_dispatch_cache`.
  - `protected dispatch` — instance reference to the class's cache.
  - `protected visit()` — looks up `node.constructor` in the cache, falls back to the prototype chain (mirrors Ruby's `klass.ancestors` walk). On miss, throws `UnsupportedVisitError("Unknown node type: X")`.

- **Error contract** — Rails raises a plain `TypeError("Cannot visit #{class}")`. Trails translates that to a named `UnsupportedVisitError extends ArelError` (now living in `packages/arel/src/errors.ts` alongside the other named arel errors). Named classes are idiomatic in TS (callers catch by `instanceof`), and `Visitors.UnsupportedVisitError` was already the public surface before this PR — pinned by `to-sql.test.ts` "unsupported input should raise UnsupportedVisitError". `NotImplementedError` moved to `errors.ts` too and now also extends `ArelError`.

- **`to-sql.ts`** — `ToSql` now `extends Visitor`. The 130-line `instanceof` chain in `visit()` is replaced by a `static {}` block that registers every Node ctor → method-name pair. The registration helper guards at runtime that each method exists on `ToSql.prototype`, so typos/renames fail the moment the module is imported (TS `keyof` can't constrain protected members at compile time).

- **Per-class dispatch wrappers** — added 9 thin methods (`visitGreaterThan`, `visitGreaterThanOrEqual`, `visitLessThan`, `visitLessThanOrEqual`, `visitCount`, `visitSum`, `visitMax`, `visitMin`, `visitAvg`) that delegate to the existing shared helpers (`visitBinaryOp`, `visitAggregate`). Mirrors Rails' per-method form so a downstream dialect visitor can override one operator/aggregate cleanly without forcing the shared helper to widen its signature.

## Why this matters

Subclass dispatch now works automatically: a node subclass of `InfixOperation` will fall back to `visitInfixOperation` via the prototype walk, mirroring Rails' ancestor lookup. The old `instanceof` chain had no such fallback — any new node subclass had to be added to the chain by hand.

The dispatch table is also the seam for the rest of the privates push: subsequent PRs land per-visitor methods without re-touching every call site.

## Coverage

`pnpm tsx scripts/api-compare/compare.ts --package arel --privates`:

| | Before | After |
|---|---|---|
| Overall | 635/820 (77.4%) | **638/820 (77.8%)** |
| `visitors/visitor.rb` | 3/6 | **6/6 ✓** |

`to-sql.rb` / dialect visitors / `dot.rb` are unchanged here — the dispatch infrastructure is the prerequisite, follow-up PRs add the missing visit methods.

## Tests

`packages/arel/src/visitors/visitor.test.ts` (new, 8 tests):
- dispatches to a registered method
- walks the prototype chain to find an ancestor's handler
- walks more than one level up the prototype chain
- memoizes ancestor lookups in the cache
- throws `UnsupportedVisitError` for nodes with no handler (instance + message)
- propagates the collector argument from accept through to the visit method
- each subclass has its own cache seeded from the parent (parent untouched by child registrations)
- a subclass override of the visit method dispatches polymorphically

## Test plan

- [x] `pnpm exec tsc --noEmit -p packages/arel` clean
- [x] `pnpm exec eslint packages/arel/src` clean (Rails-private `@internal` JSDoc tags applied to the now-private members)
- [x] `pnpm exec vitest run packages/arel/` — 1093/1093 passing
- [x] `pnpm exec vitest run packages/activerecord/src/relation packages/activerecord/src/connection-adapters` — 1979/1979 passing (downstream visitor consumers)
- [x] `pnpm tsx scripts/api-compare/compare.ts --package arel --privates` — 638/820, visitor.rb 100%, inheritance 69/69