### PR TITLE
feat(activerecord): implement _storeAccessorsModule

### DIFF
--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -831,3 +831,89 @@ describe("store private helpers — tested through public accessor API", () => {
     expect((post as any).color).toBe("red");
   });
 });
+
+describe("storeAccessorsModule", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  it("contains accessor names registered by store()", async () => {
+    const { storeAccessorsModule } = await import("./store.js");
+    class User extends Base {
+      static {
+        this._tableName = "users";
+        this.attribute("settings", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(User);
+    store(User, "settings", { accessors: ["theme", "language"] });
+    const names = storeAccessorsModule(User);
+    expect(names.has("theme")).toBe(true);
+    expect(names.has("language")).toBe(true);
+  });
+
+  it("includes prefixed accessor names", async () => {
+    const { storeAccessorsModule } = await import("./store.js");
+    class Post extends Base {
+      static {
+        this._tableName = "posts";
+        this.attribute("prefs", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(Post);
+    store(Post, "prefs", { accessors: ["color"], prefix: "ui" });
+    const names = storeAccessorsModule(Post);
+    expect(names.has("ui_color")).toBe(true);
+    expect(names.has("color")).toBe(false);
+  });
+
+  it("each class has an independent registry (no cross-class contamination)", async () => {
+    const { storeAccessorsModule } = await import("./store.js");
+    class A extends Base {
+      static {
+        this._tableName = "as";
+        this.attribute("data", "string");
+        this.adapter = adapter;
+      }
+    }
+    class B extends Base {
+      static {
+        this._tableName = "bs";
+        this.attribute("data", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(A);
+    registerModel(B);
+    store(A, "data", { accessors: ["foo"] });
+    store(B, "data", { accessors: ["bar"] });
+    expect(storeAccessorsModule(A).has("foo")).toBe(true);
+    expect(storeAccessorsModule(A).has("bar")).toBe(false);
+    expect(storeAccessorsModule(B).has("bar")).toBe(true);
+    expect(storeAccessorsModule(B).has("foo")).toBe(false);
+  });
+
+  it("subclass gets its own registry independent of parent", async () => {
+    const { storeAccessorsModule } = await import("./store.js");
+    class Parent extends Base {
+      static {
+        this._tableName = "parents";
+        this.attribute("settings", "string");
+        this.adapter = adapter;
+      }
+    }
+    class Child extends Parent {}
+    registerModel(Parent);
+    registerModel(Child);
+    store(Parent, "settings", { accessors: ["theme"] });
+    store(Child, "settings", { accessors: ["mode"] });
+    // Parent does not get Child's accessors
+    expect(storeAccessorsModule(Parent).has("mode")).toBe(false);
+    // Child does not inherit Parent's module (independent registry)
+    expect(storeAccessorsModule(Child).has("theme")).toBe(false);
+    expect(storeAccessorsModule(Child).has("mode")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -9,6 +9,25 @@ import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 const _storedAttributes = new WeakMap<typeof Base, Record<string, string[]>>();
 
 /**
+ * Tracks the set of accessor method names defined via store() on each class.
+ * Mirrors Rails' @_store_accessors_module which is a Module where store
+ * accessor methods live. In TS we track the accessor names instead of a
+ * real module (JS has no include mechanism).
+ */
+const _storeAccessorsModules = new WeakMap<typeof Base, Set<string>>();
+
+/**
+ * Returns (creating if needed) the store-accessor module for a model class.
+ * Mirrors: ActiveRecord::Store::ClassMethods#_store_accessors_module
+ */
+export function storeAccessorsModule(modelClass: typeof Base): Set<string> {
+  if (!_storeAccessorsModules.has(modelClass)) {
+    _storeAccessorsModules.set(modelClass, new Set());
+  }
+  return _storeAccessorsModules.get(modelClass)!;
+}
+
+/**
  * Returns the stored attributes registry for a model class.
  */
 export function storedAttributes(modelClass: typeof Base): Record<string, string[]> {
@@ -177,6 +196,10 @@ export function store(
     // Capture `modelClass` at definition time so subclass instances still resolve
     // the correct accessor even when `record.constructor` differs from the declaring class.
     // Mirrors Rails: accessor closures delegate through read/write_store_attribute.
+    // Register the accessor name on the _store_accessors_module.
+    // Mirrors Rails: _store_accessors_module.module_eval { define_method ... }
+    storeAccessorsModule(modelClass).add(accessorName);
+
     const declaringClass = modelClass;
     Object.defineProperty(modelClass.prototype, accessorName, {
       get: function (this: Base) {


### PR DESCRIPTION
Closes the `_store_accessors_module` stub from `store.rb`. Rails uses a dedicated module to host store accessor methods; in TS we track accessor names in a per-class `WeakMap<typeof Base, Set<string>>` and register each accessor name there when `store()` or `storeAccessor()` is called.