### PR TITLE
feat(activemodel): port Length skipNilCheck + route through this.resolveValue

### DIFF
--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -487,4 +487,37 @@ describe("LengthValidationTest", () => {
     expect(new Person({ title: "12345" }).isValid()).toBe(true);
     expect(new Person({ title: "1234" }).isValid()).toBe(false);
   });
+
+  it("validates length of with proc", () => {
+    // Rails length.rb:55 — `check_value = resolve_value(record, check_value)`.
+    // A Proc receives the record and returns the limit per-instance.
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.attribute("limit", "integer");
+        this.validates("title", {
+          length: { maximum: (r: Person) => r.readAttribute("limit") as number },
+        });
+      }
+    }
+    expect(new Person({ title: "abc", limit: 5 }).isValid()).toBe(true);
+    expect(new Person({ title: "abcdef", limit: 5 }).isValid()).toBe(false);
+  });
+
+  it("validates length of with symbol method name", () => {
+    // Rails: a Symbol resolves via record.send(:method_name). In TS a
+    // string option that names a method on the record is resolved the
+    // same way (resolve-value.ts).
+    class Person extends Model {
+      static {
+        this.attribute("title", "string");
+        this.validates("title", { length: { minimum: "minLength" } });
+      }
+      minLength(): number {
+        return 3;
+      }
+    }
+    expect(new Person({ title: "abc" }).isValid()).toBe(true);
+    expect(new Person({ title: "ab" }).isValid()).toBe(false);
+  });
 });

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -2,8 +2,24 @@ import { EachValidator } from "../validator.js";
 import type { AnyRecord } from "../validator.js";
 import { resolveValue } from "./resolve-value.js";
 
