### PR TITLE
feat(activemodel): port Format privates (recordError, checkOptionsValidity, regexpUsingMultilineAnchors)

### DIFF
--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -265,7 +265,7 @@ describe("ValidationsTest", () => {
       static {
         this.attribute("email", "string");
         this.validates("email", {
-          format: { with: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+          format: { with: /^[^@\s]+@[^@\s]+\.[^@\s]+$/, multiline: true },
         });
       }
     }
@@ -1688,7 +1688,7 @@ describe("Validations", () => {
     class Email extends Model {
       static {
         this.attribute("email", "string");
-        this.validates("email", { format: { with: /^[^@]+@[^@]+$/ } });
+        this.validates("email", { format: { with: /^[^@]+@[^@]+$/, multiline: true } });
       }
     }
 
@@ -1703,7 +1703,17 @@ describe("Validations", () => {
     });
 
     it("skips null", () => {
-      expect(new Email({}).isValid()).toBe(true);
+      // Rails format validator does NOT auto-skip nil — opt in via
+      // allow_nil: true (matches EachValidator's allow_nil dispatch).
+      class NilSkippingEmail extends Model {
+        static {
+          this.attribute("email", "string");
+          this.validates("email", {
+            format: { with: /^[^@]+@[^@]+$/, multiline: true, allowNil: true },
+          });
+        }
+      }
+      expect(new NilSkippingEmail({}).isValid()).toBe(true);
     });
   });
 

--- a/packages/activemodel/src/validations/format-validation.test.ts
+++ b/packages/activemodel/src/validations/format-validation.test.ts
@@ -15,10 +15,13 @@ describe("FormatValidationTest", () => {
   });
 
   it("validates format of without lambda without arguments", () => {
+    // JS regex has no \A/\z analogues for Ruby's start-of-string /
+    // end-of-string anchors; ^/$ are line anchors, so Rails requires
+    // multiline: true to opt in (format.rb:42).
     class Person extends Model {
       static {
         this.attribute("name", "string");
-        this.validates("name", { format: { with: /^[a-z]+$/ } });
+        this.validates("name", { format: { with: /^[a-z]+$/, multiline: true } });
       }
     }
     expect(new Person({ name: "alice" }).isValid()).toBe(true);
@@ -37,25 +40,29 @@ describe("FormatValidationTest", () => {
   });
 
   it("validates format of when with isnt a regexp should raise error", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { format: { with: "not a regexp" as any } });
+    // Rails check_validity! runs at validator construction, so the
+    // throw fires when `validates(...)` is called — match that timing.
+    expect(() => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { format: { with: "not a regexp" as any } });
+        }
       }
-    }
-    const p = new Person({ name: "test" });
-    expect(() => p.isValid()).toThrow();
+      void Person;
+    }).toThrow(/regular expression or a proc or lambda must be supplied as :with/);
   });
 
   it("validates format of when not isnt a regexp should raise error", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { format: { without: "not a regexp" as any } });
+    expect(() => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.validates("name", { format: { without: "not a regexp" as any } });
+        }
       }
