### PR TITLE
refactor(arel): port to_sql.rb statement visitors + 5 private helpers

### DIFF
--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -81,19 +81,18 @@ export class GroupingSet extends GroupingElement {
 
 export class Group extends Unary {}
 /**
- * `OptimizerHints#expr` is a list of hint strings (or SqlLiteral) — Rails'
- * Arel::Nodes::OptimizerHints stores `[hint1, hint2, ...]`. The Unary base
- * types `expr` as `Node | string | number | null` and TS won't let us
- * widen to an array via `declare`, so the constructor accepts the array
- * and we expose it via a typed `hints` getter. The visitor uses `hints`.
+ * Rails' `Arel::Nodes::OptimizerHints` stores `[hint1, hint2, ...]` and the
+ * visitor iterates them. The Unary base types `expr` as
+ * `Node | string | number | null` — TS won't let us widen `expr` to an array
+ * via `declare`, so the hints live in their own typed field and `expr` is
+ * left as `null` (consistent with the declared base type).
  */
 export class OptimizerHints extends Unary {
-  constructor(hints: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>) {
-    super(hints as unknown as null);
-  }
+  readonly hints: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;
 
-  get hints(): ReadonlyArray<string | import("./sql-literal.js").SqlLiteral> {
-    return this.expr as unknown as ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;
+  constructor(hints: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>) {
+    super(null);
+    this.hints = hints;
   }
 }
 export class RollUp extends Rollup {}

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -80,5 +80,20 @@ export class GroupingSet extends GroupingElement {
 }
 
 export class Group extends Unary {}
-export class OptimizerHints extends Unary {}
+/**
+ * `OptimizerHints#expr` is a list of hint strings (or SqlLiteral) — Rails'
+ * Arel::Nodes::OptimizerHints stores `[hint1, hint2, ...]`. The Unary base
+ * types `expr` as `Node | string | number | null` and TS won't let us
+ * widen to an array via `declare`, so the constructor accepts the array
+ * and we expose it via a typed `hints` getter. The visitor uses `hints`.
+ */
+export class OptimizerHints extends Unary {
+  constructor(hints: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>) {
+    super(hints as unknown as null);
+  }
+
+  get hints(): ReadonlyArray<string | import("./sql-literal.js").SqlLiteral> {
+    return this.expr as unknown as ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;
+  }
+}
 export class RollUp extends Rollup {}

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -43,9 +43,7 @@ export class MySQL extends ToSql {
       this.visit(node.lock);
     }
 
-    if (node.comment) {
-      this.visit(node.comment);
-    }
+    this.maybeVisit(node.comment ?? null);
 
     return this.collector;
   }

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -9,7 +9,7 @@ import { ToSql } from "./to-sql.js";
  * Mirrors: Arel::Visitors::MySQL
  */
 export class MySQL extends ToSql {
-  protected override visitSelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected override visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");
@@ -50,7 +50,7 @@ export class MySQL extends ToSql {
     return this.collector;
   }
 
-  protected override visitSelectCore(node: Nodes.SelectCore): SQLString {
+  protected override visit_Arel_Nodes_SelectCore(node: Nodes.SelectCore): SQLString {
     this.collector.append("SELECT");
 
     this.emitOptimizerHints(node);

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -22,7 +22,7 @@ export class MySQL extends ToSql {
 
     if (node.orders.length > 0) {
       this.collector.append(" ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
 
     if (node.limit) {
@@ -62,7 +62,7 @@ export class MySQL extends ToSql {
 
     if (node.projections.length > 0) {
       this.collector.append(" ");
-      this.visitArray(node.projections, ", ");
+      this.injectJoin(node.projections, ", ");
     }
 
     // MySQL emits FROM DUAL for empty FROM.
@@ -81,7 +81,7 @@ export class MySQL extends ToSql {
 
     if (node.groups.length > 0) {
       this.collector.append(" GROUP BY ");
-      this.visitArray(node.groups, ", ");
+      this.injectJoin(node.groups, ", ");
     }
 
     if (node.havings.length > 0) {
@@ -92,7 +92,7 @@ export class MySQL extends ToSql {
 
     if (node.windows.length > 0) {
       this.collector.append(" WINDOW ");
-      this.visitArray(node.windows, ", ");
+      this.injectJoin(node.windows, ", ");
     }
 
     return this.collector;

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -190,7 +190,7 @@ export class MySQL extends ToSql {
   protected override visitCte(node: Nodes.Cte): SQLString {
     // MySQL identifiers are backtick-quoted, not double-quoted, and the
     // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are
-    // ignored. Mirrors Rails' MySQL visitArelNodesCte which calls
+    // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte which calls
     // `quote_table_name` (which emits backticks on the MySQL adapter).
     const escaped = node.name.replace(/`/g, "``");
     this.collector.append(`\`${escaped}\` AS (`);

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -9,7 +9,7 @@ import { ToSql } from "./to-sql.js";
  * Mirrors: Arel::Visitors::MySQL
  */
 export class MySQL extends ToSql {
-  protected override visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected override visitArelNodesSelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");
@@ -50,7 +50,7 @@ export class MySQL extends ToSql {
     return this.collector;
   }
 
-  protected override visit_Arel_Nodes_SelectCore(node: Nodes.SelectCore): SQLString {
+  protected override visitArelNodesSelectCore(node: Nodes.SelectCore): SQLString {
     this.collector.append("SELECT");
 
     this.emitOptimizerHints(node);
@@ -192,7 +192,7 @@ export class MySQL extends ToSql {
   protected override visitCte(node: Nodes.Cte): SQLString {
     // MySQL identifiers are backtick-quoted, not double-quoted, and the
     // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are
-    // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte which calls
+    // ignored. Mirrors Rails' MySQL visitArelNodesCte which calls
     // `quote_table_name` (which emits backticks on the MySQL adapter).
     const escaped = node.name.replace(/`/g, "``");
     this.collector.append(`\`${escaped}\` AS (`);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -59,7 +59,7 @@ export class PostgreSQL extends ToSql {
 
   // Mirrors Rails Postgres formatting: `( expr )` with spaces inside
   // the parens. The base ToSql renders `(expr)` without spaces, so
-  // override to match Rails' `visit_Arel_Nodes_GroupingElement`.
+  // override to match Rails' `visitArelNodesGroupingElement`.
   protected override visitGroupingElement(node: Nodes.GroupingElement): SQLString {
     this.collector.append("( ");
     for (let i = 0; i < node.expressions.length; i++) {
@@ -143,7 +143,7 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compileWithBinds(node);
   }
 
-  protected override visit_Arel_Nodes_Casted(node: Nodes.Casted): SQLString {
+  protected override visitArelNodesCasted(node: Nodes.Casted): SQLString {
     if (this._extractBinds) {
       this.bindIndex += 1;
       this.collector.addBind(node.valueForDatabase(), () => `$${this.bindIndex}`);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -59,7 +59,7 @@ export class PostgreSQL extends ToSql {
 
   // Mirrors Rails Postgres formatting: `( expr )` with spaces inside
   // the parens. The base ToSql renders `(expr)` without spaces, so
-  // override to match Rails' `visitArelNodesGroupingElement`.
+  // override to match Rails' `visit_Arel_Nodes_GroupingElement`.
   protected override visitGroupingElement(node: Nodes.GroupingElement): SQLString {
     this.collector.append("( ");
     for (let i = 0; i < node.expressions.length; i++) {

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -143,7 +143,7 @@ export class PostgreSQLWithBinds extends PostgreSQL {
     return super.compileWithBinds(node);
   }
 
-  protected override visitCasted(node: Nodes.Casted): SQLString {
+  protected override visit_Arel_Nodes_Casted(node: Nodes.Casted): SQLString {
     if (this._extractBinds) {
       this.bindIndex += 1;
       this.collector.addBind(node.valueForDatabase(), () => `$${this.bindIndex}`);

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -21,7 +21,7 @@ export class SQLite extends ToSql {
 
     if (node.orders.length > 0) {
       this.collector.append(" ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
 
     if (node.limit) {

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -8,7 +8,7 @@ import { ToSql } from "./to-sql.js";
  * Mirrors: Arel::Visitors::SQLite
  */
 export class SQLite extends ToSql {
-  protected override visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected override visitArelNodesSelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");
@@ -51,12 +51,12 @@ export class SQLite extends ToSql {
     return this.collector;
   }
 
-  protected override visit_Arel_Nodes_True(_node: Nodes.True): SQLString {
+  protected override visitArelNodesTrue(_node: Nodes.True): SQLString {
     this.collector.append("1");
     return this.collector;
   }
 
-  protected override visit_Arel_Nodes_False(_node: Nodes.False): SQLString {
+  protected override visitArelNodesFalse(_node: Nodes.False): SQLString {
     this.collector.append("0");
     return this.collector;
   }

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -39,9 +39,7 @@ export class SQLite extends ToSql {
 
     // SQLite does not support locking; ignore lock clause entirely.
 
-    if (node.comment) {
-      this.visit(node.comment);
-    }
+    this.maybeVisit(node.comment ?? null);
 
     return this.collector;
   }

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -8,7 +8,7 @@ import { ToSql } from "./to-sql.js";
  * Mirrors: Arel::Visitors::SQLite
  */
 export class SQLite extends ToSql {
-  protected override visitSelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected override visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -51,12 +51,12 @@ export class SQLite extends ToSql {
     return this.collector;
   }
 
-  protected override visitTrue(_node: Nodes.True): SQLString {
+  protected override visit_Arel_Nodes_True(_node: Nodes.True): SQLString {
     this.collector.append("1");
     return this.collector;
   }
 
-  protected override visitFalse(_node: Nodes.False): SQLString {
+  protected override visit_Arel_Nodes_False(_node: Nodes.False): SQLString {
     this.collector.append("0");
     return this.collector;
   }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1138,10 +1138,7 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::OptimizerHints (visit)", () => {
     it("emits /*+ HINT */ for an OptimizerHints node with array expr", () => {
-      const node = new Nodes.OptimizerHints([
-        "IDX(t1)",
-        "MAX_EXEC_TIME(1000)",
-      ] as unknown as Nodes.Node);
+      const node = new Nodes.OptimizerHints(["IDX(t1)", "MAX_EXEC_TIME(1000)"]);
       const sql = new Visitors.ToSql().compile(node);
       expect(sql).toBe(" /*+ IDX(t1) MAX_EXEC_TIME(1000) */");
     });
@@ -1150,10 +1147,26 @@ describe("the to_sql visitor", () => {
       // Mirrors Rails: sanitize_as_sql_comment removes /* and */ so a hint
       // can't escape the surrounding comment block. The literal SQL inside
       // is preserved as comment text — it's still inside /*+ ... */.
-      const node = new Nodes.OptimizerHints(["A */ DROP /*"] as unknown as Nodes.Node);
+      const node = new Nodes.OptimizerHints(["A */ DROP /*"]);
       const sql = new Visitors.ToSql().compile(node);
       expect(sql).toBe(" /*+ A DROP */");
       expect(sql.match(/\*\//g)?.length).toBe(1);
+    });
+
+    it("accepts SqlLiteral hints (passes through unchanged)", () => {
+      const node = new Nodes.OptimizerHints([new Nodes.SqlLiteral("FORCE INDEX (t)")]);
+      expect(new Visitors.ToSql().compile(node)).toBe(" /*+ FORCE INDEX (t) */");
+    });
+  });
+
+  describe("schema-qualified table identifier", () => {
+    it("quotes each segment of a schema.table name in SELECT and column refs", () => {
+      const tbl = new Table("schema.table");
+      const sql = tbl.project(tbl.get("col")).toSql();
+      // Both the FROM clause and the qualified column reference should
+      // emit "schema"."table" — not "schema.table" (which would be a
+      // single identifier and reference a different relation).
+      expect(sql).toBe('SELECT "schema"."table"."col" FROM "schema"."table"');
     });
   });
 });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1159,6 +1159,18 @@ describe("the to_sql visitor", () => {
     });
   });
 
+  describe("Nodes::Comment placement", () => {
+    it("emits exactly one space before each comment in SelectCore (no double space)", () => {
+      // Regression: visitArelNodesComment used to prepend its own leading
+      // space, and SelectCore also called maybeVisit() which adds another.
+      // The visitor now leaves the leading space to the caller.
+      const tbl = new Table("users");
+      const sql = tbl.project(tbl.get("id")).comment("hi", "bye").toSql();
+      expect(sql).toBe('SELECT "users"."id" FROM "users" /* hi */ /* bye */');
+      expect(sql).not.toContain("  /*");
+    });
+  });
+
   describe("schema-qualified table identifier", () => {
     it("quotes each segment of a schema.table name in SELECT and column refs", () => {
       const tbl = new Table("schema.table");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1161,7 +1161,7 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Comment placement", () => {
     it("emits exactly one space before each comment in SelectCore (no double space)", () => {
-      // Regression: visitArelNodesComment used to prepend its own leading
+      // Regression: visit_Arel_Nodes_Comment used to prepend its own leading
       // space, and SelectCore also called maybeVisit() which adds another.
       // The visitor now leaves the leading space to the caller.
       const tbl = new Table("users");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1076,4 +1076,56 @@ describe("the to_sql visitor", () => {
       expect(new Visitors.ToSql().compile(node)).toContain("IS NOT NULL");
     });
   });
+
+  // Mirrors Rails' to_sql.rb private helpers (sanitize_as_sql_comment,
+  // quote_table_name, quote_column_name).
+  describe("Rails-mirrored private helpers", () => {
+    type ToSqlInternals = {
+      sanitizeAsSqlComment(value: string | Nodes.SqlLiteral): string;
+      quoteTableName(name: string | Nodes.SqlLiteral): string;
+      quoteColumnName(name: string | Nodes.SqlLiteral): string;
+    };
+    const make = (): ToSqlInternals => new Visitors.ToSql() as unknown as ToSqlInternals;
+
+    it("sanitizeAsSqlComment passes through SqlLiteral values", () => {
+      const literal = new Nodes.SqlLiteral("/* raw */");
+      expect(make().sanitizeAsSqlComment(literal)).toBe("/* raw */");
+    });
+
+    it("sanitizeAsSqlComment strips comment delimiters and newlines", () => {
+      const v = make();
+      expect(v.sanitizeAsSqlComment("a /* boom */ b")).toBe("a boom b");
+      expect(v.sanitizeAsSqlComment("multi\nline")).toBe("multi line");
+      expect(v.sanitizeAsSqlComment("trailing */")).toBe("trailing");
+    });
+
+    it("quoteTableName / quoteColumnName double-quote bare names and pass through SqlLiteral", () => {
+      const v = make();
+      expect(v.quoteTableName("users")).toBe('"users"');
+      expect(v.quoteColumnName("name")).toBe('"name"');
+      expect(v.quoteTableName('weird"name')).toBe('"weird""name"');
+      expect(v.quoteTableName(new Nodes.SqlLiteral("users"))).toBe("users");
+    });
+  });
+
+  describe("Nodes::OptimizerHints (visit)", () => {
+    it("emits /*+ HINT */ for an OptimizerHints node with array expr", () => {
+      const node = new Nodes.OptimizerHints([
+        "IDX(t1)",
+        "MAX_EXEC_TIME(1000)",
+      ] as unknown as Nodes.Node);
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe(" /*+ IDX(t1) MAX_EXEC_TIME(1000) */");
+    });
+
+    it("strips embedded comment delimiters from each hint (Rails parity)", () => {
+      // Mirrors Rails: sanitize_as_sql_comment removes /* and */ so a hint
+      // can't escape the surrounding comment block. The literal SQL inside
+      // is preserved as comment text — it's still inside /*+ ... */.
+      const node = new Nodes.OptimizerHints(["A */ DROP /*"] as unknown as Nodes.Node);
+      const sql = new Visitors.ToSql().compile(node);
+      expect(sql).toBe(" /*+ A DROP */");
+      expect(sql.match(/\*\//g)?.length).toBe(1);
+    });
+  });
 });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1106,6 +1106,34 @@ describe("the to_sql visitor", () => {
       expect(v.quoteTableName('weird"name')).toBe('"weird""name"');
       expect(v.quoteTableName(new Nodes.SqlLiteral("users"))).toBe("users");
     });
+
+    it("visitTable and visitAttribute now route through quoteTableName / quoteColumnName", () => {
+      // A table name with a double-quote in it would have crashed pre-PR
+      // because the inline replace was string-only; quoteTableName escapes it.
+      const weird = new Table('we"ird');
+      const sql = new Visitors.ToSql().compile(weird.get('co"l').eq(1));
+      expect(sql).toBe('"we""ird"."co""l" = 1');
+    });
+
+    it("collectNodesFor prefixes the spacer and joins with the connector", () => {
+      const tbl = new Table("users");
+      // Verify via SelectCore: Rails' WHERE collapses on " AND ".
+      const sql = tbl
+        .where(tbl.get("a").eq(1))
+        .where(tbl.get("b").eq(2))
+        .project(tbl.get("a"))
+        .toSql();
+      expect(sql).toContain('WHERE "users"."a" = 1 AND "users"."b" = 2');
+    });
+
+    it("collectNodesFor is a no-op when the list is empty", () => {
+      // SELECT with no projections / no WHERE should not emit those
+      // clauses at all (no stray spacer).
+      const sql = new Table("users").project().toSql();
+      expect(sql).toBe('SELECT FROM "users"');
+      expect(sql).not.toContain("WHERE");
+      expect(sql).not.toContain("GROUP BY");
+    });
   });
 
   describe("Nodes::OptimizerHints (visit)", () => {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -126,11 +126,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       d.set(ctor, m);
     };
     // Statements
-    reg(Nodes.SelectStatement, "visitSelectStatement");
-    reg(Nodes.SelectCore, "visitSelectCore");
-    reg(Nodes.InsertStatement, "visitInsertStatement");
-    reg(Nodes.UpdateStatement, "visitUpdateStatement");
-    reg(Nodes.DeleteStatement, "visitDeleteStatement");
+    reg(Nodes.SelectStatement, "visit_Arel_Nodes_SelectStatement");
+    reg(Nodes.SelectCore, "visit_Arel_Nodes_SelectCore");
+    reg(Nodes.InsertStatement, "visit_Arel_Nodes_InsertStatement");
+    reg(Nodes.UpdateStatement, "visit_Arel_Nodes_UpdateStatement");
+    reg(Nodes.DeleteStatement, "visit_Arel_Nodes_DeleteStatement");
     // Set operations
     reg(Nodes.UnionAll, "visitUnionAll");
     reg(Nodes.Union, "visitUnion");
@@ -205,7 +205,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     reg(Nodes.Fragments, "visitFragments");
     // Functions
     reg(Nodes.NamedFunction, "visitNamedFunction");
-    reg(Nodes.Exists, "visitExists");
+    reg(Nodes.Exists, "visit_Arel_Nodes_Exists");
     reg(Nodes.Count, "visitCount");
     reg(Nodes.Sum, "visitSum");
     reg(Nodes.Max, "visitMax");
@@ -218,7 +218,8 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     reg(Nodes.Group, "visitGroup");
     reg(Nodes.GroupingElement, "visitGroupingElement");
     reg(Nodes.Lateral, "visitLateral");
-    reg(Nodes.Comment, "visitComment");
+    reg(Nodes.Comment, "visit_Arel_Nodes_Comment");
+    reg(Nodes.OptimizerHints, "visit_Arel_Nodes_OptimizerHints");
     reg(Nodes.HomogeneousIn, "visitHomogeneousIn");
     // Boolean literals
     reg(Nodes.True, "visitTrue");
@@ -236,7 +237,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   // -- Statements --
 
-  protected visitSelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");
@@ -284,7 +285,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     }
   }
 
-  protected visitSelectCore(node: Nodes.SelectCore): SQLString {
+  protected visit_Arel_Nodes_SelectCore(node: Nodes.SelectCore): SQLString {
     this.collector.append("SELECT");
 
     this.emitOptimizerHints(node);
@@ -333,7 +334,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitInsertStatement(node: Nodes.InsertStatement): SQLString {
+  protected visit_Arel_Nodes_InsertStatement(node: Nodes.InsertStatement): SQLString {
     this.collector.retryable = false;
     this.collector.append("INSERT INTO ");
     if (node.relation) this.visit(node.relation);
@@ -360,7 +361,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitUpdateStatement(o: Nodes.UpdateStatement): SQLString {
+  protected visit_Arel_Nodes_UpdateStatement(o: Nodes.UpdateStatement): SQLString {
     const node = this.prepareUpdateStatement(o);
     this.collector.retryable = false;
     this.collector.append("UPDATE ");
@@ -395,7 +396,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visitDeleteStatement(o: Nodes.DeleteStatement): SQLString {
+  protected visit_Arel_Nodes_DeleteStatement(o: Nodes.DeleteStatement): SQLString {
     const node = this.prepareDeleteStatement(o);
     this.collector.retryable = false;
     this.collector.append("DELETE ");
@@ -882,7 +883,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitExists(node: Nodes.Exists): SQLString {
+  protected visit_Arel_Nodes_Exists(node: Nodes.Exists): SQLString {
     this.collector.append("EXISTS (");
     this.visit(node.expressions);
     this.collector.append(")");
@@ -1206,11 +1207,27 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitComment(node: Nodes.Comment): SQLString {
+  // Mirrors Rails: visit_Arel_Nodes_Comment (to_sql.rb:175). Rails joins
+  // with " " into a single string; we keep the per-comment structure with a
+  // leading space because callers append directly without a separator.
+  protected visit_Arel_Nodes_Comment(node: Nodes.Comment): SQLString {
     for (const value of node.values) {
-      const sanitized = value.replace(/\/\*/g, "").replace(/\*\//g, "").replace(/\s+/g, " ").trim();
-      this.collector.append(` /* ${sanitized} */`);
+      this.collector.append(` /* ${this.sanitizeAsSqlComment(value)} */`);
     }
+    return this.collector;
+  }
+
+  // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). Trails'
+  // SelectCore stores hints inline as `string[]`, so the OptimizerHints node
+  // class isn't constructed in normal use; this method exists for callers
+  // that pass one explicitly. `expr` may be an array or a single value.
+  protected visit_Arel_Nodes_OptimizerHints(node: Nodes.OptimizerHints): SQLString {
+    const raw = node.expr as unknown;
+    const list = Array.isArray(raw) ? (raw as unknown[]) : [raw];
+    const hints = list
+      .map((v) => this.sanitizeAsSqlComment(v as string | Nodes.SqlLiteral))
+      .join(" ");
+    this.collector.append(` /*+ ${hints} */`);
     return this.collector;
   }
 
@@ -1503,5 +1520,88 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       .replace(/--/g, "")
       .replace(/\s+/g, " ")
       .trim();
+  }
+
+  // ---------------------------------------------------------------------
+  // Rails-mirrored private helpers (to_sql.rb).
+  // ---------------------------------------------------------------------
+
+  /**
+   * Mirrors `to_sql.rb#collect_nodes_for`. Emits `spacer` then visits each
+   * node separated by `connector` (default `", "`). No-op when empty.
+   */
+  protected collectNodesFor(nodes: Node[], spacer: string, connector = ", "): SQLString {
+    if (nodes.length === 0) return this.collector;
+    this.collector.append(spacer);
+    this.injectJoin(nodes, connector);
+    return this.collector;
+  }
+
+  /**
+   * Mirrors `to_sql.rb#inject_join`: visits `list[0]`, then for each
+   * subsequent node emits `joinStr` and visits.
+   */
+  protected injectJoin(list: Node[], joinStr: string): SQLString {
+    list.forEach((n, i) => {
+      if (i > 0) this.collector.append(joinStr);
+      this.visit(n);
+    });
+    return this.collector;
+  }
+
+  /**
+   * Mirrors `to_sql.rb#maybe_visit`: if `thing` is non-null, emits a leading
+   * space and visits it; otherwise no-op. Used to thread optional clauses
+   * (limit/offset/lock/comment) through select-statement visitors.
+   */
+  protected maybeVisit(thing: Node | null | undefined): SQLString {
+    if (!thing) return this.collector;
+    this.collector.append(" ");
+    this.visit(thing);
+    return this.collector;
+  }
+
+  /**
+   * Mirrors `to_sql.rb#collect_optimizer_hints`. Visits the optimizer hint
+   * if one is present. Trails' SelectCore stores hints inline (an array on
+   * the node) rather than as a separate Arel::Nodes::OptimizerHints; this
+   * helper provides the Rails-shaped seam for callers that pass a node.
+   */
+  protected collectOptimizerHints(o: { optimizerHints?: Node | null }): SQLString {
+    return this.maybeVisit(o.optimizerHints);
+  }
+
+  /**
+   * Mirrors `to_sql.rb#sanitize_as_sql_comment`. SqlLiteral values pass
+   * through unchanged; otherwise strip newlines and `/*`/`* /` so the value
+   * is safe to embed inside a `/* … * /` SQL comment.
+   */
+  protected sanitizeAsSqlComment(value: string | Nodes.SqlLiteral): string {
+    if (value instanceof Nodes.SqlLiteral) return value.value;
+    return String(value)
+      .replace(/[\r\n]+/g, " ")
+      .replace(/\/\*/g, "")
+      .replace(/\*\//g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  /**
+   * Mirrors `to_sql.rb#quote_table_name`. SqlLiteral pass-through; otherwise
+   * default double-quoted identifier with embedded `"` doubled. MySQL
+   * overrides to backtick-quote (deferred — see project memory
+   * `arel MySQL identifier quoting`).
+   */
+  protected quoteTableName(name: string | Nodes.SqlLiteral): string {
+    if (name instanceof Nodes.SqlLiteral) return name.value;
+    return `"${String(name).replace(/"/g, '""')}"`;
+  }
+
+  /**
+   * Mirrors `to_sql.rb#quote_column_name`. Same shape as `quoteTableName`.
+   */
+  protected quoteColumnName(name: string | Nodes.SqlLiteral): string {
+    if (name instanceof Nodes.SqlLiteral) return name.value;
+    return `"${String(name).replace(/"/g, '""')}"`;
   }
 }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -126,11 +126,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       d.set(ctor, m);
     };
     // Statements
-    reg(Nodes.SelectStatement, "visit_Arel_Nodes_SelectStatement");
-    reg(Nodes.SelectCore, "visit_Arel_Nodes_SelectCore");
-    reg(Nodes.InsertStatement, "visit_Arel_Nodes_InsertStatement");
-    reg(Nodes.UpdateStatement, "visit_Arel_Nodes_UpdateStatement");
-    reg(Nodes.DeleteStatement, "visit_Arel_Nodes_DeleteStatement");
+    reg(Nodes.SelectStatement, "visitArelNodesSelectStatement");
+    reg(Nodes.SelectCore, "visitArelNodesSelectCore");
+    reg(Nodes.InsertStatement, "visitArelNodesInsertStatement");
+    reg(Nodes.UpdateStatement, "visitArelNodesUpdateStatement");
+    reg(Nodes.DeleteStatement, "visitArelNodesDeleteStatement");
     // Set operations
     reg(Nodes.UnionAll, "visitUnionAll");
     reg(Nodes.Union, "visitUnion");
@@ -205,7 +205,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     reg(Nodes.Fragments, "visitFragments");
     // Functions
     reg(Nodes.NamedFunction, "visitNamedFunction");
-    reg(Nodes.Exists, "visit_Arel_Nodes_Exists");
+    reg(Nodes.Exists, "visitArelNodesExists");
     reg(Nodes.Count, "visitCount");
     reg(Nodes.Sum, "visitSum");
     reg(Nodes.Max, "visitMax");
@@ -218,26 +218,26 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     reg(Nodes.Group, "visitGroup");
     reg(Nodes.GroupingElement, "visitGroupingElement");
     reg(Nodes.Lateral, "visitLateral");
-    reg(Nodes.Comment, "visit_Arel_Nodes_Comment");
-    reg(Nodes.OptimizerHints, "visit_Arel_Nodes_OptimizerHints");
+    reg(Nodes.Comment, "visitArelNodesComment");
+    reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
     reg(Nodes.HomogeneousIn, "visitHomogeneousIn");
     // Boolean literals
-    reg(Nodes.True, "visit_Arel_Nodes_True");
-    reg(Nodes.False, "visit_Arel_Nodes_False");
+    reg(Nodes.True, "visitArelNodesTrue");
+    reg(Nodes.False, "visitArelNodesFalse");
     // Leaf nodes
     reg(Nodes.Distinct, "visitDistinct");
     reg(Nodes.SqlLiteral, "visitSqlLiteral");
     reg(Nodes.Quoted, "visitQuoted");
-    reg(Nodes.Casted, "visit_Arel_Nodes_Casted");
+    reg(Nodes.Casted, "visitArelNodesCasted");
     reg(Nodes.UnqualifiedColumn, "visitUnqualifiedColumn");
     reg(Nodes.Attribute, "visitAttribute");
-    reg(Nodes.ValuesList, "visit_Arel_Nodes_ValuesList");
+    reg(Nodes.ValuesList, "visitArelNodesValuesList");
     reg(Table, "visitTable");
   }
 
   // -- Statements --
 
-  protected visit_Arel_Nodes_SelectStatement(node: Nodes.SelectStatement): SQLString {
+  protected visitArelNodesSelectStatement(node: Nodes.SelectStatement): SQLString {
     if (node.with) {
       this.visit(node.with);
       this.collector.append(" ");
@@ -285,11 +285,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     }
   }
 
-  // Mirrors Rails: visit_Arel_Nodes_SelectCore (to_sql.rb:149). Where Rails
+  // Mirrors Rails: visitArelNodesSelectCore (to_sql.rb:149). Where Rails
   // uses collect_nodes_for to emit `spacer` + injectJoin in one call, we do
   // the same; wheres/havings collapse multiple predicates with " AND " via
   // collect_nodes_for's connector arg.
-  protected visit_Arel_Nodes_SelectCore(node: Nodes.SelectCore): SQLString {
+  protected visitArelNodesSelectCore(node: Nodes.SelectCore): SQLString {
     this.collector.append("SELECT");
 
     this.collectOptimizerHints(node);
@@ -312,7 +312,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_InsertStatement(node: Nodes.InsertStatement): SQLString {
+  protected visitArelNodesInsertStatement(node: Nodes.InsertStatement): SQLString {
     this.collector.retryable = false;
     this.collector.append("INSERT INTO ");
     if (node.relation) this.visit(node.relation);
@@ -339,7 +339,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_UpdateStatement(o: Nodes.UpdateStatement): SQLString {
+  protected visitArelNodesUpdateStatement(o: Nodes.UpdateStatement): SQLString {
     const node = this.prepareUpdateStatement(o);
     this.collector.retryable = false;
     this.collector.append("UPDATE ");
@@ -374,7 +374,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_DeleteStatement(o: Nodes.DeleteStatement): SQLString {
+  protected visitArelNodesDeleteStatement(o: Nodes.DeleteStatement): SQLString {
     const node = this.prepareDeleteStatement(o);
     this.collector.retryable = false;
     this.collector.append("DELETE ");
@@ -861,7 +861,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_Exists(node: Nodes.Exists): SQLString {
+  protected visitArelNodesExists(node: Nodes.Exists): SQLString {
     this.collector.append("EXISTS (");
     this.visit(node.expressions);
     this.collector.append(")");
@@ -1114,12 +1114,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   // -- Boolean literals --
 
-  protected visit_Arel_Nodes_True(_node: Nodes.True): SQLString {
+  protected visitArelNodesTrue(_node: Nodes.True): SQLString {
     this.collector.append("TRUE");
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_False(_node: Nodes.False): SQLString {
+  protected visitArelNodesFalse(_node: Nodes.False): SQLString {
     this.collector.append("FALSE");
     return this.collector;
   }
@@ -1185,23 +1185,23 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  // Mirrors Rails: visit_Arel_Nodes_Comment (to_sql.rb:175). Rails joins
+  // Mirrors Rails: visitArelNodesComment (to_sql.rb:175). Rails joins
   // with " " into a single string; we keep the per-comment structure with a
   // leading space because callers append directly without a separator.
-  protected visit_Arel_Nodes_Comment(node: Nodes.Comment): SQLString {
+  protected visitArelNodesComment(node: Nodes.Comment): SQLString {
     for (const value of node.values) {
       this.collector.append(` /* ${this.sanitizeAsSqlComment(value)} */`);
     }
     return this.collector;
   }
 
-  // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). The
+  // Mirrors Rails: visitArelNodesOptimizerHints (to_sql.rb:170). The
   // OptimizerHints node carries a list of hint strings (Rails' `o.expr` is
   // an array); each hint is sanitized and the joined result wrapped in
   // /*+ ... */. Trails' SelectCore also stores hints inline as `string[]`
   // — this method exists for callers that build an OptimizerHints node
   // explicitly.
-  protected visit_Arel_Nodes_OptimizerHints(node: Nodes.OptimizerHints): SQLString {
+  protected visitArelNodesOptimizerHints(node: Nodes.OptimizerHints): SQLString {
     const hints = node.hints.map((v) => this.sanitizeAsSqlComment(v)).join(" ");
     this.collector.append(` /*+ ${hints} */`);
     return this.collector;
@@ -1304,7 +1304,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
-    // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
+    // Mirrors Arel's visitArelNodesUnqualifiedColumn — strips the table
     // qualifier so `SET col = col + 1` works in UPDATE statements.
     const attr = node.attribute as Partial<Nodes.Attribute> | undefined;
     if (!attr || typeof attr.name !== "string") {
@@ -1345,7 +1345,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visit_Arel_Nodes_Casted(node: Nodes.Casted): SQLString {
+  protected visitArelNodesCasted(node: Nodes.Casted): SQLString {
     const value = node.valueForDatabase();
     if (this._extractBinds) {
       this.collector.addBind(value);
@@ -1355,7 +1355,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visit_Arel_Nodes_ValuesList(node: Nodes.ValuesList): SQLString {
+  private visitArelNodesValuesList(node: Nodes.ValuesList): SQLString {
     this.collector.append("VALUES ");
     for (let i = 0; i < node.rows.length; i++) {
       if (i > 0) this.collector.append(", ");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1195,16 +1195,14 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). Trails'
-  // SelectCore stores hints inline as `string[]`, so the OptimizerHints node
-  // class isn't constructed in normal use; this method exists for callers
-  // that pass one explicitly. `expr` may be an array or a single value.
+  // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). The
+  // OptimizerHints node carries a list of hint strings (Rails' `o.expr` is
+  // an array); each hint is sanitized and the joined result wrapped in
+  // /*+ ... */. Trails' SelectCore also stores hints inline as `string[]`
+  // — this method exists for callers that build an OptimizerHints node
+  // explicitly.
   protected visit_Arel_Nodes_OptimizerHints(node: Nodes.OptimizerHints): SQLString {
-    const raw = node.expr as unknown;
-    const list = Array.isArray(raw) ? (raw as unknown[]) : [raw];
-    const hints = list
-      .map((v) => this.sanitizeAsSqlComment(v as string | Nodes.SqlLiteral))
-      .join(" ");
+    const hints = node.hints.map((v) => this.sanitizeAsSqlComment(v)).join(" ");
     this.collector.append(` /*+ ${hints} */`);
     return this.collector;
   }
@@ -1290,10 +1288,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitTable(node: Table): SQLString {
-    const quoted = node.name
-      .split(".")
-      .map((p) => this.quoteTableName(p))
-      .join(".");
+    const quoted = this.quoteTableName(node.name);
     if (node.tableAlias) {
       this.collector.append(`${quoted} ${this.quoteTableName(node.tableAlias)}`);
     } else {
@@ -1559,17 +1554,23 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   /**
    * Mirrors `to_sql.rb#quote_table_name`. SqlLiteral pass-through; otherwise
-   * default double-quoted identifier with embedded `"` doubled. MySQL
-   * overrides to backtick-quote (deferred — see project memory
-   * `arel MySQL identifier quoting`).
+   * default double-quoted identifier with embedded `"` doubled. Schema-
+   * qualified names (e.g. `"schema.table"`) are split on `.` and each
+   * segment is quoted independently — same behavior the connection adapter
+   * provides in Rails. MySQL overrides to backtick-quote (deferred — see
+   * project memory `arel MySQL identifier quoting`).
    */
   protected quoteTableName(name: string | Nodes.SqlLiteral): string {
     if (name instanceof Nodes.SqlLiteral) return name.value;
-    return `"${String(name).replace(/"/g, '""')}"`;
+    return String(name)
+      .split(".")
+      .map((p) => `"${p.replace(/"/g, '""')}"`)
+      .join(".");
   }
 
   /**
-   * Mirrors `to_sql.rb#quote_column_name`. Same shape as `quoteTableName`.
+   * Mirrors `to_sql.rb#quote_column_name`. Column names are not schema-
+   * qualified, so a plain double-quote suffices.
    */
   protected quoteColumnName(name: string | Nodes.SqlLiteral): string {
     if (name instanceof Nodes.SqlLiteral) return name.value;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -222,16 +222,16 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     reg(Nodes.OptimizerHints, "visit_Arel_Nodes_OptimizerHints");
     reg(Nodes.HomogeneousIn, "visitHomogeneousIn");
     // Boolean literals
-    reg(Nodes.True, "visitTrue");
-    reg(Nodes.False, "visitFalse");
+    reg(Nodes.True, "visit_Arel_Nodes_True");
+    reg(Nodes.False, "visit_Arel_Nodes_False");
     // Leaf nodes
     reg(Nodes.Distinct, "visitDistinct");
     reg(Nodes.SqlLiteral, "visitSqlLiteral");
     reg(Nodes.Quoted, "visitQuoted");
-    reg(Nodes.Casted, "visitCasted");
+    reg(Nodes.Casted, "visit_Arel_Nodes_Casted");
     reg(Nodes.UnqualifiedColumn, "visitUnqualifiedColumn");
     reg(Nodes.Attribute, "visitAttribute");
-    reg(Nodes.ValuesList, "visitValuesList");
+    reg(Nodes.ValuesList, "visit_Arel_Nodes_ValuesList");
     reg(Table, "visitTable");
   }
 
@@ -1114,12 +1114,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   // -- Boolean literals --
 
-  protected visitTrue(_node: Nodes.True): SQLString {
+  protected visit_Arel_Nodes_True(_node: Nodes.True): SQLString {
     this.collector.append("TRUE");
     return this.collector;
   }
 
-  protected visitFalse(_node: Nodes.False): SQLString {
+  protected visit_Arel_Nodes_False(_node: Nodes.False): SQLString {
     this.collector.append("FALSE");
     return this.collector;
   }
@@ -1350,7 +1350,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  protected visitCasted(node: Nodes.Casted): SQLString {
+  protected visit_Arel_Nodes_Casted(node: Nodes.Casted): SQLString {
     const value = node.valueForDatabase();
     if (this._extractBinds) {
       this.collector.addBind(value);
@@ -1360,7 +1360,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  private visitValuesList(node: Nodes.ValuesList): SQLString {
+  private visit_Arel_Nodes_ValuesList(node: Nodes.ValuesList): SQLString {
     this.collector.append("VALUES ");
     for (let i = 0; i < node.rows.length; i++) {
       if (i > 0) this.collector.append(", ");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -268,9 +268,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.visit(node.lock);
     }
 
-    if (node.comment) {
-      this.visit(node.comment);
-    }
+    this.maybeVisit(node.comment ?? null);
 
     return this.collector;
   }
@@ -1185,13 +1183,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  // Mirrors Rails: visitArelNodesComment (to_sql.rb:175). Rails joins
-  // with " " into a single string; we keep the per-comment structure with a
-  // leading space because callers append directly without a separator.
+  // Mirrors Rails: visitArelNodesComment (to_sql.rb:175) — emits the
+  // joined `/* ... */` blocks without a leading space. Callers add the
+  // leading separator (typically via `maybeVisit`).
   protected visitArelNodesComment(node: Nodes.Comment): SQLString {
-    for (const value of node.values) {
-      this.collector.append(` /* ${this.sanitizeAsSqlComment(value)} */`);
-    }
+    const blocks = node.values.map((v) => `/* ${this.sanitizeAsSqlComment(v)} */`);
+    this.collector.append(blocks.join(" "));
     return this.collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -250,7 +250,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
     if (node.orders.length > 0) {
       this.collector.append(" ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
 
     if (node.limit) {
@@ -285,51 +285,29 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     }
   }
 
+  // Mirrors Rails: visit_Arel_Nodes_SelectCore (to_sql.rb:149). Where Rails
+  // uses collect_nodes_for to emit `spacer` + injectJoin in one call, we do
+  // the same; wheres/havings collapse multiple predicates with " AND " via
+  // collect_nodes_for's connector arg.
   protected visit_Arel_Nodes_SelectCore(node: Nodes.SelectCore): SQLString {
     this.collector.append("SELECT");
 
-    this.emitOptimizerHints(node);
+    this.collectOptimizerHints(node);
+    this.maybeVisit(node.setQuantifier ?? null);
 
-    if (node.setQuantifier) {
-      this.collector.append(" ");
-      this.visit(node.setQuantifier);
-    }
-
-    if (node.projections.length > 0) {
-      this.collector.append(" ");
-      this.visitArray(node.projections, ", ");
-    }
+    this.collectNodesFor(node.projections, " ");
 
     if (node.source.left) {
       this.collector.append(" FROM ");
       this.visit(node.source);
     }
 
-    if (node.wheres.length > 0) {
-      this.collector.append(" WHERE ");
-      const conditions = node.wheres.length === 1 ? node.wheres[0] : new Nodes.And(node.wheres);
-      this.visit(conditions);
-    }
+    this.collectNodesFor(node.wheres, " WHERE ", " AND ");
+    this.collectNodesFor(node.groups, " GROUP BY ");
+    this.collectNodesFor(node.havings, " HAVING ", " AND ");
+    this.collectNodesFor(node.windows, " WINDOW ");
 
-    if (node.groups.length > 0) {
-      this.collector.append(" GROUP BY ");
-      this.visitArray(node.groups, ", ");
-    }
-
-    if (node.havings.length > 0) {
-      this.collector.append(" HAVING ");
-      const conditions = node.havings.length === 1 ? node.havings[0] : new Nodes.And(node.havings);
-      this.visit(conditions);
-    }
-
-    if (node.windows.length > 0) {
-      this.collector.append(" WINDOW ");
-      this.visitArray(node.windows, ", ");
-    }
-
-    if (node.comment) {
-      this.visit(node.comment);
-    }
+    this.maybeVisit(node.comment ?? null);
 
     return this.collector;
   }
@@ -371,7 +349,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.collector.append(" SET ");
       this._inUpdateSet = true;
       try {
-        this.visitArray(node.values, ", ");
+        this.injectJoin(node.values, ", ");
       } finally {
         this._inUpdateSet = false;
       }
@@ -385,7 +363,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
     if (node.orders.length > 0) {
       this.collector.append(" ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
 
     if (node.limit) {
@@ -430,7 +408,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
     if (node.orders.length > 0) {
       this.collector.append(" ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
 
     if (node.limit) {
@@ -861,7 +839,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     this.collector.append(node.name);
     this.collector.append("(");
     if (node.distinct) this.collector.append("DISTINCT ");
-    this.visitArray(node.expressions, ", ");
+    this.injectJoin(node.expressions, ", ");
     this.collector.append(")");
     if (node.alias) {
       this.collector.append(" AS ");
@@ -874,7 +852,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     this.collector.retryable = false;
     this.collector.append(`${name}(`);
     if (node.distinct) this.collector.append("DISTINCT ");
-    this.visitArray(node.expressions, ", ");
+    this.injectJoin(node.expressions, ", ");
     this.collector.append(")");
     if (node.alias) {
       this.collector.append(" AS ");
@@ -900,12 +878,12 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     this.collector.append("(");
     if (node.partitions.length > 0) {
       this.collector.append("PARTITION BY ");
-      this.visitArray(node.partitions, ", ");
+      this.injectJoin(node.partitions, ", ");
     }
     if (node.orders.length > 0) {
       if (node.partitions.length > 0) this.collector.append(" ");
       this.collector.append("ORDER BY ");
-      this.visitArray(node.orders, ", ");
+      this.injectJoin(node.orders, ", ");
     }
     if (node.framing) {
       this.collector.append(" ");
@@ -1103,13 +1081,13 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   private visitWith(node: Nodes.With): SQLString {
     this.collector.append("WITH ");
-    this.visitArray(node.children, ", ");
+    this.injectJoin(node.children, ", ");
     return this.collector;
   }
 
   private visitWithRecursive(node: Nodes.WithRecursive): SQLString {
     this.collector.append("WITH RECURSIVE ");
-    this.visitArray(node.children, ", ");
+    this.injectJoin(node.children, ", ");
     return this.collector;
   }
 
@@ -1314,10 +1292,10 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   private visitTable(node: Table): SQLString {
     const quoted = node.name
       .split(".")
-      .map((p) => `"${p}"`)
+      .map((p) => this.quoteTableName(p))
       .join(".");
     if (node.tableAlias) {
-      this.collector.append(`${quoted} "${node.tableAlias}"`);
+      this.collector.append(`${quoted} ${this.quoteTableName(node.tableAlias)}`);
     } else {
       this.collector.append(quoted);
     }
@@ -1325,9 +1303,8 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   private visitAttribute(node: Nodes.Attribute): SQLString {
-    const tbl = (node.relation.tableAlias || node.relation.name).replace(/"/g, '""');
-    const col = node.name.replace(/"/g, '""');
-    this.collector.append(`"${tbl}"."${col}"`);
+    const tbl = node.relation.tableAlias || node.relation.name;
+    this.collector.append(`${this.quoteTableName(tbl)}.${this.quoteColumnName(node.name)}`);
     return this.collector;
   }
 
@@ -1338,7 +1315,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     if (!attr || typeof attr.name !== "string") {
       throw new UnsupportedVisitError("UnqualifiedColumn must wrap an Attribute node with a name");
     }
-    this.collector.append(`"${attr.name.replace(/"/g, '""')}"`);
+    this.collector.append(this.quoteColumnName(attr.name));
     return this.collector;
   }
 
@@ -1444,13 +1421,6 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
       this.collector.append(String(v));
     }
     return this.collector;
-  }
-
-  protected visitArray(nodes: Node[], separator: string): void {
-    for (let i = 0; i < nodes.length; i++) {
-      if (i > 0) this.collector.append(separator);
-      this.visit(nodes[i]);
-    }
   }
 
   // Formats a date-like value as a SQL datetime string matching Rails'
@@ -1562,13 +1532,14 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   /**
-   * Mirrors `to_sql.rb#collect_optimizer_hints`. Visits the optimizer hint
-   * if one is present. Trails' SelectCore stores hints inline (an array on
-   * the node) rather than as a separate Arel::Nodes::OptimizerHints; this
-   * helper provides the Rails-shaped seam for callers that pass a node.
+   * Mirrors `to_sql.rb#collect_optimizer_hints`. Rails delegates to
+   * `maybe_visit o.optimizer_hints` since hints are an Arel node;
+   * Trails' SelectCore stores hints inline as `string[]`, so we call into
+   * the existing `emitOptimizerHints` formatter for parity at the seam.
    */
-  protected collectOptimizerHints(o: { optimizerHints?: Node | null }): SQLString {
-    return this.maybeVisit(o.optimizerHints);
+  protected collectOptimizerHints(o: Nodes.SelectCore): SQLString {
+    this.emitOptimizerHints(o);
+    return this.collector;
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -283,7 +283,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     }
   }
 
-  // Mirrors Rails: visitArelNodesSelectCore (to_sql.rb:149). Where Rails
+  // Mirrors Rails: visit_Arel_Nodes_SelectCore (to_sql.rb:149). Where Rails
   // uses collect_nodes_for to emit `spacer` + injectJoin in one call, we do
   // the same; wheres/havings collapse multiple predicates with " AND " via
   // collect_nodes_for's connector arg.
@@ -1183,7 +1183,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  // Mirrors Rails: visitArelNodesComment (to_sql.rb:175) — emits the
+  // Mirrors Rails: visit_Arel_Nodes_Comment (to_sql.rb:175) — emits the
   // joined `/* ... */` blocks without a leading space. Callers add the
   // leading separator (typically via `maybeVisit`).
   protected visitArelNodesComment(node: Nodes.Comment): SQLString {
@@ -1192,7 +1192,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
     return this.collector;
   }
 
-  // Mirrors Rails: visitArelNodesOptimizerHints (to_sql.rb:170). The
+  // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). The
   // OptimizerHints node carries a list of hint strings (Rails' `o.expr` is
   // an array); each hint is sanitized and the joined result wrapped in
   // /*+ ... */. Trails' SelectCore also stores hints inline as `string[]`
@@ -1301,7 +1301,7 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
   }
 
   protected visitUnqualifiedColumn(node: Nodes.UnqualifiedColumn): SQLString {
-    // Mirrors Arel's visitArelNodesUnqualifiedColumn — strips the table
+    // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
     // qualifier so `SET col = col + 1` works in UPDATE statements.
     const attr = node.attribute as Partial<Nodes.Attribute> | undefined;
     if (!attr || typeof attr.name !== "string") {

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -10,7 +10,11 @@ export function snakeToCamel(name: string): string {
   const match = name.match(/^(_+)/);
   const prefix = match ? match[1] : "";
   const rest = name.slice(prefix.length);
-  return prefix + rest.replace(/_([a-z0-9])/g, (_, ch: string) => ch.toUpperCase());
+  // Match `_` followed by any letter or digit so Ruby names containing
+  // capitalized segments (e.g. `visit_Arel_Nodes_SelectStatement`)
+  // collapse cleanly to camelCase TS form (`visitArelNodesSelectStatement`)
+  // — matching project style instead of leaking literal snake_case identifiers.
+  return prefix + rest.replace(/_([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
 }
 
 /** Ruby file path → expected TS file path (kebab-case, .ts extension) */


### PR DESCRIPTION
## Summary

PR 2 in the path to 100% on `pnpm api:compare --package arel --privates`. Mirrors the first 100 lines of `activerecord/lib/arel/visitors/to_sql.rb` plus the named-quoting/comment helpers from the bottom of the file.

Builds on #993 — the dispatch infrastructure landed there means renaming a visit method is a one-line dispatch-table edit, not a code-path change.

## What changed

### Statement visit-method renames (project camelCase form of Rails' `visit_Arel_Nodes_*`)

Each Trails method is named with the camelCased form of the Rails method (`visit_Arel_Nodes_X` → `visitArelNodesX`). Project style is camelCase across the codebase, so we don't leak literal Ruby snake_case into TS — instead `scripts/api-compare/conventions.ts#snakeToCamel` is extended to handle `_<Capital>` so api:compare matches the Ruby name to the TS method automatically.

| Trails before | Trails now | Rails source |
|---|---|---|
| `visitSelectStatement` | `visitArelNodesSelectStatement` | to_sql.rb:120 |
| `visitSelectCore` | `visitArelNodesSelectCore` | to_sql.rb:149 |
| `visitInsertStatement` | `visitArelNodesInsertStatement` | to_sql.rb:53 |
| `visitUpdateStatement` | `visitArelNodesUpdateStatement` | to_sql.rb:40 |
| `visitDeleteStatement` | `visitArelNodesDeleteStatement` | to_sql.rb:22 |
| `visitExists` | `visitArelNodesExists` | to_sql.rb:225 |
| `visitComment` | `visitArelNodesComment` | to_sql.rb:175 |
| `visitTrue` | `visitArelNodesTrue` | to_sql.rb |
| `visitFalse` | `visitArelNodesFalse` | to_sql.rb |
| `visitCasted` | `visitArelNodesCasted` | to_sql.rb |
| `visitValuesList` | `visitArelNodesValuesList` | to_sql.rb |

`mysql.ts` / `sqlite.ts` / `postgresql.ts` overrides updated to track. `visitArelNodesComment` is also rewritten to delegate sanitization to the new `sanitizeAsSqlComment` helper and to mirror Rails' shape exactly (no leading space; callers add it via `maybeVisit`).

### New visit method

`visitArelNodesOptimizerHints` (to_sql.rb:170). The OptimizerHints node carries hints in a typed `hints` field (`ReadonlyArray<string | SqlLiteral>`); the visitor sanitizes each and emits `/*+ ... */`.

### Private helpers (new)

| Helper | Rails source | Behavior |
|---|---|---|
| `collectNodesFor` | to_sql.rb:179 | spacer + injectJoin (no-op if empty) |
| `injectJoin` | to_sql.rb:897 | (replaces Trails-specific `visitArray` across 22 callers) |
| `maybeVisit` | to_sql.rb:891 | leading-space + visit if non-null |
| `collectOptimizerHints` | to_sql.rb:887 | adapted to Trails' inline `string[]` storage |
| `sanitizeAsSqlComment` | to_sql.rb:882 | SqlLiteral pass-through; strip newlines and `/* */` |
| `quoteTableName` | to_sql.rb:872 | SqlLiteral pass-through; default double-quoted with `.`-segment splitting (handles `schema.table`); embedded `"` doubled |
| `quoteColumnName` | to_sql.rb:877 | SqlLiteral pass-through; default double-quoted |

`visitTable` / `visitAttribute` / `visitUnqualifiedColumn` now route through `quoteTableName` / `quoteColumnName` instead of inline `replace(/"/g, '""')` so the schema-qualified form is consistent (FROM clause and column refs both emit `"schema"."table"."col"`).

`visitArelNodesSelectCore` refactored to use `collectNodesFor` / `maybeVisit` line-for-line with to_sql.rb:149.

Note: the MySQL backtick override for `quoteTableName`/`quoteColumnName` is the deferred follow-up tracked by the `arel MySQL identifier quoting` memory item.

## Coverage

`pnpm tsx scripts/api-compare/compare.ts --package arel --privates`:

| | Before | After |
|---|---|---|
| Overall | 638/820 (77.8%) | **662/820 (80.7%)** |
| `visitors/to_sql.rb` | 7/118 (6%) | **26/118 (22%)** |

(Inheritance `68/69` is pre-existing on main — `UnsupportedVisitError` was moved into `errors.ts` by #993; not introduced here.)

## Tests

- `sanitizeAsSqlComment` SqlLiteral pass-through and delimiter/newline stripping.
- `quoteTableName` / `quoteColumnName` for bare names, schema-qualified names, embedded `"` doubling, and SqlLiteral pass-through.
- `visitArelNodesOptimizerHints` emits `/*+ ... */` for an array of hints (string and SqlLiteral), with comment-delimiter stripping.
- `collectNodesFor` spacer+connector behavior on multi-WHERE; no-op on empty lists.
- Comment placement: regression test pinning single-space `SELECT … /* hi */ /* bye */` shape across SelectStatement and SelectCore.
- Schema-qualified `Table("schema.table")` round-trip.

## Test plan

- [x] `pnpm exec tsc --noEmit -p packages/arel` clean
- [x] `pnpm exec eslint packages/arel/src` clean
- [x] `pnpm exec vitest run packages/arel/` — 1105/1105 passing
- [x] `pnpm exec vitest run packages/activerecord/src/relation` — 1356/1356 passing
- [x] `pnpm tsx scripts/api-compare/compare.ts --package arel --privates` — 662/820, to_sql.rb 26/118