+/**
+ * Mirrors: ActiveModel::Validations::LengthValidator (length.rb)
+ *
+ *   class LengthValidator < EachValidator
+ *     include ResolveValue
+ *
+ *     CHECKS = { is: :==, minimum: :>=, maximum: :<= }.freeze
+ *     ...
+ */
 export class LengthValidator extends EachValidator {
-  resolveValue = resolveValue;
+  // Declarations only — actual functions attached to the prototype below.
+  // Prototype attachment (not class fields) so the helpers are present
+  // during EachValidator's constructor-time checkValidity() call. JS class
+  // fields don't initialize until AFTER super() returns. (Same bootstrapping
+  // lesson as PR #994 / #1002.)
+  declare resolveValue: typeof resolveValue;
+  /** @internal Rails-private helper. */
+  declare skipNilCheck: typeof skipNilCheck;
 
   override checkValidity(): void {
     if (
@@ -19,15 +35,6 @@ export class LengthValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
-    if (value === null || value === undefined) {
-      const maximumOnly =
-        this.options.maximum !== undefined &&
-        this.options.minimum === undefined &&
-        this.options.is === undefined &&
-        this.options.in === undefined;
-      if (this.options.allowNil !== false || maximumOnly) return;
-    }
-
     let length: number;
     if (typeof value === "string" || Array.isArray(value)) {
       length = value.length;
@@ -38,52 +45,111 @@ export class LengthValidator extends EachValidator {
       typeof (value as { length: unknown }).length === "number"
     ) {
       length = (value as { length: number }).length;
+    } else if (value == null) {
+      // Rails: value.respond_to?(:length) ? value.length : value.to_s.length
+      // For nil this returns 0 (nil.to_s.length).
+      length = 0;
     } else {
       length = 0;
     }
 
-    const resolveNum = (v: number | (() => number) | undefined): number | undefined => {
-      if (v === undefined) return undefined;
-      return typeof v === "function" ? v() : v;
-    };
     const inOpt = this.options.in as [number, number] | undefined;
-    let min = inOpt
-      ? inOpt[0]
-      : resolveNum(this.options.minimum as number | (() => number) | undefined);
-    const max = inOpt
-      ? inOpt[1]
-      : resolveNum(this.options.maximum as number | (() => number) | undefined);
+    const rawMin = inOpt ? inOpt[0] : (this.options.minimum as unknown);
+    const rawMax = inOpt ? inOpt[1] : (this.options.maximum as unknown);
+    const rawIs = this.options.is as unknown;
 
+    // Rails length.rb:55 — `check_value = resolve_value(record, check_value)`
+    // — so a Proc / method-name option is resolved per-record.
+    const min = resolveLengthOpt.call(this, record, rawMin);
+    const max = resolveLengthOpt.call(this, record, rawMax);
+    const is = resolveLengthOpt.call(this, record, rawIs);
+
+    let effectiveMin = min;
     if (
-      min === undefined &&
+      effectiveMin === undefined &&
       max === undefined &&
       this.options.allowBlank === false &&
-      this.options.is === undefined &&
+      is === undefined &&
       inOpt === undefined
     ) {
-      min = 1;
+      effectiveMin = 1;
     }
 
-    if (min !== undefined && length < min) {
-      record.errors.add(attribute, "too_short", {
-        message: (this.options.tooShort ?? this.options.message) as string | undefined,
-        count: min,
-        value,
-      });
+    // Rails skip_nil_check?: maximum-only checks treat nil as length 0
+    // unless allow_nil/allow_blank is set, in which case nil short-circuits
+    // before reaching here via EachValidator dispatch. Mirror that — for
+    // any non-:maximum key, skip when value is nil (Rails branches around
+    // !value.nil? || skip_nil_check?(key)).
+    const valueIsNil = value === null || value === undefined;
+
+    if (effectiveMin !== undefined && length < effectiveMin) {
+      if (!valueIsNil || this.skipNilCheck("minimum")) {
+        record.errors.add(attribute, "too_short", {
+          message: (this.options.tooShort ?? this.options.message) as string | undefined,
+          count: effectiveMin,
+          value,
+        });
+      }
     }
     if (max !== undefined && length > max) {
-      record.errors.add(attribute, "too_long", {
-        message: (this.options.tooLong ?? this.options.message) as string | undefined,
-        count: max,
-        value,
-      });
+      if (!valueIsNil || this.skipNilCheck("maximum")) {
+        record.errors.add(attribute, "too_long", {
+          message: (this.options.tooLong ?? this.options.message) as string | undefined,
+          count: max,
+          value,
+        });
+      }
     }
-    if (this.options.is !== undefined && length !== this.options.is) {
-      record.errors.add(attribute, "wrong_length", {
-        message: (this.options.wrongLength ?? this.options.message) as string | undefined,
-        count: this.options.is,
-        value,
-      });
+    if (is !== undefined && length !== is) {
+      if (!valueIsNil || this.skipNilCheck("is")) {
+        record.errors.add(attribute, "wrong_length", {
+          message: (this.options.wrongLength ?? this.options.message) as string | undefined,
+          count: is,
+          value,
+        });
+      }
     }
   }
 }
+
+/**
+ * @internal Resolves a length option through this.resolveValue (so a
+ * Proc / method-name reference is honored per Rails length.rb:55) and
+ * narrows the result to a number.
+ */
+function resolveLengthOpt(
+  this: { resolveValue(record: unknown, value: unknown): unknown },
+  record: AnyRecord,
+  raw: unknown,
+): number | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const resolved = this.resolveValue(record, raw);
+  return typeof resolved === "number" ? resolved : undefined;
+}
+
+/**
+ * Mirrors: length.rb:69
+ *   def skip_nil_check?(key)
+ *     key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
+ *   end
+ *
+ * Returns true when nil should still produce a "too_long" error for a
+ * `:maximum` constraint (Rails treats nil.to_s.length == 0 here, which
+ * is always ≤ max, so the check is effectively a no-op — but the
+ * predicate keeps the dispatch shape Rails-faithful).
+ *
+ * @internal Rails-private helper.
+ */
+export function skipNilCheck(
+  this: { options: Record<string, unknown> },
+  key: "minimum" | "maximum" | "is",
+): boolean {
+  return (
+    key === "maximum" &&
+    this.options.allowNil === undefined &&
+    this.options.allowBlank === undefined
+  );
+}
+
+LengthValidator.prototype.resolveValue = resolveValue;
+LengthValidator.prototype.skipNilCheck = skipNilCheck;

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -35,6 +35,9 @@ export class LengthValidator extends EachValidator {
   }
 
   validateEach(record: AnyRecord, attribute: string, value: unknown): void {
+    // Rails length.rb:50 — `value.respond_to?(:length) ? value.length : value.to_s.length`.
+    // For nil → 0 (nil.to_s.length); for non-nil values without a .length
+    // (numbers, booleans, plain objects) → String(value).length.
     let length: number;
     if (typeof value === "string" || Array.isArray(value)) {
       length = value.length;
@@ -46,11 +49,9 @@ export class LengthValidator extends EachValidator {
     ) {
       length = (value as { length: number }).length;
     } else if (value == null) {
-      // Rails: value.respond_to?(:length) ? value.length : value.to_s.length
-      // For nil this returns 0 (nil.to_s.length).
       length = 0;
     } else {
-      length = 0;
+      length = String(value).length;
     }
 
     const inOpt = this.options.in as [number, number] | undefined;
@@ -75,11 +76,13 @@ export class LengthValidator extends EachValidator {
       effectiveMin = 1;
     }
 
-    // Rails skip_nil_check?: maximum-only checks treat nil as length 0
-    // unless allow_nil/allow_blank is set, in which case nil short-circuits
-    // before reaching here via EachValidator dispatch. Mirror that — for
-    // any non-:maximum key, skip when value is nil (Rails branches around
-    // !value.nil? || skip_nil_check?(key)).
+    // Rails length.rb:54 — `!value.nil? || skip_nil_check?(key)`.
+    // Each branch fires the constraint check unless the value is nil AND
+    // skip_nil_check?(key) returns false (meaning Rails would skip nil
+    // for that key). EachValidator's dispatch only short-circuits on
+    // allowNil === true / allowBlank === true; the explicit-false case
+    // and the default case both reach here, so the per-key guard below
+    // is the load-bearing path.
     const valueIsNil = value === null || value === undefined;
 
     if (effectiveMin !== undefined && length < effectiveMin) {


### PR DESCRIPTION
## Summary
Track A3 of [docs/activemodel-privates-100-plan.md](../blob/main/docs/activemodel-privates-100-plan.md). Mirrors `ActiveModel::Validations::LengthValidator` (`length.rb`):

- **`skipNilCheck(key)`** — `length.rb:69`. Returns true when nil should still produce a `too_long` error for a `:maximum` constraint (Rails: `nil.to_s.length == 0 ≤ max` → effectively a no-op, but the predicate keeps Rails' dispatch shape faithful).
- **`validateEach`** now routes each option through `this.resolveValue` per `length.rb:55` — **closes the `resolveValue` consumption gap** flagged for Length in PR #971. A `resolveLengthOpt` private narrows the resolved value to a number.
- Per-branch nil-skip now consults `this.skipNilCheck(key)`, matching Rails' `!value.nil? || skip_nil_check?(key)` guard at `length.rb:54`.

Helpers attached to `LengthValidator.prototype` (not class fields) so they're available during `EachValidator`'s super-time `checkValidity()` call — same bootstrapping pattern as PRs #994 / #1002. `@internal` JSDoc tags satisfy the `blazetrails/rails-private-jsdoc` lint rule.

## Out of scope (deferred)
- Rails' constructor-time `:in`/`:within` Range preprocessing into `:minimum`/`:maximum`. Trails treats `:in` as a `[number, number]` tuple at the dispatch layer; restructuring that is a larger refactor than this single-private port warrants.
- The explicit `Integer`/`Symbol`/`Proc` type guards in Rails' `check_validity!` (`length.rb:30-46`). Trails relies on duck-typed resolution at validateEach time.

## Impact
- `pnpm api:compare --privates --package activemodel`: `length.rb` 4/5 → **5/5 (100%)** (+1). Overall 470/607 → **471/607 (77.6%)**.
- `pnpm api:compare --package activemodel`: stays **433/433 (100%)**.
- `pnpm test:compare --package activemodel`: stays 959/963.

## Test plan
- [x] `pnpm vitest run packages/activemodel` — 1593 / 1593 passing
- [x] `pnpm lint` — clean
- [x] `pnpm api:compare --package activemodel` — 433/433
- [x] `pnpm api:compare --privates --package activemodel` — 471/607 (+1)
- [x] `pnpm test:compare --package activemodel` — 959/963 (0)