### PR TITLE
perf(website): split TypeDoc output into per-symbol pages

### DIFF
--- a/packages/website/typedoc.json
+++ b/packages/website/typedoc.json
@@ -14,7 +14,7 @@
   "readme": "none",
   "githubPages": false,
   "excludeInternal": true,
-  "outputFileStrategy": "modules",
+  "outputFileStrategy": "members",
   "expandObjects": true,
   "parametersFormat": "table",
   "enumMembersFormat": "table",


### PR DESCRIPTION
## Summary

Flip `outputFileStrategy` from `modules` to `members` in `packages/website/typedoc.json`. TypeDoc emits one page per symbol instead of one giant page per package, which slashes the worst-case payload on initial page load.

## Measured impact

### Build time

| | local docs:build | CI Website job |
|---|---:|---:|
| `modules` (baseline) | **385s** | 285–341s (median ~290s) |
| `members` | **92s** | **192s** |
| **Δ** | **−76% (4.2× faster)** | **−33%** |

Local timing measured against the full `pnpm --filter @blazetrails/website docs:build` (TypeDoc → VitePress → static HTML). CI values pulled from recent `Website` job runs on `main` (n=4: 290, 341, 285, 336s) and this PR's first run (192s on commit e288613a).

VitePress parallelizes per-page rendering far better when no individual page is megabytes of markdown — the giant `arel/Nodes.html` (10.5 MB) was forcing serial work.

### Bundle / page sizes

| metric                | modules (before) | members (after) | delta   |
| --------------------- | ---------------: | --------------: | ------: |
| largest single page   | 10.5 MB          | 838 KB          | **−92%** |
| total HTML pages      | 34               | 1,202           | +35×    |
| total artifact disk   | 22.3 MB          | 151.9 MB        | +581%   |

**Largest pages**
- before: `arel/Nodes.html` 10.5 MB · `activerecord/README` 5.2 MB · `activesupport/README` 1.7 MB
- after: `activerecord/Base` 838 KB · `activerecord/CollectionProxy` 530 KB · `activerecord/AssociationRelation` 498 KB

## Tradeoff

Total artifact disk balloons (22 → 152 MB) because each page carries the full VitePress shell (CSS, JS, sidebar HTML). That cost only affects the deploy bucket, not what users download — bandwidth for typical browsing is comparable, and the worst-case first-paint goes from "unusable on slow connections" to "fits in a single TCP slow-start round trip."

## Compatibility

Existing VitePress sidebar links in `.vitepress/config.ts` (`/api/@blazetrails/<pkg>/README`) keep working — TypeDoc still emits a top-level `README.md` per package as the index. No config changes needed.

## Test plan

- [x] `pnpm --filter @blazetrails/website docs:build` succeeds locally (92s)
- [x] CI `Website` job succeeds on commit e288613a (192s, vs ~290s on main)
- [x] No broken VitePress sidebar links (manual sample of arel/activemodel/activerecord)
- [x] `Base.html` (the new largest page) renders correctly with all Base public surface visible