### PR TITLE
feat(activerecord): implement store private helpers (readStoreAttribute, writeStoreAttribute, storeAccessorFor)

### DIFF
--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -814,19 +814,19 @@ describe("store private helpers — tested through public accessor API", () => {
     expect((user as any).theme).toBe("light");
   });
 
-  it("store accessor for hstore column uses StringKeyedHashAccessor (type-configured)", () => {
+  it("store accessor delegates through readStoreAttribute/writeStoreAttribute pipeline", () => {
     class Post extends Base {
       static {
         this._tableName = "posts";
         this.attribute("id", "integer");
-        this.attribute("properties", "hstore");
+        this.attribute("settings", "string");
         this.adapter = adapter;
       }
     }
     registerModel(Post);
-    store(Post, "properties", { accessors: ["color"] });
-    // hstore stores string keys — string coercion should be transparent
-    const post = new Post({});
+    store(Post, "settings", { accessors: ["color"] });
+    const post = new Post({ settings: JSON.stringify({ color: "blue" }) });
+    expect((post as any).color).toBe("blue");
     (post as any).color = "red";
     expect((post as any).color).toBe("red");
   });

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -845,3 +845,45 @@ describe("storeAccessorFor, readStoreAttribute, writeStoreAttribute", () => {
     );
   });
 });
+
+describe("storeAccessorFor uses type-configured accessor", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  it("returns StringKeyedHashAccessor for hstore-typed column", async () => {
+    const { storeAccessorFor, StringKeyedHashAccessor } = await import("./store.js");
+    class Post extends Base {
+      static {
+        this._tableName = "posts";
+        this.attribute("id", "integer");
+        this.attribute("properties", "hstore");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(Post);
+    store(Post, "properties", { accessors: ["color"] });
+    const accessor = storeAccessorFor(Post, "properties");
+    expect(accessor).toBe(StringKeyedHashAccessor);
+  });
+});
+
+describe("asRegularHash", () => {
+  it("converts HashWithIndifferentAccess via toHash(), not spread", async () => {
+    const { asRegularHash } = await import("./store.js");
+    const { HashWithIndifferentAccess } = await import("@blazetrails/activesupport");
+    const hwia = new HashWithIndifferentAccess({ foo: "bar", baz: 42 });
+    const result = asRegularHash(hwia);
+    expect(result).toEqual({ foo: "bar", baz: 42 });
+    expect(result).not.toBeInstanceOf(HashWithIndifferentAccess);
+  });
+
+  it("returns a plain object copy when given a regular object", async () => {
+    const { asRegularHash } = await import("./store.js");
+    const obj = { a: 1, b: "two" };
+    const result = asRegularHash(obj);
+    expect(result).toEqual({ a: 1, b: "two" });
+    expect(result).not.toBe(obj);
+  });
+});

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -776,3 +776,72 @@ describe("StoreTest", () => {
     expect((reloaded as any).color).toBe("green");
   });
 });
+
+describe("storeAccessorFor, readStoreAttribute, writeStoreAttribute", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  it("storeAccessorFor raises ConfigurationError for undeclared store column", async () => {
+    const { storeAccessorFor } = await import("./store.js");
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("settings", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(User);
+    expect(() => storeAccessorFor(User, "settings")).toThrow(/has not been configured as a store/);
+  });
+
+  it("readStoreAttribute reads a key from a declared store column", async () => {
+    const { readStoreAttribute } = await import("./store.js");
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("settings", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(User);
+    store(User, "settings", { accessors: ["theme"] });
+    const user = new User({ settings: JSON.stringify({ theme: "dark" }) });
+    expect(readStoreAttribute(user, "settings", "theme")).toBe("dark");
+  });
+
+  it("writeStoreAttribute writes a key to a declared store column", async () => {
+    const { writeStoreAttribute, readStoreAttribute } = await import("./store.js");
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("settings", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(User);
+    store(User, "settings", { accessors: ["theme"] });
+    const user = new User({});
+    writeStoreAttribute(user, "settings", "theme", "light");
+    expect(readStoreAttribute(user, "settings", "theme")).toBe("light");
+  });
+
+  it("storeAccessorFor does not misidentify prototype properties as declared stores", async () => {
+    const { storeAccessorFor } = await import("./store.js");
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.adapter = adapter;
+      }
+    }
+    registerModel(User);
+    expect(() => storeAccessorFor(User, "toString")).toThrow(/has not been configured as a store/);
+    expect(() => storeAccessorFor(User, "constructor")).toThrow(
+      /has not been configured as a store/,
+    );
+  });
+});

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -777,28 +777,13 @@ describe("StoreTest", () => {
   });
 });
 
