### PR TITLE
feat(activemodel): port Clusivity privates (delimiter, isInclude, inclusionMethod)

### DIFF
--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -44,7 +44,10 @@ interface ClusivityHost {
  * per validator instance, matching Rails' `||=` semantics.
  */
 export function delimiter(this: ClusivityHost): unknown {
-  if (this._delimiterCache !== undefined) return this._delimiterCache;
+  // Rails `@delimiter ||= ...` re-evaluates if the cached value is
+  // nil/false. Mirror that — only treat a truthy cache as a hit so
+  // null / false / "" recompute on the next call.
+  if (this._delimiterCache) return this._delimiterCache;
   this._delimiterCache = this.options.in ?? this.options.within;
   return this._delimiterCache;
 }
@@ -88,8 +91,21 @@ export function inclusionMethod(_enumerable: unknown): "include?" | "cover?" {
  */
 export function isInclude(this: ClusivityHost, record: unknown, value: unknown): boolean {
   const members = this.resolveValue(record, delimiter.call(this));
+  // Rails: `members.public_send(inclusion_method(members), v)`. Route
+  // through inclusionMethod so the cover-vs-include branch slots in
+  // when a Range type lands without reworking the call path.
+  const method = inclusionMethod(members);
   if (Array.isArray(value)) {
-    return value.every((v) => isMemberOf(members, v));
+    return value.every((v) => testMembership(members, v, method));
+  }
+  return testMembership(members, value, method);
+}
+
+function testMembership(members: unknown, value: unknown, method: "include?" | "cover?"): boolean {
+  if (method === "cover?") {
+    // Range#cover? semantics — start/end endpoint check. No first-class
+    // Range type in TS yet; if/when it lands, dispatch goes here.
+    return isMemberOf(members, value);
   }
   return isMemberOf(members, value);
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -55,7 +55,13 @@ export function delimiter(this: ClusivityHost): unknown {
   ) {
     return this._delimiterCache;
   }
-  this._delimiterCache = this.options.in ?? this.options.within;
+  // Rails: `options[:in] || options[:within]` — Ruby's `||` falls
+  // back when the left side is nil OR false, not just nullish. JS `??`
+  // would cache an explicit `false` and ignore `within`; reproduce
+  // Ruby semantics explicitly.
+  const inOpt = this.options.in;
+  this._delimiterCache =
+    inOpt !== undefined && inOpt !== null && inOpt !== false ? inOpt : this.options.within;
   return this._delimiterCache;
 }
 

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -7,8 +7,10 @@
  * and ExclusionValidator. It provides `check_validity!`, the membership
  * test `include?`, the cached `delimiter` accessor, and the
  * `inclusion_method(enumerable)` selector. In TS we expose each as a
- * `this`-typed function that the validator classes attach as prototype
- * methods (matching Rails' `include Clusivity` mixin shape).
+ * `this`-typed function that the validator classes attach as instance
+ * fields, matching Rails' `include Clusivity` mixin shape on a
+ * per-instance level (not as prototype overrides — these are fixed
+ * Rails helpers, not user-overridable hooks).
  */
 import { resolveValue } from "./resolve-value.js";
 
@@ -93,15 +95,47 @@ export function isInclude(this: ClusivityHost, record: unknown, value: unknown):
 }
 
 function isMemberOf(members: unknown, value: unknown): boolean {
+  if (members === null || members === undefined) return false;
+  // String#include? in Ruby is substring match; JS String#includes matches
+  // when value is also a string.
+  if (typeof members === "string") {
+    return typeof value === "string" && members.includes(value);
+  }
+  // Set / Map both expose .has — for Map this is key membership, matching
+  // Ruby's Hash#include?(key). Custom collections that implement .has
+  // pick up the same fast path.
+  if (members instanceof Set || members instanceof Map) return members.has(value);
+  // Array.includes covers Array; many custom collections also expose
+  // .includes(item) and behave like Rails' #include?.
   if (Array.isArray(members)) return members.includes(value);
-  if (members instanceof Set) return members.has(value);
-  if (members && typeof (members as Iterable<unknown>)[Symbol.iterator] === "function") {
+  const m = members as { includes?: (v: unknown) => boolean; has?: (v: unknown) => boolean };
+  if (typeof m.includes === "function") return m.includes(value);
+  if (typeof m.has === "function") return m.has(value);
+  if (typeof (members as Iterable<unknown>)[Symbol.iterator] === "function") {
     for (const item of members as Iterable<unknown>) {
       if (item === value) return true;
     }
     return false;
   }
   return false;
+}
+
+/**
+ * Rails: `options.except(:in, :within).merge!(value: value)` — passes
+ * through every validator option except the collection keys, with the
+ * rejected value merged in for i18n interpolation
+ * (inclusion.rb:11, exclusion.rb:11).
+ */
+export function exceptInWithinMergeValue(
+  options: Record<string, unknown>,
+  value: unknown,
+): Record<string, unknown> {
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(options)) {
+    if (key !== "in" && key !== "within") rest[key] = options[key];
+  }
+  rest.value = value;
+  return rest;
 }
 
 /**

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -44,10 +44,17 @@ interface ClusivityHost {
  * per validator instance, matching Rails' `||=` semantics.
  */
 export function delimiter(this: ClusivityHost): unknown {
-  // Rails `@delimiter ||= ...` re-evaluates if the cached value is
-  // nil/false. Mirror that — only treat a truthy cache as a hit so
-  // null / false / "" recompute on the next call.
-  if (this._delimiterCache) return this._delimiterCache;
+  // Rails `@delimiter ||= ...` recomputes only when the cached value
+  // is nil or false (Ruby falsiness). JS falsiness is wider — `0` and
+  // `""` are truthy in Ruby but falsy in JS — so use an explicit
+  // nil-or-false sentinel check instead of plain truthiness.
+  if (
+    this._delimiterCache !== undefined &&
+    this._delimiterCache !== null &&
+    this._delimiterCache !== false
+  ) {
+    return this._delimiterCache;
+  }
   this._delimiterCache = this.options.in ?? this.options.within;
   return this._delimiterCache;
 }
@@ -172,15 +179,26 @@ export function checkValidityBang(this: ClusivityHost): void {
   if (d === undefined || d === null) {
     throw new Error(ERROR_MESSAGE);
   }
+  // Symmetric with isMemberOf: anything membership accepts must also
+  // pass validity. String is `respond_to?(:include?)` (substring);
+  // Set/Map expose .has; Array + custom collections via duck-typed
+  // .includes / .has; iterables via the iteration fallback.
+  const isStringIncludable = typeof d === "string";
+  const hasIncludeMethod =
+    typeof d === "object" &&
+    d !== null &&
+    (typeof (d as { includes?: unknown }).includes === "function" ||
+      typeof (d as { has?: unknown }).has === "function");
   const isIterable =
     Array.isArray(d) ||
     d instanceof Set ||
+    d instanceof Map ||
     (typeof d === "object" &&
       d !== null &&
       typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
   const isCallable = typeof d === "function";
   const isSymbolic = typeof d === "string";
-  if (!isIterable && !isCallable && !isSymbolic) {
+  if (!isStringIncludable && !hasIncludeMethod && !isIterable && !isCallable && !isSymbolic) {
     throw new Error(ERROR_MESSAGE);
   }
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -1,83 +1,136 @@
 /**
  * Clusivity — shared logic for inclusion/exclusion validators.
  *
- * Mirrors: ActiveModel::Validations::Clusivity
+ * Mirrors: ActiveModel::Validations::Clusivity (clusivity.rb)
  *
- * In Rails, Clusivity is a module included by both InclusionValidator
- * and ExclusionValidator. It provides check_validity! which ensures
- * the :in option is an enumerable, and the include?/exclude? membership test.
+ * Rails ships Clusivity as a module included by both InclusionValidator
+ * and ExclusionValidator. It provides `check_validity!`, the membership
+ * test `include?`, the cached `delimiter` accessor, and the
+ * `inclusion_method(enumerable)` selector. In TS we expose each as a
+ * `this`-typed function that the validator classes attach as prototype
+ * methods (matching Rails' `include Clusivity` mixin shape).
  */
 import { resolveValue } from "./resolve-value.js";
 
 export { resolveValue };
 
+export const ERROR_MESSAGE =
+  "An object with the method #include? or a proc, lambda or symbol is required, " +
+  "and must be supplied as the :in (or :within) option of the configuration hash";
+
 export interface Clusivity {
   checkValidity(): void;
   resolveValue(record: unknown, value: unknown): unknown;
+  delimiter(): unknown;
+  inclusionMethod(enumerable: unknown): "include?" | "cover?";
+  isInclude(record: unknown, value: unknown): boolean;
 }
 
-export function checkValidityBang(options: { in?: unknown; within?: unknown }): void {
-  checkClusivityValidity(options);
+interface ClusivityHost {
+  options: Record<string, unknown>;
+  resolveValue(record: unknown, value: unknown): unknown;
+  _delimiterCache?: unknown;
 }
 
-export function checkClusivityValidity(options: { in?: unknown; within?: unknown }): void {
-  const collection = options.in ?? options.within;
-  if (collection === undefined || collection === null) {
-    throw new Error(
-      "An :in or :within option must be supplied (either an Array, a Range, or a Proc)",
-    );
-  }
-  if (
-    !Array.isArray(collection) &&
-    typeof collection !== "function" &&
-    !(
-      typeof collection === "object" &&
-      Symbol.iterator in (collection as object) &&
-      typeof (collection as Record<symbol, unknown>)[Symbol.iterator] === "function"
-    )
-  ) {
-    throw new Error(
-      "An :in or :within option must be supplied (either an Array, a Range, or a Proc)",
-    );
-  }
+/**
+ * Mirrors: clusivity.rb:31-33
+ *   def delimiter
+ *     @delimiter ||= options[:in] || options[:within]
+ *   end
+ *
+ * Memoized so a Proc passed as `:in` / `:within` is captured once
+ * per validator instance, matching Rails' `||=` semantics.
+ */
+export function delimiter(this: ClusivityHost): unknown {
+  if (this._delimiterCache !== undefined) return this._delimiterCache;
+  this._delimiterCache = this.options.in ?? this.options.within;
+  return this._delimiterCache;
 }
 
-export function isMember(
-  collection: unknown[] | (() => unknown[]) | Iterable<unknown>,
-  value: unknown,
-): boolean {
-  const resolved = typeof collection === "function" ? collection() : collection;
+/**
+ * Mirrors: clusivity.rb:40-50
+ *
+ *   def inclusion_method(enumerable)
+ *     if enumerable.is_a? Range
+ *       case enumerable.begin || enumerable.end
+ *       when Numeric, Time, DateTime, Date then :cover?
+ *       else :include?
+ *       end
+ *     else
+ *       :include?
+ *     end
+ *   end
+ *
+ * TS has no first-class Range; iterables are treated uniformly as
+ * `include?`. If a Range-like type lands later, the cover-vs-include
+ * branch slots in here.
+ */
+export function inclusionMethod(_enumerable: unknown): "include?" | "cover?" {
+  return "include?";
+}
 
-  // Rails: if value is an array, check that all elements are members
+/**
+ * Mirrors: clusivity.rb:21-29
+ *   def include?(record, value)
+ *     members = resolve_value(record, delimiter)
+ *     if value.is_a?(Array)
+ *       value.all? { |v| members.public_send(inclusion_method(members), v) }
+ *     else
+ *       members.public_send(inclusion_method(members), value)
+ *     end
+ *   end
+ *
+ * `resolve_value` resolves Procs and Symbol-method references; a string
+ * option treated as a method name only if the record responds to it
+ * (resolve-value.ts).
+ */
+export function isInclude(this: ClusivityHost, record: unknown, value: unknown): boolean {
+  const members = this.resolveValue(record, delimiter.call(this));
   if (Array.isArray(value)) {
-    return value.every((v) => isMemberSingle(resolved, v));
+    return value.every((v) => isMemberOf(members, v));
   }
-
-  return isMemberSingle(resolved, value);
+  return isMemberOf(members, value);
 }
 
-export function isExcluded(
-  collection: unknown[] | (() => unknown[]) | Iterable<unknown>,
-  value: unknown,
-): boolean {
-  const resolved = typeof collection === "function" ? collection() : collection;
-
-  // Exclusion: if value is an array, fail when ANY element is in the excluded set
-  if (Array.isArray(value)) {
-    return value.some((v) => isMemberSingle(resolved, v));
+function isMemberOf(members: unknown, value: unknown): boolean {
+  if (Array.isArray(members)) return members.includes(value);
+  if (members instanceof Set) return members.has(value);
+  if (members && typeof (members as Iterable<unknown>)[Symbol.iterator] === "function") {
+    for (const item of members as Iterable<unknown>) {
+      if (item === value) return true;
+    }
+    return false;
   }
-
-  return isMemberSingle(resolved, value);
-}
-
-function isMemberSingle(resolved: unknown[] | Iterable<unknown>, value: unknown): boolean {
-  if (Array.isArray(resolved)) return resolved.includes(value);
-
-  if (resolved instanceof Set) return resolved.has(value);
-
-  for (const item of resolved as Iterable<unknown>) {
-    if (item === value) return true;
-  }
-
   return false;
+}
+
+/**
+ * Mirrors: clusivity.rb:14-18
+ *   def check_validity!
+ *     unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
+ *       raise ArgumentError, ERROR_MESSAGE
+ *     end
+ *   end
+ *
+ * TS analogues for the three Ruby duck checks:
+ * - `respond_to?(:include?)` ↔ array / iterable / Set
+ * - `respond_to?(:call)` ↔ function
+ * - `respond_to?(:to_sym)` ↔ string (resolved via resolveValue at call time)
+ */
+export function checkValidityBang(this: ClusivityHost): void {
+  const d = delimiter.call(this);
+  if (d === undefined || d === null) {
+    throw new Error(ERROR_MESSAGE);
+  }
+  const isIterable =
+    Array.isArray(d) ||
+    d instanceof Set ||
+    (typeof d === "object" &&
+      d !== null &&
+      typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
+  const isCallable = typeof d === "function";
+  const isSymbolic = typeof d === "string";
+  if (!isIterable && !isCallable && !isSymbolic) {
+    throw new Error(ERROR_MESSAGE);
+  }
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -133,7 +133,15 @@ function testMembership(members: unknown, value: unknown, method: "include?" | "
 }
 
 function isMemberOf(members: unknown, value: unknown): boolean {
-  if (members === null || members === undefined) return false;
+  // Rails: nil.include?(value) raises NoMethodError. A Proc that returns
+  // nil from resolve_value would surface a misconfigured validator
+  // loudly. Mirror that — silent `return false` would convert a config
+  // bug into a routine validation failure.
+  if (members === null || members === undefined) {
+    throw new TypeError(
+      `inclusion/exclusion: :in or :within resolved to ${members === null ? "null" : "undefined"}`,
+    );
+  }
   // String#include? in Ruby is substring match; JS String#includes matches
   // when value is also a string.
   if (typeof members === "string") {

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -7,10 +7,13 @@
  * and ExclusionValidator. It provides `check_validity!`, the membership
  * test `include?`, the cached `delimiter` accessor, and the
  * `inclusion_method(enumerable)` selector. In TS we expose each as a
- * `this`-typed function that the validator classes attach as instance
- * fields, matching Rails' `include Clusivity` mixin shape on a
- * per-instance level (not as prototype overrides — these are fixed
- * Rails helpers, not user-overridable hooks).
+ * `this`-typed function that the validator classes attach to their
+ * prototypes (see InclusionValidator.prototype.* / ExclusionValidator
+ * .prototype.* assignments in inclusion.ts / exclusion.ts). Prototype
+ * placement matters because `EachValidator`'s constructor calls
+ * `this.checkValidity()` before subclass class fields initialize — and
+ * because subclass overrides should be honored, matching Rails' Ruby
+ * method-lookup semantics.
  */
 import { resolveValue } from "./resolve-value.js";
 
@@ -191,11 +194,13 @@ export function checkValidityBang(this: ClusivityHost): void {
   if (d === undefined || d === null) {
     throw new Error(ERROR_MESSAGE);
   }
-  // Symmetric with isMemberOf: anything membership accepts must also
-  // pass validity. String is `respond_to?(:include?)` (substring);
-  // Set/Map expose .has; Array + custom collections via duck-typed
-  // .includes / .has; iterables via the iteration fallback.
-  const isStringIncludable = typeof d === "string";
+  // Symmetric with isMemberOf — anything membership accepts must also
+  // pass validity. Maps Ruby duck checks to TS analogues:
+  //   respond_to?(:include?) ↔ string (substring), Array, Set, iterable,
+  //                            custom .includes / .has
+  //   respond_to?(:call)     ↔ function
+  //   respond_to?(:to_sym)   ↔ string (resolved via resolveValue at call time)
+  const isString = typeof d === "string";
   const hasIncludeMethod =
     typeof d === "object" &&
     d !== null &&
@@ -209,8 +214,7 @@ export function checkValidityBang(this: ClusivityHost): void {
       d !== null &&
       typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
   const isCallable = typeof d === "function";
-  const isSymbolic = typeof d === "string";
-  if (!isStringIncludable && !hasIncludeMethod && !isIterable && !isCallable && !isSymbolic) {
+  if (!isString && !hasIncludeMethod && !isIterable && !isCallable) {
     throw new Error(ERROR_MESSAGE);
   }
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -31,6 +31,8 @@ export interface Clusivity {
 interface ClusivityHost {
   options: Record<string, unknown>;
   resolveValue(record: unknown, value: unknown): unknown;
+  delimiter(): unknown;
+  inclusionMethod(enumerable: unknown): "include?" | "cover?";
   _delimiterCache?: unknown;
 }
 
@@ -103,11 +105,15 @@ export function inclusionMethod(_enumerable: unknown): "include?" | "cover?" {
  * (resolve-value.ts).
  */
 export function isInclude(this: ClusivityHost, record: unknown, value: unknown): boolean {
-  const members = this.resolveValue(record, delimiter.call(this));
-  // Rails: `members.public_send(inclusion_method(members), v)`. Route
-  // through inclusionMethod so the cover-vs-include branch slots in
-  // when a Range type lands without reworking the call path.
-  const method = inclusionMethod(members);
+  // Route through `this.delimiter()` / `this.inclusionMethod(...)` so
+  // a subclass that overrides either gets the same dispatch Rails'
+  // Ruby method lookup would give it. Direct calls to the free
+  // functions would bypass overrides.
+  const members = this.resolveValue(record, this.delimiter());
+  // Rails: `members.public_send(inclusion_method(members), v)`. The
+  // cover-vs-include branch slots in via inclusionMethod when a Range
+  // type lands without reworking the call path.
+  const method = this.inclusionMethod(members);
   if (Array.isArray(value)) {
     return value.every((v) => testMembership(members, v, method));
   }
@@ -181,7 +187,7 @@ export function exceptInWithinMergeValue(
  * - `respond_to?(:to_sym)` ↔ string (resolved via resolveValue at call time)
  */
 export function checkValidityBang(this: ClusivityHost): void {
-  const d = delimiter.call(this);
+  const d = this.delimiter();
   if (d === undefined || d === null) {
     throw new Error(ERROR_MESSAGE);
   }

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -3,6 +3,7 @@ import type { AnyRecord } from "../validator.js";
 import {
   checkValidityBang,
   delimiter,
+  exceptInWithinMergeValue,
   inclusionMethod,
   isInclude,
   resolveValue,
@@ -20,6 +21,10 @@ import {
  *       end
  *     end
  *   end
+ *
+ * `nil`/`undefined` are NOT pre-skipped here — Rails relies on
+ * EachValidator's allow_nil dispatch (validator.ts:100) so excluding
+ * `nil` works when the excluded set explicitly contains it.
  */
 export class ExclusionValidator extends EachValidator {
   resolveValue = resolveValue;
@@ -32,22 +37,8 @@ export class ExclusionValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (this.options.allowNil !== false && (value === null || value === undefined)) return;
     if (this.isInclude(record, value)) {
-      record.errors.add(attribute, "exclusion", exclusionErrorOptions(this.options, value));
+      record.errors.add(attribute, "exclusion", exceptInWithinMergeValue(this.options, value));
     }
   }
-}
-
-function exclusionErrorOptions(
-  options: Record<string, unknown>,
-  value: unknown,
-): Record<string, unknown> {
-  // Rails: options.except(:in, :within).merge!(value: value)
-  const rest: Record<string, unknown> = {};
-  for (const key of Object.keys(options)) {
-    if (key !== "in" && key !== "within") rest[key] = options[key];
-  }
-  rest.value = value;
-  return rest;
 }

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -27,10 +27,14 @@ import {
  * `nil` works when the excluded set explicitly contains it.
  */
 export class ExclusionValidator extends EachValidator {
-  resolveValue = resolveValue;
-  delimiter = delimiter;
-  inclusionMethod = inclusionMethod;
-  isInclude = isInclude;
+  // Declarations only — actual functions attached to the prototype below.
+  // Prototype attachment (not class fields) so the Clusivity helpers are
+  // available during super() / EachValidator's constructor-time
+  // checkValidity() call.
+  declare resolveValue: typeof resolveValue;
+  declare delimiter: typeof delimiter;
+  declare inclusionMethod: typeof inclusionMethod;
+  declare isInclude: typeof isInclude;
 
   override checkValidity(): void {
     checkValidityBang.call(this);
@@ -42,3 +46,8 @@ export class ExclusionValidator extends EachValidator {
     }
   }
 }
+
+ExclusionValidator.prototype.resolveValue = resolveValue;
+ExclusionValidator.prototype.delimiter = delimiter;
+ExclusionValidator.prototype.inclusionMethod = inclusionMethod;
+ExclusionValidator.prototype.isInclude = isInclude;

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -1,25 +1,53 @@
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
-import { isExcluded, checkClusivityValidity } from "./clusivity.js";
-import { resolveValue } from "./resolve-value.js";
+import {
+  checkValidityBang,
+  delimiter,
+  inclusionMethod,
+  isInclude,
+  resolveValue,
+} from "./clusivity.js";
 
+/**
+ * Mirrors: ActiveModel::Validations::ExclusionValidator (exclusion.rb)
+ *
+ *   class ExclusionValidator < EachValidator
+ *     include Clusivity
+ *     def validate_each(record, attribute, value)
+ *       if include?(record, value)
+ *         record.errors.add(attribute, :exclusion,
+ *           **options.except(:in, :within).merge!(value: value))
+ *       end
+ *     end
+ *   end
+ */
 export class ExclusionValidator extends EachValidator {
   resolveValue = resolveValue;
+  delimiter = delimiter;
+  inclusionMethod = inclusionMethod;
+  isInclude = isInclude;
 
   override checkValidity(): void {
-    checkClusivityValidity(this.options);
+    checkValidityBang.call(this);
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (this.options.allowNil !== false && (value === null || value === undefined)) return;
-    const inOpt = (this.options.in ?? this.options.within) as
-      | Iterable<unknown>
-      | (() => Iterable<unknown>)
-      | undefined;
-    if (!inOpt) return;
-    const collection = typeof inOpt === "function" ? inOpt() : inOpt;
-    if (isExcluded(collection, value)) {
-      record.errors.add(attribute, "exclusion", { value, message: this.options.message });
+    if (this.isInclude(record, value)) {
+      record.errors.add(attribute, "exclusion", exclusionErrorOptions(this.options, value));
     }
   }
+}
+
+function exclusionErrorOptions(
+  options: Record<string, unknown>,
+  value: unknown,
+): Record<string, unknown> {
+  // Rails: options.except(:in, :within).merge!(value: value)
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(options)) {
+    if (key !== "in" && key !== "within") rest[key] = options[key];
+  }
+  rest.value = value;
+  return rest;
 }

--- a/packages/activemodel/src/validations/inclusion-validation.test.ts
+++ b/packages/activemodel/src/validations/inclusion-validation.test.ts
@@ -80,13 +80,16 @@ describe("InclusionValidationTest", () => {
   });
 
   it("validates inclusion of with allow nil", () => {
+    // Mirrors Rails inclusion_validation_test.rb:100-106 — allow_nil: true
+    // skips nil; non-nil values still validate against the set.
     class Person extends Model {
       static {
         this.attribute("karma", "string");
-        this.validates("karma", { inclusion: { in: ["ow", "ar"] } });
+        this.validates("karma", { inclusion: { in: ["ow", "ar"], allowNil: true } });
       }
     }
     expect(new Person({}).isValid()).toBe(true);
+    expect(new Person({ karma: "nope" }).isValid()).toBe(false);
   });
 
   it("validates inclusion of with formatted message", () => {

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -1,25 +1,53 @@
 import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
-import { isMember, checkClusivityValidity } from "./clusivity.js";
-import { resolveValue } from "./resolve-value.js";
+import {
+  checkValidityBang,
+  delimiter,
+  inclusionMethod,
+  isInclude,
+  resolveValue,
+} from "./clusivity.js";
 
+/**
+ * Mirrors: ActiveModel::Validations::InclusionValidator (inclusion.rb)
+ *
+ *   class InclusionValidator < EachValidator
+ *     include Clusivity
+ *     def validate_each(record, attribute, value)
+ *       unless include?(record, value)
+ *         record.errors.add(attribute, :inclusion,
+ *           **options.except(:in, :within).merge!(value: value))
+ *       end
+ *     end
+ *   end
+ */
 export class InclusionValidator extends EachValidator {
   resolveValue = resolveValue;
+  delimiter = delimiter;
+  inclusionMethod = inclusionMethod;
+  isInclude = isInclude;
 
   override checkValidity(): void {
-    checkClusivityValidity(this.options);
+    checkValidityBang.call(this);
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
     if (this.options.allowNil !== false && (value === null || value === undefined)) return;
-    const inOpt = (this.options.in ?? this.options.within) as
-      | Iterable<unknown>
-      | (() => Iterable<unknown>)
-      | undefined;
-    if (!inOpt) return;
-    const collection = typeof inOpt === "function" ? inOpt() : inOpt;
-    if (!isMember(collection, value)) {
-      record.errors.add(attribute, "inclusion", { value, message: this.options.message });
+    if (!this.isInclude(record, value)) {
+      record.errors.add(attribute, "inclusion", inclusionErrorOptions(this.options, value));
     }
   }
+}
+
+function inclusionErrorOptions(
+  options: Record<string, unknown>,
+  value: unknown,
+): Record<string, unknown> {
+  // Rails: options.except(:in, :within).merge!(value: value)
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(options)) {
+    if (key !== "in" && key !== "within") rest[key] = options[key];
+  }
+  rest.value = value;
+  return rest;
 }

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -27,10 +27,15 @@ import {
  * keeps its Rails-faithful "only skip when allow_nil: true" semantics.
  */
 export class InclusionValidator extends EachValidator {
-  resolveValue = resolveValue;
-  delimiter = delimiter;
-  inclusionMethod = inclusionMethod;
-  isInclude = isInclude;
+  // Declarations only — actual functions attached to the prototype below.
+  // Prototype attachment (not class fields) so the Clusivity helpers are
+  // available during super() / EachValidator's constructor-time
+  // checkValidity() call. Class fields don't initialize until AFTER
+  // super() returns.
+  declare resolveValue: typeof resolveValue;
+  declare delimiter: typeof delimiter;
+  declare inclusionMethod: typeof inclusionMethod;
+  declare isInclude: typeof isInclude;
 
   override checkValidity(): void {
     checkValidityBang.call(this);
@@ -42,3 +47,8 @@ export class InclusionValidator extends EachValidator {
     }
   }
 }
+
+InclusionValidator.prototype.resolveValue = resolveValue;
+InclusionValidator.prototype.delimiter = delimiter;
+InclusionValidator.prototype.inclusionMethod = inclusionMethod;
+InclusionValidator.prototype.isInclude = isInclude;

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -3,6 +3,7 @@ import type { AnyRecord } from "../validator.js";
 import {
   checkValidityBang,
   delimiter,
+  exceptInWithinMergeValue,
   inclusionMethod,
   isInclude,
   resolveValue,
@@ -20,6 +21,10 @@ import {
  *       end
  *     end
  *   end
+ *
+ * `nil`/`undefined` are NOT pre-skipped here — Rails relies on
+ * EachValidator's allow_nil dispatch (validator.ts:100) so the option
+ * keeps its Rails-faithful "only skip when allow_nil: true" semantics.
  */
 export class InclusionValidator extends EachValidator {
   resolveValue = resolveValue;
@@ -32,22 +37,8 @@ export class InclusionValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (this.options.allowNil !== false && (value === null || value === undefined)) return;
     if (!this.isInclude(record, value)) {
-      record.errors.add(attribute, "inclusion", inclusionErrorOptions(this.options, value));
+      record.errors.add(attribute, "inclusion", exceptInWithinMergeValue(this.options, value));
     }
   }
-}
-
-function inclusionErrorOptions(
-  options: Record<string, unknown>,
-  value: unknown,
-): Record<string, unknown> {
-  // Rails: options.except(:in, :within).merge!(value: value)
-  const rest: Record<string, unknown> = {};
-  for (const key of Object.keys(options)) {
-    if (key !== "in" && key !== "within") rest[key] = options[key];
-  }
-  rest.value = value;
-  return rest;
 }


### PR DESCRIPTION
## Summary
Track A1 of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md). Mirrors `ActiveModel::Validations::Clusivity` (Rails `clusivity.rb`) verbatim:

- `ERROR_MESSAGE` — the canonical Rails error string.
- `delimiter()` — `clusivity.rb:31-33`. Memoized per validator instance via `_delimiterCache` with explicit Ruby-`||=` semantics (re-evaluates on `null`/`undefined`/`false`, not JS truthiness — `0` and `""` cache correctly). The fallback uses Ruby-`||` semantics too, so `options.in === false` falls through to `options.within`.
- `inclusionMethod(enumerable)` — `clusivity.rb:40-50`. Returns `"include?"` today; the Range cover-vs-include branch slots in cleanly when a TS Range type lands.
- `isInclude(record, value)` — `clusivity.rb:21-29`. Calls `this.resolveValue(record, this.delimiter())` — closes the `resolveValue` consumption gap flagged for Clusivity in PR #971. Routes through `this.delimiter()` / `this.inclusionMethod(...)` so subclass overrides are honored (Rails Ruby method-lookup semantics).
- `checkValidityBang()` — `clusivity.rb:14-18`. Symmetric with `isMemberOf`: accepts string (substring), Set/Map (`.has`), Array, duck-typed `.includes`/`.has`, generic iterables, and callables.
- `isMemberOf` throws `TypeError` when the resolved members value is `null`/`undefined` (matches Rails' loud `nil.include?` `NoMethodError` instead of silently returning `false`).
- Shared `exceptInWithinMergeValue(options, value)` helper for the Rails error-payload shape.

`InclusionValidator` and `ExclusionValidator` attach the four privates to their **prototypes** (not class fields) so the helpers are present during `EachValidator`'s constructor-time `checkValidity()` call. Class fields would be `undefined` at that point — caused a CI failure that surfaced and was fixed in commit `84fa7836`. They route their dispatch through `this.isInclude(record, value)` per `inclusion.rb:11` / `exclusion.rb:11`. Error payload uses `options.except(:in, :within).merge!(value: value)`.

Drops the trails-specific top-level helpers (`checkClusivityValidity`, `isMember`, `isExcluded`) — only `inclusion.ts` and `exclusion.ts` consumed them, and both now go through the Clusivity mixin.

## Impact
- `pnpm api:compare --privates --package activemodel`:
  - `clusivity.rb` 2/5 → **5/5 (100%)**
  - `inclusion.rb` 3/6 → **6/6 (100%)**
  - `exclusion.rb` 3/6 → **6/6 (100%)**
  - Overall +13 privates closed: 454/607 (74.8%) → **467/607 (76.9%)**.
- `pnpm api:compare --package activemodel`: stays **433/433 (100%)** — no public regression.
- `pnpm test:compare --package activemodel`: stays 959/963 (no change).

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1592 / 1592 passing
- [x] `pnpm api:compare --package activemodel` — 433/433
- [x] `pnpm api:compare --privates --package activemodel` — 467/607 (+13)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)

## Copilot review history (9 rounds, converged round 9)

Round 9 produced no new comments — review loop converged. Resolved over the prior rounds:

- **Round 1** — `isMemberOf` Rails-faithful for String (substring) / Map (key membership) / duck-typed `.includes`/`.has` collections; header comment matched actual attachment shape; dropped inverted `allowNil` pre-skip in inclusion/exclusion (rely on `EachValidator`'s `allow_nil` dispatch); updated `validates inclusion of with allow nil` test body to mirror `inclusion_validation_test.rb:100-106` (`allow_nil: true`); extracted shared `exceptInWithinMergeValue` helper.
- **Round 2** — `delimiter` memo only treats truthy cache as a hit (precursor); `isInclude` routes through `inclusionMethod(members)` and `testMembership` so the cover-vs-include branch slots in cleanly.
- **Round 3** — `delimiter` memo uses explicit `!== undefined && !== null && !== false` (Ruby `||=` semantics — `0` and `""` are truthy in Ruby); `checkValidityBang` accepts the same shapes `isMemberOf` does (symmetric duck-type).
- **Round 4** — `delimiter` fallback uses Ruby `||` semantics (`undefined`/`null`/`false` → fallback) instead of JS `??`, so `options.in === false` falls through to `options.within`.
- **Round 5** — Routed `isInclude` and `checkValidityBang` through `this.delimiter()` / `this.inclusionMethod(...)` so subclass overrides are honored.
- **Round 6** — Same flag as a CI failure (3 comments, all the bootstrapping bug). **Fixed via prototype attachment** — switching from `delimiter = delimiter` class fields to `InclusionValidator.prototype.delimiter = delimiter` so helpers are available during `super()` / constructor-time `checkValidity()`. `declare` typings keep public type contract.
- **Round 7** — Header comment matches prototype attachment; collapsed duplicate `typeof === "string"` checks in `checkValidityBang`.
- **Round 8** — `isMemberOf` throws `TypeError` on `null`/`undefined` members (Rails `nil.include?` raises `NoMethodError`).
- **Round 9** — No new comments — converged.

Ready for human review.