### PR TITLE
feat(activerecord): wire initializeInternalsCallback into Base constructor

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2141,12 +2141,33 @@ export class Base extends Model {
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
     } else {
-      super(attrs);
-      // Mirrors Rails Core#initialize: initialize_internals_callback fires
-      // for new records only (not _instantiate, which suppresses via flag).
-      if (!(new.target as typeof Base | undefined)?._suppressInitializeCallback) {
+      // For the regular (non-multiparameter) path, mirror the multiparameter
+      // pattern: suppress after_initialize during super() so we can call
+      // initialize_internals_callback first, then fire after_initialize.
+      // This matches Rails' Core#initialize order:
+      //   init_internals → initialize_internals_callback → super → after_initialize
+      const ctor2 = new.target as typeof Base;
+      const suppressor2 = ctor2 as typeof ctor2 & { _suppressInitializeCallback?: boolean };
+      const hadOwn2 = Object.prototype.hasOwnProperty.call(
+        suppressor2,
+        "_suppressInitializeCallback",
+      );
+      const wasSuppressed2 = suppressor2._suppressInitializeCallback;
+      suppressor2._suppressInitializeCallback = true;
+      try {
+        super(attrs);
+      } finally {
+        if (hadOwn2) {
+          suppressor2._suppressInitializeCallback = wasSuppressed2;
+        } else {
+          delete (suppressor2 as { _suppressInitializeCallback?: boolean })
+            ._suppressInitializeCallback;
+        }
+      }
+      if (!wasSuppressed2) {
         inheritanceInitializeInternalsCallback.call(this as any);
         scopingInitializeInternalsCallback.call(this as any);
+        ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
     }
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -25,6 +25,7 @@ import {
   primaryAbstractClass,
   stiClassFor,
   polymorphicClassFor,
+  initializeInternalsCallback as inheritanceInitializeInternalsCallback,
 } from "./inheritance.js";
 import {
   NotImplementedError,
@@ -146,7 +147,10 @@ import * as _EnumModule from "./enum.js";
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
-import { ScopeRegistry } from "./scoping.js";
+import {
+  ScopeRegistry,
+  initializeInternalsCallback as scopingInitializeInternalsCallback,
+} from "./scoping.js";
 import {
   transaction as _transaction,
   currentTransactionPublic as _currentTransactionPublic,
@@ -2129,12 +2133,21 @@ export class Base extends Model {
       executeMultiparameterAssignment(this as any, multiparams);
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
-      // Now fire after_initialize with all attrs assembled.
       if (!wasSuppressed) {
+        // Mirrors Rails Core#initialize: initialize_internals_callback fires
+        // for new records after attributes are assigned (before after_initialize).
+        inheritanceInitializeInternalsCallback.call(this as any);
+        scopingInitializeInternalsCallback.call(this as any);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
     } else {
       super(attrs);
+      // Mirrors Rails Core#initialize: initialize_internals_callback fires
+      // for new records only (not _instantiate, which suppresses via flag).
+      if (!(new.target as typeof Base | undefined)?._suppressInitializeCallback) {
+        inheritanceInitializeInternalsCallback.call(this as any);
+        scopingInitializeInternalsCallback.call(this as any);
+      }
     }
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2138,6 +2138,9 @@ export class Base extends Model {
         // for new records after attributes are assigned (before after_initialize).
         inheritanceInitializeInternalsCallback.call(this as any);
         scopingInitializeInternalsCallback.call(this as any);
+        // Re-snapshot so internals writes (STI type, scope attrs) are treated
+        // as initial clean state, not as dirty changes.
+        (this as any)._dirty.snapshot((this as any)._attributes);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
     } else {
@@ -2167,6 +2170,9 @@ export class Base extends Model {
       if (!wasSuppressed2) {
         inheritanceInitializeInternalsCallback.call(this as any);
         scopingInitializeInternalsCallback.call(this as any);
+        // Re-snapshot so internals writes (STI type, scope attrs) are treated
+        // as initial clean state, not as dirty changes.
+        (this as any)._dirty.snapshot((this as any)._attributes);
         ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -147,10 +147,7 @@ import * as _EnumModule from "./enum.js";
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
-import {
-  ScopeRegistry,
-  initializeInternalsCallback as scopingInitializeInternalsCallback,
-} from "./scoping.js";
+import { ScopeRegistry } from "./scoping.js";
 import {
   transaction as _transaction,
   currentTransactionPublic as _currentTransactionPublic,
@@ -2134,12 +2131,12 @@ export class Base extends Model {
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
       if (!wasSuppressed) {
-        // Mirrors Rails Core#initialize: initialize_internals_callback fires
-        // for new records after attributes are assigned (before after_initialize).
+        // Fire initialize_internals_callback after attribute assignment and
+        // before after_initialize. Scope attribute precedence is already handled
+        // by _mergeCurrentScopeAttrs in the class-level new/create methods, so
+        // only the inheritance callback (STI type column) is called here.
         inheritanceInitializeInternalsCallback.call(this as any);
-        scopingInitializeInternalsCallback.call(this as any);
-        // Re-snapshot so internals writes (STI type, scope attrs) are treated
-        // as initial clean state, not as dirty changes.
+        // Re-snapshot so the STI type write is part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
@@ -2169,9 +2166,7 @@ export class Base extends Model {
       }
       if (!wasSuppressed2) {
         inheritanceInitializeInternalsCallback.call(this as any);
-        scopingInitializeInternalsCallback.call(this as any);
-        // Re-snapshot so internals writes (STI type, scope attrs) are treated
-        // as initial clean state, not as dirty changes.
+        // Re-snapshot so the STI type write is part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2072,3 +2072,41 @@ describe("ensureProperType / initializeInternalsCallback", () => {
     expect((car as any).readAttribute("type")).toBe("Car");
   });
 });
+
+describe("Base constructor wires initializeInternalsCallback", () => {
+  it("new STI subclass instance auto-sets the type column", async () => {
+    const { enableSti } = await import("./inheritance.js");
+    class Vehicle extends Base {
+      static {
+        this._tableName = "vehicles";
+        this.attribute("type", "string");
+      }
+    }
+    enableSti(Vehicle);
+    class Car extends Vehicle {}
+
+    const car = new Car({});
+    // type column should be set immediately on construction — no save needed
+    expect(car.readAttribute("type")).toBe("Car");
+  });
+
+  it("_instantiate (DB hydration) does NOT fire initializeInternalsCallback", async () => {
+    const { enableSti } = await import("./inheritance.js");
+    const adapter = createTestAdapter();
+    class Vehicle extends Base {
+      static {
+        this._tableName = "vehicles";
+        this.attribute("id", "integer");
+        this.attribute("type", "string");
+        this.adapter = adapter;
+      }
+    }
+    enableSti(Vehicle);
+    class Car extends Vehicle {}
+
+    // Hydrate a record as if loaded from DB — should preserve the row value,
+    // not overwrite it with the class name.
+    const record = Vehicle._instantiate({ id: 1, type: "Truck" }) as any;
+    expect(record.readAttribute("type")).toBe("Truck");
+  });
+});

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2102,11 +2102,11 @@ describe("Base constructor wires initializeInternalsCallback", () => {
       }
     }
     enableSti(Vehicle);
-    class Car extends Vehicle {}
 
-    // Hydrate a record as if loaded from DB — should preserve the row value,
-    // not overwrite it with the class name.
-    const record = Vehicle._instantiate({ id: 1, type: "Truck" }) as any;
-    expect(record.readAttribute("type")).toBe("Truck");
+    // Use type: "Vehicle" so STI discrimination routes back to Vehicle itself —
+    // no subclass lookup, so no SubclassNotFound. The value should be preserved
+    // as-is from the DB row, not overwritten by initializeInternalsCallback.
+    const record = Vehicle._instantiate({ id: 1, type: "Vehicle" }) as any;
+    expect(record.readAttribute("type")).toBe("Vehicle");
   });
 });


### PR DESCRIPTION
Deferred from #949. Rails' `Core#initialize` calls `initialize_internals_callback` for new records after attribute assignment but before `_run_initialize_callbacks` (after_initialize). Until now, `ensureProperType` was exposed as a helper but never called automatically during construction.

## What this does

Wires `inheritanceInitializeInternalsCallback` (sets the STI type column on new subclass instances) into the Base constructor, called after `super()` for new records when `_suppressInitializeCallback` is false.

- `_instantiate` (loading from DB) sets `_suppressInitializeCallback = true`, so the callback doesn't fire for persisted records — matching Rails' `init_with_attributes` which skips `initialize_internals_callback`
- Both multiparameter and regular attribute paths covered
- Dirty state re-snapshotted after the callback so the STI type write is part of the initial clean state
- `_suppressInitializeCallback` pattern mirrors the multiparameter path so `after_initialize` fires in the correct order

## Scoping

Scope attribute population (`populateWithCurrentScopeAttributes`) is NOT wired here. Scope attribute precedence is already correctly handled by `_mergeCurrentScopeAttrs` in the class-level `new`/`create` methods (`{ ...scopeAttrs, ...attrs }` — explicit attrs win). Calling the scoping callback after `super(attrs)` would incorrectly overwrite explicit attributes with scope attributes.

## Impact

`new Car()` now automatically sets `car.type = "Car"` without requiring a `save()` call — matching Rails STI behavior.