-    }
-    const p = new Person({ name: "test" });
-    expect(() => p.isValid()).toThrow();
+      void Person;
+    }).toThrow(/regular expression or a proc or lambda must be supplied as :without/);
   });
 
   it("validates format of without lambda", () => {
@@ -74,7 +81,7 @@ describe("FormatValidationTest", () => {
     class Person extends Model {
       static {
         this.attribute("title", "string");
-        this.validates("title", { format: { with: /^[A-Z]/ } });
+        this.validates("title", { format: { with: /^[A-Z]/, multiline: true } });
       }
     }
     expect(new Person({ title: "Hello" }).isValid()).toBe(true);
@@ -97,7 +104,7 @@ describe("FormatValidationTest", () => {
       static {
         this.attribute("title", "string");
         this.validates("title", {
-          format: { with: /^[A-Z]/, message: "must start with uppercase" },
+          format: { with: /^[A-Z]/, multiline: true, message: "must start with uppercase" },
         });
       }
     }
@@ -110,7 +117,9 @@ describe("FormatValidationTest", () => {
     class Person extends Model {
       static {
         this.attribute("title", "string");
-        this.validates("title", { format: { with: /^[A-Z]/, allowBlank: true } });
+        this.validates("title", {
+          format: { with: /^[A-Z]/, multiline: true, allowBlank: true },
+        });
       }
     }
     expect(new Person({ title: "" }).isValid()).toBe(true);
@@ -122,7 +131,7 @@ describe("FormatValidationTest", () => {
     class Person extends Model {
       static {
         this.attribute("value", "string");
-        this.validates("value", { format: { with: /^\d+$/ } });
+        this.validates("value", { format: { with: /^\d+$/, multiline: true } });
       }
     }
     expect(new Person({ value: "123" }).isValid()).toBe(true);

--- a/packages/activemodel/src/validations/format-validation.test.ts
+++ b/packages/activemodel/src/validations/format-validation.test.ts
@@ -221,4 +221,21 @@ describe("format with 'without' option", () => {
     expect(n.isValid()).toBe(false);
     expect(n.errors.get("name")).toContain("is invalid");
   });
+
+  it("validate format does not mutate regex lastIndex across calls (g flag)", () => {
+    // Rails regexp.match? is stateless. JS RegExp#test mutates lastIndex
+    // for /g and /y regexes — a shared regex would alternate
+    // pass/fail. Pin the stateless behavior here.
+    const sharedRe = /\d+/g;
+    class P extends Model {
+      static {
+        this.attribute("code", "string");
+        this.validates("code", { format: { with: sharedRe } });
+      }
+    }
+    expect(new P({ code: "abc123" }).isValid()).toBe(true);
+    expect(new P({ code: "abc123" }).isValid()).toBe(true);
+    expect(new P({ code: "abc123" }).isValid()).toBe(true);
+    expect(sharedRe.lastIndex).toBe(0);
+  });
 });

--- a/packages/activemodel/src/validations/format-validation.test.ts
+++ b/packages/activemodel/src/validations/format-validation.test.ts
@@ -16,8 +16,11 @@ describe("FormatValidationTest", () => {
 
   it("validates format of without lambda without arguments", () => {
     // JS regex has no \A/\z analogues for Ruby's start-of-string /
-    // end-of-string anchors; ^/$ are line anchors, so Rails requires
-    // multiline: true to opt in (format.rb:42).
+    // end-of-string anchors. JS ^/$ default to start/end of input
+    // (line anchors only with the `m` flag), but Rails inspects regex
+    // *source* for ^/$ regardless and forces opt-in via multiline: true
+    // — the security check is about the developer's intent, not the
+    // regex engine's flag state (format.rb:42, regexp_using_multiline_anchors?).
     class Person extends Model {
       static {
         this.attribute("name", "string");

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -32,8 +32,10 @@ export class FormatValidator extends EachValidator {
 
   override checkValidity(): void {
     // Rails: `unless options.include?(:with) ^ options.include?(:without)`
-    const hasWith = "with" in this.options;
-    const hasWithout = "without" in this.options;
+    // — Hash#include? checks own keys only; use Object.hasOwn to avoid
+    // prototype-chain surprises (the `in` operator would include inherited).
+    const hasWith = Object.hasOwn(this.options, "with");
+    const hasWithout = Object.hasOwn(this.options, "without");
     if (hasWith === hasWithout) {
       throw new Error("Either :with or :without must be supplied (but not both)");
     }
@@ -42,14 +44,19 @@ export class FormatValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (this.options.with !== undefined) {
+    // Rails uses Ruby truthiness on options[:with] / options[:without] —
+    // nil/false skip the branch entirely. Mirror that so an explicit
+    // `null` / `false` option doesn't crash at .test time.
+    // value.to_s in Ruby coerces nil → ""; JS String(null) → "null".
+    const target = value == null ? "" : String(value);
+    if (this.options.with) {
       const regexp = this.resolveValue(record, this.options.with) as RegExp;
-      if (!regexp.test(String(value))) {
+      if (!regexp.test(target)) {
         this.recordError(record, attribute, "with", value);
       }
-    } else if (this.options.without !== undefined) {
+    } else if (this.options.without) {
       const regexp = this.resolveValue(record, this.options.without) as RegExp;
-      if (regexp.test(String(value))) {
+      if (regexp.test(target)) {
         this.recordError(record, attribute, "without", value);
       }
     }

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -2,55 +2,135 @@ import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
 import { resolveValue } from "./resolve-value.js";
 
+/**
+ * Mirrors: ActiveModel::Validations::FormatValidator (format.rb)
+ *
+ *   class FormatValidator < EachValidator
+ *     include ResolveValue
+ *
+ *     def validate_each(record, attribute, value)
+ *       if options[:with]
+ *         regexp = resolve_value(record, options[:with])
+ *         record_error(record, attribute, :with, value) unless regexp.match?(value.to_s)
+ *       elsif options[:without]
+ *         regexp = resolve_value(record, options[:without])
+ *         record_error(record, attribute, :without, value) if regexp.match?(value.to_s)
+ *       end
+ *     end
+ *     ...
+ */
 export class FormatValidator extends EachValidator {
-  resolveValue = resolveValue;
-
-  private resolveRegexp(opt: RegExp | ((record: AnyRecord) => RegExp), record: AnyRecord): RegExp {
-    const re = typeof opt === "function" ? opt(record) : opt;
-    if (re.multiline) {
-      throw new Error(
-        "The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \\A and \\z, or pass the `multiline: true` option?",
-      );
-    }
-    return re;
-  }
+  // Declarations only — actual functions attached to the prototype below.
+  // Prototype attachment (not class fields) so the helpers are present
+  // during EachValidator's constructor-time checkValidity() call. JS class
+  // fields don't initialize until AFTER super() returns. (Same bootstrapping
+  // lesson as PR #994.)
+  declare resolveValue: typeof resolveValue;
+  declare recordError: typeof recordError;
+  declare checkOptionsValidity: typeof checkOptionsValidity;
+  declare regexpUsingMultilineAnchors: typeof regexpUsingMultilineAnchors;
 
   override checkValidity(): void {
-    const withOpt = this.options.with;
-    const withoutOpt = this.options.without;
-    if (!withOpt && !withoutOpt) {
+    // Rails: `unless options.include?(:with) ^ options.include?(:without)`
+    const hasWith = "with" in this.options;
+    const hasWithout = "without" in this.options;
+    if (hasWith === hasWithout) {
       throw new Error("Either :with or :without must be supplied (but not both)");
     }
-    if (withOpt && withoutOpt) {
-      throw new Error("Either :with or :without must be supplied (but not both)");
-    }
-    if (withOpt && withOpt instanceof RegExp && withOpt.multiline) {
-      throw new Error(
-        "The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \\A and \\z?",
-      );
-    }
+    this.checkOptionsValidity("with");
+    this.checkOptionsValidity("without");
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (value === null || value === undefined) return;
-    const str = String(value);
-    if (this.options.with) {
-      const re = this.resolveRegexp(
-        this.options.with as RegExp | ((record: AnyRecord) => RegExp),
-        record,
-      );
-      if (!re.test(str)) {
-        record.errors.add(attribute, "invalid", { value, message: this.options.message });
+    if (this.options.with !== undefined) {
+      const regexp = this.resolveValue(record, this.options.with) as RegExp;
+      if (!regexp.test(String(value))) {
+        this.recordError(record, attribute, "with", value);
       }
-    }
-    if (this.options.without) {
-      const re = this.resolveRegexp(
-        this.options.without as RegExp | ((record: AnyRecord) => RegExp),
-        record,
-      );
-      if (re.test(str)) {
-        record.errors.add(attribute, "invalid", { value, message: this.options.message });
+    } else if (this.options.without !== undefined) {
+      const regexp = this.resolveValue(record, this.options.without) as RegExp;
+      if (regexp.test(String(value))) {
+        this.recordError(record, attribute, "without", value);
       }
     }
   }
 }
+
+/**
+ * Mirrors: format.rb:30-32
+ *   def record_error(record, attribute, name, value)
+ *     record.errors.add(attribute, :invalid, **options.except(name).merge!(value: value))
+ *   end
+ */
+export function recordError(
+  this: { options: Record<string, unknown> },
+  record: AnyRecord,
+  attribute: string,
+  name: "with" | "without",
+  value: unknown,
+): void {
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(this.options)) {
+    if (key !== name) rest[key] = this.options[key];
+  }
+  rest.value = value;
+  record.errors.add(attribute, "invalid", rest);
+}
+
+/**
+ * Mirrors: format.rb:34-46
+ *   def check_options_validity(name)
+ *     if option = options[name]
+ *       if option.is_a?(Regexp)
+ *         if options[:multiline] != true && regexp_using_multiline_anchors?(option)
+ *           raise ArgumentError, "...security risk..."
+ *         end
+ *       elsif !option.respond_to?(:call)
+ *         raise ArgumentError, "A regular expression or a proc or lambda must be supplied as :#{name}"
+ *       end
+ *     end
+ *   end
+ */
+export function checkOptionsValidity(
+  this: {
+    options: Record<string, unknown>;
+    regexpUsingMultilineAnchors(regexp: RegExp): boolean;
+  },
+  name: "with" | "without",
+): void {
+  const option = this.options[name];
+  if (option === undefined || option === null) return;
+  if (option instanceof RegExp) {
+    if (this.options.multiline !== true && this.regexpUsingMultilineAnchors(option)) {
+      throw new Error(
+        "The provided regular expression is using multiline anchors (^ or $), " +
+          "which may present a security risk. Did you mean to use \\A and \\z, " +
+          "or forgot to add the :multiline => true option?",
+      );
+    }
+  } else if (typeof option !== "function") {
+    throw new Error(`A regular expression or a proc or lambda must be supplied as :${name}`);
+  }
+}
+
+/**
+ * Mirrors: format.rb:48-51
+ *   def regexp_using_multiline_anchors?(regexp)
+ *     source = regexp.source
+ *     source.start_with?("^") || (source.end_with?("$") && !source.end_with?("\\$"))
+ *   end
+ *
+ * Inspects the regex source text — NOT the `m` (multiline) flag — for
+ * the user-facing `^` / `$` anchors that match per-line in Ruby. Rails
+ * forces the user to opt in via `multiline: true` to acknowledge the
+ * security implication of accepting input across line boundaries.
+ */
+export function regexpUsingMultilineAnchors(regexp: RegExp): boolean {
+  const source = regexp.source;
+  return source.startsWith("^") || (source.endsWith("$") && !source.endsWith("\\$"));
+}
+
+FormatValidator.prototype.resolveValue = resolveValue;
+FormatValidator.prototype.recordError = recordError;
+FormatValidator.prototype.checkOptionsValidity = checkOptionsValidity;
+FormatValidator.prototype.regexpUsingMultilineAnchors = regexpUsingMultilineAnchors;

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -54,12 +54,12 @@ export class FormatValidator extends EachValidator {
     const target = value == null ? "" : String(value);
     if (this.options.with) {
       const regexp = this.resolveValue(record, this.options.with) as RegExp;
-      if (!regexp.test(target)) {
+      if (!matchStateless(regexp, target)) {
         this.recordError(record, attribute, "with", value);
       }
     } else if (this.options.without) {
       const regexp = this.resolveValue(record, this.options.without) as RegExp;
-      if (regexp.test(target)) {
+      if (matchStateless(regexp, target)) {
         this.recordError(record, attribute, "without", value);
       }
     }
@@ -148,6 +148,23 @@ export function checkOptionsValidity(
 export function regexpUsingMultilineAnchors(regexp: RegExp): boolean {
   const source = regexp.source;
   return source.startsWith("^") || (source.endsWith("$") && !source.endsWith("\\$"));
+}
+
+/**
+ * Stateless equivalent of Rails' `regexp.match?(value.to_s)`. JS
+ * `RegExp#test` mutates `lastIndex` for regexes carrying the `g` /
+ * `y` flag, so a single regex shared across calls would alternate
+ * between passing and failing. Snapshot and restore `lastIndex` so the
+ * caller's regex is observably unchanged.
+ */
+function matchStateless(regexp: RegExp, target: string): boolean {
+  const before = regexp.lastIndex;
+  regexp.lastIndex = 0;
+  try {
+    return regexp.test(target);
+  } finally {
+    regexp.lastIndex = before;
+  }
 }
 
 FormatValidator.prototype.resolveValue = resolveValue;

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -113,7 +113,11 @@ export function checkOptionsValidity(
   name: "with" | "without",
 ): void {
   const option = this.options[name];
-  if (option === undefined || option === null) return;
+  // Rails `if option = options[name]` skips on Ruby falsiness (nil OR
+  // false). validateEach also short-circuits on these via Rails
+  // truthiness, so the validity check stays consistent with the
+  // dispatch path.
+  if (option === undefined || option === null || option === false) return;
   if (option instanceof RegExp) {
     if (this.options.multiline !== true && this.regexpUsingMultilineAnchors(option)) {
       throw new Error(

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -26,8 +26,11 @@ export class FormatValidator extends EachValidator {
   // fields don't initialize until AFTER super() returns. (Same bootstrapping
   // lesson as PR #994.)
   declare resolveValue: typeof resolveValue;
+  /** @internal Rails-private helper. */
   declare recordError: typeof recordError;
+  /** @internal Rails-private helper. */
   declare checkOptionsValidity: typeof checkOptionsValidity;
+  /** @internal Rails-private helper. */
   declare regexpUsingMultilineAnchors: typeof regexpUsingMultilineAnchors;
 
   override checkValidity(): void {
@@ -68,6 +71,8 @@ export class FormatValidator extends EachValidator {
  *   def record_error(record, attribute, name, value)
  *     record.errors.add(attribute, :invalid, **options.except(name).merge!(value: value))
  *   end
+ *
+ * @internal Rails-private helper.
  */
 export function recordError(
   this: { options: Record<string, unknown> },
@@ -97,6 +102,8 @@ export function recordError(
  *       end
  *     end
  *   end
+ *
+ * @internal Rails-private helper.
  */
 export function checkOptionsValidity(
   this: {
@@ -131,6 +138,8 @@ export function checkOptionsValidity(
  * the user-facing `^` / `$` anchors that match per-line in Ruby. Rails
  * forces the user to opt in via `multiline: true` to acknowledge the
  * security implication of accepting input across line boundaries.
+ *
+ * @internal Rails-private helper.
  */
 export function regexpUsingMultilineAnchors(regexp: RegExp): boolean {
   const source = regexp.source;


### PR DESCRIPTION
## Summary
Track A2 of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md). Mirrors `ActiveModel::Validations::FormatValidator` (`format.rb`):

- `recordError(record, attribute, name, value)` — `format.rb:30-32`. `record.errors.add(attribute, :invalid, **options.except(name).merge!(value: value))`.
- `checkOptionsValidity(name)` — `format.rb:34-46`. Type-guards `:with` / `:without`; raises if a Regex uses multiline anchors without `multiline: true`; raises if option is neither Regex nor callable.
- `regexpUsingMultilineAnchors(regexp)` — `format.rb:48-51`. Inspects regex **source** for `^`/`$` anchors (not the `m` flag — that was a pre-existing trails bug). Rails forces opt-in via `multiline: true` to acknowledge the per-line anchor security implication.
- `validateEach` now calls `this.resolveValue(record, options.with)` / `this.resolveValue(record, options.without)` per `format.rb:12,15` — **closes the `resolveValue` consumption gap** flagged for Format in PR #971.
- `validateEach` uses Rails' `with`-elsif-`without` dispatch (not "both at once" like the prior trails impl).
- `checkValidity` uses Rails XOR (`:with ^ :without`) instead of separate checks, then dispatches through `this.checkOptionsValidity(...)` per Rails.

Helpers attached to `FormatValidator.prototype` (not class fields) so they're available during `EachValidator`'s super-time `checkValidity()` call — same bootstrapping pattern as PR #994.

## Test fixes (names preserved per CLAUDE.md)
- 5 tests with `/^...$/` regexes updated to add `multiline: true`. JS regex has no `\A`/`\z` analogues for Ruby's start-of-string anchors; `^`/`$` are line anchors in JS too, so `multiline: true` is the correct opt-in.
- 2 "isnt a regexp should raise error" tests now wrap class construction in `expect(() => ...).toThrow()` since `checkValidity` fires at validator construction (Rails parity).
- "skips null" subtest now uses `allowNil: true` on the validator (Rails format validator doesn't auto-skip nil; the option is the opt-in).

## Impact
- `pnpm api:compare --privates --package activemodel`: `format.rb` 3/6 → **6/6 (100%)** (+3). Overall 467/607 → **470/607 (77.4%)**.
- `pnpm api:compare --package activemodel`: stays **433/433 (100%)**.
- `pnpm test:compare --package activemodel`: stays 959/963.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1592 / 1592 passing
- [x] `pnpm api:compare --package activemodel` — 433/433
- [x] `pnpm api:compare --privates --package activemodel` — 470/607 (+3)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)