### PR TITLE
docs(activesupport): annotate intentional Date boundaries

### DIFF
--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -1,5 +1,10 @@
 /**
  * ActiveSupport::Duration — mirrors the Rails API as closely as possible.
+ *
+ * @boundary-file: This file's public API is Date-typed by Rails parity
+ *   (`since`/`ago`/`from_now`/`until`/`after`/`before` all take and return
+ *   `Time`-like values, which JS expresses as `Date`). The Temporal flip lives
+ *   on `TimeWithZone` instead.
  */
 
 export type DurationParts = {

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -93,8 +93,9 @@ export class Logger {
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
     // boundary: Logger#formatter receives a Date timestamp by Rails parity
     // (Ruby Logger::Formatter#call(severity, time, progname, msg) — time is a Time).
+    const now = new Date();
     const line = this.formatter
-      ? this.formatter(severityName, new Date(), this.progname, msg)
+      ? this.formatter(severityName, now, this.progname, msg)
       : `${msg}\n`;
     this.output?.write(line);
     return true;

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -91,6 +91,8 @@ export class Logger {
     if (severity < this.level) return true;
     const msg = message != null ? String(message) : (progname ?? this.progname);
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
+    // boundary: Logger#formatter receives a Date timestamp by Rails parity
+    // (Ruby Logger::Formatter#call(severity, time, progname, msg) — time is a Time).
     const line = this.formatter
       ? this.formatter(severityName, new Date(), this.progname, msg)
       : `${msg}\n`;

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -93,9 +93,8 @@ export class Logger {
     const severityName = (LEVEL_NAMES[severity] ?? "unknown").toUpperCase();
     // boundary: Logger#formatter receives a Date timestamp by Rails parity
     // (Ruby Logger::Formatter#call(severity, time, progname, msg) — time is a Time).
-    const now = new Date();
     const line = this.formatter
-      ? this.formatter(severityName, now, this.progname, msg)
+      ? this.formatter(severityName, new Date(), this.progname, msg)
       : `${msg}\n`;
     this.output?.write(line);
     return true;

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -61,6 +61,7 @@ export class MessageVerifier {
     if (options.expiresAt) {
       payload._expiresAt = options.expiresAt.toISOString();
     } else if (options.expiresIn !== undefined) {
+      // boundary: ISO timestamp serialized into the signed payload.
       payload._expiresAt = new Date(Date.now() + options.expiresIn * 1000).toISOString();
     }
 
@@ -100,6 +101,7 @@ export class MessageVerifier {
 
       const payload = parsed as Record<string, unknown>;
 
+      // boundary: parse the embedded ISO timestamp and compare to wall clock.
       if (payload._expiresAt && new Date(payload._expiresAt as string) < new Date()) {
         throw new InvalidSignature("Expired message");
       }

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -5,6 +5,9 @@
  *   const sub = Notifications.subscribe("sql.active_record", (event) => { ... });
  *   Notifications.instrument("sql.active_record", { sql: "SELECT 1" }, () => { ... });
  *   Notifications.unsubscribe(sub);
+ *
+ * @boundary-file: emits `Event` instances whose `time`/`end` fields are
+ *   JS `Date` by Rails parity (see `notifications/instrumenter.ts`).
  */
 
 import { Event } from "./notifications/instrumenter.js";

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -1,3 +1,8 @@
+/**
+ * @boundary-file: subscriber group implementations time their callbacks with
+ *   JS `Date` because the public `Event.time`/`end` contract is Date-typed
+ *   (Rails parity — see notifications/instrumenter.ts).
+ */
 import { Event } from "./instrumenter.js";
 
 export class InstrumentationSubscriberError extends Error {

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -1,7 +1,8 @@
 /**
- * @boundary-file: subscriber group implementations time their callbacks with
- *   JS `Date` because the public `Event.time`/`end` contract is Date-typed
- *   (Rails parity — see notifications/instrumenter.ts).
+ * @boundary-file: subscriber group implementations may time their callbacks
+ *   with either JS `Date` values or monotonic numeric timestamps, depending on
+ *   the timing source. The public `Event.time`/`end` contract remains
+ *   Date-typed for Rails parity — see notifications/instrumenter.ts.
  */
 import { Event } from "./instrumenter.js";
 

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -1,8 +1,9 @@
 /**
  * @boundary-file: ActiveSupport::Notifications::Event exposes `time: Date` /
- *   `end: Date` as a public contract for log subscribers and listeners
- *   (Rails parity — Ruby Event#time returns a Time). The Temporal flip on
- *   this surface is tracked separately as a cross-cutting subscriber refactor.
+ *   `end: Date | null` as a public contract for log subscribers and listeners;
+ *   `end` becomes a `Date` once `finish()` runs (Rails parity — Ruby
+ *   Event#time returns a Time). The Temporal flip on this surface is tracked
+ *   separately as a cross-cutting subscriber refactor.
  */
 
 export type EventPayload = Record<string, unknown>;

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -1,3 +1,10 @@
+/**
+ * @boundary-file: ActiveSupport::Notifications::Event exposes `time: Date` /
+ *   `end: Date` as a public contract for log subscribers and listeners
+ *   (Rails parity — Ruby Event#time returns a Time). The Temporal flip on
+ *   this surface is tracked separately as a cross-cutting subscriber refactor.
+ */
+
 export type EventPayload = Record<string, unknown>;
 
 let _txCounter = 0;

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -1,5 +1,9 @@
 /**
  * Range utility functions mirroring ActiveSupport's Range extensions.
+ *
+ * @boundary-file: Date-aware range comparators (`overlap`, `cover`, `each`)
+ *   coerce `Date` ↔ epoch number for ordering since Rails' `Range#include?`
+ *   accepts any `<=>`-comparable value. Temporal-typed ranges live elsewhere.
  */
 
 export interface Range<T> {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -2,7 +2,10 @@
  * Time/Date extension functions following Rails' ActiveSupport::CoreExt::Time
  * and ActiveSupport::CoreExt::Date patterns.
  *
- * All functions operate on JavaScript Date objects (local time).
+ * @boundary-file: All functions operate on JavaScript `Date` objects by Rails
+ *   parity — the file mirrors `core_ext/time` / `core_ext/date`, both of which
+ *   are Ruby Time/Date-typed in Rails. Temporal-typed equivalents live on
+ *   `TimeWithZone` (instant, plain date/time) and `Duration`.
  */
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -4,6 +4,11 @@
  *
  * Separated from testing-helpers so production code doesn't need to import
  * test assertion utilities.
+ *
+ * @boundary-file: `currentTime()` returns a JS `Date` because most consumers
+ *   (legacy Rails-port code in `time-ext`, `duration`, etc.) are Date-typed.
+ *   Callers that want Temporal use `Temporal.Now.instant()` directly or bridge
+ *   via `instantFrom(currentTime())`.
  */
 
 let _frozenTime: Date | null = null;

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -81,6 +81,7 @@ function pad3(n: number): string {
 }
 
 function daysInMonth(year: number, month: number): number {
+  // boundary: classic JS days-in-month trick (day 0 of next month).
   return new Date(year, month, 0).getDate();
 }
 
@@ -100,7 +101,11 @@ export class TimeWithZone {
     return this._zoned.epochMilliseconds;
   }
 
-  /** Build a Date snapshot for legacy Date-based helpers and formatters. */
+  /**
+   * Build a Date snapshot for legacy Date-based helpers and formatters.
+   * boundary: bridges the Temporal-typed storage to the still-Date-typed
+   * `TimeZone` lookup helpers and `time-ext`/`duration` arithmetic.
+   */
   private _toDate(): Date {
     return new Date(this._epochMs);
   }
@@ -235,13 +240,14 @@ export class TimeWithZone {
 
   /** Day of the week, 0=Sunday */
   get wday(): number {
-    // Calculate from the local date
+    // boundary: JS Date constructor for cheap weekday-of arithmetic.
     const l = this._local();
     return new Date(l.year, l.month - 1, l.day).getDay();
   }
 
   /** Day of the year, 1-366 */
   get yday(): number {
+    // boundary: JS Date arithmetic for day-of-year span calculation.
     const l = this._local();
     const jan1 = new Date(l.year, 0, 1);
     const localDate = new Date(l.year, l.month - 1, l.day);
@@ -562,6 +568,8 @@ export class TimeWithZone {
     if (arg instanceof TimeWithZone) {
       return (this._epochMs - arg._epochMs) / 1000;
     }
+    // boundary: minus accepts Date for backwards compat with Rails' `t1 - t2`
+    // overload that takes any Time-like value (including Ruby Time / DateTime).
     if (arg instanceof Date) {
       return (this._epochMs - arg.getTime()) / 1000;
     }
@@ -715,6 +723,7 @@ export class TimeWithZone {
     if (other instanceof TimeWithZone) {
       return this._epochMs === other._epochMs;
     }
+    // boundary: eql is duck-typed in Rails (any Time-like); accept Date.
     if (other instanceof Date) {
       return this._epochMs === other.getTime();
     }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -101,12 +101,10 @@ export class TimeWithZone {
     return this._zoned.epochMilliseconds;
   }
 
-  /**
-   * Build a Date snapshot for legacy Date-based helpers and formatters.
-   * boundary: bridges the Temporal-typed storage to the still-Date-typed
-   * `TimeZone` lookup helpers and `time-ext`/`duration` arithmetic.
-   */
+  /** Build a Date snapshot for legacy Date-based helpers and formatters. */
   private _toDate(): Date {
+    // boundary: bridges Temporal-backed state to still-Date-typed TimeZone
+    // helpers and time-ext/duration arithmetic.
     return new Date(this._epochMs);
   }
 
@@ -240,16 +238,17 @@ export class TimeWithZone {
 
   /** Day of the week, 0=Sunday */
   get wday(): number {
-    // boundary: JS Date constructor for cheap weekday-of arithmetic.
     const l = this._local();
+    // boundary: JS Date constructor for cheap weekday-of arithmetic.
     return new Date(l.year, l.month - 1, l.day).getDay();
   }
 
   /** Day of the year, 1-366 */
   get yday(): number {
-    // boundary: JS Date arithmetic for day-of-year span calculation.
     const l = this._local();
+    // boundary: JS Date arithmetic for day-of-year span calculation.
     const jan1 = new Date(l.year, 0, 1);
+    // boundary: JS Date arithmetic for day-of-year span calculation.
     const localDate = new Date(l.year, l.month - 1, l.day);
     return Math.floor((localDate.getTime() - jan1.getTime()) / 86400000) + 1;
   }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -2,6 +2,11 @@
  * ActiveSupport::TimeZone — mirrors the Rails API.
  *
  * Uses the built-in Intl API for timezone data, wrapping IANA timezone names.
+ *
+ * @boundary-file: `Intl.DateTimeFormat#formatToParts` requires a JS `Date`
+ *   input, so this file traffics in `Date` for offset/abbrev/DST lookups and
+ *   for the `local`-to-UTC ambiguity search. The Temporal-aware public surface
+ *   lives on `TimeWithZone`; this module is its calculation backend.
  */
 
 import { TimeWithZone } from "../time-with-zone.js";


### PR DESCRIPTION
## Summary

PR 11c of the Temporal migration's incidental-Date audit. Annotates every `new Date` / `instanceof Date` site in `packages/activesupport/src` (outside test files and the testing helpers) so the PR 12 lint rule has explicit per-file or per-line escape hatches.

The PR 12 lint rule will accept three forms:
- File-level `@boundary-file:` JSDoc directive (entire module).
- Same-line trailing `// boundary:` comment.
- Immediately-preceding `// boundary:` comment line.

### File-level `@boundary-file:` directives

Entire module is Date-typed by Rails parity:

- `duration.ts` — Rails `Duration` ports (`since`/`ago`/`from_now`/etc.) take and return `Time`-like values.
- `time-ext.ts` — `core_ext/time` and `core_ext/date` Date helpers.
- `range-ext.ts` — Date-aware Range comparators (`overlap`, `cover`, `each`).
- `time-travel.ts` — `currentTime()` returns Date by Rails `Time.zone.travel_to` parity.
- `values/time-zone.ts` — `Intl.DateTimeFormat#formatToParts` requires Date input.
- `notifications.ts`, `notifications/instrumenter.ts`, `notifications/fanout.ts` — `Event#time`/`#end` is Date by Rails parity (Ruby `Notifications::Event#time` returns a `Time`).

### Line-level `// boundary:` annotations

- `time-with-zone.ts` — `daysInMonth`, `_toDate` snapshot, `wday`/`yday` helpers, `minus`/`eql` Date-arg overloads.
- `logger.ts` — `Logger#formatter` receives Date by Rails parity (Ruby `Logger::Formatter#call(severity, time, progname, msg)` — `time` is a `Time`).
- `message-verifier.ts` — ISO timestamp serialization for token expiry.

Comments-only; no behavior change.

Migration of `Notifications::Event#time` to `Temporal.Instant` is deliberately deferred — it's a cross-cutting subscriber refactor that warrants its own PR.

## Test plan

- [x] `vitest run packages/activesupport` — 3604/3604 pass
- [x] `pnpm typecheck`
- [x] Diff size: 56 LOC well under the 300 ceiling