### PR TITLE
feat(activerecord): wire scoping initializeInternalsCallback into Base constructor

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3384,3 +3384,54 @@ describe("quoteSqlValue", () => {
 // ==========================================================================
 // BasicsTest — targets base_test.rb (continued)
 // ==========================================================================
+
+describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => {
+  const adapter = createTestAdapter();
+
+  function makeModel() {
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("id", "integer");
+        this.attribute("role", "string");
+        this.attribute("status", "string");
+        this.adapter = adapter;
+      }
+    }
+    return User;
+  }
+
+  it("applies current-scope attributes to new instances", async () => {
+    const User = makeModel();
+    const rel = User.where({ role: "admin" });
+    await User.scoping(rel, async () => {
+      const u = new User({});
+      expect(u.readAttribute("role")).toBe("admin");
+    });
+  });
+
+  it("explicit constructor attrs take precedence over scope attrs", async () => {
+    const User = makeModel();
+    const rel = User.where({ role: "admin" });
+    await User.scoping(rel, async () => {
+      const u = new User({ role: "guest" });
+      expect(u.readAttribute("role")).toBe("guest");
+    });
+  });
+
+  it("scope attrs fill in keys not provided explicitly", async () => {
+    const User = makeModel();
+    const rel = User.where({ role: "admin", status: "active" });
+    await User.scoping(rel, async () => {
+      const u = new User({ role: "guest" }); // only role is explicit
+      expect(u.readAttribute("role")).toBe("guest"); // explicit wins
+      expect(u.readAttribute("status")).toBe("active"); // scope fills in
+    });
+  });
+
+  it("no scope → no change to constructor attrs", async () => {
+    const User = makeModel();
+    const u = new User({ role: "user" });
+    expect(u.readAttribute("role")).toBe("user");
+  });
+});

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3386,7 +3386,10 @@ describe("quoteSqlValue", () => {
 // ==========================================================================
 
 describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => {
-  const adapter = createTestAdapter();
+  let adapter: ReturnType<typeof createTestAdapter>;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
 
   function makeModel() {
     class User extends Base {
@@ -3437,7 +3440,10 @@ describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => 
 });
 
 describe("_applyScopeAttributes — multiparameter path", () => {
-  const adapter = createTestAdapter();
+  let adapter: ReturnType<typeof createTestAdapter>;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
 
   it("scope attrs applied in multiparameter constructor path", async () => {
     class Event extends Base {
@@ -3483,7 +3489,10 @@ describe("_applyScopeAttributes — multiparameter path", () => {
 });
 
 describe("_applyScopeAttributes — STI type column wins over scope", () => {
-  const adapter = createTestAdapter();
+  let adapter: ReturnType<typeof createTestAdapter>;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
 
   it("STI type column is not overwritten by a scope that sets type", async () => {
     class Vehicle extends Base {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3481,3 +3481,28 @@ describe("_applyScopeAttributes — multiparameter path", () => {
     });
   });
 });
+
+describe("_applyScopeAttributes — STI type column wins over scope", () => {
+  const adapter = createTestAdapter();
+
+  it("STI type column is not overwritten by a scope that sets type", async () => {
+    class Vehicle extends Base {
+      static {
+        this._tableName = "vehicles";
+        this.attribute("id", "integer");
+        this.attribute("type", "string");
+        this.adapter = adapter;
+      }
+    }
+    const { enableSti } = await import("./inheritance.js");
+    enableSti(Vehicle);
+    class Car extends Vehicle {}
+
+    // Scope includes type: "Vehicle" — but new Car() should still have type: "Car"
+    const rel = Vehicle.where({ type: "Vehicle" });
+    await Vehicle.scoping(rel, async () => {
+      const car = new Car({});
+      expect(car.readAttribute("type")).toBe("Car");
+    });
+  });
+});

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3435,3 +3435,49 @@ describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => 
     expect(u.readAttribute("role")).toBe("user");
   });
 });
+
+describe("_applyScopeAttributes — multiparameter path", () => {
+  const adapter = createTestAdapter();
+
+  it("scope attrs applied in multiparameter constructor path", async () => {
+    class Event extends Base {
+      static {
+        this._tableName = "events";
+        this.attribute("id", "integer");
+        this.attribute("role", "string");
+        this.attribute("starts_on", "date");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Event.where({ role: "organizer" });
+    await Event.scoping(rel, async () => {
+      // Use multiparameter date keys — triggers the multiparameter constructor path
+      const e = new Event({ "starts_on(1i)": "2024", "starts_on(2i)": "6", "starts_on(3i)": "15" });
+      // Scope attr should be applied (role was not in the explicit multiparams)
+      expect(e.readAttribute("role")).toBe("organizer");
+    });
+  });
+
+  it("explicit multiparameter attrs take precedence over scope attrs with same key", async () => {
+    class Event extends Base {
+      static {
+        this._tableName = "events";
+        this.attribute("id", "integer");
+        this.attribute("role", "string");
+        this.attribute("starts_on", "date");
+        this.adapter = adapter;
+      }
+    }
+    const rel = Event.where({ role: "organizer" });
+    await Event.scoping(rel, async () => {
+      // role is provided explicitly (non-multiparameter key alongside multiparameter keys)
+      const e = new Event({
+        "starts_on(1i)": "2024",
+        "starts_on(2i)": "6",
+        "starts_on(3i)": "15",
+        role: "guest",
+      });
+      expect(e.readAttribute("role")).toBe("guest"); // explicit wins
+    });
+  });
+});

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2176,15 +2176,15 @@ export class Base extends Model {
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
       if (!wasSuppressed) {
-        // Fire initialize_internals_callback after attribute assignment.
-        inheritanceInitializeInternalsCallback.call(this as any);
-        // Scoping: apply current-scope attrs non-destructively — skip keys
-        // already in the explicit multiparams (those take precedence).
+        // Mirrors Rails' initialize_internals_callback chain order:
+        //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
+        // Scope attrs applied first so the STI type column write wins last.
         _applyScopeAttributes(
           ctor,
           this as any,
           new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
         );
+        inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
@@ -2214,11 +2214,10 @@ export class Base extends Model {
         }
       }
       if (!wasSuppressed2) {
-        inheritanceInitializeInternalsCallback.call(this as any);
-        // Scoping: apply current-scope attrs non-destructively — skip keys
-        // already in the explicit attrs (explicit attrs take precedence, mirroring
-        // Rails where scope attrs are set first then overwritten by explicit attrs).
+        // Mirrors Rails' initialize_internals_callback chain order:
+        //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
         _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
+        inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -411,7 +411,7 @@ async function performClassUpdate(
 function _applyScopeAttributes(
   ctor: typeof Base,
   record: InstanceType<typeof Base>,
-  explicitAttrs: Record<string, unknown>,
+  explicitKeys: Set<string>,
 ): void {
   const scope = (ctor as any).currentScope;
   if (!scope) return;
@@ -419,12 +419,13 @@ function _applyScopeAttributes(
   if (!attrs || Object.keys(attrs).length === 0) return;
   const toApply: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(attrs)) {
-    if (!Object.prototype.hasOwnProperty.call(explicitAttrs, k)) {
+    if (!explicitKeys.has(k)) {
       toApply[k] = v;
     }
   }
   if (Object.keys(toApply).length > 0) {
-    (record as any).assignAttributes?.(toApply);
+    // assignAttributes is always mixed into Base instances; call directly.
+    (record as any).assignAttributes(toApply);
   }
 }
 
@@ -2179,7 +2180,11 @@ export class Base extends Model {
         inheritanceInitializeInternalsCallback.call(this as any);
         // Scoping: apply current-scope attrs non-destructively — skip keys
         // already in the explicit multiparams (those take precedence).
-        _applyScopeAttributes(ctor, this as any, { ...multiparams, ...regular });
+        _applyScopeAttributes(
+          ctor,
+          this as any,
+          new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
+        );
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
@@ -2213,7 +2218,7 @@ export class Base extends Model {
         // Scoping: apply current-scope attrs non-destructively — skip keys
         // already in the explicit attrs (explicit attrs take precedence, mirroring
         // Rails where scope attrs are set first then overwritten by explicit attrs).
-        _applyScopeAttributes(ctor2, this as any, attrs);
+        _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2178,12 +2178,14 @@ export class Base extends Model {
       if (!wasSuppressed) {
         // Mirrors Rails' initialize_internals_callback chain order:
         //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
-        // Scope attrs applied first so the STI type column write wins last.
-        _applyScopeAttributes(
-          ctor,
-          this as any,
-          new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
-        );
+        // Guard on currentScope before allocating the Set — the no-scope case is the hot path.
+        if ((ctor as any).currentScope) {
+          _applyScopeAttributes(
+            ctor,
+            this as any,
+            new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
+          );
+        }
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
@@ -2216,7 +2218,10 @@ export class Base extends Model {
       if (!wasSuppressed2) {
         // Mirrors Rails' initialize_internals_callback chain order:
         //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
-        _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
+        // Guard on currentScope before allocating the Set — the no-scope case is the hot path.
+        if ((ctor2 as any).currentScope) {
+          _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
+        }
         inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -147,7 +147,7 @@ import * as _EnumModule from "./enum.js";
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
-import { ScopeRegistry } from "./scoping.js";
+import { ScopeRegistry, scopeAttributes } from "./scoping.js";
 import {
   transaction as _transaction,
   currentTransactionPublic as _currentTransactionPublic,
@@ -399,6 +399,35 @@ async function performClassUpdate(
  *
  * Mirrors: ActiveRecord::Base
  */
+
+/**
+ * Apply current-scope attributes to a new record instance, skipping any key
+ * that was already explicitly provided in `explicitAttrs`.
+ *
+ * Rails calls populate_with_current_scope_attributes BEFORE super (so explicit
+ * attrs overwrite scope attrs). In TS we call it after super, so we invert:
+ * only write scope attrs for keys NOT in the explicit set.
+ */
+function _applyScopeAttributes(
+  ctor: typeof Base,
+  record: InstanceType<typeof Base>,
+  explicitAttrs: Record<string, unknown>,
+): void {
+  const scope = (ctor as any).currentScope;
+  if (!scope) return;
+  const attrs = scopeAttributes.call(ctor as any);
+  if (!attrs || Object.keys(attrs).length === 0) return;
+  const toApply: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (!Object.prototype.hasOwnProperty.call(explicitAttrs, k)) {
+      toApply[k] = v;
+    }
+  }
+  if (Object.keys(toApply).length > 0) {
+    (record as any).assignAttributes?.(toApply);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
   // --- Translation mixin (wired via extend() after class) ---
@@ -2146,12 +2175,12 @@ export class Base extends Model {
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
       if (!wasSuppressed) {
-        // Fire initialize_internals_callback after attribute assignment and
-        // before after_initialize. Scope attribute precedence is already handled
-        // by _mergeCurrentScopeAttrs in the class-level new/create methods, so
-        // only the inheritance callback (STI type column) is called here.
+        // Fire initialize_internals_callback after attribute assignment.
         inheritanceInitializeInternalsCallback.call(this as any);
-        // Re-snapshot so the STI type write is part of the initial clean state.
+        // Scoping: apply current-scope attrs non-destructively — skip keys
+        // already in the explicit multiparams (those take precedence).
+        _applyScopeAttributes(ctor, this as any, { ...multiparams, ...regular });
+        // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }
@@ -2181,7 +2210,11 @@ export class Base extends Model {
       }
       if (!wasSuppressed2) {
         inheritanceInitializeInternalsCallback.call(this as any);
-        // Re-snapshot so the STI type write is part of the initial clean state.
+        // Scoping: apply current-scope attrs non-destructively — skip keys
+        // already in the explicit attrs (explicit attrs take precedence, mirroring
+        // Rails where scope attrs are set first then overwritten by explicit attrs).
+        _applyScopeAttributes(ctor2, this as any, attrs);
+        // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         ctor2._callbackChain.runAfter("initialize", this, { strict: "sync" } as any);
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -417,7 +417,7 @@ function _applyScopeAttributes(
   if (!scope) return;
   const attrs = scopeAttributes.call(ctor as any);
   if (!attrs || Object.keys(attrs).length === 0) return;
-  const toApply: Record<string, unknown> = {};
+  const toApply: Record<string, unknown> = Object.create(null);
   for (const [k, v] of Object.entries(attrs)) {
     if (!explicitKeys.has(k)) {
       toApply[k] = v;


### PR DESCRIPTION
Deferred from #996. Applies current-scope attributes during construction non-destructively — skips keys already in the explicit `attrs` so `User.where(role: 'admin').new(role: 'guest')` correctly produces `role: 'guest'`. Rails achieves this by calling `populate_with_current_scope_attributes` BEFORE `super`; we invert: call AFTER `super` but filter out explicit keys.