-describe("storeAccessorFor, readStoreAttribute, writeStoreAttribute", () => {
+describe("store private helpers — tested through public accessor API", () => {
   let adapter: DatabaseAdapter;
   beforeEach(() => {
     adapter = createTestAdapter();
   });
 
-  it("storeAccessorFor raises ConfigurationError for undeclared store column", async () => {
-    const { storeAccessorFor } = await import("./store.js");
-    class User extends Base {
-      static {
-        this._tableName = "users";
-        this.attribute("id", "integer");
-        this.attribute("settings", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(User);
-    expect(() => storeAccessorFor(User, "settings")).toThrow(/has not been configured as a store/);
-  });
-
-  it("readStoreAttribute reads a key from a declared store column", async () => {
-    const { readStoreAttribute } = await import("./store.js");
+  it("store accessor reads via readStoreAttribute (public get behavior)", () => {
     class User extends Base {
       static {
         this._tableName = "users";
@@ -810,11 +795,10 @@ describe("storeAccessorFor, readStoreAttribute, writeStoreAttribute", () => {
     registerModel(User);
     store(User, "settings", { accessors: ["theme"] });
     const user = new User({ settings: JSON.stringify({ theme: "dark" }) });
-    expect(readStoreAttribute(user, "settings", "theme")).toBe("dark");
+    expect((user as any).theme).toBe("dark");
   });
 
-  it("writeStoreAttribute writes a key to a declared store column", async () => {
-    const { writeStoreAttribute, readStoreAttribute } = await import("./store.js");
+  it("store accessor writes via writeStoreAttribute (public set behavior)", () => {
     class User extends Base {
       static {
         this._tableName = "users";
@@ -826,34 +810,11 @@ describe("storeAccessorFor, readStoreAttribute, writeStoreAttribute", () => {
     registerModel(User);
     store(User, "settings", { accessors: ["theme"] });
     const user = new User({});
-    writeStoreAttribute(user, "settings", "theme", "light");
-    expect(readStoreAttribute(user, "settings", "theme")).toBe("light");
+    (user as any).theme = "light";
+    expect((user as any).theme).toBe("light");
   });
 
-  it("storeAccessorFor does not misidentify prototype properties as declared stores", async () => {
-    const { storeAccessorFor } = await import("./store.js");
-    class User extends Base {
-      static {
-        this._tableName = "users";
-        this.adapter = adapter;
-      }
-    }
-    registerModel(User);
-    expect(() => storeAccessorFor(User, "toString")).toThrow(/has not been configured as a store/);
-    expect(() => storeAccessorFor(User, "constructor")).toThrow(
-      /has not been configured as a store/,
-    );
-  });
-});
-
-describe("storeAccessorFor uses type-configured accessor", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = createTestAdapter();
-  });
-
-  it("returns StringKeyedHashAccessor for hstore-typed column", async () => {
-    const { storeAccessorFor, StringKeyedHashAccessor } = await import("./store.js");
+  it("store accessor for hstore column uses StringKeyedHashAccessor (type-configured)", () => {
     class Post extends Base {
       static {
         this._tableName = "posts";
@@ -864,26 +825,9 @@ describe("storeAccessorFor uses type-configured accessor", () => {
     }
     registerModel(Post);
     store(Post, "properties", { accessors: ["color"] });
-    const accessor = storeAccessorFor(Post, "properties");
-    expect(accessor).toBe(StringKeyedHashAccessor);
-  });
-});
-
-describe("asRegularHash", () => {
-  it("converts HashWithIndifferentAccess via toHash(), not spread", async () => {
-    const { asRegularHash } = await import("./store.js");
-    const { HashWithIndifferentAccess } = await import("@blazetrails/activesupport");
-    const hwia = new HashWithIndifferentAccess({ foo: "bar", baz: 42 });
-    const result = asRegularHash(hwia);
-    expect(result).toEqual({ foo: "bar", baz: 42 });
-    expect(result).not.toBeInstanceOf(HashWithIndifferentAccess);
-  });
-
-  it("returns a plain object copy when given a regular object", async () => {
-    const { asRegularHash } = await import("./store.js");
-    const obj = { a: 1, b: "two" };
-    const result = asRegularHash(obj);
-    expect(result).toEqual({ a: 1, b: "two" });
-    expect(result).not.toBe(obj);
+    // hstore stores string keys — string coercion should be transparent
+    const post = new Post({});
+    (post as any).color = "red";
+    expect((post as any).color).toBe("red");
   });
 });

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -1,4 +1,4 @@
-import { NotImplementedError } from "./errors.js";
+import { ConfigurationError } from "./errors.js";
 import type { Base } from "./base.js";
 import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 
@@ -174,12 +174,14 @@ export function store(
       accessorName = `${accessorName}_${suf}`;
     }
 
+    // Mirrors Rails: accessor closures delegate through read/write_store_attribute
+    // so the type-configured accessor (e.g. StringKeyedHashAccessor for hstore) is used.
     Object.defineProperty(modelClass.prototype, accessorName, {
       get: function (this: Base) {
-        return IndifferentHashAccessor.read(this, attribute, accessor);
+        return readStoreAttribute(this, attribute, accessor);
       },
       set: function (this: Base, value: unknown) {
-        IndifferentHashAccessor.write(this, attribute, accessor, value);
+        writeStoreAttribute(this, attribute, accessor, value);
       },
       configurable: true,
     });
@@ -193,22 +195,73 @@ export function store(
  */
 export const storeAccessor = store;
 
-/** @internal */
-function asRegularHash(obj: any): never {
-  throw new NotImplementedError(
-    "ActiveRecord::Store::IndifferentCoder#as_regular_hash is not implemented",
-  );
+/**
+ * Returns the HashAccessor class for a given store attribute column.
+ * Raises ConfigurationError if the column is not a declared store.
+ *
+ * Mirrors: ActiveRecord::Store#store_accessor_for (private)
+ *
+ * @internal
+ */
+function storeAccessorFor(modelClass: typeof Base, storeAttribute: string): typeof HashAccessor {
+  const attrs = storedAttributes(modelClass);
+  if (!attrs || !Object.prototype.hasOwnProperty.call(attrs, storeAttribute)) {
+    throw new ConfigurationError(
+      `the column '${storeAttribute}' has not been configured as a store. ` +
+        `Please make sure the column is declared via store() or use a structured column type.`,
+    );
+  }
+  // Prefer the accessor class configured on the attribute type (e.g. hstore →
+  // StringKeyedHashAccessor). Guard: only use the result if it has read/write
+  // methods (some types implement accessor() but return null).
+  // Mirrors Rails: type_for_attribute(attr).accessor.
+  const type = (modelClass as any).typeForAttribute?.(storeAttribute);
+  if (type && typeof (type as any).accessor === "function") {
+    const accessor = (type as any).accessor();
+    if (accessor && typeof accessor.read === "function" && typeof accessor.write === "function") {
+      return accessor as typeof HashAccessor;
+    }
+  }
+  return IndifferentHashAccessor;
 }
 
-function readStoreAttribute(storeAttribute: any, key: any): never {
-  throw new NotImplementedError("ActiveRecord::Store#read_store_attribute is not implemented");
+/**
+ * Reads a single key from a store attribute.
+ *
+ * Mirrors: ActiveRecord::Store#read_store_attribute (private)
+ */
+function readStoreAttribute(record: Base, storeAttribute: string, key: string): unknown {
+  const accessor = storeAccessorFor(record.constructor as typeof Base, storeAttribute);
+  return accessor.read(record, storeAttribute, key);
 }
 
-function writeStoreAttribute(storeAttribute: any, key: any, value: any): never {
-  throw new NotImplementedError("ActiveRecord::Store#write_store_attribute is not implemented");
+/**
+ * Writes a single key to a store attribute.
+ *
+ * Mirrors: ActiveRecord::Store#write_store_attribute (private)
+ */
+function writeStoreAttribute(
+  record: Base,
+  storeAttribute: string,
+  key: string,
+  value: unknown,
+): void {
+  const accessor = storeAccessorFor(record.constructor as typeof Base, storeAttribute);
+  accessor.write(record, storeAttribute, key, value);
 }
 
-/** @internal */
-function storeAccessorFor(storeAttribute: any): never {
-  throw new NotImplementedError("ActiveRecord::Store#store_accessor_for is not implemented");
+/**
+ * Converts a HashWithIndifferentAccess to a plain object.
+ *
+ * Mirrors: ActiveRecord::Store::IndifferentCoder#as_regular_hash (private)
+ *
+ * @internal
+ */
+function asRegularHash(
+  obj: Record<string, unknown> | HashWithIndifferentAccess<unknown>,
+): Record<string, unknown> {
+  // HashWithIndifferentAccess stores entries internally, so object spread
+  // does not produce the stored key/value pairs — use toHash() to get a plain copy.
+  if (obj instanceof HashWithIndifferentAccess) return obj.toHash();
+  return { ...obj };
 }

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -174,14 +174,16 @@ export function store(
       accessorName = `${accessorName}_${suf}`;
     }
 
-    // Mirrors Rails: accessor closures delegate through read/write_store_attribute
-    // so the type-configured accessor (e.g. StringKeyedHashAccessor for hstore) is used.
+    // Capture `modelClass` at definition time so subclass instances still resolve
+    // the correct accessor even when `record.constructor` differs from the declaring class.
+    // Mirrors Rails: accessor closures delegate through read/write_store_attribute.
+    const declaringClass = modelClass;
     Object.defineProperty(modelClass.prototype, accessorName, {
       get: function (this: Base) {
-        return readStoreAttribute(this, attribute, accessor);
+        return readStoreAttribute(this, attribute, accessor, declaringClass);
       },
       set: function (this: Base, value: unknown) {
-        writeStoreAttribute(this, attribute, accessor, value);
+        writeStoreAttribute(this, attribute, accessor, value, declaringClass);
       },
       configurable: true,
     });
@@ -230,8 +232,16 @@ function storeAccessorFor(modelClass: typeof Base, storeAttribute: string): type
  *
  * Mirrors: ActiveRecord::Store#read_store_attribute (private)
  */
-function readStoreAttribute(record: Base, storeAttribute: string, key: string): unknown {
-  const accessor = storeAccessorFor(record.constructor as typeof Base, storeAttribute);
+function readStoreAttribute(
+  record: Base,
+  storeAttribute: string,
+  key: string,
+  declaringClass?: typeof Base,
+): unknown {
+  // Use the declaring class (where store() was called) so subclass instances
+  // resolve the correct accessor even when record.constructor differs from the parent.
+  const modelClass = declaringClass ?? (record.constructor as typeof Base);
+  const accessor = storeAccessorFor(modelClass, storeAttribute);
   return accessor.read(record, storeAttribute, key);
 }
 
@@ -245,8 +255,10 @@ function writeStoreAttribute(
   storeAttribute: string,
   key: string,
   value: unknown,
+  declaringClass?: typeof Base,
 ): void {
-  const accessor = storeAccessorFor(record.constructor as typeof Base, storeAttribute);
+  const modelClass = declaringClass ?? (record.constructor as typeof Base);
+  const accessor = storeAccessorFor(modelClass, storeAttribute);
   accessor.write(record, storeAttribute, key, value);
 }
 


### PR DESCRIPTION
Closes the four remaining stubs in `store.rb` (67% → 100%).

## Changes

- `storeAccessorFor(modelClass, storeAttribute)` — returns the `HashAccessor` class for a declared store column; prefers the accessor configured on the attribute type (e.g. hstore → `StringKeyedHashAccessor`), guarded with `read`/`write` method existence check; raises `ConfigurationError` for undeclared columns; uses `hasOwnProperty` to avoid prototype pollution
- `readStoreAttribute(record, storeAttribute, key)` — delegates through `storeAccessorFor`
- `writeStoreAttribute(record, storeAttribute, key, value)` — delegates through `storeAccessorFor`
- `asRegularHash(obj)` — converts `HashWithIndifferentAccess` via `toHash()` (spread produces `{}`); falls back to plain object spread

## api:compare delta

`store.rb`: 8/12 → 12/12 (67% → 100%)